### PR TITLE
Use porscheinformatik image for openshift-route source example

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag jgrumboe/external-dns
+      run: docker build . --file Dockerfile --tag porscheinformatik/external-dns
     - name: Login to DockerHub Registry
       run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
     - name: Push Docker image
-      run: docker push jgrumboe/external-dns
+      run: docker push porscheinformatik/external-dns

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,21 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: 
+    - master
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag jgrumboe/external-dns
+    - name: Login to DockerHub Registry
+      run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+    - name: Push Docker image
+      run: docker push jgrumboe/external-dns

--- a/docs/tutorials/openshift.md
+++ b/docs/tutorials/openshift.md
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: docker.io/porscheinformatik/external-dns:latest
         args:
         - --source=openshift-route
         - --domain-filter=external-dns-test.my-org.com # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
@@ -92,7 +92,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: docker.io/porscheinformatik/external-dns:latest
         args:
         - --source=openshift-route
         - --domain-filter=external-dns-test.my-org.com # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones

--- a/docs/tutorials/openshift.md
+++ b/docs/tutorials/openshift.md
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: docker.io/porscheinformatik/external-dns:latest
+        image: registry.opensource.zalan.do/teapot/external-dns:latest
         args:
         - --source=openshift-route
         - --domain-filter=external-dns-test.my-org.com # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
@@ -92,7 +92,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: docker.io/porscheinformatik/external-dns:latest
+        image: registry.opensource.zalan.do/teapot/external-dns:latest
         args:
         - --source=openshift-route
         - --domain-filter=external-dns-test.my-org.com # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones

