### PR TITLE
fix alibaba cloud ducp create record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Improve errors context for AWS provider
 - Scaleway Provider (#1643) @Sh4d1
 - Fix typos in documentation @ddymko
+- Fix: alibaba cloud keeping create record (#1682) @LXM
 
 ## v0.7.3 - 2020-08-05
 

--- a/provider/alibabacloud/alibaba_cloud.go
+++ b/provider/alibabacloud/alibaba_cloud.go
@@ -326,10 +326,6 @@ func (p *AlibabaCloudProvider) recordsForDNS() (endpoints []*endpoint.Endpoint, 
 		recordType := recordList[0].Type
 		ttl := recordList[0].TTL
 
-		if ttl == defaultAlibabaCloudRecordTTL {
-			ttl = 0
-		}
-
 		var targets []string
 		for _, record := range recordList {
 			target := record.Value

--- a/provider/alibabacloud/alibaba_cloud_test.go
+++ b/provider/alibabacloud/alibaba_cloud_test.go
@@ -276,6 +276,12 @@ func TestAlibabaCloudProvider_Records(t *testing.T) {
 
 func TestAlibabaCloudProvider_ApplyChanges(t *testing.T) {
 	p := newTestAlibabaCloudProvider(false)
+	defaultTtlPlan := &endpoint.Endpoint{
+		DNSName:    "ttl.container-service.top",
+		RecordType: "A",
+		RecordTTL:  defaultAlibabaCloudRecordTTL,
+		Targets:    endpoint.NewTargets("4.3.2.1"),
+	}
 	changes := plan.Changes{
 		Create: []*endpoint.Endpoint{
 			{
@@ -284,6 +290,7 @@ func TestAlibabaCloudProvider_ApplyChanges(t *testing.T) {
 				RecordTTL:  300,
 				Targets:    endpoint.NewTargets("4.3.2.1"),
 			},
+			defaultTtlPlan,
 		},
 		UpdateNew: []*endpoint.Endpoint{
 			{
@@ -308,11 +315,18 @@ func TestAlibabaCloudProvider_ApplyChanges(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to get records: %v", err)
 	} else {
-		if len(endpoints) != 2 {
+		if len(endpoints) != 3 {
 			t.Errorf("Incorrect number of records: %d", len(endpoints))
 		}
 		for _, endpoint := range endpoints {
 			t.Logf("Endpoint for %++v", *endpoint)
+		}
+	}
+	for _, ep := range endpoints {
+		if ep.DNSName == defaultTtlPlan.DNSName {
+			if ep.RecordTTL != defaultTtlPlan.RecordTTL {
+				t.Error("default ttl execute error")
+			}
 		}
 	}
 }


### PR DESCRIPTION
no sure why set ttl to `0` when ttl act actually is `600`
this will get the controller keep update A record when use crd source
because `shouldUpdateTTL` will always be `true`