### PR TITLE
Add support for the PTR record type in the CRD source

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -151,7 +151,7 @@ func (c *Controller) RunOnce(ctx context.Context) error {
 		Desired:            endpoints,
 		DomainFilter:       c.DomainFilter,
 		PropertyComparator: c.Registry.PropertyValuesEqual,
-		ManagedRecords:     []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
+		ManagedRecords:     []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME, endpoint.RecordTypePTR},
 	}
 
 	plan = plan.Calculate()

--- a/docs/contributing/crd-source.md
+++ b/docs/contributing/crd-source.md
@@ -77,7 +77,7 @@ $ build/external-dns --source crd --crd-source-apiversion externaldns.k8s.io/v1a
 
 ### Creating DNS Records
 
-Create the objects of CRD type by filling in the fields of CRD and DNS record would be created accordingly.
+Create the objects of CRD type by filling in the fields of CRD and DNS record would be created accordingly. Currently, the following DNS record types are supported: A, CNAME, TXT, SRV, NS and PTR
 
 ### Example
 

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -35,6 +35,8 @@ const (
 	RecordTypeSRV = "SRV"
 	// RecordTypeNS is a RecordType enum value
 	RecordTypeNS = "NS"
+	// RecordTypePTR is a RecordType enum value
+	RecordTypePTR = "PTR"
 )
 
 // TTL is a structure defining the TTL of a DNS record
@@ -149,7 +151,11 @@ func NewEndpoint(dnsName, recordType string, targets ...string) *Endpoint {
 func NewEndpointWithTTL(dnsName, recordType string, ttl TTL, targets ...string) *Endpoint {
 	cleanTargets := make([]string, len(targets))
 	for idx, target := range targets {
-		cleanTargets[idx] = strings.TrimSuffix(target, ".")
+		if recordType == "PTR" {
+			cleanTargets[idx] = target
+		} else {
+			cleanTargets[idx] = strings.TrimSuffix(target, ".")
+		}
 	}
 
 	return &Endpoint{

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -33,6 +33,11 @@ func TestNewEndpoint(t *testing.T) {
 	if w.DNSName != "example.org" || w.Targets[0] != "load-balancer.com" || w.RecordType != "" {
 		t.Error("endpoint is not initialized correctly")
 	}
+
+	p := NewEndpoint("4.3.2.1.in-addr.arpa.", "PTR", "my.load-balancer.com.")
+	if p.DNSName != "4.3.2.1.in-addr.arpa" || p.Targets[0] != "my.load-balancer.com." || p.RecordType != "PTR" {
+		t.Errorf("endpoint is not initialized correctly %s", p.Targets[0])
+	}
 }
 
 func TestTargetsSame(t *testing.T) {

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -160,7 +160,7 @@ func (p *Plan) Calculate() *Plan {
 		Current:        p.Current,
 		Desired:        p.Desired,
 		Changes:        changes,
-		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME, endpoint.RecordTypePTR},
 	}
 
 	return plan

--- a/provider/recordfilter.go
+++ b/provider/recordfilter.go
@@ -20,7 +20,7 @@ package provider
 // Currently A, CNAME, SRV, TXT and NS record types are supported.
 func SupportedRecordType(recordType string) bool {
 	switch recordType {
-	case "A", "CNAME", "SRV", "TXT", "NS":
+	case "A", "CNAME", "SRV", "TXT", "NS", "PTR":
 		return true
 	default:
 		return false

--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -371,6 +371,26 @@ func testCRDSourceEndpoints(t *testing.T) {
 			expectEndpoints: true,
 			expectError:     false,
 		},
+		{
+			title:                "Create PTR record",
+			registeredAPIVersion: "test.k8s.io/v1alpha1",
+			apiVersion:           "test.k8s.io/v1alpha1",
+			registeredKind:       "DNSEndpoint",
+			kind:                 "DNSEndpoint",
+			namespace:            "foo",
+			registeredNamespace:  "foo",
+			labels:               map[string]string{"test": "that"},
+			labelFilter:          "test=that",
+			endpoints: []*endpoint.Endpoint{
+				{DNSName: "1.2.3.4.in-addr.arpa",
+					Targets:    endpoint.Targets{"my.server.org."},
+					RecordType: endpoint.RecordTypePTR,
+					RecordTTL:  180,
+				},
+			},
+			expectEndpoints: true,
+			expectError:     false,
+		},
 	} {
 		t.Run(ti.title, func(t *testing.T) {
 			restClient := startCRDServerToServeTargets(ti.endpoints, ti.registeredAPIVersion, ti.registeredKind, ti.registeredNamespace, "test", ti.annotations, ti.labels, t)


### PR DESCRIPTION
**Add support for the PTR record type in the CRD source **

This change adds support to allow management of PTR records through the DNSEndpoint CRD resource.

**Checklist**

- [X] Unit tests updated
- [X] End user documentation updated
