### PR TITLE
Improve documentation about rfc2136 TTLs

### DIFF
--- a/docs/tutorials/rfc2136.md
+++ b/docs/tutorials/rfc2136.md
@@ -108,9 +108,29 @@ spec:
                 serviceName: my-service
                 servicePort: 8000
 ```
-There are other annotation that can affect the generation of DNS records like
-external-dns.alpha.kubernetes.io/ttl. These are beyond the scope of this
-tutorial and are covered elsewhere in the docs.
+
+### Custom TTL
+
+The default DNS record TTL (Time-To-Live) is 0 seconds. You can customize this value by setting the annotation `external-dns.alpha.kubernetes.io/ttl`. e.g., modify the service manifest YAML file above:
+
+```
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: nginx.external-dns-test.my-org.com
+    external-dns.alpha.kubernetes.io/ttl: 60
+spec:
+    ...
+```
+
+This will set the DNS record's TTL to 60 seconds.
+
+A default TTL for all records can be set using the the flag with a time in seconds, minutes or hours, such as `--rfc2136-min-ttl=60s`
+
+There are other annotation that can affect the generation of DNS records, but these are beyond the scope of this
+tutorial and are covered in the main documentation.
 
 ### Test with external-dns installed on local machine (optional)
 You may install external-dns and test on a local machine by running:


### PR DESCRIPTION
Now that `--rfc2136-min-ttl` is an option, show how to set it and also how to override it using an annotation.