### PR TITLE
Avoid nil pointer deference in extractHeadlessEndpoints

### DIFF
--- a/source/service.go
+++ b/source/service.go
@@ -284,7 +284,7 @@ func (sc *serviceSource) extractHeadlessEndpoints(svc *v1.Service, hostname stri
 
 		for _, address := range addresses {
 			// find pod for this address
-			if address.TargetRef.APIVersion != "" || address.TargetRef.Kind != "Pod" {
+			if address.TargetRef == nil || address.TargetRef.APIVersion != "" || address.TargetRef.Kind != "Pod" {
 				log.Debugf("Skipping address because its target is not a pod: %v", address)
 				continue
 			}


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Avoid a nil pointer deference in extractHeadlessEndpoints when TargetRef is nil. This was observed for an endpoint created by `kube-prometheus-stack`.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2029

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
