### PR TITLE
update to go 1.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # builder image
-FROM golang:1.13 as builder
+FROM golang:1.14 as builder
 
 ARG VERSION
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/external-dns
 
-go 1.13
+go 1.14
 
 require (
 	cloud.google.com/go v0.44.3


### PR DESCRIPTION
external dns crashed with some linux kernel-versions.

https://go-review.googlesource.com/c/go/+/223121/

with go 1.14.1 it is fixed.