### PR TITLE
fix: don't keep updating because of defaulted annotations

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -141,7 +141,7 @@ func (c *Controller) RunOnce(ctx context.Context) error {
 		DomainFilter: c.DomainFilter,
 	}
 
-	plan = plan.Calculate()
+	plan = plan.Calculate(c.Registry)
 
 	err = c.Registry.ApplyChanges(ctx, plan.Changes)
 	if err != nil {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -35,6 +35,7 @@ import (
 
 // mockProvider returns mock endpoints and validates changes.
 type mockProvider struct {
+	provider.BaseProvider
 	RecordsStore  []*endpoint.Endpoint
 	ExpectChanges *plan.Changes
 }

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -26,6 +26,23 @@ import (
 	"sigs.k8s.io/external-dns/internal/testutils"
 )
 
+type PlanTestComparator struct {
+}
+
+func (p PlanTestComparator) AttributeValuesEqual(attribute string, value1 *string, value2 *string) bool {
+	if (value1 == nil) != (value2 == nil) {
+		return false
+	}
+
+	if value1 == nil {
+		return true
+	}
+
+	return *value1 == *value2
+}
+
+var testComparator = PlanTestComparator{}
+
 type PlanTestSuite struct {
 	suite.Suite
 	fooV1Cname                       *endpoint.Endpoint
@@ -200,7 +217,7 @@ func (suite *PlanTestSuite) TestSyncFirstRound() {
 		Desired:  desired,
 	}
 
-	changes := p.Calculate().Changes
+	changes := p.Calculate(testComparator).Changes
 	validateEntries(suite.T(), changes.Create, expectedCreate)
 	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
 	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
@@ -221,7 +238,7 @@ func (suite *PlanTestSuite) TestSyncSecondRound() {
 		Desired:  desired,
 	}
 
-	changes := p.Calculate().Changes
+	changes := p.Calculate(testComparator).Changes
 	validateEntries(suite.T(), changes.Create, expectedCreate)
 	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
 	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
@@ -242,7 +259,7 @@ func (suite *PlanTestSuite) TestSyncSecondRoundMigration() {
 		Desired:  desired,
 	}
 
-	changes := p.Calculate().Changes
+	changes := p.Calculate(testComparator).Changes
 	validateEntries(suite.T(), changes.Create, expectedCreate)
 	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
 	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
@@ -263,7 +280,7 @@ func (suite *PlanTestSuite) TestSyncSecondRoundWithTTLChange() {
 		Desired:  desired,
 	}
 
-	changes := p.Calculate().Changes
+	changes := p.Calculate(testComparator).Changes
 	validateEntries(suite.T(), changes.Create, expectedCreate)
 	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
 	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
@@ -284,7 +301,7 @@ func (suite *PlanTestSuite) TestSyncSecondRoundWithProviderSpecificChange() {
 		Desired:  desired,
 	}
 
-	changes := p.Calculate().Changes
+	changes := p.Calculate(testComparator).Changes
 	validateEntries(suite.T(), changes.Create, expectedCreate)
 	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
 	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
@@ -315,7 +332,7 @@ func (suite *PlanTestSuite) TestSyncSecondRoundWithOwnerInherited() {
 		Desired:  desired,
 	}
 
-	changes := p.Calculate().Changes
+	changes := p.Calculate(testComparator).Changes
 	validateEntries(suite.T(), changes.Create, expectedCreate)
 	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
 	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
@@ -336,7 +353,7 @@ func (suite *PlanTestSuite) TestIdempotency() {
 		Desired:  desired,
 	}
 
-	changes := p.Calculate().Changes
+	changes := p.Calculate(testComparator).Changes
 	validateEntries(suite.T(), changes.Create, expectedCreate)
 	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
 	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
@@ -357,7 +374,7 @@ func (suite *PlanTestSuite) TestDifferentTypes() {
 		Desired:  desired,
 	}
 
-	changes := p.Calculate().Changes
+	changes := p.Calculate(testComparator).Changes
 	validateEntries(suite.T(), changes.Create, expectedCreate)
 	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
 	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
@@ -378,7 +395,7 @@ func (suite *PlanTestSuite) TestIgnoreTXT() {
 		Desired:  desired,
 	}
 
-	changes := p.Calculate().Changes
+	changes := p.Calculate(testComparator).Changes
 	validateEntries(suite.T(), changes.Create, expectedCreate)
 	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
 	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
@@ -399,7 +416,7 @@ func (suite *PlanTestSuite) TestRemoveEndpoint() {
 		Desired:  desired,
 	}
 
-	changes := p.Calculate().Changes
+	changes := p.Calculate(testComparator).Changes
 	validateEntries(suite.T(), changes.Create, expectedCreate)
 	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
 	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
@@ -420,7 +437,7 @@ func (suite *PlanTestSuite) TestRemoveEndpointWithUpsert() {
 		Desired:  desired,
 	}
 
-	changes := p.Calculate().Changes
+	changes := p.Calculate(testComparator).Changes
 	validateEntries(suite.T(), changes.Create, expectedCreate)
 	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
 	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
@@ -442,7 +459,7 @@ func (suite *PlanTestSuite) TestDuplicatedEndpointsForSameResourceReplace() {
 		Desired:  desired,
 	}
 
-	changes := p.Calculate().Changes
+	changes := p.Calculate(testComparator).Changes
 	validateEntries(suite.T(), changes.Create, expectedCreate)
 	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
 	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
@@ -465,7 +482,7 @@ func (suite *PlanTestSuite) TestDuplicatedEndpointsForSameResourceRetain() {
 		Desired:  desired,
 	}
 
-	changes := p.Calculate().Changes
+	changes := p.Calculate(testComparator).Changes
 	validateEntries(suite.T(), changes.Create, expectedCreate)
 	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
 	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
@@ -487,7 +504,7 @@ func (suite *PlanTestSuite) TestMultipleRecordsSameNameDifferentSetIdentifier() 
 		Desired:  desired,
 	}
 
-	changes := p.Calculate().Changes
+	changes := p.Calculate(testComparator).Changes
 	validateEntries(suite.T(), changes.Create, expectedCreate)
 	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
 	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
@@ -509,7 +526,7 @@ func (suite *PlanTestSuite) TestSetIdentifierUpdateCreatesAndDeletes() {
 		Desired:  desired,
 	}
 
-	changes := p.Calculate().Changes
+	changes := p.Calculate(testComparator).Changes
 	validateEntries(suite.T(), changes.Create, expectedCreate)
 	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
 	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
@@ -532,7 +549,7 @@ func (suite *PlanTestSuite) TestDomainFiltersInitial() {
 		DomainFilter: endpoint.NewDomainFilterWithExclusions([]string{"domain.tld"}, []string{"ex.domain.tld"}),
 	}
 
-	changes := p.Calculate().Changes
+	changes := p.Calculate(testComparator).Changes
 	validateEntries(suite.T(), changes.Create, expectedCreate)
 	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
 	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
@@ -555,7 +572,7 @@ func (suite *PlanTestSuite) TestDomainFiltersUpdate() {
 		DomainFilter: endpoint.NewDomainFilterWithExclusions([]string{"domain.tld"}, []string{"ex.domain.tld"}),
 	}
 
-	changes := p.Calculate().Changes
+	changes := p.Calculate(testComparator).Changes
 	validateEntries(suite.T(), changes.Create, expectedCreate)
 	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
 	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)

--- a/provider/akamai.go
+++ b/provider/akamai.go
@@ -60,6 +60,7 @@ type AkamaiConfig struct {
 
 // AkamaiProvider implements the DNS provider for Akamai.
 type AkamaiProvider struct {
+	BaseProvider
 	domainFilter endpoint.DomainFilter
 	zoneIDFilter ZoneIDFilter
 	config       edgegrid.Config

--- a/provider/alibaba_cloud.go
+++ b/provider/alibaba_cloud.go
@@ -66,6 +66,7 @@ type AlibabaCloudPrivateZoneAPI interface {
 
 // AlibabaCloudProvider implements the DNS provider for Alibaba Cloud.
 type AlibabaCloudProvider struct {
+	BaseProvider
 	domainFilter         endpoint.DomainFilter
 	zoneIDFilter         ZoneIDFilter // Private Zone only
 	MaxChangeCount       int

--- a/provider/aws.go
+++ b/provider/aws.go
@@ -113,6 +113,7 @@ type Route53API interface {
 
 // AWSProvider is an implementation of Provider for AWS Route53.
 type AWSProvider struct {
+	BaseProvider
 	client               Route53API
 	dryRun               bool
 	batchChangeSize      int

--- a/provider/aws_sd.go
+++ b/provider/aws_sd.go
@@ -73,6 +73,7 @@ type AWSSDClient interface {
 
 // AWSSDProvider is an implementation of Provider for AWS Cloud Map.
 type AWSSDProvider struct {
+	BaseProvider
 	client AWSSDClient
 	dryRun bool
 	// only consider namespaces ending in this suffix

--- a/provider/azure.go
+++ b/provider/azure.go
@@ -66,6 +66,7 @@ type RecordSetsClient interface {
 
 // AzureProvider implements the DNS provider for Microsoft's Azure cloud platform.
 type AzureProvider struct {
+	BaseProvider
 	domainFilter                 endpoint.DomainFilter
 	zoneIDFilter                 ZoneIDFilter
 	dryRun                       bool

--- a/provider/azure_private_dns.go
+++ b/provider/azure_private_dns.go
@@ -45,6 +45,7 @@ type PrivateRecordSetsClient interface {
 
 // AzurePrivateDNSProvider implements the DNS provider for Microsoft's Azure Private DNS service
 type AzurePrivateDNSProvider struct {
+	BaseProvider
 	domainFilter     endpoint.DomainFilter
 	zoneIDFilter     ZoneIDFilter
 	dryRun           bool

--- a/provider/coredns.go
+++ b/provider/coredns.go
@@ -56,6 +56,7 @@ type coreDNSClient interface {
 }
 
 type coreDNSProvider struct {
+	BaseProvider
 	dryRun        bool
 	coreDNSPrefix string
 	domainFilter  endpoint.DomainFilter

--- a/provider/designate.go
+++ b/provider/designate.go
@@ -226,6 +226,7 @@ func (c designateClient) DeleteRecordSet(zoneID, recordSetID string) error {
 
 // designate provider type
 type designateProvider struct {
+	BaseProvider
 	client designateClientInterface
 
 	// only consider hosted zones managing domains ending in this suffix

--- a/provider/digital_ocean.go
+++ b/provider/digital_ocean.go
@@ -44,6 +44,7 @@ const (
 
 // DigitalOceanProvider is an implementation of Provider for Digital Ocean's DNS.
 type DigitalOceanProvider struct {
+	BaseProvider
 	Client godo.DomainsService
 	// only consider hosted zones managing domains ending in this suffix
 	domainFilter endpoint.DomainFilter

--- a/provider/dnsimple.go
+++ b/provider/dnsimple.go
@@ -84,6 +84,7 @@ func (z dnsimpleZoneService) UpdateRecord(accountID string, zoneID string, recor
 }
 
 type dnsimpleProvider struct {
+	BaseProvider
 	client       dnsimpleZoneServiceInterface
 	identity     identityService
 	accountID    string

--- a/provider/dyn.go
+++ b/provider/dyn.go
@@ -103,6 +103,7 @@ func (snap *ZoneSnapshot) StoreRecordsForSerial(zone string, serial int, records
 
 // DynProvider is the actual interface impl.
 type dynProviderState struct {
+	BaseProvider
 	DynConfig
 	LastLoginErrorTime int64
 

--- a/provider/exoscale.go
+++ b/provider/exoscale.go
@@ -38,6 +38,7 @@ type EgoscaleClientI interface {
 
 // ExoscaleProvider initialized as dns provider with no records
 type ExoscaleProvider struct {
+	BaseProvider
 	domain         endpoint.DomainFilter
 	client         EgoscaleClientI
 	filter         *zoneFilter

--- a/provider/google.go
+++ b/provider/google.go
@@ -98,6 +98,7 @@ func (c changesService) Create(project string, managedZone string, change *dns.C
 
 // GoogleProvider is an implementation of Provider for Google CloudDNS.
 type GoogleProvider struct {
+	BaseProvider
 	// The Google project to work in
 	project string
 	// Enabled dry-run will print any modifying actions rather than execute them.

--- a/provider/infoblox.go
+++ b/provider/infoblox.go
@@ -48,6 +48,7 @@ type InfobloxConfig struct {
 
 // InfobloxProvider implements the DNS provider for Infoblox.
 type InfobloxProvider struct {
+	BaseProvider
 	client       ibclient.IBConnector
 	domainFilter endpoint.DomainFilter
 	zoneIDFilter ZoneIDFilter

--- a/provider/inmemory.go
+++ b/provider/inmemory.go
@@ -43,6 +43,7 @@ var (
 // InMemoryProvider - dns provider only used for testing purposes
 // initialized as dns provider with no records
 type InMemoryProvider struct {
+	BaseProvider
 	domain         endpoint.DomainFilter
 	client         *inMemoryClient
 	filter         *filter

--- a/provider/linode.go
+++ b/provider/linode.go
@@ -43,6 +43,7 @@ type LinodeDomainClient interface {
 
 // LinodeProvider is an implementation of Provider for Digital Ocean's DNS.
 type LinodeProvider struct {
+	BaseProvider
 	Client       LinodeDomainClient
 	domainFilter endpoint.DomainFilter
 	DryRun       bool

--- a/provider/ns1.go
+++ b/provider/ns1.go
@@ -93,6 +93,7 @@ type NS1Config struct {
 
 // NS1Provider is the NS1 provider
 type NS1Provider struct {
+	BaseProvider
 	client       NS1DomainClient
 	domainFilter endpoint.DomainFilter
 	zoneIDFilter ZoneIDFilter

--- a/provider/oci.go
+++ b/provider/oci.go
@@ -52,6 +52,7 @@ type OCIConfig struct {
 // OCIProvider is an implementation of Provider for Oracle Cloud Infrastructure
 // (OCI) DNS.
 type OCIProvider struct {
+	BaseProvider
 	client ociDNSClient
 	cfg    OCIConfig
 

--- a/provider/ovh.go
+++ b/provider/ovh.go
@@ -45,6 +45,8 @@ var (
 
 // OVHProvider is an implementation of Provider for OVH DNS.
 type OVHProvider struct {
+	BaseProvider
+
 	client ovhClient
 
 	domainFilter endpoint.DomainFilter

--- a/provider/pdns.go
+++ b/provider/pdns.go
@@ -221,6 +221,7 @@ func (c *PDNSAPIClient) PatchZone(zoneID string, zoneStruct pgo.Zone) (resp *htt
 
 // PDNSProvider is an implementation of the Provider interface for PowerDNS
 type PDNSProvider struct {
+	BaseProvider
 	client PDNSAPIProvider
 }
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -29,6 +29,22 @@ import (
 type Provider interface {
 	Records(ctx context.Context) ([]*endpoint.Endpoint, error)
 	ApplyChanges(ctx context.Context, changes *plan.Changes) error
+	AttributeValuesEqual(attribute string, value1 *string, value2 *string) bool
+}
+
+type BaseProvider struct {
+}
+
+func (b BaseProvider) AttributeValuesEqual(attribute string, value1 *string, value2 *string) bool {
+	if (value1 == nil) != (value2 == nil) {
+		return false
+	}
+
+	if value1 == nil {
+		return true
+	}
+
+	return *value1 == *value2
 }
 
 type contextKey struct {

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
@@ -43,4 +44,16 @@ func TestEnsureTrailingDot(t *testing.T) {
 			t.Errorf("expected %s, got %s", tc.expected, output)
 		}
 	}
+}
+
+func TestBaseProviderAttributeEquality(t *testing.T) {
+	p := BaseProvider{}
+	foo := "Foo"
+	bar := "Bar"
+
+	assert.True(t, p.AttributeValuesEqual("some.attribute", nil, nil), "Both attributes not present")
+	assert.False(t, p.AttributeValuesEqual("some.attribute", nil, &foo), "First attribute missing")
+	assert.False(t, p.AttributeValuesEqual("some.attribute", &foo, nil), "Second attribute missing")
+	assert.True(t, p.AttributeValuesEqual("some.attribute", &foo, &foo), "Attributes the same")
+	assert.False(t, p.AttributeValuesEqual("some.attribute", &foo, &bar), "Attributes differ")
 }

--- a/provider/rcode0.go
+++ b/provider/rcode0.go
@@ -32,6 +32,7 @@ import (
 
 // RcodeZeroProvider implements the DNS provider for RcodeZero Anycast DNS.
 type RcodeZeroProvider struct {
+	BaseProvider
 	Client *rc0.Client
 
 	DomainFilter endpoint.DomainFilter

--- a/provider/rdns.go
+++ b/provider/rdns.go
@@ -65,6 +65,7 @@ type RDNSConfig struct {
 
 // RDNSProvider is an implementation of Provider for Rancher DNS(RDNS).
 type RDNSProvider struct {
+	BaseProvider
 	client       RDNSClient
 	dryRun       bool
 	domainFilter endpoint.DomainFilter

--- a/provider/rfc2136.go
+++ b/provider/rfc2136.go
@@ -34,6 +34,7 @@ import (
 
 // rfc2136 provider type
 type rfc2136Provider struct {
+	BaseProvider
 	nameserver    string
 	zoneName      string
 	tsigKeyName   string

--- a/provider/transip.go
+++ b/provider/transip.go
@@ -22,6 +22,7 @@ const (
 
 // TransIPProvider is an implementation of Provider for TransIP.
 type TransIPProvider struct {
+	BaseProvider
 	client       gotransip.SOAPClient
 	domainFilter endpoint.DomainFilter
 	dryRun       bool

--- a/provider/vinyldns.go
+++ b/provider/vinyldns.go
@@ -47,6 +47,7 @@ type vinyldnsZoneInterface interface {
 }
 
 type vinyldnsProvider struct {
+	BaseProvider
 	client       vinyldnsZoneInterface
 	zoneFilter   ZoneIDFilter
 	domainFilter endpoint.DomainFilter

--- a/provider/vultr.go
+++ b/provider/vultr.go
@@ -37,6 +37,8 @@ const (
 )
 
 type VultrProvider struct {
+	BaseProvider
+
 	client govultr.Client
 
 	domainFilter endpoint.DomainFilter

--- a/registry/aws_sd_registry.go
+++ b/registry/aws_sd_registry.go
@@ -87,3 +87,8 @@ func (sdr *AWSSDRegistry) updateLabels(endpoints []*endpoint.Endpoint) {
 		ep.Labels[endpoint.AWSSDDescriptionLabel] = ep.Labels.Serialize(false)
 	}
 }
+
+// AttributeValuesEqual compares two attribute values for equality
+func (sdr *AWSSDRegistry) AttributeValuesEqual(attribute string, value1 *string, value2 *string) bool {
+	return sdr.provider.AttributeValuesEqual(attribute, value1, value2)
+}

--- a/registry/aws_sd_registry_test.go
+++ b/registry/aws_sd_registry_test.go
@@ -26,9 +26,11 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/internal/testutils"
 	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
 )
 
 type inMemoryProvider struct {
+	provider.BaseProvider
 	endpoints      []*endpoint.Endpoint
 	onApplyChanges func(changes *plan.Changes)
 }

--- a/registry/noop.go
+++ b/registry/noop.go
@@ -45,3 +45,8 @@ func (im *NoopRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, erro
 func (im *NoopRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
 	return im.provider.ApplyChanges(ctx, changes)
 }
+
+// AttributeValuesEqual compares two attribute values for equality
+func (im *NoopRegistry) AttributeValuesEqual(attribute string, value1 *string, value2 *string) bool {
+	return im.provider.AttributeValuesEqual(attribute, value1, value2)
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -32,6 +32,7 @@ import (
 type Registry interface {
 	Records(ctx context.Context) ([]*endpoint.Endpoint, error)
 	ApplyChanges(ctx context.Context, changes *plan.Changes) error
+	AttributeValuesEqual(attribute string, value1 *string, value2 *string) bool
 }
 
 //TODO(ideahitme): consider moving this to Plan

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -187,6 +187,11 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 	return im.provider.ApplyChanges(ctx, filteredChanges)
 }
 
+// AttributeValuesEqual compares two attribute values for equality
+func (im *TXTRegistry) AttributeValuesEqual(attribute string, value1 *string, value2 *string) bool {
+	return im.provider.AttributeValuesEqual(attribute, value1, value2)
+}
+
 /**
   TXT registry specific private methods
 */


### PR DESCRIPTION
The Cloudflare provider supports a special annotation to tell
Cloudflare whether or not to proxy for the hostname in question.  It
also has a default setting that it will use if the annotation isn't
specified.  Unfortunately, because it always returns the value read
from Cloudflare, if you don't explicitly specify it on your ingresses,
External DNS will update the DNS records over and over because the
ingresses' lists of provider specific attributes don't match the ones
the provider claims it has.

The fix for this is to allow the provider to intervene in the
comparison process, so that it can tell the planner that e.g. the lack
of a particular annotation is the same as setting that thing to true
or false.

Fixes issue #1463.