### PR TITLE
feat: support NodePort services with aws-lb-controller-v2

### DIFF
--- a/source/service_test.go
+++ b/source/service_test.go
@@ -1898,6 +1898,34 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 				},
 			}},
 		},
+		{
+			title:        "annotated NodePort services with an AWS Load Balancer annotation return an endpoint with the address from the status.loadBalancer.ingress",
+			svcNamespace: "testing",
+			svcName:      "foo",
+			svcType:      v1.ServiceTypeNodePort,
+			labels:       map[string]string{},
+			annotations: map[string]string{
+				hostnameAnnotationKey:         "foo.example.org.",
+				AwsLoadBalancerTypeAnnotation: "nlb-ip",
+			},
+			lbs: []string{"some-load-balancer.elb.us-east-1-amazonaws.com"},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "foo.example.org",
+					Targets:    endpoint.Targets{"some-load-balancer.elb.us-east-1-amazonaws.com"},
+					RecordType: endpoint.RecordTypeCNAME,
+					ProviderSpecific: []endpoint.ProviderSpecificProperty{
+						{
+							Name:  AwsLoadBalancerTypeAnnotation,
+							Value: "nlb-ip",
+						},
+					},
+				},
+			},
+			// podNames:  []string{},
+			// nodeIndex: []int{},
+			// phases:    []v1.PodPhase{},
+		},
 	} {
 		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
@@ -1935,7 +1963,14 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 				_, err := kubernetes.CoreV1().Pods(tc.svcNamespace).Create(context.Background(), pod, metav1.CreateOptions{})
 				require.NoError(t, err)
 			}
-
+			ingresses := []v1.LoadBalancerIngress{}
+			for _, lb := range tc.lbs {
+				if net.ParseIP(lb) != nil {
+					ingresses = append(ingresses, v1.LoadBalancerIngress{IP: lb})
+				} else {
+					ingresses = append(ingresses, v1.LoadBalancerIngress{Hostname: lb})
+				}
+			}
 			// Create a service to test against
 			service := &v1.Service{
 				Spec: v1.ServiceSpec{
@@ -1952,6 +1987,11 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Name:        tc.svcName,
 					Labels:      tc.labels,
 					Annotations: tc.annotations,
+				},
+				Status: v1.ServiceStatus{
+					LoadBalancer: v1.LoadBalancerStatus{
+						Ingress: ingresses,
+					},
 				},
 			}
 

--- a/source/source.go
+++ b/source/source.go
@@ -65,6 +65,10 @@ const (
 	CloudflareProxiedKey = "external-dns.alpha.kubernetes.io/cloudflare-proxied"
 
 	SetIdentifierKey = "external-dns.alpha.kubernetes.io/set-identifier"
+
+	// This annotation is used to distinguish NodePort services that will create load balancers
+	// via aws-load-balancer-controller-v2
+	AwsLoadBalancerTypeAnnotation = "service.beta.kubernetes.io/aws-load-balancer-type"
 )
 
 const (
@@ -174,6 +178,15 @@ func getProviderSpecificAnnotations(annotations map[string]string) (endpoint.Pro
 			Value: v,
 		})
 	}
+
+	// aws-load-balancer-v2 NodePort Service Annotation
+	if v, exists := annotations[AwsLoadBalancerTypeAnnotation]; exists {
+		providerSpecificAnnotations = append(providerSpecificAnnotations, endpoint.ProviderSpecificProperty{
+			Name:  AwsLoadBalancerTypeAnnotation,
+			Value: v,
+		})
+	}
+
 	if getAliasFromAnnotations(annotations) {
 		providerSpecificAnnotations = append(providerSpecificAnnotations, endpoint.ProviderSpecificProperty{
 			Name:  "alias",


### PR DESCRIPTION
** Description **
AWS Load Balancer Controller v2 relies upon NodePort services on certain Kubernetes versions to be able to provision NLB resources without the core provider code competing with it to create load balancers. In order for this to work in combination with external-dns, external-dns needs to detect when the NodePort service is being managed by the AWS Load Balancer controller, and treat the NodePort as a service, and create the CNAME record to the loadBalancer.ingress.hostname[].

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1899

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
