### PR TITLE
Add istio-virtualservice source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ lint:
 .PHONY: verify test
 
 test:
-	go test -v -race $(shell go list ./... | grep -v /vendor/)
+	go test -v -race $(shell go list ./...)
 
 # The build targets allow to build the binary and docker image
 .PHONY: build build.docker build.mini

--- a/docs/tutorials/istio.md
+++ b/docs/tutorials/istio.md
@@ -32,7 +32,7 @@ spec:
         args:
         - --source=service
         - --source=ingress
-        - --source=istio-gateway        # chose one
+        - --source=istio-gateway        # choose one
         - --source=istio-virtualservice # or both
         - --domain-filter=external-dns-test.my-org.com # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
         - --provider=aws
@@ -64,7 +64,7 @@ rules:
   resources: ["nodes"]
   verbs: ["list"]
 - apiGroups: ["networking.istio.io"]
-  # chose one or both; using the VirtualService source requires both:
+  # choose one or both; using the VirtualService source requires both:
   resources: ["gateways", "virtualservices"]
   verbs: ["get","watch","list"]
 ---
@@ -103,7 +103,7 @@ spec:
         args:
         - --source=service
         - --source=ingress
-        - --source=istio-gateway        # chose one
+        - --source=istio-gateway        # choose one
         - --source=istio-virtualservice # or both
         - --domain-filter=external-dns-test.my-org.com # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
         - --provider=aws

--- a/docs/tutorials/istio.md
+++ b/docs/tutorials/istio.md
@@ -32,7 +32,7 @@ spec:
         args:
         - --source=service
         - --source=ingress
-        - --source=istio-gateway        # chose on
+        - --source=istio-gateway        # chose one
         - --source=istio-virtualservice # or both
         - --domain-filter=external-dns-test.my-org.com # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
         - --provider=aws
