### PR TITLE
fix doc: Correct document for aws.md

### DIFF
--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -410,7 +410,7 @@ For any given DNS name, only **one** of the following routing policies can be us
 ## Associating DNS records with healthchecks
 
 You can configure Route53 to associate DNS records with healthchecks for automated DNS failover using 
-`external-dns.alpha.kubernetes.io/health-check-id: <health-check-id>` annotation.
+`external-dns.alpha.kubernetes.io/aws-health-check-id: <health-check-id>` annotation.
 
 Note: ExternalDNS does not support creating healthchecks, and assumes that `<health-check-id>` already exists.
 


### PR DESCRIPTION
**Description**

As https://github.com/kubernetes-sigs/external-dns/pull/1288#issuecomment-567119199

`external-dns.alpha.kubernetes.io/aws-health-check-id: {my-health-check-identifier}` is correct.

I have test with release 0.7.5 on my AWS environment, it worked with annotation `external-dns.alpha.kubernetes.io/aws-health-check-id`.



**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
