### PR TITLE
Bump kustomize version to 0.7.6

### DIFF
--- a/kustomize/kustomization.yaml
+++ b/kustomize/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
   - name: k8s.gcr.io/external-dns/external-dns
-    newTag: v0.7.5
+    newTag: v0.7.6
 
 resources:
   - ./external-dns-deployment.yaml


### PR DESCRIPTION
Before we change the way we do the kustomize release management, one more PR with the old workflow. 

/cc @njuettner 