### PR TITLE
Move ownership filters to the plan

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -105,6 +105,7 @@ func init() {
 // * Take both lists and calculate a Plan to move current towards desired state.
 // * Tell the DNS provider to apply the changes calculated by the Plan.
 type Controller struct {
+	OwnerID  string
 	Source   source.Source
 	Registry registry.Registry
 	// The policy that defines which changes to DNS records are allowed
@@ -145,6 +146,7 @@ func (c *Controller) RunOnce(ctx context.Context) error {
 
 	plan := &plan.Plan{
 		Policies:           []plan.Policy{c.Policy},
+		OwnerID:            c.OwnerID,
 		Current:            records,
 		Desired:            endpoints,
 		DomainFilter:       c.DomainFilter,

--- a/main.go
+++ b/main.go
@@ -313,9 +313,9 @@ func main() {
 	case "noop":
 		r, err = registry.NewNoopRegistry(p)
 	case "txt":
-		r, err = registry.NewTXTRegistry(p, cfg.TXTPrefix, cfg.TXTSuffix, cfg.TXTOwnerID, cfg.TXTCacheInterval, cfg.TXTWildcardReplacement)
+		r, err = registry.NewTXTRegistry(p, cfg.TXTPrefix, cfg.TXTSuffix, cfg.TXTCacheInterval, cfg.TXTWildcardReplacement)
 	case "aws-sd":
-		r, err = registry.NewAWSSDRegistry(p.(*awssd.AWSSDProvider), cfg.TXTOwnerID)
+		r, err = registry.NewAWSSDRegistry(p.(*awssd.AWSSDProvider))
 	default:
 		log.Fatalf("unknown registry: %s", cfg.Registry)
 	}
@@ -330,6 +330,7 @@ func main() {
 	}
 
 	ctrl := controller.Controller{
+		OwnerID:            cfg.TXTOwnerID,
 		Source:             endpointsSource,
 		Registry:           r,
 		Policy:             policy,

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -1066,8 +1066,8 @@ func TestProviderPropertiesIdempotency(t *testing.T) {
 		assert.Equal(t, 0, len(plan.Changes.Delete), "should not have deletes")
 
 		if test.ShouldBeUpdated {
-			assert.Equal(t, 1, len(plan.Changes.UpdateNew), "should not have new updates")
-			assert.Equal(t, 1, len(plan.Changes.UpdateOld), "should not have old updates")
+			assert.Equal(t, 1, len(plan.Changes.UpdateNew), "should have new updates")
+			assert.Equal(t, 1, len(plan.Changes.UpdateOld), "should have old updates")
 		} else {
 			assert.Equal(t, 0, len(plan.Changes.UpdateNew), "should not have new updates")
 			assert.Equal(t, 0, len(plan.Changes.UpdateOld), "should not have old updates")

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -19,8 +19,6 @@ package registry
 import (
 	"context"
 
-	log "github.com/sirupsen/logrus"
-
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 )
@@ -34,17 +32,4 @@ type Registry interface {
 	ApplyChanges(ctx context.Context, changes *plan.Changes) error
 	PropertyValuesEqual(attribute string, previous string, current string) bool
 	AdjustEndpoints(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint
-}
-
-//TODO(ideahitme): consider moving this to Plan
-func filterOwnedRecords(ownerID string, eps []*endpoint.Endpoint) []*endpoint.Endpoint {
-	filtered := []*endpoint.Endpoint{}
-	for _, ep := range eps {
-		if endpointOwner, ok := ep.Labels[endpoint.OwnerLabelKey]; !ok || endpointOwner != ownerID {
-			log.Debugf(`Skipping endpoint %v because owner id does not match, found: "%s", required: "%s"`, ep, endpointOwner, ownerID)
-			continue
-		}
-		filtered = append(filtered, ep)
-	}
-	return filtered
 }

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -33,7 +33,6 @@ import (
 // TXTRegistry implements registry interface with ownership implemented via associated TXT records
 type TXTRegistry struct {
 	provider provider.Provider
-	ownerID  string //refers to the owner id of the current instance
 	mapper   nameMapper
 
 	// cache the records in memory and update on an interval instead.
@@ -48,11 +47,7 @@ type TXTRegistry struct {
 }
 
 // NewTXTRegistry returns new TXTRegistry object
-func NewTXTRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID string, cacheInterval time.Duration, txtWildcardReplacement string) (*TXTRegistry, error) {
-	if ownerID == "" {
-		return nil, errors.New("owner id cannot be empty")
-	}
-
+func NewTXTRegistry(provider provider.Provider, txtPrefix, txtSuffix string, cacheInterval time.Duration, txtWildcardReplacement string) (*TXTRegistry, error) {
 	if len(txtPrefix) > 0 && len(txtSuffix) > 0 {
 		return nil, errors.New("txt-prefix and txt-suffix are mutual exclusive")
 	}
@@ -61,7 +56,6 @@ func NewTXTRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID st
 
 	return &TXTRegistry{
 		provider:            provider,
-		ownerID:             ownerID,
 		mapper:              mapper,
 		cacheInterval:       cacheInterval,
 		wildcardReplacement: txtWildcardReplacement,
@@ -139,33 +133,26 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 // ApplyChanges updates dns provider with the changes
 // for each created/deleted record it will also take into account TXT records for creation/deletion
 func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
-	filteredChanges := &plan.Changes{
-		Create:    changes.Create,
-		UpdateNew: filterOwnedRecords(im.ownerID, changes.UpdateNew),
-		UpdateOld: filterOwnedRecords(im.ownerID, changes.UpdateOld),
-		Delete:    filterOwnedRecords(im.ownerID, changes.Delete),
-	}
-	for _, r := range filteredChanges.Create {
+	for _, r := range changes.Create {
 		if r.Labels == nil {
 			r.Labels = make(map[string]string)
 		}
-		r.Labels[endpoint.OwnerLabelKey] = im.ownerID
 		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
 		txt.ProviderSpecific = r.ProviderSpecific
-		filteredChanges.Create = append(filteredChanges.Create, txt)
+		changes.Create = append(changes.Create, txt)
 
 		if im.cacheInterval > 0 {
 			im.addToCache(r)
 		}
 	}
 
-	for _, r := range filteredChanges.Delete {
+	for _, r := range changes.Delete {
 		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
 		txt.ProviderSpecific = r.ProviderSpecific
 
 		// when we delete TXT records for which value has changed (due to new label) this would still work because
 		// !!! TXT record value is uniquely generated from the Labels of the endpoint. Hence old TXT record can be uniquely reconstructed
-		filteredChanges.Delete = append(filteredChanges.Delete, txt)
+		changes.Delete = append(changes.Delete, txt)
 
 		if im.cacheInterval > 0 {
 			im.removeFromCache(r)
@@ -173,12 +160,12 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 	}
 
 	// make sure TXT records are consistently updated as well
-	for _, r := range filteredChanges.UpdateOld {
+	for _, r := range changes.UpdateOld {
 		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
 		txt.ProviderSpecific = r.ProviderSpecific
 		// when we updateOld TXT records for which value has changed (due to new label) this would still work because
 		// !!! TXT record value is uniquely generated from the Labels of the endpoint. Hence old TXT record can be uniquely reconstructed
-		filteredChanges.UpdateOld = append(filteredChanges.UpdateOld, txt)
+		changes.UpdateOld = append(changes.UpdateOld, txt)
 		// remove old version of record from cache
 		if im.cacheInterval > 0 {
 			im.removeFromCache(r)
@@ -186,10 +173,10 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 	}
 
 	// make sure TXT records are consistently updated as well
-	for _, r := range filteredChanges.UpdateNew {
+	for _, r := range changes.UpdateNew {
 		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
 		txt.ProviderSpecific = r.ProviderSpecific
-		filteredChanges.UpdateNew = append(filteredChanges.UpdateNew, txt)
+		changes.UpdateNew = append(changes.UpdateNew, txt)
 		// add new version of record to cache
 		if im.cacheInterval > 0 {
 			im.addToCache(r)
@@ -200,7 +187,7 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 	if im.cacheInterval > 0 {
 		ctx = context.WithValue(ctx, provider.RecordsContextKey, nil)
 	}
-	return im.provider.ApplyChanges(ctx, filteredChanges)
+	return im.provider.ApplyChanges(ctx, changes)
 }
 
 // PropertyValuesEqual compares two attribute values for equality


### PR DESCRIPTION
As commented in the registry code, filtering the ownership should be
done when planning.
Moving the filtering at the planning level allows to have the same
behaviour regardless the registry implementation, and hence introduces a
more predictible behaviour by sharing the logic, and keeps the registry
logic to holding trace of records ownership only.

## Checklist

- [x] Update changelog in CHANGELOG.md, use section "Unreleased".
