### PR TITLE
Update azure-private-dns tutorial image tag to v0.8.0

### DIFF
--- a/docs/tutorials/azure-private-dns.md
+++ b/docs/tutorials/azure-private-dns.md
@@ -171,7 +171,7 @@ spec:
     spec:
       containers:
       - name: externaldns
-        image: k8s.gcr.io/external-dns/external-dns:v0.7.6
+        image: k8s.gcr.io/external-dns/external-dns:v0.8.0
         args:
         - --source=service
         - --source=ingress
@@ -242,7 +242,7 @@ spec:
       serviceAccountName: externaldns
       containers:
       - name: externaldns
-        image: k8s.gcr.io/external-dns/external-dns:v0.7.6
+        image: k8s.gcr.io/external-dns/external-dns:v0.8.0
         args:
         - --source=service
         - --source=ingress
@@ -313,7 +313,7 @@ spec:
       serviceAccountName: externaldns
       containers:
       - name: externaldns
-        image: k8s.gcr.io/external-dns/external-dns:v0.7.6
+        image: k8s.gcr.io/external-dns/external-dns:v0.8.0
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
#1912 introduced `azure.json` auth for the `azure-private-dns` provider. This change was released with `v0.8.0`.

The current tutorial includes this new `azure.json` syntax, but uses the `v0.7.6` image (which relies on values from environment variables).

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
When trying to run the tutorial template as-is today, the container started, but I received the somewhat cryptic error:
```
azure.BearerAuthorizer#WithAuthorization: Failed to refresh the Token for request to https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/<resource-group>/providers/Microsoft.Network/privateDnsZones?api-version=2018-09-01: StatusCode=400 -- Original Error: adal: Refresh request failed. Status Code = '400'. Response body: {\"error\":\"invalid_request\",\"error_description\":\"Identity not found\"}
```

After updating the template to `v0.8.0` (as done in this PR), the application started working as expected.

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
