### PR TITLE
rename project root package to sigs.k8s.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # builder image
 FROM golang:1.13 as builder
 
-WORKDIR /github.com/kubernetes-sigs/external-dns
+WORKDIR /sigs.k8s.io/external-dns
 
 COPY . .
 RUN go mod vendor && \
@@ -29,7 +29,7 @@ LABEL maintainer="Team Teapot @ Zalando SE <team-teapot@zalando.de>"
 RUN apk add --no-cache ca-certificates && \
     update-ca-certificates
 
-COPY --from=builder /github.com/kubernetes-sigs/external-dns/build/external-dns /bin/external-dns
+COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /bin/external-dns
 
 # Run as UID for nobody since k8s pod securityContext runAsNonRoot can't resolve the user ID:
 # https://github.com/kubernetes/kubernetes/issues/40958

--- a/Dockerfile.mini
+++ b/Dockerfile.mini
@@ -14,7 +14,7 @@
 
 FROM golang:1.13 as builder
 
-WORKDIR /github.com/kubernetes-sigs/external-dns
+WORKDIR /sigs.k8s.io/external-dns
 
 COPY . .
 RUN apt-get update && \
@@ -27,7 +27,7 @@ RUN apt-get update && \
 FROM gcr.io/distroless/static
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=builder /github.com/kubernetes-sigs/external-dns/build/external-dns /bin/external-dns
+COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /bin/external-dns
 
 # Run as UID for nobody since k8s pod securityContext runAsNonRoot can't resolve the user ID:
 # https://github.com/kubernetes/kubernetes/issues/40958

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ SOURCES        = $(shell find . -name '*.go')
 IMAGE         ?= registry.opensource.zalan.do/teapot/$(BINARY)
 VERSION       ?= $(shell git describe --tags --always --dirty)
 BUILD_FLAGS   ?= -v
