### PR TITLE
Bump the version of golangci-lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
   - go: tip
 
 env:
-- GOLANGCI_RELEASE="v1.17.1"
+- GOLANGCI_RELEASE="v1.21.0"
 
 before_install:
 - GO111MODULE=off go get github.com/mattn/goveralls

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ cover-html: cover
 
 # Run all the linters
 lint:
-	golangci-lint run ./...
+	golangci-lint run --timeout=5m ./...
 
 
 # The verify target runs tasks similar to the CI tasks, but without code coverage

--- a/provider/azure_private_dns.go
+++ b/provider/azure_private_dns.go
@@ -19,8 +19,9 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/Azure/go-autorest/autorest"
 	"strings"
+
+	"github.com/Azure/go-autorest/autorest"
 
 	log "github.com/sirupsen/logrus"
 
@@ -104,17 +105,15 @@ func (p *AzurePrivateDNSProvider) Records() (endpoints []*endpoint.Endpoint, _ e
 			if recordSet.Type == nil {
 				log.Debugf("Skipping invalid record set with missing type.")
 				return
-			} else {
-				recordType = strings.TrimLeft(*recordSet.Type, "Microsoft.Network/privateDnsZones")
 			}
+			recordType = strings.TrimLeft(*recordSet.Type, "Microsoft.Network/privateDnsZones")
 
 			var name string
 			if recordSet.Name == nil {
 				log.Debugf("Skipping invalid record set with missing name.")
 				return
-			} else {
-				name = formatAzureDNSName(*recordSet.Name, *zone.Name)
 			}
+			name = formatAzureDNSName(*recordSet.Name, *zone.Name)
 
 			targets := extractAzurePrivateDNSTargets(&recordSet)
 			if len(targets) == 0 {

--- a/provider/azure_privatedns_test.go
+++ b/provider/azure_privatedns_test.go
@@ -18,8 +18,9 @@ package provider
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -261,6 +262,10 @@ func TestAzurePrivateDNSRecord(t *testing.T) {
 			createPrivateMockRecordSetWithTTL("hack", endpoint.RecordTypeCNAME, "hack.azurewebsites.net", 10),
 		})
 
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	actual, err := provider.Records()
 
 	if err != nil {
@@ -292,6 +297,10 @@ func TestAzurePrivateDNSMultiRecord(t *testing.T) {
 			createPrivateMockRecordSetWithTTL("nginx", endpoint.RecordTypeTXT, "heritage=external-dns,external-dns/owner=default", recordTTL),
 			createPrivateMockRecordSetWithTTL("hack", endpoint.RecordTypeCNAME, "hack.azurewebsites.net", 10),
 		})
+
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	actual, err := provider.Records()
 
@@ -363,9 +372,8 @@ func testAzurePrivateDNSApplyChangesInternal(t *testing.T, dryRun bool, client P
 			result := results[0]
 			results = nil
 			return result, nil
-		} else {
-			return privatedns.PrivateZoneListResult{}, nil
 		}
+		return privatedns.PrivateZoneListResult{}, nil
 	})
 	mockZoneClientIterator := privatedns.NewPrivateZoneListResultIterator(mockZoneListResultPage)
 

--- a/provider/azure_test.go
+++ b/provider/azure_test.go
@@ -268,6 +268,10 @@ func TestAzureRecord(t *testing.T) {
 			createMockRecordSetWithTTL("hack", endpoint.RecordTypeCNAME, "hack.azurewebsites.net", 10),
 		})
 
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	actual, err := provider.Records()
 
 	if err != nil {
@@ -299,6 +303,10 @@ func TestAzureMultiRecord(t *testing.T) {
 			createMockRecordSetWithTTL("nginx", endpoint.RecordTypeTXT, "heritage=external-dns,external-dns/owner=default", recordTTL),
 			createMockRecordSetWithTTL("hack", endpoint.RecordTypeCNAME, "hack.azurewebsites.net", 10),
 		})
+
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	actual, err := provider.Records()
 

--- a/provider/designate.go
+++ b/provider/designate.go
@@ -19,17 +19,18 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets"
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/zones"
 	"github.com/gophercloud/gophercloud/pagination"
 	log "github.com/sirupsen/logrus"
-	"net"
-	"net/http"
-	"os"
-	"strings"
-	"time"
 
 	"github.com/kubernetes-sigs/external-dns/endpoint"
 	"github.com/kubernetes-sigs/external-dns/pkg/tlsutils"

--- a/source/node_test.go
+++ b/source/node_test.go
@@ -78,7 +78,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 			"",
 			"",
 			"node1",
