### PR TITLE
fix coredns provider records

### DIFF
--- a/provider/coredns/coredns.go
+++ b/provider/coredns/coredns.go
@@ -317,8 +317,7 @@ func (p coreDNSProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, err
 			ep.Labels[randomPrefixLabel] = prefix
 			ep.Labels[service.Host] = prefix
 			result = append(result, ep)
-		}
-		if service.Text != "" {
+		}else if service.Text != "" {
 			ep := endpoint.NewEndpoint(
 				dnsName,
 				endpoint.RecordTypeTXT,


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
change Records function at provider/coredns.
I found the record which create by externalDNS in coreDNS:
```
/skydns/org/example/my-nginx/277767f4
{"host":"10.173.32.42","text":"\"heritage=external-dns,external-dns/owner=default,external-dns/resource=ingress/default/my-nginx\"","targetstrip":1}
```
and the Records function code in  provider/coredns is:
```
func (p coreDNSProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
	……
	for _, service := range services {
		……
		if service.Host != "" {
			ep, found := findEp(result, dnsName)
			……
			result = append(result, ep)
		}
		if service.Text != "" {
			ep := endpoint.NewEndpoint(
				dnsName,
				endpoint.RecordTypeTXT,
				service.Text,
			)
			ep.Labels[randomPrefixLabel] = prefix
			result = append(result, ep)
		}
	}
	return result, nil
}
```
it may produce two endpoints for a record
<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
