### PR TITLE
Add GOARM for arm32v7 images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ build.amd64:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o build/$(BINARY) $(BUILD_FLAGS) -ldflags "$(LDFLAGS)" .
 
 build.arm32v7:
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -o build/$(BINARY) $(BUILD_FLAGS) -ldflags "$(LDFLAGS)" .
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -o build/$(BINARY) $(BUILD_FLAGS) -ldflags "$(LDFLAGS)" .
 
 build.docker:
 	docker build --rm --tag "$(IMAGE):$(VERSION)" --build-arg VERSION="$(VERSION)" --build-arg ARCH="amd64" .


### PR DESCRIPTION
Follow up to https://github.com/kubernetes-sigs/external-dns/pull/1838.

/cc @njuettner @xUnholy


