### PR TITLE
Remove duplicate targets from endpoints for headless services

### DIFF
--- a/source/service.go
+++ b/source/service.go
@@ -263,14 +263,14 @@ func (sc *serviceSource) extractHeadlessEndpoints(svc *v1.Service, hostname stri
 		allTargets := targetsByHeadlessDomain[headlessDomain]
 		targets := []string{}
 
-		deduppedTargets := map[string]bool{}
+		deduppedTargets := map[string]struct{}{}
 		for _, target := range allTargets {
 			if _, ok := deduppedTargets[target]; ok {
 				log.Debugf("Removing duplicate target %s", target)
 				continue
 			}
 
-			deduppedTargets[target] = true
+			deduppedTargets[target] = struct{}{}
 			targets = append(targets, target)
 		}
 

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -1788,6 +1788,33 @@ func TestHeadlessServices(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"annotated Headless services return only a unique set of targets",
+			"",
+			"testing",
+			"foo",
+			v1.ServiceTypeClusterIP,
+			"",
+			"",
+			false,
+			map[string]string{"component": "foo"},
+			map[string]string{
+				hostnameAnnotationKey: "service.example.org",
+			},
+			v1.ClusterIPNone,
+			[]string{"1.1.1.1", "1.1.1.1", "1.1.1.2"},
+			map[string]string{
+				"component": "foo",
+			},
+			[]string{},
+			[]string{"foo-0", "foo-1", "foo-3"},
+			[]string{"", "", ""},
+			[]v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodRunning},
+			[]*endpoint.Endpoint{
+				{DNSName: "service.example.org", Targets: endpoint.Targets{"1.1.1.1", "1.1.1.2"}},
+			},
+			false,
+		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
 			// Create a Kubernetes testing client


### PR DESCRIPTION
Fixes #1015 

PR #645 introduced an issue where endpoints for headless services could return duplicate target IP addresses, which the Route53 API does not allow. This PR ensures that an endpoint can only point to a unique set of target IP addresses. 

