### PR TITLE
Publish ExternalIPs for LoadBalancer services

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ The [tutorials](docs/tutorials) section contains examples, including Ingress res
 
 If using a txt registry and attempting to use a CNAME the `--txt-prefix` must be set to avoid conflicts.  Changing `--txt-prefix` will result in lost ownership over previously created records.
 
+If `externalIPs` list is defined for a `LoadBalancer` service, this list will be used instead of an assigned load balancer IP to create a DNS record. It's useful when you run bare metal Kubernetes clusters behind NAT or in a similar setup, where a load balancer IP differs from a public IP (e.g. with [MetalLB](https://metallb.universe.tf)).
+
 # Roadmap
 
 ExternalDNS was built with extensibility in mind. Adding and experimenting with new DNS providers and sources of desired DNS records should be as easy as possible. It should also be possible to modify how ExternalDNS behaves—e.g. whether it should add records but never delete them.

--- a/source/service.go
+++ b/source/service.go
@@ -491,7 +491,6 @@ func extractLoadBalancerTargets(svc *v1.Service) endpoint.Targets {
 		externalIPs endpoint.Targets
 	)
 
-
 	// Create a corresponding endpoint for each configured external entrypoint.
 	for _, lb := range svc.Status.LoadBalancer.Ingress {
 		if lb.IP != "" {
@@ -503,14 +502,14 @@ func extractLoadBalancerTargets(svc *v1.Service) endpoint.Targets {
 	}
 
 	if svc.Spec.ExternalIPs != nil {
-	for _, ext := range svc.Spec.ExternalIPs {
-		externalIPs = append(externalIPs, ext)
+		for _, ext := range svc.Spec.ExternalIPs {
+			externalIPs = append(externalIPs, ext)
 		}
 	}
 
 	if len(externalIPs) > 0 {
 		return externalIPs
-		}
+	}
 
 	return targets
 }

--- a/source/service.go
+++ b/source/service.go
@@ -486,7 +486,11 @@ func extractServiceExternalName(svc *v1.Service) endpoint.Targets {
 }
 
 func extractLoadBalancerTargets(svc *v1.Service) endpoint.Targets {
-	var targets endpoint.Targets
+	var (
+		targets     endpoint.Targets
+		externalIPs endpoint.Targets
+	)
+
 
 	// Create a corresponding endpoint for each configured external entrypoint.
 	for _, lb := range svc.Status.LoadBalancer.Ingress {
@@ -497,6 +501,16 @@ func extractLoadBalancerTargets(svc *v1.Service) endpoint.Targets {
 			targets = append(targets, lb.Hostname)
 		}
 	}
+
+	if svc.Spec.ExternalIPs != nil {
+	for _, ext := range svc.Spec.ExternalIPs {
+		externalIPs = append(externalIPs, ext)
+		}
+	}
+
+	if len(externalIPs) > 0 {
+		return externalIPs
+		}
 
 	return targets
 }

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -174,6 +174,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 		labels                   map[string]string
 		annotations              map[string]string
 		clusterIP                string
+		externalIPs              []string
 		lbs                      []string
 		serviceTypesFilter       []string
 		expected                 []*endpoint.Endpoint
@@ -193,13 +194,14 @@ func testServiceSourceEndpoints(t *testing.T) {
 			map[string]string{},
 			map[string]string{},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{},
 			false,
 		},
 		{
-			"no annotated services return no endpoints when ignoreing annotations",
+			"no annotated services return no endpoints when ignoring annotations",
 			"",
 			"",
 			"testing",
@@ -212,6 +214,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			map[string]string{},
 			map[string]string{},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{},
@@ -233,6 +236,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org.",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -256,6 +260,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org.",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{},
@@ -279,6 +284,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			"1.2.3.4",
 			[]string{},
 			[]string{},
+			[]string{},
 			[]*endpoint.Endpoint{},
 			false,
 		},
@@ -296,6 +302,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			map[string]string{},
 			map[string]string{},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -318,6 +325,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			map[string]string{},
 			map[string]string{},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -342,6 +350,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org., bar.example.org.",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -368,6 +377,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org., bar.example.org.",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -392,6 +402,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org., bar.example.org.",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -416,6 +427,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org, bar.example.org",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -440,6 +452,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org.",
 			},
 			"",
