### PR TITLE
Approve crd v1

### DIFF
--- a/docs/contributing/crd-source/crd-manifest.yaml
+++ b/docs/contributing/crd-source/crd-manifest.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
+    api-approved.kubernetes.io: "https://github.com/kubernetes-sigs/external-dns/pull/2007"
   creationTimestamp: null
   name: dnsendpoints.externaldns.k8s.io
 spec:


### PR DESCRIPTION
All CRDs under k8s.io and kubernetes.io API groups should go through API
approval.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
CRD must be approved

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
