### PR TITLE
Add endpoints to kustomize base

### DIFF
--- a/kustomize/external-dns-clusterrole.yaml
+++ b/kustomize/external-dns-clusterrole.yaml
@@ -15,3 +15,6 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["list"]
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["get","watch","list"]


### PR DESCRIPTION
With the latest release, we need endpoints permission in the ClusterRole. I'm adding this to the kustomize base to not reduce friction for the user. Of course, kustomize allows for full customization of the YAML so that isn't strictly necessary. 