### PR TITLE
External DNS should uses ALIAS for AWS Global Accelerator

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -99,6 +99,8 @@ var (
 		"elb.cn-north-1.amazonaws.com.cn":     "Z3QFB96KMJ7ED6",
 		"elb.cn-northwest-1.amazonaws.com.cn": "ZQEIKTCZ8352D",
 		"elb.me-south-1.amazonaws.com":        "Z3QSRYVP46NYYV",
+		// Global Accelerator
+		"awsglobalaccelerator.com": "Z2BJ6XQ5FK7U4H",
 	}
 )
 


### PR DESCRIPTION
External DNS should use ALIAS for AWS Global Accelerator instead of CNAME.

ZoneId defined there: https://docs.aws.amazon.com/Route53/latest/APIReference/API_AliasTarget.html

DNS name defined there:
https://docs.aws.amazon.com/global-accelerator/latest/dg/introduction-components.html