@@ -153,7 +153,7 @@ $ kubectl apply -f <(istioctl kube-inject -f https://raw.githubusercontent.com/i
 
 ##### Create an Istio Gateway:
 ```bash
-$ cat <<EOF | kubectlapply -f -
+$ cat <<EOF | kubectl apply -f -
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:

--- a/main.go
+++ b/main.go
@@ -324,7 +324,7 @@ func handleSigterm(stopChan chan struct{}) {
 func serveMetrics(address string) {
 	http.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("OK"))
+		_, _ = w.Write([]byte("OK"))
 	})
 
 	http.Handle("/metrics", promhttp.Handler())

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -295,7 +295,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("skipper-routegroup-groupversion", "The resource version for skipper routegroup").Default(source.DefaultRoutegroupVersion).StringVar(&cfg.SkipperRouteGroupVersion)
 
 	// Flags related to processing sources
-	app.Flag("source", "The resource types that are queried for endpoints; specify multiple times for multiple sources (required, options: service, ingress, node, fake, connector, istio-gateway, cloudfoundry, contour-ingressroute, crd, empty, skipper-routegroup)").Required().PlaceHolder("source").EnumsVar(&cfg.Sources, "service", "ingress", "node", "istio-gateway", "cloudfoundry", "contour-ingressroute", "fake", "connector", "crd", "empty", "skipper-routegroup")
+	app.Flag("source", "The resource types that are queried for endpoints; specify multiple times for multiple sources (required, options: service, ingress, node, fake, connector, istio-gateway, istio-virtualservice, cloudfoundry, contour-ingressroute, crd, empty, skipper-routegroup)").Required().PlaceHolder("source").EnumsVar(&cfg.Sources, "service", "ingress", "node", "istio-gateway", "istio-virtualservice", "cloudfoundry", "contour-ingressroute", "fake", "connector", "crd", "empty", "skipper-routegroup")
 
 	app.Flag("namespace", "Limit sources of endpoints to a specific namespace (default: all namespaces)").Default(defaultConfig.Namespace).StringVar(&cfg.Namespace)
 	app.Flag("annotation-filter", "Filter sources managed by external-dns via annotation using label selector semantics (default: all sources)").Default(defaultConfig.AnnotationFilter).StringVar(&cfg.AnnotationFilter)

--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -126,7 +126,7 @@ func (sc *istioGatewaySource) Endpoints() ([]*endpoint.Endpoint, error) {
 		return nil, err
 	}
 
-	endpoints := []*endpoint.Endpoint{}
+	var endpoints []*endpoint.Endpoint
 
 	for _, config := range configs {
 		// Check controller annotation to see if we are responsible.
@@ -224,7 +224,7 @@ func (sc *istioGatewaySource) filterByAnnotations(configs []istiomodel.Config) (
 		return configs, nil
 	}
 
-	filteredList := []istiomodel.Config{}
+	var filteredList []istiomodel.Config
 
 	for _, config := range configs {
 		// convert the annotations to an equivalent label selector

--- a/source/istio_gateway_test.go
+++ b/source/istio_gateway_test.go
@@ -1,0 +1,1409 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	istionetworking "istio.io/api/networking/v1alpha3"
+	istiomodel "istio.io/istio/pilot/pkg/model"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"sigs.k8s.io/external-dns/endpoint"
+)
+
+// This is a compile-time validation that gatewaySource is a Source.
+var _ Source = &istioGatewaySource{}
+
+var gatewayType = istiomodel.Gateway.Type
+
+type GatewaySuite struct {
+	suite.Suite
+	source     Source
+	lbServices []*v1.Service
+	config     istiomodel.Config
+}
+
+func (suite *GatewaySuite) SetupTest() {
+	fakeKubernetesClient := fake.NewSimpleClientset()
+	fakeIstioClient := NewFakeConfigStore()
+	var err error
+
+	suite.lbServices = []*v1.Service{
+		(fakeIngressGatewayService{
+			ips:       []string{"8.8.8.8"},
+			hostnames: []string{"v1"},
+			namespace: "istio-system",
+			name:      "istio-gateway1",
+		}).Service(),
+		(fakeIngressGatewayService{
+			ips:       []string{"1.1.1.1"},
+			hostnames: []string{"v42"},
+			namespace: "istio-system",
+			name:      "istio-gateway2",
+		}).Service(),
+	}
+
+	for _, service := range suite.lbServices {
+		_, err = fakeKubernetesClient.CoreV1().Services(service.Namespace).Create(service)
+		suite.NoError(err, "should succeed")
+	}
+
+	suite.source, err = NewIstioGatewaySource(
+		fakeKubernetesClient,
+		fakeIstioClient,
+		"",
+		"",
+		"{{.Name}}",
+		false,
+		false,
+	)
+	suite.NoError(err, "should initialize gateway source")
+
+	suite.config = (fakeGatewayConfig{
+		name:      "foo-gateway-with-targets",
+		namespace: "istio-system",
+		dnsnames:  [][]string{{"foo"}},
+	}).Config()
+	_, err = fakeIstioClient.Create(suite.config)
+	suite.NoError(err, "should succeed")
+}
+
+func (suite *GatewaySuite) TestResourceLabelIsSet() {
+	endpoints, err := suite.source.Endpoints()
+	suite.NoError(err, "should succeed")
+	suite.Equal(len(endpoints), 2, "should return the correct number of endpoints")
+	for _, ep := range endpoints {
+		suite.Equal("gateway/istio-system/foo-gateway-with-targets", ep.Labels[endpoint.ResourceLabelKey], "should set correct resource label")
+	}
+}
+
+func TestGateway(t *testing.T) {
+	suite.Run(t, new(GatewaySuite))
+	t.Run("endpointsFromGatewayConfig", testEndpointsFromGatewayConfig)
+	t.Run("Endpoints", testGatewayEndpoints)
+}
+
+func TestNewIstioGatewaySource(t *testing.T) {
+	for _, ti := range []struct {
+		title                    string
+		annotationFilter         string
+		fqdnTemplate             string
+		combineFQDNAndAnnotation bool
+		expectError              bool
+	}{
+		{
+			title:        "invalid template",
+			expectError:  true,
+			fqdnTemplate: "{{.Name",
+		},
+		{
+			title:       "valid empty template",
+			expectError: false,
+		},
+		{
+			title:        "valid template",
+			expectError:  false,
+			fqdnTemplate: "{{.Name}}-{{.Namespace}}.ext-dns.test.com",
+		},
+		{
+			title:        "valid template",
+			expectError:  false,
+			fqdnTemplate: "{{.Name}}-{{.Namespace}}.ext-dns.test.com, {{.Name}}-{{.Namespace}}.ext-dna.test.com",
+		},
+		{
+			title:                    "valid template",
+			expectError:              false,
+			fqdnTemplate:             "{{.Name}}-{{.Namespace}}.ext-dns.test.com, {{.Name}}-{{.Namespace}}.ext-dna.test.com",
+			combineFQDNAndAnnotation: true,
+		},
+		{
+			title:            "non-empty annotation filter label",
+			expectError:      false,
+			annotationFilter: "kubernetes.io/gateway.class=nginx",
+		},
+	} {
+		t.Run(ti.title, func(t *testing.T) {
+			_, err := NewIstioGatewaySource(
+				fake.NewSimpleClientset(),
+				NewFakeConfigStore(),
+				"",
+				ti.annotationFilter,
+				ti.fqdnTemplate,
+				ti.combineFQDNAndAnnotation,
+				false,
+			)
+			if ti.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func testEndpointsFromGatewayConfig(t *testing.T) {
+	for _, ti := range []struct {
+		title      string
+		lbServices []fakeIngressGatewayService
+		config     fakeGatewayConfig
+		expected   []*endpoint.Endpoint
+	}{
+		{
+			title: "one rule.host one lb.hostname",
+			lbServices: []fakeIngressGatewayService{
+				{
+					hostnames: []string{"lb.com"}, // Kubernetes omits the trailing dot
+				},
+			},
+			config: fakeGatewayConfig{
+				dnsnames: [][]string{
+					{"foo.bar"}, // Kubernetes requires removal of trailing dot
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName: "foo.bar",
+					Targets: endpoint.Targets{"lb.com"},
+				},
+			},
+		},
+		{
+			title: "one namespaced rule.host one lb.hostname",
+			lbServices: []fakeIngressGatewayService{
+				{
+					hostnames: []string{"lb.com"}, // Kubernetes omits the trailing dot
+				},
+			},
+			config: fakeGatewayConfig{
+				dnsnames: [][]string{
+					{"my-namespace/foo.bar"}, // Kubernetes requires removal of trailing dot
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName: "foo.bar",
+					Targets: endpoint.Targets{"lb.com"},
+				},
+			},
+		},
+		{
+			title: "one rule.host one lb.IP",
+			lbServices: []fakeIngressGatewayService{
+				{
+					ips: []string{"8.8.8.8"},
+				},
+			},
+			config: fakeGatewayConfig{
+				dnsnames: [][]string{
+					{"foo.bar"},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName: "foo.bar",
+					Targets: endpoint.Targets{"8.8.8.8"},
+				},
+			},
+		},
+		{
+			title: "one rule.host two lb.IP and two lb.Hostname",
+			lbServices: []fakeIngressGatewayService{
+				{
+					ips:       []string{"8.8.8.8", "127.0.0.1"},
+					hostnames: []string{"elb.com", "alb.com"},
+				},
+			},
+			config: fakeGatewayConfig{
+				dnsnames: [][]string{
+					{"foo.bar"},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName: "foo.bar",
+					Targets: endpoint.Targets{"8.8.8.8", "127.0.0.1"},
+				},
+				{
+					DNSName: "foo.bar",
+					Targets: endpoint.Targets{"elb.com", "alb.com"},
+				},
+			},
+		},
+		{
+			title: "no rule.host",
+			lbServices: []fakeIngressGatewayService{
+				{
+					ips:       []string{"8.8.8.8", "127.0.0.1"},
+					hostnames: []string{"elb.com", "alb.com"},
+				},
+			},
+			config: fakeGatewayConfig{
+				dnsnames: [][]string{},
+			},
+			expected: []*endpoint.Endpoint{},
+		},
+		{
+			title: "one empty rule.host",
+			lbServices: []fakeIngressGatewayService{
+				{
+					ips:       []string{"8.8.8.8", "127.0.0.1"},
+					hostnames: []string{"elb.com", "alb.com"},
+				},
+			},
+			config: fakeGatewayConfig{
+				dnsnames: [][]string{
+					{""},
+				},
+			},
+			expected: []*endpoint.Endpoint{},
+		},
+		{
+			title:      "no targets",
+			lbServices: []fakeIngressGatewayService{{}},
+			config: fakeGatewayConfig{
+				dnsnames: [][]string{
+					{""},
+				},
+			},
+			expected: []*endpoint.Endpoint{},
+		},
+		{
+			title: "one gateway, two ingressgateway loadbalancer hostnames",
+			lbServices: []fakeIngressGatewayService{
+				{
+					hostnames: []string{"lb.com"},
+					namespace: "istio-other",
+					name:      "gateway1",
+				},
+				{
+					hostnames: []string{"lb2.com"},
+					namespace: "istio-other",
+					name:      "gateway2",
+				},
+			},
+			config: fakeGatewayConfig{
+				dnsnames: [][]string{
+					{"foo.bar"}, // Kubernetes requires removal of trailing dot
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName: "foo.bar",
+					Targets: endpoint.Targets{"lb.com", "lb2.com"},
+				},
+			},
+		},
+	} {
+		t.Run(ti.title, func(t *testing.T) {
+			if source, err := newTestGatewaySource(ti.lbServices); err != nil {
+				require.NoError(t, err)
+			} else if endpoints, err := source.endpointsFromGatewayConfig(ti.config.Config()); err != nil {
+				require.NoError(t, err)
+			} else {
+				validateEndpoints(t, endpoints, ti.expected)
+			}
+		})
+	}
+}
+
+func testGatewayEndpoints(t *testing.T) {
+	namespace := "testing"
+	for _, ti := range []struct {
+		title                    string
+		targetNamespace          string
+		annotationFilter         string
+		lbServices               []fakeIngressGatewayService
+		configItems              []fakeGatewayConfig
+		expected                 []*endpoint.Endpoint
+		expectError              bool
+		fqdnTemplate             string
+		combineFQDNAndAnnotation bool
+		ignoreHostnameAnnotation bool
+	}{
+		{
+			title:           "no gateway",
+			targetNamespace: "",
+		},
+		{
+			title:           "two simple gateways, one ingressgateway loadbalancer service",
+			targetNamespace: "",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: namespace,
+					ips:       []string{"8.8.8.8"},
+					hostnames: []string{"lb.com"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					dnsnames:  [][]string{{"example.org"}},
+				},
+				{
+					name:      "fake2",
+					namespace: namespace,
+					dnsnames:  [][]string{{"new.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName: "example.org",
+					Targets: endpoint.Targets{"8.8.8.8"},
+				},
+				{
+					DNSName: "example.org",
+					Targets: endpoint.Targets{"lb.com"},
+				},
+				{
+					DNSName: "new.org",
+					Targets: endpoint.Targets{"8.8.8.8"},
+				},
+				{
+					DNSName: "new.org",
+					Targets: endpoint.Targets{"lb.com"},
+				},
+			},
+		},
+		{
+			title:           "two simple gateways on different namespaces, one ingressgateway loadbalancer service",
+			targetNamespace: "",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: "testing1",
+					ips:       []string{"8.8.8.8"},
+					hostnames: []string{"lb.com"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: "testing1",
+					dnsnames:  [][]string{{"example.org"}},
+				},
+				{
+					name:      "fake2",
+					namespace: "testing2",
+					dnsnames:  [][]string{{"new.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName: "example.org",
+					Targets: endpoint.Targets{"8.8.8.8"},
+				},
+				{
+					DNSName: "example.org",
+					Targets: endpoint.Targets{"lb.com"},
+				},
+			},
+		},
+		{
+			title:           "two simple gateways on different namespaces, two ingressgateway loadbalancer service",
+			targetNamespace: "",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: "testing1",
+					ips:       []string{"8.8.8.8"},
+					hostnames: []string{"lb.com"},
+				},
+				{
+					namespace: "testing2",
+					ips:       []string{"4.4.4.4"},
+					hostnames: []string{"otherlb.com"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: "testing1",
+					dnsnames:  [][]string{{"example.org"}},
+				},
+				{
+					name:      "fake2",
+					namespace: "testing2",
+					dnsnames:  [][]string{{"new.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName: "example.org",
+					Targets: endpoint.Targets{"8.8.8.8"},
+				},
+				{
+					DNSName: "example.org",
+					Targets: endpoint.Targets{"lb.com"},
+				},
+				{
+					DNSName: "new.org",
+					Targets: endpoint.Targets{"4.4.4.4"},
+				},
+				{
+					DNSName: "new.org",
+					Targets: endpoint.Targets{"otherlb.com"},
+				},
+			},
+		},
+		{
+			title:           "two simple gateways on different namespaces and a target namespace, two ingressgateway loadbalancer services",
+			targetNamespace: "testing1",
+			lbServices: []fakeIngressGatewayService{
+				{
+					ips:       []string{"8.8.8.8"},
+					hostnames: []string{"lb.com"},
+					namespace: "testing1",
+				},
+				{
+					ips:       []string{"4.4.4.4"},
+					hostnames: []string{"otherlb.com"},
+					namespace: "testing2",
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: "testing1",
+					dnsnames:  [][]string{{"example.org"}},
+				},
+				{
+					name:      "fake2",
+					namespace: "testing2",
+					dnsnames:  [][]string{{"new.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName: "example.org",
+					Targets: endpoint.Targets{"8.8.8.8"},
+				},
+				{
+					DNSName: "example.org",
+					Targets: endpoint.Targets{"lb.com"},
+				},
+			},
+		},
+		{
+			title:            "valid matching annotation filter expression",
+			targetNamespace:  "",
+			annotationFilter: "kubernetes.io/gateway.class in (alb, nginx)",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: namespace,
+					ips: []string{"8.8.8.8"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					annotations: map[string]string{
+						"kubernetes.io/gateway.class": "nginx",
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName: "example.org",
+					Targets: endpoint.Targets{"8.8.8.8"},
+				},
+			},
+		},
+		{
+			title:            "valid non-matching annotation filter expression",
+			targetNamespace:  "",
+			annotationFilter: "kubernetes.io/gateway.class in (alb, nginx)",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: namespace,
+					ips: []string{"8.8.8.8"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					annotations: map[string]string{
+						"kubernetes.io/gateway.class": "tectonic",
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{},
+		},
+		{
+			title:            "invalid annotation filter expression",
+			targetNamespace:  "",
+			annotationFilter: "kubernetes.io/gateway.name in (a b)",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: namespace,
+					ips: []string{"8.8.8.8"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					annotations: map[string]string{
+						"kubernetes.io/gateway.class": "alb",
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+			},
+			expected:    []*endpoint.Endpoint{},
+			expectError: true,
+		},
+		{
+			title:            "valid matching annotation filter label",
+			targetNamespace:  "",
+			annotationFilter: "kubernetes.io/gateway.class=nginx",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: namespace,
+					ips: []string{"8.8.8.8"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					annotations: map[string]string{
+						"kubernetes.io/gateway.class": "nginx",
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName: "example.org",
+					Targets: endpoint.Targets{"8.8.8.8"},
+				},
+			},
+		},
+		{
+			title:            "valid non-matching annotation filter label",
+			targetNamespace:  "",
+			annotationFilter: "kubernetes.io/gateway.class=nginx",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: namespace,
+					ips: []string{"8.8.8.8"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					annotations: map[string]string{
+						"kubernetes.io/gateway.class": "alb",
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{},
+		},
+		{
+			title:           "our controller type is dns-controller",
+			targetNamespace: "",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: namespace,
+					ips: []string{"8.8.8.8"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					annotations: map[string]string{
+						controllerAnnotationKey: controllerAnnotationValue,
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName: "example.org",
+					Targets: endpoint.Targets{"8.8.8.8"},
+				},
+			},
+		},
+		{
+			title:           "different controller types are ignored",
+			targetNamespace: "",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: namespace,
+					ips: []string{"8.8.8.8"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					annotations: map[string]string{
+						controllerAnnotationKey: "some-other-tool",
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{},
+		},
+		{
+			title:           "template for gateway if host is missing",
+			targetNamespace: "",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: namespace,
+					ips:       []string{"8.8.8.8"},
+					hostnames: []string{"elb.com"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					annotations: map[string]string{
+						controllerAnnotationKey: controllerAnnotationValue,
+					},
+					dnsnames: [][]string{},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName: "fake1.ext-dns.test.com",
+					Targets: endpoint.Targets{"8.8.8.8"},
+				},
+				{
+					DNSName: "fake1.ext-dns.test.com",
+					Targets: endpoint.Targets{"elb.com"},
+				},
+			},
+			fqdnTemplate: "{{.Name}}.ext-dns.test.com",
+		},
+		{
+			title:           "another controller annotation skipped even with template",
+			targetNamespace: "",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: namespace,
+					ips: []string{"8.8.8.8"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					annotations: map[string]string{
+						controllerAnnotationKey: "other-controller",
+					},
+					dnsnames: [][]string{},
+				},
+			},
+			expected:     []*endpoint.Endpoint{},
+			fqdnTemplate: "{{.Name}}.ext-dns.test.com",
+		},
+		{
+			title:           "multiple FQDN template hostnames",
+			targetNamespace: "",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: namespace,
+					ips: []string{"8.8.8.8"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:        "fake1",
+					namespace:   namespace,
+					annotations: map[string]string{},
+					dnsnames:    [][]string{},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "fake1.ext-dns.test.com",
+					Targets:    endpoint.Targets{"8.8.8.8"},
+					RecordType: endpoint.RecordTypeA,
+				},
+				{
+					DNSName:    "fake1.ext-dna.test.com",
+					Targets:    endpoint.Targets{"8.8.8.8"},
+					RecordType: endpoint.RecordTypeA,
+				},
+			},
+			fqdnTemplate: "{{.Name}}.ext-dns.test.com, {{.Name}}.ext-dna.test.com",
+		},
+		{
+			title:           "multiple FQDN template hostnames",
+			targetNamespace: "",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: namespace,
+					ips: []string{"8.8.8.8"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:        "fake1",
+					namespace:   namespace,
+					annotations: map[string]string{},
+					dnsnames:    [][]string{},
+				},
+				{
+					name:      "fake2",
+					namespace: namespace,
+					annotations: map[string]string{
+						targetAnnotationKey: "gateway-target.com",
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "fake1.ext-dns.test.com",
+					Targets:    endpoint.Targets{"8.8.8.8"},
+					RecordType: endpoint.RecordTypeA,
+				},
+				{
+					DNSName:    "fake1.ext-dna.test.com",
+					Targets:    endpoint.Targets{"8.8.8.8"},
+					RecordType: endpoint.RecordTypeA,
+				},
+				{
+					DNSName:    "example.org",
+					Targets:    endpoint.Targets{"gateway-target.com"},
+					RecordType: endpoint.RecordTypeCNAME,
+				},
+				{
+					DNSName:    "fake2.ext-dns.test.com",
+					Targets:    endpoint.Targets{"gateway-target.com"},
+					RecordType: endpoint.RecordTypeCNAME,
+				},
+				{
+					DNSName:    "fake2.ext-dna.test.com",
+					Targets:    endpoint.Targets{"gateway-target.com"},
+					RecordType: endpoint.RecordTypeCNAME,
+				},
+			},
+			fqdnTemplate:             "{{.Name}}.ext-dns.test.com, {{.Name}}.ext-dna.test.com",
+			combineFQDNAndAnnotation: true,
+		},
+		{
+			title:           "gateway rules with annotation",
+			targetNamespace: "",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: namespace,
+					ips: []string{"8.8.8.8"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					annotations: map[string]string{
+						targetAnnotationKey: "gateway-target.com",
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+				{
+					name:      "fake2",
+					namespace: namespace,
+					annotations: map[string]string{
+						targetAnnotationKey: "gateway-target.com",
+					},
+					dnsnames: [][]string{{"example2.org"}},
+				},
+				{
+					name:      "fake3",
+					namespace: namespace,
+					annotations: map[string]string{
+						targetAnnotationKey: "1.2.3.4",
+					},
+					dnsnames: [][]string{{"example3.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					Targets:    endpoint.Targets{"gateway-target.com"},
+					RecordType: endpoint.RecordTypeCNAME,
+				},
+				{
+					DNSName:    "example2.org",
+					Targets:    endpoint.Targets{"gateway-target.com"},
+					RecordType: endpoint.RecordTypeCNAME,
+				},
+				{
+					DNSName:    "example3.org",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+				},
+			},
+		},
+		{
+			title:           "gateway rules with hostname annotation",
+			targetNamespace: "",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: namespace,
+					ips: []string{"1.2.3.4"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					annotations: map[string]string{
+						hostnameAnnotationKey: "dns-through-hostname.com",
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+				},
+				{
+					DNSName:    "dns-through-hostname.com",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+				},
+			},
+		},
+		{
+			title:           "gateway rules with hostname annotation having multiple hostnames",
+			targetNamespace: "",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: namespace,
+					ips: []string{"1.2.3.4"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					annotations: map[string]string{
+						hostnameAnnotationKey: "dns-through-hostname.com, another-dns-through-hostname.com",
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+				},
+				{
+					DNSName:    "dns-through-hostname.com",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+				},
+				{
+					DNSName:    "another-dns-through-hostname.com",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+				},
+			},
+		},
+		{
+			title:           "gateway rules with hostname and target annotation",
+			targetNamespace: "",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: namespace,
+					ips: []string{},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					annotations: map[string]string{
+						hostnameAnnotationKey: "dns-through-hostname.com",
+						targetAnnotationKey:   "gateway-target.com",
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					Targets:    endpoint.Targets{"gateway-target.com"},
+					RecordType: endpoint.RecordTypeCNAME,
+				},
+				{
+					DNSName:    "dns-through-hostname.com",
+					Targets:    endpoint.Targets{"gateway-target.com"},
+					RecordType: endpoint.RecordTypeCNAME,
+				},
+			},
+		},
+		{
+			title:           "gateway rules with annotation and custom TTL",
+			targetNamespace: "",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: namespace,
+					ips: []string{"8.8.8.8"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					annotations: map[string]string{
+						targetAnnotationKey: "gateway-target.com",
+						ttlAnnotationKey:    "6",
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+				{
+					name:      "fake2",
+					namespace: namespace,
+					annotations: map[string]string{
+						targetAnnotationKey: "gateway-target.com",
+						ttlAnnotationKey:    "1",
+					},
+					dnsnames: [][]string{{"example2.org"}},
+				},
+				{
+					name:      "fake3",
+					namespace: namespace,
+					annotations: map[string]string{
+						targetAnnotationKey: "gateway-target.com",
+						ttlAnnotationKey:    "10s",
+					},
+					dnsnames: [][]string{{"example3.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:   "example.org",
+					Targets:   endpoint.Targets{"gateway-target.com"},
+					RecordTTL: endpoint.TTL(6),
+				},
+				{
+					DNSName:   "example2.org",
+					Targets:   endpoint.Targets{"gateway-target.com"},
+					RecordTTL: endpoint.TTL(1),
+				},
+				{
+					DNSName:   "example3.org",
+					Targets:   endpoint.Targets{"gateway-target.com"},
+					RecordTTL: endpoint.TTL(10),
+				},
+			},
+		},
+		{
+			title:           "template for gateway with annotation",
+			targetNamespace: "",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: namespace,
+					ips:       []string{},
+					hostnames: []string{},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					annotations: map[string]string{
+						targetAnnotationKey: "gateway-target.com",
+					},
+					dnsnames: [][]string{},
+				},
+				{
+					name:      "fake2",
+					namespace: namespace,
+					annotations: map[string]string{
+						targetAnnotationKey: "gateway-target.com",
+					},
+					dnsnames: [][]string{},
+				},
+				{
+					name:      "fake3",
+					namespace: namespace,
+					annotations: map[string]string{
+						targetAnnotationKey: "1.2.3.4",
+					},
+					dnsnames: [][]string{},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "fake1.ext-dns.test.com",
+					Targets:    endpoint.Targets{"gateway-target.com"},
+					RecordType: endpoint.RecordTypeCNAME,
+				},
+				{
+					DNSName:    "fake2.ext-dns.test.com",
+					Targets:    endpoint.Targets{"gateway-target.com"},
+					RecordType: endpoint.RecordTypeCNAME,
+				},
+				{
+					DNSName:    "fake3.ext-dns.test.com",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+				},
+			},
+			fqdnTemplate: "{{.Name}}.ext-dns.test.com",
+		},
+		{
+			title:           "Ingress with empty annotation",
+			targetNamespace: "",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: namespace,
+					ips:       []string{},
+					hostnames: []string{},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					annotations: map[string]string{
+						targetAnnotationKey: "",
+					},
+					dnsnames: [][]string{},
+				},
+			},
+			expected:     []*endpoint.Endpoint{},
+			fqdnTemplate: "{{.Name}}.ext-dns.test.com",
+		},
+		{
+			title:           "ignore hostname annotations",
+			targetNamespace: "",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: namespace,
+					ips:       []string{"8.8.8.8"},
+					hostnames: []string{"lb.com"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					annotations: map[string]string{
+						hostnameAnnotationKey: "ignore.me",
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+				{
+					name:      "fake2",
+					namespace: namespace,
+					annotations: map[string]string{
+						hostnameAnnotationKey: "ignore.me.too",
+					},
+					dnsnames: [][]string{{"new.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName: "example.org",
+					Targets: endpoint.Targets{"8.8.8.8"},
+				},
+				{
+					DNSName: "example.org",
+					Targets: endpoint.Targets{"lb.com"},
+				},
+				{
+					DNSName: "new.org",
+					Targets: endpoint.Targets{"8.8.8.8"},
+				},
+				{
+					DNSName: "new.org",
+					Targets: endpoint.Targets{"lb.com"},
+				},
+			},
+			ignoreHostnameAnnotation: true,
+		},
+	} {
+		t.Run(ti.title, func(t *testing.T) {
+			configs := make([]istiomodel.Config, 0)
+			for _, item := range ti.configItems {
+				configs = append(configs, item.Config())
+			}
+
+			fakeKubernetesClient := fake.NewSimpleClientset()
+
+			for _, lb := range ti.lbServices {
+				service := lb.Service()
+				_, err := fakeKubernetesClient.CoreV1().Services(service.Namespace).Create(service)
+				require.NoError(t, err)
+			}
+
+			fakeIstioClient := NewFakeConfigStore()
+			for _, config := range configs {
+				_, err := fakeIstioClient.Create(config)
+				require.NoError(t, err)
+			}
+
+			gatewaySource, err := NewIstioGatewaySource(
+				fakeKubernetesClient,
+				fakeIstioClient,
+				ti.targetNamespace,
+				ti.annotationFilter,
+				ti.fqdnTemplate,
+				ti.combineFQDNAndAnnotation,
+				ti.ignoreHostnameAnnotation,
+			)
+			require.NoError(t, err)
+
+			res, err := gatewaySource.Endpoints()
+			if ti.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			validateEndpoints(t, res, ti.expected)
+		})
+	}
+}
+
+// gateway specific helper functions
+func newTestGatewaySource(loadBalancerList []fakeIngressGatewayService) (*istioGatewaySource, error) {
+	fakeKubernetesClient := fake.NewSimpleClientset()
+	fakeIstioClient := NewFakeConfigStore()
+
+	for _, lb := range loadBalancerList {
+		service := lb.Service()
+		_, err := fakeKubernetesClient.CoreV1().Services(service.Namespace).Create(service)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	src, err := NewIstioGatewaySource(
+		fakeKubernetesClient,
+		fakeIstioClient,
+		"",
+		"",
+		"{{.Name}}",
+		false,
+		false,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	gwsrc, ok := src.(*istioGatewaySource)
+	if !ok {
+		return nil, errors.New("underlying source type was not gateway")
+	}
+
+	return gwsrc, nil
+}
+
+type fakeIngressGatewayService struct {
+	ips       []string
+	hostnames []string
+	namespace string
+	name      string
+}
+
+func (ig fakeIngressGatewayService) Service() *v1.Service {
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ig.namespace,
+			Name:      ig.name,
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{},
+			},
+		},
+	}
+
+	for _, ip := range ig.ips {
+		svc.Status.LoadBalancer.Ingress = append(svc.Status.LoadBalancer.Ingress, v1.LoadBalancerIngress{
+			IP: ip,
+		})
+	}
+	for _, hostname := range ig.hostnames {
+		svc.Status.LoadBalancer.Ingress = append(svc.Status.LoadBalancer.Ingress, v1.LoadBalancerIngress{
+			Hostname: hostname,
+		})
+	}
+
+	return svc
+}
+
+type fakeGatewayConfig struct {
+	namespace   string
+	name        string
+	annotations map[string]string
+	dnsnames    [][]string
+	selector    map[string]string
+}
+
+func (c fakeGatewayConfig) Config() istiomodel.Config {
+	gw := &istionetworking.Gateway{
+		Servers: []*istionetworking.Server{},
+	}
+
+	for _, dnsnames := range c.dnsnames {
+		gw.Servers = append(gw.Servers, &istionetworking.Server{
+			Hosts: dnsnames,
+		})
+	}
+
+	gw.Selector = c.selector
+
+	config := istiomodel.Config{
+		ConfigMeta: istiomodel.ConfigMeta{
+			Namespace:   c.namespace,
+			Name:        c.name,
+			Type:        gatewayType,
+			Annotations: c.annotations,
+		},
+		Spec: gw,
+	}
+
+	return config
+}
+
+type fakeConfigStore struct {
+	descriptor istiomodel.ConfigDescriptor
+	configs    []*istiomodel.Config
+	sync.RWMutex
+}
+
+func NewFakeConfigStore() istiomodel.ConfigStore {
+	return &fakeConfigStore{
+		descriptor: istiomodel.ConfigDescriptor{
+			istiomodel.Gateway,
+			istiomodel.VirtualService,
+		},
+		configs: make([]*istiomodel.Config, 0),
+	}
+}
+
+func (f *fakeConfigStore) ConfigDescriptor() istiomodel.ConfigDescriptor {
+	return f.descriptor
+}
+
+func (f *fakeConfigStore) Get(typ, name, namespace string) (config *istiomodel.Config) {
+	f.RLock()
+	defer f.RUnlock()
+
+	if cfg, _ := f.get(typ, name, namespace); cfg != nil {
+		config = cfg
+	}
+
+	return
+}
+
+func (f *fakeConfigStore) get(typ, name, namespace string) (*istiomodel.Config, int) {
+	for idx, cfg := range f.configs {
+		if cfg.Type == typ && cfg.Name == name && cfg.Namespace == namespace {
+			return cfg, idx
+		}
+	}
+
+	return nil, -1
+}
+
+func (f *fakeConfigStore) List(typ, namespace string) (configs []istiomodel.Config, err error) {
+	f.RLock()
+	defer f.RUnlock()
+
+	if namespace == "" {
+		for _, cfg := range f.configs {
+			if cfg.Type == typ {
+				configs = append(configs, *cfg)
+			}
+		}
+	} else {
+		for _, cfg := range f.configs {
+			if cfg.Type == typ && cfg.Namespace == namespace {
+				configs = append(configs, *cfg)
+			}
+		}
+	}
+
+	return
+}
+
+func (f *fakeConfigStore) Create(config istiomodel.Config) (revision string, err error) {
+	f.Lock()
+	defer f.Unlock()
+
+	if cfg, _ := f.get(config.Type, config.Name, config.Namespace); cfg != nil {
+		err = errors.New("config already exists")
+	} else {
+		revision = "0"
+		cfg := &config
+		cfg.ResourceVersion = revision
+		f.configs = append(f.configs, cfg)
+	}
+
+	return
+}
+
+func (f *fakeConfigStore) Update(config istiomodel.Config) (newRevision string, err error) {
+	f.Lock()
+	defer f.Unlock()
+
+	if oldCfg, idx := f.get(config.Type, config.Name, config.Namespace); oldCfg == nil {
+		err = errors.New("config does not exist")
+	} else if oldRevision, e := strconv.Atoi(oldCfg.ResourceVersion); e != nil {
+		err = e
+	} else {
+		newRevision = strconv.Itoa(oldRevision + 1)
+		cfg := &config
+		cfg.ResourceVersion = newRevision
+		f.configs[idx] = cfg
+	}
+
+	return
+}
+
+func (f *fakeConfigStore) Delete(typ, name, namespace string) error {
+	f.Lock()
+	defer f.Unlock()
+
+	_, idx := f.get(typ, name, namespace)
+	if idx < 0 {
+		return errors.New("config does not exist")
+	}
+
+	copy(f.configs[idx:], f.configs[idx+1:])
+	f.configs[len(f.configs)-1] = nil
+	f.configs = f.configs[:len(f.configs)-1]
+
+	return nil
+}

--- a/source/istio_gateway_test.go
+++ b/source/istio_gateway_test.go
@@ -512,7 +512,7 @@ func testGatewayEndpoints(t *testing.T) {
 			lbServices: []fakeIngressGatewayService{
 				{
 					namespace: namespace,
-					ips: []string{"8.8.8.8"},
+					ips:       []string{"8.8.8.8"},
 				},
 			},
 			configItems: []fakeGatewayConfig{
@@ -539,7 +539,7 @@ func testGatewayEndpoints(t *testing.T) {
 			lbServices: []fakeIngressGatewayService{
 				{
 					namespace: namespace,
-					ips: []string{"8.8.8.8"},
+					ips:       []string{"8.8.8.8"},
 				},
 			},
 			configItems: []fakeGatewayConfig{
@@ -561,7 +561,7 @@ func testGatewayEndpoints(t *testing.T) {
 			lbServices: []fakeIngressGatewayService{
 				{
 					namespace: namespace,
-					ips: []string{"8.8.8.8"},
+					ips:       []string{"8.8.8.8"},
 				},
 			},
 			configItems: []fakeGatewayConfig{
@@ -584,7 +584,7 @@ func testGatewayEndpoints(t *testing.T) {
 			lbServices: []fakeIngressGatewayService{
 				{
 					namespace: namespace,
-					ips: []string{"8.8.8.8"},
+					ips:       []string{"8.8.8.8"},
 				},
 			},
 			configItems: []fakeGatewayConfig{
@@ -611,7 +611,7 @@ func testGatewayEndpoints(t *testing.T) {
 			lbServices: []fakeIngressGatewayService{
 				{
 					namespace: namespace,
-					ips: []string{"8.8.8.8"},
+					ips:       []string{"8.8.8.8"},
 				},
 			},
 			configItems: []fakeGatewayConfig{
@@ -632,7 +632,7 @@ func testGatewayEndpoints(t *testing.T) {
 			lbServices: []fakeIngressGatewayService{
 				{
 					namespace: namespace,
-					ips: []string{"8.8.8.8"},
+					ips:       []string{"8.8.8.8"},
 				},
 			},
 			configItems: []fakeGatewayConfig{
@@ -658,7 +658,7 @@ func testGatewayEndpoints(t *testing.T) {
 			lbServices: []fakeIngressGatewayService{
 				{
 					namespace: namespace,
-					ips: []string{"8.8.8.8"},
+					ips:       []string{"8.8.8.8"},
 				},
 			},
 			configItems: []fakeGatewayConfig{
@@ -711,7 +711,7 @@ func testGatewayEndpoints(t *testing.T) {
 			lbServices: []fakeIngressGatewayService{
 				{
 					namespace: namespace,
-					ips: []string{"8.8.8.8"},
+					ips:       []string{"8.8.8.8"},
 				},
 			},
 			configItems: []fakeGatewayConfig{
@@ -733,7 +733,7 @@ func testGatewayEndpoints(t *testing.T) {
 			lbServices: []fakeIngressGatewayService{
 				{
 					namespace: namespace,
-					ips: []string{"8.8.8.8"},
+					ips:       []string{"8.8.8.8"},
 				},
 			},
 			configItems: []fakeGatewayConfig{
@@ -764,7 +764,7 @@ func testGatewayEndpoints(t *testing.T) {
 			lbServices: []fakeIngressGatewayService{
 				{
 					namespace: namespace,
-					ips: []string{"8.8.8.8"},
+					ips:       []string{"8.8.8.8"},
 				},
 			},
 			configItems: []fakeGatewayConfig{
@@ -819,7 +819,7 @@ func testGatewayEndpoints(t *testing.T) {
 			lbServices: []fakeIngressGatewayService{
 				{
 					namespace: namespace,
-					ips: []string{"8.8.8.8"},
+					ips:       []string{"8.8.8.8"},
 				},
 			},
 			configItems: []fakeGatewayConfig{
@@ -872,7 +872,7 @@ func testGatewayEndpoints(t *testing.T) {
 			lbServices: []fakeIngressGatewayService{
 				{
 					namespace: namespace,
-					ips: []string{"1.2.3.4"},
+					ips:       []string{"1.2.3.4"},
 				},
 			},
 			configItems: []fakeGatewayConfig{
@@ -904,7 +904,7 @@ func testGatewayEndpoints(t *testing.T) {
 			lbServices: []fakeIngressGatewayService{
 				{
 					namespace: namespace,
-					ips: []string{"1.2.3.4"},
+					ips:       []string{"1.2.3.4"},
 				},
 			},
 			configItems: []fakeGatewayConfig{
@@ -941,7 +941,7 @@ func testGatewayEndpoints(t *testing.T) {
 			lbServices: []fakeIngressGatewayService{
 				{
 					namespace: namespace,
-					ips: []string{},
+					ips:       []string{},
 				},
 			},
 			configItems: []fakeGatewayConfig{
@@ -974,7 +974,7 @@ func testGatewayEndpoints(t *testing.T) {
 			lbServices: []fakeIngressGatewayService{
 				{
 					namespace: namespace,
-					ips: []string{"8.8.8.8"},
+					ips:       []string{"8.8.8.8"},
 				},
 			},
 			configItems: []fakeGatewayConfig{
@@ -1233,6 +1233,7 @@ type fakeIngressGatewayService struct {
 	hostnames []string
 	namespace string
 	name      string
+	selector  map[string]string
 }
 
 func (ig fakeIngressGatewayService) Service() *v1.Service {
@@ -1245,6 +1246,9 @@ func (ig fakeIngressGatewayService) Service() *v1.Service {
 			LoadBalancer: v1.LoadBalancerStatus{
 				Ingress: []v1.LoadBalancerIngress{},
 			},
+		},
+		Spec: v1.ServiceSpec{
+			Selector: ig.selector,
 		},
 	}
 

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -1,0 +1,365 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+	"text/template"
+	"time"
+
+	kubeinformers "k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	log "github.com/sirupsen/logrus"
+
+	istionetworking "istio.io/api/networking/v1alpha3"
+	istiomodel "istio.io/istio/pilot/pkg/model"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/kubernetes-sigs/external-dns/endpoint"
+	"k8s.io/client-go/kubernetes"
+)
+
+// istioVirtualServiceSource is an implementation of Source for Istio VirtualService objects.
+// The implementation uses the spec.hosts values for the hostnames.
+// Use targetAnnotationKey to explicitly set Endpoint.
+type istioVirtualServiceSource struct {
+	kubeClient               kubernetes.Interface
+	istioClient              istiomodel.ConfigStore
+	namespace                string
+	annotationFilter         string
+	fqdnTemplate             *template.Template
+	combineFQDNAnnotation    bool
+	ignoreHostnameAnnotation bool
+	serviceInformer          coreinformers.ServiceInformer
+}
+
+// NewIstioGatewaySource creates a new istioVirtualServiceSource with the given config.
+func NewIstioVirtualServiceSource(
+	kubeClient kubernetes.Interface,
+	istioClient istiomodel.ConfigStore,
+	namespace string,
+	annotationFilter string,
+	fqdnTemplate string,
+	combineFqdnAnnotation bool,
+	ignoreHostnameAnnotation bool,
+) (Source, error) {
+	var (
+		tmpl *template.Template
+		err  error
+	)
+
+	if fqdnTemplate != "" {
+		tmpl, err = template.New("endpoint").Funcs(template.FuncMap{
+			"trimPrefix": strings.TrimPrefix,
+		}).Parse(fqdnTemplate)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Use shared informers to listen for add/update/delete of services/pods/nodes in the specified namespace.
+	// Set resync period to 0, to prevent processing when nothing has changed
+	informerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 0, kubeinformers.WithNamespace(namespace))
+	serviceInformer := informerFactory.Core().V1().Services()
+
+	// Add default resource event handlers to properly initialize informer.
+	serviceInformer.Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				log.Debug("service added")
+			},
+		},
+	)
+
+	// TODO informer is not explicitly stopped since controller is not passing in its channel.
+	informerFactory.Start(wait.NeverStop)
+
+	// wait for the local cache to be populated.
+	err = wait.Poll(time.Second, 60*time.Second, func() (bool, error) {
+		return serviceInformer.Informer().HasSynced() == true, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to sync cache: %v", err)
+	}
+
+	return &istioVirtualServiceSource{
+		kubeClient:               kubeClient,
+		istioClient:              istioClient,
+		namespace:                namespace,
+		annotationFilter:         annotationFilter,
+		fqdnTemplate:             tmpl,
+		combineFQDNAnnotation:    combineFqdnAnnotation,
+		ignoreHostnameAnnotation: ignoreHostnameAnnotation,
+		serviceInformer:          serviceInformer,
+	}, nil
+}
+
+// Endpoints returns endpoint objects for each host-target combination that should be processed.
+// Retrieves all virtualservice resources in the source's namespace(s).
+func (sc *istioVirtualServiceSource) Endpoints() ([]*endpoint.Endpoint, error) {
+	configs, err := sc.istioClient.List(istiomodel.VirtualService.Type, sc.namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	configs, err = sc.filterByAnnotations(configs)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoints := []*endpoint.Endpoint{}
+
+	for _, config := range configs {
+		// Check controller annotation to see if we are responsible.
+		controller, ok := config.Annotations[controllerAnnotationKey]
+		if ok && controller != controllerAnnotationValue {
+			log.Debugf("Skipping virtualservice %s/%s because controller value does not match, found: %s, required: %s",
+				config.Namespace, config.Name, controller, controllerAnnotationValue)
+			continue
+		}
+
+		gwEndpoints, err := sc.endpointsFromVirtualServiceConfig(config)
+		if err != nil {
+			return nil, err
+		}
+
+		// apply template if host is missing on virtualservice
+		if (sc.combineFQDNAnnotation || len(gwEndpoints) == 0) && sc.fqdnTemplate != nil {
+			iEndpoints, err := sc.endpointsFromTemplate(&config)
+			if err != nil {
+				return nil, err
+			}
+
+			if sc.combineFQDNAnnotation {
+				gwEndpoints = append(gwEndpoints, iEndpoints...)
+			} else {
+				gwEndpoints = iEndpoints
+			}
+		}
+
+		if len(gwEndpoints) == 0 {
+			log.Debugf("No endpoints could be generated from virtualservice %s/%s", config.Namespace, config.Name)
+			continue
+		}
+
+		log.Debugf("Endpoints generated from virtualservice: %s/%s: %v", config.Namespace, config.Name, gwEndpoints)
+		sc.setResourceLabel(config, gwEndpoints)
+		endpoints = append(endpoints, gwEndpoints...)
+	}
+
+	for _, ep := range endpoints {
+		sort.Sort(ep.Targets)
+	}
+
+	return endpoints, nil
+}
+
+func (sc *istioVirtualServiceSource) endpointsFromTemplate(config *istiomodel.Config) ([]*endpoint.Endpoint, error) {
+	// Process the whole template string
+	var buf bytes.Buffer
+	err := sc.fqdnTemplate.Execute(&buf, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to apply template on istio config %s: %v", config, err)
+	}
+
+	hostnames := buf.String()
+
+	ttl, err := getTTLFromAnnotations(config.Annotations)
+	if err != nil {
+		log.Warn(err)
+	}
+
+	var endpoints []*endpoint.Endpoint
+
+	targets, err := sc.targetsFromVirtualServiceConfig(config)
+	if err != nil {
+		return endpoints, err
+	}
+
+	providerSpecific, setIdentifier := getProviderSpecificAnnotations(config.Annotations)
+
+	// splits the FQDN template and removes the trailing periods
+	hostnameList := strings.Split(strings.Replace(hostnames, " ", "", -1), ",")
+	for _, hostname := range hostnameList {
+		hostname = strings.TrimSuffix(hostname, ".")
+		endpoints = append(endpoints, endpointsForHostname(hostname, targets, ttl, providerSpecific, setIdentifier)...)
+	}
+	return endpoints, nil
+}
+
+// filterByAnnotations filters a list of configs by a given annotation selector.
+func (sc *istioVirtualServiceSource) filterByAnnotations(configs []istiomodel.Config) ([]istiomodel.Config, error) {
+	labelSelector, err := metav1.ParseToLabelSelector(sc.annotationFilter)
+	if err != nil {
+		return nil, err
+	}
+	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	// empty filter returns original list
+	if selector.Empty() {
+		return configs, nil
+	}
+
+	filteredList := []istiomodel.Config{}
+
+	for _, config := range configs {
+		// convert the annotations to an equivalent label selector
+		annotations := labels.Set(config.Annotations)
+
+		// include if the annotations match the selector
+		if selector.Matches(annotations) {
+			filteredList = append(filteredList, config)
+		}
+	}
+
+	return filteredList, nil
+}
+
+func (sc *istioVirtualServiceSource) setResourceLabel(config istiomodel.Config, endpoints []*endpoint.Endpoint) {
+	for _, ep := range endpoints {
+		ep.Labels[endpoint.ResourceLabelKey] = fmt.Sprintf("virtualservice/%s/%s", config.Namespace, config.Name)
+	}
+}
+
+func (sc *istioVirtualServiceSource) targetsFromGatewayConfig(config *istiomodel.Config) (targets endpoint.Targets, err error) {
+	gateway := config.Spec.(*istionetworking.Gateway)
+
+	services, err := sc.serviceInformer.Lister().Services(config.Namespace).List(labels.Everything())
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	for _, service := range services {
+		if !labels.Equals(service.Spec.Selector, gateway.Selector) {
+			// Only consider services which have the same selector as the Gateway CR.
+			// Use the target annotation to override if this picks the wrong service.
+			continue
+		}
+		for _, lb := range service.Status.LoadBalancer.Ingress {
+			if lb.IP != "" {
+				targets = append(targets, lb.IP)
+			}
+			if lb.Hostname != "" {
+				targets = append(targets, lb.Hostname)
+			}
+		}
+	}
+
+	return
+}
+
+func (sc *istioVirtualServiceSource) targetsFromVirtualServiceConfig(config *istiomodel.Config) (targets endpoint.Targets, err error) {
+	targets = getTargetsFromTargetAnnotation(config.Annotations)
+	if len(targets) > 0 {
+		return targets, nil
+	}
+
+	virtualservice := config.Spec.(*istionetworking.VirtualService)
+
+	for _, gateway := range virtualservice.Gateways {
+		if gateway == "" || gateway == "mesh" {
+			// This refers to "all sidecars in the mesh"; ignore.
+			continue
+		}
+		namespace, name, err := parseIngressGateway(gateway)
+		if err != nil {
+			log.Debugf("Failed parsing gateway %s of virtualservice %s/%s", gateway, config.Namespace, config.Name)
+			continue
+		}
+
+		gwconfig := sc.istioClient.Get(istiomodel.Gateway.Type, name, namespace)
+		if err != nil {
+			log.Debugf("Failed reading gateway %s/%s of virtualservice %s/%s", namespace, name, config.Namespace, config.Name)
+			continue
+		}
+
+		// TODO check if this virtualservice can be bound to this gateway
+		// (i.e. if gateway doesn't have a namespace restriction in its hosts list)
+
+		targets = getTargetsFromTargetAnnotation(gwconfig.Annotations)
+		if len(targets) > 0 {
+			break
+		}
+
+		targets, err = sc.targetsFromGatewayConfig(gwconfig)
+		if err != nil {
+			return targets, err
+		}
+
+		if len(targets) > 0 {
+			break
+		}
+	}
+
+	return targets, err
+}
+
+// endpointsFromGatewayConfig extracts the endpoints from an Istio Gateway Config object
+func (sc *istioVirtualServiceSource) endpointsFromVirtualServiceConfig(config istiomodel.Config) ([]*endpoint.Endpoint, error) {
+	var endpoints []*endpoint.Endpoint
+
+	ttl, err := getTTLFromAnnotations(config.Annotations)
+	if err != nil {
+		log.Warn(err)
+	}
+
+	targets, err := sc.targetsFromVirtualServiceConfig(&config)
+	if err != nil {
+		return endpoints, err
+	}
+
+	providerSpecific, setIdentifier := getProviderSpecificAnnotations(config.Annotations)
+
+	virtualservice := config.Spec.(*istionetworking.VirtualService)
+
+	for _, host := range virtualservice.Hosts {
+		if host == "" || host == "*" {
+			continue
+		}
+
+		parts := strings.Split(host, "/")
+
+		// If the input hostname is of the form my-namespace/foo.bar.com, remove the namespace
+		// before appending it to the list of endpoints to create
+		if len(parts) == 2 {
+			host = parts[1]
+		}
+
+		endpoints = append(endpoints, endpointsForHostname(host, targets, ttl, providerSpecific, setIdentifier)...)
+	}
+
+	// Skip endpoints if we do not want entries from annotations
+	if !sc.ignoreHostnameAnnotation {
+		hostnameList := getHostnamesFromAnnotations(config.Annotations)
+		for _, hostname := range hostnameList {
+			endpoints = append(endpoints, endpointsForHostname(hostname, targets, ttl, providerSpecific, setIdentifier)...)
+		}
+	}
+
+	return endpoints, nil
+}

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -97,7 +97,7 @@ func NewIstioVirtualServiceSource(
 
 	// wait for the local cache to be populated.
 	err = wait.Poll(time.Second, 60*time.Second, func() (bool, error) {
-		return serviceInformer.Informer().HasSynced() == true, nil
+		return serviceInformer.Informer().HasSynced(), nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to sync cache: %v", err)
@@ -422,7 +422,7 @@ func virtualServiceBindsToGateway(vsconfig, gwconfig *istiomodel.Config, vsHost 
 					suffixMatch = true
 				}
 
-				if host == vsHost || (suffixMatch && strings.HasSuffix(vsHost, host[1:len(host)])) {
+				if host == vsHost || (suffixMatch && strings.HasSuffix(vsHost, host[1:])) {
 					return true
 				}
 			}

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -175,6 +175,9 @@ func (sc *istioVirtualServiceSource) Endpoints() ([]*endpoint.Endpoint, error) {
 	return endpoints, nil
 }
 
+func (sc *istioVirtualServiceSource) AddEventHandler(handler func() error, stopChan <-chan struct{}, minInterval time.Duration) {
+}
+
 func (sc *istioVirtualServiceSource) getGateway(gateway string, vsconfig *istiomodel.Config) *istiomodel.Config {
 	if gateway == "" || gateway == "mesh" {
 		// This refers to "all sidecars in the mesh"; ignore.

--- a/source/istio_virtualservice_test.go
+++ b/source/istio_virtualservice_test.go
@@ -24,15 +24,11 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 
-	//"strconv"
-	//"sync"
-
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	v1 "k8s.io/api/core/v1"
-	//metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 

--- a/source/store.go
+++ b/source/store.go
@@ -141,7 +141,7 @@ func (p *SingletonClientGenerator) ContourClient() (contour.Interface, error) {
 
 // ByNames returns multiple Sources given multiple names.
 func ByNames(p ClientGenerator, names []string, cfg *Config) ([]Source, error) {
-	sources := []Source{}
+	var sources []Source
 	for _, name := range names {
 		source, err := BuildWithConfig(name, p, cfg)
 		if err != nil {

--- a/source/store.go
+++ b/source/store.go
@@ -184,6 +184,16 @@ func BuildWithConfig(source string, p ClientGenerator, cfg *Config) (Source, err
 			return nil, err
 		}
 		return NewIstioGatewaySource(kubernetesClient, istioClient, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.IgnoreHostnameAnnotation)
+	case "istio-virtualservice":
+		kubernetesClient, err := p.KubeClient()
+		if err != nil {
+			return nil, err
+		}
+		istioClient, err := p.IstioClient()
+		if err != nil {
+			return nil, err
+		}
+		return NewIstioVirtualServiceSource(kubernetesClient, istioClient, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.IgnoreHostnameAnnotation)
 	case "cloudfoundry":
 		cfClient, err := p.CloudFoundryClient(cfg.CFAPIEndpoint, cfg.CFUsername, cfg.CFPassword)
 		if err != nil {
@@ -307,7 +317,7 @@ func NewIstioClient(kubeConfig string) (*istiocontroller.Client, error) {
 	client, err := istiocontroller.NewClient(
 		kubeConfig,
 		"",
-		istiomodel.ConfigDescriptor{istiomodel.Gateway},
+		istiomodel.ConfigDescriptor{istiomodel.Gateway, istiomodel.VirtualService},
 		"",
 	)
 	if err != nil {

--- a/source/store_test.go
+++ b/source/store_test.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"testing"
 
-	cfclient "github.com/cloudfoundry-community/go-cfclient"
+	"github.com/cloudfoundry-community/go-cfclient"
 	contour "github.com/heptio/contour/apis/generated/clientset/versioned"
 	fakeContour "github.com/heptio/contour/apis/generated/clientset/versioned/fake"
 	"github.com/stretchr/testify/mock"


### PR DESCRIPTION
This adds a source for istio `VirtualService`s. DNS names are given via the `hosts` field in the `VirtualService`, the target for the DNS record is extracted from the associated istio `Gateway`.

**Note:** This also changes the behavior of istio `Gateways`:
* it now finds the Kubernetes `Service` corresponding to the gateway by searching for `Services` which have the _same selector_ as the `Gateway`; previously it used the `Gateway` selector to query for services _directly_ via label selector; I did this change because the `Gateway` selector selects `Pod`s, not `Service`s
* it now only finds corresponding Kubernetes `Service`s in the same namespace as the `Gateway`; while it is actually possible to use `Gateway`s to configure ingress gateway pods in other namespace, this is contrary to what's written in the documentation; I opened up a bug report for this here: https://github.com/istio/istio/issues/19970
I did these changes because I had to touch a bit of the code for the gateway source anyways. Let me know if this is out of scope and I should create a separate PR for this.


This closes #1340.

- [x] make unit tests work
- [x] add documentation