### PR TITLE
Downgrade Azure provider "Failed to extract" log message to debug

### DIFF
--- a/provider/azure/azure.go
+++ b/provider/azure/azure.go
@@ -119,7 +119,7 @@ func (p *AzureProvider) Records(ctx context.Context) (endpoints []*endpoint.Endp
 			}
 			targets := extractAzureTargets(&recordSet)
 			if len(targets) == 0 {
-				log.Errorf("Failed to extract targets for '%s' with type '%s'.", name, recordType)
+				log.Debugf("Failed to extract targets for '%s' with type '%s'.", name, recordType)
 				return true
 			}
 			var ttl endpoint.TTL


### PR DESCRIPTION
The only thing present in the external-dns when running with the Azure provider is:
```
time="2021-03-19T21:11:37Z" level=error msg="Failed to extract targets for 'example.com' with type 'NS'."
time="2021-03-19T21:12:37Z" level=error msg="Failed to extract targets for 'example.com' with type 'NS'."
time="2021-03-19T21:13:38Z" level=error msg="Failed to extract targets for 'example.com' with type 'NS'."
time="2021-03-19T21:14:38Z" level=error msg="Failed to extract targets for 'example.com' with type 'NS'."
time="2021-03-19T21:15:39Z" level=error msg="Failed to extract targets for 'example.com' with type 'NS'."
time="2021-03-19T21:16:39Z" level=error msg="Failed to extract targets for 'example.com' with type 'NS'."
time="2021-03-19T21:17:40Z" level=error msg="Failed to extract targets for 'example.com' with type 'NS'."
time="2021-03-19T21:18:47Z" level=error msg="Failed to extract targets for 'example.com' with type 'NS'."
```
It is not really an error to have an NS record in one's zone. Nor is external-dns expected to act on it. Looking at the Azure private provider https://github.com/kubernetes-sigs/external-dns/blob/030d86c201c7cc0f73fc9d41df09b93c6788832a/provider/azure/azure_private_dns.go#L117, this message is debug, which seems more reasonable. This PR changes the Azure public provider to match.