### PR TITLE
Pre pull of images to make builds pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,8 @@ build.push/multiarch:
 	arch_specific_tags=()
 	for arch in $(ARCHS); do \
 		image="$(IMAGE):$(VERSION)-$${arch}" ;\
+		# pre-pull due to https://github.com/kubernetes-sigs/cluster-addons/pull/84/files ;\
+		docker pull $${arch}/alpine:3.12 ;\
 		DOCKER_BUILDKIT=1 docker build --rm --tag $${image} --build-arg VERSION="$(VERSION)" --build-arg ARCH="$${arch}" . ;\
 		docker push $${image} ;\
 		arch_specific_tags+=( "--amend $${image}" ) ;\


### PR DESCRIPTION
TL;DR: @justinsb saves the day.

At the time of writing this issue, all the docker builds for the staging images fail. This is due to the fact that cloud builder fails to pull some valid images. I think this is the same issue mentioned in https://github.com/kubernetes-sigs/cluster-addons/pull/84 , so I will try to pre-pull the images that we will use.

/cc @njuettner

