### PR TITLE
Feature matchparent

### DIFF
--- a/docs/tutorials/pdns.md
+++ b/docs/tutorials/pdns.md
@@ -54,12 +54,14 @@ spec:
         - --interval=30s
 ```
 
-#### Domain Filter (--domain-filter)
-When the domain-filter argument is specified, external-dns will automatically create DNS records based on host names specified in ingress objects and services with the external-dns annotation that match the domain-filter argument in the external-dns deployment manifest.
+#### Domain Filter (`--domain-filter`)
+When the `--domain-filter` argument is specified, external-dns will only create DNS records for host names (specified in ingress objects and services with the external-dns annotation) related to zones that match the `--domain-filter` argument in the external-dns deployment manifest.
 
 eg. ```--domain-filter=example.org``` will allow for zone `example.org` and any zones in PowerDNS that ends in `.example.org`, including `an.example.org`, ie. the subdomains of example.org.
 
 eg. ```--domain-filter=.example.org``` will allow *only* zones that end in `.example.org`, ie. the subdomains of example.org but not the `example.org` zone itself.
+
+The filter can also match parent zones. For example `--domain-filter=a.example.com` will allow for zone `example.com`. If you want to match parent zones, you cannot pre-pend your filter with a ".", eg. `--domain-filter=.example.com` will not attempt to match parent zones.
 
 ## RBAC
 

--- a/endpoint/domain_filter.go
+++ b/endpoint/domain_filter.go
@@ -106,6 +106,31 @@ func matchRegex(regex *regexp.Regexp, negativeRegex *regexp.Regexp, domain strin
 	return regex.MatchString(strippedDomain)
 }
 
+// MatchParent checks wether DomainFilter matches a given parent domain.
+func (df DomainFilter) MatchParent(domain string) bool {
+	if !df.IsConfigured() {
+		return true
+	}
+
+	for _, filter := range df.Filters {
+		if strings.HasPrefix(filter, ".") {
+			// We don't check parents if the filter is prefixed with "."
+			continue
+		}
+
+		if filter == "" {
+			return true
+		}
+
+		strippedDomain := strings.ToLower(strings.TrimSuffix(domain, "."))
+		if strings.HasSuffix(filter, "."+strippedDomain) && !matchFilter(df.exclude, domain, false) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // IsConfigured returns true if DomainFilter is configured, false otherwise
 func (df DomainFilter) IsConfigured() bool {
 	if df.regex != nil && df.regex.String() != "" {

--- a/endpoint/domain_filter_test.go
+++ b/endpoint/domain_filter_test.go
@@ -296,6 +296,72 @@ func TestDomainFilterMatchWithEmptyFilter(t *testing.T) {
 	}
 }
 
+func TestDomainFilterMatchParent(t *testing.T) {
+	parentMatchTests := []domainFilterTest{
+		{
+			[]string{"a.example.com."},
+			[]string{},
+			[]string{"example.com"},
+			true,
+		},
+		{
+			[]string{" a.example.com "},
+			[]string{},
+			[]string{"example.com"},
+			true,
+		},
+		{
+			[]string{""},
+			[]string{},
+			[]string{"example.com"},
+			true,
+		},
+		{
+			[]string{".a.example.com."},
+			[]string{},
+			[]string{"example.com"},
+			false,
+		},
+		{
+			[]string{"a.example.com.", "b.example.com"},
+			[]string{},
+			[]string{"example.com"},
+			true,
+		},
+		{
+			[]string{"a.example.com"},
+			[]string{},
+			[]string{"b.example.com"},
+			false,
+		},
+		{
+			[]string{"example.com"},
+			[]string{},
+			[]string{"example.com"},
+			false,
+		},
+		{
+			[]string{"example.com"},
+			[]string{},
+			[]string{"anexample.com"},
+			false,
+		},
+		{
+			[]string{""},
+			[]string{},
+			[]string{""},
+			true,
+		},
+	}
+	for i, tt := range parentMatchTests {
+		domainFilter := NewDomainFilterWithExclusions(tt.domainFilter, tt.exclusions)
+		for _, domain := range tt.domains {
+			assert.Equal(t, tt.expected, domainFilter.MatchParent(domain), "should not fail: %v in test-case #%v", domain, i)
+			assert.Equal(t, tt.expected, domainFilter.MatchParent(domain+"."), "should not fail: %v in test-case #%v", domain+".", i)
+		}
+	}
+}
+
 func TestRegexDomainFilter(t *testing.T) {
 	for i, tt := range regexDomainFilterTests {
 		domainFilter := NewRegexDomainFilter(tt.regex, tt.regexExclusion)

--- a/provider/pdns/pdns.go
+++ b/provider/pdns/pdns.go
@@ -166,7 +166,7 @@ func (c *PDNSAPIClient) ListZones() (zones []pgo.Zone, resp *http.Response, err 
 func (c *PDNSAPIClient) PartitionZones(zones []pgo.Zone) (filteredZones []pgo.Zone, residualZones []pgo.Zone) {
 	if c.domainFilter.IsConfigured() {
 		for _, zone := range zones {
-			if c.domainFilter.Match(zone.Name) {
+			if c.domainFilter.Match(zone.Name) || c.domainFilter.MatchParent(zone.Name) {
 				filteredZones = append(filteredZones, zone)
 			} else {
 				residualZones = append(residualZones, zone)

--- a/provider/pdns/pdns_test.go
+++ b/provider/pdns/pdns_test.go
@@ -478,10 +478,23 @@ var (
 		},
 	}
 
+	DomainFilterChildListSingle = endpoint.DomainFilter{
+		Filters: []string{
+			"a.example.com",
+		},
+	}
+
 	DomainFilterListMultiple = endpoint.DomainFilter{
 		Filters: []string{
 			"example.com",
 			"mock.com",
+		},
+	}
+
+	DomainFilterChildListMultiple = endpoint.DomainFilter{
+		Filters: []string{
+			"a.example.com",
+			"c.example.com",
 		},
 	}
 
@@ -503,11 +516,25 @@ var (
 		domainFilter: DomainFilterListSingle,
 	}
 
+	DomainFilterChildSingleClient = &PDNSAPIClient{
+		dryRun:       false,
+		authCtx:      context.WithValue(context.Background(), pgo.ContextAPIKey, pgo.APIKey{Key: "TEST-API-KEY"}),
+		client:       pgo.NewAPIClient(pgo.NewConfiguration()),
+		domainFilter: DomainFilterChildListSingle,
+	}
+
 	DomainFilterMultipleClient = &PDNSAPIClient{
 		dryRun:       false,
 		authCtx:      context.WithValue(context.Background(), pgo.ContextAPIKey, pgo.APIKey{Key: "TEST-API-KEY"}),
 		client:       pgo.NewAPIClient(pgo.NewConfiguration()),
 		domainFilter: DomainFilterListMultiple,
+	}
+
+	DomainFilterChildMultipleClient = &PDNSAPIClient{
+		dryRun:       false,
+		authCtx:      context.WithValue(context.Background(), pgo.ContextAPIKey, pgo.APIKey{Key: "TEST-API-KEY"}),
+		client:       pgo.NewAPIClient(pgo.NewConfiguration()),
+		domainFilter: DomainFilterChildListMultiple,
 	}
 )
 
@@ -1013,6 +1040,16 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSClientPartitionZones() {
 
 	// Check filtered, residual zones when a multiple domain filter specified
 	filteredZones, residualZones = DomainFilterMultipleClient.PartitionZones(zoneList)
+	assert.Equal(suite.T(), partitionResultFilteredMultipleFilter, filteredZones)
+	assert.Equal(suite.T(), partitionResultResidualMultipleFilter, residualZones)
+
+	// Check filtered, residual zones when a single child domain filter specified
+	filteredZones, residualZones = DomainFilterChildSingleClient.PartitionZones(zoneList)
+	assert.Equal(suite.T(), partitionResultFilteredSingleFilter, filteredZones)
+	assert.Equal(suite.T(), partitionResultResidualSingleFilter, residualZones)
+
+	// Check filter, residual zones when multiple child domain filters specified
+	filteredZones, residualZones = DomainFilterChildMultipleClient.PartitionZones(zoneList)
 	assert.Equal(suite.T(), partitionResultFilteredMultipleFilter, filteredZones)
 	assert.Equal(suite.T(), partitionResultResidualMultipleFilter, residualZones)
 }


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This change introduces a `MatchParent` DomainFilter method that can be utilised by providers to enhance `--domain-filter` to also match "parent" zones. This change then further enhances the `pdns` provider in such a way.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2040 

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
