### PR TITLE
Add missing service account to spec

### DIFF
--- a/docs/tutorials/dnsimple.md
+++ b/docs/tutorials/dnsimple.md
@@ -94,6 +94,7 @@ spec:
       labels:
         app: external-dns
     spec:
+      serviceAccountName: external-dns
       containers:
       - name: external-dns
         image: registry.opensource.zalan.do/teapot/external-dns:latest


### PR DESCRIPTION
Sets the ServiceAccount so it picks up the correct rbac rules as pointed out here: https://github.com/kubernetes-sigs/external-dns/issues/1303