### PR TITLE
Try #2: Support encrypted DNS txt records

### DIFF
--- a/endpoint/crypto.go
+++ b/endpoint/crypto.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This code is based on the article https://www.thepolyglotdeveloper.com/2018/02/encrypt-decrypt-data-golang-application-crypto-packages/
+written by Nic Raboy.
+Gzip compression/decompression has ben added as there as there are issues with txt records longer than
+255 characters and encryption + base64 encoding adds some characters to the resulting text record.
+*/
+
+package endpoint
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Decompress data
+func DecompressData(data []byte) (resData []byte, err error) {
+	gz, err := gzip.NewReader(bytes.NewBuffer(data))
+	if err != nil {
+		return data, err
+	}
+	defer gz.Close()
+	var b bytes.Buffer
+	if _, err = b.ReadFrom(gz); err != nil {
+		return data, err
+	}
+	return b.Bytes(), nil
+}
+
+// Compress data
+func CompressData(data []byte) (compressedData []byte, err error) {
+	var b bytes.Buffer
+	gz, err := gzip.NewWriterLevel(&b, gzip.BestCompression)
+	if err != nil {
+		return data, nil
+	}
+	// defer gz.Close()
+	if _, err = gz.Write(data); err != nil {
+		return data, nil
+	}
+
+	if err = gz.Flush(); err != nil {
+		return data, nil
+	}
+
+	if err = gz.Close(); err != nil {
+		return data, nil
+	}
+
+	return b.Bytes(), nil
+}
+
+// Encrypt data using the supplied AES key
+func EncryptText(text string, aesKey []byte) (string, error) {
+	block, _ := aes.NewCipher(aesKey)
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return text, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return text, err
+	}
+	data := []byte(text)
+	data, err = CompressData(data)
+	if err != nil {
+		log.Debugf("Failed to compress data based on the text %#v. Got error %#v.", text, err)
+	}
+	cipherdata := gcm.Seal(nonce, nonce, data, nil)
+	return base64.StdEncoding.EncodeToString(cipherdata), nil
+}
+
+// Decrypt data using a supplied AES encryption key
+func DecryptText(text string, aesKey []byte) (string, error) {
+	block, err := aes.NewCipher(aesKey)
+	if err != nil {
+		return text, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return text, err
+	}
+	nonceSize := gcm.NonceSize()
+	data, err := base64.StdEncoding.DecodeString(text)
+	if err != nil {
+		return text, err
+	}
+	if len(data) <= nonceSize {
+		return text, fmt.Errorf("The encoded data from text %#v is shorter than %#v bytes and can't be decoded", text, nonceSize)
+	}
+	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
+	plaindata, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return text, err
+	}
+	plaindata, err = DecompressData(plaindata)
+	if err != nil {
+		log.Debugf("Failed to decompress data based on the base64 encoded text %#v. Got error %#v.", text, err)
+	}
+	return string(plaindata), nil
+}

