### PR TITLE
Adds release script

### DIFF
--- a/releaser.sh
+++ b/releaser.sh
@@ -4,18 +4,31 @@ set -e
 current_tag="${GITHUB_REF#refs/tags/}"
 start_ref="HEAD"
 
-# Find the previous release on the same branch, skipping prereleases if the
-# current tag is a full release
-previous_tag=""
-while [[ -z $previous_tag || ( $previous_tag == *-* && $current_tag != *-* ) ]]; do
-  previous_tag="$(git describe --tags "$start_ref"^ --abbrev=0)"
-  start_ref="$previous_tag"
-done
-
-git log "$previous_tag".. --reverse --merges --oneline --grep='Merge pull request #' | \
-  while read -r sha title; do
-    pr_num="$(grep -o '#[[:digit:]]\+' <<<"$title")"
-    pr_desc="$(git show -s --format=%b "$sha" | sed -n '1,/^$/p' | tr $'\n' ' ')"
-    pr_author="$(gh pr view $pr_num | grep author | awk '{ print $2 }' | tr $'\n' ' ')"
-    printf "* %s (%s) @%s\n\n" "$pr_desc" "$pr_num" "$pr_author"
+function generate_changelog {
+  # Find the previous release on the same branch, skipping prereleases if the
+  # current tag is a full release
+  previous_tag=""
+  while [[ -z $previous_tag || ( $previous_tag == *-* && $current_tag != *-* ) ]]; do
+    previous_tag="$(git describe --tags "$start_ref"^ --abbrev=0)"
+    start_ref="$previous_tag"
   done
+
+  git log "$previous_tag".. --reverse --merges --oneline --grep='Merge pull request #' | \
+    while read -r sha title; do
+      pr_num="$(grep -o '#[[:digit:]]\+' <<<"$title")"
+      pr_desc="$(git show -s --format=%b "$sha" | sed -n '1,/^$/p' | tr $'\n' ' ')"
+      pr_author="$(gh pr view "$pr_num" | grep author | awk '{ print $2 }' | tr $'\n' ' ')"
+      printf "* %s (%s) @%s\n\n" "$pr_desc" "$pr_num" "$pr_author"
+    done
+}
+
+function replace_kustomize_version {
+  sed -i -e "s/newTag: */newTag: $1/g" kustomization.yaml
+  git commit -sam "updates kustomize with newly released version"
+}
+
+function create_pr {
+  generate_changelog
+}
+
+create_pr

--- a/releaser.sh
+++ b/releaser.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+current_tag="${GITHUB_REF#refs/tags/}"
+start_ref="HEAD"
+
+# Find the previous release on the same branch, skipping prereleases if the
+# current tag is a full release
+previous_tag=""
+while [[ -z $previous_tag || ( $previous_tag == *-* && $current_tag != *-* ) ]]; do
+  previous_tag="$(git describe --tags "$start_ref"^ --abbrev=0)"
+  start_ref="$previous_tag"
+done
+
+git log "$previous_tag".. --reverse --merges --oneline --grep='Merge pull request #' | \
+  while read -r sha title; do
+    pr_num="$(grep -o '#[[:digit:]]\+' <<<"$title")"
+    pr_desc="$(git show -s --format=%b "$sha" | sed -n '1,/^$/p' | tr $'\n' ' ')"
+    pr_author="$(gh pr view $pr_num | grep author | awk '{ print $2 }' | tr $'\n' ' ')"
+    printf "* %s (%s) @%s\n\n" "$pr_desc" "$pr_num" "$pr_author"
+  done

--- a/scripts/kustomize-version-udapter.sh
+++ b/scripts/kustomize-version-udapter.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+sed -i -e "s/newTag: */newTag: $1/g" kustomize/kustomization.yaml
+git commit -sam "updates kustomize with newly released version"

--- a/scripts/kustomize-version-udapter.sh
+++ b/scripts/kustomize-version-udapter.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
 
-sed -i -e "s/newTag: */newTag: $1/g" kustomize/kustomization.yaml
-git commit -sam "updates kustomize with newly released version"
+sed -i -e "s/newTag: .*/newTag: $1/g" kustomize/kustomization.yaml
+git add kustomize/kustomization.yaml
+git commit -sm "updates kustomize with newly released version"

--- a/scripts/releaser.sh
+++ b/scripts/releaser.sh
@@ -22,13 +22,14 @@ function generate_changelog {
     done
 }
 
-function replace_kustomize_version {
-  sed -i -e "s/newTag: */newTag: $1/g" kustomization.yaml
-  git commit -sam "updates kustomize with newly released version"
+function create_release {
+  generate_changelog | gh release create "$1" -t "$1" -F -
 }
 
-function create_pr {
-  generate_changelog
-}
+if [ $# -ne 1 ]; then
+    echo "$0: usage: releaser [release number]"
+    echo "example: /releaser.sh v0.7.5"
+    exit 1
+fi
 
-create_pr
+create_release "$1"

--- a/scripts/releaser.sh
+++ b/scripts/releaser.sh
@@ -28,7 +28,7 @@ function create_release {
 
 if [ $# -ne 1 ]; then
     echo "$0: usage: releaser [release number]"
-    echo "example: /releaser.sh v0.7.5"
+    echo "example: ./releaser.sh v0.7.5"
     exit 1
 fi
 


### PR DESCRIPTION
Closes #1754 .

This is largely the same script from https://github.com/cli/cli/blob/trunk/script/changelog, requires `gh` to be run as well. It generates a release note compliant to what we have been using in ExternalDNS till today.

The scripts must be run manually by whoever has permissions to create releases. My initial idea was to use GitHub actions today by leveraging a manually triggered workflow, but actions does not support limiting who can run workflows to specific users or groups. This means that any user with write access could potentially make a release and that's clearly not ideal. I'll wait building the automation for that for when actions will support any functionality that will allow us to limit who can do releases.

This PR also updates the documentation for the release process.