### PR TITLE
Support TTL in rcode0 provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/natefinch/lumberjack v2.0.0+incompatible // indirect
 	github.com/nesv/go-dynect v0.6.0
-	github.com/nic-at/rc0go v1.1.0
+	github.com/nic-at/rc0go v1.1.1
 	github.com/onsi/ginkgo v1.8.0 // indirect
 	github.com/onsi/gomega v1.5.0 // indirect
 	github.com/oracle/oci-go-sdk v1.8.0

--- a/provider/rcode0.go
+++ b/provider/rcode0.go
@@ -324,7 +324,7 @@ func (p *RcodeZeroProvider) NewRcodezeroChange(action string, endpoint *endpoint
 		Type:       endpoint.RecordType,
 		ChangeType: action,
 		Name:       endpoint.DNSName,
-		TTL:        enpoint.TTL,
+		TTL:        endpoint.TTL,
 		Records: []*rc0.Record{{
 			Disabled: false,
 			Content:  endpoint.Targets[0],

--- a/provider/rcode0.go
+++ b/provider/rcode0.go
@@ -324,7 +324,7 @@ func (p *RcodeZeroProvider) NewRcodezeroChange(action string, endpoint *endpoint
 		Type:       endpoint.RecordType,
 		ChangeType: action,
 		Name:       endpoint.DNSName,
-		Ttl:        enpoint.TTL,
+		TTL:        enpoint.TTL,
 		Records: []*rc0.Record{{
 			Disabled: false,
 			Content:  endpoint.Targets[0],

--- a/provider/rcode0.go
+++ b/provider/rcode0.go
@@ -324,6 +324,7 @@ func (p *RcodeZeroProvider) NewRcodezeroChange(action string, endpoint *endpoint
 		Type:       endpoint.RecordType,
 		ChangeType: action,
 		Name:       endpoint.DNSName,
+		Ttl:        enpoint.TTL,
 		Records: []*rc0.Record{{
 			Disabled: false,
 			Content:  endpoint.Targets[0],


### PR DESCRIPTION
Just from reading the code of https://github.com/kubernetes-incubator/external-dns/blob/master/provider/aws.go and looking into the API:
https://my.rcodezero.at/api-doc/#api-zone-management-rrsets-patch

I would guess that the proposed change will support TTL for rcode0.