### PR TITLE
Adding issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,0 +1,25 @@
+---
+name: "\U0001F41E Bug report"
+about: Report a bug encountered while operating external-dns
+title: ''
+labels: kind/bug
+assignees: ''
+
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
+
+-->
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+**Environment**:
+- External-DNS version (use `external-dns --version`):
+- DNS provider:
+- Others:

--- a/.github/ISSUE_TEMPLATE/--enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/--enhancement-request.md
@@ -1,0 +1,14 @@
+---
+name: "✨ Enhancement Request"
+about: Suggest an enhancement to external-dns
+title: ''
+labels: kind/feature
+assignees: ''
+
+---
+
+<!-- Please only use this template for submitting enhancement requests. This can be something like a new provider or a new gateway.  -->
+
+**What would you like to be added**:
+
+**Why is this needed**:

--- a/.github/ISSUE_TEMPLATE/-support-request.md
+++ b/.github/ISSUE_TEMPLATE/-support-request.md
@@ -1,0 +1,19 @@
+---
+name: "❓Support Request"
+about: Support request or question relating to external-dns
+title: ''
+labels: triage/support
+assignees: ''
+
+---
+
+<!--
+STOP -- PLEASE READ!
+
+GitHub is not the right place for support requests.
+
+If you're looking for help, check our [docs](https://github.com/kubernetes-sigs/external-dns/tree/master/docs).
+
+You can also post your question on the [Kubernetes Slack #external-dns](https://kubernetes.slack.com/archives/C771MKDKQ).
+
+-->


### PR DESCRIPTION
I think there's a lack of quality when it comes to external-dns issues. I'd like to improve it by providing templates which help user to fill out issues properly. 