### PR TITLE
docs: add REgion for aws-sd external-dns deployment

### DIFF
--- a/docs/tutorials/aws-sd.md
+++ b/docs/tutorials/aws-sd.md
@@ -82,6 +82,9 @@ spec:
       containers:
       - name: external-dns
         image: registry.opensource.zalan.do/teapot/external-dns:latest
+        env:
+          - name: AWS_REGION
+            value: us-east-1 # put your CloudMap NameSpace region
         args:
         - --source=service
         - --source=ingress
@@ -149,6 +152,9 @@ spec:
       containers:
       - name: external-dns
         image: registry.opensource.zalan.do/teapot/external-dns:latest
+        env:
+          - name: AWS_REGION
+            value: us-east-1 # put your CloudMap NameSpace region
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
Updating tutorial with aws-sd to include guide for adding AWS_REGION env. Missing this env will cause region error message and external-dns won't work.

> level=error msg="MissingRegion: could not find region configuration"

ref: https://github.com/kubernetes-sigs/external-dns/issues/584