### PR TITLE
Prometheus metric: timestamp of last successful sync with the DNS provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.7.1 - 2020-04-01
+
+  - Prometheus metric: timestamp of last successful sync with the DNS provider (#1480) @njuettner
+  - Bump alpine base image to 3.11.5 (#1477) @Annegies
+  - Docs: Add first maintainers in list (#1472) @Raffo
+  - Fix DomainFilter type in OVH provider (#1469) @ytsarev
+  - New provider: OVH (#1439) @Hugome
+
 ## v0.7.0 - 2020-03-10
 
   - New source: Add support for Skipper's RouteGroup CRD (#1444) @szuecs

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -63,6 +63,14 @@ var (
 			Help:      "Number of Endpoints in the registry",
 		},
 	)
+	lastSyncTimestamp = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "external_dns",
+			Subsystem: "controller",
+			Name:      "last_sync_timestamp_seconds",
+			Help:      "Timestamp of last successful sync with the DNS provider",
+		},
+	)
 	deprecatedRegistryErrors = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Subsystem: "registry",
@@ -84,6 +92,7 @@ func init() {
 	prometheus.MustRegister(sourceErrorsTotal)
 	prometheus.MustRegister(sourceEndpointsTotal)
 	prometheus.MustRegister(registryEndpointsTotal)
+	prometheus.MustRegister(lastSyncTimestamp)
 	prometheus.MustRegister(deprecatedRegistryErrors)
 	prometheus.MustRegister(deprecatedSourceErrors)
 }
@@ -140,6 +149,8 @@ func (c *Controller) RunOnce(ctx context.Context) error {
 		deprecatedRegistryErrors.Inc()
 		return err
 	}
+
+	lastSyncTimestamp.SetToCurrentTime()
 	return nil
 }
 


### PR DESCRIPTION
* Prometheus metric to see when external-dns had the last successful sync with the DNS provider