### PR TITLE
aws-r53 adding Africa (Cape Town) ELB endpoints and hosted zone id's

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -80,6 +80,7 @@ var (
 		"us-gov-west-1.elb.amazonaws.com":     "Z33AYJ8TM3BH4J",
 		"us-gov-east-1.elb.amazonaws.com":     "Z166TLBEWOO7G0",
 		"me-south-1.elb.amazonaws.com":        "ZS929ML54UICD",
+		"af-south-1.elb.amazonaws.com":        "Z268VQBMOI5EKX",
 		// Network Load Balancers
 		"elb.us-east-2.amazonaws.com":         "ZLMOA37VPKANP",
 		"elb.us-east-1.amazonaws.com":         "Z26RNL4JYFTOTI",
@@ -103,6 +104,7 @@ var (
 		"elb.us-gov-west-1.amazonaws.com":     "ZMG1MZ2THAWF1",
 		"elb.us-gov-east-1.amazonaws.com":     "Z1ZSMQQ6Q24QQ8",
 		"elb.me-south-1.amazonaws.com":        "Z3QSRYVP46NYYV",
+		"elb.af-south-1.amazonaws.com":        "Z203XCE67M25HM",		
 		// Global Accelerator
 		"awsglobalaccelerator.com": "Z2BJ6XQ5FK7U4H",
 	}

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -1031,6 +1031,7 @@ func TestAWSCanonicalHostedZone(t *testing.T) {
 		{"foo.sa-east-1.elb.amazonaws.com", "Z2P70J7HTTTPLU"},
 		{"foo.cn-north-1.elb.amazonaws.com.cn", "Z1GDH35T77C1KE"},
 		{"foo.cn-northwest-1.elb.amazonaws.com.cn", "ZM7IZAIOVVDZF"},
+		{"foo.af-south-1.elb.amazonaws.com", "Z268VQBMOI5EKX"},
 		// Network Load Balancers
 		{"foo.elb.us-east-2.amazonaws.com", "ZLMOA37VPKANP"},
 		{"foo.elb.us-east-1.amazonaws.com", "Z26RNL4JYFTOTI"},
@@ -1050,6 +1051,7 @@ func TestAWSCanonicalHostedZone(t *testing.T) {
 		{"foo.elb.sa-east-1.amazonaws.com", "ZTK26PT1VY4CU"},
 		{"foo.elb.cn-north-1.amazonaws.com.cn", "Z3QFB96KMJ7ED6"},
 		{"foo.elb.cn-northwest-1.amazonaws.com.cn", "ZQEIKTCZ8352D"},
+		{"foo.elb.af-south-1.amazonaws.com", "Z203XCE67M25HM"},
 		// No Load Balancer
 		{"foo.example.org", ""},
 	} {


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
This addresses external-dns running in af-south-1 whereby only CNAME entries are created when A records are intended

<!-- Please provide a summary of the change here. -->
Adding Africa (Cape Town) ELB endpoint and hosted zone id's

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1830 

**Checklist**

- [X] Unit tests updated
- [x] End user documentation updated
