### PR TITLE
added --txt-prefix to google deployment

### DIFF
--- a/docs/tutorials/gke.md
+++ b/docs/tutorials/gke.md
@@ -100,6 +100,7 @@ spec:
 #        - --google-project=zalando-external-dns-test # Use this to specify a project different from the one external-dns is running inside
         - --policy=upsert-only # would prevent ExternalDNS from deleting any records, omit to enable full synchronization
         - --registry=txt
+        - --txt-prefix=extdns # when using `registry=txt` option, make sure to also use the `txt-prefix` and `txt-owner-id` options as well. If you try to create a `TXT` record in VinylDNS without a prefix, it will try to create a `TXT` record with the same name as your actual DNS record and fail (creating a stranded record `external-dns` cannot manage).
         - --txt-owner-id=my-identifier
 ```
 

--- a/docs/tutorials/gke.md
+++ b/docs/tutorials/gke.md
@@ -100,7 +100,7 @@ spec:
 #        - --google-project=zalando-external-dns-test # Use this to specify a project different from the one external-dns is running inside
         - --policy=upsert-only # would prevent ExternalDNS from deleting any records, omit to enable full synchronization
         - --registry=txt
-        - --txt-prefix=extdns # when using `registry=txt` option, make sure to also use the `txt-prefix` and `txt-owner-id` options as well. If you try to create a `TXT` record in VinylDNS without a prefix, it will try to create a `TXT` record with the same name as your actual DNS record and fail (creating a stranded record `external-dns` cannot manage).
+        - --txt-prefix=extdns # when using `registry=txt` option, make sure to also use the `txt-prefix` and `txt-owner-id` options as well. If you try to create a `TXT` record without a prefix, it will try to create a `TXT` record with the same name as your actual DNS record and fail (creating a stranded record `external-dns` cannot manage).
         - --txt-owner-id=my-identifier
 ```
 


### PR DESCRIPTION
when using `registry=txt` option, make sure to also use the `txt-prefix` and `txt-owner-id` options as well. If you try to create a `TXT` record without a prefix, it will try to create a `TXT` record with the same name as your actual DNS record and fail (creating a stranded record `external-dns` cannot manage).

## Checklist

- [ ] Update changelog in CHANGELOG.md, use section "Unreleased".
