### PR TITLE
Fix RFC2316 Windows Documentation

### DIFF
--- a/docs/tutorials/rfc2136.md
+++ b/docs/tutorials/rfc2136.md
@@ -271,9 +271,7 @@ You'll want to configure `external-dns` similarly to the following:
         - --rfc2136-host=123.123.123.123
         - --rfc2136-port=53
         - --rfc2136-zone=your-domain.com
-        - --rfc2136-tsig-secret=not-needed
-        - --rfc2136-tsig-secret-alg=hmac-sha256
-        - --rfc2136-tsig-keyname=externaldns-key
+        - --rfc2136-insecure
         - --rfc2136-tsig-axfr # needed to enable zone transfers, which is required for deletion of records.
 ...
 ```


### PR DESCRIPTION
Added documentation to show the use of the `--rfc2136-insecure` flag when integrating with Windows DNS when using insecure zone updates.