### PR TITLE
Use consistent headless service name in example

### DIFF
--- a/docs/tutorials/hostport.md
+++ b/docs/tutorials/hostport.md
@@ -17,7 +17,7 @@ A simple deploy could look like this:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: exeternal-dns
+  name: external-dns
 spec:
   strategy:
     type: Recreate
@@ -111,7 +111,7 @@ spec:
 
 ### Kafka Stateful Set
 
-First lets deploy a Kafka Stateful set, a simple example(a lot of stuff is missing) with a headless service called `kafka-hsvc`
+First lets deploy a Kafka Stateful set, a simple example(a lot of stuff is missing) with a headless service called `ksvc`
 
 ```yaml
 apiVersion: apps/v1beta1
@@ -155,7 +155,7 @@ spec:
         requests:
           storage:  500Gi
 ```
-Very important here, is to set the `hostport`(only works if the PodSecurityPolicy allows it)! and in case your app requires an actual hostname inside the container, unlike Kafka, which can advertise on another address, you have to set the hostname yourself.
+Very important here, is to set the `hostPort`(only works if the PodSecurityPolicy allows it)! and in case your app requires an actual hostname inside the container, unlike Kafka, which can advertise on another address, you have to set the hostname yourself.
 
 ### Headless Service
 

--- a/docs/tutorials/hostport.md
+++ b/docs/tutorials/hostport.md
@@ -9,7 +9,7 @@ The main use cases that inspired this feature is the necessity for fixed address
 
 We will go through a small example of deploying a simple Kafka with use of a headless service.
 
-### Exernal DNS
+### External DNS
 
 A simple deploy could look like this:
 ### Manifest (for clusters without RBAC enabled)
@@ -81,7 +81,7 @@ subjects:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: exeternal-dns
+  name: external-dns
 spec:
   strategy:
     type: Recreate


### PR DESCRIPTION
Fix a typo and update the headless service name to be consistent.