### PR TITLE
remove unused field IstioIngressGatewayServices

### DIFF
--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -42,7 +42,6 @@ type Config struct {
 	APIServerURL                      string
 	KubeConfig                        string
 	RequestTimeout                    time.Duration
-	IstioIngressGatewayServices       []string
 	ContourLoadBalancerService        string
 	SkipperRouteGroupVersion          string
 	Sources                           []string


### PR DESCRIPTION
## Checklist

This field was added by mistake, I believe, in https://github.com/kubernetes-sigs/external-dns/pull/1636/files
