### PR TITLE
Enable azure_private_dns to work with non "AzurePublicCloud" clouds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Improve errors context for AWS provider
 - Scaleway Provider (#1643) @Sh4d1
+- Enable azure_private_dns to work with non "AzurePublicCloud" clouds (#1578) @daddonpa
 - Fix typos in documentation @ddymko
 
 ## v0.7.3 - 2020-08-05

--- a/provider/azure/azure_private_dns.go
+++ b/provider/azure/azure_private_dns.go
@@ -65,9 +65,15 @@ func NewAzurePrivateDNSProvider(domainFilter endpoint.DomainFilter, zoneIDFilter
 		return nil, err
 	}
 
-	zonesClient := privatedns.NewPrivateZonesClient(subscriptionID)
+	settings, err := auth.GetSettingsFromEnvironment()
+	if err != nil {
+		return nil, err
+	}
+
+
+	zonesClient := privatedns.NewPrivateZonesClientWithBaseURI(settings.Environment.ResourceManagerEndpoint, subscriptionID)
 	zonesClient.Authorizer = authorizer
-	recordSetsClient := privatedns.NewRecordSetsClient(subscriptionID)
+	recordSetsClient := privatedns.NewRecordSetsClientWithBaseURI(settings.Environment.ResourceManagerEndpoint, subscriptionID)
 	recordSetsClient.Authorizer = authorizer
 
 	provider := &AzurePrivateDNSProvider{

--- a/provider/azure/azure_private_dns.go
+++ b/provider/azure/azure_private_dns.go
@@ -70,7 +70,6 @@ func NewAzurePrivateDNSProvider(domainFilter endpoint.DomainFilter, zoneIDFilter
 		return nil, err
 	}
 
-
 	zonesClient := privatedns.NewPrivateZonesClientWithBaseURI(settings.Environment.ResourceManagerEndpoint, subscriptionID)
 	zonesClient.Authorizer = authorizer
 	recordSetsClient := privatedns.NewRecordSetsClientWithBaseURI(settings.Environment.ResourceManagerEndpoint, subscriptionID)

--- a/provider/azure/azure_privatedns_test.go
+++ b/provider/azure/azure_privatedns_test.go
@@ -18,15 +18,15 @@ package azure
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
-	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/azure/auth"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/stretchr/testify/assert"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"

--- a/provider/azure/azure_privatedns_test.go
+++ b/provider/azure/azure_privatedns_test.go
@@ -18,9 +18,12 @@ package azure
 
 import (
 	"context"
-	"testing"
-
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
 
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -250,6 +253,36 @@ func newAzurePrivateDNSProvider(domainFilter endpoint.DomainFilter, zoneIDFilter
 		zonesClient:      privateZonesClient,
 		recordSetsClient: privateRecordsClient,
 	}
+}
+
+func validateAzurePrivateDNSClientsResourceManager(t *testing.T, environmentName string, expectedResourceManagerEndpoint string) {
+	err := os.Setenv(auth.EnvironmentName, environmentName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	azurePrivateDNSProvider, err := NewAzurePrivateDNSProvider(endpoint.NewDomainFilter([]string{"example.com"}), provider.NewZoneIDFilter([]string{""}), "k8s", "sub", true)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	zonesClientBaseURI := azurePrivateDNSProvider.zonesClient.(privatedns.PrivateZonesClient).BaseURI
+	recordSetsClientBaseURI := azurePrivateDNSProvider.recordSetsClient.(privatedns.RecordSetsClient).BaseURI
+
+	assert.Equal(t, zonesClientBaseURI, expectedResourceManagerEndpoint, "expected and actual resource manager endpoints don't match. expected: %s, got: %s", expectedResourceManagerEndpoint, zonesClientBaseURI)
+	assert.Equal(t, recordSetsClientBaseURI, expectedResourceManagerEndpoint, "expected and actual resource manager endpoints don't match. expected: %s, got: %s", expectedResourceManagerEndpoint, recordSetsClientBaseURI)
+}
+
+func TestNewAzurePrivateDNSProvider(t *testing.T) {
+	// make sure to reset the environment variables at the end again
+	originalEnv := os.Getenv(auth.EnvironmentName)
+	defer os.Setenv(auth.EnvironmentName, originalEnv)
+
+	validateAzurePrivateDNSClientsResourceManager(t, "", azure.PublicCloud.ResourceManagerEndpoint)
+	validateAzurePrivateDNSClientsResourceManager(t, "AZURECHINACLOUD", azure.ChinaCloud.ResourceManagerEndpoint)
+	validateAzurePrivateDNSClientsResourceManager(t, "AZUREGERMANCLOUD", azure.GermanCloud.ResourceManagerEndpoint)
+	validateAzurePrivateDNSClientsResourceManager(t, "AZUREUSGOVERNMENTCLOUD", azure.USGovernmentCloud.ResourceManagerEndpoint)
 }
 
 func TestAzurePrivateDNSRecord(t *testing.T) {


### PR DESCRIPTION
The PrivateZoneClient by default communicates to the AzurePublicCloud resource manager endpoint.

To make the `azure_private_dns` work with other clouds like
* AzureUSGovernmentCloud 
* AzureChinaCloud
* AzureGermanCloud

it should use the endpoint specific to the selected cloud.

This change makes it behave like the `NewAzureProvider` from `azure.go` 