### PR TITLE
Support for openshift routes

### DIFF
--- a/docs/tutorials/openshift.md
+++ b/docs/tutorials/openshift.md
@@ -1,0 +1,172 @@
+# Configuring ExternalDNS to use the OpenShift Route Source
+This tutorial describes how to configure ExternalDNS to use the OpenShift Route source.
+It is meant to supplement the other provider-specific setup tutorials.
+
+### Prepare ROUTER_CANONICAL_HOSTNAME in default/router deployment
+Read and go through [Finding the Host Name of the Router](https://docs.openshift.com/container-platform/3.11/install_config/router/default_haproxy_router.html#finding-router-hostname).
+If no ROUTER_CANONICAL_HOSTNAME is set, you must annotate each route with external-dns.alpha.kubernetes.io/target!
+
+### Manifest (for clusters without RBAC enabled)
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      containers:
+      - name: external-dns
+        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        args:
+        - --source=openshift-route
+        - --domain-filter=external-dns-test.my-org.com # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
+        - --provider=aws
+        - --policy=upsert-only # would prevent ExternalDNS from deleting any records, omit to enable full synchronization
+        - --aws-zone-type=public # only look at public hosted zones (valid values are public, private or no value for both)
+        - --registry=txt
+        - --txt-owner-id=my-identifier
+```
+
+### Manifest (for clusters with RBAC enabled)
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups: [""]
+  resources: ["services","endpoints","pods"]
+  verbs: ["get","watch","list"]
+- apiGroups: ["extensions"] 
+  resources: ["ingresses"] 
+  verbs: ["get","watch","list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["list"]
+- apiGroups: ["route.openshift.io"]
+  resources: ["routes"]
+  verbs: ["get","watch","list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+  namespace: default
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      serviceAccountName: external-dns
+      containers:
+      - name: external-dns
+        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        args:
+        - --source=openshift-route
+        - --domain-filter=external-dns-test.my-org.com # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
+        - --provider=aws
+        - --policy=upsert-only # would prevent ExternalDNS from deleting any records, omit to enable full synchronization
+        - --aws-zone-type=public # only look at public hosted zones (valid values are public, private or no value for both)
+        - --registry=txt
+        - --txt-owner-id=my-identifier
+```
+
+### Verify External DNS works (OpenShift Route example)
+The following instructions are based on the 
+[Hello Openshift](https://github.com/openshift/origin/tree/master/examples/hello-openshift).
+
+#### Install a sample service and expose it
+```bash
+$ oc apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: hello-openshift
+  name: hello-openshift
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hello-openshift
+  template:
+    metadata:
+      labels:
+        app: hello-openshift
+    spec:
+      containers:
+      - image: openshift/hello-openshift
+        name: hello-openshift
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hello-openshift
+  name: hello-openshift
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: hello-openshift
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: hello-openshift
+spec:
+  host: hello-openshift.example.com
+  to:
+    kind: Service
+    name: hello-openshift
+    weight: 100
+  wildcardPolicy: None
+EOF
+```
+
+#### Access the sample route using `curl`
+```bash
+$ curl -i http://hello-openshift.example.com
+HTTP/1.1 200 OK
+Date: Fri, 10 Apr 2020 09:36:41 GMT
+Content-Length: 17
+Content-Type: text/plain; charset=utf-8
+
+Hello OpenShift!
+```

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,8 @@ require (
 	github.com/miekg/dns v1.0.14
 	github.com/nesv/go-dynect v0.6.0
 	github.com/nic-at/rc0go v1.1.0
+	github.com/openshift/api v0.0.0-20190322043348-8741ff068a47
+	github.com/openshift/client-go v3.9.0+incompatible
 	github.com/oracle/oci-go-sdk v1.8.0
 	github.com/ovh/go-ovh v0.0.0-20181109152953-ba5adb4cf014
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -438,7 +438,10 @@ github.com/open-policy-agent/opa v0.8.2/go.mod h1:rlfeSeHuZmMEpmrcGla42AjkOUjP4r
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
+github.com/openshift/api v0.0.0-20190322043348-8741ff068a47 h1:PAlaAXvwmPxgh8gm0/eVmNMGLeJ1bURwyKvJVLnsr6s=
 github.com/openshift/api v0.0.0-20190322043348-8741ff068a47/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/openshift/client-go v3.9.0+incompatible h1:13k3Ok0B7TA2hA3bQW2aFqn6y04JaJWdk7ITTyg+Ek0=
+github.com/openshift/client-go v3.9.0+incompatible/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/operator-framework/operator-sdk v0.7.0/go.mod h1:iVyukRkam5JZa8AnjYf+/G3rk7JI1+M6GsU0sq0B9NA=

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -295,7 +295,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("skipper-routegroup-groupversion", "The resource version for skipper routegroup").Default(source.DefaultRoutegroupVersion).StringVar(&cfg.SkipperRouteGroupVersion)
 
 	// Flags related to processing sources
-	app.Flag("source", "The resource types that are queried for endpoints; specify multiple times for multiple sources (required, options: service, ingress, node, fake, connector, istio-gateway, cloudfoundry, contour-ingressroute, crd, empty, skipper-routegroup)").Required().PlaceHolder("source").EnumsVar(&cfg.Sources, "service", "ingress", "node", "istio-gateway", "cloudfoundry", "contour-ingressroute", "fake", "connector", "crd", "empty", "skipper-routegroup")
+	app.Flag("source", "The resource types that are queried for endpoints; specify multiple times for multiple sources (required, options: service, ingress, node, fake, connector, istio-gateway, cloudfoundry, contour-ingressroute, crd, empty, skipper-routegroup,openshift-route)").Required().PlaceHolder("source").EnumsVar(&cfg.Sources, "service", "ingress", "node", "istio-gateway", "cloudfoundry", "contour-ingressroute", "fake", "connector", "crd", "empty", "skipper-routegroup", "openshift-route")
 
 	app.Flag("namespace", "Limit sources of endpoints to a specific namespace (default: all namespaces)").Default(defaultConfig.Namespace).StringVar(&cfg.Namespace)
 	app.Flag("annotation-filter", "Filter sources managed by external-dns via annotation using label selector semantics (default: all sources)").Default(defaultConfig.AnnotationFilter).StringVar(&cfg.AnnotationFilter)

--- a/source/ocproute.go
+++ b/source/ocproute.go
@@ -273,8 +273,8 @@ func targetsFromOcpRouteStatus(status routeapi.RouteStatus) endpoint.Targets {
 	var targets endpoint.Targets
 
 	for _, ing := range status.Ingress {
-		if ing.Host != "" {
-			targets = append(targets, ing.Host)
+		if ing.RouterCanonicalHostname != "" {
+			targets = append(targets, ing.RouterCanonicalHostname)
 		}
 	}
 

--- a/source/ocproute.go
+++ b/source/ocproute.go
@@ -108,6 +108,9 @@ func NewOcpRouteSource(
 	}, nil
 }
 
+func (ors *ocpRouteSource) AddEventHandler(handler func() error, stopChan <-chan struct{}, minInterval time.Duration) {
+}
+
 // Endpoints returns endpoint objects for each host-target combination that should be processed.
 // Retrieves all OpenShift Route resources on all namespaces
 func (ors *ocpRouteSource) Endpoints() ([]*endpoint.Endpoint, error) {

--- a/source/ocproute.go
+++ b/source/ocproute.go
@@ -173,7 +173,7 @@ func (ors *ocpRouteSource) endpointsFromTemplate(ocpRoute *routeapi.Route) ([]*e
 	var buf bytes.Buffer
 	err := ors.fqdnTemplate.Execute(&buf, ocpRoute)
 	if err != nil {
-		return nil, fmt.Errorf("failed to apply template on OpenShift Route #{route.String()}: #{err}")
+		return nil, fmt.Errorf("failed to apply template on OpenShift Route %s: %s", ocpRoute.Name, err)
 	}
 
 	hostnames := buf.String()
@@ -233,7 +233,7 @@ func (ors *ocpRouteSource) filterByAnnotations(ocpRoutes []*routeapi.Route) ([]*
 
 func (ors *ocpRouteSource) setResourceLabel(ocpRoute *routeapi.Route, endpoints []*endpoint.Endpoint) {
 	for _, ep := range endpoints {
-		ep.Labels[endpoint.ResourceLabelKey] = fmt.Sprintf("route/${ocpRoute.Namespace}/${ocpRoute.Name}")
+		ep.Labels[endpoint.ResourceLabelKey] = fmt.Sprintf("route/%s/%s", ocpRoute.Namespace, ocpRoute.Name)
 	}
 }
 

--- a/source/ocproute.go
+++ b/source/ocproute.go
@@ -91,10 +91,10 @@ func NewOcpRouteSource(
 
 	// wait for the local cache to be populated.
 	err = wait.Poll(time.Second, 60*time.Second, func() (bool, error) {
-		return routeInformer.Informer().HasSynced() == true, nil
+		return routeInformer.Informer().HasSynced(), nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to sync cache: ${err}")
+		return nil, fmt.Errorf("failed to sync cache: %v", err)
 	}
 
 	return &ocpRouteSource{

--- a/source/ocproute.go
+++ b/source/ocproute.go
@@ -108,6 +108,7 @@ func NewOcpRouteSource(
 	}, nil
 }
 
+// TODO add a meaningful EventHandler
 func (ors *ocpRouteSource) AddEventHandler(handler func() error, stopChan <-chan struct{}, minInterval time.Duration) {
 }
 
@@ -138,7 +139,7 @@ func (ors *ocpRouteSource) Endpoints() ([]*endpoint.Endpoint, error) {
 		orEndpoints := endpointsFromOcpRoute(ocpRoute, ors.ignoreHostnameAnnotation)
 
 		// apply template if host is missing on OpenShift Route
-		if (ors.combineFQDNAnnotation || len(orEndpoints) ==0) && ors.fqdnTemplate != nil {
+		if (ors.combineFQDNAnnotation || len(orEndpoints) == 0) && ors.fqdnTemplate != nil {
 			oEndpoints, err := ors.endpointsFromTemplate(ocpRoute)
 			if err != nil {
 				return nil, err

--- a/source/ocproute.go
+++ b/source/ocproute.go
@@ -24,11 +24,11 @@ import (
 	"text/template"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	routeapi "github.com/openshift/api/route/v1"
 	versioned "github.com/openshift/client-go/route/clientset/versioned"
 	extInformers "github.com/openshift/client-go/route/informers/externalversions"
 	routeInformer "github.com/openshift/client-go/route/informers/externalversions/route/v1"
+	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -43,7 +43,7 @@ import (
 // does not update, or to override with alternative endpoint)
 type ocpRouteSource struct {
 	client                   versioned.Interface
-	namespace 	             string
+	namespace                string
 	annotationFilter         string
 	fqdnTemplate             *template.Template
 	combineFQDNAnnotation    bool
@@ -81,7 +81,7 @@ func NewOcpRouteSource(
 	// Add default resource event handlers to properly initialize informer.
 	routeInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc:    func(obj interface{}) {
+			AddFunc: func(obj interface{}) {
 			},
 		},
 	)

--- a/source/ocproute.go
+++ b/source/ocproute.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+	"text/template"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	routeapi "github.com/openshift/api/route/v1"
+	versioned "github.com/openshift/client-go/route/clientset/versioned"
+	extInformers "github.com/openshift/client-go/route/informers/externalversions"
+	routeInformer "github.com/openshift/client-go/route/informers/externalversions/route/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+
+	"sigs.k8s.io/external-dns/endpoint"
+)
+
+// ocpRouteSource is an implementation of Source for OpenShift Route objects.
+// Route implementation will use the spec.host value for the hostname
+// Use targetAnnotationKey to explicitly set Endpoint. (useful if the router
+// does not update, or to override with alternative endpoint)
+type ocpRouteSource struct {
+	client                   versioned.Interface
+	namespace 	             string
+	annotationFilter         string
+	fqdnTemplate             *template.Template
+	combineFQDNAnnotation    bool
+	ignoreHostnameAnnotation bool
+	routeInformer            routeInformer.RouteInformer
+}
+
+// NewOcpRouteSource creates a new ocpRouteSource with the given config.
+func NewOcpRouteSource(
+	ocpClient versioned.Interface,
+	namespace string,
+	annotationFilter string,
+	fqdnTemplate string,
+	combineFQDNAnnotation bool,
+	ignoreHostnameAnnotation bool,
+) (Source, error) {
+	var (
+		tmpl *template.Template
+		err  error
+	)
+	if fqdnTemplate != "" {
+		tmpl, err = template.New("endpoint").Funcs(template.FuncMap{
+			"trimPrefix": strings.TrimPrefix,
+		}).Parse(fqdnTemplate)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Use shared informer to listen for add/update/delete of Routes in the specified namespace.
+	// Set resync period to 0, to prevent processing when nothing has changed.
+	informerFactory := extInformers.NewFilteredSharedInformerFactory(ocpClient, 0, namespace, nil)
+	routeInformer := informerFactory.Route().V1().Routes()
+
+	// Add default resource event handlers to properly initialize informer.
+	routeInformer.Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    func(obj interface{}) {
+			},
+		},
+	)
+
+	// TODO informer is not explicitly stopped since controller is not passing in its channel.
+	informerFactory.Start(wait.NeverStop)
+
+	// wait for the local cache to be populated.
+	err = wait.Poll(time.Second, 60*time.Second, func() (bool, error) {
+		return routeInformer.Informer().HasSynced() == true, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to sync cache: ${err}")
+	}
+
+	return &ocpRouteSource{
+		client:                   ocpClient,
+		namespace:                namespace,
+		annotationFilter:         annotationFilter,
+		fqdnTemplate:             tmpl,
+		combineFQDNAnnotation:    combineFQDNAnnotation,
+		ignoreHostnameAnnotation: ignoreHostnameAnnotation,
+		routeInformer:            routeInformer,
+	}, nil
+}
+
+// Endpoints returns endpoint objects for each host-target combination that should be processed.
+// Retrieves all OpenShift Route resources on all namespaces
+func (ors *ocpRouteSource) Endpoints() ([]*endpoint.Endpoint, error) {
+	ocpRoutes, err := ors.routeInformer.Lister().Routes(ors.namespace).List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	ocpRoutes, err = ors.filterByAnnotations(ocpRoutes)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoints := []*endpoint.Endpoint{}
+
+	for _, ocpRoute := range ocpRoutes {
+		// Check controller annotation to see if we are responsible.
+		controller, ok := ocpRoute.Annotations[controllerAnnotationKey]
+		if ok && controller != controllerAnnotationValue {
+			log.Debugf("Skipping OpenShift Route %s/%s because controller value does not match, found: %s, required: %s",
+				ocpRoute.Namespace, ocpRoute.Name, controller, controllerAnnotationValue)
+			continue
+		}
+
+		orEndpoints := endpointsFromOcpRoute(ocpRoute, ors.ignoreHostnameAnnotation)
+
+		// apply template if host is missing on OpenShift Route
+		if (ors.combineFQDNAnnotation || len(orEndpoints) ==0) && ors.fqdnTemplate != nil {
+			oEndpoints, err := ors.endpointsFromTemplate(ocpRoute)
+			if err != nil {
+				return nil, err
+			}
+
+			if ors.combineFQDNAnnotation {
+				orEndpoints = append(orEndpoints, oEndpoints...)
+			} else {
+				orEndpoints = oEndpoints
+			}
+		}
+
+		if len(orEndpoints) == 0 {
+			log.Debugf("No endpoints could be generated from OpenShift Route %s/%s", ocpRoute.Namespace, ocpRoute.Name)
+			continue
+		}
+
+		log.Debugf("Endpoints generated from OpenShift Route: %s/%s: %v", ocpRoute.Namespace, ocpRoute.Name, orEndpoints)
+		ors.setResourceLabel(ocpRoute, orEndpoints)
+		endpoints = append(endpoints, orEndpoints...)
+	}
+
+	for _, ep := range endpoints {
+		sort.Sort(ep.Targets)
+	}
+
+	return endpoints, nil
+}
+
+func (ors *ocpRouteSource) endpointsFromTemplate(ocpRoute *routeapi.Route) ([]*endpoint.Endpoint, error) {
+	// Process the whole template string
+	var buf bytes.Buffer
+	err := ors.fqdnTemplate.Execute(&buf, ocpRoute)
+	if err != nil {
+		return nil, fmt.Errorf("failed to apply template on OpenShift Route #{route.String()}: #{err}")
+	}
+
+	hostnames := buf.String()
+
+	ttl, err := getTTLFromAnnotations(ocpRoute.Annotations)
+	if err != nil {
+		log.Warn(err)
+	}
+
+	targets := getTargetsFromTargetAnnotation(ocpRoute.Annotations)
+
+	if len(targets) == 0 {
+		targets = targetsFromOcpRouteStatus(ocpRoute.Status)
+	}
+
+	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ocpRoute.Annotations)
+
+	var endpoints []*endpoint.Endpoint
+	// splits the FQDN template and removes the trailing periods
+	hostnameList := strings.Split(strings.Replace(hostnames, " ", "", -1), ",")
+	for _, hostname := range hostnameList {
+		hostname = strings.TrimSuffix(hostname, ".")
+		endpoints = append(endpoints, endpointsForHostname(hostname, targets, ttl, providerSpecific, setIdentifier)...)
+	}
+	return endpoints, nil
+}
+
+func (ors *ocpRouteSource) filterByAnnotations(ocpRoutes []*routeapi.Route) ([]*routeapi.Route, error) {
+	labelSelector, err := metav1.ParseToLabelSelector(ors.annotationFilter)
+	if err != nil {
+		return nil, err
+	}
+	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	// empty filter returns original list
+	if selector.Empty() {
+		return ocpRoutes, nil
+	}
+
+	filteredList := []*routeapi.Route{}
+
+	for _, ocpRoute := range ocpRoutes {
+		// convert the Route's annotations to an equivalent label selector
+		annotations := labels.Set(ocpRoute.Annotations)
+
+		// include ocpRoute if its annotations match the selector
+		if selector.Matches(annotations) {
+			filteredList = append(filteredList, ocpRoute)
+		}
+	}
+
+	return filteredList, nil
+}
+
+func (ors *ocpRouteSource) setResourceLabel(ocpRoute *routeapi.Route, endpoints []*endpoint.Endpoint) {
+	for _, ep := range endpoints {
+		ep.Labels[endpoint.ResourceLabelKey] = fmt.Sprintf("route/${ocpRoute.Namespace}/${ocpRoute.Name}")
+	}
+}
+
+// endpointsFromOcpRoute extracts the endpoints from a OpenShift Route object
+func endpointsFromOcpRoute(ocpRoute *routeapi.Route, ignoreHostnameAnnotation bool) []*endpoint.Endpoint {
+	var endpoints []*endpoint.Endpoint
+
+	ttl, err := getTTLFromAnnotations(ocpRoute.Annotations)
+	if err != nil {
+		log.Warn(err)
+	}
+
+	targets := getTargetsFromTargetAnnotation(ocpRoute.Annotations)
+
+	if len(targets) == 0 {
+		targets = targetsFromOcpRouteStatus(ocpRoute.Status)
+	}
+
+	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ocpRoute.Annotations)
+
+	if host := ocpRoute.Spec.Host; host != "" {
+		endpoints = append(endpoints, endpointsForHostname(host, targets, ttl, providerSpecific, setIdentifier)...)
+	}
+
+	// Skip endpoints if we do not want entries from annotations
+	if !ignoreHostnameAnnotation {
+		hostnameList := getHostnamesFromAnnotations(ocpRoute.Annotations)
+		for _, hostname := range hostnameList {
+			endpoints = append(endpoints, endpointsForHostname(hostname, targets, ttl, providerSpecific, setIdentifier)...)
+		}
+	}
+	return endpoints
+}
+
+func targetsFromOcpRouteStatus(status routeapi.RouteStatus) endpoint.Targets {
+	var targets endpoint.Targets
+
+	for _, ing := range status.Ingress {
+		if ing.Host != "" {
+			targets = append(targets, ing.Host)
+		}
+	}
+
+	return targets
+}

--- a/source/store.go
+++ b/source/store.go
@@ -143,6 +143,7 @@ func (p *SingletonClientGenerator) ContourClient() (contour.Interface, error) {
 	return p.contourClient, err
 }
 
+// OpenShiftClient generates an openshift client if it was not created before
 func (p *SingletonClientGenerator) OpenShiftClient() (openshift.Interface, error) {
 	var err error
 	p.openshiftOnce.Do(func() {
@@ -373,6 +374,9 @@ func NewContourClient(kubeConfig, kubeMaster string, requestTimeout time.Duratio
 	return client, nil
 }
 
+// NewOpenShiftClient returns a new Openshift client object. It takes a Config and
+// uses KubeMaster and KubeConfig attributes to connect to the cluster. If
+// KubeConfig isn't provided it defaults to using the recommended default.
 func NewOpenShiftClient(kubeConfig, kubeMaster string, requestTimeout time.Duration) (*openshift.Clientset, error) {
 	if kubeConfig == "" {
 		if _, err := os.Stat(clientcmd.RecommendedHomeFile); err == nil {

--- a/source/store.go
+++ b/source/store.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/cloudfoundry-community/go-cfclient"
 	contour "github.com/heptio/contour/apis/generated/clientset/versioned"
-	openshift "github.com/openshift/client-go/route/clientset/versioned"
 	"github.com/linki/instrumented_http"
+	openshift "github.com/openshift/client-go/route/clientset/versioned"
 	log "github.com/sirupsen/logrus"
 	istiocontroller "istio.io/istio/pilot/pkg/config/kube/crd/controller"
 	istiomodel "istio.io/istio/pilot/pkg/model"
@@ -391,7 +391,7 @@ func NewOpenShiftClient(kubeConfig, kubeMaster string, requestTimeout time.Durat
 
 	config.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
 		return instrumented_http.NewTransport(rt, &instrumented_http.Callbacks{
-			PathProcessor:  func(path string) string {
+			PathProcessor: func(path string) string {
 				parts := strings.Split(path, "/")
 				return parts[len(parts)-1]
 			},

--- a/source/store_test.go
+++ b/source/store_test.go
@@ -22,8 +22,8 @@ import (
 
 	cfclient "github.com/cloudfoundry-community/go-cfclient"
 	contour "github.com/heptio/contour/apis/generated/clientset/versioned"
-	openshift "github.com/openshift/client-go/route/clientset/versioned"
 	fakeContour "github.com/heptio/contour/apis/generated/clientset/versioned/fake"
+	openshift "github.com/openshift/client-go/route/clientset/versioned"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	istiomodel "istio.io/istio/pilot/pkg/model"

--- a/source/store_test.go
+++ b/source/store_test.go
@@ -22,6 +22,7 @@ import (
 
 	cfclient "github.com/cloudfoundry-community/go-cfclient"
 	contour "github.com/heptio/contour/apis/generated/clientset/versioned"
+	openshift "github.com/openshift/client-go/route/clientset/versioned"
 	fakeContour "github.com/heptio/contour/apis/generated/clientset/versioned/fake"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -36,6 +37,7 @@ type MockClientGenerator struct {
 	istioClient        istiomodel.ConfigStore
 	cloudFoundryClient *cfclient.Client
 	contourClient      contour.Interface
+	openshiftClient    openshift.Interface
 }
 
 func (m *MockClientGenerator) KubeClient() (kubernetes.Interface, error) {
@@ -70,6 +72,15 @@ func (m *MockClientGenerator) ContourClient() (contour.Interface, error) {
 	if args.Error(1) == nil {
 		m.contourClient = args.Get(0).(contour.Interface)
 		return m.contourClient, nil
+	}
+	return nil, args.Error(1)
+}
+
+func (m *MockClientGenerator) OpenShiftClient() (openshift.Interface, error) {
+	args := m.Called()
+	if args.Error(1) == nil {
+		m.openshiftClient = args.Get(0).(openshift.Interface)
+		return m.openshiftClient, nil
 	}
 	return nil, args.Error(1)
 }


### PR DESCRIPTION
This implements a new source type "openshift-route" and adds support for openshift routes #706
I've taken the mentioned ocproute implementation from https://github.com/KohlsTechnology/external-dns/blob/timcurless-feature/source/ocproute.go and rebased it to master.

Tested against OpenShift 3.11 and Infoblox as provider.