### PR TITLE
chore(aws): Adds BestZoneMatch as an alternative way to target zones.

### DIFF
--- a/main.go
+++ b/main.go
@@ -175,6 +175,7 @@ func main() {
 				APIRetries:           cfg.AWSAPIRetries,
 				PreferCNAME:          cfg.AWSPreferCNAME,
 				DryRun:               cfg.DryRun,
+				AwsUseBestZoneMatch:  cfg.AwsUseBestZoneMatch,
 			},
 		)
 	case "aws-sd":

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -142,6 +142,7 @@ type Config struct {
 	TransIPAccountName                string
 	TransIPPrivateKeyFile             string
 	DigitalOceanAPIPageSize           int
+	AwsUseBestZoneMatch               bool
 }
 
 var defaultConfig = &Config{
@@ -241,6 +242,7 @@ var defaultConfig = &Config{
 	TransIPAccountName:          "",
 	TransIPPrivateKeyFile:       "",
 	DigitalOceanAPIPageSize:     50,
+	AwsUseBestZoneMatch:         false,
 }
 
 // NewConfig returns new Config object
@@ -415,6 +417,8 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("metrics-address", "Specify where to serve the metrics and health check endpoint (default: :7979)").Default(defaultConfig.MetricsAddress).StringVar(&cfg.MetricsAddress)
 	app.Flag("log-level", "Set the level of logging. (default: info, options: panic, debug, info, warning, error, fatal").Default(defaultConfig.LogLevel).EnumVar(&cfg.LogLevel, allLogLevelsAsStrings()...)
 
+	// Best Zone Match flag
+	app.Flag("aws-best-zone-match", "Search for the longest zone suffix possible when filtering zones (default: disabled)").Default(strconv.FormatBool(defaultConfig.AwsUseBestZoneMatch)).BoolVar(&cfg.AwsUseBestZoneMatch)
 	_, err := app.Parse(args)
 	if err != nil {
 		return err

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -670,7 +670,7 @@ func changesByZone(zones map[string]*route53.HostedZone, changeSet []*route53.Ch
 		changes[aws.StringValue(z.Id)] = []*route53.Change{}
 	}
 	for _, c := range changeSet {
-		hostname := ensureTrailingDot(aws.StringValue(c.ResourceRecordSet.Name))
+		hostname := provider.EnsureTrailingDot(aws.StringValue(c.ResourceRecordSet.Name))
 		var thisZones []*route53.HostedZone
 		if awsUseBestZoneMatch {
 			thisZones = findBestZone(hostname, zones)

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -637,7 +637,7 @@ func TestAWSChangesByZones(t *testing.T) {
 		},
 	}
 
-	changesByZone := changesByZone(zones, changes)
+	changesByZone := changesByZone(zones, changes, false)
 	require.Len(t, changesByZone, 3)
 
 	validateAWSChangeRecords(t, changesByZone["foo-example-org"], []*route53.Change{
@@ -681,6 +681,40 @@ func TestAWSChangesByZones(t *testing.T) {
 			Action: aws.String(route53.ChangeActionDelete),
 			ResourceRecordSet: &route53.ResourceRecordSet{
 				Name: aws.String("wambo.bar.example.org"), TTL: aws.Int64(20),
+			},
+		},
+	})
+}
+
+func TestAWSChangesByZonesWithBestzone(t *testing.T) {
+	changes := []*route53.Change{
+		{
+			Action: aws.String(route53.ChangeActionCreate),
+			ResourceRecordSet: &route53.ResourceRecordSet{
+				Name: aws.String("bar.foo.example.org"), TTL: aws.Int64(1),
+			},
+		},
+	}
+
+	zones := map[string]*route53.HostedZone{
+		"foo-example-org": {
+			Id:   aws.String("foo-example-org"),
+			Name: aws.String("foo.example.org."),
+		},
+		"example-org": {
+			Id:   aws.String("example-org"),
+			Name: aws.String("example.org."),
+		},
+	}
+
+	changesByZone := changesByZone(zones, changes, true)
+	require.Len(t, changesByZone, 1)
+
+	validateAWSChangeRecords(t, changesByZone["foo-example-org"], []*route53.Change{
+		{
+			Action: aws.String(route53.ChangeActionCreate),
+			ResourceRecordSet: &route53.ResourceRecordSet{
+				Name: aws.String("bar.foo.example.org"), TTL: aws.Int64(1),
 			},
 		},
 	})


### PR DESCRIPTION
When calculating the changes needed for the registry `bar.foo.example.org`, `external-dns` will match `foo.example.org` and  `example.org`, creating *two*  different changeSets on *two*  separated zones.

On my environment, Route 53, where `foo.example.org` is a private subzone of `example.com` this behavior is a security concern.

This PR adds the flag `aws-best-zone-match` that activates the use of `findBestZone` to return the list of zones that cover the longest suffix.

Signed-off-by: Sergio Morales <sergio@cornershopapp.com>