### PR TITLE
Fixed AWSSDRegistry nil labels map

### DIFF
--- a/registry/aws_sd_registry.go
+++ b/registry/aws_sd_registry.go
@@ -83,6 +83,9 @@ func (sdr *AWSSDRegistry) ApplyChanges(ctx context.Context, changes *plan.Change
 
 func (sdr *AWSSDRegistry) updateLabels(endpoints []*endpoint.Endpoint) {
 	for _, ep := range endpoints {
+		if ep.Labels == nil {
+			ep.Labels = make(map[string]string)
+		}
 		ep.Labels[endpoint.OwnerLabelKey] = sdr.ownerID
 		ep.Labels[endpoint.AWSSDDescriptionLabel] = ep.Labels.Serialize(false)
 	}

--- a/source/node.go
+++ b/source/node.go
@@ -151,6 +151,7 @@ func (ns *nodeSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, erro
 		}
 
 		ep.Targets = endpoint.Targets(addrs)
+		ep.Labels = endpoint.NewLabels()
 
 		log.Debugf("adding endpoint %s", ep)
 		if _, ok := endpoints[ep.DNSName]; ok {

--- a/source/node_test.go
+++ b/source/node_test.go
@@ -307,6 +307,19 @@ func testNodeSourceEndpoints(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"node with nil Lables returns valid endpoint",
+			"",
+			"",
+			"node1",
+			[]v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}},
+			nil,
+			map[string]string{},
+			[]*endpoint.Endpoint{
+				{RecordType: "A", DNSName: "node1", Targets: endpoint.Targets{"1.2.3.4"}, Labels: map[string]string{}},
+			},
+			false,
+		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
 			// Create a Kubernetes testing client

--- a/source/shared_test.go
+++ b/source/shared_test.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"reflect"
 
 	"sigs.k8s.io/external-dns/endpoint"
 )
@@ -59,5 +60,10 @@ func validateEndpoint(t *testing.T, endpoint, expected *endpoint.Endpoint) {
 	// if non-empty record type is expected, check that it matches.
 	if expected.RecordType != "" && endpoint.RecordType != expected.RecordType {
 		t.Errorf("expected %s, got %s", expected.RecordType, endpoint.RecordType)
+	}
+
+	// if non-empty labels are expected, check that they matches.
+	if expected.Labels != nil && !reflect.DeepEqual(endpoint.Labels,expected.Labels) {
+		t.Errorf("expected %s, got %s", expected.Labels, endpoint.Labels)
 	}
 }


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
Running external-dns for node source with aws-sd registry will crash on initial loop due to labels being nil map.
IDK what would be more suitable fix here:
* to add a simple check to init a map if Endpoint Labels are nil in aws-sd registry
* to init Labels map with NewLabels() when creating Endpoints for node source.

Fixes #2094

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
