### PR TITLE
Bump CI timeout

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 3000s
+timeout: 5000s
 options:
   substitution_option: ALLOW_LOOSE
 steps:


### PR DESCRIPTION
Our last release build failed with a timeout. This PR gives much more time. We should look into having shorter jobs in the future, but for now we try this. 


/cc @njuettner 