### PR TITLE
Allow for normalizing any fields of desired endpoint

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -140,11 +140,11 @@ func (c *Controller) RunOnce(ctx context.Context) error {
 	sourceEndpointsTotal.Set(float64(len(endpoints)))
 
 	plan := &plan.Plan{
-		Policies:           []plan.Policy{c.Policy},
-		Current:            records,
-		Desired:            endpoints,
-		DomainFilter:       c.DomainFilter,
-		PropertyComparator: c.Registry.PropertyValuesEqual,
+		Policies:                 []plan.Policy{c.Policy},
+		Current:                  records,
+		Desired:                  endpoints,
+		DomainFilter:             c.DomainFilter,
+		NormalizeDesiredEndpoint: c.Registry.NormalizeDesiredEndpoint,
 	}
 
 	plan = plan.Calculate()

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -313,8 +313,12 @@ func (suite *PlanTestSuite) TestSyncSecondRoundWithProviderSpecificDefaultFalse(
 		Policies: []Policy{&SyncPolicy{}},
 		Current:  current,
 		Desired:  desired,
-		PropertyComparator: func(name, previous, current string) bool {
-			return CompareBoolean(false, name, previous, current)
+		NormalizeDesiredEndpoint: func(e *endpoint.Endpoint) {
+			e.NormalizeProviderSpecific(endpoint.NormalizeProviderSpecificConfig{
+				"external-dns.alpha.kubernetes.io/cloudflare-proxied": func(value string) string {
+					return endpoint.NormalizeBoolean(value, false)
+				},
+			})
 		},
 	}
 
@@ -337,8 +341,12 @@ func (suite *PlanTestSuite) TestSyncSecondRoundWithProviderSpecificDefualtTrue()
 		Policies: []Policy{&SyncPolicy{}},
 		Current:  current,
 		Desired:  desired,
-		PropertyComparator: func(name, previous, current string) bool {
-			return CompareBoolean(true, name, previous, current)
+		NormalizeDesiredEndpoint: func(e *endpoint.Endpoint) {
+			e.NormalizeProviderSpecific(endpoint.NormalizeProviderSpecificConfig{
+				"external-dns.alpha.kubernetes.io/cloudflare-proxied": func(value string) string {
+					return endpoint.NormalizeBoolean(value, true)
+				},
+			})
 		},
 	}
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -29,14 +29,13 @@ import (
 type Provider interface {
 	Records(ctx context.Context) ([]*endpoint.Endpoint, error)
 	ApplyChanges(ctx context.Context, changes *plan.Changes) error
-	PropertyValuesEqual(name string, previous string, current string) bool
+	NormalizeDesiredEndpoint(endpoint *endpoint.Endpoint)
 }
 
 type BaseProvider struct {
 }
 
-func (b BaseProvider) PropertyValuesEqual(name, previous, current string) bool {
-	return previous == current
+func (b BaseProvider) NormalizeDesiredEndpoint(endpoint *endpoint.Endpoint) {
 }
 
 type contextKey struct {

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -54,12 +54,3 @@ func TestDifference(t *testing.T) {
 	assert.Equal(t, remove, []string{"foo"})
 	assert.Equal(t, leave, []string{"bar"})
 }
-
-func TestBaseProviderPropertyEquality(t *testing.T) {
-	p := BaseProvider{}
-	assert.True(t, p.PropertyValuesEqual("some.property", "", ""), "Both properties not present")
-	assert.False(t, p.PropertyValuesEqual("some.property", "", "Foo"), "First property missing")
-	assert.False(t, p.PropertyValuesEqual("some.property", "Foo", ""), "Second property missing")
-	assert.True(t, p.PropertyValuesEqual("some.property", "Foo", "Foo"), "Properties the same")
-	assert.False(t, p.PropertyValuesEqual("some.property", "Foo", "Bar"), "Attributes differ")
-}

--- a/registry/aws_sd_registry.go
+++ b/registry/aws_sd_registry.go
@@ -88,6 +88,7 @@ func (sdr *AWSSDRegistry) updateLabels(endpoints []*endpoint.Endpoint) {
 	}
 }
 
-func (sdr *AWSSDRegistry) PropertyValuesEqual(name string, previous string, current string) bool {
-	return sdr.provider.PropertyValuesEqual(name, previous, current)
+// NormalizeDesiredEndpoint normalizes desired endpoint (e.g. applies defaults)
+func (sdr *AWSSDRegistry) NormalizeDesiredEndpoint(endpoint *endpoint.Endpoint) {
+	sdr.provider.NormalizeDesiredEndpoint(endpoint)
 }

--- a/registry/noop.go
+++ b/registry/noop.go
@@ -46,7 +46,7 @@ func (im *NoopRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes)
 	return im.provider.ApplyChanges(ctx, changes)
 }
 
-// PropertyValuesEqual compares two property values for equality
-func (im *NoopRegistry) PropertyValuesEqual(attribute string, previous string, current string) bool {
-	return im.provider.PropertyValuesEqual(attribute, previous, current)
+// NormalizeDesiredEndpoint normalizes desired endpoint (e.g. applies defaults)
+func (im *NoopRegistry) NormalizeDesiredEndpoint(endpoint *endpoint.Endpoint) {
+	im.provider.NormalizeDesiredEndpoint(endpoint)
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -32,7 +32,7 @@ import (
 type Registry interface {
 	Records(ctx context.Context) ([]*endpoint.Endpoint, error)
 	ApplyChanges(ctx context.Context, changes *plan.Changes) error
-	PropertyValuesEqual(attribute string, previous string, current string) bool
+	NormalizeDesiredEndpoint(endpoint *endpoint.Endpoint)
 }
 
 //TODO(ideahitme): consider moving this to Plan

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -191,9 +191,9 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 	return im.provider.ApplyChanges(ctx, filteredChanges)
 }
 
-// PropertyValuesEqual compares two attribute values for equality
-func (im *TXTRegistry) PropertyValuesEqual(name string, previous string, current string) bool {
-	return im.provider.PropertyValuesEqual(name, previous, current)
+// NormalizeDesiredEndpoint normalizes desired endpoint (e.g. applies defaults)
+func (im *TXTRegistry) NormalizeDesiredEndpoint(endpoint *endpoint.Endpoint) {
+	im.provider.NormalizeDesiredEndpoint(endpoint)
 }
 
 /**


### PR DESCRIPTION
**Description**

This alternative solution to https://github.com/kubernetes-sigs/external-dns/issues/1820 (previous one is https://github.com/kubernetes-sigs/external-dns/pull/1822)

This avoids adding new method to BaseProvider, and instead it replaces PropertyValuesEqual with more powerful NormalizeDesiredEndpoint which is able to implement custom handling for all properties of Endpoint, not only ProviderSpecific (in this case endpoint.RecordTTL)

Fixes #1820

**Checklist**

- [x] Unit tests updated