### PR TITLE
Enhance openshift routes support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@
 - Fix NodePort with externaltrafficpolicy targets duplication @codearky
 - Update contributing section in README (#1760) @seanmalloy
 - Option to cache AWS zones list @bpineau
-- Enhance openshift routes support (#1725) @ahmedwaleedmalik
 
 ## v0.7.3 - 2020-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fix NodePort with externaltrafficpolicy targets duplication @codearky
 - Update contributing section in README (#1760) @seanmalloy
 - Option to cache AWS zones list @bpineau
+- Enhance openshift routes support (#1725) @ahmedwaleedmalik
 
 ## v0.7.3 - 2020-08-05
 

--- a/docs/tutorials/openshift.md
+++ b/docs/tutorials/openshift.md
@@ -2,12 +2,14 @@
 This tutorial describes how to configure ExternalDNS to use the OpenShift Route source.
 It is meant to supplement the other provider-specific setup tutorials.
 
-### Prepare ROUTER_CANONICAL_HOSTNAME in default/router deployment
+### For OCP v3.x, Prepare ROUTER_CANONICAL_HOSTNAME in default/router deployment
 Read and go through [Finding the Host Name of the Router](https://docs.openshift.com/container-platform/3.11/install_config/router/default_haproxy_router.html#finding-router-hostname).
 If no ROUTER_CANONICAL_HOSTNAME is set, you must annotate each route with external-dns.alpha.kubernetes.io/target!
 
+**NOTE:** This is only required for OCP v3.x as this workflow is automated in OCP v4.x
+
 ### Manifest (for clusters without RBAC enabled)
-```yaml
+```yaml 
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/source/ocproute.go
+++ b/source/ocproute.go
@@ -30,12 +30,25 @@ import (
 	extInformers "github.com/openshift/client-go/route/informers/externalversions"
 	routeInformer "github.com/openshift/client-go/route/informers/externalversions/route/v1"
 	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
 	"sigs.k8s.io/external-dns/endpoint"
+)
+
+const (
+	ingressControllerOwnerLabel = "ingresscontroller.operator.openshift.io/owning-ingresscontroller"
+	ocpMajorVersion3            = 3
+	ocpMajorVersion4            = 4
+)
+
+var (
+	// Openshift Container Platform Major version for openshift cluster
+	ocpMajorVersion int
 )
 
 // ocpRouteSource is an implementation of Source for OpenShift Route objects.
@@ -43,7 +56,8 @@ import (
 // Use targetAnnotationKey to explicitly set Endpoint. (useful if the router
 // does not update, or to override with alternative endpoint)
 type ocpRouteSource struct {
-	client                   versioned.Interface
+	ocpClient                versioned.Interface
+	kubeClient               kubernetes.Interface
 	namespace                string
 	annotationFilter         string
 	fqdnTemplate             *template.Template
@@ -55,6 +69,7 @@ type ocpRouteSource struct {
 // NewOcpRouteSource creates a new ocpRouteSource with the given config.
 func NewOcpRouteSource(
 	ocpClient versioned.Interface,
+	kubeClient kubernetes.Interface,
 	namespace string,
 	annotationFilter string,
 	fqdnTemplate string,
@@ -98,8 +113,11 @@ func NewOcpRouteSource(
 		return nil, fmt.Errorf("failed to sync cache: %v", err)
 	}
 
+	ocpMajorVersion = getOCPMajorVersion(kubeClient)
+
 	return &ocpRouteSource{
-		client:                   ocpClient,
+		ocpClient:                ocpClient,
+		kubeClient:               kubeClient,
 		namespace:                namespace,
 		annotationFilter:         annotationFilter,
 		fqdnTemplate:             tmpl,
@@ -137,7 +155,7 @@ func (ors *ocpRouteSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint,
 			continue
 		}
 
-		orEndpoints := endpointsFromOcpRoute(ocpRoute, ors.ignoreHostnameAnnotation)
+		orEndpoints := ors.endpointsFromOcpRoute(ocpRoute, ors.ignoreHostnameAnnotation)
 
 		// apply template if host is missing on OpenShift Route
 		if (ors.combineFQDNAnnotation || len(orEndpoints) == 0) && ors.fqdnTemplate != nil {
@@ -188,7 +206,7 @@ func (ors *ocpRouteSource) endpointsFromTemplate(ocpRoute *routeapi.Route) ([]*e
 	targets := getTargetsFromTargetAnnotation(ocpRoute.Annotations)
 
 	if len(targets) == 0 {
-		targets = targetsFromOcpRouteStatus(ocpRoute.Status)
+		targets = ors.targetsFromOcpRouteStatus(ocpRoute.Status)
 	}
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ocpRoute.Annotations)
@@ -240,7 +258,7 @@ func (ors *ocpRouteSource) setResourceLabel(ocpRoute *routeapi.Route, endpoints 
 }
 
 // endpointsFromOcpRoute extracts the endpoints from a OpenShift Route object
-func endpointsFromOcpRoute(ocpRoute *routeapi.Route, ignoreHostnameAnnotation bool) []*endpoint.Endpoint {
+func (ors *ocpRouteSource) endpointsFromOcpRoute(ocpRoute *routeapi.Route, ignoreHostnameAnnotation bool) []*endpoint.Endpoint {
 	var endpoints []*endpoint.Endpoint
 
 	ttl, err := getTTLFromAnnotations(ocpRoute.Annotations)
@@ -251,7 +269,7 @@ func endpointsFromOcpRoute(ocpRoute *routeapi.Route, ignoreHostnameAnnotation bo
 	targets := getTargetsFromTargetAnnotation(ocpRoute.Annotations)
 
 	if len(targets) == 0 {
-		targets = targetsFromOcpRouteStatus(ocpRoute.Status)
+		targets = ors.targetsFromOcpRouteStatus(ocpRoute.Status)
 	}
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ocpRoute.Annotations)
@@ -270,14 +288,71 @@ func endpointsFromOcpRoute(ocpRoute *routeapi.Route, ignoreHostnameAnnotation bo
 	return endpoints
 }
 
-func targetsFromOcpRouteStatus(status routeapi.RouteStatus) endpoint.Targets {
+func (ors *ocpRouteSource) targetsFromOcpRouteStatus(status routeapi.RouteStatus) endpoint.Targets {
 	var targets endpoint.Targets
 
 	for _, ing := range status.Ingress {
-		if ing.RouterCanonicalHostname != "" {
+		if ing.RouterName != "" && ocpMajorVersion == ocpMajorVersion4 {
+			// Extract load balancer IPs/Hostnames for the route
+			target, err := ors.getRouterLoadBalancerTargets(ing.RouterName)
+			if err != nil {
+				log.Warn(err)
+			}
+			targets = append(targets, target...)
+		} else if ing.RouterCanonicalHostname != "" && ocpMajorVersion == ocpMajorVersion3 {
+			// Append RouterCanonicalHostname in case it's OCP v3
 			targets = append(targets, ing.RouterCanonicalHostname)
 		}
 	}
-
 	return targets
+}
+
+func (ors *ocpRouteSource) getRouterLoadBalancerTargets(routerName string) (endpoint.Targets, error) {
+	// LabelSelector for selecting services corresponding to router
+	labelSelector, err := metav1.ParseToLabelSelector(ingressControllerOwnerLabel + "=" + routerName)
+	if err != nil {
+		return nil, err
+	}
+	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	listOptions := metav1.ListOptions{
+		LabelSelector: selector.String(),
+	}
+
+	// List of services filtered by owning ingress controller
+	services, err := ors.kubeClient.CoreV1().Services(ors.namespace).List(context.TODO(), listOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	// Iterate through services and find service of loadbalancer type
+	var targets endpoint.Targets
+	for _, service := range services.Items {
+		if service.Spec.Type == v1.ServiceTypeLoadBalancer {
+			// Add load balancer IPs/Hostnames against the route
+			targets = append(targets, ExtractLoadBalancerTargets(&service)...)
+		}
+	}
+	return targets, err
+}
+
+// Returns Openshift Container Platform Major Version
+func getOCPMajorVersion(kubeClient kubernetes.Interface) int {
+	// Since, IngressController was introduced in OCP v4.x we can verify if the current cluster is on OCP v4.x by
+	// ensuring that resource exists against Group(operator.openshift.io), Version(v1) and Kind(IngressController)
+	// In case it doesn't exist we assume that it's running on OCP v3.x
+	resources, err := kubeClient.Discovery().ServerResourcesForGroupVersion("operator.openshift.io/v1")
+	if err != nil {
+		return ocpMajorVersion3
+	}
+
+	for _, apiResource := range resources.APIResources {
+		if apiResource.Kind == "IngressController" {
+			return ocpMajorVersion4
+		}
+	}
+	return ocpMajorVersion3
 }

--- a/source/service.go
+++ b/source/service.go
@@ -431,7 +431,7 @@ func (sc *serviceSource) generateEndpoints(svc *v1.Service, hostname string, pro
 
 	switch svc.Spec.Type {
 	case v1.ServiceTypeLoadBalancer:
-		targets = append(targets, extractLoadBalancerTargets(svc)...)
+		targets = append(targets, ExtractLoadBalancerTargets(svc)...)
 	case v1.ServiceTypeClusterIP:
 		if sc.publishInternal {
 			targets = append(targets, extractServiceIps(svc)...)
@@ -485,7 +485,7 @@ func extractServiceExternalName(svc *v1.Service) endpoint.Targets {
 	return endpoint.Targets{svc.Spec.ExternalName}
 }
 
-func extractLoadBalancerTargets(svc *v1.Service) endpoint.Targets {
+func ExtractLoadBalancerTargets(svc *v1.Service) endpoint.Targets {
 	var (
 		targets     endpoint.Targets
 		externalIPs endpoint.Targets

--- a/source/store.go
+++ b/source/store.go
@@ -234,7 +234,11 @@ func BuildWithConfig(source string, p ClientGenerator, cfg *Config) (Source, err
 		if err != nil {
 			return nil, err
 		}
-		return NewOcpRouteSource(ocpClient, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.IgnoreHostnameAnnotation)
+		kubeClient, err := p.KubeClient()
+		if err != nil {
+			return nil, err
+		}
+		return NewOcpRouteSource(ocpClient, kubeClient, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.IgnoreHostnameAnnotation)
 	case "fake":
 		return NewFakeSource(cfg.FQDNTemplate)
 	case "connector":


### PR DESCRIPTION
This enhances current implementation for source type "openshift-route" and uses loadbalancer IP/Hostname(s) instead of `RouterCanonicalHostName`.

Details mentioned in issue #1605  

Tested against OpenShift 4.3.28 and 4.4.9