### PR TITLE
Add support for record ownership transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ The following tutorials are provided:
 * [Vultr](docs/tutorials/vultr.md)
 * [UltraDNS](docs/tutorials/ultradns.md)
 * [GoDaddy](docs/tutorials/godaddy.md)
+* [Ownership Transfer](docs/tutorials/ownership-transfer.md)
 
 ### Running Locally
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -129,6 +129,7 @@ func (c *Controller) RunOnce(ctx context.Context) error {
 		deprecatedRegistryErrors.Inc()
 		return err
 	}
+
 	registryEndpointsTotal.Set(float64(len(records)))
 
 	ctx = context.WithValue(ctx, provider.RecordsContextKey, records)

--- a/docs/tutorials/ownership-transfer.md
+++ b/docs/tutorials/ownership-transfer.md
@@ -1,0 +1,83 @@
+# Transferring ownership between resources
+
+When using a [registry](../proposal/registry.md) (aside from noop), it is possible to transfer ownership from
+one Kubernets resource to another, even between different instances of external-dns. For this purpose the following
+annotations are available:
+
+```
+external-dns.alpha.kubernetes.io/permit-claim-by-owner: "<owner id>"
+external-dns.alpha.kubernetes.io/permit-claim-by-resource: "<source>/<namespace>/<resource name>"
+external-dns.alpha.kubernetes.io/claim: "<true|false>"
+```
+
+The "owner id" is a value as set by the `--txt-owner-id` parameter. "source" is an identifier used by the sources activated
+with  the `--source` parameter. Check the documentation of the different source (or the source if necessary) for the different
+ids used by the providers.
+
+If a resource wants to permit another resource to claim the record it holds ownership of, it has to set
+the `external-dns.alpha.kubernetes.io/permit-claim-by-resource` and optionally the `external-dns.alpha.kubernetes.io/permit-claim-by-owner` annotations. If the `permit-claim-by-owner` annotation is not set, it is assumed to have the same
+value as the current owner of the resource (e.g. given a resource with the owner id of "x", setting the `permit-claim-by-resource` and leaving the `permit-claim-by-owner` annotation away would result in `permit-claim-by-owner` being set to "x").
+
+Setting only the 
+
+If a resource wants to claim ownership of a record for which it has permission to do so (e.g. its `<source>/<namespace>/<resource name>` matches and it is managed by an external-dns instance configured with the proper owner id), it has to set the `external-dns.alpha.kubernetes.io/claim` annotation to "true".
+
+Note: the `<source>/<namespace>/<resource name>` value of a claiming resource cannot be set manually, it actually has to be a
+resource with the proper name in the proper namespace, managed by the appropriate [source module](../contributing/sources-and-providers.md) of external-dns.
+
+## Example
+
+The resource that wants to transfer its ownership:
+
+```yaml
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: ns-record-a
+  annotations:
+    external-dns.alpha.kubernetes.io/permit-claim-by-resource: "crd/external-dns/ns-record-a"
+    external-dns.alpha.kubernetes.io/permit-claim-by-owner: "someowner"
+spec:
+  endpoints:
+  - dnsName: zone.example.com
+    recordTTL: 300
+    recordType: NS
+    targets:
+    - ns1.example.com
+    - ns2.example.com
+```
+
+The example assumes the resource is managed by an external-dns instance with `--txt-owner-id` != "someowner" and `--source=crd`.
+
+The resource that wants to claim ownership:
+
+```yaml
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: ns-record-b
+  namespace: external-dns
+  annotations:
+    external-dns.alpha.kubernetes.io/claim: "true"
+spec:
+  endpoints:
+  - dnsName: zone.example.com
+    recordTTL: 300
+    recordType: NS
+    targets:
+    - ns1.example.com
+    - ns2.example.com
+```
+
+The example assumes the resource is managed by an external-dns instance with `--txt-owner-id=someowner` and `--source=crd`.
+
+## Resource priority
+
+To allow for ownership transfers between Kubernetes resources managed by the same external-dns instance, 
+Kubernetes resources with `external-dns.alpha.kubernetes.io/claim: "true"` have a higher priority than resources
+without that label, if the dns record has proper claim permissions set.
+
+Given the above resources, if both would be managed by the same external-dns instance (e.g. both have the same owner,
+but the owner id not "someowner"), updates to the "ns-record-a" resource would be ignored by external-dns because
+the "ns-record-b" resource has a higher priority and matches the `external-dns.alpha.kubernetes.io/permit-claim-by-resource`
+annotation of "ns-record-a".

