### PR TITLE
Bump Scaleway DNS API to v2beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Option to cache AWS zones list @bpineau
 - Refactor, enhance and test Akamai provider and documentation (#1846) @edglynes
 - Fix: only use absolute CNAMEs in Scaleway provider (#1859) @Sh4d1
+- Change Scaleway DNS API version from v2alpha2 to v2beta1 (#1938) @Sh4d1
 
 ## v0.7.3 - 2020-08-05
 

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/projectcontour/contour v1.5.0
 	github.com/prometheus/client_golang v1.7.1
 	github.com/sanyu/dynectsoap v0.0.0-20181203081243-b83de5edc4e0
-	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.6.0.20200623155123-84df6c4b5301
+	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7.0.20210127161313-bd30bebeac4f
 	github.com/sirupsen/logrus v1.6.0
 	github.com/smartystreets/gunit v1.3.4 // indirect
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -789,8 +789,8 @@ github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0
 github.com/sanyu/dynectsoap v0.0.0-20181203081243-b83de5edc4e0 h1:vOcHdR1nu7DO4BAx1rwzdHV7jQTzW3gqcBT5qxHSc6A=
 github.com/sanyu/dynectsoap v0.0.0-20181203081243-b83de5edc4e0/go.mod h1:FeplEtXXejBYC4NPAFTrs5L7KuK+5RL9bf5nB2vZe9o=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
-github.com/scaleway/scaleway-sdk-go v1.0.0-beta.6.0.20200623155123-84df6c4b5301 h1:qj0du14RIOnmePII/eTlw1aHKDYL6zxDIk/Dq7Tef9k=
-github.com/scaleway/scaleway-sdk-go v1.0.0-beta.6.0.20200623155123-84df6c4b5301/go.mod h1:CJJ5VAbozOl0yEw7nHB9+7BXTJbIn6h7W+f6Gau5IP8=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7.0.20210127161313-bd30bebeac4f h1:WSnaD0/cvbKJgSTYbjAPf4RJXVvNNDAwVm+W8wEmnGE=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7.0.20210127161313-bd30bebeac4f/go.mod h1:CJJ5VAbozOl0yEw7nHB9+7BXTJbIn6h7W+f6Gau5IP8=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=

--- a/provider/scaleway/interface.go
+++ b/provider/scaleway/interface.go
@@ -17,7 +17,7 @@ limitations under the License.
 package scaleway
 
 import (
-	domain "github.com/scaleway/scaleway-sdk-go/api/domain/v2alpha2"
+	domain "github.com/scaleway/scaleway-sdk-go/api/domain/v2beta1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 

--- a/provider/scaleway/scaleway.go
+++ b/provider/scaleway/scaleway.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	domain "github.com/scaleway/scaleway-sdk-go/api/domain/v2alpha2"
+	domain "github.com/scaleway/scaleway-sdk-go/api/domain/v2beta1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	log "github.com/sirupsen/logrus"
 
@@ -297,9 +297,11 @@ func endpointToScalewayRecordsChangeDelete(zoneName string, ep *endpoint.Endpoin
 
 		records = append(records, &domain.RecordChange{
 			Delete: &domain.RecordChangeDelete{
-				Data: finalTargetName,
-				Name: strings.Trim(strings.TrimSuffix(ep.DNSName, zoneName), ". "),
-				Type: domain.RecordType(ep.RecordType),
+				IDFields: &domain.RecordIdentifier{
+					Data: &finalTargetName,
+					Name: strings.Trim(strings.TrimSuffix(ep.DNSName, zoneName), ". "),
+					Type: domain.RecordType(ep.RecordType),
+				},
 			},
 		})
 	}
@@ -330,15 +332,15 @@ func logChanges(req *domain.UpdateDNSZoneRecordsRequest) {
 				log.WithFields(logFields).Info("Adding record")
 			}
 		} else if change.Delete != nil {
-			name := change.Delete.Name + "."
-			if change.Delete.Name == "" {
+			name := change.Delete.IDFields.Name + "."
+			if change.Delete.IDFields.Name == "" {
 				name = ""
 			}
 
 			logFields := log.Fields{
 				"record": name + req.DNSZone,
-				"type":   change.Delete.Type.String(),
-				"data":   change.Delete.Data,
+				"type":   change.Delete.IDFields.Type.String(),
+				"data":   *change.Delete.IDFields.Data,
 			}
 
 			log.WithFields(logFields).Info("Deleting record")

--- a/provider/scaleway/scaleway_test.go
+++ b/provider/scaleway/scaleway_test.go
@@ -22,7 +22,7 @@ import (
 	"reflect"
 	"testing"
 
-	domain "github.com/scaleway/scaleway-sdk-go/api/domain/v2alpha2"
+	domain "github.com/scaleway/scaleway-sdk-go/api/domain/v2beta1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -302,23 +302,29 @@ func TestScalewayProvider_generateApplyRequests(t *testing.T) {
 				},
 				{
 					Delete: &domain.RecordChangeDelete{
-						Data: "3.3.3.3",
-						Name: "me",
-						Type: domain.RecordTypeA,
+						IDFields: &domain.RecordIdentifier{
+							Data: scw.StringPtr("3.3.3.3"),
+							Name: "me",
+							Type: domain.RecordTypeA,
+						},
 					},
 				},
 				{
 					Delete: &domain.RecordChangeDelete{
-						Data: "1.1.1.1",
-						Name: "here",
-						Type: domain.RecordTypeA,
+						IDFields: &domain.RecordIdentifier{
+							Data: scw.StringPtr("1.1.1.1"),
+							Name: "here",
+							Type: domain.RecordTypeA,
+						},
 					},
 				},
 				{
 					Delete: &domain.RecordChangeDelete{
-						Data: "1.1.1.2",
-						Name: "here",
-						Type: domain.RecordTypeA,
+						IDFields: &domain.RecordIdentifier{
+							Data: scw.StringPtr("1.1.1.2"),
+							Name: "here",
+							Type: domain.RecordTypeA,
+						},
 					},
 				},
 			},
@@ -355,23 +361,29 @@ func TestScalewayProvider_generateApplyRequests(t *testing.T) {
 				},
 				{
 					Delete: &domain.RecordChangeDelete{
-						Data: "1.1.1.1",
-						Name: "here.is.my",
-						Type: domain.RecordTypeA,
+						IDFields: &domain.RecordIdentifier{
+							Data: scw.StringPtr("1.1.1.1"),
+							Name: "here.is.my",
+							Type: domain.RecordTypeA,
+						},
 					},
 				},
 				{
 					Delete: &domain.RecordChangeDelete{
-						Data: "4.4.4.4",
-						Name: "my",
-						Type: domain.RecordTypeA,
+						IDFields: &domain.RecordIdentifier{
+							Data: scw.StringPtr("4.4.4.4"),
+							Name: "my",
+							Type: domain.RecordTypeA,
+						},
 					},
 				},
 				{
 					Delete: &domain.RecordChangeDelete{
-						Data: "5.5.5.5",
-						Name: "my",
-						Type: domain.RecordTypeA,
+						IDFields: &domain.RecordIdentifier{
+							Data: scw.StringPtr("5.5.5.5"),
+							Name: "my",
+							Type: domain.RecordTypeA,
+						},
 					},
 				},
 			},
@@ -488,7 +500,7 @@ func checkScalewayReqChanges(r1, r2 *domain.UpdateDNSZoneRecordsRequest) bool {
 			if c1.Add != nil && c2.Add != nil && checkScalewayRecords(c1.Add.Records, c2.Add.Records) {
 				total--
 			} else if c1.Delete != nil && c2.Delete != nil {
-				if c1.Delete.Data == c2.Delete.Data && c1.Delete.Name == c2.Delete.Name && c1.Delete.Type == c2.Delete.Type {
+				if *c1.Delete.IDFields.Data == *c2.Delete.IDFields.Data && c1.Delete.IDFields.Name == c2.Delete.IDFields.Name && c1.Delete.IDFields.Type == c2.Delete.IDFields.Type {
 					total--
 				}
 			}

--- a/provider/scaleway/scaleway_test.go
+++ b/provider/scaleway/scaleway_test.go
@@ -158,6 +158,90 @@ func TestScalewayProvider_NewScalewayProvider(t *testing.T) {
 	}
 }
 
+func TestScalewayProvider_AdjustEndpoints(t *testing.T) {
+	provider := &ScalewayProvider{}
+
+	before := []*endpoint.Endpoint{
+		{
+			DNSName:    "one.example.com",
+			RecordTTL:  300,
+			RecordType: "A",
+			Targets:    []string{"1.1.1.1"},
+			ProviderSpecific: endpoint.ProviderSpecific{
+				{
+					Name:  scalewayPriorityKey,
+					Value: "0",
+				},
+			},
+		},
+		{
+			DNSName:    "two.example.com",
+			RecordTTL:  0,
+			RecordType: "A",
+			Targets:    []string{"1.1.1.1"},
+			ProviderSpecific: endpoint.ProviderSpecific{
+				{
+					Name:  scalewayPriorityKey,
+					Value: "10",
+				},
+			},
+		},
+		{
+			DNSName:          "three.example.com",
+			RecordTTL:        600,
+			RecordType:       "A",
+			Targets:          []string{"1.1.1.1"},
+			ProviderSpecific: endpoint.ProviderSpecific{},
+		},
+	}
+
+	expected := []*endpoint.Endpoint{
+		{
+			DNSName:    "one.example.com",
+			RecordTTL:  300,
+			RecordType: "A",
+			Targets:    []string{"1.1.1.1"},
+			ProviderSpecific: endpoint.ProviderSpecific{
+				{
+					Name:  scalewayPriorityKey,
+					Value: "0",
+				},
+			},
+		},
+		{
+			DNSName:    "two.example.com",
+			RecordTTL:  300,
+			RecordType: "A",
+			Targets:    []string{"1.1.1.1"},
+			ProviderSpecific: endpoint.ProviderSpecific{
+				{
+					Name:  scalewayPriorityKey,
+					Value: "10",
+				},
+			},
+		},
+		{
+			DNSName:    "three.example.com",
+			RecordTTL:  600,
+			RecordType: "A",
+			Targets:    []string{"1.1.1.1"},
+			ProviderSpecific: endpoint.ProviderSpecific{
+				{
+					Name:  scalewayPriorityKey,
+					Value: "0",
+				},
+			},
+		},
+	}
+
+	after := provider.AdjustEndpoints(before)
+	for i := range after {
+		if !checkRecordEquality(after[i], expected[i]) {
+			t.Errorf("got record %s instead of %s", after[i], expected[i])
+		}
+	}
+}
+
 func TestScalewayProvider_Zones(t *testing.T) {
 	mocked := mockScalewayDomain{nil}
 	provider := &ScalewayProvider{


### PR DESCRIPTION
Signed-off-by: Patrik Cyvoct <patrik@ptrk.io>

**Description**

Bump the API version of the Scaleway DNS to v2beta1

**Checklist**

- [x ] Unit tests updated

~Waiting for #1859 to rebase on it~ 
/hold
