### PR TITLE
Add version to binary for --version flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@
 # builder image
 FROM golang:1.13 as builder
 
+ARG VERSION
+
 WORKDIR /sigs.k8s.io/external-dns
 
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,10 @@ build.push: build.docker
 	docker push "$(IMAGE):$(VERSION)"
 
 build.docker:
-	docker build --rm --tag "$(IMAGE):$(VERSION)" .
+	docker build --rm --tag "$(IMAGE):$(VERSION)" --build-arg VERSION="$(VERSION)" .
 
 build.mini:
-	docker build --rm --tag "$(IMAGE):$(VERSION)-mini" -f Dockerfile.mini .
+	docker build --rm --tag "$(IMAGE):$(VERSION)-mini" --build-arg VERSION="$(VERSION)" -f Dockerfile.mini .
 
 clean:
 	@rm -rf build
@@ -72,7 +72,7 @@ clean:
 .PHONY: release.staging
 
 release.staging:
-	IMAGE=$(IMAGE_STAGING) VERSION=$(TAG) $(MAKE) build.docker build.push
+	IMAGE=$(IMAGE_STAGING) $(MAKE) build.docker build.push
 
 release.prod:
 	$(MAKE) build.docker build.push

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
     entrypoint: make
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
-      - TAG=$_GIT_TAG
+      - VERSION=$_GIT_TAG
       - PULL_BASE_REF=$_PULL_BASE_REF
     args:
       - release.staging


### PR DESCRIPTION
The new build process lead to losing the LDFLAGS for the version, so `--version` wouldn't correctly print the version anymore. This fixes it.