### PR TITLE
Bump cloudbuild timeout for new release process

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 1200s
+timeout: 3000s
 options:
   substitution_option: ALLOW_LOOSE
 steps:


### PR DESCRIPTION
Builds are still not passing, this time due to a timeout. Follow up of https://github.com/kubernetes-sigs/external-dns/pull/1821 

This should give us enough time to build 2 architectures, but it's mostly trial and error at this point. 