### PR TITLE
Generate cmdline args documentation automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,8 @@ jobs:
 
     - name: Get modified files
       id: modified-files
-      uses: jitterbit/get-changed-files@v1        
+      uses: jitterbit/get-changed-files@v1
+      if: startsWith(github.ref,'refs/pull/')        
 
     - name: Generate cmdline argument documentation
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,29 @@ jobs:
             dep ensure
         fi
 
+    - name: Get modified files
+      id: modified-files
+      uses: jitterbit/get-changed-files@v1        
+
+    - name: Generate cmdline argument documentation
+      run: |
+        make
+        echo -e "# Commandline arguments\n\nThis document is auto-generated from \`external-dns --help\`.\n\n" > docs/cmdline-args.md
+        echo -e "## Output\n\n\`\`\`" >> docs/cmdline-args.md
+        build/external-dns --help >> docs/cmdline-args.md 2>&1
+        echo "\`\`\`" >> docs/cmdline-args.md
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add docs/cmdline-args.md
+        git commit -m "Add new cmdline argument docs"
+      if: contains(steps.modified-files.all,'pkg/apis/externaldns/types.go')
+
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+      if: contains(steps.modified-files.all,'pkg/apis/externaldns/types.go') && github.actor != 'nektos/act'
+
     - name: Lint
       run: |
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ${{ github.ref }}
       if: contains(steps.modified-files.outputs.all,'pkg/apis/externaldns/types.go') && github.actor != 'nektos/act'
 
     - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,13 @@ jobs:
         git config --local user.name "GitHub Action"
         git add docs/cmdline-args.md
         git commit -m "Add new cmdline argument docs"
-      if: contains(steps.modified-files.all,'pkg/apis/externaldns/types.go')
+      if: contains(steps.modified-files.outputs.all,'pkg/apis/externaldns/types.go')
 
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-      if: contains(steps.modified-files.all,'pkg/apis/externaldns/types.go') && github.actor != 'nektos/act'
+      if: contains(steps.modified-files.outputs.all,'pkg/apis/externaldns/types.go') && github.actor != 'nektos/act'
 
     - name: Lint
       run: |

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -287,7 +287,7 @@ func allLogLevelsAsStrings() []string {
 
 // ParseFlags adds and parses flags from command line
 func (cfg *Config) ParseFlags(args []string) error {
-	app := kingpin.New("external-dns", "ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.\n\nNote that all flags may be replaced with env vars - `--flag` -> `EXTERNAL_DNS_FLAG=1` or `--flag value` -> `EXTERNAL_DNS_FLAG=value`")
+	app := kingpin.New("external-dns", "ExternalDNS synchronizes exposed Kubernetes Services, Ingresses and other sources with DNS providers.\n\nNote that all flags may be replaced with env vars - `--flag` -> `EXTERNAL_DNS_FLAG=1` or `--flag value` -> `EXTERNAL_DNS_FLAG=value`")
 	app.Version(Version)
 	app.DefaultEnvars()
 


### PR DESCRIPTION
**Description**
This PR introduces a new CI step which generates new cmdline args documentation, depending if pkg/apis/externaldns/types.go is modified by a PR.

Fixes #1780 

**Checklist**
- [ ] End user documentation updated
