### PR TITLE
Fixed bug in reading and matching Labels from TXT records.

### DIFF
--- a/registry/txt.go
+++ b/registry/txt.go
@@ -233,7 +233,7 @@ func (pr affixNameMapper) toEndpointName(txtDNSName string) string {
 			return strings.TrimSuffix(DNSName[0], pr.suffix) + "." + DNSName[1]
 		}
 	}
-	return ""
+	return lowerDNSName
 }
 
 func (pr affixNameMapper) toTXTName(endpointDNSName string) string {

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -148,7 +148,7 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 			Targets:    endpoint.Targets{"foobar.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
+				endpoint.OwnerLabelKey: "owner",
 			},
 		},
 		{
@@ -157,7 +157,7 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 			SetIdentifier: "test-set-1",
 			RecordType:    endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
+				endpoint.OwnerLabelKey: "owner",
 			},
 		},
 		{
@@ -166,7 +166,7 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 			SetIdentifier: "test-set-2",
 			RecordType:    endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
+				endpoint.OwnerLabelKey: "owner",
 			},
 		},
 	}
@@ -253,7 +253,7 @@ func testTXTRegistryRecordsSuffixed(t *testing.T) {
 			Targets:    endpoint.Targets{"foobar.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
+				endpoint.OwnerLabelKey: "owner",
 			},
 		},
 		{
@@ -262,7 +262,7 @@ func testTXTRegistryRecordsSuffixed(t *testing.T) {
 			SetIdentifier: "test-set-1",
 			RecordType:    endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
+				endpoint.OwnerLabelKey: "owner",
 			},
 		},
 		{
@@ -271,7 +271,7 @@ func testTXTRegistryRecordsSuffixed(t *testing.T) {
 			SetIdentifier: "test-set-2",
 			RecordType:    endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
+				endpoint.OwnerLabelKey: "owner",
 			},
 		},
 	}


### PR DESCRIPTION
I am not sure if I am missing something obvious here but it seems to me that the `Labels` matching in the `txt` registry is wrong.
If I understood correctly how it should work, if there are 2 DNS records like the following:

```
CNAME bar.test-zone.example.org my-domain.com
TXT bar.test-zone.example.org "heritage=external-dns,external-dns/owner=owner"
```

The resulting endpoint should be:

```
DNSName: bar.test-zone.example.org
RecordType: CNAME			
Targets: [my-domain.com]
Labels: [owner: owner]
```

If this is true then I think there is a bug in the `txt` registry code and tests and this PR is an attempt to fix that bug.