### PR TITLE
Fix handling of DNS updates for RFC2136 provider.

### DIFF
--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -221,14 +221,14 @@ func (r rfc2136Provider) ApplyChanges(ctx context.Context, changes *plan.Changes
 
 		r.AddRecord(m, ep)
 	}
-	for _, ep := range changes.UpdateNew {
+	for i, ep := range changes.UpdateNew {
 
 		if !r.domainFilter.Match(ep.DNSName) {
 			log.Debugf("Skipping record %s because it was filtered out by the specified --domain-filter", ep.DNSName)
 			continue
 		}
 
-		r.UpdateRecord(m, ep)
+		r.UpdateRecord(m, changes.UpdateOld[i], ep)
 	}
 	for _, ep := range changes.Delete {
 
@@ -251,13 +251,13 @@ func (r rfc2136Provider) ApplyChanges(ctx context.Context, changes *plan.Changes
 	return nil
 }
 
-func (r rfc2136Provider) UpdateRecord(m *dns.Msg, ep *endpoint.Endpoint) error {
-	err := r.RemoveRecord(m, ep)
+func (r rfc2136Provider) UpdateRecord(m *dns.Msg, oldEp *endpoint.Endpoint, newEp *endpoint.Endpoint) error {
+	err := r.RemoveRecord(m, oldEp)
 	if err != nil {
 		return err
 	}
 
-	return r.AddRecord(m, ep)
+	return r.AddRecord(m, newEp)
 }
 
 func (r rfc2136Provider) AddRecord(m *dns.Msg, ep *endpoint.Endpoint) error {


### PR DESCRIPTION
When receiving an update, we should be removing the old record and
adding the new.  Previously, we were removing and readding the new
record, which would cause the old DNS record to be left lying around.