### PR TITLE
docs: fix log-level param in tutorials

### DIFF
--- a/docs/tutorials/externalname.md
+++ b/docs/tutorials/externalname.md
@@ -23,7 +23,7 @@ spec:
       - name: external-dns
         image: registry.opensource.zalan.do/teapot/external-dns:latest
         args:
-        - --debug
+        - --log-level=debug
         - --source=service
         - --source=ingress
         - --namespace=dev

--- a/docs/tutorials/hostport.md
+++ b/docs/tutorials/hostport.md
@@ -27,7 +27,7 @@ spec:
       - name: external-dns
         image: registry.opensource.zalan.do/teapot/external-dns:latest
         args:
-        - --debug
+        - --log-level=debug
         - --source=service
         - --source=ingress
         - --namespace=dev
@@ -89,7 +89,7 @@ spec:
       - name: external-dns
         image: registry.opensource.zalan.do/teapot/external-dns:latest
         args:
-        - --debug
+        - --log-level=debug
         - --source=service
         - --source=ingress
         - --namespace=dev


### PR DESCRIPTION
* arg --debug is now --log-level=debug
* flag --log-level was merged 2017 with
  PR https://github.com/kubernetes-sigs/external-dns/pull/339