### PR TITLE
Add NLB IP dualstack mode support (ipv6 support for NLB)

### DIFF
--- a/docs/tutorials/aws-load-balancer-controller.md
+++ b/docs/tutorials/aws-load-balancer-controller.md
@@ -179,3 +179,46 @@ spec:
 The above Ingress object will result in the creation of an ALB with a dualstack
 interface. ExternalDNS will create both an A `echoserver.example.org` record and
 an AAAA record of the same name, that each are aliases for the same ALB.
+
+## Dualstack NLBs
+
+[AWS Load Balancer Controller][5] satisifies service of "LoadBalancer"
+type with annotation `service.beta.kubernetes.io/aws-load-balancer-type` value
+`nlb-ip`.  This service supports dualstack mode via
+`service.beta.kubernetes.io/aws-load-balancer-ip-address-type` [annotation][6]
+(which defaults to `ipv4`). If this annotation is set to `dualstack` then
+ExternalDNS will create two alias records (one A record and one AAAA record)
+for each hostname associated with the Ingress object.
+
+[5]: https://github.com/kubernetes-sigs/aws-load-balancer-controller#aws-load-balancer-controller
+[6]: https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/guide/service/annotations.md
+
+Example:
+
+```yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-svc
+  labels:
+    app.kubernetes.io/name: my-app
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: foo.example.com
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb-ip"
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "tcp"
+    service.beta.kubernetes.io/aws-load-balancer-ip-address-type: "dualstack"
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    app: my-app
+```
+
+The above Service object will result in the creation of an NLB with a dualstack
+interface. ExternalDNS will create both an A `echoserver.example.org` record and
+an AAAA record of the same name, that each are aliases for the same NLB.

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -48,9 +48,11 @@ func (suite *ServiceSuite) SetupTest() {
 			Type: v1.ServiceTypeLoadBalancer,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   "default",
-			Name:        "foo-with-targets",
-			Annotations: map[string]string{},
+			Namespace: "default",
+			Name:      "foo-with-targets",
+			Annotations: map[string]string{
+				NLBDualstackAnnotationKey: NLBDualstackAnnotationValue,
+			},
 		},
 		Status: v1.ServiceStatus{
 			LoadBalancer: v1.LoadBalancerStatus{
@@ -2965,6 +2967,13 @@ func TestExternalServices(t *testing.T) {
 			// Validate returned endpoints against desired endpoints.
 			validateEndpoints(t, endpoints, tc.expected)
 		})
+	}
+}
+
+func (suite *ServiceSuite) TestDualstackLabelIsSet() {
+	endpoints, _ := suite.sc.Endpoints(context.TODO())
+	for _, ep := range endpoints {
+		suite.Equal("true", ep.Labels[endpoint.DualstackLabelKey], "should set dualstack label to true")
 	}
 }
 


### PR DESCRIPTION

**Description**

AWS Loadbalancer Ingress controller supports [service resource of
LoadBalancer type](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/guide/service/nlb_ip_mode.md).
Currently dualstack annotation for `service` is ignored by external dns
and corresponding `AAAA` record is not being created.
This PR adds support of ipv6 similar to ingress resource/ALB.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
