### PR TITLE
Support for multiple targets per hostname, enabling DNS round robining

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -18,10 +18,10 @@ package plan
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/kubernetes-incubator/external-dns/endpoint"
-	"sort"
 )
 
 // Plan can convert a list of desired and current records to a series of create,

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -111,7 +111,8 @@ func (t planTable) getUpdates() (updateNew []*endpoint.Endpoint, updateOld []*en
 		// At this point, we're only supporting updates when there is a single current/candidate record
 		if len(row.candidates) > 0 && len(row.candidates) > 0 { //dns name is taken
 			current := row.currents[0]
-			update := t.resolver.ResolveUpdate(current, row.candidates)
+			candidates := []*endpoint.Endpoint{row.candidates[0]}
+			update := t.resolver.ResolveUpdate(current, candidates)
 			// compare "update" to "current" to figure out if actual update is required
 			if recordChanged(update, current) {
 				inheritOwner(current, update)

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package plan
 
 import (
+	"testing"
+
 	"github.com/kubernetes-incubator/external-dns/endpoint"
 	"github.com/kubernetes-incubator/external-dns/internal/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"testing"
 )
 
 type PlanTestSuite struct {


### PR DESCRIPTION
I am attempting to use external-dns to create DNS round-robining in Dyn. In other words, I would like to:
* Have multiple (type=LoadBalanacer) Kubernetes services, all mapping to the same DNS name, say foo.com.
* Have external-dns create a DNS entry foo.com -> <load_balanacer_ip> for each service.
This doesn't work currently, and after some digging, I found a few open issues others have filed, and TODOs in the code related to supporting this. I found a fairly simple way to add support for this, by modifying the logic in plan/plan.go so that it considers all of the endpoint.Endpoints associated with a hostname, instead of only considering one.

**UPDATED** So what this PR does is:
* Changes the planTableRow's current to currents, which is a list of Endpoints.
* In the routines that build up the create/delete/update list:
    * Changes to _single record_ row are handled exactly the saw as before.
    * Any changes to a _multi record_ row triggers deletion and recreation of all elements in the row.  I settled on this behavior after my comments below: in order to handle updates to multiple records associated with a hostname, provider changes would be necessary as well (the Dyn provider for sure doesn't work as-is)...  So to avoid that rat hole for now, deleting/recreating in this (newly supported) situation seems like the easiest way forward.
* A few unit tests have been added to verify the new behavior.
* A few unit tests have been removed that explicitly verified the old behavior (a single Endpoint per hostname only).