### PR TITLE
[RFC] Add support for all AWS Route53 routing policies; add additional Setldentifier abstraction layer

### DIFF
--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -320,6 +320,23 @@ spec:
 
 This will set the DNS record's TTL to 60 seconds.
 
+## Routing policies
+
+Route53 offers [different routing policies](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy.html). The routing policy for a record can be controlled with the following annotations:
+
+* `external-dns.alpha.kubernetes.io/set-identifier`: this **needs** to be set to use any of the following routing policies
+
+For any given DNS name, only **one** of the following routing policies can be used:
+
+* Weighted records: `external-dns.alpha.kubernetes.io/aws-weight`
+* Latency-based routing: `external-dns.alpha.kubernetes.io/aws-region`
+* Failover:`external-dns.alpha.kubernetes.io/aws-failover`
+* Geolocation-based routing:
+  * `external-dns.alpha.kubernetes.io/aws-geolocation-continent-code`
+  * `external-dns.alpha.kubernetes.io/aws-geolocation-country-code`
+  * `external-dns.alpha.kubernetes.io/aws-geolocation-subdivision-code`
+* Multi-value answer:`external-dns.alpha.kubernetes.io/aws-multi-value-answer`
+
 ## Clean up
 
 Make sure to delete all Service objects before terminating the cluster so all load balancers get cleaned up correctly.

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -126,6 +126,8 @@ type Endpoint struct {
 	Targets Targets `json:"targets,omitempty"`
 	// RecordType type of record, e.g. CNAME, A, SRV, TXT etc
 	RecordType string `json:"recordType,omitempty"`
+	// Identifier to distinguish multiple records with the same name and type (e.g. Route53 records with routing policies other than 'simple')
+	SetIdentifier string `json:"setIdentifier,omitempty"`
 	// TTL for the record
 	RecordTTL TTL `json:"recordTTL,omitempty"`
 	// Labels stores labels defined for the Endpoint
@@ -157,6 +159,11 @@ func NewEndpointWithTTL(dnsName, recordType string, ttl TTL, targets ...string) 
 	}
 }
 
+func (e *Endpoint) WithSetIdentifier(setIdentifier string) *Endpoint {
+	e.SetIdentifier = setIdentifier
+	return e
+}
+
 // WithProviderSpecific attaches a key/value pair to the Endpoint and returns the Endpoint.
 // This can be used to pass additional data through the stages of ExternalDNS's Endpoint processing.
 // The assumption is that most of the time this will be provider specific metadata that doesn't
@@ -182,7 +189,7 @@ func (e *Endpoint) GetProviderSpecificProperty(key string) (ProviderSpecificProp
 }
 
 func (e *Endpoint) String() string {
-	return fmt.Sprintf("%s %d IN %s %s %s", e.DNSName, e.RecordTTL, e.RecordType, e.Targets, e.ProviderSpecific)
+	return fmt.Sprintf("%s %d IN %s %s %s %s", e.DNSName, e.RecordTTL, e.RecordType, e.SetIdentifier, e.Targets, e.ProviderSpecific)
 }
 
 // DNSEndpointSpec defines the desired state of DNSEndpoint

