### PR TITLE
include github.com/infobloxopen/infoblox-go-client/pull/58

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -285,7 +285,7 @@
   branch = "master"
   name = "github.com/infobloxopen/infoblox-go-client"
   packages = ["."]
-  revision = "e2811d86bed7bb487eeb0806337b6f9e9d93d5e7"
+  revision = "61dc5f9b0a655ebf43026f0d8a837ad1e28e4b96"
 
 [[projects]]
   name = "github.com/jmespath/go-jmespath"
@@ -428,7 +428,8 @@
     "http2",
     "http2/hpack",
     "idna",
-    "lex/httplex"
+    "lex/httplex",
+    "publicsuffix"
   ]
   revision = "e90d6d0afc4c315a0d87a568ae68577cc15149a0"
 
@@ -666,6 +667,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8d8869be9b64013c9670a0ba7f6a6eeaf31941fcfbdfc13f0fa57626e767c517"
+  inputs-digest = "84dd4d46f1682b174b47c24afd13104daa26c16da187d07513cb9a58bb3f4820"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/provider/infoblox.go
+++ b/provider/infoblox.go
@@ -114,9 +114,9 @@ func (p *InfobloxProvider) Records() (endpoints []*endpoint.Endpoint, err error)
 		}
 
 		// Include Host records since they should be treated synonymously with A records
-		var resH []ibclient.RecordHost
-		objH := ibclient.NewRecordHost(
-			ibclient.RecordHost{
+		var resH []ibclient.HostRecord
+		objH := ibclient.NewHostRecord(
+			ibclient.HostRecord{
 				Zone: zone.Fqdn,
 			},
 		)

--- a/provider/infoblox_test.go
+++ b/provider/infoblox_test.go
@@ -62,18 +62,18 @@ func (client *mockIBConnector) CreateObject(obj ibclient.IBObject) (ref string, 
 		ref = fmt.Sprintf("%s/%s:%s/default", obj.ObjectType(), base64.StdEncoding.EncodeToString([]byte(obj.(*ibclient.RecordCNAME).Name)), obj.(*ibclient.RecordCNAME).Name)
 		obj.(*ibclient.RecordCNAME).Ref = ref
 	case "record:host":
-		for _, i := range obj.(*ibclient.RecordHost).Ipv4Addrs {
+		for _, i := range obj.(*ibclient.HostRecord).Ipv4Addrs {
 			client.createdEndpoints = append(
 				client.createdEndpoints,
 				endpoint.NewEndpoint(
-					obj.(*ibclient.RecordHost).Name,
+					obj.(*ibclient.HostRecord).Name,
 					endpoint.RecordTypeA,
 					i.Ipv4Addr,
 				),
 			)
 		}
-		ref = fmt.Sprintf("%s/%s:%s/default", obj.ObjectType(), base64.StdEncoding.EncodeToString([]byte(obj.(*ibclient.RecordHost).Name)), obj.(*ibclient.RecordHost).Name)
-		obj.(*ibclient.RecordHost).Ref = ref
+		ref = fmt.Sprintf("%s/%s:%s/default", obj.ObjectType(), base64.StdEncoding.EncodeToString([]byte(obj.(*ibclient.HostRecord).Name)), obj.(*ibclient.HostRecord).Name)
+		obj.(*ibclient.HostRecord).Ref = ref
 	case "record:txt":
 		client.createdEndpoints = append(
 			client.createdEndpoints,
@@ -128,21 +128,21 @@ func (client *mockIBConnector) GetObject(obj ibclient.IBObject, ref string, res 
 		}
 		*res.(*[]ibclient.RecordCNAME) = result
 	case "record:host":
-		var result []ibclient.RecordHost
+		var result []ibclient.HostRecord
 		for _, object := range *client.mockInfobloxObjects {
 			if object.ObjectType() == "record:host" {
 				if ref != "" &&
-					ref != object.(*ibclient.RecordHost).Ref {
+					ref != object.(*ibclient.HostRecord).Ref {
 					continue
 				}
-				if obj.(*ibclient.RecordHost).Name != "" &&
-					obj.(*ibclient.RecordHost).Name != object.(*ibclient.RecordHost).Name {
+				if obj.(*ibclient.HostRecord).Name != "" &&
+					obj.(*ibclient.HostRecord).Name != object.(*ibclient.HostRecord).Name {
 					continue
 				}
-				result = append(result, *object.(*ibclient.RecordHost))
+				result = append(result, *object.(*ibclient.HostRecord))
 			}
 		}
-		*res.(*[]ibclient.RecordHost) = result
+		*res.(*[]ibclient.HostRecord) = result
 	case "record:txt":
 		var result []ibclient.RecordTXT
 		for _, object := range *client.mockInfobloxObjects {
@@ -207,9 +207,9 @@ func (client *mockIBConnector) DeleteObject(ref string) (refRes string, err erro
 			)
 		}
 	case "record:host":
-		var records []ibclient.RecordHost
-		obj := ibclient.NewRecordHost(
-			ibclient.RecordHost{
+		var records []ibclient.HostRecord
+		obj := ibclient.NewHostRecord(
+			ibclient.HostRecord{
 				Name: result[2],
 			},
 		)
@@ -267,11 +267,11 @@ func (client *mockIBConnector) UpdateObject(obj ibclient.IBObject, ref string) (
 			),
 		)
 	case "record:host":
-		for _, i := range obj.(*ibclient.RecordHost).Ipv4Addrs {
+		for _, i := range obj.(*ibclient.HostRecord).Ipv4Addrs {
 			client.updatedEndpoints = append(
 				client.updatedEndpoints,
 				endpoint.NewEndpoint(
-					obj.(*ibclient.RecordHost).Name,
+					obj.(*ibclient.HostRecord).Name,
 					i.Ipv4Addr,
 					endpoint.RecordTypeA,
 				),


### PR DESCRIPTION
`infoblox-go-client` was only setting timeout for `http.Transport.ResponseHeaderTimeout` instead of for `http.Client` as a whole, leaving bad requests in limbo

https://github.com/infobloxopen/infoblox-go-client/pull/58 includes the fix

The following was run to update the package:

```
dep ensure -update github.com/infobloxopen/infoblox-go-client
```