-LDFLAGS       ?= -X github.com/kubernetes-sigs/external-dns/pkg/apis/externaldns.Version=$(VERSION) -w -s
+LDFLAGS       ?= -X sigs.k8s.io/external-dns/pkg/apis/externaldns.Version=$(VERSION) -w -s
 
 build: build/$(BINARY)
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -23,10 +23,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/kubernetes-sigs/external-dns/plan"
-	"github.com/kubernetes-sigs/external-dns/provider"
-	"github.com/kubernetes-sigs/external-dns/registry"
-	"github.com/kubernetes-sigs/external-dns/source"
+	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
+	"sigs.k8s.io/external-dns/registry"
+	"sigs.k8s.io/external-dns/source"
 )
 
 var (

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -22,11 +22,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/internal/testutils"
-	"github.com/kubernetes-sigs/external-dns/plan"
-	"github.com/kubernetes-sigs/external-dns/provider"
-	"github.com/kubernetes-sigs/external-dns/registry"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
+	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
+	"sigs.k8s.io/external-dns/registry"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kubernetes-sigs/external-dns
+module sigs.k8s.io/external-dns
 
 go 1.13
 

--- a/internal/testutils/endpoint.go
+++ b/internal/testutils/endpoint.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 /** test utility functions for endpoints verifications */

--- a/internal/testutils/endpoint_test.go
+++ b/internal/testutils/endpoint_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 func ExampleSameEndpoints() {

--- a/internal/testutils/mock_source.go
+++ b/internal/testutils/mock_source.go
@@ -19,7 +19,7 @@ package testutils
 import (
 	"github.com/stretchr/testify/mock"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 // MockSource returns mock endpoints.

--- a/main.go
+++ b/main.go
@@ -27,13 +27,13 @@ import (
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
-	"github.com/kubernetes-sigs/external-dns/controller"
-	"github.com/kubernetes-sigs/external-dns/pkg/apis/externaldns"
-	"github.com/kubernetes-sigs/external-dns/pkg/apis/externaldns/validation"
-	"github.com/kubernetes-sigs/external-dns/plan"
-	"github.com/kubernetes-sigs/external-dns/provider"
-	"github.com/kubernetes-sigs/external-dns/registry"
-	"github.com/kubernetes-sigs/external-dns/source"
+	"sigs.k8s.io/external-dns/controller"
+	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
+	"sigs.k8s.io/external-dns/pkg/apis/externaldns/validation"
+	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
+	"sigs.k8s.io/external-dns/registry"
+	"sigs.k8s.io/external-dns/source"
 )
 
 func main() {

--- a/pkg/apis/externaldns/validation/validation.go
+++ b/pkg/apis/externaldns/validation/validation.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/kubernetes-sigs/external-dns/pkg/apis/externaldns"
+	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 )
 
 // ValidateConfig performs validation on the Config object

--- a/pkg/apis/externaldns/validation/validation_test.go
+++ b/pkg/apis/externaldns/validation/validation_test.go
@@ -19,7 +19,7 @@ package validation
 import (
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/pkg/apis/externaldns"
+	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/plan/conflict.go
+++ b/plan/conflict.go
@@ -19,7 +19,7 @@ package plan
 import (
 	"sort"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 // ConflictResolver is used to make a decision in case of two or more different kubernetes resources

--- a/plan/conflict_test.go
+++ b/plan/conflict_test.go
@@ -19,8 +19,9 @@ package plan
 import (
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
 	"github.com/stretchr/testify/suite"
+
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 var _ ConflictResolver = PerResource{}

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 // Plan can convert a list of desired and current records to a series of create,

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -19,10 +19,11 @@ package plan
 import (
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/internal/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
 )
 
 type PlanTestSuite struct {

--- a/plan/policy_test.go
+++ b/plan/policy_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 // TestApply tests that applying a policy results in the correct set of changes.

--- a/provider/alibaba_cloud.go
+++ b/provider/alibaba_cloud.go
@@ -28,10 +28,11 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/alidns"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/pvtz"
 	"github.com/denverdino/aliyungo/metadata"
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 const (

--- a/provider/alibaba_cloud_test.go
+++ b/provider/alibaba_cloud_test.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/alidns"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/pvtz"
-	"github.com/kubernetes-sigs/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/endpoint"
 
-	"github.com/kubernetes-sigs/external-dns/plan"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 type MockAlibabaCloudDNSAPI struct {

--- a/provider/aws.go
+++ b/provider/aws.go
@@ -28,10 +28,11 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53"
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	"github.com/linki/instrumented_http"
 	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 const (

--- a/provider/aws_sd.go
+++ b/provider/aws_sd.go
@@ -31,11 +31,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	sd "github.com/aws/aws-sdk-go/service/servicediscovery"
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/pkg/apis/externaldns"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	"github.com/linki/instrumented_http"
 	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 const (

--- a/provider/aws_sd_test.go
+++ b/provider/aws_sd_test.go
@@ -26,11 +26,12 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	sd "github.com/aws/aws-sdk-go/service/servicediscovery"
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/internal/testutils"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 // Compile time check for interface conformance

--- a/provider/aws_test.go
+++ b/provider/aws_test.go
@@ -27,12 +27,13 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/internal/testutils"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 const (

--- a/provider/azure.go
+++ b/provider/azure.go
@@ -32,8 +32,8 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 const (

--- a/provider/azure_private_dns.go
+++ b/provider/azure_private_dns.go
@@ -29,8 +29,8 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/go-autorest/autorest/to"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 type azurePrivateDNSConfig struct {

--- a/provider/azure_privatedns_test.go
+++ b/provider/azure_privatedns_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 // mockPrivateZonesClient implements the methods of the Azure Private DNS Zones Client which are used in the Azure Private DNS Provider

--- a/provider/azure_test.go
+++ b/provider/azure_test.go
@@ -24,11 +24,11 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
-
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/internal/testutils"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	"github.com/stretchr/testify/assert"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 // mockZonesClient implements the methods of the Azure DNS Zones Client which are used in the Azure Provider

--- a/provider/cloudflare.go
+++ b/provider/cloudflare.go
@@ -27,9 +27,9 @@ import (
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
-	"github.com/kubernetes-sigs/external-dns/source"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/source"
 )
 
 const (

--- a/provider/cloudflare_test.go
+++ b/provider/cloudflare_test.go
@@ -23,10 +23,11 @@ import (
 	"testing"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 type mockCloudFlareClient struct{}

--- a/provider/coredns.go
+++ b/provider/coredns.go
@@ -33,8 +33,8 @@ import (
 	etcdcv3 "github.com/coreos/etcd/clientv3"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 func init() {

--- a/provider/coredns_test.go
+++ b/provider/coredns_test.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 const defaultCoreDNSPrefix = "/skydns/"

--- a/provider/designate.go
+++ b/provider/designate.go
@@ -32,9 +32,9 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/pkg/tlsutils"
-	"github.com/kubernetes-sigs/external-dns/plan"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/tlsutils"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 const (

--- a/provider/designate_test.go
+++ b/provider/designate_test.go
@@ -31,8 +31,9 @@ import (
 
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets"
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/zones"
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 var lastGeneratedDesignateID int32

--- a/provider/digital_ocean.go
+++ b/provider/digital_ocean.go
@@ -26,8 +26,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 const (

--- a/provider/digital_ocean_test.go
+++ b/provider/digital_ocean_test.go
@@ -23,12 +23,11 @@ import (
 	"testing"
 
 	"github.com/digitalocean/godo"
-
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 type mockDigitalOceanInterface interface {

--- a/provider/dnsimple.go
+++ b/provider/dnsimple.go
@@ -24,9 +24,10 @@ import (
 	"strings"
 
 	"github.com/dnsimple/dnsimple-go/dnsimple"
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 const dnsimpleRecordTTL = 3600 // Default TTL of 1 hour if not set (DNSimple's default)

--- a/provider/dnsimple_test.go
+++ b/provider/dnsimple_test.go
@@ -25,11 +25,12 @@ import (
 	"strconv"
 
 	"github.com/dnsimple/dnsimple-go/dnsimple"
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 var mockProvider dnsimpleProvider

--- a/provider/dyn.go
+++ b/provider/dyn.go
@@ -29,8 +29,8 @@ import (
 	"github.com/nesv/go-dynect/dynect"
 	"github.com/sanyu/dynectsoap/dynectsoap"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 const (

--- a/provider/dyn_test.go
+++ b/provider/dyn_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/nesv/go-dynect/dynect"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 func TestDynMerge_NoUpdateOnTTL0Changes(t *testing.T) {

--- a/provider/exoscale.go
+++ b/provider/exoscale.go
@@ -21,9 +21,10 @@ import (
 	"strings"
 
 	"github.com/exoscale/egoscale"
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 // EgoscaleClientI for replaceable implementation

--- a/provider/exoscale_test.go
+++ b/provider/exoscale_test.go
@@ -22,9 +22,10 @@ import (
 	"testing"
 
 	"github.com/exoscale/egoscale"
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	"github.com/stretchr/testify/assert"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 type createRecordExoscale struct {

--- a/provider/google.go
+++ b/provider/google.go
@@ -26,17 +26,14 @@ import (
 	"cloud.google.com/go/compute/metadata"
 	"github.com/linki/instrumented_http"
 	log "github.com/sirupsen/logrus"
-
-	dns "google.golang.org/api/dns/v1"
-
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
-
+	dns "google.golang.org/api/dns/v1"
 	googleapi "google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 const (

--- a/provider/google_test.go
+++ b/provider/google_test.go
@@ -23,17 +23,14 @@ import (
 	"strings"
 	"testing"
 
-	dns "google.golang.org/api/dns/v1"
-
-	"golang.org/x/net/context"
-
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
-
-	"google.golang.org/api/googleapi"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+	dns "google.golang.org/api/dns/v1"
+	"google.golang.org/api/googleapi"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 var (

--- a/provider/infoblox.go
+++ b/provider/infoblox.go
@@ -25,9 +25,10 @@ import (
 	"strings"
 
 	ibclient "github.com/infobloxopen/infoblox-go-client"
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	"github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 // InfobloxConfig clarifies the method signature

--- a/provider/infoblox_test.go
+++ b/provider/infoblox_test.go
@@ -25,9 +25,10 @@ import (
 	"testing"
 
 	ibclient "github.com/infobloxopen/infoblox-go-client"
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	"github.com/stretchr/testify/assert"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 type mockIBConnector struct {

--- a/provider/inmemory.go
+++ b/provider/inmemory.go
@@ -23,8 +23,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 var (

--- a/provider/inmemory_test.go
+++ b/provider/inmemory_test.go
@@ -20,12 +20,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/internal/testutils"
-	"github.com/kubernetes-sigs/external-dns/plan"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 var (

--- a/provider/linode.go
+++ b/provider/linode.go
@@ -22,15 +22,14 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/linode/linodego"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 
-	"strings"
-
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 // LinodeDomainClient interface to ease testing

--- a/provider/linode_test.go
+++ b/provider/linode_test.go
@@ -21,12 +21,13 @@ import (
 	"os"
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	"github.com/linode/linodego"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 type MockDomainClient struct {

--- a/provider/ns1.go
+++ b/provider/ns1.go
@@ -25,12 +25,11 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-
 	api "gopkg.in/ns1/ns1-go.v2/rest"
 	"gopkg.in/ns1/ns1-go.v2/rest/model/dns"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 const (

--- a/provider/ns1_test.go
+++ b/provider/ns1_test.go
@@ -23,13 +23,14 @@ import (
 	"os"
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	api "gopkg.in/ns1/ns1-go.v2/rest"
 	"gopkg.in/ns1/ns1-go.v2/rest/model/dns"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 type MockNS1DomainClient struct {

--- a/provider/oci.go
+++ b/provider/oci.go
@@ -27,8 +27,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 const ociRecordTTL = 300

--- a/provider/oci_test.go
+++ b/provider/oci_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 type mockOCIDNSClient struct{}

--- a/provider/pdns.go
+++ b/provider/pdns.go
@@ -19,23 +19,22 @@ package provider
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"math"
+	"net"
 	"net/http"
 	"sort"
 	"strings"
 	"time"
 
+	pgo "github.com/ffledgling/pdns-go"
 	log "github.com/sirupsen/logrus"
 
-	"crypto/tls"
-	"net"
-
-	pgo "github.com/ffledgling/pdns-go"
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/pkg/tlsutils"
-	"github.com/kubernetes-sigs/external-dns/plan"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/tlsutils"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 type pdnsChangeType string

--- a/provider/pdns_test.go
+++ b/provider/pdns_test.go
@@ -19,17 +19,15 @@ package provider
 import (
 	"context"
 	"errors"
-
-	//"fmt"
 	"net/http"
 	"strings"
 	"testing"
 
+	pgo "github.com/ffledgling/pdns-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
-	pgo "github.com/ffledgling/pdns-go"
-	"github.com/kubernetes-sigs/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 // FIXME: What do we do about labels?

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -21,8 +21,8 @@ import (
 	"net"
 	"strings"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 // Provider defines the interface DNS providers should implement.

--- a/provider/rcode0.go
+++ b/provider/rcode0.go
@@ -23,10 +23,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	rc0 "github.com/nic-at/rc0go"
 	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 // RcodeZeroProvider implements the DNS provider for RcodeZero Anycast DNS.

--- a/provider/rcode0_test.go
+++ b/provider/rcode0_test.go
@@ -22,10 +22,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	rc0 "github.com/nic-at/rc0go"
 	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 const (

--- a/provider/rdns.go
+++ b/provider/rdns.go
@@ -29,13 +29,12 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/coreos/etcd/clientv3"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 const (

--- a/provider/rdns_test.go
+++ b/provider/rdns_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/coreos/etcd/mvcc/mvccpb"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 type fakeEtcdv3Client struct {

--- a/provider/rfc2136.go
+++ b/provider/rfc2136.go
@@ -28,8 +28,8 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 // rfc2136 provider type

--- a/provider/rfc2136_test.go
+++ b/provider/rfc2136_test.go
@@ -21,11 +21,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 type rfc2136Stub struct {

--- a/provider/transip.go
+++ b/provider/transip.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	log "github.com/sirupsen/logrus"
 	"github.com/transip/gotransip"
 	transip "github.com/transip/gotransip/domain"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 const (

--- a/provider/transip_test.go
+++ b/provider/transip_test.go
@@ -3,9 +3,10 @@ package provider
 import (
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
 	"github.com/stretchr/testify/assert"
 	transip "github.com/transip/gotransip/domain"
+
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 func TestTransIPDnsEntriesAreEqual(t *testing.T) {

--- a/provider/vinyldns.go
+++ b/provider/vinyldns.go
@@ -22,10 +22,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	log "github.com/sirupsen/logrus"
 	"github.com/vinyldns/go-vinyldns/vinyldns"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 const (

--- a/provider/vinyldns_test.go
+++ b/provider/vinyldns_test.go
@@ -22,11 +22,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/vinyldns/go-vinyldns/vinyldns"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 type mockVinyldnsZoneInterface struct {

--- a/registry/aws_sd_registry.go
+++ b/registry/aws_sd_registry.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"errors"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
-	"github.com/kubernetes-sigs/external-dns/provider"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
 )
 
 // AWSSDRegistry implements registry interface with ownership information associated via the Description field of SD Service

--- a/registry/aws_sd_registry_test.go
+++ b/registry/aws_sd_registry_test.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/internal/testutils"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 type inMemoryProvider struct {

--- a/registry/noop.go
+++ b/registry/noop.go
@@ -19,9 +19,9 @@ package registry
 import (
 	"context"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
-	"github.com/kubernetes-sigs/external-dns/provider"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
 )
 
 // NoopRegistry implements registry interface without ownership directly propagating changes to dns provider

--- a/registry/noop_test.go
+++ b/registry/noop_test.go
@@ -20,13 +20,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/internal/testutils"
-	"github.com/kubernetes-sigs/external-dns/plan"
-	"github.com/kubernetes-sigs/external-dns/provider"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
+	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
 )
 
 var _ Registry = &NoopRegistry{}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -19,9 +19,10 @@ package registry
 import (
 	"context"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
 	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 // Registry is an interface which should enables ownership concept in external-dns

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -19,15 +19,15 @@ package registry
 import (
 	"context"
 	"errors"
-	"time"
-
 	"fmt"
 	"strings"
+	"time"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/plan"
-	"github.com/kubernetes-sigs/external-dns/provider"
 	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
 )
 
 // TXTRegistry implements registry interface with ownership implemented via associated TXT records

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -22,13 +22,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/internal/testutils"
-	"github.com/kubernetes-sigs/external-dns/plan"
-	"github.com/kubernetes-sigs/external-dns/provider"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
+	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
 )
 
 const (

--- a/source/cloudfoundry.go
+++ b/source/cloudfoundry.go
@@ -20,7 +20,8 @@ import (
 	"net/url"
 
 	cfclient "github.com/cloudfoundry-community/go-cfclient"
-	"github.com/kubernetes-sigs/external-dns/endpoint"
+
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 type cloudfoundrySource struct {

--- a/source/compatibility.go
+++ b/source/compatibility.go
@@ -19,8 +19,9 @@ package source
 import (
 	"strings"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
 	v1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 const (

--- a/source/connector.go
+++ b/source/connector.go
@@ -21,8 +21,9 @@ import (
 	"net"
 	"time"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
 	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 const (

--- a/source/connector_test.go
+++ b/source/connector_test.go
@@ -21,9 +21,10 @@ import (
 	"net"
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 type ConnectorSuite struct {

--- a/source/crd.go
+++ b/source/crd.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -30,6 +29,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 // crdSource is an implementation of Source that provides endpoints by listing

--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +34,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
+
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 type CRDSuite struct {

--- a/source/dedup_source.go
+++ b/source/dedup_source.go
@@ -19,7 +19,7 @@ package source
 import (
 	log "github.com/sirupsen/logrus"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 // dedupSource is a Source that removes duplicate endpoints from its wrapped source.

--- a/source/dedup_source_test.go
+++ b/source/dedup_source_test.go
@@ -19,8 +19,8 @@ package source
 import (
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/internal/testutils"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
 )
 
 // Validates that dedupSource is a Source

--- a/source/empty.go
+++ b/source/empty.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package source
 
-import "github.com/kubernetes-sigs/external-dns/endpoint"
+import "sigs.k8s.io/external-dns/endpoint"
 
 // emptySource is a Source that returns no endpoints.
 type emptySource struct{}

--- a/source/fake.go
+++ b/source/fake.go
@@ -26,7 +26,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 // fakeSource is an implementation of Source that provides dummy endpoints for

--- a/source/fake_test.go
+++ b/source/fake_test.go
@@ -21,7 +21,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 func generateTestEndpoints() []*endpoint.Endpoint {

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -24,20 +24,18 @@ import (
 	"text/template"
 	"time"
 
-	kubeinformers "k8s.io/client-go/informers"
-	coreinformers "k8s.io/client-go/informers/core/v1"
-	"k8s.io/client-go/tools/cache"
-
 	log "github.com/sirupsen/logrus"
-
 	istionetworking "istio.io/api/networking/v1alpha3"
 	istiomodel "istio.io/istio/pilot/pkg/model"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
-
-	"github.com/kubernetes-sigs/external-dns/endpoint"
+	kubeinformers "k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 // gatewaySource is an implementation of Source for Istio Gateway objects.

--- a/source/gateway_test.go
+++ b/source/gateway_test.go
@@ -17,23 +17,21 @@ limitations under the License.
 package source
 
 import (
-	"testing"
-
-	istionetworking "istio.io/api/networking/v1alpha3"
-	istiomodel "istio.io/istio/pilot/pkg/model"
-
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-
 	"strconv"
 	"sync"
+	"testing"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	istionetworking "istio.io/api/networking/v1alpha3"
+	istiomodel "istio.io/istio/pilot/pkg/model"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 // This is a compile-time validation that gatewaySource is a Source.

--- a/source/ingress.go
+++ b/source/ingress.go
@@ -22,10 +22,8 @@ import (
 	"sort"
 	"strings"
 	"text/template"
-
 	"time"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +33,8 @@ import (
 	extinformers "k8s.io/client-go/informers/extensions/v1beta1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 const (

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -20,17 +20,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 // Validates that ingressSource is a Source

--- a/source/ingressroute.go
+++ b/source/ingressroute.go
@@ -28,7 +28,6 @@ import (
 	contour "github.com/heptio/contour/apis/generated/clientset/versioned"
 	contourinformers "github.com/heptio/contour/apis/generated/informers/externalversions"
 	extinformers "github.com/heptio/contour/apis/generated/informers/externalversions/contour/v1beta1"
-	"github.com/kubernetes-sigs/external-dns/endpoint"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,6 +35,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 // ingressRouteSource is an implementation of Source for Heptio Contour IngressRoute objects.

--- a/source/ingressroute_test.go
+++ b/source/ingressroute_test.go
@@ -29,7 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakeKube "k8s.io/client-go/kubernetes/fake"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 // This is a compile-time validation that ingressRouteSource is a Source.

--- a/source/multi_source.go
+++ b/source/multi_source.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package source
 
-import "github.com/kubernetes-sigs/external-dns/endpoint"
+import "sigs.k8s.io/external-dns/endpoint"
 
 // multiSource is a Source that merges the endpoints of its nested Sources.
 type multiSource struct {

--- a/source/multi_source_test.go
+++ b/source/multi_source_test.go
@@ -20,11 +20,11 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-	"github.com/kubernetes-sigs/external-dns/internal/testutils"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
 )
 
 func TestMultiSource(t *testing.T) {

--- a/source/node.go
+++ b/source/node.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 type nodeSource struct {

--- a/source/node_test.go
+++ b/source/node_test.go
@@ -3,12 +3,13 @@ package source
 import (
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 func TestNodeSource(t *testing.T) {

--- a/source/service.go
+++ b/source/service.go
@@ -22,22 +22,19 @@ import (
 	"sort"
 	"strings"
 	"text/template"
-
-	kubeinformers "k8s.io/client-go/informers"
-	coreinformers "k8s.io/client-go/informers/core/v1"
-	"k8s.io/client-go/tools/cache"
+	"time"
 
 	log "github.com/sirupsen/logrus"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
+	kubeinformers "k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 
-	"time"
-
-	"github.com/kubernetes-sigs/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 const (

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -21,17 +21,15 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
-
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
-
-	"github.com/kubernetes-sigs/external-dns/endpoint"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 type ServiceSuite struct {

--- a/source/shared_test.go
+++ b/source/shared_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 // test helper functions

--- a/source/source.go
+++ b/source/source.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 const (

--- a/source/source_test.go
+++ b/source/source_test.go
@@ -20,8 +20,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kubernetes-sigs/external-dns/endpoint"
 	"github.com/stretchr/testify/assert"
+
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 func TestGetTTLFromAnnotations(t *testing.T) {

--- a/source/store.go
+++ b/source/store.go
@@ -21,9 +21,8 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"time"
-
 	"sync"
+	"time"
 
 	"github.com/cloudfoundry-community/go-cfclient"
 	contour "github.com/heptio/contour/apis/generated/clientset/versioned"


### PR DESCRIPTION
Renaming package to conform to `kubernetes-sigs` standards.