### PR TITLE
replace errors package with built in fmt.Errorf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/openshift/client-go v0.0.0-20200608144219-584632b8fc73
 	github.com/oracle/oci-go-sdk v21.4.0+incompatible
 	github.com/ovh/go-ovh v0.0.0-20181109152953-ba5adb4cf014
-	github.com/pkg/errors v0.9.1
 	github.com/projectcontour/contour v1.5.0
 	github.com/prometheus/client_golang v1.7.1
 	github.com/sanyu/dynectsoap v0.0.0-20181203081243-b83de5edc4e0

--- a/provider/oci/oci_test.go
+++ b/provider/oci/oci_test.go
@@ -18,12 +18,12 @@ package oci
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"testing"
 
 	"github.com/oracle/oci-go-sdk/common"
 	"github.com/oracle/oci-go-sdk/dns"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/external-dns/endpoint"
@@ -177,7 +177,7 @@ hKRtDhmSdWBo3tJK12RrAe4t7CUe8gMgTvU7ExlcA3xQkseFPx9K
 `,
 				},
 			},
-			err: errors.New("initializing OCI DNS API client: can not create client, bad configuration: PEM data was not found in buffer"),
+			err: fmt.Errorf("failed to initialize OCI DNS API client: can not create client, bad configuration: PEM data was not found in buffer"),
 		},
 	}
 	for name, tc := range testCases {
@@ -491,13 +491,13 @@ func (c *mutableMockOCIDNSClient) ListZones(ctx context.Context, request dns.Lis
 
 func (c *mutableMockOCIDNSClient) GetZoneRecords(ctx context.Context, request dns.GetZoneRecordsRequest) (response dns.GetZoneRecordsResponse, err error) {
 	if request.ZoneNameOrId == nil {
-		err = errors.New("no name or id")
+		err = fmt.Errorf("name or id")
 		return
 	}
 
 	records, ok := c.records[*request.ZoneNameOrId]
 	if !ok {
-		err = errors.New("zone not found")
+		err = fmt.Errorf("zone not found")
 		return
 	}
 
@@ -516,13 +516,13 @@ func ociRecordKey(rType, domain string) string {
 
 func (c *mutableMockOCIDNSClient) PatchZoneRecords(ctx context.Context, request dns.PatchZoneRecordsRequest) (response dns.PatchZoneRecordsResponse, err error) {
 	if request.ZoneNameOrId == nil {
-		err = errors.New("no name or id")
+		err = fmt.Errorf("no name or id")
 		return
 	}
 
 	records, ok := c.records[*request.ZoneNameOrId]
 	if !ok {
-		err = errors.New("zone not found")
+		err = fmt.Errorf("zone not found")
 		return
 	}
 
@@ -544,7 +544,7 @@ func (c *mutableMockOCIDNSClient) PatchZoneRecords(ctx context.Context, request 
 		case dns.RecordOperationOperationRemove:
 			delete(records, k)
 		default:
-			err = errors.Errorf("unsupported operation %q", op.Operation)
+			err = fmt.Errorf("unsupported operation: %q", op.Operation)
 			return
 		}
 	}

--- a/provider/rdns/rdns.go
+++ b/provider/rdns/rdns.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"go.etcd.io/etcd/clientv3"
 
@@ -104,7 +103,7 @@ func NewRDNSProvider(config RDNSConfig) (*RDNSProvider, error) {
 	}
 	domain := os.Getenv("RDNS_ROOT_DOMAIN")
 	if domain == "" {
-		return nil, errors.New("needed root domain environment")
+		return nil, fmt.Errorf("needed root domain environment")
 	}
 	return &RDNSProvider{
 		client:       client,
@@ -290,7 +289,7 @@ func newEtcdv3Client() (RDNSClient, error) {
 		isInsecure := insecure == "true" || insecure == "yes" || insecure == "1"
 
 		if ca != "" && key == "" || cert == "" && key != "" {
-			return nil, errors.New("either both cert and key or none must be provided")
+			return nil, fmt.Errorf("either both cert and key or none must be provided")
 		}
 
 		if cert != "" {
@@ -323,7 +322,7 @@ func newEtcdv3Client() (RDNSClient, error) {
 		cfg.Endpoints = urls
 		cfg.TLS = config
 	default:
-		return nil, errors.New("etcdv3 URLs must start with either http:// or https://")
+		return nil, fmt.Errorf("etcdv3 URLs must start with either http:// or https://")
 	}
 
 	c, err := clientv3.New(*cfg)

--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/external-dns/endpoint"
@@ -75,7 +74,7 @@ type rfc2136Actions interface {
 func NewRfc2136Provider(host string, port int, zoneName string, insecure bool, keyName string, secret string, secretAlg string, axfr bool, domainFilter endpoint.DomainFilter, dryRun bool, minTTL time.Duration, actions rfc2136Actions) (provider.Provider, error) {
 	secretAlgChecked, ok := tsigAlgs[secretAlg]
 	if !ok && !insecure {
-		return nil, errors.Errorf("%s is not supported TSIG algorithm", secretAlg)
+		return nil, fmt.Errorf("%s is not supported TSIG algorithm", secretAlg)
 	}
 
 	r := &rfc2136Provider{

--- a/source/gateway_test.go
+++ b/source/gateway_test.go
@@ -18,9 +18,9 @@ package source
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -1200,7 +1200,7 @@ func newTestGatewaySource(loadBalancerList []fakeIngressGatewayService) (*gatewa
 
 	gwsrc, ok := src.(*gatewaySource)
 	if !ok {
-		return nil, errors.New("underlying source type was not gateway")
+		return nil, fmt.Errorf("underlying source type was not gateway")
 	}
 
 	return gwsrc, nil

--- a/source/ingressroute.go
+++ b/source/ingressroute.go
@@ -25,7 +25,6 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/pkg/errors"
 	contourapi "github.com/projectcontour/contour/apis/contour/v1beta1"
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -143,7 +142,7 @@ func (sc *ingressRouteSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoi
 	for _, ir := range irs {
 		unstrucuredIR, ok := ir.(*unstructured.Unstructured)
 		if !ok {
-			return nil, errors.New("could not convert")
+			return nil, fmt.Errorf("could not convert")
 		}
 
 		irConverted := &contourapi.IngressRoute{}
@@ -306,7 +305,7 @@ func (sc *ingressRouteSource) targetsFromContourLoadBalancer(ctx context.Context
 // endpointsFromIngressRouteConfig extracts the endpoints from a Contour IngressRoute object
 func (sc *ingressRouteSource) endpointsFromIngressRoute(ctx context.Context, ingressRoute *contourapi.IngressRoute) ([]*endpoint.Endpoint, error) {
 	if ingressRoute.CurrentStatus != "valid" {
-		log.Warn(errors.Errorf("cannot generate endpoints for ingressroute with status %s", ingressRoute.CurrentStatus))
+		log.Warn(fmt.Errorf("cannot generate endpoints for ingressroute with status %s", ingressRoute.CurrentStatus))
 		return nil, nil
 	}
 

--- a/source/ingressroute_test.go
+++ b/source/ingressroute_test.go
@@ -18,9 +18,9 @@ package source
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
 	contour "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/stretchr/testify/assert"
@@ -1070,7 +1070,7 @@ func newTestIngressRouteSource(loadBalancer fakeLoadBalancerService) (*ingressRo
 
 	irsrc, ok := src.(*ingressRouteSource)
 	if !ok {
-		return nil, errors.New("underlying source type was not ingressroute")
+		return nil, fmt.Errorf("underlying source type was not ingressroute")
 	}
 
 	return irsrc, nil

--- a/source/routegroup_test.go
+++ b/source/routegroup_test.go
@@ -18,9 +18,9 @@ package source
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/external-dns/endpoint"
 )
@@ -230,7 +230,7 @@ type fakeRouteGroupClient struct {
 
 func (f *fakeRouteGroupClient) getRouteGroupList(string) (*routeGroupList, error) {
 	if f.returnErr {
-		return nil, errors.New("Fake route group list error")
+		return nil, fmt.Errorf("Fake route group list error")
 	}
 	return f.rg, nil
 }

--- a/source/store.go
+++ b/source/store.go
@@ -17,6 +17,7 @@ limitations under the License.
 package source
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -26,7 +27,6 @@ import (
 	"github.com/cloudfoundry-community/go-cfclient"
 	"github.com/linki/instrumented_http"
 	openshift "github.com/openshift/client-go/route/clientset/versioned"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	istioclient "istio.io/client-go/pkg/clientset/versioned"
 	"k8s.io/client-go/dynamic"
@@ -34,9 +34,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
-
-// ErrSourceNotFound is returned when a requested source doesn't exist.
-var ErrSourceNotFound = errors.New("source not found")
 
 // Config holds shared configuration options for all Sources.
 type Config struct {
@@ -253,7 +250,7 @@ func BuildWithConfig(source string, p ClientGenerator, cfg *Config) (Source, err
 		}
 		return NewRouteGroupSource(cfg.RequestTimeout, token, tokenPath, apiServerURL, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.SkipperRouteGroupVersion, cfg.CombineFQDNAndAnnotation, cfg.IgnoreHostnameAnnotation)
 	}
-	return nil, ErrSourceNotFound
+	return nil, fmt.Errorf("source not found")
 }
 
 // GetRestConfig returns the rest clients config to get automatically
@@ -338,7 +335,7 @@ func NewIstioClient(kubeConfig string, apiServerURL string) (*istioclient.Client
 
 	ic, err := istioclient.NewForConfig(restCfg)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to create istio client")
+		return nil, fmt.Errorf("failed to create istio client: %w", err)
 	}
 
 	return ic, nil

--- a/source/store_test.go
+++ b/source/store_test.go
@@ -116,7 +116,7 @@ func (suite *ByNamesTestSuite) TestSourceNotFound() {
 	mockClientGenerator.On("KubeClient").Return(fakeKube.NewSimpleClientset(), nil)
 
 	sources, err := ByNames(mockClientGenerator, []string{"foo"}, minimalConfig)
-	suite.Equal(err, ErrSourceNotFound, "should return source not found")
+	suite.Error(err, "should return source not found")
 	suite.Len(sources, 0, "should not returns any source")
 }
 
@@ -155,5 +155,5 @@ func TestByNames(t *testing.T) {
 }
 
 var minimalConfig = &Config{
-	ContourLoadBalancerService:  "heptio-contour/contour",
+	ContourLoadBalancerService: "heptio-contour/contour",
 }

--- a/source/virtualservice_test.go
+++ b/source/virtualservice_test.go
@@ -18,11 +18,11 @@ package source
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -1518,7 +1518,7 @@ func newTestVirtualServiceSource(loadBalancerList []fakeIngressGatewayService, g
 
 	vssrc, ok := src.(*virtualServiceSource)
 	if !ok {
-		return nil, errors.New("underlying source type was not virtualservice")
+		return nil, fmt.Errorf("underlying source type was not virtualservice")
 	}
 
 	return vssrc, nil


### PR DESCRIPTION
Rather than using a errors package for generating errors, the standard
library fmt.Errorf can be used, and we can remove the dependency
github.com/pkg/errors. fmt.Errorf is used throughout the rest of the
repo so it should be kept consistent across the codebase.

## Checklist

- [ ] Update changelog in CHANGELOG.md, use section "Unreleased".
