### PR TITLE
bluecat: support getting credentials from environment variables

### DIFF
--- a/provider/bluecat/bluecat.go
+++ b/provider/bluecat/bluecat.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 
@@ -39,8 +40,8 @@ import (
 
 type bluecatConfig struct {
 	GatewayHost      string `json:"gatewayHost"`
-	GatewayUsername  string `json:"gatewayUsername"`
-	GatewayPassword  string `json:"gatewayPassword"`
+	GatewayUsername  string `json:"gatewayUsername,omitempty"`
+	GatewayPassword  string `json:"gatewayPassword,omitempty"`
 	DNSConfiguration string `json:"dnsConfiguration"`
 	View             string `json:"dnsView"`
 	RootZone         string `json:"rootZone"`
@@ -539,9 +540,25 @@ func (p *BluecatProvider) recordSet(ep *endpoint.Endpoint, getObject bool) (reco
 
 // getBluecatGatewayToken retrieves a Bluecat Gateway API token.
 func getBluecatGatewayToken(cfg bluecatConfig) (string, http.Cookie, error) {
+	var username string
+	if cfg.GatewayUsername != "" {
+		username = cfg.GatewayUsername
+	}
+	if v, ok := os.LookupEnv("BLUECAT_USERNAME"); ok {
+		username = v
+	}
+
+	var password string
+	if cfg.GatewayPassword != "" {
+		password = cfg.GatewayPassword
+	}
+	if v, ok := os.LookupEnv("BLUECAT_PASSWORD"); ok {
+		password = v
+	}
+
 	body, err := json.Marshal(map[string]string{
-		"username": cfg.GatewayUsername,
-		"password": cfg.GatewayPassword,
+		"username": username,
+		"password": password,
 	})
 	if err != nil {
 		return "", http.Cookie{}, errors.Wrap(err, "could not unmarshal credentials for bluecat gateway config")


### PR DESCRIPTION
**Description**

Adds support for getting BlueCat API credentials from environment
variables BLUECAT_USERNAME and BLUECAT_PASSWORD. Providing credentails
using the BlueCat JSON configuration file is still supported.
Credentials from environment variables take precedence over credentials
provided in the JSON configuration file.

Using environment variables avoids having to store credentials as k8s
secrets.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
