### PR TITLE
Fix CNAME update for hetzner provider

### DIFF
--- a/provider/hetzner/hetzner.go
+++ b/provider/hetzner/hetzner.go
@@ -152,14 +152,6 @@ func (p *HetznerProvider) submitChanges(ctx context.Context, changes []*HetznerC
 				"zone_id": change.ZoneID,
 			}).Info("Changing record")
 
-			change.ResourceRecordSet.Name = strings.TrimSuffix(change.ResourceRecordSet.Name, "."+change.ZoneName)
-			if change.ResourceRecordSet.Name == change.ZoneName {
-				change.ResourceRecordSet.Name = "@"
-			}
-			if change.ResourceRecordSet.RecordType == endpoint.RecordTypeCNAME {
-				change.ResourceRecordSet.Value += "."
-			}
-
 			switch change.Action {
 			case hetznerCreate:
 				record := hclouddns.HCloudRecord{


### PR DESCRIPTION
**Description**

The name conditioning was applied twice which caused CNAMES to be suffixed by a double '.'. This leads to the value being rejected by the Hetzner API with error-code 422 which is not being checked at the moment.

We should probably check the error-code to be 0 so this doesn't fail silently, I can do that in another PR.

Fixes #1869

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated

/assign @21h 