### PR TITLE
Use porscheinformatik-images because zalando/teapot isn't built timely

### DIFF
--- a/docs/tutorials/openshift.md
+++ b/docs/tutorials/openshift.md
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: docker.io/porscheinformatik/external-dns:latest
         args:
         - --source=openshift-route
         - --domain-filter=external-dns-test.my-org.com # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
@@ -92,7 +92,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: docker.io/porscheinformatik/external-dns:latest
         args:
         - --source=openshift-route
         - --domain-filter=external-dns-test.my-org.com # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones


### PR DESCRIPTION
I would like to change the tutorial for openshift-route source to use images from docker.io/porscheinformatik/external-dns, because I currently don't know when the images for registry.opensource.zalan.do/teapot/external-dns are built.

Furthermore it would be good to have images in an "official" kubernetes-sigs registry, if such exists.