### PR TITLE
Add owners for cloudflare and coredns providers

### DIFF
--- a/provider/cloudflare/OWNERS
+++ b/provider/cloudflare/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - sheerun

--- a/provider/coredns/OWNERS
+++ b/provider/coredns/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - ytsarev


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/external-dns/issues/1558 

This is at the moment only for the providers part. I will do the sources later as they are less critical right now. 

/cc @njuettner @ytsarev @sheerun 