### PR TITLE
Allow ZoneIDFilter for Cloudflare

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.github
+docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,13 @@
 FROM golang:1.13 as builder
 
 WORKDIR /github.com/kubernetes-sigs/external-dns
+COPY go.mod .
+COPY go.sum .
+RUN go mod vendor && \
+    go mod download
 
 COPY . .
-RUN go mod vendor && \
-    make test && \
+RUN make test && \
     make build
 
 # final image

--- a/Dockerfile.mini
+++ b/Dockerfile.mini
@@ -16,12 +16,17 @@ FROM golang:1.13 as builder
 
 WORKDIR /github.com/kubernetes-sigs/external-dns
 
-COPY . .
 RUN apt-get update && \
     apt-get install ca-certificates && \
-    update-ca-certificates && \
-    go mod vendor && \
-    make test && \
+    update-ca-certificates
+
+COPY go.mod .
+COPY go.sum .
+RUN go mod vendor && \
+    go mod download
+
+COPY . .
+RUN make test && \
     make build
 
 FROM gcr.io/distroless/static

--- a/provider/cloudflare.go
+++ b/provider/cloudflare.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors. ewf
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/provider/cloudflare_test.go
+++ b/provider/cloudflare_test.go
@@ -77,6 +77,23 @@ func (m *mockCloudFlareClient) ListZonesContext(ctx context.Context, opts ...clo
 	}, nil
 }
 
+func (m *mockCloudFlareClient) ZoneDetails(zoneID string) (cloudflare.Zone, error) {
+	switch zoneID {
+	case "1234567890":
+		return cloudflare.Zone{
+			ID:   "1234567890",
+			Name: "ext-dns-test.zalando.to.",
+		}, nil
+	case "1234567891":
+		return cloudflare.Zone{
+			ID:   "1234567891",
+			Name: "foo.com.",
+		}, nil
+	default:
+		return cloudflare.Zone{}, fmt.Errorf("zoneID %s is not mocked", zoneID)
+	}
+}
+
 type mockCloudFlareUserDetailsFail struct{}
 
 func (m *mockCloudFlareUserDetailsFail) CreateDNSRecord(zoneID string, rr cloudflare.DNSRecord) (*cloudflare.DNSRecordResponse, error) {
@@ -181,6 +198,23 @@ func (m *mockCloudFlareDNSRecordsFail) ListZonesContext(ctx context.Context, opt
 	}, nil
 }
 
+func (m *mockCloudFlareDNSRecordsFail) ZoneDetails(zoneID string) (cloudflare.Zone, error) {
+	switch zoneID {
+	case "1234567890":
+		return cloudflare.Zone{
+			ID:   "1234567890",
+			Name: "ext-dns-test.zalando.to.",
+		}, nil
+	case "1234567891":
+		return cloudflare.Zone{
+			ID:   "1234567891",
+			Name: "foo.com.",
+		}, nil
+	default:
+		return cloudflare.Zone{}, fmt.Errorf("zoneID %s is not mocked", zoneID)
+	}
+}
+
 type mockCloudFlareZoneIDByNameFail struct{}
 
 func (m *mockCloudFlareZoneIDByNameFail) CreateDNSRecord(zoneID string, rr cloudflare.DNSRecord) (*cloudflare.DNSRecordResponse, error) {
@@ -275,6 +309,10 @@ func (m *mockCloudFlareListZonesFail) ListZonesContext(ctx context.Context, opts
 	return cloudflare.ZonesResponse{}, fmt.Errorf("no zones available")
 }
 
+func (m *mockCloudFlareListZonesFail) ZoneDetails(zoneID string) (cloudflare.Zone, error) {
+	return cloudflare.Zone{}, fmt.Errorf("no zones available")
+}
+
 type mockCloudFlareCreateRecordsFail struct{}
 
 func (m *mockCloudFlareCreateRecordsFail) CreateDNSRecord(zoneID string, rr cloudflare.DNSRecord) (*cloudflare.DNSRecordResponse, error) {
@@ -303,6 +341,10 @@ func (m *mockCloudFlareCreateRecordsFail) ZoneIDByName(zoneName string) (string,
 
 func (m *mockCloudFlareCreateRecordsFail) ListZones(zoneID ...string) ([]cloudflare.Zone, error) {
 	return []cloudflare.Zone{{}}, fmt.Errorf("no zones available")
+}
+
+func (m *mockCloudFlareCreateRecordsFail) ZoneDetails(zoneID string) (cloudflare.Zone, error) {
+	return cloudflare.Zone{}, fmt.Errorf("no zones available")
 }
 
 func (m *mockCloudFlareCreateRecordsFail) ListZonesContext(ctx context.Context, opts ...cloudflare.ReqOption) (cloudflare.ZonesResponse, error) {
@@ -474,6 +516,23 @@ func TestCloudFlareZones(t *testing.T) {
 		Client:       &mockCloudFlareClient{},
 		domainFilter: NewDomainFilter([]string{"zalando.to."}),
 		zoneIDFilter: NewZoneIDFilter([]string{""}),
+	}
+
+	zones, err := provider.Zones()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validateCloudFlareZones(t, zones, []cloudflare.Zone{
+		{Name: "ext-dns-test.zalando.to."},
+	})
+}
+
+func TestCloudFlareZonesWithIDFilter(t *testing.T) {
+	provider := &CloudFlareProvider{
+		Client:       &mockCloudFlareClient{},
+		domainFilter: NewDomainFilter([]string{""}),
+		zoneIDFilter: NewZoneIDFilter([]string{"1234567890"}),
 	}
 
 	zones, err := provider.Zones()


### PR DESCRIPTION
Additionally:
* add a .dockerignore so we don't copy .git and docs to the
  container (gotta go fast)
* Change Dockerfile{,.mini} to not run `go mod` every time a file is
  changed.

This commit _should_ help with #1127. While users in the past were able to
define ZoneIDFilter for this provider, it did not actually do anything
under the hood.

In this case, we're changing Zones() to iterate over the provided
zoneIDs and return only those zones.

I would have also done this for domainFilter, but unfortunately the
CloudFlare API requires that in order to list zones (and find them by
name) that you have "all" permissions, which seems silly. After talking
to their support, this is probably the best way to do this.