### PR TITLE
Make tests faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,28 @@ matrix:
   allow_failures:
   - go: tip
 
-env:
-- GOLANGCI_RELEASE="v1.26.0"
-
-before_install:
-- GO111MODULE=off go get github.com/mattn/goveralls
-- GO111MODULE=off go get github.com/lawrencewoodman/roveralls
-- curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_RELEASE}
+cache:
+  directories:
+    - $GOPATH/pkg/mod
 
 script:
 - make test
-- make lint
-- travis_wait 20 roveralls
-- goveralls -coverprofile=roveralls.coverprofile -service=travis-ci
+
+jobs:
+  include:
+  - name: "Linting"
+    go: "1.14.x"
+    env:
+    - GOLANGCI_RELEASE="v1.26.0"
+    before_install:
+    - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_RELEASE}
+    script:
+    - make lint
+  - name: "Coverage"
+    go: "1.14.x"
+    before_install:
+    - GO111MODULE=off go get github.com/mattn/goveralls
+    - GO111MODULE=off go get github.com/lawrencewoodman/roveralls
+    script:
+    - travis_wait 20 roveralls
+    - goveralls -coverprofile=roveralls.coverprofile -service=travis-ci

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ lint:
 .PHONY: verify test
 
 test:
-	go test -v -race $(shell go list ./... | grep -v /vendor/)
+	go test -v -race ./...
 
 # The build targets allow to build the binary and docker image
 .PHONY: build build.docker build.mini

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,4 @@
+package config
+
+// FAST_POLL used for fast testing
+var FAST_POLL = false

--- a/internal/testutils/init.go
+++ b/internal/testutils/init.go
@@ -1,0 +1,23 @@
+package testutils
+
+import (
+	"io/ioutil"
+	"os"
+
+	"log"
+
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/external-dns/internal/config"
+)
+
+func init() {
+	config.FAST_POLL = true
+	if os.Getenv("DEBUG") == "" {
+		logrus.SetOutput(ioutil.Discard)
+		log.SetOutput(ioutil.Discard)
+	} else {
+		if level, err := logrus.ParseLevel(os.Getenv("DEBUG")); err == nil {
+			logrus.SetLevel(level)
+		}
+	}
+}

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -94,7 +94,7 @@ func NewIstioGatewaySource(
 	informerFactory.Start(wait.NeverStop)
 
 	// wait for the local cache to be populated.
-	err = wait.Poll(time.Second, 60*time.Second, func() (bool, error) {
+	err = poll(time.Second, 60*time.Second, func() (bool, error) {
 		return serviceInformer.Informer().HasSynced(), nil
 	})
 	if err != nil {

--- a/source/ingress.go
+++ b/source/ingress.go
@@ -91,7 +91,7 @@ func NewIngressSource(kubeClient kubernetes.Interface, namespace, annotationFilt
 	informerFactory.Start(wait.NeverStop)
 
 	// wait for the local cache to be populated.
-	err = wait.Poll(time.Second, 60*time.Second, func() (bool, error) {
+	err = poll(time.Second, 60*time.Second, func() (bool, error) {
 		return ingressInformer.Informer().HasSynced(), nil
 	})
 	if err != nil {

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -26,7 +26,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"sigs.k8s.io/external-dns/endpoint"
@@ -1018,7 +1017,7 @@ func testIngressEndpoints(t *testing.T) {
 			var err error
 
 			// wait up to a few seconds for new resources to appear in informer cache.
-			err = wait.Poll(time.Second, 3*time.Second, func() (bool, error) {
+			err = poll(time.Second, 3*time.Second, func() (bool, error) {
 				res, err = ingressSource.Endpoints()
 				if err != nil {
 					// stop waiting if we get an error

--- a/source/ingressroute.go
+++ b/source/ingressroute.go
@@ -103,7 +103,7 @@ func NewContourIngressRouteSource(
 	informerFactory.Start(wait.NeverStop)
 
 	// wait for the local cache to be populated.
-	err = wait.Poll(time.Second, 60*time.Second, func() (bool, error) {
+	err = poll(time.Second, 60*time.Second, func() (bool, error) {
 		return ingressRouteInformer.Informer().HasSynced(), nil
 	})
 	if err != nil {

--- a/source/node.go
+++ b/source/node.go
@@ -77,7 +77,7 @@ func NewNodeSource(kubeClient kubernetes.Interface, annotationFilter, fqdnTempla
 	informerFactory.Start(wait.NeverStop)
 
 	// wait for the local cache to be populated.
-	err = wait.Poll(time.Second, 60*time.Second, func() (bool, error) {
+	err = poll(time.Second, 60*time.Second, func() (bool, error) {
 		return nodeInformer.Informer().HasSynced(), nil
 	})
 	if err != nil {

--- a/source/ocproute.go
+++ b/source/ocproute.go
@@ -90,7 +90,7 @@ func NewOcpRouteSource(
 	informerFactory.Start(wait.NeverStop)
 
 	// wait for the local cache to be populated.
-	err = wait.Poll(time.Second, 60*time.Second, func() (bool, error) {
+	err = poll(time.Second, 60*time.Second, func() (bool, error) {
 		return routeInformer.Informer().HasSynced(), nil
 	})
 	if err != nil {

--- a/source/routegroup_test.go
+++ b/source/routegroup_test.go
@@ -709,7 +709,6 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 		}} {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.fqdnTemplate != "" {
-				println("fqdnTemplate is set")
 				tmpl, err := parseTemplate(tt.fqdnTemplate)
 				if err != nil {
 					t.Fatalf("Failed to parse template: %v", err)

--- a/source/service.go
+++ b/source/service.go
@@ -121,8 +121,11 @@ func NewServiceSource(kubeClient kubernetes.Interface, namespace, annotationFilt
 	informerFactory.Start(wait.NeverStop)
 
 	// wait for the local cache to be populated.
-	err = wait.Poll(time.Second, 60*time.Second, func() (bool, error) {
-		return serviceInformer.Informer().HasSynced(), nil
+	err = poll(time.Second, 60*time.Second, func() (bool, error) {
+		return serviceInformer.Informer().HasSynced() &&
+			endpointsInformer.Informer().HasSynced() &&
+			podInformer.Informer().HasSynced() &&
+			nodeInformer.Informer().HasSynced(), nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to sync cache: %v", err)

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"sigs.k8s.io/external-dns/endpoint"
@@ -1118,7 +1117,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			var res []*endpoint.Endpoint
 
 			// wait up to a few seconds for new resources to appear in informer cache.
-			err = wait.Poll(time.Second, 3*time.Second, func() (bool, error) {
+			err = poll(time.Second, 3*time.Second, func() (bool, error) {
 				res, err = client.Endpoints()
 				if err != nil {
 					// stop waiting if we get an error


### PR DESCRIPTION
Reduces test time on travis to 4 minutes by:

- making polling for changes faster in test environment (1 second -> 10 milliseconds)
- preserving go mod cache directory between builds
- disabling logs in test by default (can be overridden with DEBUG=info env variable)
- paralleliziling linting and coverage runs on travis