### PR TITLE
Fix OVH tutorial to match new permissions

### DIFF
--- a/docs/tutorials/ovh.md
+++ b/docs/tutorials/ovh.md
@@ -125,6 +125,9 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["list"]
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["get","watch","list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding


### PR DESCRIPTION
**Description**

External DNS now require permissions on endpoints resource. Adding it in the OVH tutorial manifest following this comment https://github.com/kubernetes-sigs/external-dns/issues/961#issuecomment-664849509 for making it continue to work out of the box.

**Checklist**

- [x] End user documentation updated
