### PR TITLE
Ignore wildcard hosts in Istio gateways

### DIFF
--- a/source/gateway.go
+++ b/source/gateway.go
@@ -300,7 +300,9 @@ func (sc *gatewaySource) hostNamesFromGateway(gateway networkingv1alpha3.Gateway
 				host = parts[1]
 			}
 
-			hostnames = append(hostnames, host)
+			if host != "*" {
+				hostnames = append(hostnames, host)
+			}
 		}
 	}
 	return hostnames, nil

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -272,11 +272,6 @@ func (sc *gatewaySource) endpointsFromGateway(hostnames []string, gateway networ
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(annotations)
 
-	// Skip endpoints if we do not want entries from annotations
-	if !sc.ignoreHostnameAnnotation {
-		hostnames = append(hostnames, getHostnamesFromAnnotations(annotations)...)
-	}
-
 	for _, host := range hostnames {
 		endpoints = append(endpoints, endpointsForHostname(host, targets, ttl, providerSpecific, setIdentifier)...)
 	}
@@ -305,6 +300,11 @@ func (sc *gatewaySource) hostNamesFromGateway(gateway networkingv1alpha3.Gateway
 			}
 		}
 	}
+
+	if !sc.ignoreHostnameAnnotation {
+		hostnames = append(hostnames, getHostnamesFromAnnotations(gateway.Annotations)...)
+	}
+
 	return hostnames, nil
 }
 

--- a/source/gateway_test.go
+++ b/source/gateway_test.go
@@ -1094,6 +1094,43 @@ func testGatewayEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{},
 		},
+		{
+			title:           "gateways with wildcard host and hostname annotation",
+			targetNamespace: "",
+			lbServices: []fakeIngressGatewayService{
+				{
+					ips: []string{"1.2.3.4"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: "",
+					annotations: map[string]string{
+						hostnameAnnotationKey: "fake1.dns-through-hostname.com",
+					},
+					dnsnames: [][]string{{"*"}},
+				},
+				{
+					name:      "fake2",
+					namespace: "",
+					annotations: map[string]string{
+						hostnameAnnotationKey: "fake2.dns-through-hostname.com",
+					},
+					dnsnames: [][]string{{"some-namespace/*"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName: "fake1.dns-through-hostname.com",
+					Targets: endpoint.Targets{"1.2.3.4"},
+				},
+				{
+					DNSName: "fake2.dns-through-hostname.com",
+					Targets: endpoint.Targets{"1.2.3.4"},
+				},
+			},
+		},
 	} {
 		t.Run(ti.title, func(t *testing.T) {
 

--- a/source/gateway_test.go
+++ b/source/gateway_test.go
@@ -1072,6 +1072,28 @@ func testGatewayEndpoints(t *testing.T) {
 			},
 			ignoreHostnameAnnotation: true,
 		},
+		{
+			title:           "gateways with wildcard host",
+			targetNamespace: "",
+			lbServices: []fakeIngressGatewayService{
+				{
+					ips: []string{"1.2.3.4"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: "",
+					dnsnames:  [][]string{{"*"}},
+				},
+				{
+					name:      "fake2",
+					namespace: "",
+					dnsnames:  [][]string{{"some-namespace/*"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{},
+		},
 	} {
 		t.Run(ti.title, func(t *testing.T) {
 


### PR DESCRIPTION
Fixes #1518
Fixes #1624 

Istio allows `*` or `namespace/*` as `Gateway` hosts, meaning that it selects all `VirtualService` hosts from the specified namespace (or all namespaces if none is specified).

This PR skips such hosts to avoid attempting to create DNS records for `*` (as described in the linked issue this currently causes external-dns to crash).