--- a/endpoint/labels.go
+++ b/endpoint/labels.go
@@ -35,6 +35,15 @@ const (
 	// ResourceLabelKey is the name of the label that identifies k8s resource which wants to acquire the DNS name
 	ResourceLabelKey = "resource"
 
+	// PermitClaimByOwnerLabelKey is the name of the label that defines which owner is permitted to claim ownership of an Endpoint.
+	PermitClaimByOwnerLabelKey = "permit-claim-by-owner"
+
+	// PermitClaimByResourceLabelKey is the name of the label that identifies which resource is permitted to claim ownership of an Endpoint.
+	PermitClaimByResourceLabelKey = "permit-claim-by-resource"
+
+	// ClaimLabelKey is the name of the label that denotes if an endpoint wants to claim an already existind record
+	ClaimLabelKey = "claim"
+
 	// AWSSDDescriptionLabel label responsible for storing raw owner/resource combination information in the Labels
 	// supposed to be inserted by AWS SD Provider, and parsed into OwnerLabelKey and ResourceLabelKey key by AWS SD Registry
 	AWSSDDescriptionLabel = "aws-sd-description"

--- a/internal/testutils/endpoint.go
+++ b/internal/testutils/endpoint.go
@@ -49,6 +49,8 @@ func SameEndpoint(a, b *endpoint.Endpoint) bool {
 	return a.DNSName == b.DNSName && a.Targets.Same(b.Targets) && a.RecordType == b.RecordType && a.SetIdentifier == b.SetIdentifier &&
 		a.Labels[endpoint.OwnerLabelKey] == b.Labels[endpoint.OwnerLabelKey] && a.RecordTTL == b.RecordTTL &&
 		a.Labels[endpoint.ResourceLabelKey] == b.Labels[endpoint.ResourceLabelKey] &&
+		a.Labels[endpoint.PermitClaimByOwnerLabelKey] == b.Labels[endpoint.PermitClaimByOwnerLabelKey] &&
+		a.Labels[endpoint.PermitClaimByResourceLabelKey] == b.Labels[endpoint.PermitClaimByResourceLabelKey] &&
 		SameProviderSpecific(a.ProviderSpecific, b.ProviderSpecific)
 }
 

--- a/registry/aws_sd_registry.go
+++ b/registry/aws_sd_registry.go
@@ -73,6 +73,17 @@ func (sdr *AWSSDRegistry) ApplyChanges(ctx context.Context, changes *plan.Change
 		Delete:    filterOwnedRecords(sdr.ownerID, changes.Delete),
 	}
 
+	for _, ep := range filteredChanges.Create {
+		ep.EnsureOwnerClaimPermission(sdr.ownerID)
+	}
+
+	for _, ep := range filteredChanges.UpdateNew {
+		ep.EnsureOwnerClaimPermission(sdr.ownerID)
+		if ep.OwnerClaimPermitted(sdr.ownerID) {
+			ep.Labels[endpoint.OwnerLabelKey] = sdr.ownerID
+		}
+	}
+
 	sdr.updateLabels(filteredChanges.Create)
 	sdr.updateLabels(filteredChanges.UpdateNew)
 	sdr.updateLabels(filteredChanges.UpdateOld)

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -597,6 +597,7 @@ func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 		Create: []*endpoint.Endpoint{
 			newEndpointWithOwner("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, ""),
 			newEndpointWithOwner("example", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwnerAndLabels("claimable.test-zone.example.org", "claimable.loadbalancer.com", endpoint.RecordTypeCNAME, "", endpoint.Labels{endpoint.PermitClaimByResourceLabelKey: "ingress/default/someingress"}),
 		},
 		Delete: []*endpoint.Endpoint{
 			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
@@ -614,6 +615,8 @@ func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 			newEndpointWithOwner("new-record-1.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("example", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "owner"),
 			newEndpointWithOwner("example", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwnerAndLabels("claimable.test-zone.example.org", "claimable.loadbalancer.com", endpoint.RecordTypeCNAME, "owner", endpoint.Labels{endpoint.PermitClaimByResourceLabelKey: "ingress/default/someingress", endpoint.PermitClaimByOwnerLabelKey: "owner"}),
+			newEndpointWithOwner("claimable.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/permit-claim-by-owner=owner,external-dns/permit-claim-by-resource=ingress/default/someingress\"", endpoint.RecordTypeTXT, ""),
 		},
 		Delete: []*endpoint.Endpoint{
 			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),

--- a/source/crd.go
+++ b/source/crd.go
@@ -170,6 +170,7 @@ func (cs *crdSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 		}
 
 		cs.setResourceLabel(&dnsEndpoint, crdEndpoints)
+		addClaimLabels(dnsEndpoint.Annotations, crdEndpoints)
 		endpoints = append(endpoints, crdEndpoints...)
 
 		if dnsEndpoint.Status.ObservedGeneration == dnsEndpoint.Generation {

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -193,6 +193,7 @@ func (sc *gatewaySource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, e
 
 		log.Debugf("Endpoints generated from gateway: %s/%s: %v", gateway.Namespace, gateway.Name, gwEndpoints)
 		sc.setResourceLabel(gateway, gwEndpoints)
+		addClaimLabels(gateway.Annotations, gwEndpoints)
 		endpoints = append(endpoints, gwEndpoints...)
 	}
 

--- a/source/httpproxy.go
+++ b/source/httpproxy.go
@@ -186,6 +186,7 @@ func (sc *httpProxySource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint,
 
 		log.Debugf("Endpoints generated from HTTPProxy: %s/%s: %v", hp.Namespace, hp.Name, hpEndpoints)
 		sc.setResourceLabel(hp, hpEndpoints)
+		addClaimLabels(hp.Annotations, hpEndpoints)
 		endpoints = append(endpoints, hpEndpoints...)
 	}
 

--- a/source/ingress.go
+++ b/source/ingress.go
@@ -158,6 +158,7 @@ func (sc *ingressSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, e
 		log.Debugf("Endpoints generated from ingress: %s/%s: %v", ing.Namespace, ing.Name, ingEndpoints)
 		sc.setResourceLabel(ing, ingEndpoints)
 		sc.setDualstackLabel(ing, ingEndpoints)
+		addClaimLabels(ing.Annotations, ingEndpoints)
 		endpoints = append(endpoints, ingEndpoints...)
 	}
 

--- a/source/ingressroute.go
+++ b/source/ingressroute.go
@@ -197,6 +197,7 @@ func (sc *ingressRouteSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoi
 
 		log.Debugf("Endpoints generated from ingressroute: %s/%s: %v", ir.Namespace, ir.Name, irEndpoints)
 		sc.setResourceLabel(ir, irEndpoints)
+		addClaimLabels(ir.Annotations, irEndpoints)
 		endpoints = append(endpoints, irEndpoints...)
 	}
 

--- a/source/ocproute.go
+++ b/source/ocproute.go
@@ -160,6 +160,7 @@ func (ors *ocpRouteSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint,
 
 		log.Debugf("Endpoints generated from OpenShift Route: %s/%s: %v", ocpRoute.Namespace, ocpRoute.Name, orEndpoints)
 		ors.setResourceLabel(ocpRoute, orEndpoints)
+		addClaimLabels(ocpRoute.Annotations, orEndpoints)
 		endpoints = append(endpoints, orEndpoints...)
 	}
 

--- a/source/routegroup.go
+++ b/source/routegroup.go
@@ -290,6 +290,7 @@ func (sc *routeGroupSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint
 		log.Debugf("Endpoints generated from ingress: %s/%s: %v", rg.Metadata.Namespace, rg.Metadata.Name, eps)
 		sc.setRouteGroupResourceLabel(rg, eps)
 		sc.setRouteGroupDualstackLabel(rg, eps)
+		addClaimLabels(rg.Metadata.Annotations, eps)
 		endpoints = append(endpoints, eps...)
 	}
 

--- a/source/service.go
+++ b/source/service.go
@@ -211,6 +211,7 @@ func (sc *serviceSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, e
 
 		log.Debugf("Endpoints generated from service: %s/%s: %v", svc.Namespace, svc.Name, svcEndpoints)
 		sc.setResourceLabel(svc, svcEndpoints)
+		addClaimLabels(svc.Annotations, svcEndpoints)
 		endpoints = append(endpoints, svcEndpoints...)
 	}
 

--- a/source/virtualservice.go
+++ b/source/virtualservice.go
@@ -191,6 +191,7 @@ func (sc *virtualServiceSource) Endpoints(ctx context.Context) ([]*endpoint.Endp
 
 		log.Debugf("Endpoints generated from VirtualService: %s/%s: %v", virtualService.Namespace, virtualService.Name, gwEndpoints)
 		sc.setResourceLabel(virtualService, gwEndpoints)
+		addClaimLabels(virtualService.Annotations, gwEndpoints)
 		endpoints = append(endpoints, gwEndpoints...)
 	}
 


### PR DESCRIPTION
**Description**
This PR introduces the following annotations to allow for record ownership transfer between different Kubernetes resources and external-dns instances:

* external-dns.alpha.kubernetes.io/permit-claim-by-owner
* external-dns.alpha.kubernetes.io/permit-claim-by-resource
* external-dns.alpha.kubernetes.io/claim

The base idea is to provide a way to migrate an application that is using external-dns from one Kubernetes cluster to another, without having to manually edit the TXT records managed by the registry.

The AWS SD based registry should work too, but has not been tested.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
