### PR TITLE
Docs: Change example manifest to use GCR image

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -204,7 +204,7 @@ $ docker run \
   -e EXTERNAL_DNS_SOURCE=$'service\ningress' \
   -e EXTERNAL_DNS_PROVIDER=google \
   -e EXTERNAL_DNS_DOMAIN_FILTER=$'foo.com\nbar.com' \
-  registry.opensource.zalan.do/teapot/external-dns:latest
+  us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
 time="2017-08-08T14:10:26Z" level=info msg="config: &{Master: KubeConfig: Sources:[service ingress] Namespace: ...
 ```
 
@@ -272,7 +272,7 @@ Separate them by `,`.
 
 ### Are there official Docker images provided?
 
-When we tag a new release, we push a Docker image on Zalando's public Docker registry with the following name: 
+When we tag a new release, we push a Docker image on Zalando's public Docker registry with the following name:
 
 ```
 registry.opensource.zalan.do/teapot/external-dns

--- a/docs/tutorials/alibabacloud.md
+++ b/docs/tutorials/alibabacloud.md
@@ -113,7 +113,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service
         - --source=ingress
@@ -187,7 +187,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service
         - --source=ingress

--- a/docs/tutorials/aws-sd.md
+++ b/docs/tutorials/aws-sd.md
@@ -81,7 +81,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         env:
           - name: AWS_REGION
             value: us-east-1 # put your CloudMap NameSpace region
@@ -148,7 +148,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         env:
           - name: AWS_REGION
             value: us-east-1 # put your CloudMap NameSpace region

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -141,7 +141,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service
         - --source=ingress
@@ -216,7 +216,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service
         - --source=ingress

--- a/docs/tutorials/azure-private-dns.md
+++ b/docs/tutorials/azure-private-dns.md
@@ -164,7 +164,7 @@ spec:
     spec:
       containers:
       - name: externaldns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service
         - --source=ingress
@@ -231,7 +231,7 @@ spec:
       serviceAccountName: externaldns
       containers:
       - name: externaldns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service
         - --source=ingress
@@ -298,7 +298,7 @@ spec:
       serviceAccountName: externaldns
       containers:
       - name: externaldns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service
         - --source=ingress

--- a/docs/tutorials/azure.md
+++ b/docs/tutorials/azure.md
@@ -191,7 +191,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service
         - --source=ingress
@@ -261,7 +261,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service
         - --source=ingress
@@ -331,7 +331,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service
         - --source=ingress

--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -48,7 +48,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
@@ -115,7 +115,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.

--- a/docs/tutorials/contour.md
+++ b/docs/tutorials/contour.md
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service
         - --source=ingress
@@ -91,7 +91,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service
         - --source=ingress

--- a/docs/tutorials/coredns.md
+++ b/docs/tutorials/coredns.md
@@ -108,7 +108,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=ingress
         - --provider=coredns
@@ -175,7 +175,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=ingress
         - --provider=coredns

--- a/docs/tutorials/designate.md
+++ b/docs/tutorials/designate.md
@@ -59,7 +59,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
@@ -132,7 +132,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.

--- a/docs/tutorials/digitalocean.md
+++ b/docs/tutorials/digitalocean.md
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
@@ -113,7 +113,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.

--- a/docs/tutorials/dnsimple.md
+++ b/docs/tutorials/dnsimple.md
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone you create in DNSimple.
@@ -100,7 +100,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone you create in DNSimple.

--- a/docs/tutorials/dyn.md
+++ b/docs/tutorials/dyn.md
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=ingress
         - --txt-prefix=_d

--- a/docs/tutorials/externalname.md
+++ b/docs/tutorials/externalname.md
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --log-level=debug
         - --source=service

--- a/docs/tutorials/gke.md
+++ b/docs/tutorials/gke.md
@@ -91,7 +91,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service
         - --source=ingress
@@ -156,7 +156,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service
         - --source=ingress

--- a/docs/tutorials/hostport.md
+++ b/docs/tutorials/hostport.md
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --log-level=debug
         - --source=service
@@ -96,7 +96,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --log-level=debug
         - --source=service

--- a/docs/tutorials/infoblox.md
+++ b/docs/tutorials/infoblox.md
@@ -69,7 +69,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service
         - --domain-filter=example.com       # (optional) limit to only example.com domains.
@@ -149,7 +149,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service
         - --domain-filter=example.com       # (optional) limit to only example.com domains.

--- a/docs/tutorials/istio.md
+++ b/docs/tutorials/istio.md
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service
         - --source=ingress
@@ -97,7 +97,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service
         - --source=ingress

--- a/docs/tutorials/linode.md
+++ b/docs/tutorials/linode.md
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
@@ -105,7 +105,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.

--- a/docs/tutorials/nginx-ingress.md
+++ b/docs/tutorials/nginx-ingress.md
@@ -262,7 +262,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=ingress
         - --domain-filter=external-dns-test.gcp.zalan.do

--- a/docs/tutorials/ns1.md
+++ b/docs/tutorials/ns1.md
@@ -61,7 +61,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
@@ -125,7 +125,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.

--- a/docs/tutorials/oracle.md
+++ b/docs/tutorials/oracle.md
@@ -91,7 +91,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service
         - --source=ingress

--- a/docs/tutorials/pdns.md
+++ b/docs/tutorials/pdns.md
@@ -42,7 +42,7 @@ spec:
       # serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service # or ingress or both
         - --provider=pdns

--- a/docs/tutorials/public-private-route53.md
+++ b/docs/tutorials/public-private-route53.md
@@ -243,7 +243,7 @@ spec:
         - --txt-owner-id=external-dns
         - --annotation-filter=kubernetes.io/ingress.class=external-ingress
         - --aws-zone-type=public
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         name: external-dns-public
 ```
 
@@ -281,7 +281,7 @@ spec:
         - --txt-owner-id=dev.k8s.nexus
         - --annotation-filter=kubernetes.io/ingress.class=internal-ingress
         - --aws-zone-type=private
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         name: external-dns-private
 ```
 

--- a/docs/tutorials/rcodezero.md
+++ b/docs/tutorials/rcodezero.md
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
@@ -120,7 +120,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.

--- a/docs/tutorials/rdns.md
+++ b/docs/tutorials/rdns.md
@@ -54,7 +54,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=ingress
         - --provider=rdns
@@ -123,7 +123,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=ingress
         - --provider=rdns

--- a/docs/tutorials/transip.md
+++ b/docs/tutorials/transip.md
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains
@@ -107,7 +107,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains

--- a/docs/tutorials/vinyldns.md
+++ b/docs/tutorials/vinyldns.md
@@ -66,7 +66,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --provider=vinyldns
         - --source=service
@@ -137,7 +137,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0
         args:
         - --provider=vinyldns
         - --source=service


### PR DESCRIPTION
Previously, an example command in the FAQ and the example manifests in
the tutorials (with a few exceptions) were citing the image to be:

  registry.opensource.zalan.do/teapot/external-dns:latest

This may lead to some confusion, since that's not where new releases are
published (as far as I can tell, anyway).

This commit replaces the zalan.do images with the one from the latest
release at the time of this commit (v0.6.0):

  us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.6.0

There are three options (asia, eu, and us) for the GCR registry. I
picked the United States one arbitrarily. In the Exoscale tutorial, it
uses the EU one. I'll leave it up to the maintainers to figure out if
this inconsistency is acceptable :)