### PR TITLE
Delete orphaned owned TXT record

### DIFF
--- a/provider/aws.go
+++ b/provider/aws.go
@@ -388,9 +388,9 @@ func (p *AWSProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) e
 
 	combinedChanges := make([]*route53.Change, 0, len(changes.Create)+len(changes.UpdateNew)+len(changes.Delete))
 
+	combinedChanges = append(combinedChanges, p.newChanges(route53.ChangeActionDelete, changes.Delete, records, zones)...)
 	combinedChanges = append(combinedChanges, p.newChanges(route53.ChangeActionCreate, changes.Create, records, zones)...)
 	combinedChanges = append(combinedChanges, p.newChanges(route53.ChangeActionUpsert, changes.UpdateNew, records, zones)...)
-	combinedChanges = append(combinedChanges, p.newChanges(route53.ChangeActionDelete, changes.Delete, records, zones)...)
 
 	return p.submitChanges(ctx, combinedChanges, zones)
 }

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -129,19 +129,6 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 		UpdateOld: filterOwnedRecords(im.ownerID, changes.UpdateOld),
 		Delete:    filterOwnedRecords(im.ownerID, changes.Delete),
 	}
-	for _, r := range filteredChanges.Create {
-		if r.Labels == nil {
-			r.Labels = make(map[string]string)
-		}
-		r.Labels[endpoint.OwnerLabelKey] = im.ownerID
-		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
-		txt.ProviderSpecific = r.ProviderSpecific
-		filteredChanges.Create = append(filteredChanges.Create, txt)
-
-		if im.cacheInterval > 0 {
-			im.addToCache(r)
-		}
-	}
 
 	for _, r := range filteredChanges.Delete {
 		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
@@ -153,6 +140,20 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 
 		if im.cacheInterval > 0 {
 			im.removeFromCache(r)
+		}
+	}
+	
+	for _, r := range filteredChanges.Create {
+		if r.Labels == nil {
+			r.Labels = make(map[string]string)
+		}
+		r.Labels[endpoint.OwnerLabelKey] = im.ownerID
+		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
+		txt.ProviderSpecific = r.ProviderSpecific
+		filteredChanges.Create = append(filteredChanges.Create, txt)
+
+		if im.cacheInterval > 0 {
+			im.addToCache(r)
 		}
 	}
 


### PR DESCRIPTION
Fixes #1502

When using the TXT registry it can sometimes happen that the A record is removed but the TXT record not. This could be caused by a human for example.

In that case, external-dns will try to recreate the missing A record. It will blindly also create a new TXT record. But that record already exists. The operation will fail and the A record won't be created until the TXT record is also removed. See #1502 for full details.

With this change, the existing TXT record will be removed before creating it again.

I will add tests once it is agreed that this is the right way to go.

## Todo

- [ ] Add tests