### PR TITLE
fix convert int to string bug

### DIFF
--- a/provider/awssd/aws_sd_test.go
+++ b/provider/awssd/aws_sd_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"math/rand"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -51,7 +52,7 @@ type AWSSDClientStub struct {
 func (s *AWSSDClientStub) CreateService(input *sd.CreateServiceInput) (*sd.CreateServiceOutput, error) {
 
 	srv := &sd.Service{
-		Id:               aws.String(string(rand.Intn(10000))),
+		Id:               aws.String(strconv.Itoa(rand.Intn(10000))),
 		DnsConfig:        input.DnsConfig,
 		Name:             input.Name,
 		Description:      input.Description,


### PR DESCRIPTION
This fixes the test failures observed in the Travis `Go tip` job.

This change follows best practices and allows for forward compatibility with future versions of Go.

`string(int)` is problematic as it interprets the `int` as a rune constant as opposed to formatting it as a string which is our actual intent.

For more details, go [here](https://github.com/golang/go/issues/3939).