### PR TITLE
rfc2136: add batch size support

### DIFF
--- a/main.go
+++ b/main.go
@@ -293,7 +293,7 @@ func main() {
 			p, err = oci.NewOCIProvider(*config, domainFilter, zoneIDFilter, cfg.DryRun)
 		}
 	case "rfc2136":
-		p, err = rfc2136.NewRfc2136Provider(cfg.RFC2136Host, cfg.RFC2136Port, cfg.RFC2136Zone, cfg.RFC2136Insecure, cfg.RFC2136TSIGKeyName, cfg.RFC2136TSIGSecret, cfg.RFC2136TSIGSecretAlg, cfg.RFC2136TAXFR, domainFilter, cfg.DryRun, cfg.RFC2136MinTTL, cfg.RFC2136GSSTSIG, cfg.RFC2136KerberosUsername, cfg.RFC2136KerberosPassword, cfg.RFC2136KerberosRealm, nil)
+		p, err = rfc2136.NewRfc2136Provider(cfg.RFC2136Host, cfg.RFC2136Port, cfg.RFC2136Zone, cfg.RFC2136Insecure, cfg.RFC2136TSIGKeyName, cfg.RFC2136TSIGSecret, cfg.RFC2136TSIGSecretAlg, cfg.RFC2136TAXFR, domainFilter, cfg.DryRun, cfg.RFC2136MinTTL, cfg.RFC2136GSSTSIG, cfg.RFC2136KerberosUsername, cfg.RFC2136KerberosPassword, cfg.RFC2136KerberosRealm, cfg.RFC2136BatchChangeSize, nil)
 	case "ns1":
 		p, err = ns1.NewNS1Provider(
 			ns1.NS1Config{

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -156,6 +156,7 @@ type Config struct {
 	RFC2136TSIGSecretAlg              string
 	RFC2136TAXFR                      bool
 	RFC2136MinTTL                     time.Duration
+	RFC2136BatchChangeSize            int
 	NS1Endpoint                       string
 	NS1IgnoreSSL                      bool
 	NS1MinTTLSeconds                  int
@@ -275,6 +276,7 @@ var defaultConfig = &Config{
 	RFC2136TSIGSecretAlg:        "",
 	RFC2136TAXFR:                true,
 	RFC2136MinTTL:               0,
+	RFC2136BatchChangeSize:      50,
 	NS1Endpoint:                 "",
 	NS1IgnoreSSL:                false,
 	TransIPAccountName:          "",
@@ -455,6 +457,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("rfc2136-kerberos-username", "When using the RFC2136 provider with GSS-TSIG, specify the username of the user with permissions to update DNS records (required when --rfc2136-gss-tsig=true)").Default(defaultConfig.RFC2136KerberosUsername).StringVar(&cfg.RFC2136KerberosUsername)
 	app.Flag("rfc2136-kerberos-password", "When using the RFC2136 provider with GSS-TSIG, specify the password of the user with permissions to update DNS records (required when --rfc2136-gss-tsig=true)").Default(defaultConfig.RFC2136KerberosPassword).StringVar(&cfg.RFC2136KerberosPassword)
 	app.Flag("rfc2136-kerberos-realm", "When using the RFC2136 provider with GSS-TSIG, specify the realm of the user with permissions to update DNS records (required when --rfc2136-gss-tsig=true)").Default(defaultConfig.RFC2136KerberosRealm).StringVar(&cfg.RFC2136KerberosRealm)
+	app.Flag("rfc2136-batch-change-size", "When using the RFC2136 provider, set the maximum number of changes that will be applied in each batch.").Default(strconv.Itoa(defaultConfig.RFC2136BatchChangeSize)).IntVar(&cfg.RFC2136BatchChangeSize)
 
 	// Flags related to TransIP provider
 	app.Flag("transip-account", "When using the TransIP provider, specify the account name (required when --provider=transip)").Default(defaultConfig.TransIPAccountName).StringVar(&cfg.TransIPAccountName)

--- a/pkg/apis/externaldns/types_test.go
+++ b/pkg/apis/externaldns/types_test.go
@@ -113,6 +113,7 @@ var (
 		TransIPPrivateKeyFile:       "",
 		DigitalOceanAPIPageSize:     50,
 		ManagedDNSRecordTypes:       []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
+		RFC2136BatchChangeSize:      50,
 	}
 
 	overriddenConfig = &Config{
@@ -205,6 +206,7 @@ var (
 		TransIPPrivateKeyFile:       "/path/to/transip.key",
 		DigitalOceanAPIPageSize:     100,
 		ManagedDNSRecordTypes:       []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
+		RFC2136BatchChangeSize:      100,
 	}
 )
 
@@ -321,6 +323,7 @@ func TestParseFlags(t *testing.T) {
 				"--transip-account=transip",
 				"--transip-keyfile=/path/to/transip.key",
 				"--digitalocean-api-page-size=100",
+				"--rfc2136-batch-change-size=100",
 			},
 			envVars:  map[string]string{},
 			expected: overriddenConfig,
@@ -417,6 +420,7 @@ func TestParseFlags(t *testing.T) {
 				"EXTERNAL_DNS_TRANSIP_ACCOUNT":                 "transip",
 				"EXTERNAL_DNS_TRANSIP_KEYFILE":                 "/path/to/transip.key",
 				"EXTERNAL_DNS_DIGITALOCEAN_API_PAGE_SIZE":      "100",
+				"EXTERNAL_DNS_RFC2136_BATCH_CHANGE_SIZE":       "100",
 			},
 			expected: overriddenConfig,
 		},

--- a/pkg/apis/externaldns/validation/validation.go
+++ b/pkg/apis/externaldns/validation/validation.go
@@ -98,7 +98,7 @@ func ValidateConfig(cfg *externaldns.Config) error {
 		}
 
 		if cfg.RFC2136BatchChangeSize < 1 {
-			return errors.New("Batch Size specified for rfc2136 cannot be less than 1")
+			return errors.New("batch size specified for rfc2136 cannot be less than 1")
 		}
 	}
 

--- a/pkg/apis/externaldns/validation/validation.go
+++ b/pkg/apis/externaldns/validation/validation.go
@@ -96,6 +96,10 @@ func ValidateConfig(cfg *externaldns.Config) error {
 				return errors.New("--rfc2136-kerberos-realm, --rfc2136-kerberos-username, and --rfc2136-kerberos-password are required when specifying --rfc2136-gss-tsig option")
 			}
 		}
+
+		if cfg.RFC2136BatchChangeSize < 1 {
+			return errors.New("Batch Size specified for rfc2136 cannot be less than 1")
+		}
 	}
 
 	if cfg.IgnoreHostnameAnnotation && cfg.FQDNTemplate == "" {

--- a/pkg/apis/externaldns/validation/validation_test.go
+++ b/pkg/apis/externaldns/validation/validation_test.go
@@ -132,6 +132,21 @@ func TestValidateBadRfc2136Config(t *testing.T) {
 	cfg.Sources = []string{"test-source"}
 	cfg.Provider = "rfc2136"
 	cfg.RFC2136MinTTL = -1
+	cfg.RFC2136BatchChangeSize = 50
+
+	err := ValidateConfig(cfg)
+
+	assert.NotNil(t, err)
+}
+
+func TestValidateBadRfc2136Batch(t *testing.T) {
+	cfg := externaldns.NewConfig()
+
+	cfg.LogFormat = "json"
+	cfg.Sources = []string{"test-source"}
+	cfg.Provider = "rfc2136"
+	cfg.RFC2136MinTTL = 3600
+	cfg.RFC2136BatchChangeSize = 0
 
 	err := ValidateConfig(cfg)
 
@@ -145,6 +160,7 @@ func TestValidateGoodRfc2136Config(t *testing.T) {
 	cfg.Sources = []string{"test-source"}
 	cfg.Provider = "rfc2136"
 	cfg.RFC2136MinTTL = 3600
+	cfg.RFC2136BatchChangeSize = 50
 
 	err := ValidateConfig(cfg)
 
@@ -162,6 +178,7 @@ func TestValidateBadRfc2136GssTsigConfig(t *testing.T) {
 			RFC2136KerberosUsername: "test-user",
 			RFC2136KerberosPassword: "",
 			RFC2136MinTTL:           3600,
+			RFC2136BatchChangeSize:  50,
 		},
 		{
 			LogFormat:               "json",
@@ -172,6 +189,7 @@ func TestValidateBadRfc2136GssTsigConfig(t *testing.T) {
 			RFC2136KerberosUsername: "",
 			RFC2136KerberosPassword: "test-pass",
 			RFC2136MinTTL:           3600,
+			RFC2136BatchChangeSize:  50,
 		},
 		{
 			LogFormat:               "json",
@@ -183,6 +201,7 @@ func TestValidateBadRfc2136GssTsigConfig(t *testing.T) {
 			RFC2136KerberosUsername: "test-user",
 			RFC2136KerberosPassword: "test-pass",
 			RFC2136MinTTL:           3600,
+			RFC2136BatchChangeSize:  50,
 		},
 		{
 			LogFormat:               "json",
@@ -193,6 +212,7 @@ func TestValidateBadRfc2136GssTsigConfig(t *testing.T) {
 			RFC2136KerberosUsername: "test-user",
 			RFC2136KerberosPassword: "",
 			RFC2136MinTTL:           3600,
+			RFC2136BatchChangeSize:  50,
 		},
 		{
 			LogFormat:               "json",
@@ -203,6 +223,7 @@ func TestValidateBadRfc2136GssTsigConfig(t *testing.T) {
 			RFC2136KerberosUsername: "",
 			RFC2136KerberosPassword: "test-pass",
 			RFC2136MinTTL:           3600,
+			RFC2136BatchChangeSize:  50,
 		},
 		{
 			LogFormat:               "json",
@@ -214,6 +235,7 @@ func TestValidateBadRfc2136GssTsigConfig(t *testing.T) {
 			RFC2136KerberosUsername: "test-user",
 			RFC2136KerberosPassword: "test-pass",
 			RFC2136MinTTL:           3600,
+			RFC2136BatchChangeSize:  50,
 		},
 		{
 			LogFormat:               "json",
@@ -224,6 +246,7 @@ func TestValidateBadRfc2136GssTsigConfig(t *testing.T) {
 			RFC2136KerberosUsername: "test-user",
 			RFC2136KerberosPassword: "test-pass",
 			RFC2136MinTTL:           3600,
+			RFC2136BatchChangeSize:  50,
 		},
 	}
 
@@ -246,6 +269,7 @@ func TestValidateGoodRfc2136GssTsigConfig(t *testing.T) {
 			RFC2136KerberosUsername: "test-user",
 			RFC2136KerberosPassword: "test-pass",
 			RFC2136MinTTL:           3600,
+			RFC2136BatchChangeSize:  50,
 		},
 	}
 

--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -48,14 +48,15 @@ const (
 // rfc2136 provider type
 type rfc2136Provider struct {
 	provider.BaseProvider
-	nameserver    string
-	zoneName      string
-	tsigKeyName   string
-	tsigSecret    string
-	tsigSecretAlg string
-	insecure      bool
-	axfr          bool
-	minTTL        time.Duration
+	nameserver      string
+	zoneName        string
+	tsigKeyName     string
+	tsigSecret      string
+	tsigSecretAlg   string
+	insecure        bool
+	axfr            bool
+	minTTL          time.Duration
+	batchChangeSize int
 
 	// options specific to rfc3645 gss-tsig support
 	gssTsig      bool
@@ -85,7 +86,7 @@ type rfc2136Actions interface {
 }
 
 // NewRfc2136Provider is a factory function for OpenStack rfc2136 providers
-func NewRfc2136Provider(host string, port int, zoneName string, insecure bool, keyName string, secret string, secretAlg string, axfr bool, domainFilter endpoint.DomainFilter, dryRun bool, minTTL time.Duration, gssTsig bool, krb5Username string, krb5Password string, krb5Realm string, actions rfc2136Actions) (provider.Provider, error) {
+func NewRfc2136Provider(host string, port int, zoneName string, insecure bool, keyName string, secret string, secretAlg string, axfr bool, domainFilter endpoint.DomainFilter, dryRun bool, minTTL time.Duration, gssTsig bool, krb5Username string, krb5Password string, krb5Realm string, batchChangeSize int, actions rfc2136Actions) (provider.Provider, error) {
 	secretAlgChecked, ok := tsigAlgs[secretAlg]
 	if !ok && !insecure && !gssTsig {
 		return nil, errors.Errorf("%s is not supported TSIG algorithm", secretAlg)
@@ -96,17 +97,18 @@ func NewRfc2136Provider(host string, port int, zoneName string, insecure bool, k
 	}
 
 	r := &rfc2136Provider{
-		nameserver:   net.JoinHostPort(host, strconv.Itoa(port)),
-		zoneName:     dns.Fqdn(zoneName),
-		insecure:     insecure,
-		gssTsig:      gssTsig,
-		krb5Username: krb5Username,
-		krb5Password: krb5Password,
-		krb5Realm:    strings.ToUpper(krb5Realm),
-		domainFilter: domainFilter,
-		dryRun:       dryRun,
-		axfr:         axfr,
-		minTTL:       minTTL,
+		nameserver:      net.JoinHostPort(host, strconv.Itoa(port)),
+		zoneName:        dns.Fqdn(zoneName),
+		insecure:        insecure,
+		gssTsig:         gssTsig,
+		krb5Username:    krb5Username,
+		krb5Password:    krb5Password,
+		krb5Realm:       strings.ToUpper(krb5Realm),
+		domainFilter:    domainFilter,
+		dryRun:          dryRun,
+		axfr:            axfr,
+		minTTL:          minTTL,
+		batchChangeSize: batchChangeSize,
 	}
 	if actions != nil {
 		r.actions = actions
@@ -246,40 +248,88 @@ func (r rfc2136Provider) List() ([]dns.RR, error) {
 func (r rfc2136Provider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
 	log.Debugf("ApplyChanges (Create: %d, UpdateOld: %d, UpdateNew: %d, Delete: %d)", len(changes.Create), len(changes.UpdateOld), len(changes.UpdateNew), len(changes.Delete))
 
-	m := new(dns.Msg)
-	m.SetUpdate(r.zoneName)
+	var errors []error
 
-	for _, ep := range changes.Create {
-		if !r.domainFilter.Match(ep.DNSName) {
-			log.Debugf("Skipping record %s because it was filtered out by the specified --domain-filter", ep.DNSName)
-			continue
+	for c, chunk := range chunkBy(changes.Create, r.batchChangeSize) {
+		log.Debugf("Processing batch %d of create changes", c)
+
+		m := new(dns.Msg)
+		m.SetUpdate(r.zoneName)
+
+		for _, ep := range chunk {
+			if !r.domainFilter.Match(ep.DNSName) {
+				log.Debugf("Skipping record %s because it was filtered out by the specified --domain-filter", ep.DNSName)
+				continue
+			}
+
+			r.AddRecord(m, ep)
 		}
 
-		r.AddRecord(m, ep)
+		// only send if there are records available
+		if len(m.Ns) > 0 {
+			err := r.actions.SendMessage(m)
+			if err != nil {
+				log.Errorf("RFC2136 update failed: %v", err)
+				errors = append(errors, err)
+				continue
+			}
+		}
 	}
-	for i, ep := range changes.UpdateNew {
-		if !r.domainFilter.Match(ep.DNSName) {
-			log.Debugf("Skipping record %s because it was filtered out by the specified --domain-filter", ep.DNSName)
-			continue
+
+	for c, chunk := range chunkBy(changes.UpdateNew, r.batchChangeSize) {
+		log.Debugf("Processing batch %d of update changes", c)
+
+		m := new(dns.Msg)
+		m.SetUpdate(r.zoneName)
+
+		for i, ep := range chunk {
+			if !r.domainFilter.Match(ep.DNSName) {
+				log.Debugf("Skipping record %s because it was filtered out by the specified --domain-filter", ep.DNSName)
+				continue
+			}
+
+			r.UpdateRecord(m, changes.UpdateOld[i], ep)
 		}
 
-		r.UpdateRecord(m, changes.UpdateOld[i], ep)
+		// only send if there are records available
+		if len(m.Ns) > 0 {
+			err := r.actions.SendMessage(m)
+			if err != nil {
+				log.Errorf("RFC2136 update failed: %v", err)
+				errors = append(errors, err)
+				continue
+			}
+		}
 	}
-	for _, ep := range changes.Delete {
-		if !r.domainFilter.Match(ep.DNSName) {
-			log.Debugf("Skipping record %s because it was filtered out by the specified --domain-filter", ep.DNSName)
-			continue
+
+	for c, chunk := range chunkBy(changes.Delete, r.batchChangeSize) {
+		log.Debugf("Processing batch %d of delete changes", c)
+
+		m := new(dns.Msg)
+		m.SetUpdate(r.zoneName)
+
+		for _, ep := range chunk {
+			if !r.domainFilter.Match(ep.DNSName) {
+				log.Debugf("Skipping record %s because it was filtered out by the specified --domain-filter", ep.DNSName)
+				continue
+			}
+
+			r.RemoveRecord(m, ep)
 		}
 
-		r.RemoveRecord(m, ep)
+		// only send if there are records available
+		if len(m.Ns) > 0 {
+			err := r.actions.SendMessage(m)
+			if err != nil {
+				log.Errorf("RFC2136 update failed: %v", err)
+				errors = append(errors, err)
+				continue
+			}
+		}
 	}
 
-	// only send if there are records available
-	if len(m.Ns) > 0 {
-		err := r.actions.SendMessage(m)
-		if err != nil {
-			return fmt.Errorf("RFC2136 update failed: %v", err)
-		}
+	if len(errors) > 0 {
+		return fmt.Errorf("RFC2136 had errors in one or more of its batches: %v", errors)
 	}
 
 	return nil
@@ -387,4 +437,20 @@ func (r rfc2136Provider) SendMessage(msg *dns.Msg) error {
 
 	log.Debugf("SendMessage.success")
 	return nil
+}
+
+func chunkBy(slice []*endpoint.Endpoint, chunkSize int) [][]*endpoint.Endpoint {
+	var chunks [][]*endpoint.Endpoint
+
+	for i := 0; i < len(slice); i += chunkSize {
+		end := i + chunkSize
+
+		if end > len(slice) {
+			end = len(slice)
+		}
+
+		chunks = append(chunks, slice[i:end])
+	}
+
+	return chunks
 }

--- a/provider/rfc2136/rfc2136_test.go
+++ b/provider/rfc2136/rfc2136_test.go
@@ -95,7 +95,7 @@ func (r *rfc2136Stub) IncomeTransfer(m *dns.Msg, a string) (env chan *dns.Envelo
 }
 
 func createRfc2136StubProvider(stub *rfc2136Stub) (provider.Provider, error) {
-	return NewRfc2136Provider("", 0, "", false, "key", "secret", "hmac-sha512", true, endpoint.DomainFilter{}, false, 300*time.Second, false, "", "", "", stub)
+	return NewRfc2136Provider("", 0, "", false, "key", "secret", "hmac-sha512", true, endpoint.DomainFilter{}, false, 300*time.Second, false, "", "", "", 50, stub)
 }
 
 func extractAuthoritySectionFromMessage(msg fmt.Stringer) []string {
@@ -324,6 +324,24 @@ func TestRfc2136ApplyChangesWithUpdate(t *testing.T) {
 	assert.True(t, strings.Contains(stub.updateMsgs[1].String(), "v1.foobar.com"))
 	assert.True(t, strings.Contains(stub.updateMsgs[1].String(), "boom"))
 
+}
+
+func TestChunkBy(t *testing.T) {
+	var records []*endpoint.Endpoint
+
+	for i := 0; i < 10; i++ {
+		records = append(records, &endpoint.Endpoint{
+			DNSName:    "v1.foo.com",
+			RecordType: "A",
+			Targets:    []string{"1.1.2.2"},
+			RecordTTL:  endpoint.TTL(400),
+		})
+	}
+
+	chunks := chunkBy(records, 2)
+	if len(chunks) != 5 {
+		t.Errorf("incorrect number of chunks returned")
+	}
 }
 
 func contains(arr []*endpoint.Endpoint, name string) bool {


### PR DESCRIPTION
**Description**

This PR adds a new `--rfc2136-batch-change-size` option, which follows the AWS and Google providers, which already support controlling the batch size.  I defaulted the batch size to 50, which seems like a sane default to prevent large updates, while at the same time keeping most transactions atomic, as was the intent with the batching support in the first place.

Savvy users who want to revert to the `0.5` behavior without batching support can set their batch size to 1 with this patch to achieve that, which would help address https://github.com/kubernetes-sigs/external-dns/issues/1517.

When the rfc2136 provider gained batching support (https://github.com/kubernetes-sigs/external-dns/pull/1164), it introduced a couple of regressions for us in behavior compared to the `0.5` series.

1.  Large updates, even with TCP, can exceed what the DNS server allows which can still result in `warn in dns.Client.Exchange: dns: message too large` errors.  We have observed this in production environments in normal operation when our ingress controllers changed their load balancer external IPs during a migration, requiring DNS updates to hundreds of records at once.  For the purpose of developing this patch, I was able to reproduce the behavior with by creating a large number (500) of new ingresses at once.

2.  If any update in the batch fails to apply, the whole transaction fails, which leads to one bad resource in the cluster (e.g., a tenant's Ingress) being able to DoS external-dns for the whole cluster.  This has also been observed in production environments for us, whereas when batching was not in use, only the bad update failed and others went through.  This regression is already noted in https://github.com/kubernetes-sigs/external-dns/issues/1517.