--- a/endpoint/crypto_test.go
+++ b/endpoint/crypto_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncrypt(t *testing.T) {
+	// Verify that text encryption and decryption works
+	aesKey := []byte("s%zF`.*'5`9.AhI2!B,.~hmbs^.*TL?;")
+	plaintext := "Til pigerene havde han skemtsomme ord, han spøkte med byens børn, han svingede sydvesten og sprang ombord; så heiste han fokken, og hjem han for i solskin, den gamle ørn."
+	encryptedtext, err := EncryptText(plaintext, aesKey)
+	require.NoError(t, err)
+	decryptedtext, err := DecryptText(encryptedtext, aesKey)
+	require.NoError(t, err)
+	if plaintext != decryptedtext {
+		t.Errorf("Original plain text %#v differs from the resulting decrypted text %#v", plaintext, decryptedtext)
+	}
+
+	// Verify that decrypt returns an error and unmodified data if wrong AES encryption key is used
+	decryptedtext, err = DecryptText(encryptedtext, []byte("s'J!jD`].LC?g&Oa11AgTub,j48ts/96"))
+	require.Error(t, err)
+	if decryptedtext != encryptedtext {
+		t.Error("Data decryption failed, but decrypt still didn't return the original input")
+	}
+
+	// Verify that decrypt returns an error and unmodified data if unencrypted input is is supplied
+	decryptedtext, err = DecryptText(plaintext, aesKey)
+	require.Error(t, err)
+	if plaintext != decryptedtext {
+		t.Errorf("Data decryption failed, but decrypt still didn't return the original input. Original input %#v, returned data %#v", plaintext, decryptedtext)
+	}
+
+	// Verify that a known encrypted text is decrypted to what is expected
+	encryptedtext = "TIBnEeYWYd+sffKZ6Wk3Js0pR58TbsFxhXUc+6jzgS4AXCb+NSuKjnlRqp6e5imh5b1hrxWmecrI/QNJzC6o/2U5FZfxY5CjSqhIbCV/gWWkgK1Qd1ohzCO4tzkF5fwGCxSW715NLDUImg6xE4D/hI2pY8wcATnvv4qUw6eR78kDzfn4cwO1IeS/HmFn+ASldPvY6Y3JHCSlbvWTekfRrknHJeLHIsPW5yZVPZCq29xGEe+A29Y="
+	decryptedtext, err = DecryptText(encryptedtext, aesKey)
+	require.NoError(t, err)
+	if decryptedtext != plaintext {
+		t.Error("Decryption of text didn't result in expected plaintext result.")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -271,7 +271,7 @@ func main() {
 	case "noop":
 		r, err = registry.NewNoopRegistry(p)
 	case "txt":
-		r, err = registry.NewTXTRegistry(p, cfg.TXTPrefix, cfg.TXTOwnerID, cfg.TXTCacheInterval)
+		r, err = registry.NewTXTRegistry(p, cfg.TXTPrefix, cfg.TXTOwnerID, cfg.TXTCacheInterval, cfg.TXTEncryptEnabled, []byte(cfg.TXTEncryptAESKey))
 	case "aws-sd":
 		r, err = registry.NewAWSSDRegistry(p.(*provider.AWSSDProvider), cfg.TXTOwnerID)
 	default:

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -109,6 +109,8 @@ type Config struct {
 	Registry                          string
 	TXTOwnerID                        string
 	TXTPrefix                         string
+	TXTEncryptEnabled                 bool
+	TXTEncryptAESKey                  string
 	Interval                          time.Duration
 	Once                              bool
 	DryRun                            bool
@@ -206,6 +208,8 @@ var defaultConfig = &Config{
 	TXTOwnerID:                  "default",
 	TXTPrefix:                   "",
 	TXTCacheInterval:            0,
+	TXTEncryptEnabled:           false,
+	TXTEncryptAESKey:            "",
 	Interval:                    time.Minute,
 	Once:                        false,
 	DryRun:                      false,
@@ -393,6 +397,8 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("registry", "The registry implementation to use to keep track of DNS record ownership (default: txt, options: txt, noop, aws-sd)").Default(defaultConfig.Registry).EnumVar(&cfg.Registry, "txt", "noop", "aws-sd")
 	app.Flag("txt-owner-id", "When using the TXT registry, a name that identifies this instance of ExternalDNS (default: default)").Default(defaultConfig.TXTOwnerID).StringVar(&cfg.TXTOwnerID)
 	app.Flag("txt-prefix", "When using the TXT registry, a custom string that's prefixed to each ownership DNS record (optional)").Default(defaultConfig.TXTPrefix).StringVar(&cfg.TXTPrefix)
+	app.Flag("txt-encrypt-enabled", "When using the TXT registry, set if TXT records should be encrypted before stored (default: disabled)").BoolVar(&cfg.TXTEncryptEnabled)
+	app.Flag("txt-encrypt-aes-key", "When using the TXT registry, set TXT record decryption and encryption 32 byte aes key (required when --txt-encrypt=true)").Default(defaultConfig.TXTEncryptAESKey).StringVar(&cfg.TXTEncryptAESKey)
 
 	// Flags related to the main control loop
 	app.Flag("txt-cache-interval", "The interval between cache synchronizations in duration format (default: disabled)").Default(defaultConfig.TXTCacheInterval.String()).DurationVar(&cfg.TXTCacheInterval)

--- a/registry/aws_sd_registry.go
+++ b/registry/aws_sd_registry.go
@@ -51,7 +51,7 @@ func (sdr *AWSSDRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, er
 	}
 
 	for _, record := range records {
-		labels, err := endpoint.NewLabelsFromString(record.Labels[endpoint.AWSSDDescriptionLabel])
+		labels, err := endpoint.NewLabelsFromStringPlain(record.Labels[endpoint.AWSSDDescriptionLabel])
 		if err != nil {
 			// if we fail to parse the output then simply assume the endpoint is not managed by any instance of External DNS
 			record.Labels = endpoint.NewLabels()
@@ -84,6 +84,6 @@ func (sdr *AWSSDRegistry) ApplyChanges(ctx context.Context, changes *plan.Change
 func (sdr *AWSSDRegistry) updateLabels(endpoints []*endpoint.Endpoint) {
 	for _, ep := range endpoints {
 		ep.Labels[endpoint.OwnerLabelKey] = sdr.ownerID
-		ep.Labels[endpoint.AWSSDDescriptionLabel] = ep.Labels.Serialize(false)
+		ep.Labels[endpoint.AWSSDDescriptionLabel] = ep.Labels.SerializePlain(false)
 	}
 }

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -40,21 +40,35 @@ type TXTRegistry struct {
 	recordsCache            []*endpoint.Endpoint
 	recordsCacheRefreshTime time.Time
 	cacheInterval           time.Duration
+
+	// encrypt text records
+	txtEncryptEnabled bool
+	txtEncryptAESKey  []byte
 }
 
 // NewTXTRegistry returns new TXTRegistry object
-func NewTXTRegistry(provider provider.Provider, txtPrefix, ownerID string, cacheInterval time.Duration) (*TXTRegistry, error) {
+func NewTXTRegistry(provider provider.Provider, txtPrefix, ownerID string, cacheInterval time.Duration, txtEncryptEnabled bool, txtEncryptAESKey []byte) (*TXTRegistry, error) {
 	if ownerID == "" {
 		return nil, errors.New("owner id cannot be empty")
+	}
+	if len(txtEncryptAESKey) == 0 {
+		txtEncryptAESKey = nil
+	} else if len(txtEncryptAESKey) != 32 {
+		return nil, errors.New("The AES Encryption key must have a length of 32 bytes")
+	}
+	if txtEncryptEnabled && txtEncryptAESKey == nil {
+		return nil, errors.New("The AES Encryption key must be set when TXT record encryption is enabled")
 	}
 
 	mapper := newPrefixNameMapper(txtPrefix)
 
 	return &TXTRegistry{
-		provider:      provider,
-		ownerID:       ownerID,
-		mapper:        mapper,
-		cacheInterval: cacheInterval,
+		provider:          provider,
+		ownerID:           ownerID,
+		mapper:            mapper,
+		cacheInterval:     cacheInterval,
+		txtEncryptEnabled: txtEncryptEnabled,
+		txtEncryptAESKey:  txtEncryptAESKey,
 	}, nil
 }
 
@@ -84,7 +98,7 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 			continue
 		}
 		// We simply assume that TXT records for the registry will always have only one target.
-		labels, err := endpoint.NewLabelsFromString(record.Targets[0])
+		labels, err := endpoint.NewLabelsFromString(record.Targets[0], im.txtEncryptAESKey)
 		if err == endpoint.ErrInvalidHeritage {
 			//if no heritage is found or it is invalid
 			//case when value of txt record cannot be identified
@@ -134,7 +148,7 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 			r.Labels = make(map[string]string)
 		}
 		r.Labels[endpoint.OwnerLabelKey] = im.ownerID
-		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
+		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true, im.txtEncryptEnabled, im.txtEncryptAESKey)).WithSetIdentifier(r.SetIdentifier)
 		txt.ProviderSpecific = r.ProviderSpecific
 		filteredChanges.Create = append(filteredChanges.Create, txt)
 
@@ -144,7 +158,7 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 	}
 
 	for _, r := range filteredChanges.Delete {
-		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
+		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true, im.txtEncryptEnabled, im.txtEncryptAESKey)).WithSetIdentifier(r.SetIdentifier)
 		txt.ProviderSpecific = r.ProviderSpecific
 
 		// when we delete TXT records for which value has changed (due to new label) this would still work because
@@ -158,7 +172,7 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 
 	// make sure TXT records are consistently updated as well
 	for _, r := range filteredChanges.UpdateOld {
-		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
+		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true, im.txtEncryptEnabled, im.txtEncryptAESKey)).WithSetIdentifier(r.SetIdentifier)
 		txt.ProviderSpecific = r.ProviderSpecific
 		// when we updateOld TXT records for which value has changed (due to new label) this would still work because
 		// !!! TXT record value is uniquely generated from the Labels of the endpoint. Hence old TXT record can be uniquely reconstructed
@@ -171,7 +185,7 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 
 	// make sure TXT records are consistently updated as well
 	for _, r := range filteredChanges.UpdateNew {
-		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
+		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true, im.txtEncryptEnabled, im.txtEncryptAESKey)).WithSetIdentifier(r.SetIdentifier)
 		txt.ProviderSpecific = r.ProviderSpecific
 		filteredChanges.UpdateNew = append(filteredChanges.UpdateNew, txt)
 		// add new version of record to cache

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -43,10 +43,10 @@ func TestTXTRegistry(t *testing.T) {
 
 func testTXTRegistryNew(t *testing.T) {
 	p := provider.NewInMemoryProvider()
-	_, err := NewTXTRegistry(p, "txt", "", time.Hour)
+	_, err := NewTXTRegistry(p, "txt", "", time.Hour, false, nil)
 	require.Error(t, err)
 
-	r, err := NewTXTRegistry(p, "txt", "owner", time.Hour)
+	r, err := NewTXTRegistry(p, "txt", "owner", time.Hour, false, nil)
 	require.NoError(t, err)
 
 	_, ok := r.mapper.(prefixNameMapper)
@@ -54,7 +54,17 @@ func testTXTRegistryNew(t *testing.T) {
 	assert.Equal(t, "owner", r.ownerID)
 	assert.Equal(t, p, r.provider)
 
-	r, err = NewTXTRegistry(p, "", "owner", time.Hour)
+	aesKey := []byte(";k&l)nUC/33:{?d{3)54+,AD?]SX%yh^")
+	_, err = NewTXTRegistry(p, "", "owner", time.Hour, false, nil)
+	require.NoError(t, err)
+
+	_, err = NewTXTRegistry(p, "", "owner", time.Hour, false, aesKey)
+	require.NoError(t, err)
+
+	_, err = NewTXTRegistry(p, "", "owner", time.Hour, true, nil)
+	require.Error(t, err)
+
+	r, err = NewTXTRegistry(p, "", "owner", time.Hour, true, aesKey)
 	require.NoError(t, err)
 
 	_, ok = r.mapper.(prefixNameMapper)
@@ -159,13 +169,13 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 		},
 	}
 
-	r, _ := NewTXTRegistry(p, "txt.", "owner", time.Hour)
+	r, _ := NewTXTRegistry(p, "txt.", "owner", time.Hour, false, nil)
 	records, _ := r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
 
 	// Ensure prefix is case-insensitive
-	r, _ = NewTXTRegistry(p, "TxT.", "owner", time.Hour)
+	r, _ = NewTXTRegistry(p, "TxT.", "owner", time.Hour, false, nil)
 	records, _ = r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpointLabels(records, expectedRecords))
@@ -240,7 +250,7 @@ func testTXTRegistryRecordsNoPrefix(t *testing.T) {
 		},
 	}
 
-	r, _ := NewTXTRegistry(p, "", "owner", time.Hour)
+	r, _ := NewTXTRegistry(p, "", "owner", time.Hour, false, nil)
 	records, _ := r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
@@ -276,7 +286,7 @@ func testTXTRegistryApplyChangesWithPrefix(t *testing.T) {
 			newEndpointWithOwner("txt.multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
 		},
 	})
-	r, _ := NewTXTRegistry(p, "txt.", "owner", time.Hour)
+	r, _ := NewTXTRegistry(p, "txt.", "owner", time.Hour, false, nil)
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
@@ -363,7 +373,7 @@ func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 			newEndpointWithOwner("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 		},
 	})
-	r, _ := NewTXTRegistry(p, "", "owner", time.Hour)
+	r, _ := NewTXTRegistry(p, "", "owner", time.Hour, false, nil)
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{


### PR DESCRIPTION
Once again creating a PR for this change. I managed to foobar my previous PR earlier today as my git experience is extremely limited.

We are running on a fork of External-DNS where txt records are encrypted. The encryption is an internal security requirement as we are not allowed to leak information about internal infrastructure through publicly available txt records.

It is a pain to keep a forked version of External-DNS up to date and it would be really nice if this PR could be considered (or at least looked at). The previous PR was created on December 6th 2019 and was absolutely, totally and completely ignored by the project maintainers for more than 4 months.

We are looking for other solutions, but this forked version of External-DNS is currently our best option. So we really hope txt record encryption will be included as a security feature in External-DNS. It doesn't mater a lot for us this code is used as a base for implementation - as long as it is implemented.