### PR TITLE
AWS-SD: Rebrand AWS Auto Naming to Cloud Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To see ExternalDNS in action, have a look at this [video](https://www.youtube.co
 ExternalDNS' current release is `v0.5`. This version allows you to keep selected zones (via `--domain-filter`) synchronized with Ingresses and Services of `type=LoadBalancer` in various cloud providers:
 * [Google Cloud DNS](https://cloud.google.com/dns/docs/)
 * [AWS Route 53](https://aws.amazon.com/route53/)
-* [AWS Service Discovery](https://docs.aws.amazon.com/Route53/latest/APIReference/overview-service-discovery.html)
+* [AWS Cloud Map](https://docs.aws.amazon.com/cloud-map/)
 * [AzureDNS](https://azure.microsoft.com/en-us/services/dns)
 * [CloudFlare](https://www.cloudflare.com/dns)
 * [RcodeZero](https://www.rcodezero.at/)
@@ -73,7 +73,7 @@ The following table clarifies the current status of the providers according to t
 | -------- | ------ |
 | Google Cloud DNS | Stable |
 | AWS Route 53 | Stable |
-| AWS Service Discovery | Beta |
+| AWS Cloud Map | Beta |
 | AzureDNS | Beta |
 | CloudFlare | Beta
 | RcodeZero | Alpha |
@@ -109,7 +109,7 @@ The following tutorials are provided:
 	* [ALB Ingress Controller](docs/tutorials/alb-ingress.md)
 	* [Route53](docs/tutorials/aws.md)
 		* [Same domain for public and private Route53 zones](docs/tutorials/public-private-route53.md)
-	* [Service Discovery](docs/tutorials/aws-sd.md)
+	* [Cloud Map](docs/tutorials/aws-sd.md)
 * [Azure DNS](docs/tutorials/azure.md)
 * [Azure Private DNS](docs/tutorials/azure-private-dns.md)
 * [Cloudflare](docs/tutorials/cloudflare.md)

--- a/docs/tutorials/aws-sd.md
+++ b/docs/tutorials/aws-sd.md
@@ -1,51 +1,50 @@
-# Setting up ExternalDNS using AWS Service Discovery API
+# Setting up ExternalDNS using AWS Cloud Map API
 
-This tutorial describes how to set up ExternalDNS for usage within a Kubernetes cluster on AWS with [Service Discovery API](https://docs.aws.amazon.com/Route53/latest/APIReference/overview-service-discovery.html).
+This tutorial describes how to set up ExternalDNS for usage within a Kubernetes cluster with [AWS Cloud Map API](https://docs.aws.amazon.com/cloud-map/).
 
-The **Service Discovery API** is an alternative approach to managing DNS records directly using the Route53 API. It is more suitable for a dynamic environment where service endpoints change frequently. It abstracts away technical details of the DNS protocol and offers a simplified model. Service discovery consists of three main API calls:
+**AWS Cloud Map** API is an alternative approach to managing DNS records directly using the Route53 API. It is more suitable for a dynamic environment where service endpoints change frequently. It abstracts away technical details of the DNS protocol and offers a simplified model. AWS Cloud Map consists of three main API calls:
 
 * CreatePublicDnsNamespace – automatically creates a DNS hosted zone
 * CreateService – creates a new named service inside the specified namespace
 * RegisterInstance/DeregisterInstance – can be called multiple times to create a DNS record for the specified *Service*
 
-Learn more about the API in the [Amazon Route 53 API Reference](https://docs.aws.amazon.com/Route53/latest/APIReference/API_Operations_Amazon_Route_53_Auto_Naming.html).
-
+Learn more about the API in the [AWS Cloud Map API Reference](https://docs.aws.amazon.com/cloud-map/latest/api/API_Operations.html).
 
 ## IAM Permissions
 
-To use the service discovery API, a user must have permissions to create the DNS namespace. Additionally you need to make sure that your nodes (on which External DNS runs) have an IAM instance profile with the `AmazonRoute53AutoNamingFullAccess` managed policy attached, this provides the permissions below.
+To use the AWS Cloud Map API, a user must have permissions to create the DNS namespace. Additionally you need to make sure that your nodes (on which External DNS runs) have an IAM instance profile with the `AWSCloudMapFullAccess` managed policy attached, that provides following permissions:
 
 ```
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "route53:GetHostedZone",
-                "route53:ListHostedZonesByName",
-                "route53:CreateHostedZone",
-                "route53:DeleteHostedZone",
-                "route53:ChangeResourceRecordSets",
-                "route53:CreateHealthCheck",
-                "route53:GetHealthCheck",
-                "route53:DeleteHealthCheck",
-                "route53:UpdateHealthCheck",
-                "ec2:DescribeVpcs",
-                "ec2:DescribeRegions",
-                "servicediscovery:*"
-            ],
-            "Resource": [
-                "*"
-            ]
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "route53:GetHostedZone",
+        "route53:ListHostedZonesByName",
+        "route53:CreateHostedZone",
+        "route53:DeleteHostedZone",
+        "route53:ChangeResourceRecordSets",
+        "route53:CreateHealthCheck",
+        "route53:GetHealthCheck",
+        "route53:DeleteHealthCheck",
+        "route53:UpdateHealthCheck",
+        "ec2:DescribeVpcs",
+        "ec2:DescribeRegions",
+        "servicediscovery:*"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
 }
 ```
 
 ## Set up a namespace
 
-Create a DNS namespace using the service discovery API
+Create a DNS namespace using the AWS Cloud Map API:
 
 ```console
 $ aws servicediscovery create-public-dns-namespace --name "external-dns-test.my-org.com"
@@ -111,8 +110,8 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get","watch","list"]
-- apiGroups: ["extensions"] 
-  resources: ["ingresses"] 
+- apiGroups: ["extensions"]
+  resources: ["ingresses"]
   verbs: ["get","watch","list"]
 - apiGroups: [""]
   resources: ["nodes"]

--- a/main.go
+++ b/main.go
@@ -129,7 +129,7 @@ func main() {
 	case "aws-sd":
 		// Check that only compatible Registry is used with AWS-SD
 		if cfg.Registry != "noop" && cfg.Registry != "aws-sd" {
-			log.Infof("Registry \"%s\" cannot be used with AWS ServiceDiscovery. Switching to \"aws-sd\".", cfg.Registry)
+			log.Infof("Registry \"%s\" cannot be used with AWS Cloud Map. Switching to \"aws-sd\".", cfg.Registry)
 			cfg.Registry = "aws-sd"
 		}
 		p, err = provider.NewAWSSDProvider(domainFilter, cfg.AWSZoneType, cfg.AWSAssumeRole, cfg.DryRun)

--- a/provider/aws_sd.go
+++ b/provider/aws_sd.go
@@ -58,7 +58,7 @@ var (
 	sdNlbHostnameRegex = regexp.MustCompile(`.+\.elb\.[^.]+\.amazonaws\.com$`)
 )
 
-// AWSSDClient is the subset of the AWS Route53 Auto Naming API that we actually use. Add methods as required.
+// AWSSDClient is the subset of the AWS Cloud Map API that we actually use. Add methods as required.
 // Signatures must match exactly. Taken from https://github.com/aws/aws-sdk-go/blob/master/service/servicediscovery/api.go
 type AWSSDClient interface {
 	CreateService(input *sd.CreateServiceInput) (*sd.CreateServiceOutput, error)
@@ -71,7 +71,7 @@ type AWSSDClient interface {
 	UpdateService(input *sd.UpdateServiceInput) (*sd.UpdateServiceOutput, error)
 }
 
-// AWSSDProvider is an implementation of Provider for AWS Route53 Auto Naming.
+// AWSSDProvider is an implementation of Provider for AWS Cloud Map.
 type AWSSDProvider struct {
 	client AWSSDClient
 	dryRun bool
@@ -81,7 +81,7 @@ type AWSSDProvider struct {
 	namespaceTypeFilter *sd.NamespaceFilter
 }
 
-// NewAWSSDProvider initializes a new AWS Route53 Auto Naming based Provider.
+// NewAWSSDProvider initializes a new AWS Cloud Map based Provider.
 func NewAWSSDProvider(domainFilter DomainFilter, namespaceType string, assumeRole string, dryRun bool) (*AWSSDProvider, error) {
 	config := aws.NewConfig()
 


### PR DESCRIPTION
Amazon Route 53 `Auto Naming` (aka `Service Discovery`) has been released as a separate service, `AWS Cloud Map`. The goal of this change is to update the documentation to avoid confusion about the service name.