### PR TITLE
remove duplicate endpoints when processing VirtualService

### DIFF
--- a/source/virtualservice.go
+++ b/source/virtualservice.go
@@ -317,7 +317,8 @@ func (sc *virtualServiceSource) setResourceLabel(virtualservice networkingv1alph
 	}
 }
 
-func appendIfMissing(targets []string, target string) []string {
+// append a target to the list of targets unless it's already in the list
+func appendUnique(targets []string, target string) []string {
 	for _, element := range targets {
 		if element == target {
 			return targets
@@ -342,7 +343,7 @@ func (sc *virtualServiceSource) targetsFromVirtualService(ctx context.Context, v
 			return targets, err
 		}
 		for _, target := range tgs {
-			targets = appendIfMissing(targets, target)
+			targets = appendUnique(targets, target)
 		}
 	}
 

--- a/source/virtualservice.go
+++ b/source/virtualservice.go
@@ -317,6 +317,15 @@ func (sc *virtualServiceSource) setResourceLabel(virtualservice networkingv1alph
 	}
 }
 
+func appendIfMissing(targets []string, target string) []string {
+	for _, element := range targets {
+		if element == target {
+			return targets
+		}
+	}
+	return append(targets, target)
+}
+
 func (sc *virtualServiceSource) targetsFromVirtualService(ctx context.Context, virtualService networkingv1alpha3.VirtualService, vsHost string) ([]string, error) {
 	var targets []string
 	// for each host we need to iterate through the gateways because each host might match for only one of the gateways
@@ -332,7 +341,9 @@ func (sc *virtualServiceSource) targetsFromVirtualService(ctx context.Context, v
 		if err != nil {
 			return targets, err
 		}
-		targets = append(targets, tgs...)
+		for _, target := range tgs {
+			targets = appendIfMissing(targets, target)
+		}
 	}
 
 	return targets, nil

--- a/source/virtualservice_test.go
+++ b/source/virtualservice_test.go
@@ -619,6 +619,41 @@ func testVirtualServiceEndpoints(t *testing.T) {
 			},
 		},
 		{
+			title: "one virtualservice with two gateways, one ingressgateway loadbalancer service",
+			lbServices: []fakeIngressGatewayService{
+				{
+					namespace: namespace,
+					ips:       []string{"8.8.8.8"},
+				},
+			},
+			gwConfigs: []fakeGatewayConfig{
+				{
+					name:      "gw1",
+					namespace: namespace,
+					dnsnames:  [][]string{{"*"}},
+				},
+				{
+					name:      "gw2",
+					namespace: namespace,
+					dnsnames:  [][]string{{"*"}},
+				},
+			},
+			vsConfigs: []fakeVirtualServiceConfig{
+				{
+					name:      "vs",
+					namespace: namespace,
+					gateways:  []string{"gw1", "gw2"},
+					dnsnames:  []string{"example.org"},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName: "example.org",
+					Targets: endpoint.Targets{"8.8.8.8"},
+				},
+			},
+		},
+		{
 			title: "two simple virtualservices on different namespaces with the same target gateway, one ingressgateway loadbalancer service",
 			lbServices: []fakeIngressGatewayService{
 				{


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Remove duplicates when collecting endpoints for Istio VirtualServices. Rather than always appending endpoints, check that it's not already in the list first.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1949 

**Checklist**

- [ *] Unit tests updated
- [ ] End user documentation updated
