### PR TITLE
Adding ability to query Infoblox API using regex for fqdn (#2102)

### DIFF
--- a/docs/tutorials/infoblox.md
+++ b/docs/tutorials/infoblox.md
@@ -260,3 +260,11 @@ $ curl -kl \
       -u ${WAPI_USERNAME}:${WAPI_PASSWORD} \
          https://${GRID_HOST}:${WAPI_PORT}/wapi/v${WAPI_VERSION}/zone_auth?fqdn=example.com
 ```
+
+## Ability to filter results from the zone auth API using a regular expression
+
+There is also the ability to filter results from the Infoblox zone_auth service based upon a regular expression.  See the [Infoblox API document](https://www.infoblox.com/wp-content/uploads/infoblox-deployment-infoblox-rest-api.pdf) for examples.  To use this feature for the zone_auth service, set the parameter infoblox-fqdn-regex for external-dns to a regular expression that makes sense for you.  For instance, to only return hosted zones that start with staging in the test.com domain (like staging.beta.test.com, or staging.test.com), use the following command line option when starting external-dns
+
+```
+--infoblox-fqdn-regex=^staging.*test.com$
+```

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+ Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -240,6 +240,7 @@ func main() {
 				View:         cfg.InfobloxView,
 				MaxResults:   cfg.InfobloxMaxResults,
 				DryRun:       cfg.DryRun,
+				FQDNRexEx:    cfg.InfobloxFQDNRedEx,
 			},
 		)
 	case "dyn":

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -105,6 +105,7 @@ type Config struct {
 	InfobloxSSLVerify                 bool
 	InfobloxView                      string
 	InfobloxMaxResults                int
+	InfobloxFQDNRedEx                 string
 	DynCustomerName                   string
 	DynUsername                       string
 	DynPassword                       string `secure:"yes"`
@@ -228,6 +229,7 @@ var defaultConfig = &Config{
 	InfobloxSSLVerify:           true,
 	InfobloxView:                "",
 	InfobloxMaxResults:          0,
+	InfobloxFQDNRedEx:           "",
 	OCIConfigFile:               "/etc/kubernetes/oci.yaml",
 	InMemoryZones:               []string{},
 	OVHEndpoint:                 "ovh-eu",
@@ -410,6 +412,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("infoblox-ssl-verify", "When using the Infoblox provider, specify whether to verify the SSL certificate (default: true, disable with --no-infoblox-ssl-verify)").Default(strconv.FormatBool(defaultConfig.InfobloxSSLVerify)).BoolVar(&cfg.InfobloxSSLVerify)
 	app.Flag("infoblox-view", "DNS view (default: \"\")").Default(defaultConfig.InfobloxView).StringVar(&cfg.InfobloxView)
 	app.Flag("infoblox-max-results", "Add _max_results as query parameter to the URL on all API requests. The default is 0 which means _max_results is not set and the default of the server is used.").Default(strconv.Itoa(defaultConfig.InfobloxMaxResults)).IntVar(&cfg.InfobloxMaxResults)
+	app.Flag("infoblox-fqdn-regex", "Apply this regular expression as a filter for obtaining zone_auth objects. This is disabled by default.").Default(defaultConfig.InfobloxFQDNRedEx).StringVar(&cfg.InfobloxFQDNRedEx)
 	app.Flag("dyn-customer-name", "When using the Dyn provider, specify the Customer Name").Default("").StringVar(&cfg.DynCustomerName)
 	app.Flag("dyn-username", "When using the Dyn provider, specify the Username").Default("").StringVar(&cfg.DynUsername)
 	app.Flag("dyn-password", "When using the Dyn provider, specify the password").Default("").StringVar(&cfg.DynPassword)

--- a/provider/infoblox/infoblox_test.go
+++ b/provider/infoblox/infoblox_test.go
@@ -533,7 +533,7 @@ func TestInfobloxZones(t *testing.T) {
 	assert.Equal(t, provider.findZone(zones, "lvl2-2.lvl1-2.example.com").Fqdn, "example.com")
 }
 
-func TestMaxResultsRequestBuilder(t *testing.T) {
+func TestExtendedRequestFDQDRegExBuilder(t *testing.T) {
 	hostConfig := ibclient.HostConfig{
 		Host:     "localhost",
 		Port:     "8080",
@@ -542,7 +542,29 @@ func TestMaxResultsRequestBuilder(t *testing.T) {
 		Version:  "2.3.1",
 	}
 
-	requestBuilder := NewMaxResultsRequestBuilder(54321)
+	requestBuilder := NewExtendedRequestBuilder(0, "^staging.*test.com$")
+	requestBuilder.Init(hostConfig)
+
+	obj := ibclient.NewZoneAuth(ibclient.ZoneAuth{})
+
+	req, _ := requestBuilder.BuildRequest(ibclient.GET, obj, "", ibclient.QueryParams{})
+
+	assert.True(t, req.URL.Query().Get("fqdn~") == "^staging.*test.com$")
+
+	req, _ = requestBuilder.BuildRequest(ibclient.CREATE, obj, "", ibclient.QueryParams{})
+
+	assert.True(t, req.URL.Query().Get("fqdn~") == "")
+}
+func TestExtendedRequestMaxResultsBuilder(t *testing.T) {
+	hostConfig := ibclient.HostConfig{
+		Host:     "localhost",
+		Port:     "8080",
+		Username: "user",
+		Password: "abcd",
+		Version:  "2.3.1",
+	}
+
+	requestBuilder := NewExtendedRequestBuilder(54321, "")
 	requestBuilder.Init(hostConfig)
 
 	obj := ibclient.NewRecordCNAME(ibclient.RecordCNAME{Zone: "foo.bar.com"})


### PR DESCRIPTION
Signed-off-by: mmerrill3 <jjpaacks@gmail.com>

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Adding option for infoblox implementation to filter using a regular expression for fqdn when invoking the GET api for zone_auth. Fixes #2102

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
