### PR TITLE
add service annotation to set public/private iface for NodePort

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -275,6 +275,16 @@ and one with `--annotation-filter=kubernetes.io/ingress.class=nginx-external`.
 Beware when using multiple sources, e.g. `--source=service --source=ingress`, `--annotation-filter` will filter every given source objects.
 If you need to filter only one specific source you have to run a separated external dns service containing only the wanted `--source`  and `--annotation-filter`.
 
+### How do I specify that I want the DNS record to point to either the Node's public or private IP when it has both?
+
+If your Nodes have both public and private IP addresses, you might want to write DNS records with one or the other.  
+For example, you may want to write a DNS record in a private zone that resolves to your Nodes' private IPs so that traffic never leaves your private network.
+
+To accomplish this, set this annotation on your service: `external-dns.alpha.kubernetes.io/access=private`  
+Conversely, to force the public IP: `external-dns.alpha.kubernetes.io/access=public`  
+
+If this annotation is not set, and the node has both public and private IP addresses, then the public IP will be used by default.
+
 ### Can external-dns manage(add/remove) records in a hosted zone which is setup in different AWS account?
 
 Yes, give it the correct cross-account/assume-role permissions and use the `--aws-assume-role` flag https://github.com/kubernetes-sigs/external-dns/pull/524#issue-181256561

--- a/source/service.go
+++ b/source/service.go
@@ -556,10 +556,16 @@ func (sc *serviceSource) extractNodePortTargets(svc *v1.Service) (endpoint.Targe
 		}
 	}
 
+	access := getAccessFromAnnotations(svc.Annotations)
+	if access == "public" {
+		return externalIPs, nil
+	}
+	if access == "private" {
+		return internalIPs, nil
+	}
 	if len(externalIPs) > 0 {
 		return externalIPs, nil
 	}
-
 	return internalIPs, nil
 }
 

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -1591,6 +1591,100 @@ func TestNodePortServices(t *testing.T) {
 			[]int{1, 1},
 			[]v1.PodPhase{v1.PodRunning, v1.PodRunning},
 		},
+		{
+			"access=private annotation NodePort services return an endpoint with private IP addresses of the cluster's nodes",
+			"",
+			"",
+			"testing",
+			"foo",
+			v1.ServiceTypeNodePort,
+			v1.ServiceExternalTrafficPolicyTypeCluster,
+			"",
+			"",
+			false,
+			map[string]string{},
+			map[string]string{
+				hostnameAnnotationKey: "foo.example.org.",
+				accessAnnotationKey:   "private",
+			},
+			nil,
+			[]*endpoint.Endpoint{
+				{DNSName: "_30192._tcp.foo.example.org", Targets: endpoint.Targets{"0 50 30192 foo.example.org"}, RecordType: endpoint.RecordTypeSRV},
+				{DNSName: "foo.example.org", Targets: endpoint.Targets{"10.0.1.1", "10.0.1.2"}, RecordType: endpoint.RecordTypeA},
+			},
+			false,
+			[]*v1.Node{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{Type: v1.NodeExternalIP, Address: "54.10.11.1"},
+						{Type: v1.NodeInternalIP, Address: "10.0.1.1"},
+					},
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node2",
+				},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{Type: v1.NodeExternalIP, Address: "54.10.11.2"},
+						{Type: v1.NodeInternalIP, Address: "10.0.1.2"},
+					},
+				},
+			}},
+			[]string{},
+			[]int{},
+			[]v1.PodPhase{},
+		},
+		{
+			"access=public annotation NodePort services return an endpoint with public IP addresses of the cluster's nodes",
+			"",
+			"",
+			"testing",
+			"foo",
+			v1.ServiceTypeNodePort,
+			v1.ServiceExternalTrafficPolicyTypeCluster,
+			"",
+			"",
+			false,
+			map[string]string{},
+			map[string]string{
+				hostnameAnnotationKey: "foo.example.org.",
+				accessAnnotationKey:   "public",
+			},
+			nil,
+			[]*endpoint.Endpoint{
+				{DNSName: "_30192._tcp.foo.example.org", Targets: endpoint.Targets{"0 50 30192 foo.example.org"}, RecordType: endpoint.RecordTypeSRV},
+				{DNSName: "foo.example.org", Targets: endpoint.Targets{"54.10.11.1", "54.10.11.2"}, RecordType: endpoint.RecordTypeA},
+			},
+			false,
+			[]*v1.Node{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{Type: v1.NodeExternalIP, Address: "54.10.11.1"},
+						{Type: v1.NodeInternalIP, Address: "10.0.1.1"},
+					},
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node2",
+				},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{Type: v1.NodeExternalIP, Address: "54.10.11.2"},
+						{Type: v1.NodeInternalIP, Address: "10.0.1.2"},
+					},
+				},
+			}},
+			[]string{},
+			[]int{},
+			[]v1.PodPhase{},
+		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
 			// Create a Kubernetes testing client

--- a/source/source.go
+++ b/source/source.go
@@ -38,6 +38,8 @@ const (
 	controllerAnnotationKey = "external-dns.alpha.kubernetes.io/controller"
 	// The annotation used for defining the desired hostname
 	hostnameAnnotationKey = "external-dns.alpha.kubernetes.io/hostname"
+	// The annotation used for specifying whether the public or private interface address is used
+	accessAnnotationKey = "external-dns.alpha.kubernetes.io/access"
 	// The annotation used for defining the desired ingress target
 	targetAnnotationKey = "external-dns.alpha.kubernetes.io/target"
 	// The annotation used for defining the desired DNS record TTL
@@ -105,6 +107,11 @@ func getHostnamesFromAnnotations(annotations map[string]string) []string {
 		return nil
 	}
 	return strings.Split(strings.Replace(hostnameAnnotation, " ", "", -1), ",")
+}
+
+func getAccessFromAnnotations(annotations map[string]string) string {
+	accessAnnotation := annotations[accessAnnotationKey]
+	return accessAnnotation
 }
 
 func getAliasFromAnnotations(annotations map[string]string) bool {

--- a/source/source.go
+++ b/source/source.go
@@ -110,8 +110,7 @@ func getHostnamesFromAnnotations(annotations map[string]string) []string {
 }
 
 func getAccessFromAnnotations(annotations map[string]string) string {
-	accessAnnotation := annotations[accessAnnotationKey]
-	return accessAnnotation
+	return annotations[accessAnnotationKey]
 }
 
 func getAliasFromAnnotations(annotations map[string]string) bool {


### PR DESCRIPTION
Scenario: in AWS with a private hosted zone, and instances with both public and private IPs, I would like some NodePort services to be registered in DNS with the node's _private_ IP so that they're only resolvable within my VPC.

This is my reattempt at https://github.com/kubernetes-sigs/external-dns/pull/898 since it appears abandoned, and I think that having the public/private interface selection should happen on a per-service basis rather than globally.

I'm open to suggestions on what the annotation should be renamed to, consider "access" a placeholder...
Finally, this change should be backwards compatible - if the annotation is not present we fall through to the previous behavior.