### PR TITLE
Normalize function return and comments on exported type

### DIFF
--- a/internal/testutils/endpoint.go
+++ b/internal/testutils/endpoint.go
@@ -76,6 +76,7 @@ func SameEndpoints(a, b []*endpoint.Endpoint) bool {
 	return true
 }
 
+// SameEndpointLabels verifies that labels of the two slices of endpoints are the same
 func SameEndpointLabels(a, b []*endpoint.Endpoint) bool {
 	if len(a) != len(b) {
 		return false

--- a/provider/azure_test.go
+++ b/provider/azure_test.go
@@ -370,9 +370,8 @@ func testAzureApplyChangesInternal(t *testing.T, dryRun bool, client RecordSetsC
 			result := results[0]
 			results = nil
 			return result, nil
-		} else {
-			return dns.ZoneListResult{}, nil
 		}
+		return dns.ZoneListResult{}, nil
 	})
 	mockZoneClientIterator := dns.NewZoneListResultIterator(mockZoneListResultPage)
 

--- a/provider/transip.go
+++ b/provider/transip.go
@@ -304,7 +304,7 @@ func (p *TransIPProvider) dnsEntriesAreEqual(a, b transip.DNSEntries) bool {
 				continue
 			}
 
-			match += 1
+			match++
 		}
 	}
 

--- a/source/ingress.go
+++ b/source/ingress.go
@@ -38,9 +38,9 @@ import (
 )
 
 const (
-	// The annotation used for determining if an ALB ingress is dualstack
+	// ALBDualstackAnnotationKey is the annotation used for determining if an ALB ingress is dualstack
 	ALBDualstackAnnotationKey = "alb.ingress.kubernetes.io/ip-address-type"
-	// The value of the ALB dualstack annotation that indicates it is dualstack
+	// ALBDualstackAnnotationValue is the value of the ALB dualstack annotation that indicates it is dualstack
 	ALBDualstackAnnotationValue = "dualstack"
 )
 

--- a/source/ingressroute.go
+++ b/source/ingressroute.go
@@ -53,7 +53,7 @@ type ingressRouteSource struct {
 	ingressRouteInformer       extinformers.IngressRouteInformer
 }
 
-// NewIngressRouteSource creates a new ingressRouteSource with the given config.
+// NewContourIngressRouteSource creates a new contourIngressRouteSource with the given config.
 func NewContourIngressRouteSource(
 	kubeClient kubernetes.Interface,
 	contourClient contour.Interface,


### PR DESCRIPTION
* comment on exported type/function/method should be of the form "XXX ..."

* if block ends with a return statement, so drop this else and outdent its block