### PR TITLE
Add tutorial for GKE with workload identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Update all container registry references to use k8s.gcr.io @seanmalloy
 - Provide available prometheus metrics in documentation @vinny-sabatini
 - Fix index out of range when hostname has no dots (#1756) @chemasan
+- Add tutorial for GKE with workload identity (#1765) @ddgenome
 
 ## v0.7.3 - 2020-08-05
 

--- a/README.md
+++ b/README.md
@@ -332,7 +332,9 @@ ExternalDNS is an effort to unify the following similar projects in order to bri
 * Molecule Software's [route53-kubernetes](https://github.com/wearemolecule/route53-kubernetes)
 
 ### User Demo How-To Blogs and Examples
+
 * A full demo on GKE Kubernetes. See [How-to Kubernetes with DNS management (ssl-manager pre-req)](https://medium.com/@jpantjsoha/how-to-kubernetes-with-dns-management-for-gitops-31239ea75d8d)
+* Run external-dns on GKE with workload identity. See [Kubernetes, ingress-nginx, cert-manager & external-dns](https://blog.atomist.com/kubernetes-ingress-nginx-cert-manager-external-dns/)
 
 ### Code of conduct
 

--- a/docs/tutorials/gke.md
+++ b/docs/tutorials/gke.md
@@ -4,8 +4,6 @@ This tutorial describes how to setup ExternalDNS for usage within a GKE cluster.
 
 ## Set up your environment
 
-*If you prefer to try-out ExternalDNS in one of the existing environments you can skip this step*
-
 Setup your environment to work with Google Cloud Platform. Fill in your values as needed, e.g. target project.
 
 ```console
@@ -13,6 +11,16 @@ $ gcloud config set project "zalando-external-dns-test"
 $ gcloud config set compute/region "europe-west1"
 $ gcloud config set compute/zone "europe-west1-d"
 ```
+
+## GKE Node Scopes
+
+*If you prefer to try-out ExternalDNS in one of the existing environments you can skip this step*
+
+The following instructions use instance scopes to provide ExternalDNS with the
+permissions it needs to manage DNS records. Note that since these permissions
+are associated with the instance, all pods in the cluster will also have these
+permissions. As such, this approach is not suitable for anything but testing
+environments.
 
 Create a GKE cluster.
 
@@ -52,59 +60,10 @@ $ gcloud dns record-sets transaction add ns-cloud-e{1..4}.googledomains.com. \
 $ gcloud dns record-sets transaction execute --zone "gcp-zalan-do"
 ```
 
-## Deploy ExternalDNS
+### Deploy ExternalDNS
 
-### Role-Based Access Control (RBAC)
+Then apply the following manifests file to deploy ExternalDNS.
 
-[RBAC]("https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control") is enabled by default on all Container clusters which are running Kubernetes version 1.6 or higher.
-
-Because of the way Container Engine checks permissions when you create a Role or ClusterRole, you must first create a RoleBinding that grants you all of the permissions included in the role you want to create.
-
-```console
-kubectl create clusterrolebinding your-user-cluster-admin-binding --clusterrole=cluster-admin --user=your.google.cloud.email@example.org
-```
-
-Connect your `kubectl` client to the cluster you just created.
-
-```console
-gcloud container clusters get-credentials "external-dns"
-```
-
-Then apply one of the following manifests file to deploy ExternalDNS.
-
-### Manifest (for clusters without RBAC enabled)
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: external-dns
-spec:
-  strategy:
-    type: Recreate
-  selector:
-    matchLabels:
-      app: external-dns
-  template:
-    metadata:
-      labels:
-        app: external-dns
-    spec:
-      containers:
-      - name: external-dns
-        image: k8s.gcr.io/external-dns/external-dns:v0.7.3
-        args:
-        - --source=service
-        - --source=ingress
-        - --domain-filter=external-dns-test.gcp.zalan.do # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
-        - --provider=google
-#        - --google-project=zalando-external-dns-test # Use this to specify a project different from the one external-dns is running inside
-        - --policy=upsert-only # would prevent ExternalDNS from deleting any records, omit to enable full synchronization
-        - --registry=txt
-        - --txt-prefix=extdns # when using `registry=txt` option, make sure to also use the `txt-prefix` and `txt-owner-id` options as well. If you try to create a `TXT` record without a prefix, it will try to create a `TXT` record with the same name as your actual DNS record and fail (creating a stranded record `external-dns` cannot manage).
-        - --txt-owner-id=my-identifier
-```
-
-### Manifest (for clusters with RBAC enabled)
 ```yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -171,8 +130,7 @@ spec:
 
 Use `--dry-run` if you want to be extra careful on the first run. Note, that you will not see any records created when you are running in dry-run mode. You can, however, inspect the logs and watch what would have been done.
 
-
-## Verify ExternalDNS works
+### Verify ExternalDNS works
 
 Create the following sample application to test that ExternalDNS works.
 
@@ -302,7 +260,7 @@ $ curl via-ingress.external-dns-test.gcp.zalan.do
 </html>
 ```
 
-## Clean up
+### Clean up
 
 Make sure to delete all Service and Ingress objects before terminating the cluster so all load balancers get cleaned up correctly.
 
@@ -327,5 +285,294 @@ $ gcloud dns record-sets transaction remove ns-cloud-e{1..4}.googledomains.com. 
 $ gcloud dns record-sets transaction execute --zone "gcp-zalan-do"
 ```
 
-### User Demo How-To Blogs and Examples
+## GKE with Workload Identity
+
+The following instructions use [GKE workload
+identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
+to provide ExternalDNS with the permissions it needs to manage DNS records.
+Workload identity is the Google-recommended way to provide GKE workloads access
+to GCP APIs.
+
+Create a GKE cluster with workload identity enabled.
+
+```console
+$ gcloud container clusters create external-dns \
+    --workload-metadata-from-node=GKE_METADATA_SERVER \
+    --identity-namespace=zalando-external-dns-test.svc.id.goog
+```
+
+Create a GCP service account (GSA) for ExternalDNS and save its email address.
+
+```console
+$ sa_name="Kubernetes external-dns"
+$ gcloud iam service-accounts create sa-edns --display-name="$sa_name"
+$ sa_email=$(gcloud iam service-accounts list --format='value(email)' \
+    --filter="displayName:$sa_name")
+```
+
+Bind the ExternalDNS GSA to the DNS admin role.
+
+```console
+$ gcloud projects add-iam-policy-binding zalando-external-dns-test \
+    --member="serviceAccount:$sa_email" --role=roles/dns.admin
+```
+
+Link the ExternalDNS GSA to the Kubernetes service account (KSA) that
+external-dns will run under, i.e., the external-dns KSA in the external-dns
+namespaces.
+
+```console
+$ gcloud iam service-accounts add-iam-policy-binding "$sa_email" \
+    --member="serviceAccount:zalando-external-dns-test.svc.id.goog[external-dns/external-dns]" \
+    --role=roles/iam.workloadIdentityUser
+```
+
+Create a DNS zone which will contain the managed DNS records.
+
+```console
+$ gcloud dns managed-zones create external-dns-test-gcp-zalan-do \
+    --dns-name=external-dns-test.gcp.zalan.do. \
+    --description="Automatically managed zone by ExternalDNS"
+```
+
+Make a note of the nameservers that were assigned to your new zone.
+
+```console
+$ gcloud dns record-sets list \
+    --zone=external-dns-test-gcp-zalan-do \
+    --name=external-dns-test.gcp.zalan.do. \
+    --type NS
+NAME                             TYPE  TTL    DATA
+external-dns-test.gcp.zalan.do.  NS    21600  ns-cloud-e1.googledomains.com.,ns-cloud-e2.googledomains.com.,ns-cloud-e3.googledomains.com.,ns-cloud-e4.googledomains.com.
+```
+
+In this case it's `ns-cloud-{e1-e4}.googledomains.com.` but your's could
+slightly differ, e.g. `{a1-a4}`, `{b1-b4}` etc.
+
+Tell the parent zone where to find the DNS records for this zone by adding the
+corresponding NS records there. Assuming the parent zone is "gcp-zalan-do" and
+the domain is "gcp.zalan.do" and that it's also hosted at Google we would do the
+following.
+
+```console
+$ gcloud dns record-sets transaction start --zone=gcp-zalan-do
+$ gcloud dns record-sets transaction add ns-cloud-e{1..4}.googledomains.com. \
+    --name=external-dns-test.gcp.zalan.do. --ttl 300 --type NS --zone=gcp-zalan-do
+$ gcloud dns record-sets transaction execute --zone=gcp-zalan-do
+```
+
+Connect your `kubectl` client to the cluster you just created and bind your GCP
+user to the cluster admin role in Kubernetes.
+
+```console
+$ gcloud container clusters get-credentials external-dns
+$ kubectl create clusterrolebinding cluster-admin-me \
+    --clusterrole=cluster-admin --user="$(gcloud config get-value account)"
+```
+
+### Deploy ExternalDNS
+
+Apply the following manifest file to deploy external-dns.
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-dns
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+  namespace: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+  - apiGroups: [""]
+    resources: ["services", "endpoints", "pods"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["extensions", "networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+  - kind: ServiceAccount
+    name: external-dns
+    namespace: external-dns
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+  namespace: external-dns
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      containers:
+        - args:
+            - --source=ingress
+            - --source=service
+            - --domain-filter=external-dns-test.gcp.zalan.do
+            - --provider=google
+            - --google-project=zalando-external-dns-test
+            - --registry=txt
+            - --txt-owner-id=my-identifier
+          image: k8s.gcr.io/external-dns/external-dns:v0.7.3
+          name: external-dns
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 65534
+      serviceAccountName: external-dns
+```
+
+Then add the proper workload identity annotation to the cert-manager service
+account.
+
+```bash
+$ kubectl annotate serviceaccount --namespace=external-dns external-dns \
+    "iam.gke.io/gcp-service-account=$sa_email"
+```
+
+### Deploy a sample application
+
+Create the following sample application to test that ExternalDNS works.
+
+```yaml
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: nginx
+spec:
+  rules:
+  - host: via-ingress.external-dns-test.gcp.zalan.do
+    http:
+      paths:
+      - backend:
+          serviceName: nginx
+          servicePort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: nginx.external-dns-test.gcp.zalan.do.
+  name: nginx
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+  selector:
+    app: nginx
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        ports:
+        - containerPort: 80
+```
+
+After roughly two minutes check that a corresponding DNS records for your
+service and ingress were created.
+
+```console
+$ gcloud dns record-sets list \
+    --zone "external-dns-test-gcp-zalan-do" \
+    --name "via-ingress.external-dns-test.gcp.zalan.do." \
+    --type A
+NAME                                         TYPE  TTL  DATA
+nginx.external-dns-test.gcp.zalan.do.        A     300  104.155.60.49
+nginx.external-dns-test.gcp.zalan.do.        TXT   300  "heritage=external-dns,external-dns/owner=my-identifier"
+via-ingress.external-dns-test.gcp.zalan.do.  TXT   300  "heritage=external-dns,external-dns/owner=my-identifier"
+via-ingress.external-dns-test.gcp.zalan.do.  A     300  35.187.1.246
+```
+
+Let's check that we can resolve this DNS name as well.
+
+```console
+$ dig +short @ns-cloud-e1.googledomains.com. via-ingress.external-dns-test.gcp.zalan.do.
+35.187.1.246
+```
+
+Try with `curl` as well.
+
+```console
+$ curl via-ingress.external-dns-test.gcp.zalan.do
+<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to nginx!</title>
+...
+</head>
+<body>
+...
+</body>
+</html>
+```
+
+### Clean up
+
+Make sure to delete all service and ingress objects before terminating the
+cluster so all load balancers and DNS entries get cleaned up correctly.
+
+```console
+$ kubectl delete ingress nginx
+$ kubectl delete service nginx
+```
+
+Give ExternalDNS some time to clean up the DNS records for you. Then delete the
+managed zone and cluster.
+
+```console
+$ gcloud dns managed-zones delete external-dns-test-gcp-zalan-do
+$ gcloud container clusters delete external-dns
+```
+
+Also delete the NS records for your removed zone from the parent zone.
+
+```console
+$ gcloud dns record-sets transaction start --zone gcp-zalan-do
+$ gcloud dns record-sets transaction remove ns-cloud-e{1..4}.googledomains.com. \
+    --name=external-dns-test.gcp.zalan.do. --ttl 300 --type NS --zone=gcp-zalan-do
+$ gcloud dns record-sets transaction execute --zone=gcp-zalan-do
+```
+
+## User Demo How-To Blogs and Examples
+
 * A full demo on GKE Kubernetes + CloudDNS + SA-Permissions [How-to Kubernetes with DNS management (ssl-manager pre-req)](https://medium.com/@jpantjsoha/how-to-kubernetes-with-dns-management-for-gitops-31239ea75d8d)
+* Run external-dns on GKE with workload identity. See [Kubernetes, ingress-nginx, cert-manager & external-dns](https://blog.atomist.com/kubernetes-ingress-nginx-cert-manager-external-dns/)

--- a/docs/tutorials/nginx-ingress.md
+++ b/docs/tutorials/nginx-ingress.md
@@ -2,6 +2,8 @@
 
 This tutorial describes how to setup ExternalDNS for usage within a GKE cluster that doesn't make use of Google's [default ingress controller](https://github.com/kubernetes/ingress-gce) but rather uses [nginx-ingress-controller](https://github.com/kubernetes/ingress-nginx) for that task.
 
+## Set up your environment
+
 Setup your environment to work with Google Cloud Platform. Fill in your values as needed, e.g. target project.
 
 ```console
@@ -9,6 +11,14 @@ $ gcloud config set project "zalando-external-dns-test"
 $ gcloud config set compute/region "europe-west1"
 $ gcloud config set compute/zone "europe-west1-d"
 ```
+
+## GKE Node Scopes
+
+The following instructions use instance scopes to provide ExternalDNS with the
+permissions it needs to manage DNS records. Note that since these permissions
+are associated with the instance, all pods in the cluster will also have these
+permissions. As such, this approach is not suitable for anything but testing
+environments.
 
 Create a GKE cluster without using the default ingress controller.
 
@@ -48,19 +58,20 @@ $ gcloud dns record-sets transaction add ns-cloud-e{1..4}.googledomains.com. \
 $ gcloud dns record-sets transaction execute --zone "gcp-zalan-do"
 ```
 
-If you decide not to create a new zone but reuse an existing one, make sure it's currently **unused** and **empty**. This version of ExternalDNS will remove all records it doesn't recognize from the zone.
-
-Connect your `kubectl` client to the cluster you just created.
+Connect your `kubectl` client to the cluster you just created and bind your GCP
+user to the cluster admin role in Kubernetes.
 
 ```console
-gcloud container clusters get-credentials "external-dns"
+$ gcloud container clusters get-credentials "external-dns"
+$ kubectl create clusterrolebinding cluster-admin-me \
+    --clusterrole=cluster-admin --user="$(gcloud config get-value account)"
 ```
 
-## Deploy the nginx ingress controller
+### Deploy the nginx ingress controller
 
 First, you need to deploy the nginx-based ingress controller. It can be deployed in at least two modes: Leveraging a Layer 4 load balancer in front of the nginx proxies or directly targeting pods with hostPorts on your worker nodes. ExternalDNS doesn't really care and supports both modes.
 
-### Default Backend
+#### Default Backend
 
 The nginx controller uses a default backend that it serves when no Ingress rule matches. This is a separate Service that can be picked by you. We'll use the default backend that's used by other ingress controllers for that matter. Apply the following manifests to your cluster to deploy the default backend.
 
@@ -96,7 +107,7 @@ spec:
         image: gcr.io/google_containers/defaultbackend:1.3
 ```
 
-### Without a separate TCP load balancer
+#### Without a separate TCP load balancer
 
 By default, the controller will update your Ingress objects with the public IPs of the nodes running your nginx controller instances. You should run multiple instances in case of pod or node failure. The controller will do leader election and will put multiple IPs as targets in your Ingress objects in that case. It could also make sense to run it as a DaemonSet. However, we'll just run a single replica. You have to open the respective ports on all of your worker nodes to allow nginx to receive traffic.
 
@@ -145,7 +156,7 @@ spec:
           hostPort: 443
 ```
 
-### With a separate TCP load balancer
+#### With a separate TCP load balancer
 
 However, you can also have the ingress controller proxied by a Kubernetes Service. This will instruct the controller to populate this Service's external IP as the external IP of the Ingress. This exposes the nginx proxies via a Layer 4 load balancer (`type=LoadBalancer`) which is more reliable than the other method. With that approach, you can run as many nginx proxy instances on your cluster as you like or have them autoscaled. This is the preferred way of running the nginx controller.
 
@@ -206,7 +217,7 @@ spec:
         - containerPort: 443
 ```
 
-## Deploy ExternalDNS
+### Deploy ExternalDNS
 
 Apply the following manifest file to deploy ExternalDNS.
 
@@ -274,7 +285,7 @@ spec:
 
 Use `--dry-run` if you want to be extra careful on the first run. Note, that you will not see any records created when you are running in dry-run mode. You can, however, inspect the logs and watch what would have been done.
 
-## Deploy a sample application
+### Deploy a sample application
 
 Create the following sample application to test that ExternalDNS works.
 
@@ -363,7 +374,7 @@ $ curl via-ingress.external-dns-test.gcp.zalan.do
 </html>
 ```
 
-## Clean up
+### Clean up
 
 Make sure to delete all Service and Ingress objects before terminating the cluster so all load balancers and DNS entries get cleaned up correctly.
 
@@ -387,3 +398,302 @@ $ gcloud dns record-sets transaction remove ns-cloud-e{1..4}.googledomains.com. 
     --name "external-dns-test.gcp.zalan.do." --ttl 300 --type NS --zone "gcp-zalan-do"
 $ gcloud dns record-sets transaction execute --zone "gcp-zalan-do"
 ```
+
+## GKE with Workload Identity
+
+The following instructions use [GKE workload
+identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
+to provide ExternalDNS with the permissions it needs to manage DNS records.
+Workload identity is the Google-recommended way to provide GKE workloads access
+to GCP APIs.
+
+Create a GKE cluster with workload identity enabled and without the
+HttpLoadBalancing add-on.
+
+```console
+$ gcloud container clusters create external-dns \
+    --workload-metadata-from-node=GKE_METADATA_SERVER \
+    --identity-namespace=zalando-external-dns-test.svc.id.goog \
+    --addons=HorizontalPodAutoscaling
+```
+
+Create a GCP service account (GSA) for ExternalDNS and save its email address.
+
+```console
+$ sa_name="Kubernetes external-dns"
+$ gcloud iam service-accounts create sa-edns --display-name="$sa_name"
+$ sa_email=$(gcloud iam service-accounts list --format='value(email)' \
+    --filter="displayName:$sa_name")
+```
+
+Bind the ExternalDNS GSA to the DNS admin role.
+
+```console
+$ gcloud projects add-iam-policy-binding zalando-external-dns-test \
+    --member="serviceAccount:$sa_email" --role=roles/dns.admin
+```
+
+Link the ExternalDNS GSA to the Kubernetes service account (KSA) that
+external-dns will run under, i.e., the external-dns KSA in the external-dns
+namespaces.
+
+```console
+$ gcloud iam service-accounts add-iam-policy-binding "$sa_email" \
+    --member="serviceAccount:zalando-external-dns-test.svc.id.goog[external-dns/external-dns]" \
+    --role=roles/iam.workloadIdentityUser
+```
+
+Create a DNS zone which will contain the managed DNS records.
+
+```console
+$ gcloud dns managed-zones create external-dns-test-gcp-zalan-do \
+    --dns-name=external-dns-test.gcp.zalan.do. \
+    --description="Automatically managed zone by ExternalDNS"
+```
+
+Make a note of the nameservers that were assigned to your new zone.
+
+```console
+$ gcloud dns record-sets list \
+    --zone=external-dns-test-gcp-zalan-do \
+    --name=external-dns-test.gcp.zalan.do. \
+    --type NS
+NAME                             TYPE  TTL    DATA
+external-dns-test.gcp.zalan.do.  NS    21600  ns-cloud-e1.googledomains.com.,ns-cloud-e2.googledomains.com.,ns-cloud-e3.googledomains.com.,ns-cloud-e4.googledomains.com.
+```
+
+In this case it's `ns-cloud-{e1-e4}.googledomains.com.` but your's could
+slightly differ, e.g. `{a1-a4}`, `{b1-b4}` etc.
+
+Tell the parent zone where to find the DNS records for this zone by adding the
+corresponding NS records there. Assuming the parent zone is "gcp-zalan-do" and
+the domain is "gcp.zalan.do" and that it's also hosted at Google we would do the
+following.
+
+```console
+$ gcloud dns record-sets transaction start --zone=gcp-zalan-do
+$ gcloud dns record-sets transaction add ns-cloud-e{1..4}.googledomains.com. \
+    --name=external-dns-test.gcp.zalan.do. --ttl 300 --type NS --zone=gcp-zalan-do
+$ gcloud dns record-sets transaction execute --zone=gcp-zalan-do
+```
+
+Connect your `kubectl` client to the cluster you just created and bind your GCP
+user to the cluster admin role in Kubernetes.
+
+```console
+$ gcloud container clusters get-credentials external-dns
+$ kubectl create clusterrolebinding cluster-admin-me \
+    --clusterrole=cluster-admin --user="$(gcloud config get-value account)"
+```
+
+### Deploy ingress-nginx
+
+Follow the [ingress-nginx GKE installation
+instructions](https://kubernetes.github.io/ingress-nginx/deploy/#gce-gke) to
+deploy it to the cluster.
+
+```console
+$ kubectl apply -f \
+    https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.35.0/deploy/static/provider/cloud/deploy.yaml
+```
+
+### Deploy ExternalDNS
+
+Apply the following manifest file to deploy external-dns.
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-dns
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+  namespace: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+  - apiGroups: [""]
+    resources: ["services", "endpoints", "pods"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["extensions", "networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+  - kind: ServiceAccount
+    name: external-dns
+    namespace: external-dns
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+  namespace: external-dns
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      containers:
+        - args:
+            - --source=ingress
+            - --domain-filter=external-dns-test.gcp.zalan.do
+            - --provider=google
+            - --google-project=zalando-external-dns-test
+            - --registry=txt
+            - --txt-owner-id=my-identifier
+          image: k8s.gcr.io/external-dns/external-dns:v0.7.3
+          name: external-dns
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 65534
+      serviceAccountName: external-dns
+```
+
+Then add the proper workload identity annotation to the cert-manager service
+account.
+
+```bash
+$ kubectl annotate serviceaccount --namespace=external-dns external-dns \
+    "iam.gke.io/gcp-service-account=$sa_email"
+```
+
+### Deploy a sample application
+
+Create the following sample application to test that ExternalDNS works.
+
+```yaml
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: nginx
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+  - host: via-ingress.external-dns-test.gcp.zalan.do
+    http:
+      paths:
+      - backend:
+          serviceName: nginx
+          servicePort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+  selector:
+    app: nginx
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        ports:
+        - containerPort: 80
+```
+
+After roughly two minutes check that a corresponding DNS record for your ingress
+was created.
+
+```console
+$ gcloud dns record-sets list \
+    --zone "external-dns-test-gcp-zalan-do" \
+    --name "via-ingress.external-dns-test.gcp.zalan.do." \
+    --type A
+NAME                                         TYPE  TTL  DATA
+via-ingress.external-dns-test.gcp.zalan.do.  A     300  35.187.1.246
+```
+
+Let's check that we can resolve this DNS name as well.
+
+```console
+$ dig +short @ns-cloud-e1.googledomains.com. via-ingress.external-dns-test.gcp.zalan.do.
+35.187.1.246
+```
+
+Try with `curl` as well.
+
+```console
+$ curl via-ingress.external-dns-test.gcp.zalan.do
+<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to nginx!</title>
+...
+</head>
+<body>
+...
+</body>
+</html>
+```
+
+### Clean up
+
+Make sure to delete all service and ingress objects before terminating the
+cluster so all load balancers and DNS entries get cleaned up correctly.
+
+```console
+$ kubectl delete service --namespace=ingress-nginx ingress-nginx-controller
+$ kubectl delete ingress nginx
+```
+
+Give ExternalDNS some time to clean up the DNS records for you. Then delete the
+managed zone and cluster.
+
+```console
+$ gcloud dns managed-zones delete external-dns-test-gcp-zalan-do
+$ gcloud container clusters delete external-dns
+```
+
+Also delete the NS records for your removed zone from the parent zone.
+
+```console
+$ gcloud dns record-sets transaction start --zone gcp-zalan-do
+$ gcloud dns record-sets transaction remove ns-cloud-e{1..4}.googledomains.com. \
+    --name=external-dns-test.gcp.zalan.do. --ttl 300 --type NS --zone=gcp-zalan-do
+$ gcloud dns record-sets transaction execute --zone=gcp-zalan-do
+```
+
+## User Demo How-To Blogs and Examples
+
+* Run external-dns on GKE with workload identity. See [Kubernetes, ingress-nginx, cert-manager & external-dns](https://blog.atomist.com/kubernetes-ingress-nginx-cert-manager-external-dns/)


### PR DESCRIPTION
**Description**

Add instructions for using GKE workload identity to allow ExternalDNS
to authenticate against Google Cloud DNS APIs. Use modern Docker
images.  Add blog link to README.

Signed-off-by: David Dooling <dooling@gmail.com>

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
- [x] CHANGELOG.md updated, use section "Unreleased"
