### PR TITLE
Force pull golang to fix prow build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ build.push/multiarch:
 		image="$(IMAGE):$(VERSION)-$${arch}" ;\
 		# pre-pull due to https://github.com/kubernetes-sigs/cluster-addons/pull/84/files ;\
 		docker pull $${arch}/alpine:3.13 ;\
+		docker pull golang:1.16 ;\
 		DOCKER_BUILDKIT=1 docker build --rm --tag $${image} --build-arg VERSION="$(VERSION)" --build-arg ARCH="$${arch}" . ;\
 		docker push $${image} ;\
 		arch_specific_tags+=( "--amend $${image}" ) ;\


### PR DESCRIPTION
This PR is an attempt at fixing the build to allow us to release the new ExternalDNS images with prow. 

Error is in: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-external-dns-push-images/1387323143240028160 

The idea is to force the pull from the makefile to see if the error will resolve itself. 

/cc @njuettner 