### PR TITLE
Support wildcard records - Optional ability to replace the asterisk in generated registry TXT records with another string

### DIFF
--- a/main.go
+++ b/main.go
@@ -299,7 +299,7 @@ func main() {
 	case "noop":
 		r, err = registry.NewNoopRegistry(p)
 	case "txt":
-		r, err = registry.NewTXTRegistry(p, cfg.TXTPrefix, cfg.TXTSuffix, cfg.TXTOwnerID, cfg.TXTCacheInterval)
+		r, err = registry.NewTXTRegistry(p, cfg.TXTPrefix, cfg.TXTSuffix, cfg.TXTOwnerID, cfg.TXTCacheInterval, cfg.TXTWildcardReplacement)
 	case "aws-sd":
 		r, err = registry.NewAWSSDRegistry(p.(*awssd.AWSSDProvider), cfg.TXTOwnerID)
 	default:

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -118,6 +118,7 @@ type Config struct {
 	MetricsAddress                    string
 	LogLevel                          string
 	TXTCacheInterval                  time.Duration
+	TXTWildcardReplacement            string
 	ExoscaleEndpoint                  string
 	ExoscaleAPIKey                    string `secure:"yes"`
 	ExoscaleAPISecret                 string `secure:"yes"`
@@ -209,6 +210,7 @@ var defaultConfig = &Config{
 	TXTPrefix:                   "",
 	TXTSuffix:                   "",
 	TXTCacheInterval:            0,
+	TXTWildcardReplacement:      "",
 	Interval:                    time.Minute,
 	Once:                        false,
 	DryRun:                      false,
@@ -400,6 +402,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("txt-owner-id", "When using the TXT registry, a name that identifies this instance of ExternalDNS (default: default)").Default(defaultConfig.TXTOwnerID).StringVar(&cfg.TXTOwnerID)
 	app.Flag("txt-prefix", "When using the TXT registry, a custom string that's prefixed to each ownership DNS record (optional). Mutual exclusive with txt-suffix!").Default(defaultConfig.TXTPrefix).StringVar(&cfg.TXTPrefix)
 	app.Flag("txt-suffix", "When using the TXT registry, a custom string that's suffixed to the host portion of each ownership DNS record (optional). Mutual exclusive with txt-prefix!").Default(defaultConfig.TXTSuffix).StringVar(&cfg.TXTSuffix)
+	app.Flag("txt-wildcard-replacement", "When using the TXT registry, a custom string that's used instead of an asterisk for TXT records corresponding to wildcard DNS records (optional)").Default(defaultConfig.TXTWildcardReplacement).StringVar(&cfg.TXTWildcardReplacement)
 
 	// Flags related to the main control loop
 	app.Flag("txt-cache-interval", "The interval between cache synchronizations in duration format (default: disabled)").Default(defaultConfig.TXTCacheInterval.String()).DurationVar(&cfg.TXTCacheInterval)

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -238,6 +238,9 @@ func (pr affixNameMapper) toEndpointName(txtDNSName string) string {
 
 func (pr affixNameMapper) toTXTName(endpointDNSName string) string {
 	DNSName := strings.SplitN(endpointDNSName, ".", 2)
+	if DNSName[0] == "*" {
+		DNSName[0] = "wildcard"
+	}
 	return pr.prefix + DNSName[0] + pr.suffix + "." + DNSName[1]
 }
 

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -55,10 +55,10 @@ func NewTXTRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID st
 	mapper := newaffixNameMapper(txtPrefix, txtSuffix, txtWildcardReplacement)
 
 	return &TXTRegistry{
-		provider:            provider,
-		ownerID:             ownerID,
-		mapper:              mapper,
-		cacheInterval:       cacheInterval,
+		provider:      provider,
+		ownerID:       ownerID,
+		mapper:        mapper,
+		cacheInterval: cacheInterval,
 	}, nil
 }
 

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -491,6 +491,7 @@ func testTXTRegistryApplyChangesWithSuffix(t *testing.T) {
 		Create: []*endpoint.Endpoint{
 			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", "", "", "ingress/default/my-ingress"),
 			newEndpointWithOwnerResource("multiple.test-zone.example.org", "lb3.loadbalancer.com", "", "", "ingress/default/my-ingress").WithSetIdentifier("test-set-3"),
+			newEndpointWithOwnerResource("*.wildcard.test-zone.example.org", "new-loadbalancer-1.lb.com", "", "", "ingress/default/my-ingress"),
 		},
 		Delete: []*endpoint.Endpoint{
 			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
@@ -511,6 +512,8 @@ func testTXTRegistryApplyChangesWithSuffix(t *testing.T) {
 			newEndpointWithOwner("new-record-1-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwnerResource("multiple.test-zone.example.org", "lb3.loadbalancer.com", "", "owner", "ingress/default/my-ingress").WithSetIdentifier("test-set-3"),
 			newEndpointWithOwner("multiple-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-3"),
+			newEndpointWithOwnerResource("*.wildcard.test-zone.example.org", "new-loadbalancer-1.lb.com", "", "owner", "ingress/default/my-ingress"),
+			newEndpointWithOwner("wildcard-txt.wildcard.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress\"", endpoint.RecordTypeTXT, ""),
 		},
 		Delete: []*endpoint.Endpoint{
 			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -97,6 +97,8 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 			newEndpointWithOwner("multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-1"),
 			newEndpointWithOwner("multiple.test-zone.example.org", "lb2.loadbalancer.com", endpoint.RecordTypeCNAME, "").WithSetIdentifier("test-set-2"),
 			newEndpointWithOwner("multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
+			newEndpointWithOwner("*.wildcard.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("txt.wc.wildcard.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 		},
 	})
 	expectedRecords := []*endpoint.Endpoint{
@@ -169,9 +171,17 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 				endpoint.OwnerLabelKey: "",
 			},
 		},
+		{
+			DNSName:       "*.wildcard.test-zone.example.org",
+			Targets:       endpoint.Targets{"foo.loadbalancer.com"},
+			RecordType:    endpoint.RecordTypeCNAME,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
 	}
 
-	r, _ := NewTXTRegistry(p, "txt.", "", "owner", time.Hour, "")
+	r, _ := NewTXTRegistry(p, "txt.", "", "owner", time.Hour, "wc")
 	records, _ := r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -44,20 +44,20 @@ func TestTXTRegistry(t *testing.T) {
 
 func testTXTRegistryNew(t *testing.T) {
 	p := inmemory.NewInMemoryProvider()
-	_, err := NewTXTRegistry(p, "txt", "", "", time.Hour)
+	_, err := NewTXTRegistry(p, "txt", "", "", time.Hour, "")
 	require.Error(t, err)
 
-	_, err = NewTXTRegistry(p, "", "txt", "", time.Hour)
+	_, err = NewTXTRegistry(p, "", "txt", "", time.Hour, "")
 	require.Error(t, err)
 
-	r, err := NewTXTRegistry(p, "txt", "", "owner", time.Hour)
+	r, err := NewTXTRegistry(p, "txt", "", "owner", time.Hour, "")
 	require.NoError(t, err)
 	assert.Equal(t, p, r.provider)
 
-	r, err = NewTXTRegistry(p, "", "txt", "owner", time.Hour)
+	r, err = NewTXTRegistry(p, "", "txt", "owner", time.Hour, "")
 	require.NoError(t, err)
 
-	_, err = NewTXTRegistry(p, "txt", "txt", "owner", time.Hour)
+	_, err = NewTXTRegistry(p, "txt", "txt", "owner", time.Hour, "")
 	require.Error(t, err)
 
 	_, ok := r.mapper.(affixNameMapper)
@@ -65,7 +65,7 @@ func testTXTRegistryNew(t *testing.T) {
 	assert.Equal(t, "owner", r.ownerID)
 	assert.Equal(t, p, r.provider)
 
-	r, err = NewTXTRegistry(p, "", "", "owner", time.Hour)
+	r, err = NewTXTRegistry(p, "", "", "owner", time.Hour, "")
 	require.NoError(t, err)
 
 	_, ok = r.mapper.(affixNameMapper)
@@ -171,13 +171,13 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 		},
 	}
 
-	r, _ := NewTXTRegistry(p, "txt.", "", "owner", time.Hour)
+	r, _ := NewTXTRegistry(p, "txt.", "", "owner", time.Hour, "")
 	records, _ := r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
 
 	// Ensure prefix is case-insensitive
-	r, _ = NewTXTRegistry(p, "TxT.", "", "owner", time.Hour)
+	r, _ = NewTXTRegistry(p, "TxT.", "", "owner", time.Hour, "")
 	records, _ = r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpointLabels(records, expectedRecords))
@@ -276,13 +276,13 @@ func testTXTRegistryRecordsSuffixed(t *testing.T) {
 		},
 	}
 
-	r, _ := NewTXTRegistry(p, "", "-txt", "owner", time.Hour)
+	r, _ := NewTXTRegistry(p, "", "-txt", "owner", time.Hour, "")
 	records, _ := r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
 
 	// Ensure prefix is case-insensitive
-	r, _ = NewTXTRegistry(p, "", "-TxT", "owner", time.Hour)
+	r, _ = NewTXTRegistry(p, "", "-TxT", "owner", time.Hour, "")
 	records, _ = r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpointLabels(records, expectedRecords))
@@ -357,7 +357,7 @@ func testTXTRegistryRecordsNoPrefix(t *testing.T) {
 		},
 	}
 
-	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour)
+	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour, "")
 	records, _ := r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
