### PR TITLE
Fix updates of unchanged records for Azure Private DNS

### DIFF
--- a/provider/azure_private_dns.go
+++ b/provider/azure_private_dns.go
@@ -105,7 +105,7 @@ func (p *AzurePrivateDNSProvider) Records(ctx context.Context) (endpoints []*end
 				log.Debugf("Skipping invalid record set with missing type.")
 				return
 			}
-			recordType = strings.TrimPrefix(*recordSet.Type, "Microsoft.Network/privateDnsZones")
+			recordType = strings.TrimPrefix(*recordSet.Type, "Microsoft.Network/privateDnsZones/")
 
 			var name string
 			if recordSet.Name == nil {

--- a/provider/azure_privatedns_test.go
+++ b/provider/azure_privatedns_test.go
@@ -157,7 +157,7 @@ func createPrivateMockRecordSetMultiWithTTL(name, recordType string, ttl int64, 
 	}
 	return privatedns.RecordSet{
 		Name:                to.StringPtr(name),
-		Type:                to.StringPtr("Microsoft.Network/privateDnsZones" + recordType),
+		Type:                to.StringPtr("Microsoft.Network/privateDnsZones/" + recordType),
 		RecordSetProperties: getterFunc(values, ttl),
 	}
 


### PR DESCRIPTION
Due to the missing `/` the record type of existing records had `/` as a prefix (i.e. `/A`). Condition in https://github.com/kubernetes-sigs/external-dns/blob/f400ded46cd1bd0a2ed133a68b2e084f7cb40119/plan/plan.go#L236-L238 was therefore never true.
 
Fixes #1373