### PR TITLE
Upgrade istio httpbin from 1.0 to 1.6 version

### DIFF
--- a/docs/tutorials/istio.md
+++ b/docs/tutorials/istio.md
@@ -139,12 +139,12 @@ The following are relevant snippets from that tutorial.
 #### Install a sample service
 With automatic sidecar injection:
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.0/samples/httpbin/httpbin.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.6/samples/httpbin/httpbin.yaml
 ```
 
 Otherwise:
 ```bash
-$ kubectl apply -f <(istioctl kube-inject -f https://raw.githubusercontent.com/istio/istio/release-1.0/samples/httpbin/httpbin.yaml)
+$ kubectl apply -f <(istioctl kube-inject -f https://raw.githubusercontent.com/istio/istio/release-1.6/samples/httpbin/httpbin.yaml)
 ```
 
 #### Create an Istio Gateway:


### PR DESCRIPTION
so I've tried to deploy it with 1.0 version:

```
service/httpbin created
error: unable to recognize "https://raw.githubusercontent.com/istio/istio/release-1.0/samples/httpbin/httpbin.yaml": no matches for kind "Deployment" in version "extensions/v1beta1"
```