### PR TITLE
Warn when endpoint exists without being owned

### DIFF
--- a/registry/aws_sd_registry.go
+++ b/registry/aws_sd_registry.go
@@ -68,9 +68,9 @@ func (sdr *AWSSDRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, er
 func (sdr *AWSSDRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
 	filteredChanges := &plan.Changes{
 		Create:    changes.Create,
-		UpdateNew: filterOwnedRecords(sdr.ownerID, changes.UpdateNew),
-		UpdateOld: filterOwnedRecords(sdr.ownerID, changes.UpdateOld),
-		Delete:    filterOwnedRecords(sdr.ownerID, changes.Delete),
+		UpdateNew: filterOwnedRecords(sdr.ownerID, changes.UpdateNew, false),
+		UpdateOld: filterOwnedRecords(sdr.ownerID, changes.UpdateOld, true),
+		Delete:    filterOwnedRecords(sdr.ownerID, changes.Delete, false),
 	}
 
 	sdr.updateLabels(filteredChanges.Create)

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -125,9 +125,9 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
 	filteredChanges := &plan.Changes{
 		Create:    changes.Create,
-		UpdateNew: filterOwnedRecords(im.ownerID, changes.UpdateNew),
-		UpdateOld: filterOwnedRecords(im.ownerID, changes.UpdateOld),
-		Delete:    filterOwnedRecords(im.ownerID, changes.Delete),
+		UpdateNew: filterOwnedRecords(im.ownerID, changes.UpdateNew, false),
+		UpdateOld: filterOwnedRecords(im.ownerID, changes.UpdateOld, true),
+		Delete:    filterOwnedRecords(im.ownerID, changes.Delete, false),
 	}
 	for _, r := range filteredChanges.Create {
 		if r.Labels == nil {


### PR DESCRIPTION
When an existing endpoint exists without being owned, it should be reported as warning instead of debug.

This way it will be clear to the cluster operator that something is wrong and can potentially go wrong in the future. For example, when the ingress changes, the endpoint cannot be updated automatically.

When an endpoint exists that is owned by something else, it will be logged as debug.

## Why?

Last weekend we had severe downtime because [kube-ingress-aws-controller](https://github.com/zalando-incubator/kube-ingress-aws-controller) decided to create a new load balancer. External DNS detected this and updated all the endpoints except 1. It turned out that the endpoint was created manually and didn't have a TXT heritage record. Therefore External DNS ignored the record. Since we run with `info` level instead of `debug` we were not aware of this issue. 

