### PR TITLE
Infoblox skip zones not matching a given view

### DIFF
--- a/provider/infoblox/infoblox.go
+++ b/provider/infoblox/infoblox.go
@@ -232,7 +232,11 @@ func (p *InfobloxProvider) ApplyChanges(ctx context.Context, changes *plan.Chang
 
 func (p *InfobloxProvider) zones() ([]ibclient.ZoneAuth, error) {
 	var res, result []ibclient.ZoneAuth
-	obj := ibclient.NewZoneAuth(ibclient.ZoneAuth{})
+	obj := ibclient.NewZoneAuth(
+		ibclient.ZoneAuth{
+			View: p.view,
+		},
+	)
 	err := p.client.GetObject(obj, "", &res)
 
 	if err != nil {
@@ -245,11 +249,6 @@ func (p *InfobloxProvider) zones() ([]ibclient.ZoneAuth, error) {
 		}
 
 		if !p.zoneIDFilter.Match(zone.Ref) {
-			continue
-		}
-
-		// Skip zones not matching the view
-		if p.view != "" && zone.View != p.view {
 			continue
 		}
 

--- a/provider/infoblox/infoblox.go
+++ b/provider/infoblox/infoblox.go
@@ -248,6 +248,11 @@ func (p *InfobloxProvider) zones() ([]ibclient.ZoneAuth, error) {
 			continue
 		}
 
+		// Skip zones not matching the view
+		if p.view != "" && zone.View != p.view {
+			continue
+		}
+
 		result = append(result, zone)
 	}
 

--- a/provider/infoblox/infoblox_test.go
+++ b/provider/infoblox/infoblox_test.go
@@ -344,6 +344,7 @@ func TestInfobloxRecords(t *testing.T) {
 	client := mockIBConnector{
 		mockInfobloxZones: &[]ibclient.ZoneAuth{
 			createMockInfobloxZone("example.com"),
+			createMockInfobloxZone("other.com"),
 		},
 		mockInfobloxObjects: &[]ibclient.IBObject{
 			createMockInfobloxObject("example.com", endpoint.RecordTypeA, "123.123.123.122"),


### PR DESCRIPTION
**Description**

Just fetch zones matching a given view from Infoblox. This reduces the load on Infoblox and the resultset received.

**Checklist**

- [x] Unit tests updated
