### PR TITLE
Fix issue with too large DNS messages

### DIFF
--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -33,6 +33,11 @@ import (
 	"sigs.k8s.io/external-dns/provider"
 )
 
+const (
+	// maximum size of a UDP transport message in DNS protocol
+	udpMaxMsgSize = 512
+)
+
 // rfc2136 provider type
 type rfc2136Provider struct {
 	nameserver    string
@@ -307,6 +312,10 @@ func (r rfc2136Provider) SendMessage(msg *dns.Msg) error {
 	if !r.insecure {
 		c.TsigSecret = map[string]string{r.tsigKeyName: r.tsigSecret}
 		msg.SetTsig(r.tsigKeyName, r.tsigSecretAlg, 300, time.Now().Unix())
+	}
+
+	if msg.Len() > udpMaxMsgSize {
+		c.Net = "tcp"
 	}
 
 	resp, _, err := c.Exchange(msg, r.nameserver)


### PR DESCRIPTION
This is an import of the fix for issue 10135 in the rancher fork of this
project ( rancher/rancher#10135 ).

This is a duplicate to PR #1589 but made against master.