@@ -394,7 +394,7 @@ func testTXTRegistryApplyChangesWithPrefix(t *testing.T) {
 			newEndpointWithOwner("txt.multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
 		},
 	})
-	r, _ := NewTXTRegistry(p, "txt.", "", "owner", time.Hour)
+	r, _ := NewTXTRegistry(p, "txt.", "", "owner", time.Hour, "")
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
@@ -485,7 +485,7 @@ func testTXTRegistryApplyChangesWithSuffix(t *testing.T) {
 			newEndpointWithOwner("multiple-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
 		},
 	})
-	r, _ := NewTXTRegistry(p, "", "-txt", "owner", time.Hour)
+	r, _ := NewTXTRegistry(p, "", "-txt", "owner", time.Hour, "wildcard")
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
@@ -575,7 +575,7 @@ func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 			newEndpointWithOwner("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 		},
 	})
-	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour)
+	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour, "")
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{


### PR DESCRIPTION
When using the txt registry, external-dns is not able to create wildcard records for many providers because the generated TXT records corresponding to the wildcard records are malformed: they contain an asterisk, but are not of the form "*.foo.bar".  For example, this is the case with the Dyn provider.

A couple providers add special handling to deal with this, like aws.go.  But rather than attempt to fix this in all providers, this PR adds an optional command line parameter that allows the asterisk in generated TXT records to be replaced with some arbitrary string.  Setting this parameter (to any value) allows wildcard records to be created successfully for providers (like Dyn) where it doesn't work currently.  This optional parameter is unset by default, meaning existing behavior is unchanged if it is not specified.

A couple of unit tests in txt_test.go has been updated to verify the new parameter.