### PR TITLE
rfc2136: merge endpoints with same name/type into single endpoint

### DIFF
--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -79,7 +79,7 @@ func TestSameFailures(t *testing.T) {
 	}
 }
 
-func TestDigitalOceanMergeRecordsByNameType(t *testing.T) {
+func TestMergeRecordsByNameType(t *testing.T) {
 	xs := []*Endpoint{
 		NewEndpoint("foo.example.com", "A", "1.2.3.4"),
 		NewEndpoint("bar.example.com", "A", "1.2.3.4"),

--- a/provider/digitalocean/digital_ocean_test.go
+++ b/provider/digitalocean/digital_ocean_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"sort"
 	"testing"
 
 	"github.com/digitalocean/godo"
@@ -625,37 +624,4 @@ func TestDigitalOceanAllRecords(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected to fail, %s", err)
 	}
-}
-
-func TestDigitalOceanMergeRecordsByNameType(t *testing.T) {
-	xs := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("foo.example.com", "A", "1.2.3.4"),
-		endpoint.NewEndpoint("bar.example.com", "A", "1.2.3.4"),
-		endpoint.NewEndpoint("foo.example.com", "A", "5.6.7.8"),
-		endpoint.NewEndpoint("foo.example.com", "CNAME", "somewhere.out.there.com"),
-	}
-
-	merged := mergeEndpointsByNameType(xs)
-
-	assert.Equal(t, 3, len(merged))
-	sort.SliceStable(merged, func(i, j int) bool {
-		if merged[i].DNSName != merged[j].DNSName {
-			return merged[i].DNSName < merged[j].DNSName
-		}
-		return merged[i].RecordType < merged[j].RecordType
-	})
-	assert.Equal(t, "bar.example.com", merged[0].DNSName)
-	assert.Equal(t, "A", merged[0].RecordType)
-	assert.Equal(t, 1, len(merged[0].Targets))
-	assert.Equal(t, "1.2.3.4", merged[0].Targets[0])
-
-	assert.Equal(t, "foo.example.com", merged[1].DNSName)
-	assert.Equal(t, "A", merged[1].RecordType)
-	assert.Equal(t, 2, len(merged[1].Targets))
-	assert.ElementsMatch(t, []string{"1.2.3.4", "5.6.7.8"}, merged[1].Targets)
-
-	assert.Equal(t, "foo.example.com", merged[2].DNSName)
-	assert.Equal(t, "CNAME", merged[2].RecordType)
-	assert.Equal(t, 1, len(merged[2].Targets))
-	assert.Equal(t, "somewhere.out.there.com", merged[2].Targets[0])
 }

--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -158,6 +158,8 @@ OuterLoop:
 		eps = append(eps, ep)
 	}
 
+	eps = endpoint.MergeEndpointsByNameType(eps)
+
 	return eps, nil
 }
 


### PR DESCRIPTION
https://github.com/kubernetes-sigs/external-dns/issues/1596#issuecomment-659701653 describes how the RFC2136 provider does not properly map multiple DNS records with the same name/type into the external-dns which models such records as a single `Endpoint` with multiple entries in the `Targets` attribute.

Solution: Generalize the solution introduced to the DigitalOcean provider by https://github.com/kubernetes-sigs/external-dns/pull/1595 by refactoring the `mergeEndpointsByNameType` function into the `endpoint` module. Then use that function in the RFC2136 provider.

@stefanlasiewski: Please test this as my production cluster is on DigitalOcean and is not a RFC2136 server. This will also need a unit test in the RFC2136 provider before landing.