### PR TITLE
Only dump config in debug mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 	if err := cfg.ParseFlags(os.Args[1:]); err != nil {
 		log.Fatalf("flag parsing error: %v", err)
 	}
-	log.Infof("config: %s", cfg)
+	log.Debugf("config: %s", cfg)
 
 	if err := validation.ValidateConfig(cfg); err != nil {
 		log.Fatalf("config validation failed: %v", err)


### PR DESCRIPTION
Doesn't make sense to dump this in normal info level:
```
INFO[0000] config: {Master: KubeConfig: RequestTimeout:30s .... }
```

