### PR TITLE
Azure Private DNS: Fix endless loop in zone-detection

### DIFF
--- a/docs/tutorials/azure-private-dns.md
+++ b/docs/tutorials/azure-private-dns.md
@@ -101,8 +101,8 @@ $ az network private-dns link vnet create -g externaldns -n mylink \
 ExternalDNS needs permissions to make changes in Azure Private DNS.  
 These permissions are roles assigned to the service principal used by ExternalDNS.
 
-A service principal with a minimum access level of `contributor` to the Private DNS zone(s) and `reader` to the resource group containing the Azure Private DNS zone(s) is necessary.
-More powerful role-assignments like `owner` or assignments on subscription-level work too. 
+A service principal with a minimum access level of `Private DNS Zone Contributor` to the Private DNS zone(s) and `Reader` to the resource group containing the Azure Private DNS zone(s) is necessary.
+More powerful role-assignments like `Owner` or assignments on subscription-level work too. 
 
 Start off by **creating the service principal** without role-assignments.
 ```
@@ -134,7 +134,7 @@ Now, **create role assignments**.
 $ az role assignment create --role "Reader" --assignee <appId GUID> --scope <resource group resource id>  
 
 # 2. as a contributor to DNS Zone itself
-$ az role assignment create --role "Contributor" --assignee <appId GUID> --scope <dns zone resource id>  
+$ az role assignment create --role "Private DNS Zone Contributor" --assignee <appId GUID> --scope <dns zone resource id>  
 ```
 
 ## Deploy ExternalDNS

--- a/provider/azure_private_dns.go
+++ b/provider/azure_private_dns.go
@@ -175,19 +175,9 @@ func (p *AzurePrivateDNSProvider) zones(ctx context.Context) ([]privatedns.Priva
 		zone := i.Value()
 		log.Debugf("Validating Zone: %v", *zone.Name)
 
-		if zone.Name == nil {
-			continue
+		if zone.Name != nil && p.domainFilter.Match(*zone.Name) && p.zoneIDFilter.Match(*zone.ID) {
+			zones = append(zones, zone)
 		}
-
-		if !p.domainFilter.Match(*zone.Name) {
-			continue
-		}
-
-		if !p.zoneIDFilter.Match(*zone.ID) {
-			continue
-		}
-
-		zones = append(zones, zone)
 
 		err := i.NextWithContext(ctx)
 		if err != nil {


### PR DESCRIPTION
**Issue**
The function detecting the Azure Private DNS Zones to manage has an endless loop because the iterator on the underlying collection is not moved properly in case zones _not matching_ zone-filters are found.

**Fix**
Change the loop by moving the iterator in all cases.