### PR TITLE
Ensure maximum run interval

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -129,8 +129,8 @@ func (c *Controller) RunOnceThrottled(ctx context.Context) error {
 		testing = true
 	}
 	if c.running || now.Before(c.minStartTime) {
-		// Normally when throttled this function is no-op, but when testing
-		// we need to signal that the function is throttled by returning an error
+		// When throttled in non-test environment this function is no-op
+		// In test environment function returns an error so we can test it
 		if testing {
 			return errors.New("throttled")
 		}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -120,7 +120,7 @@ type Controller struct {
 
 var nowValue = struct{}{}
 
-// Make sure execution happens at most once per interval
+// RunOnceThrottled  makes sure execution happens at most once per interval.
 func (c *Controller) RunOnceThrottled(ctx context.Context) error {
 	now := time.Now()
 	testing := false

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -123,15 +123,15 @@ var nowValue = struct{}{}
 // RunOnceThrottled  makes sure execution happens at most once per interval.
 func (c *Controller) RunOnceThrottled(ctx context.Context) error {
 	now := time.Now()
-	testing := false
+	testEnv := false
 	if v, ok := ctx.Value(nowValue).(time.Time); ok {
 		now = v
-		testing = true
+		testEnv = true
 	}
 	if c.running || now.Before(c.minStartTime) {
 		// When throttled in non-test environment this function is no-op
 		// In test environment function returns an error so we can test it
-		if testing {
+		if testEnv {
 			return errors.New("throttled")
 		}
 		return nil
@@ -141,7 +141,7 @@ func (c *Controller) RunOnceThrottled(ctx context.Context) error {
 	defer func() {
 		c.running = false
 	}()
-	if testing {
+	if testEnv {
 		return nil
 	}
 	return c.RunOnce(ctx)

--- a/main.go
+++ b/main.go
@@ -295,13 +295,6 @@ func main() {
 		DomainFilter: domainFilter,
 	}
 
-	if cfg.UpdateEvents {
-		// Add RunOnce as the handler function that will be called when ingress/service sources have changed.
-		// Note that k8s Informers will perform an initial list operation, which results in the handler
-		// function initially being called for every Service/Ingress that exists limted by minInterval.
-		ctrl.Source.AddEventHandler(func() error { return ctrl.RunOnce(ctx) }, stopChan, 1*time.Minute)
-	}
-
 	if cfg.Once {
 		err := ctrl.RunOnce(ctx)
 		if err != nil {
@@ -310,6 +303,14 @@ func main() {
 
 		os.Exit(0)
 	}
+
+	if cfg.UpdateEvents {
+		// Add RunOnce as the handler function that will be called when ingress/service sources have changed.
+		// Note that k8s Informers will perform an initial list operation, which results in the handler
+		// function initially being called for every Service/Ingress that exists limted by minInterval.
+		ctrl.Source.AddEventHandler(func() error { return ctrl.RunOnceThrottled(ctx) }, stopChan, 1*time.Minute)
+	}
+
 	ctrl.Run(ctx, stopChan)
 }
 


### PR DESCRIPTION
This pull request adds additional mechanism by which we can be sure synchronization won't run:

1. More than once per Interval
2. More than one at a time

This is done by keeping track of whether RunOnce is already running, and what is next possible run time (i.e. one Interval since last time RunOnce has been called).

This can fix various issue like current one that causes RunOnce to be called twice when external-dns configured with `--events` runs, or multiple overlapping updates that can cause issues like #1463, especially if update time is for some reason longer than Interval (many records, network timeouts etc.)

I've attached tests that test this behavior. I can also attest this works on real cluster (docker image at `sheerun/external-dns:v0.7.1-54-g98ac8302`).