### PR TITLE
fix goimports local import order and update golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Lint
       run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.26.0
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0
         make lint
   
     - name: Coverage

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ linters-settings:
   exhaustive:
     default-signifies-exhaustive: false
   goimports:
-    local-prefixes: github.com/kubernetes-sigs/external-dns
+    local-prefixes: sigs.k8s.io/external-dns
   golint:
     min-confidence: 0.9
   maligned:

--- a/internal/testutils/init.go
+++ b/internal/testutils/init.go
@@ -2,11 +2,11 @@ package testutils
 
 import (
 	"io/ioutil"
+	"log"
 	"os"
 
-	"log"
-
 	"github.com/sirupsen/logrus"
+
 	"sigs.k8s.io/external-dns/internal/config"
 )
 

--- a/main.go
+++ b/main.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
-
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
 	"sigs.k8s.io/external-dns/controller"
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/alecthomas/kingpin"
 	"github.com/sirupsen/logrus"
+
 	"sigs.k8s.io/external-dns/source"
 )
 

--- a/provider/akamai/akamai.go
+++ b/provider/akamai/akamai.go
@@ -28,6 +28,7 @@ import (
 	c "github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid"
 	log "github.com/sirupsen/logrus"
+
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"

--- a/provider/hetzner/hetzner.go
+++ b/provider/hetzner/hetzner.go
@@ -21,6 +21,7 @@ import (
 
 	hclouddns "git.blindage.org/21h/hcloud-dns"
 	log "github.com/sirupsen/logrus"
+
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"

--- a/provider/scaleway/scaleway.go
+++ b/provider/scaleway/scaleway.go
@@ -25,11 +25,11 @@ import (
 	domain "github.com/scaleway/scaleway-sdk-go/api/domain/v2alpha2"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	log "github.com/sirupsen/logrus"
+
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
-
-	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 )
 
 const (

--- a/provider/ultradns/ultradns.go
+++ b/provider/ultradns/ultradns.go
@@ -24,6 +24,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	udnssdk "github.com/ultradns/ultradns-sdk-go"
+
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"

--- a/provider/vultr/vultr.go
+++ b/provider/vultr/vultr.go
@@ -25,6 +25,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/vultr/govultr"
+
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"

--- a/source/routegroup.go
+++ b/source/routegroup.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+
 	"sigs.k8s.io/external-dns/endpoint"
 )
 

--- a/source/source.go
+++ b/source/source.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
+
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/internal/config"
 )


### PR DESCRIPTION
I was wondering why the linting never pointed out the import order issues only to find out we were using the old import prefix in the golang-ci config YAML :/