+			[]string{},
 			[]string{"lb.example.com"}, // Kubernetes omits the trailing dot
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -463,6 +476,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org", // Trailing dot is omitted
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4", "lb.example.com"}, // Kubernetes omits the trailing dot
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -488,6 +502,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey:   "foo.example.org.",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -512,6 +527,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey:   "foo.example.org.",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{},
@@ -533,6 +549,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org.",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -556,6 +573,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org.",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{},
@@ -577,6 +595,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org.",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -601,6 +620,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				"service.beta.kubernetes.io/external-traffic": "OnlyLocal",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -625,6 +645,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				"service.beta.kubernetes.io/external-traffic": "SomethingElse",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{},
@@ -647,6 +668,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				"service.beta.kubernetes.io/external-traffic": "OnlyLocal",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{},
@@ -669,6 +691,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				"service.beta.kubernetes.io/external-traffic": "Global",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -693,6 +716,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				"service.beta.kubernetes.io/external-traffic": "OnlyLocal",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{},
@@ -716,7 +740,32 @@ func testServiceSourceEndpoints(t *testing.T) {
 			"",
 			[]string{},
 			[]string{},
+			[]string{},
 			[]*endpoint.Endpoint{},
+			false,
+		},
+		{
+			"annotated service with externalIPs returns a single endpoint with multiple targets",
+			"",
+			"",
+			"testing",
+			"foo",
+			v1.ServiceTypeLoadBalancer,
+			"",
+			"",
+			false,
+			false,
+			map[string]string{},
+			map[string]string{
+				hostnameAnnotationKey: "foo.example.org.",
+			},
+			"",
+			[]string{"10.2.3.4", "11.2.3.4"},
+			[]string{"1.2.3.4"},
+			[]string{},
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", Targets: endpoint.Targets{"10.2.3.4", "11.2.3.4"}},
+			},
 			false,
 		},
 		{
@@ -735,6 +784,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org.",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4", "8.8.8.8"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -758,6 +808,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				"zalando.org/dnsname": "foo.example.org.",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{},
@@ -779,6 +830,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				"zalando.org/dnsname": "foo.example.org.",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -804,6 +856,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				"domainName": "foo.example.org., bar.example.org",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -826,6 +879,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			map[string]string{},
 			map[string]string{},
 			"",
+			[]string{},
 			[]string{"1.2.3.4", "elb.com"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -850,6 +904,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org.",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4", "elb.com"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -874,6 +929,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				"zalando.org/dnsname": "mate.example.org.",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -895,6 +951,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			map[string]string{},
 			map[string]string{},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{},
@@ -916,6 +973,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org.",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -940,6 +998,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				ttlAnnotationKey:      "foo",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -964,6 +1023,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				ttlAnnotationKey:      "10",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -988,6 +1048,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				ttlAnnotationKey:      "1m",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -1012,6 +1073,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				ttlAnnotationKey:      "-10",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{},
 			[]*endpoint.Endpoint{
@@ -1035,6 +1097,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org.",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{string(v1.ServiceTypeLoadBalancer)},
 			[]*endpoint.Endpoint{
@@ -1058,6 +1121,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org.",
 			},
 			"",
+			[]string{},
 			[]string{"1.2.3.4"},
 			[]string{string(v1.ServiceTypeLoadBalancer)},
 			[]*endpoint.Endpoint{},
@@ -1080,8 +1144,9 @@ func testServiceSourceEndpoints(t *testing.T) {
 
 			service := &v1.Service{
 				Spec: v1.ServiceSpec{
-					Type:      tc.svcType,
-					ClusterIP: tc.clusterIP,
+					Type:        tc.svcType,
+					ClusterIP:   tc.clusterIP,
+					ExternalIPs: tc.externalIPs,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:   tc.svcNamespace,


### PR DESCRIPTION
Add feature to publish ExternalIPs for LoadBalancer services.

Use case:
* Running K8s cluster on Bare-metal behind NAT (1:1)
* [MetalLB](https://github.com/metallb/metallb) implements on-premises LoadBalancer and assigns `loadBalancerIP` from the given pool (internal network IP).
* Running Services of type 'LoadBalancer';
* By adding external IP address we can propagate a DNS entry with publicly available external IP address instead of the internal one.

Currently, ExternalIPs in LoadBalancer services are not processed at all, so there are no breaking changes as far as I can tell.

Note: ExternalIP value is defined separately, so it's out of the scope of ExternalDNS. The only thing needed is to prefer `externalIP` to `loadBalancerIP` and let ExternalDNS do the job. 