### PR TITLE
Fix confusing arrow direction

### DIFF
--- a/docs/tutorials/azure.md
+++ b/docs/tutorials/azure.md
@@ -94,10 +94,10 @@ Create the service principal
 ``` bash
 > az ad sp create-for-rbac -n ExternalDnsServicePrincipal
 {
-  "appId": "appId GUID",  <-- aadClientId value
+  "appId": "appId GUID",  --> aadClientId value
   ...
-  "password": "password",  <-- aadClientSecret value
-  "tenant": "AzureAD Tenant Id"  <-- tenantId value
+  "password": "password",  --> aadClientSecret value
+  "tenant": "AzureAD Tenant Id"  --> tenantId value
 }
 ```
 


### PR DESCRIPTION
Switched the direction of the arrows in the documentation, they should indicate where the value comes from and where it goes.