### PR TITLE
Add quick start section to contributor docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Add quick start section to contributing docs (#1766) @seanmalloy
 - Enhance pull request template @seanmalloy
 - Improve errors context for AWS provider
 - Scaleway Provider (#1643) @Sh4d1

--- a/README.md
+++ b/README.md
@@ -155,33 +155,10 @@ The following tutorials are provided:
 
 ### Running Locally
 
-#### Technical Requirements
-
-Make sure you have the following prerequisites:
-* A local Go 1.11+ development environment.
-* Access to a Google/AWS account with the DNS API enabled.
-* Access to a Kubernetes cluster that supports exposing Services, e.g. GKE.
+See the [contributor guide](docs/contributing/getting-started.md) for details on compiling
+from source.
 
 #### Setup Steps
-
-First, get ExternalDNS:
-
-```console
-$ git clone https://github.com/kubernetes-sigs/external-dns.git && cd external-dns
-```
-
-**This project uses [Go modules](https://github.com/golang/go/wiki/Modules) as
-introduced in Go 1.11 therefore you need Go >=1.11 installed in order to build.**
-If using Go 1.11 you also need to [activate Module
-support](https://github.com/golang/go/wiki/Modules#installing-and-activating-module-support).
-
-Assuming Go has been setup with module support it can be built simply by running:
-
-```console
-$ make
-```
-
-This will create external-dns in the build directory directly from the default branch.
 
 Next, run an application and expose it via a Kubernetes Service:
 

--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -1,10 +1,33 @@
-# Project structure
+# Quick Start
 
-### Building
+- [Git](https://git-scm.com/downloads)
+- [Go 1.14+](https://golang.org/dl/)
+- [Go modules](https://github.com/golang/go/wiki/Modules)
+- [golangci-lint](https://github.com/golangci/golangci-lint)
+- [Docker](https://docs.docker.com/install/)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl)
 
-You can build ExternalDNS for your platform with `make build`, you may have to install the necessary dependencies with `make dep`. The binary will land at `build/external-dns`.
+Compile and run locally against a remote k8s cluster.
+```
+git clone https://github.com/kubernetes-sigs/external-dns.git && cd external-dns
+make build
+# login to remote k8s cluster
+./build/external-dns --source=service --provider=inmemory --once
+```
 
-### Design
+Run linting, unit tests, and coverage report.
+```
+make lint
+make test
+make cover-html
+```
+
+Build container image.
+```
+make build.docker
+```
+
+# Design
 
 ExternalDNS's sources of DNS records live in package [source](../../source). They implement the `Source` interface that has a single method `Endpoints` which returns the represented source's objects converted to `Endpoints`. Endpoints are just a tuple of DNS name and target where target can be an IP or another hostname.
 
@@ -20,7 +43,7 @@ The orchestration between the different components is controlled by the [control
 
 You can pick which `Source` and `Provider` to use at runtime via the `--source` and `--provider` flags, respectively.
 
-### Adding a DNS provider
+# Adding a DNS Provider
 
 A typical way to start on, e.g. a CoreDNS provider, would be to add a `coredns.go` to the providers package and implement the interface methods. Then you would have to register your provider under a name in `main.go`, e.g. `coredns`, and would be able to trigger it's functions via setting `--provider=coredns`.
 


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
Added a quick start section to the contributing documentation. The purpose of this documentation is to help new contributors get started working with the external-dns project.

<!-- Please provide a summary of the change here. -->
Updated `docs/contributing/getting-started.md` with recommend local development workflow. Removed documentation from `README.md` for compiling from source.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Is related to #1558 

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
- [x] CHANGELOG.md updated, use section "Unreleased"
