### PR TITLE
Fix #1540 source: explicitly handle default annotations

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,6 +120,7 @@ func main() {
 		ContourLoadBalancerService:     cfg.ContourLoadBalancerService,
 		SkipperRouteGroupVersion:       cfg.SkipperRouteGroupVersion,
 		RequestTimeout:                 cfg.RequestTimeout,
+		DefaultAnnotations:             source.DefaultAnnotations(cfg.CloudflareProxied),
 	}
 
 	// Lookup all the selected sources by names and pass them the desired configuration.
@@ -194,7 +195,7 @@ func main() {
 	case "vultr":
 		p, err = vultr.NewVultrProvider(domainFilter, cfg.DryRun)
 	case "cloudflare":
-		p, err = cloudflare.NewCloudFlareProvider(domainFilter, zoneIDFilter, cfg.CloudflareZonesPerPage, cfg.CloudflareProxied, cfg.DryRun)
+		p, err = cloudflare.NewCloudFlareProvider(domainFilter, zoneIDFilter, cfg.CloudflareZonesPerPage, cfg.DryRun)
 	case "rcodezero":
 		p, err = rcode0.NewRcodeZeroProvider(domainFilter, cfg.DryRun, cfg.RcodezeroTXTEncrypt)
 	case "google":

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -355,30 +355,6 @@ func TestCloudflareCustomTTL(t *testing.T) {
 	})
 }
 
