### PR TITLE
fix: add serviceaccount name in kustomize deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix: add serviceaccount name in kustomize deployment (#1689) @jmthvt
+
 ## v0.7.2 - 2020-06-03
 
 - Update blogpost in README (#1610) @vanhumbeecka

--- a/kustomize/external-dns-deployment.yaml
+++ b/kustomize/external-dns-deployment.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: external-dns
     spec:
+      serviceAccountName: external-dns
       containers:
       - name: external-dns
         image: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.2


### PR DESCRIPTION
The serviceaccount created by Kustomize is not referenced in the deployment, leading to crash looping pod due to insufficient permissions.