### PR TITLE
rm unused flag param istio-ingressgateways

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,7 +112,6 @@ func main() {
 		KubeConfig:                     cfg.KubeConfig,
 		KubeMaster:                     cfg.Master,
 		ServiceTypeFilter:              cfg.ServiceTypeFilter,
-		IstioIngressGatewayServices:    cfg.IstioIngressGatewayServices,
 		CFAPIEndpoint:                  cfg.CFAPIEndpoint,
 		CFUsername:                     cfg.CFUsername,
 		CFPassword:                     cfg.CFPassword,

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -41,7 +41,6 @@ type Config struct {
 	Master                            string
 	KubeConfig                        string
 	RequestTimeout                    time.Duration
-	IstioIngressGatewayServices       []string
 	ContourLoadBalancerService        string
 	SkipperRouteGroupVersion          string
 	Sources                           []string
@@ -148,7 +147,6 @@ var defaultConfig = &Config{
 	Master:                      "",
 	KubeConfig:                  "",
 	RequestTimeout:              time.Second * 30,
-	IstioIngressGatewayServices: []string{"istio-system/istio-ingressgateway"},
 	ContourLoadBalancerService:  "heptio-contour/contour",
 	SkipperRouteGroupVersion:    "zalando.org/v1",
 	Sources:                     nil,

--- a/source/store.go
+++ b/source/store.go
@@ -55,7 +55,6 @@ type Config struct {
 	KubeConfig                     string
 	KubeMaster                     string
 	ServiceTypeFilter              []string
-	IstioIngressGatewayServices    []string
 	CFAPIEndpoint                  string
 	CFUsername                     string
 	CFPassword                     string

--- a/source/store_test.go
+++ b/source/store_test.go
@@ -155,6 +155,5 @@ func TestByNames(t *testing.T) {
 }
 
 var minimalConfig = &Config{
-	IstioIngressGatewayServices: []string{"istio-system/istio-ingressgateway"},
 	ContourLoadBalancerService:  "heptio-contour/contour",
 }


### PR DESCRIPTION
This flag is no longer used as we use the gatewaySelectors to retrieve the IngressGateway services. So we don't need to specify the gateway service names explicitly anymore