### PR TITLE
Honour target annotation on Headless Services

### DIFF
--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -31,7 +31,8 @@ make build.docker
 
 ExternalDNS's sources of DNS records live in package [source](../../source). They implement the `Source` interface that has a single method `Endpoints` which returns the represented source's objects converted to `Endpoints`. Endpoints are just a tuple of DNS name and target where target can be an IP or another hostname.
 
-For example, the `ServiceSource` returns all Services converted to `Endpoints` where the hostname is the value of the `external-dns.alpha.kubernetes.io/hostname` annotation and the target is the IP of the load balancer.
+For example, the `ServiceSource` returns all Services converted to `Endpoints` where the hostname is the value of the `external-dns.alpha.kubernetes.io/hostname` annotation and the target is the IP of the load balancer. You can overwrite the targets of `ClusterIP`
+services using the `external-dns.alpha.kubernetes.io/target` annotation as for `IngressSource`.
 
 This list of endpoints is passed to the [Plan](../../plan) which determines the difference between the current DNS records and the desired list of `Endpoints`.
 

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -2551,6 +2551,35 @@ func TestHeadlessServicesHostIP(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"annotated Headless services return endpoint specified in target annotation",
+			"",
+			"testing",
+			"foo",
+			v1.ServiceTypeClusterIP,
+			"",
+			"",
+			false,
+			map[string]string{"component": "foo"},
+			map[string]string{
+				hostnameAnnotationKey: "service.example.org",
+				targetAnnotationKey:   "this.is.a.test",
+			},
+			v1.ClusterIPNone,
+			[]string{"1.1.1.1", "1.1.1.2"},
+			map[string]string{
+				"component": "foo",
+			},
+			[]string{},
+			[]string{"foo-0", "foo-1"},
+			[]string{"foo-0", "foo-1"},
+			[]bool{true, true},
+			false,
+			[]*endpoint.Endpoint{
+				{DNSName: "service.example.org", Targets: endpoint.Targets{"this.is.a.test"}},
+			},
+			false,
+		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
 			// Create a Kubernetes testing client


### PR DESCRIPTION
**Description**

As a sole user of traefik ingressroutes for ingress traefik we are not using Ingresses.

So, in order to avoid having to create externalName service to use the external-dns we'd like it to honour the `external-dns.alpha.kubernetes.io/target` annotation on ClusterIP services.

Regards.

**Checklist**

- [X] Unit tests updated
- [x] End user documentation updated
