### PR TITLE
Bump alpine base image to 3.13.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY . .
 RUN make test build.$ARCH
 
 # final image
-FROM $ARCH/alpine:3.12
+FROM $ARCH/alpine:3.13.2
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /bin/external-dns

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ build.push/multiarch:
 	for arch in $(ARCHS); do \
 		image="$(IMAGE):$(VERSION)-$${arch}" ;\
 		# pre-pull due to https://github.com/kubernetes-sigs/cluster-addons/pull/84/files ;\
-		docker pull $${arch}/alpine:3.12 ;\
+		docker pull $${arch}/alpine:3.13.2 ;\
 		DOCKER_BUILDKIT=1 docker build --rm --tag $${image} --build-arg VERSION="$(VERSION)" --build-arg ARCH="$${arch}" . ;\
 		docker push $${image} ;\
 		arch_specific_tags+=( "--amend $${image}" ) ;\


### PR DESCRIPTION
**Description**

This bump the alpine base image from 3.12 to 3.13.2. Please advise if you prefer using 3.13 instead of the specific patch version.
