### PR TITLE
Fix DomainFilter type in OVH provider

### DIFF
--- a/provider/ovh.go
+++ b/provider/ovh.go
@@ -47,7 +47,7 @@ var (
 type OVHProvider struct {
 	client ovhClient
 
-	domainFilter DomainFilter
+	domainFilter endpoint.DomainFilter
 	DryRun       bool
 }
 
@@ -76,7 +76,7 @@ type ovhChange struct {
 }
 
 // NewOVHProvider initializes a new OVH DNS based Provider.
-func NewOVHProvider(ctx context.Context, domainFilter DomainFilter, endpoint string, dryRun bool) (*OVHProvider, error) {
+func NewOVHProvider(ctx context.Context, domainFilter endpoint.DomainFilter, endpoint string, dryRun bool) (*OVHProvider, error) {
 	client, err := ovh.NewEndpointClient(endpoint)
 	if err != nil {
 		return nil, err

--- a/provider/ovh_test.go
+++ b/provider/ovh_test.go
@@ -59,7 +59,7 @@ func TestOvhZones(t *testing.T) {
 	client := new(mockOvhClient)
 	provider := &OVHProvider{
 		client:       client,
-		domainFilter: NewDomainFilter([]string{"com"}),
+		domainFilter: endpoint.NewDomainFilter([]string{"com"}),
 	}
 
 	// Basic zones


### PR DESCRIPTION
Otherwise build fails with
```
provider/ovh.go:50:15: undefined: DomainFilter
make: *** [Makefile:57: build/external-dns] Error 2
```