### PR TITLE
Fix typo in scaleway provider

### DIFF
--- a/provider/scaleway/scaleway.go
+++ b/provider/scaleway/scaleway.go
@@ -136,7 +136,7 @@ func (p *ScalewayProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, e
 			// In this case, we juste take the first one.
 			if existingEndpoint, ok := endpoints[record.Type.String()+"/"+fullRecordName]; ok {
 				existingEndpoint.Targets = append(existingEndpoint.Targets, record.Data)
-				log.Infof("Appending target %s to record %s, using TTL and priotiry of target %s", record.Data, fullRecordName, existingEndpoint.Targets[0])
+				log.Infof("Appending target %s to record %s, using TTL and priority of target %s", record.Data, fullRecordName, existingEndpoint.Targets[0])
 			} else {
 				ep := endpoint.NewEndpointWithTTL(fullRecordName, record.Type.String(), endpoint.TTL(record.TTL), record.Data)
 				ep = ep.WithProviderSpecific(scalewayPriorityKey, fmt.Sprintf("%d", record.Priority))


### PR DESCRIPTION
Replaces https://github.com/kubernetes-sigs/external-dns/pull/1947 

/cc @njuettner 