### PR TITLE
Add kinds for provider specific properties

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -140,6 +140,10 @@ type ProviderSpecificProperty struct {
 	Kind  string `json:"kind,omitempty"`
 }
 
+func (e ProviderSpecificProperty) String() string {
+	return fmt.Sprintf("{%s %s}", e.Name, e.Value)
+}
+
 // ProviderSpecific holds configuration which is specific to individual DNS providers
 type ProviderSpecific []ProviderSpecificProperty
 

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -109,10 +109,35 @@ func (t Targets) IsLess(o Targets) bool {
 	return false
 }
 
+const (
+	// This property is parsed to boolean type before comparing
+	BooleanKind = "Boolean"
+)
+
+func CompareProperty(previous, current, kind string) bool {
+	switch kind {
+	case BooleanKind:
+		p, c := false, false
+
+		if previous == "true" {
+			p = true
+		}
+
+		if current == "true" {
+			c = true
+		}
+
+		return p == c
+	}
+
+	return previous == current
+}
+
 // ProviderSpecificProperty holds the name and value of a configuration which is specific to individual DNS providers
 type ProviderSpecificProperty struct {
 	Name  string `json:"name,omitempty"`
 	Value string `json:"value,omitempty"`
+	Kind  string `json:"kind,omitempty"`
 }
 
 // ProviderSpecific holds configuration which is specific to individual DNS providers
@@ -175,6 +200,15 @@ func (e *Endpoint) WithProviderSpecific(key, value string) *Endpoint {
 	}
 
 	e.ProviderSpecific = append(e.ProviderSpecific, ProviderSpecificProperty{Name: key, Value: value})
+	return e
+}
+
+func (e *Endpoint) WithProviderSpecificKind(key, value, kind string) *Endpoint {
+	if e.ProviderSpecific == nil {
+		e.ProviderSpecific = ProviderSpecific{}
+	}
+
+	e.ProviderSpecific = append(e.ProviderSpecific, ProviderSpecificProperty{Name: key, Value: value, Kind: kind})
 	return e
 }
 

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -178,11 +178,6 @@ func shouldUpdateTTL(desired, current *endpoint.Endpoint) bool {
 	return desired.RecordTTL != current.RecordTTL
 }
 
-type propertyChange struct {
-	current string
-	desired string
-}
-
 func shouldUpdateProviderSpecific(desired, current *endpoint.Endpoint) bool {
 	desiredProperties := map[string]endpoint.ProviderSpecificProperty{}
 

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -200,11 +200,11 @@ func shouldUpdateProviderSpecific(desired, current *endpoint.Endpoint) bool {
 			}
 
 			if d, ok := desiredProperties[c.Name]; ok {
-				if !endpoint.CompareProperty(c.Value, d.Value, c.Kind) {
+				if !c.Kind.Equal(c.Name, c.Value, d.Value) {
 					return true
 				}
 			} else {
-				if !endpoint.CompareProperty(c.Value, "", c.Kind) {
+				if !c.Kind.Equal(c.Name, c.Value, "") {
 					return true
 				}
 			}

--- a/provider/cloudflare.go
+++ b/provider/cloudflare.go
@@ -392,7 +392,7 @@ func groupByNameAndType(records []cloudflare.DNSRecord) []*endpoint.Endpoint {
 				records[0].Type,
 				endpoint.TTL(records[0].TTL),
 				targets...).
-				WithProviderSpecific(source.CloudflareProxiedKey, strconv.FormatBool(records[0].Proxied)))
+				WithProviderSpecificKind(source.CloudflareProxiedKey, strconv.FormatBool(records[0].Proxied), endpoint.BooleanKind))
 	}
 
 	return endpoints

--- a/provider/cloudflare_test.go
+++ b/provider/cloudflare_test.go
@@ -301,6 +301,11 @@ func TestProviderPropertiesIdempotency(t *testing.T) {
 		},
 		{
 			ProviderProxiedByDefault: true,
+			RecordsAreProxied:        true,
+			ShouldBeUpdated:          false,
+		},
+		{
+			ProviderProxiedByDefault: true,
 			RecordsAreProxied:        false,
 			ShouldBeUpdated:          true,
 		},


### PR DESCRIPTION
This is alternative solution to #1463 issue (current solution is at #1464)

This differs in few important ways:

1. Test in `provider/cloudflare_test.go` actually tests for the bug that is described nstead of just testing how individual properties compare to each other (i.e. it tests if there are not updates when no custom properties are defined for Cloudflare DNS record)
2. There is additional test in `plan/plan_test.go` that verifies this behavior for more general case
3. The "kind" is introduced for custom properties which makes adding this behavior to other providers, achieve consistent behavior for all of them, and reduce code duplication (kind defines among others how to compare properties, but more functionality can be added in the future)
4. It doesn't modify base structure for all other providers, the only modified files are plan.go, cloudflare.go, and endpoint.go
5. As extra, it changes implementation of shouldUpdateProviderSpecific so it compares properties in O(n) time instead of current O(n^2)