### PR TITLE
fix alibaba provider ducp create record with crd source

### DIFF
--- a/provider/alibabacloud/alibaba_cloud.go
+++ b/provider/alibabacloud/alibaba_cloud.go
@@ -326,10 +326,6 @@ func (p *AlibabaCloudProvider) recordsForDNS() (endpoints []*endpoint.Endpoint, 
 		recordType := recordList[0].Type
 		ttl := recordList[0].TTL
 
-		if ttl == defaultAlibabaCloudRecordTTL {
-			ttl = 0
-		}
-
 		var targets []string
 		for _, record := range recordList {
 			target := record.Value


### PR DESCRIPTION
no sure why set ttl to `0` when ttl act actually is `600`
this will get the controller keep update A record when use crd source
because `shouldUpdateTTL` will always be `true`