### PR TITLE
Change DomainFilter to apply to records as well

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
+	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
 	"sigs.k8s.io/external-dns/registry"
@@ -100,6 +101,8 @@ type Controller struct {
 	Policy plan.Policy
 	// The interval between individual synchronizations
 	Interval time.Duration
+	// The DomainFilter defines which DNS records to keep or exclude
+	DomainFilter endpoint.DomainFilter
 }
 
 // RunOnce runs a single iteration of a reconciliation loop.
@@ -123,9 +126,10 @@ func (c *Controller) RunOnce(ctx context.Context) error {
 	sourceEndpointsTotal.Set(float64(len(endpoints)))
 
 	plan := &plan.Plan{
-		Policies: []plan.Policy{c.Policy},
-		Current:  records,
-		Desired:  endpoints,
+		Policies:     []plan.Policy{c.Policy},
+		Current:      records,
+		Desired:      endpoints,
+		DomainFilter: c.DomainFilter,
 	}
 
 	plan = plan.Calculate()

--- a/endpoint/domain_filter.go
+++ b/endpoint/domain_filter.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package provider
+package endpoint
 
 import (
 	"strings"
@@ -22,7 +22,9 @@ import (
 
 // DomainFilter holds a lists of valid domain names
 type DomainFilter struct {
-	filters []string
+	// Filters define what domains to match
+	Filters []string
+	// exclude define what domains not to match
 	exclude []string
 }
 
@@ -47,7 +49,7 @@ func NewDomainFilter(domainFilters []string) DomainFilter {
 
 // Match checks whether a domain can be found in the DomainFilter.
 func (df DomainFilter) Match(domain string) bool {
-	return matchFilter(df.filters, domain, true) && !matchFilter(df.exclude, domain, false)
+	return matchFilter(df.Filters, domain, true) && !matchFilter(df.exclude, domain, false)
 }
 
 // matchFilter determines if any `filters` match `domain`.
@@ -78,8 +80,8 @@ func matchFilter(filters []string, domain string, emptyval bool) bool {
 
 // IsConfigured returns true if DomainFilter is configured, false otherwise
 func (df DomainFilter) IsConfigured() bool {
-	if len(df.filters) == 1 {
-		return df.filters[0] != ""
+	if len(df.Filters) == 1 {
+		return df.Filters[0] != ""
 	}
-	return len(df.filters) > 0
+	return len(df.Filters) > 0
 }

--- a/endpoint/domain_filter_test.go
+++ b/endpoint/domain_filter_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package provider
+package endpoint
 
 import (
 	"testing"

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"sigs.k8s.io/external-dns/controller"
+	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns/validation"
 	"sigs.k8s.io/external-dns/plan"
@@ -111,7 +112,7 @@ func main() {
 	// Combine multiple sources into a single, deduplicated source.
 	endpointsSource := source.NewDedupSource(source.NewMultiSource(sources))
 
-	domainFilter := provider.NewDomainFilterWithExclusions(cfg.DomainFilter, cfg.ExcludeDomains)
+	domainFilter := endpoint.NewDomainFilterWithExclusions(cfg.DomainFilter, cfg.ExcludeDomains)
 	zoneIDFilter := provider.NewZoneIDFilter(cfg.ZoneIDFilter)
 	zoneTypeFilter := provider.NewZoneTypeFilter(cfg.AWSZoneType)
 	zoneTagFilter := provider.NewZoneTagFilter(cfg.AWSZoneTagFilter)
@@ -282,10 +283,11 @@ func main() {
 	}
 
 	ctrl := controller.Controller{
-		Source:   endpointsSource,
-		Registry: r,
-		Policy:   policy,
-		Interval: cfg.Interval,
+		Source:       endpointsSource,
+		Registry:     r,
+		Policy:       policy,
+		Interval:     cfg.Interval,
+		DomainFilter: domainFilter,
 	}
 
 	if cfg.UpdateEvents {

--- a/provider/akamai.go
+++ b/provider/akamai.go
@@ -49,7 +49,7 @@ func (*akamaiOpenClient) Do(config edgegrid.Config, req *http.Request) (*http.Re
 
 // AkamaiConfig clarifies the method signature
 type AkamaiConfig struct {
-	DomainFilter          DomainFilter
+	DomainFilter          endpoint.DomainFilter
 	ZoneIDFilter          ZoneIDFilter
 	ServiceConsumerDomain string
 	ClientToken           string
@@ -60,7 +60,7 @@ type AkamaiConfig struct {
 
 // AkamaiProvider implements the DNS provider for Akamai.
 type AkamaiProvider struct {
-	domainFilter DomainFilter
+	domainFilter endpoint.DomainFilter
 	zoneIDFilter ZoneIDFilter
 	config       edgegrid.Config
 	dryRun       bool

--- a/provider/akamai_test.go
+++ b/provider/akamai_test.go
@@ -108,7 +108,7 @@ func TestFetchZonesZoneIDFilter(t *testing.T) {
 
 func TestFetchZonesEmpty(t *testing.T) {
 	config := AkamaiConfig{
-		DomainFilter: NewDomainFilter([]string{"Nonexistent"}),
+		DomainFilter: endpoint.NewDomainFilter([]string{"Nonexistent"}),
 		ZoneIDFilter: NewZoneIDFilter([]string{"Nonexistent"}),
 	}
 
@@ -184,7 +184,7 @@ func TestAkamaiRecordsEmpty(t *testing.T) {
 
 func TestAkamaiRecordsFilters(t *testing.T) {
 	config := AkamaiConfig{
-		DomainFilter: NewDomainFilter([]string{"www.exclude.me"}),
+		DomainFilter: endpoint.NewDomainFilter([]string{"www.exclude.me"}),
 		ZoneIDFilter: NewZoneIDFilter([]string{"Exclude-Me"}),
 	}
 
@@ -221,7 +221,7 @@ func TestCreateRecords(t *testing.T) {
 
 func TestCreateRecordsDomainFilter(t *testing.T) {
 	config := AkamaiConfig{
-		DomainFilter: NewDomainFilter([]string{"example.com"}),
+		DomainFilter: endpoint.NewDomainFilter([]string{"example.com"}),
 	}
 
 	client := &mockAkamaiClient{}
@@ -260,7 +260,7 @@ func TestDeleteRecords(t *testing.T) {
 
 func TestDeleteRecordsDomainFilter(t *testing.T) {
 	config := AkamaiConfig{
-		DomainFilter: NewDomainFilter([]string{"example.com"}),
+		DomainFilter: endpoint.NewDomainFilter([]string{"example.com"}),
 	}
 
 	client := &mockAkamaiClient{}
@@ -299,7 +299,7 @@ func TestUpdateRecords(t *testing.T) {
 
 func TestUpdateRecordsDomainFilter(t *testing.T) {
 	config := AkamaiConfig{
-		DomainFilter: NewDomainFilter([]string{"example.com"}),
+		DomainFilter: endpoint.NewDomainFilter([]string{"example.com"}),
 	}
 
 	client := &mockAkamaiClient{}

--- a/provider/alibaba_cloud.go
+++ b/provider/alibaba_cloud.go
@@ -66,7 +66,7 @@ type AlibabaCloudPrivateZoneAPI interface {
 
 // AlibabaCloudProvider implements the DNS provider for Alibaba Cloud.
 type AlibabaCloudProvider struct {
-	domainFilter         DomainFilter
+	domainFilter         endpoint.DomainFilter
 	zoneIDFilter         ZoneIDFilter // Private Zone only
 	MaxChangeCount       int
 	EvaluateTargetHealth bool
@@ -93,7 +93,7 @@ type alibabaCloudConfig struct {
 // NewAlibabaCloudProvider creates a new Alibaba Cloud provider.
 //
 // Returns the provider or an error if a provider could not be created.
-func NewAlibabaCloudProvider(configFile string, domainFilter DomainFilter, zoneIDFileter ZoneIDFilter, zoneType string, dryRun bool) (*AlibabaCloudProvider, error) {
+func NewAlibabaCloudProvider(configFile string, domainFilter endpoint.DomainFilter, zoneIDFileter ZoneIDFilter, zoneType string, dryRun bool) (*AlibabaCloudProvider, error) {
 	cfg := alibabaCloudConfig{}
 	if configFile != "" {
 		contents, err := ioutil.ReadFile(configFile)
@@ -382,7 +382,7 @@ func (p *AlibabaCloudProvider) records() ([]alidns.Record, error) {
 	log.Infof("Retrieving Alibaba Cloud DNS Domain Records")
 	var results []alidns.Record
 
-	if len(p.domainFilter.filters) == 1 && p.domainFilter.filters[0] == "" {
+	if len(p.domainFilter.Filters) == 1 && p.domainFilter.Filters[0] == "" {
 		domainNames, tmpErr := p.getDomainList()
 		if tmpErr != nil {
 			log.Errorf("AlibabaCloudProvider getDomainList error %v", tmpErr)
@@ -397,7 +397,7 @@ func (p *AlibabaCloudProvider) records() ([]alidns.Record, error) {
 			results = append(results, tmpResults...)
 		}
 	} else {
-		for _, domainName := range p.domainFilter.filters {
+		for _, domainName := range p.domainFilter.Filters {
 			tmpResults, err := p.getDomainRecords(domainName)
 			if err != nil {
 				log.Errorf("getDomainRecords %s error %v", domainName, err)
@@ -672,7 +672,7 @@ func (p *AlibabaCloudProvider) splitDNSName(endpoint *endpoint.Endpoint) (rr str
 
 	found := false
 
-	for _, filter := range p.domainFilter.filters {
+	for _, filter := range p.domainFilter.Filters {
 		if strings.HasSuffix(name, "."+filter) {
 			rr = name[0 : len(name)-len(filter)-1]
 			domain = filter

--- a/provider/alibaba_cloud_test.go
+++ b/provider/alibaba_cloud_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/alidns"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/pvtz"
+
 	"sigs.k8s.io/external-dns/endpoint"
 
 	"sigs.k8s.io/external-dns/plan"
@@ -232,7 +233,7 @@ func newTestAlibabaCloudProvider(private bool) *AlibabaCloudProvider {
 	//	cfg.AccessKeyID,
 	//	cfg.AccessKeySecret,
 	//)
-	domainFilterTest := NewDomainFilter([]string{"container-service.top.", "example.org"})
+	domainFilterTest := endpoint.NewDomainFilter([]string{"container-service.top.", "example.org"})
 
 	return &AlibabaCloudProvider{
 		domainFilter: domainFilterTest,

--- a/provider/aws.go
+++ b/provider/aws.go
@@ -117,7 +117,7 @@ type AWSProvider struct {
 	batchChangeInterval  time.Duration
 	evaluateTargetHealth bool
 	// only consider hosted zones managing domains ending in this suffix
-	domainFilter DomainFilter
+	domainFilter endpoint.DomainFilter
 	// filter hosted zones by id
 	zoneIDFilter ZoneIDFilter
 	// filter hosted zones by type (e.g. private or public)
@@ -129,7 +129,7 @@ type AWSProvider struct {
 
 // AWSConfig contains configuration to create a new AWS provider.
 type AWSConfig struct {
-	DomainFilter         DomainFilter
+	DomainFilter         endpoint.DomainFilter
 	ZoneIDFilter         ZoneIDFilter
 	ZoneTypeFilter       ZoneTypeFilter
 	ZoneTagFilter        ZoneTagFilter

--- a/provider/aws_sd.go
+++ b/provider/aws_sd.go
@@ -76,13 +76,13 @@ type AWSSDProvider struct {
 	client AWSSDClient
 	dryRun bool
 	// only consider namespaces ending in this suffix
-	namespaceFilter DomainFilter
+	namespaceFilter endpoint.DomainFilter
 	// filter namespace by type (private or public)
 	namespaceTypeFilter *sd.NamespaceFilter
 }
 
 // NewAWSSDProvider initializes a new AWS Cloud Map based Provider.
-func NewAWSSDProvider(domainFilter DomainFilter, namespaceType string, assumeRole string, dryRun bool) (*AWSSDProvider, error) {
+func NewAWSSDProvider(domainFilter endpoint.DomainFilter, namespaceType string, assumeRole string, dryRun bool) (*AWSSDProvider, error) {
 	config := aws.NewConfig()
 
 	config = config.WithHTTPClient(

--- a/provider/aws_sd_test.go
+++ b/provider/aws_sd_test.go
@@ -180,7 +180,7 @@ func (s *AWSSDClientStub) UpdateService(input *sd.UpdateServiceInput) (*sd.Updat
 	return &sd.UpdateServiceOutput{}, nil
 }
 
-func newTestAWSSDProvider(api AWSSDClient, domainFilter DomainFilter, namespaceTypeFilter string) *AWSSDProvider {
+func newTestAWSSDProvider(api AWSSDClient, domainFilter endpoint.DomainFilter, namespaceTypeFilter string) *AWSSDProvider {
 	return &AWSSDProvider{
 		client:              api,
 		namespaceFilter:     domainFilter,
@@ -287,7 +287,7 @@ func TestAWSSDProvider_Records(t *testing.T) {
 		instances:  instances,
 	}
 
-	provider := newTestAWSSDProvider(api, NewDomainFilter([]string{}), "")
+	provider := newTestAWSSDProvider(api, endpoint.NewDomainFilter([]string{}), "")
 
 	endpoints, _ := provider.Records(context.Background())
 
@@ -315,7 +315,7 @@ func TestAWSSDProvider_ApplyChanges(t *testing.T) {
 		{DNSName: "service3.private.com", Targets: endpoint.Targets{"cname.target.com"}, RecordType: endpoint.RecordTypeCNAME, RecordTTL: 100},
 	}
 
-	provider := newTestAWSSDProvider(api, NewDomainFilter([]string{}), "")
+	provider := newTestAWSSDProvider(api, endpoint.NewDomainFilter([]string{}), "")
 
 	ctx := context.Background()
 
@@ -366,14 +366,14 @@ func TestAWSSDProvider_ListNamespaces(t *testing.T) {
 
 	for _, tc := range []struct {
 		msg                 string
-		domainFilter        DomainFilter
+		domainFilter        endpoint.DomainFilter
 		namespaceTypeFilter string
 		expectedNamespaces  []*sd.NamespaceSummary
 	}{
-		{"public filter", NewDomainFilter([]string{}), "public", []*sd.NamespaceSummary{namespaceToNamespaceSummary(namespaces["public"])}},
-		{"private filter", NewDomainFilter([]string{}), "private", []*sd.NamespaceSummary{namespaceToNamespaceSummary(namespaces["private"])}},
-		{"domain filter", NewDomainFilter([]string{"public.com"}), "", []*sd.NamespaceSummary{namespaceToNamespaceSummary(namespaces["public"])}},
-		{"non-existing domain", NewDomainFilter([]string{"xxx.com"}), "", []*sd.NamespaceSummary{}},
+		{"public filter", endpoint.NewDomainFilter([]string{}), "public", []*sd.NamespaceSummary{namespaceToNamespaceSummary(namespaces["public"])}},
+		{"private filter", endpoint.NewDomainFilter([]string{}), "private", []*sd.NamespaceSummary{namespaceToNamespaceSummary(namespaces["private"])}},
+		{"domain filter", endpoint.NewDomainFilter([]string{"public.com"}), "", []*sd.NamespaceSummary{namespaceToNamespaceSummary(namespaces["public"])}},
+		{"non-existing domain", endpoint.NewDomainFilter([]string{"xxx.com"}), "", []*sd.NamespaceSummary{}},
 	} {
 		provider := newTestAWSSDProvider(api, tc.domainFilter, tc.namespaceTypeFilter)
 
@@ -438,7 +438,7 @@ func TestAWSSDProvider_ListServicesByNamespace(t *testing.T) {
 	}{
 		{map[string]*sd.Service{"service1": services["private"]["srv1"], "service2": services["private"]["srv2"]}},
 	} {
-		provider := newTestAWSSDProvider(api, NewDomainFilter([]string{}), "")
+		provider := newTestAWSSDProvider(api, endpoint.NewDomainFilter([]string{}), "")
 
 		result, err := provider.ListServicesByNamespaceID(namespaces["private"].Id)
 		require.NoError(t, err)
@@ -494,7 +494,7 @@ func TestAWSSDProvider_ListInstancesByService(t *testing.T) {
 		instances:  instances,
 	}
 
-	provider := newTestAWSSDProvider(api, NewDomainFilter([]string{}), "")
+	provider := newTestAWSSDProvider(api, endpoint.NewDomainFilter([]string{}), "")
 
 	result, err := provider.ListInstancesByServiceID(services["private"]["srv1"].Id)
 	require.NoError(t, err)
@@ -531,7 +531,7 @@ func TestAWSSDProvider_CreateService(t *testing.T) {
 
 	expectedServices := make(map[string]*sd.Service)
 
-	provider := newTestAWSSDProvider(api, NewDomainFilter([]string{}), "")
+	provider := newTestAWSSDProvider(api, endpoint.NewDomainFilter([]string{}), "")
 
 	// A type
 	provider.CreateService(aws.String("private"), aws.String("A-srv"), &endpoint.Endpoint{
@@ -635,7 +635,7 @@ func TestAWSSDProvider_UpdateService(t *testing.T) {
 		services:   services,
 	}
 
-	provider := newTestAWSSDProvider(api, NewDomainFilter([]string{}), "")
+	provider := newTestAWSSDProvider(api, endpoint.NewDomainFilter([]string{}), "")
 
 	// update service with different TTL
 	provider.UpdateService(services["private"]["srv1"], &endpoint.Endpoint{
@@ -702,7 +702,7 @@ func TestAWSSDProvider_RegisterInstance(t *testing.T) {
 		instances:  make(map[string]map[string]*sd.Instance),
 	}
 
-	provider := newTestAWSSDProvider(api, NewDomainFilter([]string{}), "")
+	provider := newTestAWSSDProvider(api, endpoint.NewDomainFilter([]string{}), "")
 
 	expectedInstances := make(map[string]*sd.Instance)
 
@@ -819,7 +819,7 @@ func TestAWSSDProvider_DeregisterInstance(t *testing.T) {
 		instances:  instances,
 	}
 
-	provider := newTestAWSSDProvider(api, NewDomainFilter([]string{}), "")
+	provider := newTestAWSSDProvider(api, endpoint.NewDomainFilter([]string{}), "")
 
 	provider.DeregisterInstance(services["private"]["srv1"], endpoint.NewEndpoint("srv1.private.com.", endpoint.RecordTypeA, "1.2.3.4"))
 

--- a/provider/aws_test.go
+++ b/provider/aws_test.go
@@ -299,7 +299,7 @@ func TestAWSZones(t *testing.T) {
 		{"zone id filter", NewZoneIDFilter([]string{"/hostedzone/zone-3.ext-dns-test-2.teapot.zalan.do."}), NewZoneTypeFilter(""), NewZoneTagFilter([]string{}), privateZones},
 		{"tag filter", NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), NewZoneTagFilter([]string{"zone=3"}), privateZones},
 	} {
-		provider, _ := newAWSProviderWithTagFilter(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), ti.zoneIDFilter, ti.zoneTypeFilter, ti.zoneTagFilter, defaultEvaluateTargetHealth, false, []*endpoint.Endpoint{})
+		provider, _ := newAWSProviderWithTagFilter(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), ti.zoneIDFilter, ti.zoneTypeFilter, ti.zoneTagFilter, defaultEvaluateTargetHealth, false, []*endpoint.Endpoint{})
 
 		zones, err := provider.Zones(context.Background())
 		require.NoError(t, err)
@@ -309,7 +309,7 @@ func TestAWSZones(t *testing.T) {
 }
 
 func TestAWSRecords(t *testing.T) {
-	provider, _ := newAWSProvider(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), false, false, []*endpoint.Endpoint{
+	provider, _ := newAWSProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), false, false, []*endpoint.Endpoint{
 		endpoint.NewEndpointWithTTL("list-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4"),
 		endpoint.NewEndpointWithTTL("list-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "8.8.8.8"),
 		endpoint.NewEndpointWithTTL("*.wildcard-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "8.8.8.8"),
@@ -351,7 +351,7 @@ func TestAWSRecords(t *testing.T) {
 
 func TestAWSCreateRecords(t *testing.T) {
 	customTTL := endpoint.TTL(60)
-	provider, _ := newAWSProvider(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), defaultEvaluateTargetHealth, false, []*endpoint.Endpoint{})
+	provider, _ := newAWSProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), defaultEvaluateTargetHealth, false, []*endpoint.Endpoint{})
 
 	records := []*endpoint.Endpoint{
 		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
@@ -376,7 +376,7 @@ func TestAWSCreateRecords(t *testing.T) {
 }
 
 func TestAWSUpdateRecords(t *testing.T) {
-	provider, _ := newAWSProvider(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), defaultEvaluateTargetHealth, false, []*endpoint.Endpoint{
+	provider, _ := newAWSProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), defaultEvaluateTargetHealth, false, []*endpoint.Endpoint{
 		endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "8.8.8.8"),
 		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "8.8.4.4"),
 		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL), "foo.elb.amazonaws.com"),
@@ -419,7 +419,7 @@ func TestAWSDeleteRecords(t *testing.T) {
 		endpoint.NewEndpointWithTTL("delete-test-multiple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "8.8.8.8", "8.8.4.4"),
 	}
 
-	provider, _ := newAWSProvider(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), false, false, originalEndpoints)
+	provider, _ := newAWSProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), false, false, originalEndpoints)
 
 	require.NoError(t, provider.DeleteRecords(context.Background(), originalEndpoints))
 
@@ -446,7 +446,7 @@ func TestAWSApplyChanges(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		provider, _ := newAWSProvider(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), defaultEvaluateTargetHealth, false, []*endpoint.Endpoint{
+		provider, _ := newAWSProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), defaultEvaluateTargetHealth, false, []*endpoint.Endpoint{
 			endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "8.8.8.8"),
 			endpoint.NewEndpointWithTTL("delete-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "8.8.8.8"),
 			endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "8.8.4.4"),
@@ -538,7 +538,7 @@ func TestAWSApplyChangesDryRun(t *testing.T) {
 		endpoint.NewEndpointWithTTL("delete-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4", "4.3.2.1"),
 	}
 
-	provider, _ := newAWSProvider(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), defaultEvaluateTargetHealth, true, originalEndpoints)
+	provider, _ := newAWSProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), defaultEvaluateTargetHealth, true, originalEndpoints)
 
 	createRecords := []*endpoint.Endpoint{
 		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
@@ -686,7 +686,7 @@ func TestAWSChangesByZones(t *testing.T) {
 }
 
 func TestAWSsubmitChanges(t *testing.T) {
-	provider, _ := newAWSProvider(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), defaultEvaluateTargetHealth, false, []*endpoint.Endpoint{})
+	provider, _ := newAWSProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), defaultEvaluateTargetHealth, false, []*endpoint.Endpoint{})
 	const subnets = 16
 	const hosts = defaultBatchChangeSize / subnets
 
@@ -715,7 +715,7 @@ func TestAWSsubmitChanges(t *testing.T) {
 }
 
 func TestAWSsubmitChangesError(t *testing.T) {
-	provider, clientStub := newAWSProvider(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), defaultEvaluateTargetHealth, false, []*endpoint.Endpoint{})
+	provider, clientStub := newAWSProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), defaultEvaluateTargetHealth, false, []*endpoint.Endpoint{})
 	clientStub.MockMethod("ChangeResourceRecordSets", mock.Anything).Return(nil, fmt.Errorf("Mock route53 failure"))
 
 	ctx := context.Background()
@@ -851,7 +851,7 @@ func validateAWSChangeRecord(t *testing.T, record *route53.Change, expected *rou
 }
 
 func TestAWSCreateRecordsWithCNAME(t *testing.T) {
-	provider, _ := newAWSProvider(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), defaultEvaluateTargetHealth, false, []*endpoint.Endpoint{})
+	provider, _ := newAWSProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), defaultEvaluateTargetHealth, false, []*endpoint.Endpoint{})
 
 	records := []*endpoint.Endpoint{
 		{DNSName: "create-test.zone-1.ext-dns-test-2.teapot.zalan.do", Targets: endpoint.Targets{"foo.example.org"}, RecordType: endpoint.RecordTypeCNAME},
@@ -881,7 +881,7 @@ func TestAWSCreateRecordsWithALIAS(t *testing.T) {
 		"false": false,
 		"":      false,
 	} {
-		provider, _ := newAWSProvider(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), defaultEvaluateTargetHealth, false, []*endpoint.Endpoint{})
+		provider, _ := newAWSProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), defaultEvaluateTargetHealth, false, []*endpoint.Endpoint{})
 
 		// Test dualstack and ipv4 load balancer targets
 		records := []*endpoint.Endpoint{
@@ -1180,11 +1180,11 @@ func escapeAWSRecords(t *testing.T, provider *AWSProvider, zone string) {
 		require.NoError(t, err)
 	}
 }
-func newAWSProvider(t *testing.T, domainFilter DomainFilter, zoneIDFilter ZoneIDFilter, zoneTypeFilter ZoneTypeFilter, evaluateTargetHealth, dryRun bool, records []*endpoint.Endpoint) (*AWSProvider, *Route53APIStub) {
+func newAWSProvider(t *testing.T, domainFilter endpoint.DomainFilter, zoneIDFilter ZoneIDFilter, zoneTypeFilter ZoneTypeFilter, evaluateTargetHealth, dryRun bool, records []*endpoint.Endpoint) (*AWSProvider, *Route53APIStub) {
 	return newAWSProviderWithTagFilter(t, domainFilter, zoneIDFilter, zoneTypeFilter, NewZoneTagFilter([]string{}), evaluateTargetHealth, dryRun, records)
 }
 
-func newAWSProviderWithTagFilter(t *testing.T, domainFilter DomainFilter, zoneIDFilter ZoneIDFilter, zoneTypeFilter ZoneTypeFilter, zoneTagFilter ZoneTagFilter, evaluateTargetHealth, dryRun bool, records []*endpoint.Endpoint) (*AWSProvider, *Route53APIStub) {
+func newAWSProviderWithTagFilter(t *testing.T, domainFilter endpoint.DomainFilter, zoneIDFilter ZoneIDFilter, zoneTypeFilter ZoneTypeFilter, zoneTagFilter ZoneTagFilter, evaluateTargetHealth, dryRun bool, records []*endpoint.Endpoint) (*AWSProvider, *Route53APIStub) {
 	client := NewRoute53APIStub()
 
 	provider := &AWSProvider{

--- a/provider/azure.go
+++ b/provider/azure.go
@@ -66,7 +66,7 @@ type RecordSetsClient interface {
 
 // AzureProvider implements the DNS provider for Microsoft's Azure cloud platform.
 type AzureProvider struct {
-	domainFilter                 DomainFilter
+	domainFilter                 endpoint.DomainFilter
 	zoneIDFilter                 ZoneIDFilter
 	dryRun                       bool
 	resourceGroup                string
@@ -78,7 +78,7 @@ type AzureProvider struct {
 // NewAzureProvider creates a new Azure provider.
 //
 // Returns the provider or an error if a provider could not be created.
-func NewAzureProvider(configFile string, domainFilter DomainFilter, zoneIDFilter ZoneIDFilter, resourceGroup string, userAssignedIdentityClientID string, dryRun bool) (*AzureProvider, error) {
+func NewAzureProvider(configFile string, domainFilter endpoint.DomainFilter, zoneIDFilter ZoneIDFilter, resourceGroup string, userAssignedIdentityClientID string, dryRun bool) (*AzureProvider, error) {
 	contents, err := ioutil.ReadFile(configFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read Azure config file '%s': %v", configFile, err)

--- a/provider/azure_private_dns.go
+++ b/provider/azure_private_dns.go
@@ -45,7 +45,7 @@ type PrivateRecordSetsClient interface {
 
 // AzurePrivateDNSProvider implements the DNS provider for Microsoft's Azure Private DNS service
 type AzurePrivateDNSProvider struct {
-	domainFilter     DomainFilter
+	domainFilter     endpoint.DomainFilter
 	zoneIDFilter     ZoneIDFilter
 	dryRun           bool
 	subscriptionID   string
@@ -57,7 +57,7 @@ type AzurePrivateDNSProvider struct {
 // NewAzurePrivateDNSProvider creates a new Azure Private DNS provider.
 //
 // Returns the provider or an error if a provider could not be created.
-func NewAzurePrivateDNSProvider(domainFilter DomainFilter, zoneIDFilter ZoneIDFilter, resourceGroup string, subscriptionID string, dryRun bool) (*AzurePrivateDNSProvider, error) {
+func NewAzurePrivateDNSProvider(domainFilter endpoint.DomainFilter, zoneIDFilter ZoneIDFilter, resourceGroup string, subscriptionID string, dryRun bool) (*AzurePrivateDNSProvider, error) {
 	authorizer, err := auth.NewAuthorizerFromEnvironment()
 	if err != nil {
 		return nil, err

--- a/provider/azure_privatedns_test.go
+++ b/provider/azure_privatedns_test.go
@@ -203,7 +203,7 @@ func (client *mockPrivateRecordSetsClient) CreateOrUpdate(ctx context.Context, r
 }
 
 // newMockedAzurePrivateDNSProvider creates an AzureProvider comprising the mocked clients for zones and recordsets
-func newMockedAzurePrivateDNSProvider(domainFilter DomainFilter, zoneIDFilter ZoneIDFilter, dryRun bool, resourceGroup string, zones *[]privatedns.PrivateZone, recordSets *[]privatedns.RecordSet) (*AzurePrivateDNSProvider, error) {
+func newMockedAzurePrivateDNSProvider(domainFilter endpoint.DomainFilter, zoneIDFilter ZoneIDFilter, dryRun bool, resourceGroup string, zones *[]privatedns.PrivateZone, recordSets *[]privatedns.RecordSet) (*AzurePrivateDNSProvider, error) {
 	// init zone-related parts of the mock-client
 	pageIterator := mockPrivateZoneListResultPageIterator{
 		results: []privatedns.PrivateZoneListResult{
@@ -236,7 +236,7 @@ func newMockedAzurePrivateDNSProvider(domainFilter DomainFilter, zoneIDFilter Zo
 	return newAzurePrivateDNSProvider(domainFilter, zoneIDFilter, dryRun, resourceGroup, &zonesClient, &recordSetsClient), nil
 }
 
-func newAzurePrivateDNSProvider(domainFilter DomainFilter, zoneIDFilter ZoneIDFilter, dryRun bool, resourceGroup string, privateZonesClient PrivateZonesClient, privateRecordsClient PrivateRecordSetsClient) *AzurePrivateDNSProvider {
+func newAzurePrivateDNSProvider(domainFilter endpoint.DomainFilter, zoneIDFilter ZoneIDFilter, dryRun bool, resourceGroup string, privateZonesClient PrivateZonesClient, privateRecordsClient PrivateRecordSetsClient) *AzurePrivateDNSProvider {
 	return &AzurePrivateDNSProvider{
 		domainFilter:     domainFilter,
 		zoneIDFilter:     zoneIDFilter,
@@ -248,7 +248,7 @@ func newAzurePrivateDNSProvider(domainFilter DomainFilter, zoneIDFilter ZoneIDFi
 }
 
 func TestAzurePrivateDNSRecord(t *testing.T) {
-	provider, err := newMockedAzurePrivateDNSProvider(NewDomainFilter([]string{"example.com"}), NewZoneIDFilter([]string{""}), true, "k8s",
+	provider, err := newMockedAzurePrivateDNSProvider(endpoint.NewDomainFilter([]string{"example.com"}), NewZoneIDFilter([]string{""}), true, "k8s",
 		&[]privatedns.PrivateZone{
 			createMockPrivateZone("example.com", "/privateDnsZones/example.com"),
 		},
@@ -284,7 +284,7 @@ func TestAzurePrivateDNSRecord(t *testing.T) {
 }
 
 func TestAzurePrivateDNSMultiRecord(t *testing.T) {
-	provider, err := newMockedAzurePrivateDNSProvider(NewDomainFilter([]string{"example.com"}), NewZoneIDFilter([]string{""}), true, "k8s",
+	provider, err := newMockedAzurePrivateDNSProvider(endpoint.NewDomainFilter([]string{"example.com"}), NewZoneIDFilter([]string{""}), true, "k8s",
 		&[]privatedns.PrivateZone{
 			createMockPrivateZone("example.com", "/privateDnsZones/example.com"),
 		},
@@ -382,7 +382,7 @@ func testAzurePrivateDNSApplyChangesInternal(t *testing.T, dryRun bool, client P
 	}
 
 	provider := newAzurePrivateDNSProvider(
-		NewDomainFilter([]string{""}),
+		endpoint.NewDomainFilter([]string{""}),
 		NewZoneIDFilter([]string{""}),
 		dryRun,
 		"group",

--- a/provider/azure_test.go
+++ b/provider/azure_test.go
@@ -206,7 +206,7 @@ func (client *mockRecordSetsClient) CreateOrUpdate(ctx context.Context, resource
 }
 
 // newMockedAzureProvider creates an AzureProvider comprising the mocked clients for zones and recordsets
-func newMockedAzureProvider(domainFilter DomainFilter, zoneIDFilter ZoneIDFilter, dryRun bool, resourceGroup string, userAssignedIdentityClientID string, zones *[]dns.Zone, recordSets *[]dns.RecordSet) (*AzureProvider, error) {
+func newMockedAzureProvider(domainFilter endpoint.DomainFilter, zoneIDFilter ZoneIDFilter, dryRun bool, resourceGroup string, userAssignedIdentityClientID string, zones *[]dns.Zone, recordSets *[]dns.RecordSet) (*AzureProvider, error) {
 	// init zone-related parts of the mock-client
 	pageIterator := mockZoneListResultPageIterator{
 		results: []dns.ZoneListResult{
@@ -239,7 +239,7 @@ func newMockedAzureProvider(domainFilter DomainFilter, zoneIDFilter ZoneIDFilter
 	return newAzureProvider(domainFilter, zoneIDFilter, dryRun, resourceGroup, userAssignedIdentityClientID, &zonesClient, &recordSetsClient), nil
 }
 
-func newAzureProvider(domainFilter DomainFilter, zoneIDFilter ZoneIDFilter, dryRun bool, resourceGroup string, userAssignedIdentityClientID string, zonesClient ZonesClient, recordsClient RecordSetsClient) *AzureProvider {
+func newAzureProvider(domainFilter endpoint.DomainFilter, zoneIDFilter ZoneIDFilter, dryRun bool, resourceGroup string, userAssignedIdentityClientID string, zonesClient ZonesClient, recordsClient RecordSetsClient) *AzureProvider {
 	return &AzureProvider{
 		domainFilter:                 domainFilter,
 		zoneIDFilter:                 zoneIDFilter,
@@ -256,7 +256,7 @@ func validateAzureEndpoints(t *testing.T, endpoints []*endpoint.Endpoint, expect
 }
 
 func TestAzureRecord(t *testing.T) {
-	provider, err := newMockedAzureProvider(NewDomainFilter([]string{"example.com"}), NewZoneIDFilter([]string{""}), true, "k8s", "",
+	provider, err := newMockedAzureProvider(endpoint.NewDomainFilter([]string{"example.com"}), NewZoneIDFilter([]string{""}), true, "k8s", "",
 		&[]dns.Zone{
 			createMockZone("example.com", "/dnszones/example.com"),
 		},
@@ -293,7 +293,7 @@ func TestAzureRecord(t *testing.T) {
 }
 
 func TestAzureMultiRecord(t *testing.T) {
-	provider, err := newMockedAzureProvider(NewDomainFilter([]string{"example.com"}), NewZoneIDFilter([]string{""}), true, "k8s", "",
+	provider, err := newMockedAzureProvider(endpoint.NewDomainFilter([]string{"example.com"}), NewZoneIDFilter([]string{""}), true, "k8s", "",
 		&[]dns.Zone{
 			createMockZone("example.com", "/dnszones/example.com"),
 		},
@@ -392,7 +392,7 @@ func testAzureApplyChangesInternal(t *testing.T, dryRun bool, client RecordSetsC
 	}
 
 	provider := newAzureProvider(
-		NewDomainFilter([]string{""}),
+		endpoint.NewDomainFilter([]string{""}),
 		NewZoneIDFilter([]string{""}),
 		dryRun,
 		"group",

--- a/provider/cloudflare.go
+++ b/provider/cloudflare.go
@@ -102,7 +102,7 @@ func (z zoneService) ListZonesContext(ctx context.Context, opts ...cloudflare.Re
 type CloudFlareProvider struct {
 	Client cloudFlareDNS
 	// only consider hosted zones managing domains ending in this suffix
-	domainFilter      DomainFilter
+	domainFilter      endpoint.DomainFilter
 	zoneIDFilter      ZoneIDFilter
 	proxiedByDefault  bool
 	DryRun            bool
@@ -116,7 +116,7 @@ type cloudFlareChange struct {
 }
 
 // NewCloudFlareProvider initializes a new CloudFlare DNS based Provider.
-func NewCloudFlareProvider(domainFilter DomainFilter, zoneIDFilter ZoneIDFilter, zonesPerPage int, proxiedByDefault bool, dryRun bool) (*CloudFlareProvider, error) {
+func NewCloudFlareProvider(domainFilter endpoint.DomainFilter, zoneIDFilter ZoneIDFilter, zonesPerPage int, proxiedByDefault bool, dryRun bool) (*CloudFlareProvider, error) {
 	// initialize via chosen auth method and returns new API object
 	var (
 		config *cloudflare.API

--- a/provider/cloudflare_test.go
+++ b/provider/cloudflare_test.go
@@ -247,7 +247,7 @@ func TestNewCloudFlareChangeProxiable(t *testing.T) {
 func TestCloudFlareZones(t *testing.T) {
 	provider := &CloudFlareProvider{
 		Client:       &mockCloudFlareClient{},
-		domainFilter: NewDomainFilter([]string{"zalando.to."}),
+		domainFilter: endpoint.NewDomainFilter([]string{"zalando.to."}),
 		zoneIDFilter: NewZoneIDFilter([]string{""}),
 	}
 
@@ -288,7 +288,7 @@ func TestRecords(t *testing.T) {
 func TestNewCloudFlareProvider(t *testing.T) {
 	_ = os.Setenv("CF_API_TOKEN", "abc123def")
 	_, err := NewCloudFlareProvider(
-		NewDomainFilter([]string{"ext-dns-test.zalando.to."}),
+		endpoint.NewDomainFilter([]string{"ext-dns-test.zalando.to."}),
 		NewZoneIDFilter([]string{""}),
 		25,
 		false,
@@ -300,7 +300,7 @@ func TestNewCloudFlareProvider(t *testing.T) {
 	_ = os.Setenv("CF_API_KEY", "xxxxxxxxxxxxxxxxx")
 	_ = os.Setenv("CF_API_EMAIL", "test@test.com")
 	_, err = NewCloudFlareProvider(
-		NewDomainFilter([]string{"ext-dns-test.zalando.to."}),
+		endpoint.NewDomainFilter([]string{"ext-dns-test.zalando.to."}),
 		NewZoneIDFilter([]string{""}),
 		1,
 		false,
@@ -311,7 +311,7 @@ func TestNewCloudFlareProvider(t *testing.T) {
 	_ = os.Unsetenv("CF_API_KEY")
 	_ = os.Unsetenv("CF_API_EMAIL")
 	_, err = NewCloudFlareProvider(
-		NewDomainFilter([]string{"ext-dns-test.zalando.to."}),
+		endpoint.NewDomainFilter([]string{"ext-dns-test.zalando.to."}),
 		NewZoneIDFilter([]string{""}),
 		50,
 		false,

--- a/provider/coredns.go
+++ b/provider/coredns.go
@@ -58,7 +58,7 @@ type coreDNSClient interface {
 type coreDNSProvider struct {
 	dryRun        bool
 	coreDNSPrefix string
-	domainFilter  DomainFilter
+	domainFilter  endpoint.DomainFilter
 	client        coreDNSClient
 }
 
@@ -244,7 +244,7 @@ func newETCDClient() (coreDNSClient, error) {
 }
 
 // NewCoreDNSProvider is a CoreDNS provider constructor
-func NewCoreDNSProvider(domainFilter DomainFilter, prefix string, dryRun bool) (Provider, error) {
+func NewCoreDNSProvider(domainFilter endpoint.DomainFilter, prefix string, dryRun bool) (Provider, error) {
 	client, err := newETCDClient()
 	if err != nil {
 		return nil, err

--- a/provider/designate.go
+++ b/provider/designate.go
@@ -229,12 +229,12 @@ type designateProvider struct {
 	client designateClientInterface
 
 	// only consider hosted zones managing domains ending in this suffix
-	domainFilter DomainFilter
+	domainFilter endpoint.DomainFilter
 	dryRun       bool
 }
 
 // NewDesignateProvider is a factory function for OpenStack designate providers
-func NewDesignateProvider(domainFilter DomainFilter, dryRun bool) (Provider, error) {
+func NewDesignateProvider(domainFilter endpoint.DomainFilter, dryRun bool) (Provider, error) {
 	client, err := newDesignateClient()
 	if err != nil {
 		return nil, err

--- a/provider/designate_test.go
+++ b/provider/designate_test.go
@@ -191,7 +191,7 @@ func TestNewDesignateProvider(t *testing.T) {
 	os.Setenv("OS_USER_DOMAIN_NAME", "Default")
 	os.Setenv("OPENSTACK_CA_FILE", tmpfile.Name())
 
-	if _, err := NewDesignateProvider(DomainFilter{}, true); err != nil {
+	if _, err := NewDesignateProvider(endpoint.DomainFilter{}, true); err != nil {
 		t.Fatalf("Failed to initialize Designate provider: %s", err)
 	}
 }

--- a/provider/digital_ocean.go
+++ b/provider/digital_ocean.go
@@ -46,7 +46,7 @@ const (
 type DigitalOceanProvider struct {
 	Client godo.DomainsService
 	// only consider hosted zones managing domains ending in this suffix
-	domainFilter DomainFilter
+	domainFilter endpoint.DomainFilter
 	DryRun       bool
 }
 
@@ -57,7 +57,7 @@ type DigitalOceanChange struct {
 }
 
 // NewDigitalOceanProvider initializes a new DigitalOcean DNS based Provider.
-func NewDigitalOceanProvider(ctx context.Context, domainFilter DomainFilter, dryRun bool) (*DigitalOceanProvider, error) {
+func NewDigitalOceanProvider(ctx context.Context, domainFilter endpoint.DomainFilter, dryRun bool) (*DigitalOceanProvider, error) {
 	token, ok := os.LookupEnv("DO_TOKEN")
 	if !ok {
 		return nil, fmt.Errorf("No token found")

--- a/provider/digital_ocean_test.go
+++ b/provider/digital_ocean_test.go
@@ -152,7 +152,7 @@ func TestNewDigitalOceanChanges(t *testing.T) {
 func TestDigitalOceanZones(t *testing.T) {
 	provider := &DigitalOceanProvider{
 		Client:       &mockDigitalOceanClient{},
-		domainFilter: NewDomainFilter([]string{"com"}),
+		domainFilter: endpoint.NewDomainFilter([]string{"com"}),
 	}
 
 	zones, err := provider.Zones(context.Background())
@@ -187,12 +187,12 @@ func TestDigitalOceanApplyChanges(t *testing.T) {
 
 func TestNewDigitalOceanProvider(t *testing.T) {
 	_ = os.Setenv("DO_TOKEN", "xxxxxxxxxxxxxxxxx")
-	_, err := NewDigitalOceanProvider(context.Background(), NewDomainFilter([]string{"ext-dns-test.zalando.to."}), true)
+	_, err := NewDigitalOceanProvider(context.Background(), endpoint.NewDomainFilter([]string{"ext-dns-test.zalando.to."}), true)
 	if err != nil {
 		t.Errorf("should not fail, %s", err)
 	}
 	_ = os.Unsetenv("DO_TOKEN")
-	_, err = NewDigitalOceanProvider(context.Background(), NewDomainFilter([]string{"ext-dns-test.zalando.to."}), true)
+	_, err = NewDigitalOceanProvider(context.Background(), endpoint.NewDomainFilter([]string{"ext-dns-test.zalando.to."}), true)
 	if err == nil {
 		t.Errorf("expected to fail")
 	}

--- a/provider/dnsimple.go
+++ b/provider/dnsimple.go
@@ -87,7 +87,7 @@ type dnsimpleProvider struct {
 	client       dnsimpleZoneServiceInterface
 	identity     identityService
 	accountID    string
-	domainFilter DomainFilter
+	domainFilter endpoint.DomainFilter
 	zoneIDFilter ZoneIDFilter
 	dryRun       bool
 }
@@ -104,7 +104,7 @@ const (
 )
 
 // NewDnsimpleProvider initializes a new Dnsimple based provider
-func NewDnsimpleProvider(domainFilter DomainFilter, zoneIDFilter ZoneIDFilter, dryRun bool) (Provider, error) {
+func NewDnsimpleProvider(domainFilter endpoint.DomainFilter, zoneIDFilter ZoneIDFilter, dryRun bool) (Provider, error) {
 	oauthToken := os.Getenv("DNSIMPLE_OAUTH")
 	if len(oauthToken) == 0 {
 		return nil, fmt.Errorf("No dnsimple oauth token provided")

--- a/provider/dnsimple_test.go
+++ b/provider/dnsimple_test.go
@@ -203,7 +203,7 @@ func testDnsimpleSuitableZone(t *testing.T) {
 
 func TestNewDnsimpleProvider(t *testing.T) {
 	os.Setenv("DNSIMPLE_OAUTH", "xxxxxxxxxxxxxxxxxxxxxxxxxx")
-	_, err := NewDnsimpleProvider(NewDomainFilter([]string{"example.com"}), NewZoneIDFilter([]string{""}), true)
+	_, err := NewDnsimpleProvider(endpoint.NewDomainFilter([]string{"example.com"}), NewZoneIDFilter([]string{""}), true)
 	if err == nil {
 		t.Errorf("Expected to fail new provider on bad token")
 	}

--- a/provider/dyn.go
+++ b/provider/dyn.go
@@ -56,7 +56,7 @@ func unixNow() int64 {
 
 // DynConfig hold connection parameters to dyn.com and internal state
 type DynConfig struct {
-	DomainFilter  DomainFilter
+	DomainFilter  endpoint.DomainFilter
 	ZoneIDFilter  ZoneIDFilter
 	DryRun        bool
 	CustomerName  string
@@ -153,7 +153,7 @@ func NewDynProvider(config DynConfig) (Provider, error) {
 
 // filterAndFixLinks removes from `links` all the records we don't care about
 // and strops the /REST/ prefix
-func filterAndFixLinks(links []string, filter DomainFilter) []string {
+func filterAndFixLinks(links []string, filter endpoint.DomainFilter) []string {
 	var result []string
 	for _, link := range links {
 

--- a/provider/dyn_test.go
+++ b/provider/dyn_test.go
@@ -188,7 +188,7 @@ func TestDyn_buildLinkToRecord(t *testing.T) {
 	provider := &dynProviderState{
 		DynConfig: DynConfig{
 			ZoneIDFilter: NewZoneIDFilter([]string{"example.com"}),
-			DomainFilter: NewDomainFilter([]string{"the-target.example.com"}),
+			DomainFilter: endpoint.NewDomainFilter([]string{"the-target.example.com"}),
 		},
 	}
 
@@ -227,7 +227,7 @@ func TestDyn_filterAndFixLinks(t *testing.T) {
 		"/REST/NSRecord/example.com/the-target.google.com/",
 		"/REST/NSRecord/example.com/the-target.example.com/",
 	}
-	filter := NewDomainFilter([]string{"example.com"})
+	filter := endpoint.NewDomainFilter([]string{"example.com"})
 	result := filterAndFixLinks(links, filter)
 
 	// should skip non-example.com records and NS records too

--- a/provider/exoscale.go
+++ b/provider/exoscale.go
@@ -38,7 +38,7 @@ type EgoscaleClientI interface {
 
 // ExoscaleProvider initialized as dns provider with no records
 type ExoscaleProvider struct {
-	domain         DomainFilter
+	domain         endpoint.DomainFilter
 	client         EgoscaleClientI
 	filter         *zoneFilter
 	OnApplyChanges func(changes *plan.Changes)
@@ -55,11 +55,11 @@ func NewExoscaleProvider(endpoint, apiKey, apiSecret string, dryRun bool, opts .
 }
 
 // NewExoscaleProviderWithClient returns ExoscaleProvider DNS provider interface implementation (Client provided)
-func NewExoscaleProviderWithClient(endpoint, apiKey, apiSecret string, client EgoscaleClientI, dryRun bool, opts ...ExoscaleOption) *ExoscaleProvider {
+func NewExoscaleProviderWithClient(_, apiKey, apiSecret string, client EgoscaleClientI, dryRun bool, opts ...ExoscaleOption) *ExoscaleProvider {
 	ep := &ExoscaleProvider{
 		filter:         &zoneFilter{},
 		OnApplyChanges: func(changes *plan.Changes) {},
-		domain:         NewDomainFilter([]string{""}),
+		domain:         endpoint.NewDomainFilter([]string{""}),
 		client:         client,
 		dryRun:         dryRun,
 	}
@@ -202,7 +202,7 @@ func (ep *ExoscaleProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, 
 }
 
 // ExoscaleWithDomain modifies the domain on which dns zones are filtered
-func ExoscaleWithDomain(domainFilter DomainFilter) ExoscaleOption {
+func ExoscaleWithDomain(domainFilter endpoint.DomainFilter) ExoscaleOption {
 	return func(p *ExoscaleProvider) {
 		p.domain = domainFilter
 	}

--- a/provider/google.go
+++ b/provider/google.go
@@ -107,7 +107,7 @@ type GoogleProvider struct {
 	// Interval between batch updates.
 	batchChangeInterval time.Duration
 	// only consider hosted zones managing domains ending in this suffix
-	domainFilter DomainFilter
+	domainFilter endpoint.DomainFilter
 	// only consider hosted zones ending with this zone id
 	zoneIDFilter ZoneIDFilter
 	// A client for managing resource record sets
@@ -121,7 +121,7 @@ type GoogleProvider struct {
 }
 
 // NewGoogleProvider initializes a new Google CloudDNS based Provider.
-func NewGoogleProvider(ctx context.Context, project string, domainFilter DomainFilter, zoneIDFilter ZoneIDFilter, batchChangeSize int, batchChangeInterval time.Duration, dryRun bool) (*GoogleProvider, error) {
+func NewGoogleProvider(ctx context.Context, project string, domainFilter endpoint.DomainFilter, zoneIDFilter ZoneIDFilter, batchChangeSize int, batchChangeInterval time.Duration, dryRun bool) (*GoogleProvider, error) {
 	gcloud, err := google.DefaultClient(ctx, dns.NdevClouddnsReadwriteScope)
 	if err != nil {
 		return nil, err
@@ -180,14 +180,14 @@ func (p *GoogleProvider) Zones(ctx context.Context) (map[string]*dns.ManagedZone
 		return nil
 	}
 
-	log.Debugf("Matching zones against domain filters: %v", p.domainFilter.filters)
+	log.Debugf("Matching zones against domain filters: %v", p.domainFilter.Filters)
 	if err := p.managedZonesClient.List(p.project).Pages(ctx, f); err != nil {
 		return nil, err
 	}
 
 	if len(zones) == 0 {
 		if p.domainFilter.IsConfigured() {
-			log.Warnf("No zones in the project, %s, match domain filters: %v", p.project, p.domainFilter.filters)
+			log.Warnf("No zones in the project, %s, match domain filters: %v", p.project, p.domainFilter.Filters)
 		} else {
 			log.Warnf("No zones found in the project, %s", p.project)
 		}

--- a/provider/google_test.go
+++ b/provider/google_test.go
@@ -192,7 +192,7 @@ func hasTrailingDot(target string) bool {
 }
 
 func TestGoogleZonesIDFilter(t *testing.T) {
-	provider := newGoogleProviderZoneOverlap(t, NewDomainFilter([]string{"cluster.local."}), NewZoneIDFilter([]string{"10002"}), false, []*endpoint.Endpoint{})
+	provider := newGoogleProviderZoneOverlap(t, endpoint.NewDomainFilter([]string{"cluster.local."}), NewZoneIDFilter([]string{"10002"}), false, []*endpoint.Endpoint{})
 
 	zones, err := provider.Zones(context.Background())
 	require.NoError(t, err)
@@ -203,7 +203,7 @@ func TestGoogleZonesIDFilter(t *testing.T) {
 }
 
 func TestGoogleZonesNameFilter(t *testing.T) {
-	provider := newGoogleProviderZoneOverlap(t, NewDomainFilter([]string{"cluster.local."}), NewZoneIDFilter([]string{"internal-2"}), false, []*endpoint.Endpoint{})
+	provider := newGoogleProviderZoneOverlap(t, endpoint.NewDomainFilter([]string{"cluster.local."}), NewZoneIDFilter([]string{"internal-2"}), false, []*endpoint.Endpoint{})
 
 	zones, err := provider.Zones(context.Background())
 	require.NoError(t, err)
@@ -214,7 +214,7 @@ func TestGoogleZonesNameFilter(t *testing.T) {
 }
 
 func TestGoogleZones(t *testing.T) {
-	provider := newGoogleProvider(t, NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), NewZoneIDFilter([]string{""}), false, []*endpoint.Endpoint{})
+	provider := newGoogleProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), NewZoneIDFilter([]string{""}), false, []*endpoint.Endpoint{})
 
 	zones, err := provider.Zones(context.Background())
 	require.NoError(t, err)
@@ -233,7 +233,7 @@ func TestGoogleRecords(t *testing.T) {
 		endpoint.NewEndpointWithTTL("list-test-alias.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, endpoint.TTL(3), "foo.elb.amazonaws.com"),
 	}
 
-	provider := newGoogleProvider(t, NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), NewZoneIDFilter([]string{""}), false, originalEndpoints)
+	provider := newGoogleProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), NewZoneIDFilter([]string{""}), false, originalEndpoints)
 
 	records, err := provider.Records(context.Background())
 	require.NoError(t, err)
@@ -253,7 +253,7 @@ func TestGoogleRecordsFilter(t *testing.T) {
 
 	provider := newGoogleProvider(
 		t,
-		NewDomainFilter([]string{
+		endpoint.NewDomainFilter([]string{
 			// our two valid zones
 			"zone-1.ext-dns-test-2.gcp.zalan.do.",
 			"zone-2.ext-dns-test-2.gcp.zalan.do.",
@@ -286,7 +286,7 @@ func TestGoogleRecordsFilter(t *testing.T) {
 }
 
 func TestGoogleCreateRecords(t *testing.T) {
-	provider := newGoogleProvider(t, NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), NewZoneIDFilter([]string{""}), false, []*endpoint.Endpoint{})
+	provider := newGoogleProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), NewZoneIDFilter([]string{""}), false, []*endpoint.Endpoint{})
 
 	records := []*endpoint.Endpoint{
 		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
@@ -312,7 +312,7 @@ func TestGoogleUpdateRecords(t *testing.T) {
 		endpoint.NewEndpointWithTTL("update-test-ttl.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, endpoint.TTL(15), "8.8.4.4"),
 		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, googleRecordTTL, "foo.elb.amazonaws.com"),
 	}
-	provider := newGoogleProvider(t, NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), NewZoneIDFilter([]string{""}), false, currentRecords)
+	provider := newGoogleProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), NewZoneIDFilter([]string{""}), false, currentRecords)
 	updatedRecords := []*endpoint.Endpoint{
 		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
 		endpoint.NewEndpointWithTTL("update-test-ttl.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, endpoint.TTL(25), "4.3.2.1"),
@@ -338,7 +338,7 @@ func TestGoogleDeleteRecords(t *testing.T) {
 		endpoint.NewEndpointWithTTL("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, googleRecordTTL, "baz.elb.amazonaws.com"),
 	}
 
-	provider := newGoogleProvider(t, NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), NewZoneIDFilter([]string{""}), false, originalEndpoints)
+	provider := newGoogleProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), NewZoneIDFilter([]string{""}), false, originalEndpoints)
 
 	require.NoError(t, provider.DeleteRecords(originalEndpoints))
 
@@ -351,7 +351,7 @@ func TestGoogleDeleteRecords(t *testing.T) {
 func TestGoogleApplyChanges(t *testing.T) {
 	provider := newGoogleProvider(
 		t,
-		NewDomainFilter([]string{
+		endpoint.NewDomainFilter([]string{
 			// our two valid zones
 			"zone-1.ext-dns-test-2.gcp.zalan.do.",
 			"zone-2.ext-dns-test-2.gcp.zalan.do.",
@@ -433,7 +433,7 @@ func TestGoogleApplyChangesDryRun(t *testing.T) {
 		endpoint.NewEndpointWithTTL("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, googleRecordTTL, "qux.elb.amazonaws.com"),
 	}
 
-	provider := newGoogleProvider(t, NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), NewZoneIDFilter([]string{""}), true, originalEndpoints)
+	provider := newGoogleProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), NewZoneIDFilter([]string{""}), true, originalEndpoints)
 
 	createRecords := []*endpoint.Endpoint{
 		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
@@ -475,12 +475,12 @@ func TestGoogleApplyChangesDryRun(t *testing.T) {
 }
 
 func TestGoogleApplyChangesEmpty(t *testing.T) {
-	provider := newGoogleProvider(t, NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), NewZoneIDFilter([]string{""}), false, []*endpoint.Endpoint{})
+	provider := newGoogleProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), NewZoneIDFilter([]string{""}), false, []*endpoint.Endpoint{})
 	assert.NoError(t, provider.ApplyChanges(context.Background(), &plan.Changes{}))
 }
 
 func TestNewFilteredRecords(t *testing.T) {
-	provider := newGoogleProvider(t, NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), NewZoneIDFilter([]string{""}), false, []*endpoint.Endpoint{})
+	provider := newGoogleProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), NewZoneIDFilter([]string{""}), false, []*endpoint.Endpoint{})
 
 	records := provider.newFilteredRecords([]*endpoint.Endpoint{
 		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, 1, "8.8.4.4"),
@@ -670,7 +670,7 @@ func validateChangeRecord(t *testing.T, record *dns.ResourceRecordSet, expected 
 	assert.Equal(t, expected.Type, record.Type)
 }
 
-func newGoogleProviderZoneOverlap(t *testing.T, domainFilter DomainFilter, zoneIDFilter ZoneIDFilter, dryRun bool, records []*endpoint.Endpoint) *GoogleProvider {
+func newGoogleProviderZoneOverlap(t *testing.T, domainFilter endpoint.DomainFilter, zoneIDFilter ZoneIDFilter, dryRun bool, records []*endpoint.Endpoint) *GoogleProvider {
 	provider := &GoogleProvider{
 		project:                  "zalando-external-dns-test",
 		dryRun:                   false,
@@ -705,7 +705,7 @@ func newGoogleProviderZoneOverlap(t *testing.T, domainFilter DomainFilter, zoneI
 
 }
 
-func newGoogleProvider(t *testing.T, domainFilter DomainFilter, zoneIDFilter ZoneIDFilter, dryRun bool, records []*endpoint.Endpoint) *GoogleProvider {
+func newGoogleProvider(t *testing.T, domainFilter endpoint.DomainFilter, zoneIDFilter ZoneIDFilter, dryRun bool, records []*endpoint.Endpoint) *GoogleProvider {
 	provider := &GoogleProvider{
 		project:                  "zalando-external-dns-test",
 		dryRun:                   false,

--- a/provider/infoblox.go
+++ b/provider/infoblox.go
@@ -33,7 +33,7 @@ import (
 
 // InfobloxConfig clarifies the method signature
 type InfobloxConfig struct {
-	DomainFilter DomainFilter
+	DomainFilter endpoint.DomainFilter
 	ZoneIDFilter ZoneIDFilter
 	Host         string
 	Port         int
@@ -49,7 +49,7 @@ type InfobloxConfig struct {
 // InfobloxProvider implements the DNS provider for Infoblox.
 type InfobloxProvider struct {
 	client       ibclient.IBConnector
-	domainFilter DomainFilter
+	domainFilter endpoint.DomainFilter
 	zoneIDFilter ZoneIDFilter
 	view         string
 	dryRun       bool

--- a/provider/infoblox_test.go
+++ b/provider/infoblox_test.go
@@ -329,7 +329,7 @@ func createMockInfobloxObject(name, recordType, value string) ibclient.IBObject 
 	return nil
 }
 
-func newInfobloxProvider(domainFilter DomainFilter, zoneIDFilter ZoneIDFilter, dryRun bool, client ibclient.IBConnector) *InfobloxProvider {
+func newInfobloxProvider(domainFilter endpoint.DomainFilter, zoneIDFilter ZoneIDFilter, dryRun bool, client ibclient.IBConnector) *InfobloxProvider {
 	return &InfobloxProvider{
 		client:       client,
 		domainFilter: domainFilter,
@@ -354,7 +354,7 @@ func TestInfobloxRecords(t *testing.T) {
 		},
 	}
 
-	provider := newInfobloxProvider(NewDomainFilter([]string{"example.com"}), NewZoneIDFilter([]string{""}), true, &client)
+	provider := newInfobloxProvider(endpoint.NewDomainFilter([]string{"example.com"}), NewZoneIDFilter([]string{""}), true, &client)
 	actual, err := provider.Records(context.Background())
 
 	if err != nil {
@@ -427,7 +427,7 @@ func testInfobloxApplyChangesInternal(t *testing.T, dryRun bool, client ibclient
 	}
 
 	provider := newInfobloxProvider(
-		NewDomainFilter([]string{""}),
+		endpoint.NewDomainFilter([]string{""}),
 		NewZoneIDFilter([]string{""}),
 		dryRun,
 		client,
@@ -486,7 +486,7 @@ func TestInfobloxZones(t *testing.T) {
 		mockInfobloxObjects: &[]ibclient.IBObject{},
 	}
 
-	provider := newInfobloxProvider(NewDomainFilter([]string{"example.com"}), NewZoneIDFilter([]string{""}), true, &client)
+	provider := newInfobloxProvider(endpoint.NewDomainFilter([]string{"example.com"}), NewZoneIDFilter([]string{""}), true, &client)
 	zones, _ := provider.zones()
 	var emptyZoneAuth *ibclient.ZoneAuth
 	assert.Equal(t, provider.findZone(zones, "example.com").Fqdn, "example.com")

--- a/provider/inmemory.go
+++ b/provider/inmemory.go
@@ -43,7 +43,7 @@ var (
 // InMemoryProvider - dns provider only used for testing purposes
 // initialized as dns provider with no records
 type InMemoryProvider struct {
-	domain         DomainFilter
+	domain         endpoint.DomainFilter
 	client         *inMemoryClient
 	filter         *filter
 	OnApplyChanges func(ctx context.Context, changes *plan.Changes)
@@ -74,7 +74,7 @@ func InMemoryWithLogging() InMemoryOption {
 }
 
 // InMemoryWithDomain modifies the domain on which dns zones are filtered
-func InMemoryWithDomain(domainFilter DomainFilter) InMemoryOption {
+func InMemoryWithDomain(domainFilter endpoint.DomainFilter) InMemoryOption {
 	return func(p *InMemoryProvider) {
 		p.domain = domainFilter
 	}
@@ -97,7 +97,7 @@ func NewInMemoryProvider(opts ...InMemoryOption) *InMemoryProvider {
 		filter:         &filter{},
 		OnApplyChanges: func(ctx context.Context, changes *plan.Changes) {},
 		OnRecords:      func() {},
-		domain:         NewDomainFilter([]string{""}),
+		domain:         endpoint.NewDomainFilter([]string{""}),
 		client:         newInMemoryClient(),
 	}
 

--- a/provider/linode.go
+++ b/provider/linode.go
@@ -44,7 +44,7 @@ type LinodeDomainClient interface {
 // LinodeProvider is an implementation of Provider for Digital Ocean's DNS.
 type LinodeProvider struct {
 	Client       LinodeDomainClient
-	domainFilter DomainFilter
+	domainFilter endpoint.DomainFilter
 	DryRun       bool
 }
 
@@ -75,7 +75,7 @@ type LinodeChangeDelete struct {
 }
 
 // NewLinodeProvider initializes a new Linode DNS based Provider.
-func NewLinodeProvider(domainFilter DomainFilter, dryRun bool, appVersion string) (*LinodeProvider, error) {
+func NewLinodeProvider(domainFilter endpoint.DomainFilter, dryRun bool, appVersion string) (*LinodeProvider, error) {
 	token, ok := os.LookupEnv("LINODE_TOKEN")
 	if !ok {
 		return nil, fmt.Errorf("no token found")

--- a/provider/linode_test.go
+++ b/provider/linode_test.go
@@ -138,11 +138,11 @@ func TestLinodeConvertRecordType(t *testing.T) {
 
 func TestNewLinodeProvider(t *testing.T) {
 	_ = os.Setenv("LINODE_TOKEN", "xxxxxxxxxxxxxxxxx")
-	_, err := NewLinodeProvider(NewDomainFilter([]string{"ext-dns-test.zalando.to."}), true, "1.0")
+	_, err := NewLinodeProvider(endpoint.NewDomainFilter([]string{"ext-dns-test.zalando.to."}), true, "1.0")
 	require.NoError(t, err)
 
 	_ = os.Unsetenv("LINODE_TOKEN")
-	_, err = NewLinodeProvider(NewDomainFilter([]string{"ext-dns-test.zalando.to."}), true, "1.0")
+	_, err = NewLinodeProvider(endpoint.NewDomainFilter([]string{"ext-dns-test.zalando.to."}), true, "1.0")
 	require.Error(t, err)
 }
 
@@ -165,7 +165,7 @@ func TestLinodeFetchZonesNoFilters(t *testing.T) {
 
 	provider := &LinodeProvider{
 		Client:       &mockDomainClient,
-		domainFilter: NewDomainFilter([]string{}),
+		domainFilter: endpoint.NewDomainFilter([]string{}),
 		DryRun:       false,
 	}
 
@@ -188,7 +188,7 @@ func TestLinodeFetchZonesWithFilter(t *testing.T) {
 
 	provider := &LinodeProvider{
 		Client:       &mockDomainClient,
-		domainFilter: NewDomainFilter([]string{".com"}),
+		domainFilter: endpoint.NewDomainFilter([]string{".com"}),
 		DryRun:       false,
 	}
 
@@ -228,7 +228,7 @@ func TestLinodeRecords(t *testing.T) {
 
 	provider := &LinodeProvider{
 		Client:       &mockDomainClient,
-		domainFilter: NewDomainFilter([]string{}),
+		domainFilter: endpoint.NewDomainFilter([]string{}),
 		DryRun:       false,
 	}
 
@@ -278,7 +278,7 @@ func TestLinodeApplyChanges(t *testing.T) {
 
 	provider := &LinodeProvider{
 		Client:       &mockDomainClient,
-		domainFilter: NewDomainFilter([]string{}),
+		domainFilter: endpoint.NewDomainFilter([]string{}),
 		DryRun:       false,
 	}
 
@@ -389,7 +389,7 @@ func TestLinodeApplyChangesTargetAdded(t *testing.T) {
 
 	provider := &LinodeProvider{
 		Client:       &mockDomainClient,
-		domainFilter: NewDomainFilter([]string{}),
+		domainFilter: endpoint.NewDomainFilter([]string{}),
 		DryRun:       false,
 	}
 
@@ -448,7 +448,7 @@ func TestLinodeApplyChangesTargetRemoved(t *testing.T) {
 
 	provider := &LinodeProvider{
 		Client:       &mockDomainClient,
-		domainFilter: NewDomainFilter([]string{}),
+		domainFilter: endpoint.NewDomainFilter([]string{}),
 		DryRun:       false,
 	}
 
@@ -504,7 +504,7 @@ func TestLinodeApplyChangesNoChanges(t *testing.T) {
 
 	provider := &LinodeProvider{
 		Client:       &mockDomainClient,
-		domainFilter: NewDomainFilter([]string{}),
+		domainFilter: endpoint.NewDomainFilter([]string{}),
 		DryRun:       false,
 	}
 

--- a/provider/ns1.go
+++ b/provider/ns1.go
@@ -84,7 +84,7 @@ func (n NS1DomainService) ListZones() ([]*dns.Zone, *http.Response, error) {
 
 // NS1Config passes cli args to the NS1Provider
 type NS1Config struct {
-	DomainFilter DomainFilter
+	DomainFilter endpoint.DomainFilter
 	ZoneIDFilter ZoneIDFilter
 	NS1Endpoint  string
 	NS1IgnoreSSL bool
@@ -94,7 +94,7 @@ type NS1Config struct {
 // NS1Provider is the NS1 provider
 type NS1Provider struct {
 	client       NS1DomainClient
-	domainFilter DomainFilter
+	domainFilter endpoint.DomainFilter
 	zoneIDFilter ZoneIDFilter
 	dryRun       bool
 }

--- a/provider/ns1_test.go
+++ b/provider/ns1_test.go
@@ -129,7 +129,7 @@ func (m *MockNS1ListZonesFail) ListZones() ([]*dns.Zone, *http.Response, error) 
 func TestNS1Records(t *testing.T) {
 	provider := &NS1Provider{
 		client:       &MockNS1DomainClient{},
-		domainFilter: NewDomainFilter([]string{"foo.com."}),
+		domainFilter: endpoint.NewDomainFilter([]string{"foo.com."}),
 		zoneIDFilter: NewZoneIDFilter([]string{""}),
 	}
 	ctx := context.Background()
@@ -150,7 +150,7 @@ func TestNS1Records(t *testing.T) {
 func TestNewNS1Provider(t *testing.T) {
 	_ = os.Setenv("NS1_APIKEY", "xxxxxxxxxxxxxxxxx")
 	testNS1Config := NS1Config{
-		DomainFilter: NewDomainFilter([]string{"foo.com."}),
+		DomainFilter: endpoint.NewDomainFilter([]string{"foo.com."}),
 		ZoneIDFilter: NewZoneIDFilter([]string{""}),
 		DryRun:       false,
 	}
@@ -165,7 +165,7 @@ func TestNewNS1Provider(t *testing.T) {
 func TestNS1Zones(t *testing.T) {
 	provider := &NS1Provider{
 		client:       &MockNS1DomainClient{},
-		domainFilter: NewDomainFilter([]string{"foo.com."}),
+		domainFilter: endpoint.NewDomainFilter([]string{"foo.com."}),
 		zoneIDFilter: NewZoneIDFilter([]string{""}),
 	}
 

--- a/provider/oci.go
+++ b/provider/oci.go
@@ -55,7 +55,7 @@ type OCIProvider struct {
 	client ociDNSClient
 	cfg    OCIConfig
 
-	domainFilter DomainFilter
+	domainFilter endpoint.DomainFilter
 	zoneIDFilter ZoneIDFilter
 	dryRun       bool
 }
@@ -83,7 +83,7 @@ func LoadOCIConfig(path string) (*OCIConfig, error) {
 }
 
 // NewOCIProvider initialises a new OCI DNS based Provider.
-func NewOCIProvider(cfg OCIConfig, domainFilter DomainFilter, zoneIDFilter ZoneIDFilter, dryRun bool) (*OCIProvider, error) {
+func NewOCIProvider(cfg OCIConfig, domainFilter endpoint.DomainFilter, zoneIDFilter ZoneIDFilter, dryRun bool) (*OCIProvider, error) {
 	var client ociDNSClient
 	client, err := dns.NewDnsClientWithConfigurationProvider(common.NewRawConfigurationProvider(
 		cfg.Auth.TenancyID,
@@ -109,7 +109,7 @@ func NewOCIProvider(cfg OCIConfig, domainFilter DomainFilter, zoneIDFilter ZoneI
 func (p *OCIProvider) zones(ctx context.Context) (map[string]dns.ZoneSummary, error) {
 	zones := make(map[string]dns.ZoneSummary)
 
-	log.Debugf("Matching zones against domain filters: %v", p.domainFilter.filters)
+	log.Debugf("Matching zones against domain filters: %v", p.domainFilter.Filters)
 	var page *string
 	for {
 		resp, err := p.client.ListZones(ctx, dns.ListZonesRequest{
@@ -137,7 +137,7 @@ func (p *OCIProvider) zones(ctx context.Context) (map[string]dns.ZoneSummary, er
 
 	if len(zones) == 0 {
 		if p.domainFilter.IsConfigured() {
-			log.Warnf("No zones in compartment %q match domain filters %v", p.cfg.CompartmentID, p.domainFilter.filters)
+			log.Warnf("No zones in compartment %q match domain filters %v", p.cfg.CompartmentID, p.domainFilter.Filters)
 		} else {
 			log.Warnf("No zones found in compartment %q", p.cfg.CompartmentID)
 		}

--- a/provider/oci_test.go
+++ b/provider/oci_test.go
@@ -100,7 +100,7 @@ func (c *mockOCIDNSClient) PatchZoneRecords(ctx context.Context, request dns.Pat
 }
 
 // newOCIProvider creates an OCI provider with API calls mocked out.
-func newOCIProvider(client ociDNSClient, domainFilter DomainFilter, zoneIDFilter ZoneIDFilter, dryRun bool) *OCIProvider {
+func newOCIProvider(client ociDNSClient, domainFilter endpoint.DomainFilter, zoneIDFilter ZoneIDFilter, dryRun bool) *OCIProvider {
 	return &OCIProvider{
 		client: client,
 		cfg: OCIConfig{
@@ -183,7 +183,7 @@ hKRtDhmSdWBo3tJK12RrAe4t7CUe8gMgTvU7ExlcA3xQkseFPx9K
 		t.Run(name, func(t *testing.T) {
 			_, err := NewOCIProvider(
 				tc.config,
-				NewDomainFilter([]string{"com"}),
+				endpoint.NewDomainFilter([]string{"com"}),
 				NewZoneIDFilter([]string{""}),
 				false,
 			)
@@ -199,13 +199,13 @@ hKRtDhmSdWBo3tJK12RrAe4t7CUe8gMgTvU7ExlcA3xQkseFPx9K
 func TestOCIZones(t *testing.T) {
 	testCases := []struct {
 		name         string
-		domainFilter DomainFilter
+		domainFilter endpoint.DomainFilter
 		zoneIDFilter ZoneIDFilter
 		expected     map[string]dns.ZoneSummary
 	}{
 		{
 			name:         "DomainFilter_com",
-			domainFilter: NewDomainFilter([]string{"com"}),
+			domainFilter: endpoint.NewDomainFilter([]string{"com"}),
 			zoneIDFilter: NewZoneIDFilter([]string{""}),
 			expected: map[string]dns.ZoneSummary{
 				"foo.com": {
@@ -219,7 +219,7 @@ func TestOCIZones(t *testing.T) {
 			},
 		}, {
 			name:         "DomainFilter_foo.com",
-			domainFilter: NewDomainFilter([]string{"foo.com"}),
+			domainFilter: endpoint.NewDomainFilter([]string{"foo.com"}),
 			zoneIDFilter: NewZoneIDFilter([]string{""}),
 			expected: map[string]dns.ZoneSummary{
 				"foo.com": {
@@ -229,7 +229,7 @@ func TestOCIZones(t *testing.T) {
 			},
 		}, {
 			name:         "ZoneIDFilter_ocid1.dns-zone.oc1..e1e042ef0bfbb5c251b9713fd7bf8959",
-			domainFilter: NewDomainFilter([]string{""}),
+			domainFilter: endpoint.NewDomainFilter([]string{""}),
 			zoneIDFilter: NewZoneIDFilter([]string{"ocid1.dns-zone.oc1..e1e042ef0bfbb5c251b9713fd7bf8959"}),
 			expected: map[string]dns.ZoneSummary{
 				"foo.com": {
@@ -252,13 +252,13 @@ func TestOCIZones(t *testing.T) {
 func TestOCIRecords(t *testing.T) {
 	testCases := []struct {
 		name         string
-		domainFilter DomainFilter
+		domainFilter endpoint.DomainFilter
 		zoneIDFilter ZoneIDFilter
 		expected     []*endpoint.Endpoint
 	}{
 		{
 			name:         "unfiltered",
-			domainFilter: NewDomainFilter([]string{""}),
+			domainFilter: endpoint.NewDomainFilter([]string{""}),
 			zoneIDFilter: NewZoneIDFilter([]string{""}),
 			expected: []*endpoint.Endpoint{
 				endpoint.NewEndpointWithTTL("foo.foo.com", endpoint.RecordTypeA, endpoint.TTL(ociRecordTTL), "127.0.0.1"),
@@ -268,7 +268,7 @@ func TestOCIRecords(t *testing.T) {
 			},
 		}, {
 			name:         "DomainFilter_foo.com",
-			domainFilter: NewDomainFilter([]string{"foo.com"}),
+			domainFilter: endpoint.NewDomainFilter([]string{"foo.com"}),
 			zoneIDFilter: NewZoneIDFilter([]string{""}),
 			expected: []*endpoint.Endpoint{
 				endpoint.NewEndpointWithTTL("foo.foo.com", endpoint.RecordTypeA, endpoint.TTL(ociRecordTTL), "127.0.0.1"),
@@ -277,7 +277,7 @@ func TestOCIRecords(t *testing.T) {
 			},
 		}, {
 			name:         "ZoneIDFilter_ocid1.dns-zone.oc1..502aeddba262b92fd13ed7874f6f1404",
-			domainFilter: NewDomainFilter([]string{""}),
+			domainFilter: endpoint.NewDomainFilter([]string{""}),
 			zoneIDFilter: NewZoneIDFilter([]string{"ocid1.dns-zone.oc1..502aeddba262b92fd13ed7874f6f1404"}),
 			expected: []*endpoint.Endpoint{
 				endpoint.NewEndpointWithTTL("foo.bar.com", endpoint.RecordTypeA, endpoint.TTL(ociRecordTTL), "127.0.0.1"),
@@ -825,7 +825,7 @@ func TestOCIApplyChanges(t *testing.T) {
 			client := newMutableMockOCIDNSClient(tc.zones, tc.records)
 			provider := newOCIProvider(
 				client,
-				NewDomainFilter([]string{""}),
+				endpoint.NewDomainFilter([]string{""}),
 				NewZoneIDFilter([]string{""}),
 				tc.dryRun,
 			)

--- a/provider/pdns.go
+++ b/provider/pdns.go
@@ -62,7 +62,7 @@ const (
 
 // PDNSConfig is comprised of the fields necessary to create a new PDNSProvider
 type PDNSConfig struct {
-	DomainFilter DomainFilter
+	DomainFilter endpoint.DomainFilter
 	DryRun       bool
 	Server       string
 	APIKey       string
@@ -142,7 +142,7 @@ type PDNSAPIClient struct {
 	dryRun       bool
 	authCtx      context.Context
 	client       *pgo.APIClient
-	domainFilter DomainFilter
+	domainFilter endpoint.DomainFilter
 }
 
 // ListZones : Method returns all enabled zones from PowerDNS

--- a/provider/pdns_test.go
+++ b/provider/pdns_test.go
@@ -476,21 +476,21 @@ var (
 		},
 	}
 
-	DomainFilterListSingle = DomainFilter{
-		filters: []string{
+	DomainFilterListSingle = endpoint.DomainFilter{
+		Filters: []string{
 			"example.com",
 		},
 	}
 
-	DomainFilterListMultiple = DomainFilter{
-		filters: []string{
+	DomainFilterListMultiple = endpoint.DomainFilter{
+		Filters: []string{
 			"example.com",
 			"mock.com",
 		},
 	}
 
-	DomainFilterListEmpty = DomainFilter{
-		filters: []string{},
+	DomainFilterListEmpty = endpoint.DomainFilter{
+		Filters: []string{},
 	}
 
 	DomainFilterEmptyClient = &PDNSAPIClient{
@@ -643,7 +643,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSProviderCreate() {
 		context.Background(),
 		PDNSConfig{
 			Server:       "http://localhost:8081",
-			DomainFilter: NewDomainFilter([]string{""}),
+			DomainFilter: endpoint.NewDomainFilter([]string{""}),
 		})
 	assert.Error(suite.T(), err, "--pdns-api-key should be specified")
 
@@ -652,7 +652,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSProviderCreate() {
 		PDNSConfig{
 			Server:       "http://localhost:8081",
 			APIKey:       "foo",
-			DomainFilter: NewDomainFilter([]string{"example.com", "example.org"}),
+			DomainFilter: endpoint.NewDomainFilter([]string{"example.com", "example.org"}),
 		})
 	assert.Nil(suite.T(), err, "--domain-filter should raise no error")
 
@@ -661,7 +661,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSProviderCreate() {
 		PDNSConfig{
 			Server:       "http://localhost:8081",
 			APIKey:       "foo",
-			DomainFilter: NewDomainFilter([]string{""}),
+			DomainFilter: endpoint.NewDomainFilter([]string{""}),
 			DryRun:       true,
 		})
 	assert.Error(suite.T(), err, "--dry-run should raise an error")
@@ -672,7 +672,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSProviderCreate() {
 		PDNSConfig{
 			Server:       "http://localhost:8081",
 			APIKey:       "foo",
-			DomainFilter: NewDomainFilter([]string{""}),
+			DomainFilter: endpoint.NewDomainFilter([]string{""}),
 		})
 	assert.Nil(suite.T(), err, "Regular case should raise no error")
 }
@@ -684,7 +684,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSProviderCreateTLS() {
 		PDNSConfig{
 			Server:       "http://localhost:8081",
 			APIKey:       "foo",
-			DomainFilter: NewDomainFilter([]string{""}),
+			DomainFilter: endpoint.NewDomainFilter([]string{""}),
 		})
 	assert.Nil(suite.T(), err, "Omitted TLS Config case should raise no error")
 
@@ -693,7 +693,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSProviderCreateTLS() {
 		PDNSConfig{
 			Server:       "http://localhost:8081",
 			APIKey:       "foo",
-			DomainFilter: NewDomainFilter([]string{""}),
+			DomainFilter: endpoint.NewDomainFilter([]string{""}),
 			TLSConfig: TLSConfig{
 				TLSEnabled: false,
 			},
@@ -705,7 +705,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSProviderCreateTLS() {
 		PDNSConfig{
 			Server:       "http://localhost:8081",
 			APIKey:       "foo",
-			DomainFilter: NewDomainFilter([]string{""}),
+			DomainFilter: endpoint.NewDomainFilter([]string{""}),
 			TLSConfig: TLSConfig{
 				TLSEnabled:            false,
 				CAFilePath:            "/path/to/ca.crt",
@@ -720,7 +720,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSProviderCreateTLS() {
 		PDNSConfig{
 			Server:       "http://localhost:8081",
 			APIKey:       "foo",
-			DomainFilter: NewDomainFilter([]string{""}),
+			DomainFilter: endpoint.NewDomainFilter([]string{""}),
 			TLSConfig: TLSConfig{
 				TLSEnabled: true,
 			},
@@ -732,7 +732,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSProviderCreateTLS() {
 		PDNSConfig{
 			Server:       "http://localhost:8081",
 			APIKey:       "foo",
-			DomainFilter: NewDomainFilter([]string{""}),
+			DomainFilter: endpoint.NewDomainFilter([]string{""}),
 			TLSConfig: TLSConfig{
 				TLSEnabled: true,
 				CAFilePath: "../internal/testresources/ca.pem",
@@ -745,7 +745,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSProviderCreateTLS() {
 		PDNSConfig{
 			Server:       "http://localhost:8081",
 			APIKey:       "foo",
-			DomainFilter: NewDomainFilter([]string{""}),
+			DomainFilter: endpoint.NewDomainFilter([]string{""}),
 			TLSConfig: TLSConfig{
 				TLSEnabled:         true,
 				CAFilePath:         "../internal/testresources/ca.pem",
@@ -759,7 +759,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSProviderCreateTLS() {
 		PDNSConfig{
 			Server:       "http://localhost:8081",
 			APIKey:       "foo",
-			DomainFilter: NewDomainFilter([]string{""}),
+			DomainFilter: endpoint.NewDomainFilter([]string{""}),
 			TLSConfig: TLSConfig{
 				TLSEnabled:            true,
 				CAFilePath:            "../internal/testresources/ca.pem",
@@ -773,7 +773,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSProviderCreateTLS() {
 		PDNSConfig{
 			Server:       "http://localhost:8081",
 			APIKey:       "foo",
-			DomainFilter: NewDomainFilter([]string{""}),
+			DomainFilter: endpoint.NewDomainFilter([]string{""}),
 			TLSConfig: TLSConfig{
 				TLSEnabled:            true,
 				CAFilePath:            "../internal/testresources/ca.pem",

--- a/provider/rcode0.go
+++ b/provider/rcode0.go
@@ -34,7 +34,7 @@ import (
 type RcodeZeroProvider struct {
 	Client *rc0.Client
 
-	DomainFilter DomainFilter
+	DomainFilter endpoint.DomainFilter
 	DryRun       bool
 	TXTEncrypt   bool
 	Key          []byte
@@ -43,7 +43,7 @@ type RcodeZeroProvider struct {
 // NewRcodeZeroProvider creates a new RcodeZero Anycast DNS provider.
 //
 // Returns the provider or an error if a provider could not be created.
-func NewRcodeZeroProvider(domainFilter DomainFilter, dryRun bool, txtEnc bool) (*RcodeZeroProvider, error) {
+func NewRcodeZeroProvider(domainFilter endpoint.DomainFilter, dryRun bool, txtEnc bool) (*RcodeZeroProvider, error) {
 
 	client, err := rc0.NewClient(os.Getenv("RC0_API_KEY"))
 

--- a/provider/rcode0_test.go
+++ b/provider/rcode0_test.go
@@ -92,7 +92,7 @@ func TestRcodeZeroProvider_ApplyChanges(t *testing.T) {
 			Zones: mockZoneManagementService,
 			RRSet: mockRRSetService,
 		}),
-		DomainFilter: NewDomainFilter([]string{testZoneOne}),
+		DomainFilter: endpoint.NewDomainFilter([]string{testZoneOne}),
 	}
 
 	changes := mockChanges()
@@ -154,7 +154,7 @@ func Test_submitChanges(t *testing.T) {
 			Zones: mockZoneManagementService,
 			RRSet: mockRRSetService,
 		}),
-		DomainFilter: NewDomainFilter([]string{testZoneOne}),
+		DomainFilter: endpoint.NewDomainFilter([]string{testZoneOne}),
 	}
 
 	changes := mockRRSetChanges(rrsetChangesUnsupportedChangeType)
@@ -235,7 +235,7 @@ func TestRcodeZeroProvider_Zones(t *testing.T) {
 func TestNewRcodeZeroProvider(t *testing.T) {
 
 	_ = os.Setenv("RC0_API_KEY", "123")
-	p, err := NewRcodeZeroProvider(NewDomainFilter([]string{"ext-dns-test." + testZoneOne + "."}), true, true)
+	p, err := NewRcodeZeroProvider(endpoint.NewDomainFilter([]string{"ext-dns-test." + testZoneOne + "."}), true, true)
 
 	if err != nil {
 		t.Errorf("should not fail, %s", err)
@@ -246,7 +246,7 @@ func TestNewRcodeZeroProvider(t *testing.T) {
 	require.Equal(t, true, p.DomainFilter.IsConfigured())
 	require.Equal(t, false, p.DomainFilter.Match("ext-dns-test."+testZoneTwo+".")) // filter is set, so it should match only provided domains
 
-	p, err = NewRcodeZeroProvider(DomainFilter{}, false, false)
+	p, err = NewRcodeZeroProvider(endpoint.DomainFilter{}, false, false)
 
 	if err != nil {
 		t.Errorf("should not fail, %s", err)
@@ -257,7 +257,7 @@ func TestNewRcodeZeroProvider(t *testing.T) {
 	require.Equal(t, true, p.DomainFilter.Match("ext-dns-test."+testZoneOne+".")) // filter is not set, so it should match any
 
 	_ = os.Unsetenv("RC0_API_KEY")
-	_, err = NewRcodeZeroProvider(DomainFilter{}, false, false)
+	_, err = NewRcodeZeroProvider(endpoint.DomainFilter{}, false, false)
 
 	if err == nil {
 		t.Errorf("expected to fail")

--- a/provider/rdns.go
+++ b/provider/rdns.go
@@ -59,7 +59,7 @@ type RDNSClient interface {
 // RDNSConfig contains configuration to create a new Rancher DNS(RDNS) provider.
 type RDNSConfig struct {
 	DryRun       bool
-	DomainFilter DomainFilter
+	DomainFilter endpoint.DomainFilter
 	RootDomain   string
 }
 
@@ -67,7 +67,7 @@ type RDNSConfig struct {
 type RDNSProvider struct {
 	client       RDNSClient
 	dryRun       bool
-	domainFilter DomainFilter
+	domainFilter endpoint.DomainFilter
 	rootDomain   string
 }
 

--- a/provider/rfc2136.go
+++ b/provider/rfc2136.go
@@ -44,7 +44,7 @@ type rfc2136Provider struct {
 	minTTL        time.Duration
 
 	// only consider hosted zones managing domains ending in this suffix
-	domainFilter DomainFilter
+	domainFilter endpoint.DomainFilter
 	dryRun       bool
 	actions      rfc2136Actions
 }
@@ -65,7 +65,7 @@ type rfc2136Actions interface {
 }
 
 // NewRfc2136Provider is a factory function for OpenStack rfc2136 providers
-func NewRfc2136Provider(host string, port int, zoneName string, insecure bool, keyName string, secret string, secretAlg string, axfr bool, domainFilter DomainFilter, dryRun bool, minTTL time.Duration, actions rfc2136Actions) (Provider, error) {
+func NewRfc2136Provider(host string, port int, zoneName string, insecure bool, keyName string, secret string, secretAlg string, axfr bool, domainFilter endpoint.DomainFilter, dryRun bool, minTTL time.Duration, actions rfc2136Actions) (Provider, error) {
 	secretAlgChecked, ok := tsigAlgs[secretAlg]
 	if !ok && !insecure {
 		return nil, errors.Errorf("%s is not supported TSIG algorithm", secretAlg)

--- a/provider/rfc2136_test.go
+++ b/provider/rfc2136_test.go
@@ -94,7 +94,7 @@ func (r *rfc2136Stub) IncomeTransfer(m *dns.Msg, a string) (env chan *dns.Envelo
 }
 
 func createRfc2136StubProvider(stub *rfc2136Stub) (Provider, error) {
-	return NewRfc2136Provider("", 0, "", false, "key", "secret", "hmac-sha512", true, DomainFilter{}, false, 300*time.Second, stub)
+	return NewRfc2136Provider("", 0, "", false, "key", "secret", "hmac-sha512", true, endpoint.DomainFilter{}, false, 300*time.Second, stub)
 }
 
 func extractAuthoritySectionFromMessage(msg fmt.Stringer) []string {

--- a/provider/transip.go
+++ b/provider/transip.go
@@ -23,12 +23,12 @@ const (
 // TransIPProvider is an implementation of Provider for TransIP.
 type TransIPProvider struct {
 	client       gotransip.SOAPClient
-	domainFilter DomainFilter
+	domainFilter endpoint.DomainFilter
 	dryRun       bool
 }
 
 // NewTransIPProvider initializes a new TransIP Provider.
-func NewTransIPProvider(accountName, privateKeyFile string, domainFilter DomainFilter, dryRun bool) (*TransIPProvider, error) {
+func NewTransIPProvider(accountName, privateKeyFile string, domainFilter endpoint.DomainFilter, dryRun bool) (*TransIPProvider, error) {
 	// check given arguments
 	if accountName == "" {
 		return nil, errors.New("required --transip-account not set")

--- a/provider/vinyldns.go
+++ b/provider/vinyldns.go
@@ -49,7 +49,7 @@ type vinyldnsZoneInterface interface {
 type vinyldnsProvider struct {
 	client       vinyldnsZoneInterface
 	zoneFilter   ZoneIDFilter
-	domainFilter DomainFilter
+	domainFilter endpoint.DomainFilter
 	dryRun       bool
 }
 
@@ -59,7 +59,7 @@ type vinyldnsChange struct {
 }
 
 // NewVinylDNSProvider provides support for VinylDNS records
-func NewVinylDNSProvider(domainFilter DomainFilter, zoneFilter ZoneIDFilter, dryRun bool) (Provider, error) {
+func NewVinylDNSProvider(domainFilter endpoint.DomainFilter, zoneFilter ZoneIDFilter, dryRun bool) (Provider, error) {
 	_, ok := os.LookupEnv("VINYLDNS_ACCESS_KEY")
 	if !ok {
 		return nil, fmt.Errorf("no vinyldns access key found")

--- a/provider/vinyldns_test.go
+++ b/provider/vinyldns_test.go
@@ -92,7 +92,7 @@ func TestVinylDNSServices(t *testing.T) {
 func testVinylDNSProviderRecords(t *testing.T) {
 	ctx := context.Background()
 
-	mockVinylDNSProvider.domainFilter = NewDomainFilter([]string{"example.com"})
+	mockVinylDNSProvider.domainFilter = endpoint.NewDomainFilter([]string{"example.com"})
 	result, err := mockVinylDNSProvider.Records(ctx)
 	assert.Nil(t, err)
 	assert.Equal(t, len(vinylDNSRecords), len(result))
@@ -134,11 +134,11 @@ func testVinylDNSSuitableZone(t *testing.T) {
 
 func TestNewVinylDNSProvider(t *testing.T) {
 	os.Setenv("VINYLDNS_ACCESS_KEY", "xxxxxxxxxxxxxxxxxxxxxxxxxx")
-	_, err := NewVinylDNSProvider(NewDomainFilter([]string{"example.com"}), NewZoneIDFilter([]string{"0"}), true)
+	_, err := NewVinylDNSProvider(endpoint.NewDomainFilter([]string{"example.com"}), NewZoneIDFilter([]string{"0"}), true)
 	assert.Nil(t, err)
 
 	os.Unsetenv("VINYLDNS_ACCESS_KEY")
-	_, err = NewVinylDNSProvider(NewDomainFilter([]string{"example.com"}), NewZoneIDFilter([]string{"0"}), true)
+	_, err = NewVinylDNSProvider(endpoint.NewDomainFilter([]string{"example.com"}), NewZoneIDFilter([]string{"0"}), true)
 	assert.NotNil(t, err)
 	if err == nil {
 		t.Errorf("Expected to fail new provider on empty token")


### PR DESCRIPTION
These changes were implemented for the setup mentioned in #1137:

>We start multiple external-dns processes, one for each Hosted Zone where DNS entries should be created (other options omitted for brevity):
>1: `external-dns --domain-filter=cluster1.example.com`
>2: `external-dns --domain-filter=example.com --exclude-domains=cluster1.example.com`
>Process "1" does exactly what it is supposed to, creating records in the Hosted Zone `cluster1.example.com` only.
>Process "2" however tries to create DNS entries for `example.com` and `cluster1.example.com`:
>[...]

`domain_filter.go` was moved to the `endpoint` package to make it possible to filter and exclude record names in `plan.filterRecordsForPlan()` so it does not have to be implemented in every single provider. Now Process "2" will only create DNS entries for `example.com`. Before `--exclude-domains` was only filtering/excluding DNS zones.

Because some providers access `DomainFilter.filters` directly it had to be exported.

A build with these changes has been running in production at FREE NOW for a couple of weeks without issues.

Fixes #1137