### PR TITLE
Adding trimSuffix

### DIFF
--- a/source/gateway.go
+++ b/source/gateway.go
@@ -74,6 +74,7 @@ func NewIstioGatewaySource(
 	if fqdnTemplate != "" {
 		tmpl, err = template.New("endpoint").Funcs(template.FuncMap{
 			"trimPrefix": strings.TrimPrefix,
+			"trimSuffix": strings.TrimSuffix,
 		}).Parse(fqdnTemplate)
 		if err != nil {
 			return nil, err

--- a/source/httpproxy.go
+++ b/source/httpproxy.go
@@ -70,6 +70,7 @@ func NewContourHTTPProxySource(
 	if fqdnTemplate != "" {
 		tmpl, err = template.New("endpoint").Funcs(template.FuncMap{
 			"trimPrefix": strings.TrimPrefix,
+			"trimSuffix": strings.TrimSuffix,
 		}).Parse(fqdnTemplate)
 		if err != nil {
 			return nil, err

--- a/source/ingress.go
+++ b/source/ingress.go
@@ -73,6 +73,7 @@ func NewIngressSource(kubeClient kubernetes.Interface, namespace, annotationFilt
 	if fqdnTemplate != "" {
 		tmpl, err = template.New("endpoint").Funcs(template.FuncMap{
 			"trimPrefix": strings.TrimPrefix,
+			"trimSuffix": strings.TrimSuffix,
 		}).Parse(fqdnTemplate)
 		if err != nil {
 			return nil, err

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -271,8 +271,8 @@ func testEndpointsFromIngressHostnameSourceAnnotation(t *testing.T) {
 		{
 			title: "No ingress-hostname-source annotation, one rule.host",
 			ingress: fakeIngress{
-				dnsnames:    []string{"foo.bar"},
-				hostnames:   []string{"lb.com"},
+				dnsnames:  []string{"foo.bar"},
+				hostnames: []string{"lb.com"},
 			},
 			expected: []*endpoint.Endpoint{
 				{

--- a/source/ingressroute.go
+++ b/source/ingressroute.go
@@ -75,6 +75,7 @@ func NewContourIngressRouteSource(
 	if fqdnTemplate != "" {
 		tmpl, err = template.New("endpoint").Funcs(template.FuncMap{
 			"trimPrefix": strings.TrimPrefix,
+			"trimSuffix": strings.TrimSuffix,
 		}).Parse(fqdnTemplate)
 		if err != nil {
 			return nil, err

--- a/source/node.go
+++ b/source/node.go
@@ -54,6 +54,7 @@ func NewNodeSource(kubeClient kubernetes.Interface, annotationFilter, fqdnTempla
 	if fqdnTemplate != "" {
 		tmpl, err = template.New("endpoint").Funcs(template.FuncMap{
 			"trimPrefix": strings.TrimPrefix,
+			"trimSuffix": strings.TrimSuffix,
 		}).Parse(fqdnTemplate)
 		if err != nil {
 			return nil, err

--- a/source/ocproute.go
+++ b/source/ocproute.go
@@ -69,6 +69,7 @@ func NewOcpRouteSource(
 	if fqdnTemplate != "" {
 		tmpl, err = template.New("endpoint").Funcs(template.FuncMap{
 			"trimPrefix": strings.TrimPrefix,
+			"trimSuffix": strings.TrimSuffix,
 		}).Parse(fqdnTemplate)
 		if err != nil {
 			return nil, err

--- a/source/routegroup.go
+++ b/source/routegroup.go
@@ -194,6 +194,7 @@ func parseTemplate(fqdnTemplate string) (tmpl *template.Template, err error) {
 	if fqdnTemplate != "" {
 		tmpl, err = template.New("endpoint").Funcs(template.FuncMap{
 			"trimPrefix": strings.TrimPrefix,
+			"trimSuffix": strings.TrimSuffix,
 		}).Parse(fqdnTemplate)
 	}
 	return tmpl, err

--- a/source/service.go
+++ b/source/service.go
@@ -76,6 +76,7 @@ func NewServiceSource(kubeClient kubernetes.Interface, namespace, annotationFilt
 	if fqdnTemplate != "" {
 		tmpl, err = template.New("endpoint").Funcs(template.FuncMap{
 			"trimPrefix": strings.TrimPrefix,
+			"trimSuffix": strings.TrimSuffix,
 		}).Parse(fqdnTemplate)
 		if err != nil {
 			return nil, err

--- a/source/shared_test.go
+++ b/source/shared_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package source
 
 import (
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
-	"reflect"
 
 	"sigs.k8s.io/external-dns/endpoint"
 )
@@ -63,7 +63,7 @@ func validateEndpoint(t *testing.T, endpoint, expected *endpoint.Endpoint) {
 	}
 
 	// if non-empty labels are expected, check that they matches.
-	if expected.Labels != nil && !reflect.DeepEqual(endpoint.Labels,expected.Labels) {
+	if expected.Labels != nil && !reflect.DeepEqual(endpoint.Labels, expected.Labels) {
 		t.Errorf("expected %s, got %s", expected.Labels, endpoint.Labels)
 	}
 }

--- a/source/virtualservice.go
+++ b/source/virtualservice.go
@@ -78,6 +78,7 @@ func NewIstioVirtualServiceSource(
 	if fqdnTemplate != "" {
 		tmpl, err = template.New("endpoint").Funcs(template.FuncMap{
 			"trimPrefix": strings.TrimPrefix,
+			"trimSuffix": strings.TrimSuffix,
 		}).Parse(fqdnTemplate)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Adding trimSuffix to the functions passed to the template parser, this allows you to check if an ingress/annotation etc contain a given domain and do validation eg:
```
--fqdn-template="{{ if eq (len .Name) (len (trimSuffix .Name \"your.domain\")) }}this.will.fail{{ else }}{{ .Name }}{{ end }}"
```

**Checklist**

- [ X ] Unit tests updated (no test coverarge)
- [ X ] End user documentation updated (Documentation should be updated to reflect both funcs passed to the template parser)
