### PR TITLE
Add the --default-targets flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -124,6 +124,7 @@ func main() {
 		GlooNamespace:                  cfg.GlooNamespace,
 		SkipperRouteGroupVersion:       cfg.SkipperRouteGroupVersion,
 		RequestTimeout:                 cfg.RequestTimeout,
+		DefaultTargets:                 cfg.DefaultTargets,
 	}
 
 	// Lookup all the selected sources by names and pass them the desired configuration.
@@ -143,7 +144,7 @@ func main() {
 	}
 
 	// Combine multiple sources into a single, deduplicated source.
-	endpointsSource := source.NewDedupSource(source.NewMultiSource(sources))
+	endpointsSource := source.NewDedupSource(source.NewMultiSource(sources, sourceCfg.DefaultTargets))
 
 	// RegexDomainFilter overrides DomainFilter
 	var domainFilter endpoint.DomainFilter

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -45,6 +45,7 @@ type Config struct {
 	APIServerURL                      string
 	KubeConfig                        string
 	RequestTimeout                    time.Duration
+	DefaultTargets                    []string
 	ContourLoadBalancerService        string
 	GlooNamespace                     string
 	SkipperRouteGroupVersion          string
@@ -173,6 +174,7 @@ var defaultConfig = &Config{
 	APIServerURL:                "",
 	KubeConfig:                  "",
 	RequestTimeout:              time.Second * 30,
+	DefaultTargets:              []string{},
 	ContourLoadBalancerService:  "heptio-contour/contour",
 	GlooNamespace:               "gloo-system",
 	SkipperRouteGroupVersion:    "zalando.org/v1",
@@ -365,6 +367,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("crd-source-kind", "Kind of the CRD for the crd source in API group and version specified by crd-source-apiversion").Default(defaultConfig.CRDSourceKind).StringVar(&cfg.CRDSourceKind)
 	app.Flag("service-type-filter", "The service types to take care about (default: all, expected: ClusterIP, NodePort, LoadBalancer or ExternalName)").StringsVar(&cfg.ServiceTypeFilter)
 	app.Flag("managed-record-types", "Comma separated list of record types to manage (default: A, CNAME) (supported records: CNAME, A, NS").Default("A", "CNAME").StringsVar(&cfg.ManagedDNSRecordTypes)
+	app.Flag("default-targets", "Set globally default IP address that will apply as a target instead of source addresses. Specify multiple times for multiple targets (optional)").StringsVar(&cfg.DefaultTargets)
 
 	// Flags related to providers
 	app.Flag("provider", "The DNS provider where the DNS records will be created (required, options: aws, aws-sd, godaddy, google, azure, azure-dns, azure-private-dns, bluecat, cloudflare, rcodezero, digitalocean, hetzner, dnsimple, akamai, infoblox, dyn, designate, coredns, skydns, inmemory, ovh, pdns, oci, exoscale, linode, rfc2136, ns1, transip, vinyldns, rdns, scaleway, vultr, ultradns)").Required().PlaceHolder("provider").EnumVar(&cfg.Provider, "aws", "aws-sd", "google", "azure", "azure-dns", "hetzner", "azure-private-dns", "alibabacloud", "cloudflare", "rcodezero", "digitalocean", "dnsimple", "akamai", "infoblox", "dyn", "designate", "coredns", "skydns", "inmemory", "ovh", "pdns", "oci", "exoscale", "linode", "rfc2136", "ns1", "transip", "vinyldns", "rdns", "scaleway", "vultr", "ultradns", "godaddy", "bluecat")

--- a/source/multi_source.go
+++ b/source/multi_source.go
@@ -24,7 +24,8 @@ import (
 
 // multiSource is a Source that merges the endpoints of its nested Sources.
 type multiSource struct {
-	children []Source
+	children       []Source
+	defaultTargets []string
 }
 
 // Endpoints collects endpoints of all nested Sources and returns them in a single slice.
@@ -36,7 +37,11 @@ func (ms *multiSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, err
 		if err != nil {
 			return nil, err
 		}
-
+		if len(ms.defaultTargets) > 0 {
+			for i := range endpoints {
+				endpoints[i].Targets = ms.defaultTargets
+			}
+		}
 		result = append(result, endpoints...)
 	}
 
@@ -50,6 +55,6 @@ func (ms *multiSource) AddEventHandler(ctx context.Context, handler func()) {
 }
 
 // NewMultiSource creates a new multiSource.
-func NewMultiSource(children []Source) Source {
-	return &multiSource{children: children}
+func NewMultiSource(children []Source, defaultTargets []string) Source {
+	return &multiSource{children: children, defaultTargets: defaultTargets}
 }

--- a/source/multi_source_test.go
+++ b/source/multi_source_test.go
@@ -32,6 +32,7 @@ func TestMultiSource(t *testing.T) {
 	t.Run("Interface", testMultiSourceImplementsSource)
 	t.Run("Endpoints", testMultiSourceEndpoints)
 	t.Run("EndpointsWithError", testMultiSourceEndpointsWithError)
+	t.Run("EndpointsDefaultTargets", testMultiSourceEndpointsDefaultTargets)
 }
 
 // testMultiSourceImplementsSource tests that multiSource is a valid Source.
@@ -83,7 +84,7 @@ func testMultiSourceEndpoints(t *testing.T) {
 			}
 
 			// Create our object under test and get the endpoints.
-			source := NewMultiSource(sources)
+			source := NewMultiSource(sources, nil)
 
 			// Get endpoints from the source.
 			endpoints, err := source.Endpoints(context.Background())
@@ -110,12 +111,46 @@ func testMultiSourceEndpointsWithError(t *testing.T) {
 	src.On("Endpoints").Return(nil, errSomeError)
 
 	// Create our object under test and get the endpoints.
-	source := NewMultiSource([]Source{src})
+	source := NewMultiSource([]Source{src}, nil)
 
 	// Get endpoints from our source.
 	_, err := source.Endpoints(context.Background())
 	assert.EqualError(t, err, "some error")
 
 	// Validate that the nested source was called.
+	src.AssertExpectations(t)
+}
+
+func testMultiSourceEndpointsDefaultTargets(t *testing.T) {
+	// Create the expected default targets
+	defaultTargets := []string{"127.0.0.1", "127.0.0.2"}
+
+	// Create the expected endpoints
+	expectedEndpoints := []*endpoint.Endpoint{
+		{DNSName: "foo", Targets: defaultTargets},
+		{DNSName: "bar", Targets: defaultTargets},
+	}
+
+	// Create the source endpoints with different targets
+	sourceEndpoints := []*endpoint.Endpoint{
+		{DNSName: "foo", Targets: endpoint.Targets{"8.8.8.8"}},
+		{DNSName: "bar", Targets: endpoint.Targets{"8.8.4.4"}},
+	}
+
+	// Create a mocked source returning source targets
+	src := new(testutils.MockSource)
+	src.On("Endpoints").Return(sourceEndpoints, nil)
+
+	// Create our object under test with non-empty defaultTargets and get the endpoints.
+	source := NewMultiSource([]Source{src}, defaultTargets)
+
+	// Get endpoints from our source.
+	endpoints, err := source.Endpoints(context.Background())
+	require.NoError(t, err)
+
+	// Validate returned endpoints against desired endpoints.
+	validateEndpoints(t, endpoints, expectedEndpoints)
+
+	// Validate that the nested sources were called.
 	src.AssertExpectations(t)
 }

--- a/source/store.go
+++ b/source/store.go
@@ -64,6 +64,7 @@ type Config struct {
 	GlooNamespace                  string
 	SkipperRouteGroupVersion       string
 	RequestTimeout                 time.Duration
+	DefaultTargets                 []string
 }
 
 // ClientGenerator provides clients


### PR DESCRIPTION
**Description**

This is a useful feature in environments with public global WAN addresses.
In our case we're using AKS which is Dnat'ed by Azure Firewall, hence ingress/services addresses are private. Only Azure Firewall public IP is exposed.

Fixes #1394 
Fixes #1495

Basically, you can set the `--default-targets` flag which will override the source addresses, e.g.:

```bash
external-dns  --source=ingress  --provider azure-dns --default-targets 8.8.8.8
```


**Checklist**

- [X] Unit tests updated
- [x] End user documentation updated