--- a/main.go
+++ b/main.go
@@ -299,7 +299,7 @@ func main() {
 	case "noop":
 		r, err = registry.NewNoopRegistry(p)
 	case "txt":
-		r, err = registry.NewTXTRegistry(p, cfg.TXTPrefix, cfg.TXTOwnerID, cfg.TXTCacheInterval)
+		r, err = registry.NewTXTRegistry(p, cfg.TXTPrefix, cfg.TXTSuffix, cfg.TXTOwnerID, cfg.TXTCacheInterval)
 	case "aws-sd":
 		r, err = registry.NewAWSSDRegistry(p.(*awssd.AWSSDProvider), cfg.TXTOwnerID)
 	default:

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -109,6 +109,7 @@ type Config struct {
 	Registry                          string
 	TXTOwnerID                        string
 	TXTPrefix                         string
+	TXTSuffix                         string
 	Interval                          time.Duration
 	Once                              bool
 	DryRun                            bool
@@ -205,6 +206,7 @@ var defaultConfig = &Config{
 	Registry:                    "txt",
 	TXTOwnerID:                  "default",
 	TXTPrefix:                   "",
+	TXTSuffix:                   "",
 	TXTCacheInterval:            0,
 	Interval:                    time.Minute,
 	Once:                        false,
@@ -392,7 +394,8 @@ func (cfg *Config) ParseFlags(args []string) error {
 	// Flags related to the registry
 	app.Flag("registry", "The registry implementation to use to keep track of DNS record ownership (default: txt, options: txt, noop, aws-sd)").Default(defaultConfig.Registry).EnumVar(&cfg.Registry, "txt", "noop", "aws-sd")
 	app.Flag("txt-owner-id", "When using the TXT registry, a name that identifies this instance of ExternalDNS (default: default)").Default(defaultConfig.TXTOwnerID).StringVar(&cfg.TXTOwnerID)
-	app.Flag("txt-prefix", "When using the TXT registry, a custom string that's prefixed to each ownership DNS record (optional)").Default(defaultConfig.TXTPrefix).StringVar(&cfg.TXTPrefix)
+	app.Flag("txt-prefix", "When using the TXT registry, a custom string that's prefixed to each ownership DNS record (optional). Mutual exclusive with txt-suffix!").Default(defaultConfig.TXTPrefix).StringVar(&cfg.TXTPrefix)
+	app.Flag("txt-suffix", "When using the TXT registry, a custom string that's suffixed to the host portion of each ownership DNS record (optional). Mutual exclusive with txt-prefix!").Default(defaultConfig.TXTSuffix).StringVar(&cfg.TXTSuffix)
 
 	// Flags related to the main control loop
 	app.Flag("txt-cache-interval", "The interval between cache synchronizations in duration format (default: disabled)").Default(defaultConfig.TXTCacheInterval.String()).DurationVar(&cfg.TXTCacheInterval)

--- a/pkg/apis/externaldns/validation/validation.go
+++ b/pkg/apis/externaldns/validation/validation.go
@@ -91,5 +91,10 @@ func ValidateConfig(cfg *externaldns.Config) error {
 	if cfg.IgnoreHostnameAnnotation && cfg.FQDNTemplate == "" {
 		return errors.New("FQDN Template must be set if ignoring annotations")
 	}
+
+	if len(cfg.TXTPrefix) > 0 && len(cfg.TXTSuffix) > 0 {
+		return errors.New("txt-prefix and txt-suffix are mutual exclusive")
+	}
+
 	return nil
 }

--- a/provider/infoblox/infoblox.go
+++ b/provider/infoblox/infoblox.go
@@ -253,8 +253,8 @@ func (p *InfobloxProvider) zones() ([]ibclient.ZoneAuth, error) {
 		}
 
 		// Skip Reversemapping-zones as long as creation of PTR records is not supported
-		matchrevers, _ := regexp.MatchString("(/[0-9]+|.arpa)$", zone.Fqdn)
-		if matchrevers {
+		matchReverse, _ := regexp.MatchString("(/[0-9]+|.arpa)$", zone.Fqdn)
+		if matchReverse {
 			continue
 		}
 

--- a/provider/infoblox/infoblox.go
+++ b/provider/infoblox/infoblox.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 

--- a/provider/infoblox/infoblox.go
+++ b/provider/infoblox/infoblox.go
@@ -247,6 +247,10 @@ func (p *InfobloxProvider) zones() ([]ibclient.ZoneAuth, error) {
 			continue
 		}
 
+		if p.view != "" && p.view != zone.View {
+			continue
+		}
+
 		result = append(result, zone)
 	}
 

--- a/provider/infoblox/infoblox.go
+++ b/provider/infoblox/infoblox.go
@@ -251,6 +251,12 @@ func (p *InfobloxProvider) zones() ([]ibclient.ZoneAuth, error) {
 			continue
 		}
 
+		// Skip Reversemapping-zones as long as creation of PTR records is not supported
+		matchrevers, _ := regexp.MatchString("(/[0-9]+|.arpa)$", zone.Fqdn)
+		if matchrevers {
+			continue
+		}
+
 		result = append(result, zone)
 	}
 

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -44,7 +44,7 @@ func TestTXTRegistry(t *testing.T) {
 
 func testTXTRegistryNew(t *testing.T) {
 	p := inmemory.NewInMemoryProvider()
-	_, err := NewTXTRegistry(p, "txt", "", time.Hour)
+	_, err := NewTXTRegistry(p, "txt", "", "", time.Hour)
 	require.Error(t, err)
 
 	_, err = NewTXTRegistry(p, "", "txt", "", time.Hour)

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -47,23 +47,33 @@ func testTXTRegistryNew(t *testing.T) {
 	_, err := NewTXTRegistry(p, "txt", "", time.Hour)
 	require.Error(t, err)
 
-	r, err := NewTXTRegistry(p, "txt", "owner", time.Hour)
+	_, err = NewTXTRegistry(p, "", "txt", "", time.Hour)
+	require.Error(t, err)
+
+	r, err := NewTXTRegistry(p, "txt", "", "owner", time.Hour)
 	require.NoError(t, err)
 
-	_, ok := r.mapper.(prefixNameMapper)
+	r, err = NewTXTRegistry(p, "", "txt", "owner", time.Hour)
+	require.NoError(t, err)
+
+	_, err = NewTXTRegistry(p, "txt", "txt", "owner", time.Hour)
+	require.Error(t, err)
+
+	_, ok := r.mapper.(affixNameMapper)
 	require.True(t, ok)
 	assert.Equal(t, "owner", r.ownerID)
 	assert.Equal(t, p, r.provider)
 
-	r, err = NewTXTRegistry(p, "", "owner", time.Hour)
+	r, err = NewTXTRegistry(p, "", "", "owner", time.Hour)
 	require.NoError(t, err)
 
-	_, ok = r.mapper.(prefixNameMapper)
+	_, ok = r.mapper.(affixNameMapper)
 	assert.True(t, ok)
 }
 
 func testTXTRegistryRecords(t *testing.T) {
 	t.Run("With prefix", testTXTRegistryRecordsPrefixed)
+	t.Run("With suffix", testTXTRegistryRecordsSuffixed)
 	t.Run("No prefix", testTXTRegistryRecordsNoPrefix)
 }
 
@@ -160,13 +170,118 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 		},
 	}
 
-	r, _ := NewTXTRegistry(p, "txt.", "owner", time.Hour)
+	r, _ := NewTXTRegistry(p, "txt.", "", "owner", time.Hour)
 	records, _ := r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
 
 	// Ensure prefix is case-insensitive
-	r, _ = NewTXTRegistry(p, "TxT.", "owner", time.Hour)
+	r, _ = NewTXTRegistry(p, "TxT.", "", "owner", time.Hour)
+	records, _ = r.Records(ctx)
+
+	assert.True(t, testutils.SameEndpointLabels(records, expectedRecords))
+}
+
+func testTXTRegistryRecordsSuffixed(t *testing.T) {
+	ctx := context.Background()
+	p := inmemory.NewInMemoryProvider()
+	p.CreateZone(testZone)
+	p.ApplyChanges(ctx, &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			newEndpointWithOwnerAndLabels("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, "", endpoint.Labels{"foo": "somefoo"}),
+			newEndpointWithOwnerAndLabels("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, "", endpoint.Labels{"bar": "somebar"}),
+			newEndpointWithOwner("bar-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("bar-txt.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwnerAndLabels("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, "", endpoint.Labels{"tar": "sometar"}),
+			newEndpointWithOwner("tar-TxT.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""), // case-insensitive TXT prefix
+			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("multiple.test-zone.example.org", "lb1.loadbalancer.com", endpoint.RecordTypeCNAME, "").WithSetIdentifier("test-set-1"),
+			newEndpointWithOwner("multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-1"),
+			newEndpointWithOwner("multiple.test-zone.example.org", "lb2.loadbalancer.com", endpoint.RecordTypeCNAME, "").WithSetIdentifier("test-set-2"),
+			newEndpointWithOwner("multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
+		},
+	})
+	expectedRecords := []*endpoint.Endpoint{
+		{
+			DNSName:    "foo.test-zone.example.org",
+			Targets:    endpoint.Targets{"foo.loadbalancer.com"},
+			RecordType: endpoint.RecordTypeCNAME,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "",
+				"foo":                  "somefoo",
+			},
+		},
+		{
+			DNSName:    "bar.test-zone.example.org",
+			Targets:    endpoint.Targets{"my-domain.com"},
+			RecordType: endpoint.RecordTypeCNAME,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+				"bar":                  "somebar",
+			},
+		},
+		{
+			DNSName:    "bar-txt.test-zone.example.org",
+			Targets:    endpoint.Targets{"baz.test-zone.example.org"},
+			RecordType: endpoint.RecordTypeCNAME,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "",
+			},
+		},
+		{
+			DNSName:    "qux.test-zone.example.org",
+			Targets:    endpoint.Targets{"random"},
+			RecordType: endpoint.RecordTypeTXT,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "",
+			},
+		},
+		{
+			DNSName:    "tar.test-zone.example.org",
+			Targets:    endpoint.Targets{"tar.loadbalancer.com"},
+			RecordType: endpoint.RecordTypeCNAME,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner-2",
+				"tar":                  "sometar",
+			},
+		},
+		{
+			DNSName:    "foobar.test-zone.example.org",
+			Targets:    endpoint.Targets{"foobar.loadbalancer.com"},
+			RecordType: endpoint.RecordTypeCNAME,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "",
+			},
+		},
+		{
+			DNSName:       "multiple.test-zone.example.org",
+			Targets:       endpoint.Targets{"lb1.loadbalancer.com"},
+			SetIdentifier: "test-set-1",
+			RecordType:    endpoint.RecordTypeCNAME,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "",
+			},
+		},
+		{
+			DNSName:       "multiple.test-zone.example.org",
+			Targets:       endpoint.Targets{"lb2.loadbalancer.com"},
+			SetIdentifier: "test-set-2",
+			RecordType:    endpoint.RecordTypeCNAME,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "",
+			},
+		},
+	}
+
+	r, _ := NewTXTRegistry(p, "", "-txt", "owner", time.Hour)
+	records, _ := r.Records(ctx)
+
+	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
+
+	// Ensure prefix is case-insensitive
+	r, _ = NewTXTRegistry(p, "", "-TxT", "owner", time.Hour)
 	records, _ = r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpointLabels(records, expectedRecords))
