### PR TITLE
fix(scaleway): only use absolute CNAMEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Update contributing section in README (#1760) @seanmalloy
 - Option to cache AWS zones list @bpineau
 - Refactor, enhance and test Akamai provider and documentation (#1846) @edglynes
+- Fix: only use absolute CNAMEs in Scaleway provider (#1859) @Sh4d1
 
 ## v0.7.3 - 2020-08-05
 

--- a/provider/scaleway/scaleway.go
+++ b/provider/scaleway/scaleway.go
@@ -269,8 +269,13 @@ func endpointToScalewayRecords(zoneName string, ep *endpoint.Endpoint) []*domain
 	records := []*domain.Record{}
 
 	for _, target := range ep.Targets {
+		finalTargetName := target
+		if domain.RecordType(ep.RecordType) == domain.RecordTypeCNAME {
+			finalTargetName = provider.EnsureTrailingDot(target)
+		}
+
 		records = append(records, &domain.Record{
-			Data:     target,
+			Data:     finalTargetName,
 			Name:     strings.Trim(strings.TrimSuffix(ep.DNSName, zoneName), ". "),
 			Priority: priority,
 			TTL:      ttl,
@@ -285,9 +290,14 @@ func endpointToScalewayRecordsChangeDelete(zoneName string, ep *endpoint.Endpoin
 	records := []*domain.RecordChange{}
 
 	for _, target := range ep.Targets {
+		finalTargetName := target
+		if domain.RecordType(ep.RecordType) == domain.RecordTypeCNAME {
+			finalTargetName = provider.EnsureTrailingDot(target)
+		}
+
 		records = append(records, &domain.RecordChange{
 			Delete: &domain.RecordChangeDelete{
-				Data: target,
+				Data: finalTargetName,
 				Name: strings.Trim(strings.TrimSuffix(ep.DNSName, zoneName), ". "),
 				Type: domain.RecordType(ep.RecordType),
 			},

--- a/provider/scaleway/scaleway_test.go
+++ b/provider/scaleway/scaleway_test.go
@@ -93,7 +93,7 @@ func (m *mockScalewayDomain) ListDNSZoneRecords(req *domain.ListDNSZoneRecordsRe
 				Type:     domain.RecordTypeA,
 			},
 			{
-				Data:     "test.example.com",
+				Data:     "test.example.com.",
 				Name:     "two",
 				TTL:      600,
 				Priority: 30,
@@ -330,7 +330,7 @@ func TestScalewayProvider_generateApplyRequests(t *testing.T) {
 					Add: &domain.RecordChangeAdd{
 						Records: []*domain.Record{
 							{
-								Data:     "example.com",
+								Data:     "example.com.",
 								Name:     "",
 								TTL:      600,
 								Type:     domain.RecordTypeCNAME,


### PR DESCRIPTION
Signed-off-by: Patrik Cyvoct <patrik@ptrk.io>

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Scaleway DNS allow "relative" CNAME without a trailing dot, this PR ensures we only uses absolute CNAMEs

**Checklist**

- [x] Unit tests updated
- [NA] End user documentation updated
