### PR TITLE
Fix invalid build: key "_PULL_BASE_REF" in cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,7 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
 timeout: 1200s
+options:
+  substitution_option: ALLOW_LOOSE
 steps:
   - name: "gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4"
     entrypoint: make
@@ -12,3 +14,4 @@ substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution
   _GIT_TAG: "12345"
+  _PULL_BASE_REF: 'master'


### PR DESCRIPTION
ERROR: (gcloud.builds.submit) INVALID_ARGUMENT: invalid build: key "_PULL_BASE_REF" in the substitution data is not matched in the template