### PR TITLE
Add option to define minimum TTL for rfc2136 provider

### DIFF
--- a/main.go
+++ b/main.go
@@ -240,7 +240,7 @@ func main() {
 			p, err = provider.NewOCIProvider(*config, domainFilter, zoneIDFilter, cfg.DryRun)
 		}
 	case "rfc2136":
-		p, err = provider.NewRfc2136Provider(cfg.RFC2136Host, cfg.RFC2136Port, cfg.RFC2136Zone, cfg.RFC2136Insecure, cfg.RFC2136TSIGKeyName, cfg.RFC2136TSIGSecret, cfg.RFC2136TSIGSecretAlg, cfg.RFC2136TAXFR, domainFilter, cfg.DryRun, nil)
+		p, err = provider.NewRfc2136Provider(cfg.RFC2136Host, cfg.RFC2136Port, cfg.RFC2136Zone, cfg.RFC2136Insecure, cfg.RFC2136TSIGKeyName, cfg.RFC2136TSIGSecret, cfg.RFC2136TSIGSecretAlg, cfg.RFC2136TAXFR, domainFilter, cfg.DryRun, nil, cfg.RFC2136MinTTLSeconds)
 	case "ns1":
 		p, err = provider.NewNS1Provider(
 			provider.NS1Config{

--- a/main.go
+++ b/main.go
@@ -240,7 +240,7 @@ func main() {
 			p, err = provider.NewOCIProvider(*config, domainFilter, zoneIDFilter, cfg.DryRun)
 		}
 	case "rfc2136":
-		p, err = provider.NewRfc2136Provider(cfg.RFC2136Host, cfg.RFC2136Port, cfg.RFC2136Zone, cfg.RFC2136Insecure, cfg.RFC2136TSIGKeyName, cfg.RFC2136TSIGSecret, cfg.RFC2136TSIGSecretAlg, cfg.RFC2136TAXFR, domainFilter, cfg.DryRun, nil, cfg.RFC2136MinTTLSeconds)
+		p, err = provider.NewRfc2136Provider(cfg.RFC2136Host, cfg.RFC2136Port, cfg.RFC2136Zone, cfg.RFC2136Insecure, cfg.RFC2136TSIGKeyName, cfg.RFC2136TSIGSecret, cfg.RFC2136TSIGSecretAlg, cfg.RFC2136TAXFR, domainFilter, cfg.DryRun, cfg.RFC2136MinTTLSeconds, nil)
 	case "ns1":
 		p, err = provider.NewNS1Provider(
 			provider.NS1Config{

--- a/main.go
+++ b/main.go
@@ -240,7 +240,7 @@ func main() {
 			p, err = provider.NewOCIProvider(*config, domainFilter, zoneIDFilter, cfg.DryRun)
 		}
 	case "rfc2136":
-		p, err = provider.NewRfc2136Provider(cfg.RFC2136Host, cfg.RFC2136Port, cfg.RFC2136Zone, cfg.RFC2136Insecure, cfg.RFC2136TSIGKeyName, cfg.RFC2136TSIGSecret, cfg.RFC2136TSIGSecretAlg, cfg.RFC2136TAXFR, domainFilter, cfg.DryRun, cfg.RFC2136MinTTLSeconds, nil)
+		p, err = provider.NewRfc2136Provider(cfg.RFC2136Host, cfg.RFC2136Port, cfg.RFC2136Zone, cfg.RFC2136Insecure, cfg.RFC2136TSIGKeyName, cfg.RFC2136TSIGSecret, cfg.RFC2136TSIGSecretAlg, cfg.RFC2136TAXFR, domainFilter, cfg.DryRun, cfg.RFC2136MinTTL, nil)
 	case "ns1":
 		p, err = provider.NewNS1Provider(
 			provider.NS1Config{

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -130,7 +130,7 @@ type Config struct {
 	RFC2136TSIGSecret                 string `secure:"yes"`
 	RFC2136TSIGSecretAlg              string
 	RFC2136TAXFR                      bool
-	RFC2136MinTTLSeconds              int64
+	RFC2136MinTTL                     time.Duration
 	NS1Endpoint                       string
 	NS1IgnoreSSL                      bool
 	TransIPAccountName                string
@@ -224,7 +224,7 @@ var defaultConfig = &Config{
 	RFC2136TSIGSecret:           "",
 	RFC2136TSIGSecretAlg:        "",
 	RFC2136TAXFR:                true,
-	RFC2136MinTTLSeconds:        0,
+	RFC2136MinTTL:               0,
 	NS1Endpoint:                 "",
 	NS1IgnoreSSL:                false,
 	TransIPAccountName:          "",
@@ -368,7 +368,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("rfc2136-tsig-secret", "When using the RFC2136 provider, specify the TSIG (base64) value to attached to DNS messages (required when --rfc2136-insecure=false)").Default(defaultConfig.RFC2136TSIGSecret).StringVar(&cfg.RFC2136TSIGSecret)
 	app.Flag("rfc2136-tsig-secret-alg", "When using the RFC2136 provider, specify the TSIG (base64) value to attached to DNS messages (required when --rfc2136-insecure=false)").Default(defaultConfig.RFC2136TSIGSecretAlg).StringVar(&cfg.RFC2136TSIGSecretAlg)
 	app.Flag("rfc2136-tsig-axfr", "When using the RFC2136 provider, specify the TSIG (base64) value to attached to DNS messages (required when --rfc2136-insecure=false)").BoolVar(&cfg.RFC2136TAXFR)
-	app.Flag("rfc2136-min-ttl", "When using the RFC2136 provider, specify minimal TTL (in seconds) for records. This value will be used if the provided TTL for a service/ingress is lower than this").Default(strconv.FormatInt(defaultConfig.RFC2136MinTTLSeconds, 10)).Int64Var(&cfg.RFC2136MinTTLSeconds)
+	app.Flag("rfc2136-min-ttl", "When using the RFC2136 provider, specify minimal TTL (in duration format) for records. This value will be used if the provided TTL for a service/ingress is lower than this").Default(defaultConfig.RFC2136MinTTL.String()).DurationVar(&cfg.RFC2136MinTTL)
 
 	// Flags related to TransIP provider
 	app.Flag("transip-account", "When using the TransIP provider, specify the account name (required when --provider=transip)").Default(defaultConfig.TransIPAccountName).StringVar(&cfg.TransIPAccountName)

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -130,6 +130,7 @@ type Config struct {
 	RFC2136TSIGSecret                 string `secure:"yes"`
 	RFC2136TSIGSecretAlg              string
 	RFC2136TAXFR                      bool
+	RFC2136MinTTLSeconds              int
 	NS1Endpoint                       string
 	NS1IgnoreSSL                      bool
 	TransIPAccountName                string
@@ -223,6 +224,7 @@ var defaultConfig = &Config{
 	RFC2136TSIGSecret:           "",
 	RFC2136TSIGSecretAlg:        "",
 	RFC2136TAXFR:                true,
+	RFC2136MinTTLSeconds:        0,
 	NS1Endpoint:                 "",
 	NS1IgnoreSSL:                false,
 	TransIPAccountName:          "",
@@ -366,6 +368,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("rfc2136-tsig-secret", "When using the RFC2136 provider, specify the TSIG (base64) value to attached to DNS messages (required when --rfc2136-insecure=false)").Default(defaultConfig.RFC2136TSIGSecret).StringVar(&cfg.RFC2136TSIGSecret)
 	app.Flag("rfc2136-tsig-secret-alg", "When using the RFC2136 provider, specify the TSIG (base64) value to attached to DNS messages (required when --rfc2136-insecure=false)").Default(defaultConfig.RFC2136TSIGSecretAlg).StringVar(&cfg.RFC2136TSIGSecretAlg)
 	app.Flag("rfc2136-tsig-axfr", "When using the RFC2136 provider, specify the TSIG (base64) value to attached to DNS messages (required when --rfc2136-insecure=false)").BoolVar(&cfg.RFC2136TAXFR)
+	app.Flag("rfc2136-min-ttl", "When using the RFC2136 provider, specify minimal TTL (in seconds) for records. This value will be used if the provided TTL for a service/ingress is lower than this").Default(strconv.Itoa(defaultConfig.RFC2136MinTTLSeconds)).IntVar(&cfg.RFC2136MinTTLSeconds)
 
 	// Flags related to TransIP provider
 	app.Flag("transip-account", "When using the TransIP provider, specify the account name (required when --provider=transip)").Default(defaultConfig.TransIPAccountName).StringVar(&cfg.TransIPAccountName)

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -130,7 +130,7 @@ type Config struct {
 	RFC2136TSIGSecret                 string `secure:"yes"`
 	RFC2136TSIGSecretAlg              string
 	RFC2136TAXFR                      bool
-	RFC2136MinTTLSeconds              int
+	RFC2136MinTTLSeconds              int64
 	NS1Endpoint                       string
 	NS1IgnoreSSL                      bool
 	TransIPAccountName                string
@@ -368,7 +368,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("rfc2136-tsig-secret", "When using the RFC2136 provider, specify the TSIG (base64) value to attached to DNS messages (required when --rfc2136-insecure=false)").Default(defaultConfig.RFC2136TSIGSecret).StringVar(&cfg.RFC2136TSIGSecret)
 	app.Flag("rfc2136-tsig-secret-alg", "When using the RFC2136 provider, specify the TSIG (base64) value to attached to DNS messages (required when --rfc2136-insecure=false)").Default(defaultConfig.RFC2136TSIGSecretAlg).StringVar(&cfg.RFC2136TSIGSecretAlg)
 	app.Flag("rfc2136-tsig-axfr", "When using the RFC2136 provider, specify the TSIG (base64) value to attached to DNS messages (required when --rfc2136-insecure=false)").BoolVar(&cfg.RFC2136TAXFR)
-	app.Flag("rfc2136-min-ttl", "When using the RFC2136 provider, specify minimal TTL (in seconds) for records. This value will be used if the provided TTL for a service/ingress is lower than this").Default(strconv.Itoa(defaultConfig.RFC2136MinTTLSeconds)).IntVar(&cfg.RFC2136MinTTLSeconds)
+	app.Flag("rfc2136-min-ttl", "When using the RFC2136 provider, specify minimal TTL (in seconds) for records. This value will be used if the provided TTL for a service/ingress is lower than this").Default(strconv.FormatInt(defaultConfig.RFC2136MinTTLSeconds, 10)).Int64Var(&cfg.RFC2136MinTTLSeconds)
 
 	// Flags related to TransIP provider
 	app.Flag("transip-account", "When using the TransIP provider, specify the account name (required when --provider=transip)").Default(defaultConfig.TransIPAccountName).StringVar(&cfg.TransIPAccountName)

--- a/pkg/apis/externaldns/validation/validation.go
+++ b/pkg/apis/externaldns/validation/validation.go
@@ -83,7 +83,7 @@ func ValidateConfig(cfg *externaldns.Config) error {
 	}
 
 	if cfg.Provider == "rfc2136" {
-		if cfg.RFC2136MinTTLSeconds < 0 {
+		if cfg.RFC2136MinTTL < 0 {
 			return errors.New("TTL specified for rfc2136 is negative")
 		}
 	}

--- a/pkg/apis/externaldns/validation/validation.go
+++ b/pkg/apis/externaldns/validation/validation.go
@@ -82,6 +82,12 @@ func ValidateConfig(cfg *externaldns.Config) error {
 		}
 	}
 
+	if cfg.Provider == "rfc2136" {
+		if cfg.RFC2136MinTTLSeconds < 0 {
+			return errors.New("TTL specified for rfc2136 is negative")
+		}
+	}
+
 	if cfg.IgnoreHostnameAnnotation && cfg.FQDNTemplate == "" {
 		return errors.New("FQDN Template must be set if ignoring annotations")
 	}

--- a/pkg/apis/externaldns/validation/validation_test.go
+++ b/pkg/apis/externaldns/validation/validation_test.go
@@ -131,7 +131,7 @@ func TestValidateBadRfc2136Config(t *testing.T) {
 	cfg.LogFormat = "json"
 	cfg.Sources = []string{"test-source"}
 	cfg.Provider = "rfc2136"
-	cfg.RFC2136MinTTLSeconds = -1
+	cfg.RFC2136MinTTL = -1
 
 	err := ValidateConfig(cfg)
 
@@ -144,7 +144,7 @@ func TestValidateGoodRfc2136Config(t *testing.T) {
 	cfg.LogFormat = "json"
 	cfg.Sources = []string{"test-source"}
 	cfg.Provider = "rfc2136"
-	cfg.RFC2136MinTTLSeconds = 3600
+	cfg.RFC2136MinTTL = 3600
 
 	err := ValidateConfig(cfg)
 

--- a/pkg/apis/externaldns/validation/validation_test.go
+++ b/pkg/apis/externaldns/validation/validation_test.go
@@ -124,3 +124,29 @@ func TestValidateBadIgnoreHostnameAnnotationsConfig(t *testing.T) {
 
 	assert.Error(t, ValidateConfig(cfg))
 }
+
+func TestValidateBadRfc2136Config(t *testing.T) {
+	cfg := externaldns.NewConfig()
+
+	cfg.LogFormat = "json"
+	cfg.Sources = []string{"test-source"}
+	cfg.Provider = "rfc2136"
+	cfg.RFC2136MinTTLSeconds = -1
+
+	err := ValidateConfig(cfg)
+
+	assert.NotNil(t, err)
+}
+
+func TestValidateGoodRfc2136Config(t *testing.T) {
+	cfg := externaldns.NewConfig()
+
+	cfg.LogFormat = "json"
+	cfg.Sources = []string{"test-source"}
+	cfg.Provider = "rfc2136"
+	cfg.RFC2136MinTTLSeconds = 3600
+
+	err := ValidateConfig(cfg)
+
+	assert.Nil(t, err)
+}

--- a/provider/rfc2136.go
+++ b/provider/rfc2136.go
@@ -41,6 +41,7 @@ type rfc2136Provider struct {
 	tsigSecretAlg string
 	insecure      bool
 	axfr          bool
+	minTTLSeconds int
 
 	// only consider hosted zones managing domains ending in this suffix
 	domainFilter DomainFilter
@@ -64,19 +65,20 @@ type rfc2136Actions interface {
 }
 
 // NewRfc2136Provider is a factory function for OpenStack rfc2136 providers
-func NewRfc2136Provider(host string, port int, zoneName string, insecure bool, keyName string, secret string, secretAlg string, axfr bool, domainFilter DomainFilter, dryRun bool, actions rfc2136Actions) (Provider, error) {
+func NewRfc2136Provider(host string, port int, zoneName string, insecure bool, keyName string, secret string, secretAlg string, axfr bool, domainFilter DomainFilter, dryRun bool, actions rfc2136Actions, minTTLSeconds int) (Provider, error) {
 	secretAlgChecked, ok := tsigAlgs[secretAlg]
 	if !ok && !insecure {
 		return nil, errors.Errorf("%s is not supported TSIG algorithm", secretAlg)
 	}
 
 	r := &rfc2136Provider{
-		nameserver:   net.JoinHostPort(host, strconv.Itoa(port)),
-		zoneName:     dns.Fqdn(zoneName),
-		insecure:     insecure,
-		domainFilter: domainFilter,
-		dryRun:       dryRun,
-		axfr:         axfr,
+		nameserver:    net.JoinHostPort(host, strconv.Itoa(port)),
+		zoneName:      dns.Fqdn(zoneName),
+		insecure:      insecure,
+		domainFilter:  domainFilter,
+		dryRun:        dryRun,
+		axfr:          axfr,
+		minTTLSeconds: minTTLSeconds,
 	}
 	if actions != nil {
 		r.actions = actions
@@ -253,8 +255,14 @@ func (r rfc2136Provider) UpdateRecord(m *dns.Msg, ep *endpoint.Endpoint) error {
 
 func (r rfc2136Provider) AddRecord(m *dns.Msg, ep *endpoint.Endpoint) error {
 	log.Debugf("AddRecord.ep=%s", ep)
+
+	var ttl = int64(r.minTTLSeconds)
+	if ep.RecordTTL.IsConfigured() && int64(ep.RecordTTL) > ttl {
+		ttl = int64(ep.RecordTTL)
+	}
+
 	for _, target := range ep.Targets {
-		newRR := fmt.Sprintf("%s %d %s %s", ep.DNSName, ep.RecordTTL, ep.RecordType, target)
+		newRR := fmt.Sprintf("%s %d %s %s", ep.DNSName, ttl, ep.RecordType, target)
 		log.Infof("Adding RR: %s", newRR)
 
 		rr, err := dns.NewRR(newRR)

--- a/provider/rfc2136.go
+++ b/provider/rfc2136.go
@@ -41,7 +41,7 @@ type rfc2136Provider struct {
 	tsigSecretAlg string
 	insecure      bool
 	axfr          bool
-	minTTLSeconds int
+	minTTLSeconds int64
 
 	// only consider hosted zones managing domains ending in this suffix
 	domainFilter DomainFilter
@@ -65,7 +65,7 @@ type rfc2136Actions interface {
 }
 
 // NewRfc2136Provider is a factory function for OpenStack rfc2136 providers
-func NewRfc2136Provider(host string, port int, zoneName string, insecure bool, keyName string, secret string, secretAlg string, axfr bool, domainFilter DomainFilter, dryRun bool, actions rfc2136Actions, minTTLSeconds int) (Provider, error) {
+func NewRfc2136Provider(host string, port int, zoneName string, insecure bool, keyName string, secret string, secretAlg string, axfr bool, domainFilter DomainFilter, dryRun bool, minTTLSeconds int64, actions rfc2136Actions) (Provider, error) {
 	secretAlgChecked, ok := tsigAlgs[secretAlg]
 	if !ok && !insecure {
 		return nil, errors.Errorf("%s is not supported TSIG algorithm", secretAlg)
@@ -256,7 +256,7 @@ func (r rfc2136Provider) UpdateRecord(m *dns.Msg, ep *endpoint.Endpoint) error {
 func (r rfc2136Provider) AddRecord(m *dns.Msg, ep *endpoint.Endpoint) error {
 	log.Debugf("AddRecord.ep=%s", ep)
 
-	var ttl = int64(r.minTTLSeconds)
+	var ttl = r.minTTLSeconds
 	if ep.RecordTTL.IsConfigured() && int64(ep.RecordTTL) > ttl {
 		ttl = int64(ep.RecordTTL)
 	}

--- a/provider/rfc2136_test.go
+++ b/provider/rfc2136_test.go
@@ -44,14 +44,8 @@ func newStub() *rfc2136Stub {
 }
 
 func (r *rfc2136Stub) SendMessage(msg *dns.Msg) error {
-	const searchPattern = "AUTHORITY SECTION:"
-
-	data := msg.String()
-	log.Info(data)
-
-	authoritySectionOffset := strings.Index(data, searchPattern)
-	lines := strings.Split(strings.TrimSpace(data[authoritySectionOffset+len(searchPattern):]), "\n")
-
+	log.Info(msg.String())
+	lines := extractAuthoritySectionFromMessage(msg)
 	for _, line := range lines {
 		// break at first empty line
 		if len(strings.TrimSpace(line)) == 0 {
@@ -98,7 +92,14 @@ func (r *rfc2136Stub) IncomeTransfer(m *dns.Msg, a string) (env chan *dns.Envelo
 }
 
 func createRfc2136StubProvider(stub *rfc2136Stub) (Provider, error) {
-	return NewRfc2136Provider("", 0, "", false, "key", "secret", "hmac-sha512", true, DomainFilter{}, false, stub)
+	return NewRfc2136Provider("", 0, "", false, "key", "secret", "hmac-sha512", true, DomainFilter{}, false, stub, 300)
+}
+
+func extractAuthoritySectionFromMessage(msg *dns.Msg) []string {
+	const searchPattern = "AUTHORITY SECTION:"
+	data := msg.String()
+	authoritySectionOffset := strings.Index(data, searchPattern)
+	return strings.Split(strings.TrimSpace(data[authoritySectionOffset+len(searchPattern):]), "\n")
 }
 
 // TestRfc2136GetRecordsMultipleTargets simulates a single record with multiple targets.
@@ -162,6 +163,7 @@ func TestRfc2136ApplyChanges(t *testing.T) {
 				DNSName:    "v1.foo.com",
 				RecordType: "A",
 				Targets:    []string{"1.2.3.4"},
+				RecordTTL:  endpoint.TTL(400),
 			},
 			{
 				DNSName:    "v1.foobar.com",
@@ -196,5 +198,50 @@ func TestRfc2136ApplyChanges(t *testing.T) {
 	assert.Equal(t, 2, len(stub.updateMsgs))
 	assert.True(t, strings.Contains(stub.updateMsgs[0].String(), "v2.foo.com"))
 	assert.True(t, strings.Contains(stub.updateMsgs[1].String(), "v2.foobar.com"))
+
+}
+
+func TestRfc2136ApplyChangesWithDifferentTTLs(t *testing.T) {
+	stub := newStub()
+
+	provider, err := createRfc2136StubProvider(stub)
+	assert.NoError(t, err)
+
+	p := &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			{
+				DNSName:    "v1.foo.com",
+				RecordType: "A",
+				Targets:    []string{"2.1.1.1"},
+				RecordTTL:  endpoint.TTL(400),
+			},
+			{
+				DNSName:    "v2.foo.com",
+				RecordType: "A",
+				Targets:    []string{"3.2.2.2"},
+				RecordTTL:  endpoint.TTL(200),
+			},
+			{
+				DNSName:    "v3.foo.com",
+				RecordType: "A",
+				Targets:    []string{"4.3.3.3"},
+			},
+		},
+	}
+
+	err = provider.ApplyChanges(context.Background(), p)
+	assert.NoError(t, err)
+
+	createRecords := extractAuthoritySectionFromMessage(stub.createMsgs[0])
+	assert.Equal(t, 3, len(createRecords))
+	assert.True(t, strings.Contains(createRecords[0], "v1.foo.com"))
+	assert.True(t, strings.Contains(createRecords[0], "2.1.1.1"))
+	assert.True(t, strings.Contains(createRecords[0], "400"))
+	assert.True(t, strings.Contains(createRecords[1], "v2.foo.com"))
+	assert.True(t, strings.Contains(createRecords[1], "3.2.2.2"))
+	assert.True(t, strings.Contains(createRecords[1], "300"))
+	assert.True(t, strings.Contains(createRecords[2], "v3.foo.com"))
+	assert.True(t, strings.Contains(createRecords[2], "4.3.3.3"))
+	assert.True(t, strings.Contains(createRecords[2], "300"))
 
 }

--- a/provider/rfc2136_test.go
+++ b/provider/rfc2136_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
@@ -93,7 +94,7 @@ func (r *rfc2136Stub) IncomeTransfer(m *dns.Msg, a string) (env chan *dns.Envelo
 }
 
 func createRfc2136StubProvider(stub *rfc2136Stub) (Provider, error) {
-	return NewRfc2136Provider("", 0, "", false, "key", "secret", "hmac-sha512", true, DomainFilter{}, false, 300, stub)
+	return NewRfc2136Provider("", 0, "", false, "key", "secret", "hmac-sha512", true, DomainFilter{}, false, 300*time.Second, stub)
 }
 
 func extractAuthoritySectionFromMessage(msg fmt.Stringer) []string {

--- a/provider/rfc2136_test.go
+++ b/provider/rfc2136_test.go
@@ -93,14 +93,13 @@ func (r *rfc2136Stub) IncomeTransfer(m *dns.Msg, a string) (env chan *dns.Envelo
 }
 
 func createRfc2136StubProvider(stub *rfc2136Stub) (Provider, error) {
-	return NewRfc2136Provider("", 0, "", false, "key", "secret", "hmac-sha512", true, DomainFilter{}, false, stub, 300)
+	return NewRfc2136Provider("", 0, "", false, "key", "secret", "hmac-sha512", true, DomainFilter{}, false, 300, stub)
 }
 
 func extractAuthoritySectionFromMessage(msg fmt.Stringer) []string {
 	const searchPattern = "AUTHORITY SECTION:"
-	data := msg.String()
-	authoritySectionOffset := strings.Index(data, searchPattern)
-	return strings.Split(strings.TrimSpace(data[authoritySectionOffset+len(searchPattern):]), "\n")
+	authoritySectionOffset := strings.Index(msg.String(), searchPattern)
+	return strings.Split(strings.TrimSpace(msg.String()[authoritySectionOffset+len(searchPattern):]), "\n")
 }
 
 // TestRfc2136GetRecordsMultipleTargets simulates a single record with multiple targets.

--- a/provider/rfc2136_test.go
+++ b/provider/rfc2136_test.go
@@ -18,6 +18,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -95,7 +96,7 @@ func createRfc2136StubProvider(stub *rfc2136Stub) (Provider, error) {
 	return NewRfc2136Provider("", 0, "", false, "key", "secret", "hmac-sha512", true, DomainFilter{}, false, stub, 300)
 }
 
-func extractAuthoritySectionFromMessage(msg *dns.Msg) []string {
+func extractAuthoritySectionFromMessage(msg fmt.Stringer) []string {
 	const searchPattern = "AUTHORITY SECTION:"
 	data := msg.String()
 	authoritySectionOffset := strings.Index(data, searchPattern)


### PR DESCRIPTION
This pr also fulfills #1249 by allowing a minimum TTL to RFC which can also be used as a default TTL value.