--- a/internal/testutils/endpoint.go
+++ b/internal/testutils/endpoint.go
@@ -47,10 +47,10 @@ func (b byAllFields) Less(i, j int) bool {
 // SameEndpoint returns true if two endpoints are same
 // considers example.org. and example.org DNSName/Target as different endpoints
 func SameEndpoint(a, b *endpoint.Endpoint) bool {
-	return a.DNSName == b.DNSName && a.Targets.Same(b.Targets) && a.RecordType == b.RecordType &&
+	return a.DNSName == b.DNSName && a.Targets.Same(b.Targets) && a.RecordType == b.RecordType && a.SetIdentifier == b.SetIdentifier &&
 		a.Labels[endpoint.OwnerLabelKey] == b.Labels[endpoint.OwnerLabelKey] && a.RecordTTL == b.RecordTTL &&
 		a.Labels[endpoint.ResourceLabelKey] == b.Labels[endpoint.ResourceLabelKey] &&
-		SameProverSpecific(a.ProviderSpecific, b.ProviderSpecific)
+		SameProviderSpecific(a.ProviderSpecific, b.ProviderSpecific)
 }
 
 // SameEndpoints compares two slices of endpoints regardless of order
@@ -100,7 +100,7 @@ func SamePlanChanges(a, b map[string][]*endpoint.Endpoint) bool {
 		SameEndpoints(a["UpdateOld"], b["UpdateOld"]) && SameEndpoints(a["UpdateNew"], b["UpdateNew"])
 }
 
-// SameProverSpecific verifies that two maps contain the same string/string key/value pairs
-func SameProverSpecific(a, b endpoint.ProviderSpecific) bool {
+// SameProviderSpecific verifies that two maps contain the same string/string key/value pairs
+func SameProviderSpecific(a, b endpoint.ProviderSpecific) bool {
 	return reflect.DeepEqual(a, b)
 }

--- a/internal/testutils/endpoint_test.go
+++ b/internal/testutils/endpoint_test.go
@@ -40,9 +40,10 @@ func ExampleSameEndpoints() {
 			RecordType: endpoint.RecordTypeTXT,
 		},
 		{
-			DNSName:    "abc.com",
-			Targets:    endpoint.Targets{"1.2.3.4"},
-			RecordType: endpoint.RecordTypeA,
+			DNSName:       "abc.com",
+			Targets:       endpoint.Targets{"1.2.3.4"},
+			RecordType:    endpoint.RecordTypeA,
+			SetIdentifier: "test-set-1",
 		},
 		{
 			DNSName:    "bbc.com",
@@ -68,11 +69,11 @@ func ExampleSameEndpoints() {
 		fmt.Println(ep)
 	}
 	// Output:
-	// abc.com 0 IN A 1.2.3.4 []
-	// abc.com 0 IN TXT something []
-	// bbc.com 0 IN CNAME foo.com []
-	// cbc.com 60 IN CNAME foo.com []
-	// example.org 0 IN  load-balancer.org []
-	// example.org 0 IN  load-balancer.org [{foo bar}]
-	// example.org 0 IN TXT load-balancer.org []
+	// abc.com 0 IN A test-set-1 1.2.3.4 []
+	// abc.com 0 IN TXT  something []
+	// bbc.com 0 IN CNAME  foo.com []
+	// cbc.com 60 IN CNAME  foo.com []
+	// example.org 0 IN   load-balancer.org []
+	// example.org 0 IN   load-balancer.org [{foo bar}]
+	// example.org 0 IN TXT  load-balancer.org []
 }

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -187,10 +187,33 @@ func shouldUpdateProviderSpecific(desired, current *endpoint.Endpoint) bool {
 			continue
 		}
 
+		found := false
 		for _, d := range desired.ProviderSpecific {
-			if d.Name == c.Name && d.Value != c.Value {
-				return true
+			if d.Name == c.Name {
+				if d.Value != c.Value {
+					// provider-specific attribute updated
+					return true
+				}
+				found = true
+				break
 			}
+		}
+		if !found {
+			// provider-specific attribute deleted
+			return true
+		}
+	}
+	for _, d := range desired.ProviderSpecific {
+		found := false
+		for _, c := range current.ProviderSpecific {
+			if d.Name == c.Name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			// provider-specific attribute added
+			return true
 		}
 	}
 

--- a/provider/aws.go
+++ b/provider/aws.go
@@ -39,11 +39,9 @@ const (
 	// provider specific key that designates whether an AWS ALIAS record has the EvaluateTargetHealth
 	// field set to true.
 	providerSpecificEvaluateTargetHealth       = "aws/evaluate-target-health"
-	providerSpecificSetIdentifier              = "aws/set-identifier"
 	providerSpecificWeight                     = "aws/weight"
 	providerSpecificRegion                     = "aws/region"
 	providerSpecificFailover                   = "aws/failover"
-	providerSpecificGeolocation                = "aws/geolocation"
 	providerSpecificGeolocationContinentCode   = "aws/geolocation-continent-code"
 	providerSpecificGeolocationCountryCode     = "aws/geolocation-country-code"
 	providerSpecificGeolocationSubdivisionCode = "aws/geolocation-subdivision-code"

--- a/provider/aws.go
+++ b/provider/aws.go
@@ -519,10 +519,10 @@ func (p *AWSProvider) newChange(action string, ep *endpoint.Endpoint, recordsCac
 		}
 	}
 
-	setIdentifier := endpoint.SetIdentifier
+	setIdentifier := ep.SetIdentifier
 	if setIdentifier != "" {
 		change.ResourceRecordSet.SetIdentifier = aws.String(setIdentifier)
-		if prop, ok := endpoint.GetProviderSpecificProperty(providerSpecificWeight); ok {
+		if prop, ok := ep.GetProviderSpecificProperty(providerSpecificWeight); ok {
 			weight, err := strconv.ParseInt(prop.Value, 10, 64)
 			if err != nil {
 				log.Errorf("Failed parsing value of %s: %s: %v; using weight of 0", providerSpecificWeight, prop.Value, err)
@@ -530,27 +530,27 @@ func (p *AWSProvider) newChange(action string, ep *endpoint.Endpoint, recordsCac
 			}
 			change.ResourceRecordSet.Weight = aws.Int64(weight)
 		}
-		if prop, ok := endpoint.GetProviderSpecificProperty(providerSpecificRegion); ok {
+		if prop, ok := ep.GetProviderSpecificProperty(providerSpecificRegion); ok {
 			change.ResourceRecordSet.Region = aws.String(prop.Value)
 		}
-		if prop, ok := endpoint.GetProviderSpecificProperty(providerSpecificFailover); ok {
+		if prop, ok := ep.GetProviderSpecificProperty(providerSpecificFailover); ok {
 			change.ResourceRecordSet.Failover = aws.String(prop.Value)
 		}
-		if _, ok := endpoint.GetProviderSpecificProperty(providerSpecificMultiValueAnswer); ok {
+		if _, ok := ep.GetProviderSpecificProperty(providerSpecificMultiValueAnswer); ok {
 			change.ResourceRecordSet.MultiValueAnswer = aws.Bool(true)
 		}
 
 		var geolocation = &route53.GeoLocation{}
 		useGeolocation := false
-		if prop, ok := endpoint.GetProviderSpecificProperty(providerSpecificGeolocationContinentCode); ok {
+		if prop, ok := ep.GetProviderSpecificProperty(providerSpecificGeolocationContinentCode); ok {
 			geolocation.ContinentCode = aws.String(prop.Value)
 			useGeolocation = true
 		} else {
-			if prop, ok := endpoint.GetProviderSpecificProperty(providerSpecificGeolocationCountryCode); ok {
+			if prop, ok := ep.GetProviderSpecificProperty(providerSpecificGeolocationCountryCode); ok {
 				geolocation.CountryCode = aws.String(prop.Value)
 				useGeolocation = true
 			}
-			if prop, ok := endpoint.GetProviderSpecificProperty(providerSpecificGeolocationSubdivisionCode); ok {
+			if prop, ok := ep.GetProviderSpecificProperty(providerSpecificGeolocationSubdivisionCode); ok {
 				geolocation.SubdivisionCode = aws.String(prop.Value)
 				useGeolocation = true
 			}

--- a/provider/aws.go
+++ b/provider/aws.go
@@ -290,19 +290,16 @@ func (p *AWSProvider) records(zones map[string]*route53.HostedZone) ([]*endpoint
 			for _, ep := range newEndpoints {
 				if r.SetIdentifier != nil {
 					ep.SetIdentifier = aws.StringValue(r.SetIdentifier)
-					if r.Weight != nil {
+					switch {
+					case r.Weight != nil:
 						ep.WithProviderSpecific(providerSpecificWeight, fmt.Sprintf("%d", aws.Int64Value(r.Weight)))
-					}
-					if r.Region != nil {
+					case r.Region != nil:
 						ep.WithProviderSpecific(providerSpecificRegion, aws.StringValue(r.Region))
-					}
-					if r.Failover != nil {
+					case r.Failover != nil:
 						ep.WithProviderSpecific(providerSpecificFailover, aws.StringValue(r.Failover))
-					}
-					if r.MultiValueAnswer != nil && aws.BoolValue(r.MultiValueAnswer) {
+					case r.MultiValueAnswer != nil && aws.BoolValue(r.MultiValueAnswer):
 						ep.WithProviderSpecific(providerSpecificMultiValueAnswer, "")
-					}
-					if r.GeoLocation != nil {
+					case r.GeoLocation != nil:
 						if r.GeoLocation.ContinentCode != nil {
 							ep.WithProviderSpecific(providerSpecificGeolocationContinentCode, aws.StringValue(r.GeoLocation.ContinentCode))
 						} else {
@@ -313,6 +310,8 @@ func (p *AWSProvider) records(zones map[string]*route53.HostedZone) ([]*endpoint
 								ep.WithProviderSpecific(providerSpecificGeolocationSubdivisionCode, aws.StringValue(r.GeoLocation.SubdivisionCode))
 							}
 						}
+					default:
+						// one of the above needs to be set, otherwise SetIdentifier doesn't make sense
 					}
 				}
 				endpoints = append(endpoints, ep)

--- a/provider/inmemory_test.go
+++ b/provider/inmemory_test.go
@@ -43,11 +43,12 @@ func TestInMemoryProvider(t *testing.T) {
 
 func testInMemoryFindByType(t *testing.T) {
 	for _, ti := range []struct {
-		title         string
-		findType      string
-		records       []*inMemoryRecord
-		expected      *inMemoryRecord
-		expectedEmpty bool
+		title             string
+		findType          string
+		findSetIdentifier string
+		records           []*inMemoryRecord
+		expected          *inMemoryRecord
+		expectedEmpty     bool
 	}{
 		{
 			title:         "no records, empty type",
@@ -112,10 +113,32 @@ func testInMemoryFindByType(t *testing.T) {
 				Type: endpoint.RecordTypeA,
 			},
 		},
+		{
+			title:             "multiple records, right type and set identifier",
+			findType:          endpoint.RecordTypeA,
+			findSetIdentifier: "test-set-1",
+			records: []*inMemoryRecord{
+				{
+					Type:          endpoint.RecordTypeA,
+					SetIdentifier: "test-set-1",
+				},
+				{
+					Type:          endpoint.RecordTypeA,
+					SetIdentifier: "test-set-2",
+				},
+				{
+					Type: endpoint.RecordTypeTXT,
+				},
+			},
+			expected: &inMemoryRecord{
+				Type:          endpoint.RecordTypeA,
+				SetIdentifier: "test-set-1",
+			},
+		},
 	} {
 		t.Run(ti.title, func(t *testing.T) {
 			c := newInMemoryClient()
-			record := c.findByType(ti.findType, ti.records)
+			record := c.findByTypeAndSetIdentifier(ti.findType, ti.findSetIdentifier, ti.records)
 			if ti.expectedEmpty {
 				assert.Nil(t, record)
 			} else {

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -135,6 +135,7 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 		}
 		r.Labels[endpoint.OwnerLabelKey] = im.ownerID
 		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
+		txt.ProviderSpecific = r.ProviderSpecific
 		filteredChanges.Create = append(filteredChanges.Create, txt)
 
 		if im.cacheInterval > 0 {
@@ -144,6 +145,7 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 
 	for _, r := range filteredChanges.Delete {
 		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
+		txt.ProviderSpecific = r.ProviderSpecific
 
 		// when we delete TXT records for which value has changed (due to new label) this would still work because
 		// !!! TXT record value is uniquely generated from the Labels of the endpoint. Hence old TXT record can be uniquely reconstructed
@@ -157,6 +159,7 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 	// make sure TXT records are consistently updated as well
 	for _, r := range filteredChanges.UpdateOld {
 		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
+		txt.ProviderSpecific = r.ProviderSpecific
 		// when we updateOld TXT records for which value has changed (due to new label) this would still work because
 		// !!! TXT record value is uniquely generated from the Labels of the endpoint. Hence old TXT record can be uniquely reconstructed
 		filteredChanges.UpdateOld = append(filteredChanges.UpdateOld, txt)
@@ -169,6 +172,7 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 	// make sure TXT records are consistently updated as well
 	for _, r := range filteredChanges.UpdateNew {
 		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
+		txt.ProviderSpecific = r.ProviderSpecific
 		filteredChanges.UpdateNew = append(filteredChanges.UpdateNew, txt)
 		// add new version of record to cache
 		if im.cacheInterval > 0 {

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"time"
 
+	"fmt"
 	"strings"
 
 	"github.com/kubernetes-incubator/external-dns/endpoint"
@@ -94,15 +95,16 @@ func (im *TXTRegistry) Records() ([]*endpoint.Endpoint, error) {
 		if err != nil {
 			return nil, err
 		}
-		endpointDNSName := im.mapper.toEndpointName(record.DNSName)
-		labelMap[endpointDNSName] = labels
+		key := fmt.Sprintf("%s::%s", im.mapper.toEndpointName(record.DNSName), record.SetIdentifier)
+		labelMap[key] = labels
 	}
 
 	for _, ep := range endpoints {
 		if ep.Labels == nil {
 			ep.Labels = endpoint.NewLabels()
 		}
-		if labels, ok := labelMap[ep.DNSName]; ok {
+		key := fmt.Sprintf("%s::%s", ep.DNSName, ep.SetIdentifier)
+		if labels, ok := labelMap[key]; ok {
 			for k, v := range labels {
 				ep.Labels[k] = v
 			}
@@ -132,7 +134,7 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 			r.Labels = make(map[string]string)
 		}
 		r.Labels[endpoint.OwnerLabelKey] = im.ownerID
-		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true))
+		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
 		filteredChanges.Create = append(filteredChanges.Create, txt)
 
 		if im.cacheInterval > 0 {
@@ -141,7 +143,7 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 	}
 
 	for _, r := range filteredChanges.Delete {
-		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true))
+		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
 
 		// when we delete TXT records for which value has changed (due to new label) this would still work because
 		// !!! TXT record value is uniquely generated from the Labels of the endpoint. Hence old TXT record can be uniquely reconstructed
@@ -154,7 +156,7 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 
 	// make sure TXT records are consistently updated as well
 	for _, r := range filteredChanges.UpdateOld {
-		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true))
+		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
 		// when we updateOld TXT records for which value has changed (due to new label) this would still work because
 		// !!! TXT record value is uniquely generated from the Labels of the endpoint. Hence old TXT record can be uniquely reconstructed
 		filteredChanges.UpdateOld = append(filteredChanges.UpdateOld, txt)
@@ -166,7 +168,7 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 
 	// make sure TXT records are consistently updated as well
 	for _, r := range filteredChanges.UpdateNew {
-		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true))
+		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
 		filteredChanges.UpdateNew = append(filteredChanges.UpdateNew, txt)
 		// add new version of record to cache
 		if im.cacheInterval > 0 {
@@ -230,7 +232,7 @@ func (im *TXTRegistry) removeFromCache(ep *endpoint.Endpoint) {
 	}
 
 	for i, e := range im.recordsCache {
-		if e.DNSName == ep.DNSName && e.RecordType == ep.RecordType && e.Targets.Same(ep.Targets) {
+		if e.DNSName == ep.DNSName && e.RecordType == ep.RecordType && e.SetIdentifier == ep.SetIdentifier && e.Targets.Same(ep.Targets) {
 			// We found a match delete the endpoint from the cache.
 			im.recordsCache = append(im.recordsCache[:i], im.recordsCache[i+1:]...)
 			return

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -80,6 +80,10 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 			newEndpointWithOwner("TxT.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""), // case-insensitive TXT prefix
 			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
 			newEndpointWithOwner("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("multiple.test-zone.example.org", "lb1.loadbalancer.com", endpoint.RecordTypeCNAME, "").WithSetIdentifier("test-set-1"),
+			newEndpointWithOwner("multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-1"),
+			newEndpointWithOwner("multiple.test-zone.example.org", "lb2.loadbalancer.com", endpoint.RecordTypeCNAME, "").WithSetIdentifier("test-set-2"),
+			newEndpointWithOwner("multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
 		},
 	})
 	expectedRecords := []*endpoint.Endpoint{
@@ -130,6 +134,24 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 			DNSName:    "foobar.test-zone.example.org",
 			Targets:    endpoint.Targets{"foobar.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeCNAME,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "",
+			},
+		},
+		{
+			DNSName:       "multiple.test-zone.example.org",
+			Targets:       endpoint.Targets{"lb1.loadbalancer.com"},
+			SetIdentifier: "test-set-1",
+			RecordType:    endpoint.RecordTypeCNAME,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "",
+			},
+		},
+		{
+			DNSName:       "multiple.test-zone.example.org",
+			Targets:       endpoint.Targets{"lb2.loadbalancer.com"},
+			SetIdentifier: "test-set-2",
+			RecordType:    endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "",
 			},
@@ -246,6 +268,10 @@ func testTXTRegistryApplyChangesWithPrefix(t *testing.T) {
 			newEndpointWithOwner("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
 			newEndpointWithOwner("txt.foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("multiple.test-zone.example.org", "lb1.loadbalancer.com", endpoint.RecordTypeCNAME, "").WithSetIdentifier("test-set-1"),
+			newEndpointWithOwner("txt.multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-1"),
+			newEndpointWithOwner("multiple.test-zone.example.org", "lb2.loadbalancer.com", endpoint.RecordTypeCNAME, "").WithSetIdentifier("test-set-2"),
+			newEndpointWithOwner("txt.multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
 		},
 	})
 	r, _ := NewTXTRegistry(p, "txt.", "owner", time.Hour)
@@ -253,33 +279,45 @@ func testTXTRegistryApplyChangesWithPrefix(t *testing.T) {
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
 			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", "", "", "ingress/default/my-ingress"),
+			newEndpointWithOwnerResource("multiple.test-zone.example.org", "lb3.loadbalancer.com", "", "", "ingress/default/my-ingress").WithSetIdentifier("test-set-3"),
 		},
 		Delete: []*endpoint.Endpoint{
 			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
+			newEndpointWithOwner("multiple.test-zone.example.org", "lb1.loadbalancer.com", endpoint.RecordTypeCNAME, "owner").WithSetIdentifier("test-set-1"),
 		},
 		UpdateNew: []*endpoint.Endpoint{
 			newEndpointWithOwnerResource("tar.test-zone.example.org", "new-tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress-2"),
+			newEndpointWithOwnerResource("multiple.test-zone.example.org", "new.loadbalancer.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress-2").WithSetIdentifier("test-set-2"),
 		},
 		UpdateOld: []*endpoint.Endpoint{
 			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
+			newEndpointWithOwner("multiple.test-zone.example.org", "lb2.loadbalancer.com", endpoint.RecordTypeCNAME, "owner").WithSetIdentifier("test-set-2"),
 		},
 	}
 	expected := &plan.Changes{
 		Create: []*endpoint.Endpoint{
 			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", "", "owner", "ingress/default/my-ingress"),
 			newEndpointWithOwner("txt.new-record-1.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwnerResource("multiple.test-zone.example.org", "lb3.loadbalancer.com", "", "owner", "ingress/default/my-ingress").WithSetIdentifier("test-set-3"),
+			newEndpointWithOwner("txt.multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-3"),
 		},
 		Delete: []*endpoint.Endpoint{
 			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
 			newEndpointWithOwner("txt.foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("multiple.test-zone.example.org", "lb1.loadbalancer.com", endpoint.RecordTypeCNAME, "owner").WithSetIdentifier("test-set-1"),
+			newEndpointWithOwner("txt.multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-1"),
 		},
 		UpdateNew: []*endpoint.Endpoint{
 			newEndpointWithOwnerResource("tar.test-zone.example.org", "new-tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress-2"),
 			newEndpointWithOwner("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress-2\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwnerResource("multiple.test-zone.example.org", "new.loadbalancer.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress-2").WithSetIdentifier("test-set-2"),
+			newEndpointWithOwner("txt.multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress-2\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
 		},
 		UpdateOld: []*endpoint.Endpoint{
 			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
 			newEndpointWithOwner("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("multiple.test-zone.example.org", "lb2.loadbalancer.com", endpoint.RecordTypeCNAME, "owner").WithSetIdentifier("test-set-2"),
+			newEndpointWithOwner("txt.multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
 		},
 	}
 	p.OnApplyChanges = func(ctx context.Context, got *plan.Changes) {

--- a/source/dedup_source.go
+++ b/source/dedup_source.go
@@ -43,7 +43,7 @@ func (ms *dedupSource) Endpoints() ([]*endpoint.Endpoint, error) {
 	}
 
 	for _, ep := range endpoints {
-		identifier := ep.DNSName + " / " + ep.Targets.String()
+		identifier := ep.DNSName + " / " + ep.SetIdentifier + " / " + ep.Targets.String()
 
 		if _, ok := collected[identifier]; ok {
 			log.Debugf("Removing duplicate endpoint %s", ep)

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -174,14 +174,14 @@ func (sc *gatewaySource) endpointsFromTemplate(config *istiomodel.Config) ([]*en
 		}
 	}
 
-	providerSpecific := getProviderSpecificAnnotations(config.Annotations)
+	providerSpecific, setIdentifier := getProviderSpecificAnnotations(config.Annotations)
 
 	var endpoints []*endpoint.Endpoint
 	// splits the FQDN template and removes the trailing periods
 	hostnameList := strings.Split(strings.Replace(hostnames, " ", "", -1), ",")
 	for _, hostname := range hostnameList {
 		hostname = strings.TrimSuffix(hostname, ".")
-		endpoints = append(endpoints, endpointsForHostname(hostname, targets, ttl, providerSpecific)...)
+		endpoints = append(endpoints, endpointsForHostname(hostname, targets, ttl, providerSpecific, setIdentifier)...)
 	}
 	return endpoints, nil
 }
@@ -266,7 +266,7 @@ func (sc *gatewaySource) endpointsFromGatewayConfig(config istiomodel.Config) ([
 
 	gateway := config.Spec.(*istionetworking.Gateway)
 
-	providerSpecific := getProviderSpecificAnnotations(config.Annotations)
+	providerSpecific, setIdentifier := getProviderSpecificAnnotations(config.Annotations)
 
 	for _, server := range gateway.Servers {
 		for _, host := range server.Hosts {
@@ -282,7 +282,7 @@ func (sc *gatewaySource) endpointsFromGatewayConfig(config istiomodel.Config) ([
 				host = parts[1]
 			}
 
-			endpoints = append(endpoints, endpointsForHostname(host, targets, ttl, providerSpecific)...)
+			endpoints = append(endpoints, endpointsForHostname(host, targets, ttl, providerSpecific, setIdentifier)...)
 		}
 	}
 
@@ -290,7 +290,7 @@ func (sc *gatewaySource) endpointsFromGatewayConfig(config istiomodel.Config) ([
 	if !sc.ignoreHostnameAnnotation {
 		hostnameList := getHostnamesFromAnnotations(config.Annotations)
 		for _, hostname := range hostnameList {
-			endpoints = append(endpoints, endpointsForHostname(hostname, targets, ttl, providerSpecific)...)
+			endpoints = append(endpoints, endpointsForHostname(hostname, targets, ttl, providerSpecific, setIdentifier)...)
 		}
 	}
 

--- a/source/ingress.go
+++ b/source/ingress.go
@@ -187,14 +187,14 @@ func (sc *ingressSource) endpointsFromTemplate(ing *v1beta1.Ingress) ([]*endpoin
 		targets = targetsFromIngressStatus(ing.Status)
 	}
 
-	providerSpecific := getProviderSpecificAnnotations(ing.Annotations)
+	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ing.Annotations)
 
 	var endpoints []*endpoint.Endpoint
 	// splits the FQDN template and removes the trailing periods
 	hostnameList := strings.Split(strings.Replace(hostnames, " ", "", -1), ",")
 	for _, hostname := range hostnameList {
 		hostname = strings.TrimSuffix(hostname, ".")
-		endpoints = append(endpoints, endpointsForHostname(hostname, targets, ttl, providerSpecific)...)
+		endpoints = append(endpoints, endpointsForHostname(hostname, targets, ttl, providerSpecific, setIdentifier)...)
 	}
 	return endpoints, nil
 }
@@ -261,13 +261,13 @@ func endpointsFromIngress(ing *v1beta1.Ingress, ignoreHostnameAnnotation bool) [
 		targets = targetsFromIngressStatus(ing.Status)
 	}
 
-	providerSpecific := getProviderSpecificAnnotations(ing.Annotations)
+	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ing.Annotations)
 
 	for _, rule := range ing.Spec.Rules {
 		if rule.Host == "" {
 			continue
 		}
-		endpoints = append(endpoints, endpointsForHostname(rule.Host, targets, ttl, providerSpecific)...)
+		endpoints = append(endpoints, endpointsForHostname(rule.Host, targets, ttl, providerSpecific, setIdentifier)...)
 	}
 
 	for _, tls := range ing.Spec.TLS {
@@ -275,7 +275,7 @@ func endpointsFromIngress(ing *v1beta1.Ingress, ignoreHostnameAnnotation bool) [
 			if host == "" {
 				continue
 			}
-			endpoints = append(endpoints, endpointsForHostname(host, targets, ttl, providerSpecific)...)
+			endpoints = append(endpoints, endpointsForHostname(host, targets, ttl, providerSpecific, setIdentifier)...)
 		}
 	}
 
@@ -283,7 +283,7 @@ func endpointsFromIngress(ing *v1beta1.Ingress, ignoreHostnameAnnotation bool) [
 	if !ignoreHostnameAnnotation {
 		hostnameList := getHostnamesFromAnnotations(ing.Annotations)
 		for _, hostname := range hostnameList {
-			endpoints = append(endpoints, endpointsForHostname(hostname, targets, ttl, providerSpecific)...)
+			endpoints = append(endpoints, endpointsForHostname(hostname, targets, ttl, providerSpecific, setIdentifier)...)
 		}
 	}
 	return endpoints

--- a/source/ingressroute.go
+++ b/source/ingressroute.go
@@ -209,14 +209,14 @@ func (sc *ingressRouteSource) endpointsFromTemplate(ingressRoute *contourapi.Ing
 		}
 	}
 
-	providerSpecific := getProviderSpecificAnnotations(ingressRoute.Annotations)
+	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ingressRoute.Annotations)
 
 	var endpoints []*endpoint.Endpoint
 	// splits the FQDN template and removes the trailing periods
 	hostnameList := strings.Split(strings.Replace(hostnames, " ", "", -1), ",")
 	for _, hostname := range hostnameList {
 		hostname = strings.TrimSuffix(hostname, ".")
-		endpoints = append(endpoints, endpointsForHostname(hostname, targets, ttl, providerSpecific)...)
+		endpoints = append(endpoints, endpointsForHostname(hostname, targets, ttl, providerSpecific, setIdentifier)...)
 	}
 	return endpoints, nil
 }
@@ -302,11 +302,11 @@ func (sc *ingressRouteSource) endpointsFromIngressRoute(ingressRoute *contourapi
 		}
 	}
 
-	providerSpecific := getProviderSpecificAnnotations(ingressRoute.Annotations)
+	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ingressRoute.Annotations)
 
 	if virtualHost := ingressRoute.Spec.VirtualHost; virtualHost != nil {
 		if fqdn := virtualHost.Fqdn; fqdn != "" {
-			endpoints = append(endpoints, endpointsForHostname(fqdn, targets, ttl, providerSpecific)...)
+			endpoints = append(endpoints, endpointsForHostname(fqdn, targets, ttl, providerSpecific, setIdentifier)...)
 		}
 	}
 
@@ -314,7 +314,7 @@ func (sc *ingressRouteSource) endpointsFromIngressRoute(ingressRoute *contourapi
 	if !sc.ignoreHostnameAnnotation {
 		hostnameList := getHostnamesFromAnnotations(ingressRoute.Annotations)
 		for _, hostname := range hostnameList {
-			endpoints = append(endpoints, endpointsForHostname(hostname, targets, ttl, providerSpecific)...)
+			endpoints = append(endpoints, endpointsForHostname(hostname, targets, ttl, providerSpecific, setIdentifier)...)
 		}
 	}
 


### PR DESCRIPTION
This adds support for all AWS Route53 routing policies, namely:
* simple (default)
* weighted
* latency
* failover
* geolocation
* multi value answer

These routing policies allow to create multiple records with the same
name, but different "SetIdentifiers". Therefor, as a prerequisite for
implementing support for above routing policies, there is a new
"abstraction layer" added that handles this SetIdentifier by adding a
new attribute in the Endpoint struct and adding another level in the
plan table.

This closes #196, #469, #571.

ToDo:
- [x] needs manual testing
- [x] needs documentation update