-func TestCloudflareProxiedDefault(t *testing.T) {
-	endpoints := []*endpoint.Endpoint{
-		{
-			RecordType: "A",
-			DNSName:    "bar.com",
-			Targets:    endpoint.Targets{"127.0.0.1"},
-		},
-	}
-
-	AssertActions(t, &CloudFlareProvider{proxiedByDefault: true}, endpoints, []MockAction{
-		{
-			Name:   "Create",
-			ZoneId: "001",
-			RecordData: cloudflare.DNSRecord{
-				Type:    "A",
-				Name:    "bar.com",
-				Content: "127.0.0.1",
-				TTL:     1,
-				Proxied: true,
-			},
-		},
-	})
-}
-
 func TestCloudflareProxiedOverrideTrue(t *testing.T) {
 	endpoints := []*endpoint.Endpoint{
 		{
@@ -424,7 +400,7 @@ func TestCloudflareProxiedOverrideFalse(t *testing.T) {
 		},
 	}
 
-	AssertActions(t, &CloudFlareProvider{proxiedByDefault: true}, endpoints, []MockAction{
+	AssertActions(t, &CloudFlareProvider{}, endpoints, []MockAction{
 		{
 			Name:   "Create",
 			ZoneId: "001",
@@ -454,7 +430,7 @@ func TestCloudflareProxiedOverrideIllegal(t *testing.T) {
 		},
 	}
 
-	AssertActions(t, &CloudFlareProvider{proxiedByDefault: true}, endpoints, []MockAction{
+	AssertActions(t, &CloudFlareProvider{}, endpoints, []MockAction{
 		{
 			Name:   "Create",
 			ZoneId: "001",
@@ -463,7 +439,7 @@ func TestCloudflareProxiedOverrideIllegal(t *testing.T) {
 				Name:    "bar.com",
 				Content: "127.0.0.1",
 				TTL:     1,
-				Proxied: true,
+				Proxied: false,
 			},
 		},
 	})
@@ -567,8 +543,7 @@ func TestCloudflareProvider(t *testing.T) {
 		endpoint.NewDomainFilter([]string{"bar.com"}),
 		provider.NewZoneIDFilter([]string{""}),
 		25,
-		false,
-		true)
+		false)
 	if err != nil {
 		t.Errorf("should not fail, %s", err)
 	}
@@ -579,8 +554,7 @@ func TestCloudflareProvider(t *testing.T) {
 		endpoint.NewDomainFilter([]string{"bar.com"}),
 		provider.NewZoneIDFilter([]string{""}),
 		1,
-		false,
-		true)
+		false)
 	if err != nil {
 		t.Errorf("should not fail, %s", err)
 	}
@@ -590,8 +564,7 @@ func TestCloudflareProvider(t *testing.T) {
 		endpoint.NewDomainFilter([]string{"bar.com"}),
 		provider.NewZoneIDFilter([]string{""}),
 		50,
-		false,
-		true)
+		false)
 	if err == nil {
 		t.Errorf("expected to fail")
 	}

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -50,6 +50,7 @@ type gatewaySource struct {
 	combineFQDNAnnotation    bool
 	ignoreHostnameAnnotation bool
 	serviceInformer          coreinformers.ServiceInformer
+	defaultAnnotations       map[string]string
 }
 
 // NewIstioGatewaySource creates a new gatewaySource with the given config.
@@ -61,6 +62,7 @@ func NewIstioGatewaySource(
 	fqdnTemplate string,
 	combineFqdnAnnotation bool,
 	ignoreHostnameAnnotation bool,
+	defaultAnnotations map[string]string,
 ) (Source, error) {
 	var (
 		tmpl *template.Template
@@ -110,6 +112,7 @@ func NewIstioGatewaySource(
 		combineFQDNAnnotation:    combineFqdnAnnotation,
 		ignoreHostnameAnnotation: ignoreHostnameAnnotation,
 		serviceInformer:          serviceInformer,
+		defaultAnnotations:       defaultAnnotations,
 	}, nil
 }
 
@@ -200,7 +203,7 @@ func (sc *gatewaySource) endpointsFromTemplate(config *istiomodel.Config) ([]*en
 		}
 	}
 
-	providerSpecific, setIdentifier := getProviderSpecificAnnotations(config.Annotations)
+	providerSpecific, setIdentifier := getProviderSpecificAnnotations(annotationsWithDefaults(config.Annotations, sc.defaultAnnotations))
 
 	var endpoints []*endpoint.Endpoint
 	// splits the FQDN template and removes the trailing periods
@@ -300,7 +303,7 @@ func (sc *gatewaySource) endpointsFromGatewayConfig(config istiomodel.Config) ([
 
 	gateway := config.Spec.(*istionetworking.Gateway)
 
-	providerSpecific, setIdentifier := getProviderSpecificAnnotations(config.Annotations)
+	providerSpecific, setIdentifier := getProviderSpecificAnnotations(annotationsWithDefaults(config.Annotations, sc.defaultAnnotations))
 
 	for _, server := range gateway.Servers {
 		for _, host := range server.Hosts {

--- a/source/gateway_test.go
+++ b/source/gateway_test.go
@@ -79,6 +79,7 @@ func (suite *GatewaySuite) SetupTest() {
 		"{{.Name}}",
 		false,
 		false,
+		DefaultAnnotations(false),
 	)
 	suite.NoError(err, "should initialize gateway source")
 
@@ -152,6 +153,7 @@ func TestNewIstioGatewaySource(t *testing.T) {
 				ti.fqdnTemplate,
 				ti.combineFQDNAndAnnotation,
 				false,
+				DefaultAnnotations(false),
 			)
 			if ti.expectError {
 				assert.Error(t, err)
@@ -1113,6 +1115,7 @@ func testGatewayEndpoints(t *testing.T) {
 				ti.fqdnTemplate,
 				ti.combineFQDNAndAnnotation,
 				ti.ignoreHostnameAnnotation,
+				DefaultAnnotations(false),
 			)
 			require.NoError(t, err)
 
@@ -1149,6 +1152,7 @@ func newTestGatewaySource(loadBalancerList []fakeIngressGatewayService) (*gatewa
 		"{{.Name}}",
 		false,
 		false,
+		DefaultAnnotations(false),
 	)
 	if err != nil {
 		return nil, err

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -51,6 +51,7 @@ func (suite *IngressSuite) SetupTest() {
 		"{{.Name}}",
 		false,
 		false,
+		DefaultAnnotations(false),
 	)
 	suite.NoError(err, "should initialize ingress source")
 
@@ -133,6 +134,7 @@ func TestNewIngressSource(t *testing.T) {
 				ti.fqdnTemplate,
 				ti.combineFQDNAndAnnotation,
 				false,
+				DefaultAnnotations(false),
 			)
 			if ti.expectError {
 				assert.Error(t, err)
@@ -220,7 +222,7 @@ func testEndpointsFromIngress(t *testing.T) {
 	} {
 		t.Run(ti.title, func(t *testing.T) {
 			realIngress := ti.ingress.Ingress()
-			validateEndpoints(t, endpointsFromIngress(realIngress, false), ti.expected)
+			validateEndpoints(t, (&ingressSource{}).endpointsFromIngress(realIngress, false), ti.expected)
 		})
 	}
 }
@@ -1007,6 +1009,7 @@ func testIngressEndpoints(t *testing.T) {
 				ti.fqdnTemplate,
 				ti.combineFQDNAndAnnotation,
 				ti.ignoreHostnameAnnotation,
+				DefaultAnnotations(false),
 			)
 			for _, ingress := range ingresses {
 				_, err := fakeClient.Extensions().Ingresses(ingress.Namespace).Create(ingress)

--- a/source/ingressroute.go
+++ b/source/ingressroute.go
@@ -56,6 +56,7 @@ type ingressRouteSource struct {
 	ignoreHostnameAnnotation   bool
 	ingressRouteInformer       informers.GenericInformer
 	unstructuredConverter      *UnstructuredConverter
+	defaultAnnotations         map[string]string
 }
 
 // NewContourIngressRouteSource creates a new contourIngressRouteSource with the given config.
@@ -68,6 +69,7 @@ func NewContourIngressRouteSource(
 	fqdnTemplate string,
 	combineFqdnAnnotation bool,
 	ignoreHostnameAnnotation bool,
+	defaultAnnotations map[string]string,
 ) (Source, error) {
 	var (
 		tmpl *template.Template
@@ -126,6 +128,7 @@ func NewContourIngressRouteSource(
 		ignoreHostnameAnnotation:   ignoreHostnameAnnotation,
 		ingressRouteInformer:       ingressRouteInformer,
 		unstructuredConverter:      uc,
+		defaultAnnotations:         defaultAnnotations,
 	}, nil
 }
 
@@ -232,7 +235,7 @@ func (sc *ingressRouteSource) endpointsFromTemplate(ingressRoute *contourapi.Ing
 		}
 	}
 
-	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ingressRoute.Annotations)
+	providerSpecific, setIdentifier := getProviderSpecificAnnotations(annotationsWithDefaults(ingressRoute.Annotations, sc.defaultAnnotations))
 
 	var endpoints []*endpoint.Endpoint
 	// splits the FQDN template and removes the trailing periods
@@ -325,7 +328,7 @@ func (sc *ingressRouteSource) endpointsFromIngressRoute(ingressRoute *contourapi
 		}
 	}
 
-	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ingressRoute.Annotations)
+	providerSpecific, setIdentifier := getProviderSpecificAnnotations(annotationsWithDefaults(ingressRoute.Annotations, sc.defaultAnnotations))
 
 	if virtualHost := ingressRoute.Spec.VirtualHost; virtualHost != nil {
 		if fqdn := virtualHost.Fqdn; fqdn != "" {

--- a/source/ingressroute_test.go
+++ b/source/ingressroute_test.go
@@ -70,6 +70,7 @@ func (suite *IngressRouteSuite) SetupTest() {
 		"{{.Name}}",
 		false,
 		false,
+		DefaultAnnotations(false),
 	)
 	suite.NoError(err, "should initialize ingressroute source")
 
@@ -167,6 +168,7 @@ func TestNewContourIngressRouteSource(t *testing.T) {
 				ti.fqdnTemplate,
 				ti.combineFQDNAndAnnotation,
 				false,
+				DefaultAnnotations(false),
 			)
 			if ti.expectError {
 				assert.Error(t, err)
@@ -1028,6 +1030,7 @@ func testIngressRouteEndpoints(t *testing.T) {
 				ti.fqdnTemplate,
 				ti.combineFQDNAndAnnotation,
 				ti.ignoreHostnameAnnotation,
+				DefaultAnnotations(false),
 			)
 			require.NoError(t, err)
 
@@ -1063,6 +1066,7 @@ func newTestIngressRouteSource(loadBalancer fakeLoadBalancerService) (*ingressRo
 		"{{.Name}}",
 		false,
 		false,
+		DefaultAnnotations(false),
 	)
 	if err != nil {
 		return nil, err

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -53,6 +53,7 @@ func (suite *ServiceSuite) SetupTest() {
 		false,
 		[]string{},
 		false,
+		DefaultAnnotations(false),
 	)
 	suite.fooWithTargets = &v1.Service{
 		Spec: v1.ServiceSpec{
@@ -146,6 +147,7 @@ func testServiceSourceNewServiceSource(t *testing.T) {
 				false,
 				ti.serviceTypesFilter,
 				false,
+				DefaultAnnotations(false),
 			)
 
 			if ti.expectError {
@@ -1111,6 +1113,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				false,
 				tc.serviceTypesFilter,
 				tc.ignoreHostnameAnnotation,
+				DefaultAnnotations(false),
 			)
 			require.NoError(t, err)
 
@@ -1282,6 +1285,7 @@ func TestClusterIpServices(t *testing.T) {
 				false,
 				[]string{},
 				tc.ignoreHostnameAnnotation,
+				DefaultAnnotations(false),
 			)
 			require.NoError(t, err)
 
@@ -1614,6 +1618,7 @@ func TestNodePortServices(t *testing.T) {
 				false,
 				[]string{},
 				tc.ignoreHostnameAnnotation,
+				DefaultAnnotations(false),
 			)
 			require.NoError(t, err)
 
@@ -1943,6 +1948,7 @@ func TestHeadlessServices(t *testing.T) {
 				false,
 				[]string{},
 				tc.ignoreHostnameAnnotation,
+				DefaultAnnotations(false),
 			)
 			require.NoError(t, err)
 
@@ -2245,6 +2251,7 @@ func TestHeadlessServicesHostIP(t *testing.T) {
 				false,
 				[]string{},
 				tc.ignoreHostnameAnnotation,
+				DefaultAnnotations(false),
 			)
 			require.NoError(t, err)
 
@@ -2350,6 +2357,7 @@ func TestExternalServices(t *testing.T) {
 				false,
 				[]string{},
 				tc.ignoreHostnameAnnotation,
+				DefaultAnnotations(false),
 			)
 			require.NoError(t, err)
 
@@ -2390,7 +2398,7 @@ func BenchmarkServiceEndpoints(b *testing.B) {
 	_, err := kubernetes.CoreV1().Services(service.Namespace).Create(service)
 	require.NoError(b, err)
 
-	client, err := NewServiceSource(kubernetes, v1.NamespaceAll, "", "", false, "", false, false, false, []string{}, false)
+	client, err := NewServiceSource(kubernetes, v1.NamespaceAll, "", "", false, "", false, false, false, []string{}, false, DefaultAnnotations(false))
 	require.NoError(b, err)
 
 	for i := 0; i < b.N; i++ {

--- a/source/source.go
+++ b/source/source.go
@@ -247,3 +247,21 @@ func poll(interval time.Duration, timeout time.Duration, condition wait.Conditio
 
 	return wait.Poll(interval, timeout, condition)
 }
+
+// DefaultAnnotations produces a map of default annotations to be used by sources.
+func DefaultAnnotations(cloudflareProxied bool) map[string]string {
+	return map[string]string{
+		CloudflareProxiedKey: strconv.FormatBool(cloudflareProxied),
+	}
+}
+
+func annotationsWithDefaults(annotations, defaults map[string]string) map[string]string {
+	m := make(map[string]string)
+	for k, v := range defaults {
+		m[k] = v
+	}
+	for k, v := range annotations {
+		m[k] = v
+	}
+	return m
+}

--- a/source/store.go
+++ b/source/store.go
@@ -63,6 +63,7 @@ type Config struct {
 	ContourLoadBalancerService     string
 	SkipperRouteGroupVersion       string
 	RequestTimeout                 time.Duration
+	DefaultAnnotations             map[string]string
 }
 
 // ClientGenerator provides clients
@@ -180,13 +181,13 @@ func BuildWithConfig(source string, p ClientGenerator, cfg *Config) (Source, err
 		if err != nil {
 			return nil, err
 		}
-		return NewServiceSource(client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.Compatibility, cfg.PublishInternal, cfg.PublishHostIP, cfg.AlwaysPublishNotReadyAddresses, cfg.ServiceTypeFilter, cfg.IgnoreHostnameAnnotation)
+		return NewServiceSource(client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.Compatibility, cfg.PublishInternal, cfg.PublishHostIP, cfg.AlwaysPublishNotReadyAddresses, cfg.ServiceTypeFilter, cfg.IgnoreHostnameAnnotation, cfg.DefaultAnnotations)
 	case "ingress":
 		client, err := p.KubeClient()
 		if err != nil {
 			return nil, err
 		}
-		return NewIngressSource(client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.IgnoreHostnameAnnotation)
+		return NewIngressSource(client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.IgnoreHostnameAnnotation, cfg.DefaultAnnotations)
 	case "istio-gateway":
 		kubernetesClient, err := p.KubeClient()
 		if err != nil {
@@ -196,7 +197,7 @@ func BuildWithConfig(source string, p ClientGenerator, cfg *Config) (Source, err
 		if err != nil {
 			return nil, err
 		}
-		return NewIstioGatewaySource(kubernetesClient, istioClient, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.IgnoreHostnameAnnotation)
+		return NewIstioGatewaySource(kubernetesClient, istioClient, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.IgnoreHostnameAnnotation, cfg.DefaultAnnotations)
 	case "cloudfoundry":
 		cfClient, err := p.CloudFoundryClient(cfg.CFAPIEndpoint, cfg.CFUsername, cfg.CFPassword)
 		if err != nil {
@@ -212,13 +213,13 @@ func BuildWithConfig(source string, p ClientGenerator, cfg *Config) (Source, err
 		if err != nil {
 			return nil, err
 		}
-		return NewContourIngressRouteSource(dynamicClient, kubernetesClient, cfg.ContourLoadBalancerService, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.IgnoreHostnameAnnotation)
+		return NewContourIngressRouteSource(dynamicClient, kubernetesClient, cfg.ContourLoadBalancerService, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.IgnoreHostnameAnnotation, cfg.DefaultAnnotations)
 	case "openshift-route":
 		ocpClient, err := p.OpenShiftClient()
 		if err != nil {
 			return nil, err
 		}
-		return NewOcpRouteSource(ocpClient, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.IgnoreHostnameAnnotation)
+		return NewOcpRouteSource(ocpClient, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.IgnoreHostnameAnnotation, cfg.DefaultAnnotations)
 	case "fake":
 		return NewFakeSource(cfg.FQDNTemplate)
 	case "connector":
@@ -243,7 +244,7 @@ func BuildWithConfig(source string, p ClientGenerator, cfg *Config) (Source, err
 			tokenPath = restConfig.BearerTokenFile
 			token = restConfig.BearerToken
 		}
-		return NewRouteGroupSource(cfg.RequestTimeout, token, tokenPath, master, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.SkipperRouteGroupVersion, cfg.CombineFQDNAndAnnotation, cfg.IgnoreHostnameAnnotation)
+		return NewRouteGroupSource(cfg.RequestTimeout, token, tokenPath, master, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.SkipperRouteGroupVersion, cfg.CombineFQDNAndAnnotation, cfg.IgnoreHostnameAnnotation, cfg.DefaultAnnotations)
 	}
 	return nil, ErrSourceNotFound
 }


### PR DESCRIPTION
This commit fixes a bug that causes the Cloudflare provider to delete
and recreate all records every minute.
The controller is running into trouble when reconciling endpoints with
values with implicit defaults. This is caused because the providers
produce records with all values explicitly set, however the sources
generate endpoints with implicit provider-specific values, i.e. when an
annotation is not set. This causes the planner to always detect a diff.

Fixes: #1540

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>