### PR TITLE
Fixing ClusterRoleBinding default namespace

### DIFF
--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -195,7 +195,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: external-dns
-  namespace: default
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Fixing ClusterRoleBinding explicitly set to deploy to default namespace where other resources are not set to any namespace.