### PR TITLE
fix(scaleway): drop support for organization ID as it's not needed

### DIFF
--- a/docs/tutorials/scaleway.md
+++ b/docs/tutorials/scaleway.md
@@ -24,7 +24,6 @@ Note that you will also need to the Organization ID, which can be retrieve on th
 Three environment variables are needed to run ExternalDNS with Scaleway DNS:
 - `SCW_ACCESS_KEY` which is the Access Key.
 - `SCW_SECRET_KEY` which is the Secret Key.
-- `SCW_DEFAULT_ORGANIZATION_ID` which is your Organization ID.
 
 ## Deploy ExternalDNS
 
@@ -63,8 +62,6 @@ spec:
           value: "<your access key>"
         - name: SCW_SECRET_KEY
           value: "<your secret key>"
-        - name: SCW_DEFAULT_ORGANIZATION_ID
-          value: "<your organization ID>"
 ```
 
 ### Manifest (for clusters with RBAC enabled)
@@ -131,8 +128,6 @@ spec:
           value: "<your access key>"
         - name: SCW_SECRET_KEY
           value: "<your secret key>"
-        - name: SCW_DEFAULT_ORGANIZATION_ID
-          value: "<your organization ID>"
 ```
 
 

--- a/provider/scaleway/scaleway.go
+++ b/provider/scaleway/scaleway.go
@@ -63,10 +63,6 @@ func NewScalewayProvider(ctx context.Context, domainFilter endpoint.DomainFilter
 		return nil, err
 	}
 
-	if _, ok := scwClient.GetDefaultOrganizationID(); !ok {
-		return nil, fmt.Errorf("default organization is not set")
-	}
-
 	if _, ok := scwClient.GetAccessKey(); !ok {
 		return nil, fmt.Errorf("access key no set")
 	}

--- a/provider/scaleway/scaleway_test.go
+++ b/provider/scaleway/scaleway_test.go
@@ -113,26 +113,12 @@ func (m *mockScalewayDomain) UpdateDNSZoneRecords(req *domain.UpdateDNSZoneRecor
 func TestScalewayProvider_NewScalewayProvider(t *testing.T) {
 	_ = os.Setenv(scw.ScwAccessKeyEnv, "SCWXXXXXXXXXXXXXXXXX")
 	_ = os.Setenv(scw.ScwSecretKeyEnv, "11111111-1111-1111-1111-111111111111")
-	_ = os.Setenv(scw.ScwDefaultOrganizationIDEnv, "11111111-1111-1111-1111-111111111111")
 	_, err := NewScalewayProvider(context.TODO(), endpoint.NewDomainFilter([]string{"example.com"}), true)
 	if err != nil {
 		t.Errorf("failed : %s", err)
 	}
 
-	_ = os.Unsetenv(scw.ScwDefaultOrganizationIDEnv)
-	_, err = NewScalewayProvider(context.TODO(), endpoint.NewDomainFilter([]string{"example.com"}), true)
-	if err == nil {
-		t.Errorf("expected to fail")
-	}
-
-	_ = os.Setenv(scw.ScwDefaultOrganizationIDEnv, "dummy")
-	_, err = NewScalewayProvider(context.TODO(), endpoint.NewDomainFilter([]string{"example.com"}), true)
-	if err == nil {
-		t.Errorf("expected to fail")
-	}
-
 	_ = os.Unsetenv(scw.ScwSecretKeyEnv)
-	_ = os.Setenv(scw.ScwDefaultOrganizationIDEnv, "11111111-1111-1111-1111-111111111111")
 	_, err = NewScalewayProvider(context.TODO(), endpoint.NewDomainFilter([]string{"example.com"}), true)
 	if err == nil {
 		t.Errorf("expected to fail")


### PR DESCRIPTION
Signed-off-by: Patrik Cyvoct <patrik@ptrk.io>

**Description**

This PR drop the need to specify the Scaleway Organization ID as it's not needed.
I'll update the documentation once the new release is cut.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
