### PR TITLE
Update hostport.md

### DIFF
--- a/docs/tutorials/hostport.md
+++ b/docs/tutorials/hostport.md
@@ -34,6 +34,7 @@ spec:
         image: k8s.gcr.io/external-dns/external-dns:v0.7.3
         args:
         - --log-level=debug
+        - --publish-host-ip
         - --source=service
         - --source=ingress
         - --namespace=dev
@@ -99,6 +100,7 @@ spec:
         image: k8s.gcr.io/external-dns/external-dns:v0.7.3
         args:
         - --log-level=debug
+        - --publish-host-ip
         - --source=service
         - --source=ingress
         - --namespace=dev


### PR DESCRIPTION
deployment must include '--publish-host-ip' for headless host port services to exported

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
hostport tutorial is missing an essential parameter

**Checklist**

- [ ] Unit tests updated
- [X] End user documentation updated
