### PR TITLE
Fix goreportcard warnings

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -159,6 +159,7 @@ func NewEndpointWithTTL(dnsName, recordType string, ttl TTL, targets ...string) 
 	}
 }
 
+// WithSetIdentifier applies the given set identifier to the endpoint.
 func (e *Endpoint) WithSetIdentifier(setIdentifier string) *Endpoint {
 	e.SetIdentifier = setIdentifier
 	return e

--- a/provider/aws_test.go
+++ b/provider/aws_test.go
@@ -184,11 +184,11 @@ func (r *Route53APIStub) ChangeResourceRecordSetsWithContext(ctx context.Context
 			change.ResourceRecordSet.AliasTarget.DNSName = aws.String(wildcardEscape(ensureTrailingDot(aws.StringValue(change.ResourceRecordSet.AliasTarget.DNSName))))
 		}
 
-		setId := ""
+		setID := ""
 		if change.ResourceRecordSet.SetIdentifier != nil {
-			setId = aws.StringValue(change.ResourceRecordSet.SetIdentifier)
+			setID = aws.StringValue(change.ResourceRecordSet.SetIdentifier)
 		}
-		key := aws.StringValue(change.ResourceRecordSet.Name) + "::" + aws.StringValue(change.ResourceRecordSet.Type) + "::" + setId
+		key := aws.StringValue(change.ResourceRecordSet.Name) + "::" + aws.StringValue(change.ResourceRecordSet.Type) + "::" + setID
 		switch aws.StringValue(change.Action) {
 		case route53.ChangeActionCreate:
 			if _, found := recordSets[key]; found {

--- a/provider/cloudflare_test.go
+++ b/provider/cloudflare_test.go
@@ -173,9 +173,9 @@ func (m *mockCloudFlareClient) ListZones(zoneID ...string) ([]cloudflare.Zone, e
 
 	result := []cloudflare.Zone{}
 
-	for zoneId, zoneName := range m.Zones {
+	for zoneID, zoneName := range m.Zones {
 		result = append(result, cloudflare.Zone{
-			ID:   zoneId,
+			ID:   zoneID,
 			Name: zoneName,
 		})
 	}

--- a/provider/cloudflare_test.go
+++ b/provider/cloudflare_test.go
@@ -619,7 +619,7 @@ func TestCloudflareApplyChanges(t *testing.T) {
 	}
 
 	td.Cmp(t, client.Actions, []MockAction{
-		MockAction{
+		{
 			Name:   "Create",
 			ZoneId: "001",
 			RecordData: cloudflare.DNSRecord{
@@ -628,7 +628,7 @@ func TestCloudflareApplyChanges(t *testing.T) {
 				TTL:     1,
 			},
 		},
-		MockAction{
+		{
 			Name:   "Create",
 			ZoneId: "001",
 			RecordData: cloudflare.DNSRecord{
@@ -947,12 +947,12 @@ func TestCloudflareComplexUpdate(t *testing.T) {
 	}
 
 	td.CmpDeeply(t, client.Actions, []MockAction{
-		MockAction{
+		{
 			Name:     "Delete",
 			ZoneId:   "001",
 			RecordId: "1234567890",
 		},
-		MockAction{
+		{
 			Name:   "Create",
 			ZoneId: "001",
 			RecordData: cloudflare.DNSRecord{
@@ -963,7 +963,7 @@ func TestCloudflareComplexUpdate(t *testing.T) {
 				Proxied: true,
 			},
 		},
-		MockAction{
+		{
 			Name:   "Create",
 			ZoneId: "001",
 			RecordData: cloudflare.DNSRecord{

--- a/provider/ovh_test.go
+++ b/provider/ovh_test.go
@@ -142,9 +142,9 @@ func TestOvhRecords(t *testing.T) {
 		sort.Strings(endoint.Targets)
 	}
 	assert.ElementsMatch(endpoints, []*endpoint.Endpoint{
-		&endpoint.Endpoint{DNSName: "example.org", RecordType: "A", RecordTTL: 10, Labels: endpoint.NewLabels(), Targets: []string{"203.0.113.42"}},
-		&endpoint.Endpoint{DNSName: "www.example.org", RecordType: "CNAME", RecordTTL: 10, Labels: endpoint.NewLabels(), Targets: []string{"example.org"}},
-		&endpoint.Endpoint{DNSName: "ovh.example.net", RecordType: "A", RecordTTL: 10, Labels: endpoint.NewLabels(), Targets: []string{"203.0.113.42", "203.0.113.43"}},
+		{DNSName: "example.org", RecordType: "A", RecordTTL: 10, Labels: endpoint.NewLabels(), Targets: []string{"203.0.113.42"}},
+		{DNSName: "www.example.org", RecordType: "CNAME", RecordTTL: 10, Labels: endpoint.NewLabels(), Targets: []string{"example.org"}},
+		{DNSName: "ovh.example.net", RecordType: "A", RecordTTL: 10, Labels: endpoint.NewLabels(), Targets: []string{"203.0.113.42", "203.0.113.43"}},
 	})
 	client.AssertExpectations(t)
 
@@ -283,10 +283,10 @@ func TestOvhCountTargets(t *testing.T) {
 		endpoints [][]*endpoint.Endpoint
 		count     int
 	}{
-		{[][]*endpoint.Endpoint{[]*endpoint.Endpoint{{DNSName: "ovh.example.net", Targets: endpoint.Targets{"target"}}}}, 1},
-		{[][]*endpoint.Endpoint{[]*endpoint.Endpoint{{DNSName: "ovh.example.net", Targets: endpoint.Targets{"target"}}, {DNSName: "ovh.example.net", Targets: endpoint.Targets{"target"}}}}, 2},
-		{[][]*endpoint.Endpoint{[]*endpoint.Endpoint{{DNSName: "ovh.example.net", Targets: endpoint.Targets{"target", "target", "target"}}}}, 3},
-		{[][]*endpoint.Endpoint{[]*endpoint.Endpoint{{DNSName: "ovh.example.net", Targets: endpoint.Targets{"target", "target"}}}, []*endpoint.Endpoint{{DNSName: "ovh.example.net", Targets: endpoint.Targets{"target", "target"}}}}, 4},
+		{[][]*endpoint.Endpoint{{{DNSName: "ovh.example.net", Targets: endpoint.Targets{"target"}}}}, 1},
+		{[][]*endpoint.Endpoint{{{DNSName: "ovh.example.net", Targets: endpoint.Targets{"target"}}, {DNSName: "ovh.example.net", Targets: endpoint.Targets{"target"}}}}, 2},
+		{[][]*endpoint.Endpoint{{{DNSName: "ovh.example.net", Targets: endpoint.Targets{"target", "target", "target"}}}}, 3},
+		{[][]*endpoint.Endpoint{{{DNSName: "ovh.example.net", Targets: endpoint.Targets{"target", "target"}}}, {{DNSName: "ovh.example.net", Targets: endpoint.Targets{"target", "target"}}}}, 4},
 	}
 	for _, test := range cases {
 		count := countTargets(test.endpoints...)

--- a/provider/vultr.go
+++ b/provider/vultr.go
@@ -36,6 +36,7 @@ const (
 	vultrTTL    = 3600
 )
 
+// VultrProvider is an implementation of Provider for Vultr DNS.
 type VultrProvider struct {
 	client govultr.Client
 
@@ -43,6 +44,7 @@ type VultrProvider struct {
 	DryRun       bool
 }
 
+// VultrChanges differentiates between ChangActions.
 type VultrChanges struct {
 	Action string
 
@@ -78,6 +80,7 @@ func (p *VultrProvider) Zones(ctx context.Context) ([]govultr.DNSDomain, error) 
 	return zones, nil
 }
 
+// Records returns the list of records.
 func (p *VultrProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
 	zones, err := p.Zones(ctx)
 	if err != nil {
@@ -201,6 +204,7 @@ func (p *VultrProvider) submitChanges(ctx context.Context, changes []*VultrChang
 	return nil
 }
 
+// ApplyChanges applies a given set of changes in a given zone.
 func (p *VultrProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
 	combinedChanges := make([]*VultrChanges, 0, len(changes.Create)+len(changes.UpdateNew)+len(changes.Delete))
 

--- a/source/routegroup.go
+++ b/source/routegroup.go
@@ -37,7 +37,8 @@ import (
 )
 
 const (
-	defaultIdleConnTimeout       = 30 * time.Second
+	defaultIdleConnTimeout = 30 * time.Second
+	// DefaultRoutegroupVersion is the default version for route groups.
 	DefaultRoutegroupVersion     = "zalando.org/v1"
 	routeGroupListResource       = "/apis/%s/routegroups"
 	routeGroupNamespacedResource = "/apis/%s/namespaces/%s/routegroups"


### PR DESCRIPTION
This PR fixes the golint and gofmt warnings shown on goreportcard https://goreportcard.com/report/github.com/kubernetes-sigs/external-dns#golint