-			[]v1.NodeAddress{{v1.NodeExternalIP, "1.2.3.4"}},
+			[]v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}},
 			map[string]string{},
 			map[string]string{},
 			[]*endpoint.Endpoint{
@@ -91,7 +91,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 			"",
 			"",
 			"node1.example.org",
-			[]v1.NodeAddress{{v1.NodeExternalIP, "1.2.3.4"}},
+			[]v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}},
 			map[string]string{},
 			map[string]string{},
 			[]*endpoint.Endpoint{
@@ -104,7 +104,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 			"",
 			"{{.Name}}.example.org",
 			"node1",
-			[]v1.NodeAddress{{v1.NodeExternalIP, "1.2.3.4"}},
+			[]v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}},
 			map[string]string{},
 			map[string]string{},
 			[]*endpoint.Endpoint{
@@ -117,7 +117,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 			"",
 			"{{.Name}}.example.org",
 			"node1.example.org",
-			[]v1.NodeAddress{{v1.NodeExternalIP, "1.2.3.4"}},
+			[]v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}},
 			map[string]string{},
 			map[string]string{},
 			[]*endpoint.Endpoint{
@@ -130,7 +130,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 			"",
 			"{{.Name}}.example.org",
 			"node1",
-			[]v1.NodeAddress{{v1.NodeExternalIP, "1.2.3.4"}, {v1.NodeExternalIP, "5.6.7.8"}},
+			[]v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}, {Type: v1.NodeExternalIP, Address: "5.6.7.8"}},
 			map[string]string{},
 			map[string]string{},
 			[]*endpoint.Endpoint{
@@ -143,7 +143,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 			"",
 			"",
 			"node1",
-			[]v1.NodeAddress{{v1.NodeExternalIP, "1.2.3.4"}, {v1.NodeInternalIP, "2.3.4.5"}},
+			[]v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}, {Type: v1.NodeInternalIP, Address: "2.3.4.5"}},
 			map[string]string{},
 			map[string]string{},
 			[]*endpoint.Endpoint{
@@ -156,7 +156,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 			"",
 			"",
 			"node1",
-			[]v1.NodeAddress{{v1.NodeInternalIP, "2.3.4.5"}},
+			[]v1.NodeAddress{{Type: v1.NodeInternalIP, Address: "2.3.4.5"}},
 			map[string]string{},
 			map[string]string{},
 			[]*endpoint.Endpoint{
@@ -180,7 +180,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 			"",
 			"",
 			"node1",
-			[]v1.NodeAddress{{v1.NodeExternalIP, "1.2.3.4"}},
+			[]v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}},
 			map[string]string{},
 			map[string]string{
 				"service.beta.kubernetes.io/external-traffic": "OnlyLocal",
@@ -195,7 +195,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 			"service.beta.kubernetes.io/external-traffic in (Global, OnlyLocal)",
 			"",
 			"node1",
-			[]v1.NodeAddress{{v1.NodeExternalIP, "1.2.3.4"}},
+			[]v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}},
 			map[string]string{},
 			map[string]string{
 				"service.beta.kubernetes.io/external-traffic": "OnlyLocal",
@@ -210,7 +210,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 			"service.beta.kubernetes.io/external-traffic in (Global, OnlyLocal)",
 			"",
 			"node1",
-			[]v1.NodeAddress{{v1.NodeExternalIP, "1.2.3.4"}},
+			[]v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}},
 			map[string]string{},
 			map[string]string{
 				"service.beta.kubernetes.io/external-traffic": "SomethingElse",
@@ -223,7 +223,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 			"",
 			"",
 			"node1",
-			[]v1.NodeAddress{{v1.NodeExternalIP, "1.2.3.4"}},
+			[]v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}},
 			map[string]string{},
 			map[string]string{
 				controllerAnnotationKey: controllerAnnotationValue,
@@ -238,7 +238,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 			"",
 			"",
 			"node1",
-			[]v1.NodeAddress{{v1.NodeExternalIP, "1.2.3.4"}},
+			[]v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}},
 			map[string]string{},
 			map[string]string{
 				controllerAnnotationKey: "not-dns-controller",
@@ -251,7 +251,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 			"",
 			"",
 			"node1",
-			[]v1.NodeAddress{{v1.NodeExternalIP, "1.2.3.4"}},
+			[]v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}},
 			map[string]string{},
 			map[string]string{},
 			[]*endpoint.Endpoint{
@@ -264,7 +264,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 			"",
 			"",
 			"node1",
-			[]v1.NodeAddress{{v1.NodeExternalIP, "1.2.3.4"}},
+			[]v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}},
 			map[string]string{},
 			map[string]string{
 				ttlAnnotationKey: "foo",
@@ -279,7 +279,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 			"",
 			"",
 			"node1",
-			[]v1.NodeAddress{{v1.NodeExternalIP, "1.2.3.4"}},
+			[]v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}},
 			map[string]string{},
 			map[string]string{
 				ttlAnnotationKey: "10",


### PR DESCRIPTION
Update golangci-lint to the latest version:

https://github.com/golangci/golangci-lint/releases/tag/v1.21.0