@@ -241,7 +356,7 @@ func testTXTRegistryRecordsNoPrefix(t *testing.T) {
 		},
 	}
 
-	r, _ := NewTXTRegistry(p, "", "owner", time.Hour)
+	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour)
 	records, _ := r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
@@ -249,6 +364,7 @@ func testTXTRegistryRecordsNoPrefix(t *testing.T) {
 
 func testTXTRegistryApplyChanges(t *testing.T) {
 	t.Run("With Prefix", testTXTRegistryApplyChangesWithPrefix)
+	t.Run("With Suffix", testTXTRegistryApplyChangesWithSuffix)
 	t.Run("No prefix", testTXTRegistryApplyChangesNoPrefix)
 }
 
@@ -277,7 +393,7 @@ func testTXTRegistryApplyChangesWithPrefix(t *testing.T) {
 			newEndpointWithOwner("txt.multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
 		},
 	})
-	r, _ := NewTXTRegistry(p, "txt.", "owner", time.Hour)
+	r, _ := NewTXTRegistry(p, "txt.", "", "owner", time.Hour)
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
@@ -343,6 +459,97 @@ func testTXTRegistryApplyChangesWithPrefix(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func testTXTRegistryApplyChangesWithSuffix(t *testing.T) {
+	p := inmemory.NewInMemoryProvider()
+	p.CreateZone(testZone)
+	ctxEndpoints := []*endpoint.Endpoint{}
+	ctx := context.WithValue(context.Background(), provider.RecordsContextKey, ctxEndpoints)
+	p.OnApplyChanges = func(ctx context.Context, got *plan.Changes) {
+		assert.Equal(t, ctxEndpoints, ctx.Value(provider.RecordsContextKey))
+	}
+	p.ApplyChanges(ctx, &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			newEndpointWithOwner("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("bar-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("bar-txt.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("tar-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("foobar-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("multiple.test-zone.example.org", "lb1.loadbalancer.com", endpoint.RecordTypeCNAME, "").WithSetIdentifier("test-set-1"),
+			newEndpointWithOwner("multiple-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-1"),
+			newEndpointWithOwner("multiple.test-zone.example.org", "lb2.loadbalancer.com", endpoint.RecordTypeCNAME, "").WithSetIdentifier("test-set-2"),
+			newEndpointWithOwner("multiple-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
+		},
+	})
+	r, _ := NewTXTRegistry(p, "", "-txt", "owner", time.Hour)
+
+	changes := &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", "", "", "ingress/default/my-ingress"),
+			newEndpointWithOwnerResource("multiple.test-zone.example.org", "lb3.loadbalancer.com", "", "", "ingress/default/my-ingress").WithSetIdentifier("test-set-3"),
+		},
+		Delete: []*endpoint.Endpoint{
+			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
+			newEndpointWithOwner("multiple.test-zone.example.org", "lb1.loadbalancer.com", endpoint.RecordTypeCNAME, "owner").WithSetIdentifier("test-set-1"),
+		},
+		UpdateNew: []*endpoint.Endpoint{
+			newEndpointWithOwnerResource("tar.test-zone.example.org", "new-tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress-2"),
+			newEndpointWithOwnerResource("multiple.test-zone.example.org", "new.loadbalancer.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress-2").WithSetIdentifier("test-set-2"),
+		},
+		UpdateOld: []*endpoint.Endpoint{
+			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
+			newEndpointWithOwner("multiple.test-zone.example.org", "lb2.loadbalancer.com", endpoint.RecordTypeCNAME, "owner").WithSetIdentifier("test-set-2"),
+		},
+	}
+	expected := &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", "", "owner", "ingress/default/my-ingress"),
+			newEndpointWithOwner("new-record-1-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwnerResource("multiple.test-zone.example.org", "lb3.loadbalancer.com", "", "owner", "ingress/default/my-ingress").WithSetIdentifier("test-set-3"),
+			newEndpointWithOwner("multiple-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-3"),
+		},
+		Delete: []*endpoint.Endpoint{
+			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
+			newEndpointWithOwner("foobar-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("multiple.test-zone.example.org", "lb1.loadbalancer.com", endpoint.RecordTypeCNAME, "owner").WithSetIdentifier("test-set-1"),
+			newEndpointWithOwner("multiple-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-1"),
+		},
+		UpdateNew: []*endpoint.Endpoint{
+			newEndpointWithOwnerResource("tar.test-zone.example.org", "new-tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress-2"),
+			newEndpointWithOwner("tar-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress-2\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwnerResource("multiple.test-zone.example.org", "new.loadbalancer.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress-2").WithSetIdentifier("test-set-2"),
+			newEndpointWithOwner("multiple-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress-2\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
+		},
+		UpdateOld: []*endpoint.Endpoint{
+			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
+			newEndpointWithOwner("tar-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("multiple.test-zone.example.org", "lb2.loadbalancer.com", endpoint.RecordTypeCNAME, "owner").WithSetIdentifier("test-set-2"),
+			newEndpointWithOwner("multiple-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
+		},
+	}
+	p.OnApplyChanges = func(ctx context.Context, got *plan.Changes) {
+		mExpected := map[string][]*endpoint.Endpoint{
+			"Create":    expected.Create,
+			"UpdateNew": expected.UpdateNew,
+			"UpdateOld": expected.UpdateOld,
+			"Delete":    expected.Delete,
+		}
+		mGot := map[string][]*endpoint.Endpoint{
+			"Create":    got.Create,
+			"UpdateNew": got.UpdateNew,
+			"UpdateOld": got.UpdateOld,
+			"Delete":    got.Delete,
+		}
+		assert.True(t, testutils.SamePlanChanges(mGot, mExpected))
+		assert.Equal(t, nil, ctx.Value(provider.RecordsContextKey))
+	}
+	err := r.ApplyChanges(ctx, changes)
+	require.NoError(t, err)
+}
+
 func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 	p := inmemory.NewInMemoryProvider()
 	p.CreateZone(testZone)
@@ -364,7 +571,7 @@ func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 			newEndpointWithOwner("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 		},
 	})
-	r, _ := NewTXTRegistry(p, "", "owner", time.Hour)
+	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour)
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{


### PR DESCRIPTION
I would like to change the tutorial for openshift-route source to docker.io/porscheinformatik/external-dns, because I currently don't know when the images for registry.opensource.zalan.do/teapot/external-dns are built.

Furthermore it would be good to have images in an "official" kubernetes-sigs registry, if such exists.