### PR TITLE
Fix cloudflare problem with multiple targets

### DIFF
--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -227,7 +227,9 @@ func (p *CloudFlareProvider) ApplyChanges(ctx context.Context, changes *plan.Cha
 
 	for _, endpoint := range changes.Create {
 		for _, target := range endpoint.Targets {
-			cloudflareChanges = append(cloudflareChanges, p.newCloudFlareChange(cloudFlareCreate, endpoint, target))
+			singleEndpoint := endpoint
+			singleEndpoint.Targets = []string{target}
+			cloudflareChanges = append(cloudflareChanges, p.newCloudFlareChange(cloudFlareCreate, singleEndpoint, target))
 		}
 	}
 


### PR DESCRIPTION
For specific cases, when ingress has multiple addresses, external-dns throw an exception: Updates should have just one target. This PR solves this case with limit updating targets to one.

