### PR TITLE
Improve Cloudflare tests in preparation to fix other issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/linki/instrumented_http v0.2.0
 	github.com/linode/linodego v0.3.0
 	github.com/mattn/go-isatty v0.0.11 // indirect
+	github.com/maxatome/go-testdeep v1.4.0
 	github.com/miekg/dns v1.1.25
 	github.com/nesv/go-dynect v0.6.0
 	github.com/nic-at/rc0go v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -423,6 +423,8 @@ github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/maxatome/go-testdeep v1.4.0 h1:vKQh3/lHKAMsxggya/fXB6fLbf70c7k6wlLveuS9sKE=
+github.com/maxatome/go-testdeep v1.4.0/go.mod h1:011SgQ6efzZYAen6fDn4BqQ+lUR72ysdyKe7Dyogw70=
 github.com/mdempsky/unconvert v0.0.0-20190325185700-2f5dc3378ed3/go.mod h1:9+3Wp2ccIz73BJqVfc7n2+1A+mzvnEwtDTqEjeRngBQ=
 github.com/mholt/archiver v3.1.1+incompatible/go.mod h1:Dh2dOXnSdiLxRiPoVfIr/fI1TwETms9B8CTWfeh7ROU=
 github.com/miekg/dns v1.0.14 h1:9jZdLNd/P4+SfEJ0TNyxYpsK8N4GtfylBLqtbYN1sbA=

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -17,8 +17,17 @@ limitations under the License.
 package provider
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
+
+	log "github.com/sirupsen/logrus"
 )
+
+func TestMain(m *testing.M) {
+	log.SetOutput(ioutil.Discard)
+	os.Exit(m.Run())
+}
 
 func TestEnsureTrailingDot(t *testing.T) {
 	for _, tc := range []struct {


### PR DESCRIPTION
This PR is first stepping stone to implement fix for #1514. It improves test suite in a way that documents current behavior in tests and will allow to change it in the future. Changes are:

1. Merge 3 separate mock clients into single, configurable one
2. Allow to introspect actions performed by provider on client and set expectations on them
3. Make sure each cloudflare test starts with "TestCloudflare" for easy targeting with `-run` flag
4. Improve ApplyChanges test so it shows that indeed Create is performed instead of Update
5. Disable logrus logging in tests in `provider/provider_test.go` so it's easier to see test errors
6. Rewrites existing tests in a way that is agnostic to implementation details (i.e. now tests don't use methods like `newCloudFlareChanges`)
6. Adds extra test that shows current end-to-end behavior and bug from #1514

I hope because this PR modifies only tests, it will be quick to review and merge. After that I can start working on fix of #1514 so it will modify much less core and will be easier to review