### PR TITLE
Add Vultr to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ ExternalDNS' current release is `v0.7`. This version allows you to keep selected
 * [NS1](https://ns1.com/)
 * [TransIP](https://www.transip.eu/domain-name/)
 * [VinylDNS](https://www.vinyldns.io)
+* [Vultr](https://www.vultr.com)
 * [OVH](https://www.ovh.com)
 * [Scaleway](https://www.scaleway.com)
 


### PR DESCRIPTION

**Description**

Looks like Vultr is missing in the `Latest release v0.7` section of the readme

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
I can create a ticket for this if need be
Fixes N/A 

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
