### PR TITLE
Remove changelog from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,11 +7,3 @@
 
 <!-- Please provide a summary of the change here. -->
 
-<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
-Fixes #ISSUE
-
-**Checklist**
-
-- [ ] Unit tests updated
-- [ ] End user documentation updated
-- [ ] CHANGELOG.md updated, use section "Unreleased"


### PR DESCRIPTION
This PR removes the changelog requirement from the new PR template. We figured that this was causing a lot of unfair conflicts for users. https://github.com/kubernetes-sigs/external-dns/issues/1754 will address the issue of generating the final changelog. 