### PR TITLE
cloudflare: readme update for RBAC config

### DIFF
--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -85,7 +85,7 @@ rules:
   verbs: ["get","watch","list"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["list"]
+  verbs: ["list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding


### PR DESCRIPTION
**Description**

This change adds the `"watch"` configuration for the `"nodes"` resource under the example RBAC configuration for Cloudflare.
The two stable providers contain this configuration. [AWS Route 53 documentation](https://github.com/kubernetes-sigs/external-dns/blame/master/docs/tutorials/aws.md#L182) has this permission, and so does the [GKE documentation](https://github.com/kubernetes-sigs/external-dns/blame/master/docs/tutorials/gke.md#L86).

This resolved a problem for me where the pod would timeout and crash with the following error `"failed to sync cache: timed out waiting for the condition"`


**Checklist**

- [ ] Unit tests updated
- [X] End user documentation updated
