### PR TITLE
Multiple A records support for the same FQDN

### DIFF
--- a/provider/coredns.go
+++ b/provider/coredns.go
@@ -259,14 +259,14 @@ func NewCoreDNSProvider(domainFilter endpoint.DomainFilter, prefix string, dryRu
 }
 
 // Find takes a Endpoint slice and looks for an element in it. If found it will
-// return its key, otherwise it will return -1 and a bool of false.
-func findEp(slice []*endpoint.Endpoint, dnsName string) (int, bool) {
-	for i, item := range slice {
+// return Endpoint, otherwise it will return nil and a bool of false.
+func findEp(slice []*endpoint.Endpoint, dnsName string) (*endpoint.Endpoint, bool) {
+	for _, item := range slice {
 		if item.DNSName == dnsName {
-			return i, true
+			return item, true
 		}
 	}
-	return -1, false
+	return nil, false
 }
 
 // Find takes a ep.Targets string slice and looks for an element in it. If found it will
@@ -298,10 +298,8 @@ func (p coreDNSProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, err
 		log.Debugf("Getting service (%v) with service host (%s)", service, service.Host)
 		prefix := strings.Join(domains[:service.TargetStrip], ".")
 		if service.Host != "" {
-			foundEpIndex, found := findEp(result, dnsName)
-			var ep *endpoint.Endpoint
+			ep, found := findEp(result, dnsName)
 			if found {
-				ep = result[foundEpIndex]
 				ep.Targets = append(ep.Targets, service.Host)
 				log.Debugf("Exteding ep (%s) with new service host (%s)", ep, service.Host)
 			} else {

--- a/provider/coredns.go
+++ b/provider/coredns.go
@@ -258,7 +258,7 @@ func NewCoreDNSProvider(domainFilter endpoint.DomainFilter, prefix string, dryRu
 	}, nil
 }
 
-// Find takes a Endpoint slice and looks for an element in it. If found it will
+// findEp takes an Endpoint slice and looks for an element in it. If found it will
 // return Endpoint, otherwise it will return nil and a bool of false.
 func findEp(slice []*endpoint.Endpoint, dnsName string) (*endpoint.Endpoint, bool) {
 	for _, item := range slice {
@@ -269,7 +269,7 @@ func findEp(slice []*endpoint.Endpoint, dnsName string) (*endpoint.Endpoint, boo
 	return nil, false
 }
 
-// Find takes a ep.Targets string slice and looks for an element in it. If found it will
+// findLabelInTargets takes an ep.Targets string slice and looks for an element in it. If found it will
 // return its string value, otherwise it will return empty string and a bool of false.
 func findLabelInTargets(targets []string, label string) (string, bool) {
 	for _, target := range targets {
@@ -301,7 +301,7 @@ func (p coreDNSProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, err
 			ep, found := findEp(result, dnsName)
 			if found {
 				ep.Targets = append(ep.Targets, service.Host)
-				log.Debugf("Exteding ep (%s) with new service host (%s)", ep, service.Host)
+				log.Debugf("Extending ep (%s) with new service host (%s)", ep, service.Host)
 			} else {
 				ep = endpoint.NewEndpointWithTTL(
 					dnsName,
@@ -337,7 +337,7 @@ func (p coreDNSProvider) ApplyChanges(ctx context.Context, changes *plan.Changes
 	}
 	for i, ep := range changes.UpdateNew {
 		ep.Labels = changes.UpdateOld[i].Labels
-		log.Debugf("Updating labels (%s)  with old labels(%s)", ep.Labels, changes.UpdateOld[i].Labels)
+		log.Debugf("Updating labels (%s) with old labels(%s)", ep.Labels, changes.UpdateOld[i].Labels)
 		grouped[ep.DNSName] = append(grouped[ep.DNSName], ep)
 	}
 	for dnsName, group := range grouped {

--- a/provider/coredns.go
+++ b/provider/coredns.go
@@ -269,7 +269,7 @@ func findEp(slice []*endpoint.Endpoint, dnsName string) (int, bool) {
 	return -1, false
 }
 
-// Find takes a EndpointLabels map and looks for an element in it. If found it will
+// Find takes a ep.Targets string slice and looks for an element in it. If found it will
 // return it's key, otherwise it will return -1 and a bool of false.
 func findLabelInTargets(targets []string, label string) (string, bool) {
 	for _, target := range targets {
@@ -376,6 +376,12 @@ func (p coreDNSProvider) ApplyChanges(ctx context.Context, changes *plan.Changes
 
 			// Clean outdated targets
 			for label, labelPrefix := range ep.Labels {
+				// Skip non Target related labels
+				labelsToSkip := []string{"originalText", "prefix", "resource"}
+				if _, ok := findLabelInTargets(labelsToSkip, label); ok {
+					continue
+				}
+
 				log.Debugf("Finding label (%s) in targets(%v)", label, ep.Targets)
 				if _, ok := findLabelInTargets(ep.Targets, label); !ok {
 					log.Debugf("Found non existing label(%s) in targets(%v)", label, ep.Targets)

--- a/provider/coredns.go
+++ b/provider/coredns.go
@@ -259,7 +259,7 @@ func NewCoreDNSProvider(domainFilter endpoint.DomainFilter, prefix string, dryRu
 }
 
 // Find takes a Endpoint slice and looks for an element in it. If found it will
-// return it's key, otherwise it will return -1 and a bool of false.
+// return its key, otherwise it will return -1 and a bool of false.
 func findEp(slice []*endpoint.Endpoint, dnsName string) (int, bool) {
 	for i, item := range slice {
 		if item.DNSName == dnsName {
@@ -270,7 +270,7 @@ func findEp(slice []*endpoint.Endpoint, dnsName string) (int, bool) {
 }
 
 // Find takes a ep.Targets string slice and looks for an element in it. If found it will
-// return it's key, otherwise it will return -1 and a bool of false.
+// return its string value, otherwise it will return empty string and a bool of false.
 func findLabelInTargets(targets []string, label string) (string, bool) {
 	for _, target := range targets {
 		if target == label {


### PR DESCRIPTION
* Fixes https://github.com/kubernetes-sigs/external-dns/issues/1313
* Logic is to have unique key for every of multiple `ep.Targets` and keep
  them around in `ep.Labels` for further consistency
* Unit test is not very strict as testing functions are not ready for
  multiple Services with the same key but is imho good enough