### PR TITLE
Move Inactive Maintainers To Emeritus Approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,9 @@
 #  https://github.com/kubernetes/community/blob/HEAD/contributors/guide/owners.md
 
 approvers:
-  - hjacobs
   - raffo
-  - linki
   - njuettner
+
+emeritus_approvers:
+  - hjacobs
+  - linki


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
The goal of this pull requests it to make it easier for contributors to identify the active project maintainers, so that there is not confusion around pull requests reviews.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Is related to #1558.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
- [ ] CHANGELOG.md updated, use section "Unreleased"
