### PR TITLE
[docs]update minimum go version to 1.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ The following tutorials are provided:
 #### Technical Requirements
 
 Make sure you have the following prerequisites:
-* A local Go 1.11+ development environment.
+* A local Go 1.13+ development environment.
 * Access to a Google/AWS account with the DNS API enabled.
 * Access to a Kubernetes cluster that supports exposing Services, e.g. GKE.
 
@@ -167,12 +167,9 @@ First, get ExternalDNS:
 $ git clone https://github.com/kubernetes-sigs/external-dns.git && cd external-dns
 ```
 
-**This project uses [Go modules](https://github.com/golang/go/wiki/Modules) as
-introduced in Go 1.11 therefore you need Go >=1.11 installed in order to build.**
-If using Go 1.11 you also need to [activate Module
-support](https://github.com/golang/go/wiki/Modules#installing-and-activating-module-support).
+**This project needs Go >=1.13 installed in order to build.**
 
-Assuming Go has been setup with module support it can be built simply by running:
+Assuming Go has been setup with [module support]((https://github.com/golang/go/wiki/Modules#installing-and-activating-module-support)), it can be built simply by running:
 
 ```console
 $ make

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/external-dns
 
-go 1.14
+go 1.13
 
 require (
 	cloud.google.com/go v0.50.0


### PR DESCRIPTION
Now that external-dns uses the k8s 1.17, it is recommended to use atleast go 1.13 when building the source code.