### PR TITLE
Reworked tutorial for Azure Private DNS

### DIFF
--- a/docs/tutorials/azure-private-dns.md
+++ b/docs/tutorials/azure-private-dns.md
@@ -22,7 +22,7 @@ Helm is used to deploy the ingress controller.
 We employ the popular chart [stable/nginx-ingress](https://github.com/helm/charts/tree/master/stable/nginx-ingress).
 
 ```
-helm install stable/nginx-ingress \
+$ helm install stable/nginx-ingress \
      --name nginx-ingress \
      --set controller.publishService.enabled=true
 ```
@@ -32,6 +32,18 @@ The parameter `controller.publishService.enabled` needs to be set to `true.`
 It will make the ingress controller update the endpoint records of ingress-resources to contain the external-ip of the loadbalancer serving the ingress-controller. 
 This is crucial as ExternalDNS reads those endpoints records when creating DNS-Records from ingress-resources.  
 In the subsequent parameter we will make use of this. If you don't want to work with ingress-resources in your later use, you can leave the parameter out.
+
+Verify the correct propagation of the loadbalancer's ip by listing the ingresses.
+```
+$ kubectl get ingress
+```
+The address column should contain the ip for each ingress. ExternalDNS will pick up exactly this piece of information.
+```
+NAME     HOSTS             ADDRESS          PORTS   AGE
+nginx1   sample1.aks.com   52.167.195.110   80      6d22h
+nginx2   sample2.aks.com   52.167.195.110   80      6d21h
+```
+
 
 If you do not want to deploy the ingress controller with Helm, ensure to pass the following cmdline-flags to it through the mechanism of your choice:
 

--- a/docs/tutorials/azure-private-dns.md
+++ b/docs/tutorials/azure-private-dns.md
@@ -3,7 +3,7 @@
 This tutorial describes how to set up ExternalDNS for managing records in Azure Private DNS.  
 
 It comprises of the following steps:
-1) Install 	NGINX Ingress Controller 
+1) Install NGINX Ingress Controller 
 2) Provision Azure Private DNS
 3) Configure service principal for managing the zone
 4) Deploy ExternalDNS  


### PR DESCRIPTION
First use showed the tutorial for _Azure DNS & Azure Private DNS_ to be not practically usable for all users.
In particular, it required some special knowledge about the required configuration of the employeed _nginx-ingress-controller_.

This PR refines the tutorial to make endusers be able to work through it completely.