### PR TITLE
Cleanup Docker context and decrease build time

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Git Related Items
+.git
+.github
+.gitignore
+
+# CI Related Items
+.travis.yml
+cloudbuild.yaml
+.golangci.yml
+.zappr.yaml
+
+# Other
+docs
+OWNERS
+vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,12 @@ ARG ARCH
 
 WORKDIR /sigs.k8s.io/external-dns
 
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
 COPY . .
-RUN make test && make build.$ARCH
+RUN make test build.$ARCH
 
 # final image
 FROM $ARCH/alpine:3.12

--- a/Dockerfile.mini
+++ b/Dockerfile.mini
@@ -16,13 +16,17 @@ FROM golang:1.15 as builder
 
 WORKDIR /sigs.k8s.io/external-dns
 
+RUN apt-get update \
+    && apt-get install \
+        ca-certificates \
+    && update-ca-certificates
+
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
 COPY . .
-RUN apt-get update && \
-    apt-get install ca-certificates && \
-    update-ca-certificates && \
-    go mod vendor && \
-    make test && \
-    make build
+RUN make test build
 
 FROM gcr.io/distroless/static
 


### PR DESCRIPTION
This is based off the work found in #1307 that was never merged. It
moves around the install and copy of certain conponents to take better
advantage of the Docker cache ad well as drops running tests during the
build of the image.

The reason for dropping tests is to improve build time and as running
tests within the build while they're already being run in CI seems like
an unnecessary added tax.

Signed-off-by: Danny Grove <danny@drgrovellc.com>