### PR TITLE
Make Powerdns support rrsets with multiple records more smartly

### DIFF
--- a/provider/pdns/pdns.go
+++ b/provider/pdns/pdns.go
@@ -257,13 +257,16 @@ func NewPDNSProvider(ctx context.Context, config PDNSConfig) (*PDNSProvider, err
 
 func (p *PDNSProvider) convertRRSetToEndpoints(rr pgo.RrSet) (endpoints []*endpoint.Endpoint, _ error) {
 	endpoints = []*endpoint.Endpoint{}
+	var targets = []string{}
 
 	for _, record := range rr.Records {
 		// If a record is "Disabled", it's not supposed to be "visible"
 		if !record.Disabled {
-			endpoints = append(endpoints, endpoint.NewEndpointWithTTL(rr.Name, rr.Type_, endpoint.TTL(rr.Ttl), record.Content))
+			targets = append(targets, record.Content)
 		}
 	}
+
+	endpoints = append(endpoints, endpoint.NewEndpointWithTTL(rr.Name, rr.Type_, endpoint.TTL(rr.Ttl), targets...))
 	return endpoints, nil
 }
 

--- a/provider/pdns/pdns_test.go
+++ b/provider/pdns/pdns_test.go
@@ -125,17 +125,13 @@ var (
 		endpoint.NewEndpointWithTTL("does.not.exist.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
 	}
 	endpointsMultipleRecords = []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.4.4"),
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "4.4.4.4"),
+		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8", "8.8.4.4", "4.4.4.4"),
 	}
 
 	endpointsMixedRecords = []*endpoint.Endpoint{
 		endpoint.NewEndpointWithTTL("cname.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(300), "example.by.any.other.name.com"),
 		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "'would smell as sweet'"),
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.4.4"),
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "4.4.4.4"),
+		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8", "8.8.4.4", "4.4.4.4"),
 	}
 
 	endpointsMultipleZones = []*endpoint.Endpoint{


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Hey!

I'm not sure if I've overlooked something here but I've written in in #1967 about the problem I saw where external-dns would continually update a zone even when it was already in the correct state.

From my debugging it appears this is down to the way it fetches its Endpoints from the pdns API. I can't see *why* it's written as it is but I think my change is legit.

I've tweaked the pdns provider so that when it encounters an rrset with multiple records, instead of building one Endpoint per record, it builds a single Endpoint with multiple targets. This stops it from making the same update over and over. 

I will add this is my first time writing any Go so please shout at me if I've done something dumb -- even in this small PR!

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1967 

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
