### PR TITLE
Add gov LB hosted zone

### DIFF
--- a/provider/aws.go
+++ b/provider/aws.go
@@ -42,6 +42,7 @@ const (
 
 var (
 	// see: https://docs.aws.amazon.com/general/latest/gr/rande.html#elb_region
+	// and: https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/using-govcloud-endpoints.html
 	canonicalHostedZones = map[string]string{
 		// Application Load Balancers and Classic Load Balancers
 		"us-east-2.elb.amazonaws.com":         "Z3AADJGX6KTTL2",
@@ -63,6 +64,7 @@ var (
 		"sa-east-1.elb.amazonaws.com":         "Z2P70J7HTTTPLU",
 		"cn-north-1.elb.amazonaws.com.cn":     "Z3BX2TMKNYI13Y",
 		"cn-northwest-1.elb.amazonaws.com.cn": "Z3BX2TMKNYI13Y",
+		"us-gov-west-1.amazonaws.com":         "Z1K6XKP9SAGWDV",
 		// Network Load Balancers
 		"elb.us-east-2.amazonaws.com":         "ZLMOA37VPKANP",
 		"elb.us-east-1.amazonaws.com":         "Z26RNL4JYFTOTI",


### PR DESCRIPTION
At the bottom of https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/using-govcloud-endpoints.html it says:
> Amazon Route 53 hosted Zone ID for the regional endpoint in the AWS GovCloud (US) region is Z1K6XKP9SAGWDV.