### PR TITLE
Emit events on Sources when Providers change records

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/external-dns/provider/digitalocean"
 	"sigs.k8s.io/external-dns/provider/dnsimple"
 	"sigs.k8s.io/external-dns/provider/dyn"
+	"sigs.k8s.io/external-dns/provider/evented"
 	"sigs.k8s.io/external-dns/provider/exoscale"
 	"sigs.k8s.io/external-dns/provider/godaddy"
 	"sigs.k8s.io/external-dns/provider/google"
@@ -126,8 +127,7 @@ func main() {
 		RequestTimeout:                 cfg.RequestTimeout,
 	}
 
-	// Lookup all the selected sources by names and pass them the desired configuration.
-	sources, err := source.ByNames(&source.SingletonClientGenerator{
+	clientGenerator := &source.SingletonClientGenerator{
 		KubeConfig:   cfg.KubeConfig,
 		APIServerURL: cfg.APIServerURL,
 		// If update events are enabled, disable timeout.
@@ -137,7 +137,10 @@ func main() {
 			}
 			return cfg.RequestTimeout
 		}(),
-	}, cfg.Sources, sourceCfg)
+	}
+
+	// Lookup all the selected sources by names and pass them the desired configuration.
+	sources, err := source.ByNames(clientGenerator, cfg.Sources, sourceCfg)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -314,6 +317,11 @@ func main() {
 	default:
 		log.Fatalf("unknown dns provider: %s", cfg.Provider)
 	}
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	p, err = evented.NewEventedProvider(p, clientGenerator)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/provider/evented/evented.go
+++ b/provider/evented/evented.go
@@ -1,0 +1,128 @@
+package evented
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/reference"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
+	"sigs.k8s.io/external-dns/source"
+)
+
+type EventedProvider struct {
+	wrappedProvider provider.Provider
+	eventRecorder   record.EventRecorder
+	kubeClient      kubernetes.Interface
+}
+
+func NewEventedProvider(provider provider.Provider, clientGenerator source.ClientGenerator) (*EventedProvider, error) {
+	client, err := clientGenerator.KubeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	broadcaster := record.NewBroadcaster()
+	broadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: client.CoreV1().Events(v1.NamespaceAll)})
+	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "externaldns"})
+
+	eventedProvider := &EventedProvider{
+		wrappedProvider: provider,
+		eventRecorder:   recorder,
+		kubeClient:      client,
+	}
+
+	return eventedProvider, nil
+}
+
+func (p *EventedProvider) PropertyValuesEqual(name string, previous string, current string) bool {
+	return p.wrappedProvider.PropertyValuesEqual(name, previous, current)
+}
+
+func (p *EventedProvider) Records(ctx context.Context) (endpoints []*endpoint.Endpoint, _ error) {
+	return p.wrappedProvider.Records(ctx)
+}
+
+func (p *EventedProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
+	if err := p.wrappedProvider.ApplyChanges(ctx, changes); err != nil {
+		return err
+	}
+
+	for _, ep := range changes.Create {
+		ref, err := p.parseOwner(ctx, ep.Labels[endpoint.ResourceLabelKey])
+		if err != nil {
+			log.Warnf("Unable to parse owner: %v", err)
+		}
+		if ref != nil {
+			p.eventRecorder.Eventf(ref, v1.EventTypeNormal, "CreateRecord", "Create DNS record '%s' with targets '%s'", ep.DNSName, ep.Targets)
+		}
+	}
+
+	for _, ep := range changes.UpdateNew {
+		ref, err := p.parseOwner(ctx, ep.Labels[endpoint.ResourceLabelKey])
+		if err != nil {
+			log.Warnf("Unable to parse owner: %v", err)
+		}
+		if ref != nil {
+			p.eventRecorder.Eventf(ref, v1.EventTypeNormal, "UpdateRecord", "Update DNS record '%s' with targets '%s'", ep.DNSName, ep.Targets)
+		}
+	}
+
+	for _, ep := range changes.Delete {
+		ref, err := p.parseOwner(ctx, ep.Labels[endpoint.ResourceLabelKey])
+		if err != nil {
+			log.Warnf("Unable to parse owner: %v", err)
+		}
+		if ref != nil {
+			p.eventRecorder.Eventf(ref, v1.EventTypeNormal, "DeleteRecord", "Delete DNS record '%s' with targets '%s'", ep.DNSName, ep.Targets)
+		}
+	}
+
+	return nil
+}
+
+func (p *EventedProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint {
+	return p.wrappedProvider.AdjustEndpoints(endpoints)
+}
+
+func (p *EventedProvider) parseOwner(ctx context.Context, resourceLabelValue string) (*v1.ObjectReference, error) {
+	ownerResource := strings.Split(resourceLabelValue, "/")
+
+	if len(ownerResource) != 3 {
+		return nil, fmt.Errorf("incompatible owner: %s", resourceLabelValue)
+	}
+
+	var (
+		obj runtime.Object
+		err error
+	)
+
+	switch ownerResource[0] {
+	case "ingress":
+		obj, err = p.kubeClient.NetworkingV1beta1().Ingresses(ownerResource[1]).Get(ctx, ownerResource[2], metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+	case "service":
+		obj, err = p.kubeClient.CoreV1().Services(ownerResource[1]).Get(ctx, ownerResource[2], metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unknown type: %s", ownerResource[0])
+	}
+
+	return reference.GetReference(scheme.Scheme, obj)
+}


### PR DESCRIPTION
This is an attempt to tackle https://github.com/kubernetes-sigs/external-dns/issues/646 and follow up on https://github.com/kubernetes-sigs/external-dns/pull/821#issuecomment-456877723 by @taylor-chen.

It attaches events to the Sources when DNS records were created for them:
```console
$ kubectl describe ing linki-test                                                                                                                                                         ✱

Name:             linki-test
Namespace:        default
....

Events:
  Type    Reason        Age   From         Message
  ----    ------        ----  ----         -------
  Normal  CreateRecord  28m   externaldns  Create DNS record 'linki-test.example.org' with targets 'kube-ing-lb-123345567-32434535645.eu-central-1.elb.amazonaws.com'
  Normal  CreateRecord  22m   externaldns  Create DNS record 'linki-test-2.example.org' with targets 'kube-ing-lb-123345567-32434535645.eu-central-1.elb.amazonaws.com'
```

`EventedProvider` wraps any of the other providers and forwards the Provider interface methods unchanged. The exception is `ApplyChanges` where it emits events for each change on the respective Source. Therefore, this works for all providers, in theory.

Getting the Source at this stage is tricky. I'm using the `Endpoint.Labels[ResourceLabelKey]` to extract and parse the resource. I believe this will only work when using the default TXTRegistry. This is very crude in practice but uses the metadata on the Endpoint itself which makes sense, imo. It would be nice if there was a proper field on Endpoint that holds the Kubernetes object that generated the Endpoint (or something like that).

Having the events on the Sources is nice but if the parsing is too awkward we could also attach them to something static, like the ExternalDNS pod, similar to how it was done in https://github.com/kubernetes-sigs/external-dns/pull/821.

It currently only supports Ingresses and Services. I'm not sure how many types we support and whether the ResourceLabel is even attached everywhere :man_shrugging: The ResourceLabel has the form `ingress/namespace/name` or `service/namespace/name` etc. and is stored like that in the TXTRegistry's TXT records.

Maybe this can spark a discussion about what events we want to have and how it can be done in a good way.