### PR TITLE
Fix managed-record-types option

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -151,7 +151,7 @@ func (c *Controller) RunOnce(ctx context.Context) error {
 		Desired:            endpoints,
 		DomainFilter:       c.DomainFilter,
 		PropertyComparator: c.Registry.PropertyValuesEqual,
-		ManagedRecords:     []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
+		ManagedRecords:     c.ManagedRecordTypes,
 	}
 
 	plan = plan.Calculate()

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -25,6 +25,7 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/internal/testutils"
+	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
 	"sigs.k8s.io/external-dns/registry"
@@ -95,6 +96,8 @@ func newMockProvider(endpoints []*endpoint.Endpoint, changes *plan.Changes) prov
 func TestRunOnce(t *testing.T) {
 	// Fake some desired endpoints coming from our source.
 	source := new(testutils.MockSource)
+	cfg := externaldns.NewConfig()
+	cfg.ManagedDNSRecordTypes = []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME}
 	source.On("Endpoints").Return([]*endpoint.Endpoint{
 		{
 			DNSName:    "create-record",
@@ -143,9 +146,10 @@ func TestRunOnce(t *testing.T) {
 
 	// Run our controller once to trigger the validation.
 	ctrl := &Controller{
-		Source:   source,
-		Registry: r,
-		Policy:   &plan.SyncPolicy{},
+		Source:             source,
+		Registry:           r,
+		Policy:             &plan.SyncPolicy{},
+		ManagedRecordTypes: cfg.ManagedDNSRecordTypes,
 	}
 
 	assert.NoError(t, ctrl.RunOnce(context.Background()))


### PR DESCRIPTION
Use config option instead of passing just A and CNAME

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2081

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
