### PR TITLE
Source IPv6 node IPs as AAAA endpoints

### DIFF
--- a/source/node_test.go
+++ b/source/node_test.go
@@ -194,6 +194,33 @@ func testNodeSourceEndpoints(t *testing.T) {
 			true,
 		},
 		{
+			"node with both IPv4 and IPv6 addresses results in both A and AAAA records",
+			"",
+			"",
+			"node1",
+			[]v1.NodeAddress{{Type: v1.NodeInternalIP, Address: "2.3.4.5"}, {Type: v1.NodeInternalIP, Address: "2::5"}},
+			map[string]string{},
+			map[string]string{},
+			[]*endpoint.Endpoint{
+				{RecordType: "A", DNSName: "node1", Targets: endpoint.Targets{"2.3.4.5"}},
+				{RecordType: "AAAA", DNSName: "node1", Targets: endpoint.Targets{"2::5"}},
+			},
+			false,
+		},
+		{
+			"node with only IPv6 addresses results in only AAAA records",
+			"",
+			"",
+			"node1",
+			[]v1.NodeAddress{{Type: v1.NodeInternalIP, Address: "1::1"}, {Type: v1.NodeInternalIP, Address: "2::5"}},
+			map[string]string{},
+			map[string]string{},
+			[]*endpoint.Endpoint{
+				{RecordType: "AAAA", DNSName: "node1", Targets: endpoint.Targets{"1::1", "2::5"}},
+			},
+			false,
+		},
+		{
 			"annotated node without annotation filter returns endpoint",
 			"",
 			"",


### PR DESCRIPTION
**Description**

In an IPv6-enabled cluster, it's possible (and legitiment) for a node's `.status.addresses` list to contain IPv6 addresses. Usually alongside an IPv4 address for dual-stack clusters. Here's a partial example: https://kubernetes.io/docs/tasks/network/validate-dual-stack/#validate-node-addressing

Multiple external-dns sources assume that every IP address is IPv4 and thus has `A` hardcoded as the record type. This results in invalid DNS endpoints being generated. With the node source, this means the sync loop is broken while such a node is still present.

This PR replaces some of the `node.go` logic to support creating either an A endpoint, or an AAAA endpoint, or both at the same time, for each node. Some of the logic might be questionable and I welcome the review.

Fixes #1875 but **does not** actually result in AAAA records being created at this time because external-dns itself does not support AAAA records yet. The planner needs some work to support dual-stack records properly and I'm considering it out of scope of upgrading each source to emit proper endpoints.

So, this PR fixes invalid A endpoints being generated, and replaces them with correct AAAA endpoints that simply aren't actioned on at this point in time.

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
