### PR TITLE
Source: Deflake and Parallelize Tests

### DIFF
--- a/source/connector_test.go
+++ b/source/connector_test.go
@@ -57,6 +57,8 @@ func startServerToServeTargets(t *testing.T, endpoints []*endpoint.Endpoint) net
 }
 
 func TestConnectorSource(t *testing.T) {
+	t.Parallel()
+
 	suite.Run(t, new(ConnectorSuite))
 	t.Run("Interface", testConnectorSourceImplementsSource)
 	t.Run("Endpoints", testConnectorSourceEndpoints)
@@ -115,7 +117,10 @@ func testConnectorSourceEndpoints(t *testing.T) {
 			expectError: false,
 		},
 	} {
+		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
+
 			addr := "localhost:9999"
 			if ti.server {
 				ln := startServerToServeTargets(t, ti.expected)

--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -57,7 +57,7 @@ func objBody(codec runtime.Encoder, obj runtime.Object) io.ReadCloser {
 	return ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(codec, obj))))
 }
 
-func startCRDServerToServeTargets(endpoints []*endpoint.Endpoint, apiVersion, kind, namespace, name string, annotations map[string]string, labels map[string]string, t *testing.T) rest.Interface {
+func fakeRESTClient(endpoints []*endpoint.Endpoint, apiVersion, kind, namespace, name string, annotations map[string]string, labels map[string]string, t *testing.T) rest.Interface {
 	groupVersion, _ := schema.ParseGroupVersion(apiVersion)
 	scheme := runtime.NewScheme()
 	addKnownTypes(scheme, groupVersion)
@@ -372,8 +372,11 @@ func testCRDSourceEndpoints(t *testing.T) {
 			expectError:     false,
 		},
 	} {
+		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
-			restClient := startCRDServerToServeTargets(ti.endpoints, ti.registeredAPIVersion, ti.registeredKind, ti.registeredNamespace, "test", ti.annotations, ti.labels, t)
+			t.Parallel()
+
+			restClient := fakeRESTClient(ti.endpoints, ti.registeredAPIVersion, ti.registeredKind, ti.registeredNamespace, "test", ti.annotations, ti.labels, t)
 			groupVersion, err := schema.ParseGroupVersion(ti.apiVersion)
 			require.NoError(t, err)
 

--- a/source/gateway_test.go
+++ b/source/gateway_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	networkingv1alpha3api "istio.io/api/networking/v1alpha3"
 	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
-	istioclient "istio.io/client-go/pkg/clientset/versioned"
 	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,7 +45,7 @@ type GatewaySuite struct {
 
 func (suite *GatewaySuite) SetupTest() {
 	fakeKubernetesClient := fake.NewSimpleClientset()
-	fakeIstioClient := NewFakeConfigStore()
+	fakeIstioClient := istiofake.NewSimpleClientset()
 	var err error
 
 	suite.lbServices = []*v1.Service{
@@ -137,7 +136,7 @@ func TestNewIstioGatewaySource(t *testing.T) {
 		t.Run(ti.title, func(t *testing.T) {
 			_, err := NewIstioGatewaySource(
 				fake.NewSimpleClientset(),
-				NewFakeConfigStore(),
+				istiofake.NewSimpleClientset(),
 				"",
 				ti.annotationFilter,
 				ti.fqdnTemplate,
@@ -1142,7 +1141,7 @@ func testGatewayEndpoints(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			fakeIstioClient := NewFakeConfigStore()
+			fakeIstioClient := istiofake.NewSimpleClientset()
 			for _, config := range ti.configItems {
 				gatewayCfg := config.Config()
 				_, err := fakeIstioClient.NetworkingV1alpha3().Gateways(ti.targetNamespace).Create(context.Background(), &gatewayCfg, metav1.CreateOptions{})
@@ -1175,7 +1174,7 @@ func testGatewayEndpoints(t *testing.T) {
 // gateway specific helper functions
 func newTestGatewaySource(loadBalancerList []fakeIngressGatewayService) (*gatewaySource, error) {
 	fakeKubernetesClient := fake.NewSimpleClientset()
-	fakeIstioClient := NewFakeConfigStore()
+	fakeIstioClient := istiofake.NewSimpleClientset()
 
 	for _, lb := range loadBalancerList {
 		service := lb.Service()
@@ -1275,8 +1274,4 @@ func (c fakeGatewayConfig) Config() networkingv1alpha3.Gateway {
 	gw.Spec.Servers = servers
 
 	return gw
-}
-
-func NewFakeConfigStore() istioclient.Interface {
-	return istiofake.NewSimpleClientset()
 }

--- a/source/gateway_test.go
+++ b/source/gateway_test.go
@@ -89,12 +89,16 @@ func (suite *GatewaySuite) TestResourceLabelIsSet() {
 }
 
 func TestGateway(t *testing.T) {
+	t.Parallel()
+
 	suite.Run(t, new(GatewaySuite))
 	t.Run("endpointsFromGatewayConfig", testEndpointsFromGatewayConfig)
 	t.Run("Endpoints", testGatewayEndpoints)
 }
 
 func TestNewIstioGatewaySource(t *testing.T) {
+	t.Parallel()
+
 	for _, ti := range []struct {
 		title                    string
 		annotationFilter         string
@@ -133,7 +137,10 @@ func TestNewIstioGatewaySource(t *testing.T) {
 			annotationFilter: "kubernetes.io/gateway.class=nginx",
 		},
 	} {
+		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
+
 			_, err := NewIstioGatewaySource(
 				fake.NewSimpleClientset(),
 				istiofake.NewSimpleClientset(),
@@ -153,6 +160,8 @@ func TestNewIstioGatewaySource(t *testing.T) {
 }
 
 func testEndpointsFromGatewayConfig(t *testing.T) {
+	t.Parallel()
+
 	for _, ti := range []struct {
 		title      string
 		lbServices []fakeIngressGatewayService
@@ -305,7 +314,10 @@ func testEndpointsFromGatewayConfig(t *testing.T) {
 			},
 		},
 	} {
+		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
+
 			gatewayCfg := ti.config.Config()
 			if source, err := newTestGatewaySource(ti.lbServices); err != nil {
 				require.NoError(t, err)
@@ -321,6 +333,8 @@ func testEndpointsFromGatewayConfig(t *testing.T) {
 }
 
 func testGatewayEndpoints(t *testing.T) {
+	t.Parallel()
+
 	for _, ti := range []struct {
 		title                    string
 		targetNamespace          string
@@ -1131,7 +1145,9 @@ func testGatewayEndpoints(t *testing.T) {
 			},
 		},
 	} {
+		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
 
 			fakeKubernetesClient := fake.NewSimpleClientset()
 

--- a/source/gloo_test.go
+++ b/source/gloo_test.go
@@ -211,6 +211,8 @@ var externalProxySource = metav1.PartialObjectMetadata{
 }
 
 func TestGlooSource(t *testing.T) {
+	t.Parallel()
+
 	fakeKubernetesClient := fakeKube.NewSimpleClientset()
 	fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(runtime.NewScheme())
 

--- a/source/httpproxy_test.go
+++ b/source/httpproxy_test.go
@@ -18,7 +18,6 @@ package source
 
 import (
 	"context"
-	v1 "k8s.io/api/core/v1"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -26,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -87,12 +87,16 @@ func convertHTTPProxyToUnstructured(hp *projectcontour.HTTPProxy, s *runtime.Sch
 }
 
 func TestHTTPProxy(t *testing.T) {
+	t.Parallel()
+
 	suite.Run(t, new(HTTPProxySuite))
 	t.Run("endpointsFromHTTPProxy", testEndpointsFromHTTPProxy)
 	t.Run("Endpoints", testHTTPProxyEndpoints)
 }
 
 func TestNewContourHTTPProxySource(t *testing.T) {
+	t.Parallel()
+
 	for _, ti := range []struct {
 		title                    string
 		annotationFilter         string
@@ -131,7 +135,10 @@ func TestNewContourHTTPProxySource(t *testing.T) {
 			annotationFilter: "contour.heptio.com/ingress.class=contour",
 		},
 	} {
+		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
+
 			fakeDynamicClient, _ := newDynamicKubernetesClient()
 
 			_, err := NewContourHTTPProxySource(
@@ -152,6 +159,8 @@ func TestNewContourHTTPProxySource(t *testing.T) {
 }
 
 func testEndpointsFromHTTPProxy(t *testing.T) {
+	t.Parallel()
+
 	for _, ti := range []struct {
 		title     string
 		httpProxy fakeHTTPProxy
@@ -233,7 +242,10 @@ func testEndpointsFromHTTPProxy(t *testing.T) {
 			expected: []*endpoint.Endpoint{},
 		},
 	} {
+		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
+
 			if source, err := newTestHTTPProxySource(); err != nil {
 				require.NoError(t, err)
 			} else if endpoints, err := source.endpointsFromHTTPProxy(ti.httpProxy.HTTPProxy()); err != nil {
@@ -246,6 +258,8 @@ func testEndpointsFromHTTPProxy(t *testing.T) {
 }
 
 func testHTTPProxyEndpoints(t *testing.T) {
+	t.Parallel()
+
 	namespace := "testing"
 	for _, ti := range []struct {
 		title                    string
@@ -958,7 +972,10 @@ func testHTTPProxyEndpoints(t *testing.T) {
 			ignoreHostnameAnnotation: true,
 		},
 	} {
+		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
+
 			httpProxies := make([]*projectcontour.HTTPProxy, 0)
 			for _, item := range ti.httpProxyItems {
 				item.loadBalancer = ti.loadBalancer

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -995,6 +995,9 @@ func testIngressEndpoints(t *testing.T) {
 					DNSName:    "example.org",
 					Targets:    endpoint.Targets{"ingress-target.com"},
 					RecordType: endpoint.RecordTypeCNAME,
+					ProviderSpecific: endpoint.ProviderSpecific{{
+						Name: "alias", Value: "true",
+					}},
 				},
 			},
 		},

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -82,6 +82,8 @@ func (suite *IngressSuite) TestDualstackLabelIsSet() {
 }
 
 func TestIngress(t *testing.T) {
+	t.Parallel()
+
 	suite.Run(t, new(IngressSuite))
 	t.Run("endpointsFromIngress", testEndpointsFromIngress)
 	t.Run("endpointsFromIngressHostnameSourceAnnotation", testEndpointsFromIngressHostnameSourceAnnotation)
@@ -89,6 +91,8 @@ func TestIngress(t *testing.T) {
 }
 
 func TestNewIngressSource(t *testing.T) {
+	t.Parallel()
+
 	for _, ti := range []struct {
 		title                    string
 		annotationFilter         string
@@ -127,7 +131,10 @@ func TestNewIngressSource(t *testing.T) {
 			annotationFilter: "kubernetes.io/ingress.class=nginx",
 		},
 	} {
+		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
+
 			_, err := NewIngressSource(
 				fake.NewSimpleClientset(),
 				"",
@@ -148,6 +155,8 @@ func TestNewIngressSource(t *testing.T) {
 }
 
 func testEndpointsFromIngress(t *testing.T) {
+	t.Parallel()
+
 	for _, ti := range []struct {
 		title                    string
 		ingress                  fakeIngress
@@ -334,6 +343,8 @@ func testEndpointsFromIngressHostnameSourceAnnotation(t *testing.T) {
 }
 
 func testIngressEndpoints(t *testing.T) {
+	t.Parallel()
+
 	namespace := "testing"
 	for _, ti := range []struct {
 		title                    string
@@ -1159,7 +1170,10 @@ func testIngressEndpoints(t *testing.T) {
 			},
 		},
 	} {
+		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
+
 			fakeClient := fake.NewSimpleClientset()
 			for _, item := range ti.ingressItems {
 				ingress := item.Ingress()

--- a/source/ingressroute_test.go
+++ b/source/ingressroute_test.go
@@ -112,12 +112,16 @@ func convertIngressRouteToUnstructured(ir *contour.IngressRoute, s *runtime.Sche
 }
 
 func TestIngressRoute(t *testing.T) {
+	t.Parallel()
+
 	suite.Run(t, new(IngressRouteSuite))
 	t.Run("endpointsFromIngressRoute", testEndpointsFromIngressRoute)
 	t.Run("Endpoints", testIngressRouteEndpoints)
 }
 
 func TestNewContourIngressRouteSource(t *testing.T) {
+	t.Parallel()
+
 	for _, ti := range []struct {
 		title                    string
 		annotationFilter         string
@@ -156,7 +160,10 @@ func TestNewContourIngressRouteSource(t *testing.T) {
 			annotationFilter: "contour.heptio.com/ingress.class=contour",
 		},
 	} {
+		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
+
 			fakeDynamicClient, _ := newDynamicKubernetesClient()
 
 			_, err := NewContourIngressRouteSource(
@@ -273,7 +280,10 @@ func testEndpointsFromIngressRoute(t *testing.T) {
 			expected: []*endpoint.Endpoint{},
 		},
 	} {
+		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
+
 			if source, err := newTestIngressRouteSource(ti.loadBalancer); err != nil {
 				require.NoError(t, err)
 			} else if endpoints, err := source.endpointsFromIngressRoute(context.Background(), ti.ingressRoute.IngressRoute()); err != nil {
@@ -286,6 +296,8 @@ func testEndpointsFromIngressRoute(t *testing.T) {
 }
 
 func testIngressRouteEndpoints(t *testing.T) {
+	t.Parallel()
+
 	namespace := "testing"
 	for _, ti := range []struct {
 		title                    string
@@ -998,7 +1010,10 @@ func testIngressRouteEndpoints(t *testing.T) {
 			ignoreHostnameAnnotation: true,
 		},
 	} {
+		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
+
 			ingressRoutes := make([]*contour.IngressRoute, 0)
 			for _, item := range ti.ingressRouteItems {
 				ingressRoutes = append(ingressRoutes, item.IngressRoute())

--- a/source/kong_tcpingress_test.go
+++ b/source/kong_tcpingress_test.go
@@ -19,6 +19,8 @@ package source
 import (
 	"context"
 	"encoding/json"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,7 +29,6 @@ import (
 	fakeDynamic "k8s.io/client-go/dynamic/fake"
 	fakeKube "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/external-dns/endpoint"
-	"testing"
 )
 
 // This is a compile-time validation that glooSource is a Source.
@@ -36,6 +37,8 @@ var _ Source = &kongTCPIngressSource{}
 const defaultKongNamespace = "kong"
 
 func TestKongTCPIngressEndpoints(t *testing.T) {
+	t.Parallel()
+
 	for _, ti := range []struct {
 		title    string
 		tcpProxy TCPIngress
@@ -218,7 +221,10 @@ func TestKongTCPIngressEndpoints(t *testing.T) {
 			},
 		},
 	} {
+		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
+
 			fakeKubernetesClient := fakeKube.NewSimpleClientset()
 			scheme := runtime.NewScheme()
 			scheme.AddKnownTypes(kongGroupdVersionResource.GroupVersion(), &TCPIngress{}, &TCPIngressList{})

--- a/source/multi_source_test.go
+++ b/source/multi_source_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 func TestMultiSource(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Interface", testMultiSourceImplementsSource)
 	t.Run("Endpoints", testMultiSourceEndpoints)
 	t.Run("EndpointsWithError", testMultiSourceEndpointsWithError)
@@ -71,7 +73,10 @@ func testMultiSourceEndpoints(t *testing.T) {
 			[]*endpoint.Endpoint{foo, bar},
 		},
 	} {
+		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
 			// Prepare the nested mock sources.
 			sources := make([]Source, 0, len(tc.nestedEndpoints))
 

--- a/source/node_test.go
+++ b/source/node_test.go
@@ -30,12 +30,16 @@ import (
 )
 
 func TestNodeSource(t *testing.T) {
+	t.Parallel()
+
 	t.Run("NewNodeSource", testNodeSourceNewNodeSource)
 	t.Run("Endpoints", testNodeSourceEndpoints)
 }
 
 // testNodeSourceNewNodeSource tests that NewNodeService doesn't return an error.
 func testNodeSourceNewNodeSource(t *testing.T) {
+	t.Parallel()
+
 	for _, ti := range []struct {
 		title            string
 		annotationFilter string
@@ -62,7 +66,10 @@ func testNodeSourceNewNodeSource(t *testing.T) {
 			annotationFilter: "kubernetes.io/ingress.class=nginx",
 		},
 	} {
+		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
+
 			_, err := NewNodeSource(
 				fake.NewSimpleClientset(),
 				ti.annotationFilter,
@@ -80,6 +87,8 @@ func testNodeSourceNewNodeSource(t *testing.T) {
 
 // testNodeSourceEndpoints tests that various node generate the correct endpoints.
 func testNodeSourceEndpoints(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		title            string
 		annotationFilter string
@@ -321,7 +330,10 @@ func testNodeSourceEndpoints(t *testing.T) {
 			false,
 		},
 	} {
+		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
 			// Create a Kubernetes testing client
 			kubernetes := fake.NewSimpleClientset()
 

--- a/source/ocproute_test.go
+++ b/source/ocproute_test.go
@@ -19,7 +19,6 @@ package source
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -250,18 +249,7 @@ func testOcpRouteSourceEndpoints(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			var res []*endpoint.Endpoint
-
-			// wait up to a few seconds for new resources to appear in informer cache.
-			err = poll(time.Second, 3*time.Second, func() (bool, error) {
-				res, err = source.Endpoints(context.Background())
-				if err != nil {
-					// stop waiting if we get an error
-					return true, err
-				}
-				return len(res) >= len(tc.expected), nil
-			})
-
+			res, err := source.Endpoints(context.Background())
 			if tc.expectError {
 				require.Error(t, err)
 			} else {

--- a/source/ocproute_test.go
+++ b/source/ocproute_test.go
@@ -82,6 +82,8 @@ func (suite *OCPRouteSuite) TestResourceLabelIsSet() {
 }
 
 func TestOcpRouteSource(t *testing.T) {
+	t.Parallel()
+
 	suite.Run(t, new(OCPRouteSuite))
 	t.Run("Interface", testOcpRouteSourceImplementsSource)
 	t.Run("NewOcpRouteSource", testOcpRouteSourceNewOcpRouteSource)
@@ -95,6 +97,8 @@ func testOcpRouteSourceImplementsSource(t *testing.T) {
 
 // testOcpRouteSourceNewOcpRouteSource tests that NewOcpRouteSource doesn't return an error.
 func testOcpRouteSourceNewOcpRouteSource(t *testing.T) {
+	t.Parallel()
+
 	for _, ti := range []struct {
 		title            string
 		annotationFilter string
@@ -121,7 +125,10 @@ func testOcpRouteSourceNewOcpRouteSource(t *testing.T) {
 			annotationFilter: "kubernetes.io/ingress.class=nginx",
 		},
 	} {
+		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
+
 			_, err := NewOcpRouteSource(
 				fake.NewSimpleClientset(),
 				"",
@@ -142,6 +149,8 @@ func testOcpRouteSourceNewOcpRouteSource(t *testing.T) {
 
 // testOcpRouteSourceEndpoints tests that various OCP routes generate the correct endpoints.
 func testOcpRouteSourceEndpoints(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		title                    string
 		targetNamespace          string
@@ -232,7 +241,10 @@ func testOcpRouteSourceEndpoints(t *testing.T) {
 			expectError: false,
 		},
 	} {
+		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
 			// Create a Kubernetes testing client
 			fakeClient := fake.NewSimpleClientset()
 

--- a/source/pod_test.go
+++ b/source/pod_test.go
@@ -29,6 +29,8 @@ import (
 
 // testPodSource tests that various services generate the correct endpoints.
 func TestPodSource(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		title           string
 		targetNamespace string
@@ -387,7 +389,10 @@ func TestPodSource(t *testing.T) {
 			},
 		},
 	} {
+		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
 			// Create a Kubernetes testing client
 			kubernetes := fake.NewSimpleClientset()
 			ctx := context.Background()

--- a/source/routegroup_test.go
+++ b/source/routegroup_test.go
@@ -44,6 +44,8 @@ func createTestRouteGroup(ns, name string, annotations map[string]string, hosts 
 }
 
 func TestEndpointsFromRouteGroups(t *testing.T) {
+	t.Parallel()
+
 	for _, tt := range []struct {
 		name   string
 		source *routeGroupSource

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -87,6 +87,8 @@ func (suite *ServiceSuite) TestResourceLabelIsSet() {
 }
 
 func TestServiceSource(t *testing.T) {
+	t.Parallel()
+
 	suite.Run(t, new(ServiceSuite))
 	t.Run("Interface", testServiceSourceImplementsSource)
 	t.Run("NewServiceSource", testServiceSourceNewServiceSource)
@@ -101,6 +103,8 @@ func testServiceSourceImplementsSource(t *testing.T) {
 
 // testServiceSourceNewServiceSource tests that NewServiceSource doesn't return an error.
 func testServiceSourceNewServiceSource(t *testing.T) {
+	t.Parallel()
+
 	for _, ti := range []struct {
 		title              string
 		annotationFilter   string
@@ -133,7 +137,10 @@ func testServiceSourceNewServiceSource(t *testing.T) {
 			serviceTypesFilter: []string{string(v1.ServiceTypeClusterIP)},
 		},
 	} {
+		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
+
 			_, err := NewServiceSource(
 				fake.NewSimpleClientset(),
 				"",
@@ -159,6 +166,8 @@ func testServiceSourceNewServiceSource(t *testing.T) {
 
 // testServiceSourceEndpoints tests that various services generate the correct endpoints.
 func testServiceSourceEndpoints(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		title                    string
 		targetNamespace          string
@@ -1230,7 +1239,10 @@ func testServiceSourceEndpoints(t *testing.T) {
 			false,
 		},
 	} {
+		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
 			// Create a Kubernetes testing client
 			kubernetes := fake.NewSimpleClientset()
 
@@ -1297,6 +1309,8 @@ func testServiceSourceEndpoints(t *testing.T) {
 
 // testMultipleServicesEndpoints tests that multiple services generate correct merged endpoints
 func testMultipleServicesEndpoints(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		title                    string
 		targetNamespace          string
@@ -1392,7 +1406,9 @@ func testMultipleServicesEndpoints(t *testing.T) {
 			false,
 		},
 	} {
+		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
 
 			// Create a Kubernetes testing client
 			kubernetes := fake.NewSimpleClientset()
@@ -1471,6 +1487,8 @@ func testMultipleServicesEndpoints(t *testing.T) {
 
 // testServiceSourceEndpoints tests that various services generate the correct endpoints.
 func TestClusterIpServices(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		title                    string
 		targetNamespace          string
@@ -1565,7 +1583,10 @@ func TestClusterIpServices(t *testing.T) {
 			false,
 		},
 	} {
+		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
 			// Create a Kubernetes testing client
 			kubernetes := fake.NewSimpleClientset()
 
@@ -1631,6 +1652,8 @@ func TestClusterIpServices(t *testing.T) {
 
 // testNodePortServices tests that various services generate the correct endpoints.
 func TestServiceSourceNodePortServices(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		title                    string
 		targetNamespace          string
@@ -2222,7 +2245,10 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 			[]v1.PodPhase{},
 		},
 	} {
+		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
 			// Create a Kubernetes testing client
 			kubernetes := fake.NewSimpleClientset()
 
@@ -2309,6 +2335,8 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 
 // TestHeadlessServices tests that headless services generate the correct endpoints.
 func TestHeadlessServices(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		title                    string
 		targetNamespace          string
@@ -2534,7 +2562,10 @@ func TestHeadlessServices(t *testing.T) {
 			false,
 		},
 	} {
+		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
 			// Create a Kubernetes testing client
 			kubernetes := fake.NewSimpleClientset()
 
@@ -2638,6 +2669,8 @@ func TestHeadlessServices(t *testing.T) {
 
 // TestHeadlessServices tests that headless services generate the correct endpoints.
 func TestHeadlessServicesHostIP(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		title                    string
 		targetNamespace          string
@@ -2887,7 +2920,10 @@ func TestHeadlessServicesHostIP(t *testing.T) {
 			false,
 		},
 	} {
+		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
 			// Create a Kubernetes testing client
 			kubernetes := fake.NewSimpleClientset()
 
@@ -2988,6 +3024,8 @@ func TestHeadlessServicesHostIP(t *testing.T) {
 
 // TestExternalServices tests that external services generate the correct endpoints.
 func TestExternalServices(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		title                    string
 		targetNamespace          string
@@ -3042,7 +3080,10 @@ func TestExternalServices(t *testing.T) {
 			false,
 		},
 	} {
+		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
 			// Create a Kubernetes testing client
 			kubernetes := fake.NewSimpleClientset()
 

--- a/source/shared_test.go
+++ b/source/shared_test.go
@@ -48,6 +48,8 @@ func sortEndpoints(endpoints []*endpoint.Endpoint) {
 }
 
 func validateEndpoints(t *testing.T, endpoints, expected []*endpoint.Endpoint) {
+	t.Helper()
+
 	if len(endpoints) != len(expected) {
 		t.Fatalf("expected %d endpoints, got %d", len(expected), len(endpoints))
 	}
@@ -62,12 +64,14 @@ func validateEndpoints(t *testing.T, endpoints, expected []*endpoint.Endpoint) {
 }
 
 func validateEndpoint(t *testing.T, endpoint, expected *endpoint.Endpoint) {
+	t.Helper()
+
 	if endpoint.DNSName != expected.DNSName {
-		t.Errorf("DNSName expected %s, got %s", expected.DNSName, endpoint.DNSName)
+		t.Errorf("DNSName expected %q, got %q", expected.DNSName, endpoint.DNSName)
 	}
 
 	if !endpoint.Targets.Same(expected.Targets) {
-		t.Errorf("Targets expected %s, got %s", expected.Targets, endpoint.Targets)
+		t.Errorf("Targets expected %q, got %q", expected.Targets, endpoint.Targets)
 	}
 
 	if endpoint.RecordTTL != expected.RecordTTL {
@@ -76,11 +80,20 @@ func validateEndpoint(t *testing.T, endpoint, expected *endpoint.Endpoint) {
 
 	// if non-empty record type is expected, check that it matches.
 	if expected.RecordType != "" && endpoint.RecordType != expected.RecordType {
-		t.Errorf("RecordType expected %s, got %s", expected.RecordType, endpoint.RecordType)
+		t.Errorf("RecordType expected %q, got %q", expected.RecordType, endpoint.RecordType)
 	}
 
 	// if non-empty labels are expected, check that they matches.
 	if expected.Labels != nil && !reflect.DeepEqual(endpoint.Labels, expected.Labels) {
 		t.Errorf("Labels expected %s, got %s", expected.Labels, endpoint.Labels)
+	}
+
+	if (len(expected.ProviderSpecific) != 0 || len(endpoint.ProviderSpecific) != 0) &&
+		!reflect.DeepEqual(endpoint.ProviderSpecific, expected.ProviderSpecific) {
+		t.Errorf("ProviderSpecific expected %s, got %s", expected.ProviderSpecific, endpoint.ProviderSpecific)
+	}
+
+	if endpoint.SetIdentifier != expected.SetIdentifier {
+		t.Errorf("SetIdentifier expected %q, got %q", expected.SetIdentifier, endpoint.SetIdentifier)
 	}
 }

--- a/source/shared_test.go
+++ b/source/shared_test.go
@@ -17,27 +17,44 @@ limitations under the License.
 package source
 
 import (
-	"sort"
-	"strings"
-	"testing"
 	"reflect"
+	"sort"
+	"testing"
 
 	"sigs.k8s.io/external-dns/endpoint"
 )
 
-// test helper functions
+func sortEndpoints(endpoints []*endpoint.Endpoint) {
+	for _, ep := range endpoints {
+		sort.Strings([]string(ep.Targets))
+	}
+	sort.Slice(endpoints, func(i, k int) bool {
+		// Sort by DNSName and Targets
+		ei, ek := endpoints[i], endpoints[k]
+		if ei.DNSName != ek.DNSName {
+			return ei.DNSName < ek.DNSName
+		}
+		// Targets are sorted ahead of time.
+		for j, ti := range ei.Targets {
+			if j >= len(ek.Targets) {
+				return true
+			}
+			if tk := ek.Targets[j]; ti != tk {
+				return ti < tk
+			}
+		}
+		return false
+	})
+}
 
 func validateEndpoints(t *testing.T, endpoints, expected []*endpoint.Endpoint) {
 	if len(endpoints) != len(expected) {
 		t.Fatalf("expected %d endpoints, got %d", len(expected), len(endpoints))
 	}
+
 	// Make sure endpoints are sorted - validateEndpoint() depends on it.
-	sort.SliceStable(endpoints, func(i, j int) bool {
-		return strings.Compare(endpoints[i].DNSName, endpoints[j].DNSName) < 0
-	})
-	sort.SliceStable(expected, func(i, j int) bool {
-		return strings.Compare(expected[i].DNSName, expected[j].DNSName) < 0
-	})
+	sortEndpoints(endpoints)
+	sortEndpoints(expected)
 
 	for i := range endpoints {
 		validateEndpoint(t, endpoints[i], expected[i])
@@ -46,24 +63,24 @@ func validateEndpoints(t *testing.T, endpoints, expected []*endpoint.Endpoint) {
 
 func validateEndpoint(t *testing.T, endpoint, expected *endpoint.Endpoint) {
 	if endpoint.DNSName != expected.DNSName {
-		t.Errorf("expected %s, got %s", expected.DNSName, endpoint.DNSName)
+		t.Errorf("DNSName expected %s, got %s", expected.DNSName, endpoint.DNSName)
 	}
 
 	if !endpoint.Targets.Same(expected.Targets) {
-		t.Errorf("expected %s, got %s", expected.Targets, endpoint.Targets)
+		t.Errorf("Targets expected %s, got %s", expected.Targets, endpoint.Targets)
 	}
 
 	if endpoint.RecordTTL != expected.RecordTTL {
-		t.Errorf("expected %v, got %v", expected.RecordTTL, endpoint.RecordTTL)
+		t.Errorf("RecordTTL expected %v, got %v", expected.RecordTTL, endpoint.RecordTTL)
 	}
 
 	// if non-empty record type is expected, check that it matches.
 	if expected.RecordType != "" && endpoint.RecordType != expected.RecordType {
-		t.Errorf("expected %s, got %s", expected.RecordType, endpoint.RecordType)
+		t.Errorf("RecordType expected %s, got %s", expected.RecordType, endpoint.RecordType)
 	}
 
 	// if non-empty labels are expected, check that they matches.
-	if expected.Labels != nil && !reflect.DeepEqual(endpoint.Labels,expected.Labels) {
-		t.Errorf("expected %s, got %s", expected.Labels, endpoint.Labels)
+	if expected.Labels != nil && !reflect.DeepEqual(endpoint.Labels, expected.Labels) {
+		t.Errorf("Labels expected %s, got %s", expected.Labels, endpoint.Labels)
 	}
 }

--- a/source/store_test.go
+++ b/source/store_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	istioclient "istio.io/client-go/pkg/clientset/versioned"
+	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	fakeKube "k8s.io/client-go/kubernetes/fake"
@@ -93,7 +94,7 @@ func (suite *ByNamesTestSuite) TestAllInitialized() {
 
 	mockClientGenerator := new(MockClientGenerator)
 	mockClientGenerator.On("KubeClient").Return(fakeKube.NewSimpleClientset(), nil)
-	mockClientGenerator.On("IstioClient").Return(NewFakeConfigStore(), nil)
+	mockClientGenerator.On("IstioClient").Return(istiofake.NewSimpleClientset(), nil)
 	mockClientGenerator.On("DynamicKubernetesClient").Return(fakeDynamic, nil)
 
 	sources, err := ByNames(mockClientGenerator, []string{"service", "ingress", "istio-gateway", "contour-ingressroute", "contour-httpproxy", "kong-tcpingress", "fake"}, minimalConfig)

--- a/source/virtualservice_test.go
+++ b/source/virtualservice_test.go
@@ -110,6 +110,8 @@ func (suite *VirtualServiceSuite) TestResourceLabelIsSet() {
 }
 
 func TestVirtualService(t *testing.T) {
+	t.Parallel()
+
 	suite.Run(t, new(VirtualServiceSuite))
 	t.Run("virtualServiceBindsToGateway", testVirtualServiceBindsToGateway)
 	t.Run("endpointsFromVirtualServiceConfig", testEndpointsFromVirtualServiceConfig)
@@ -118,6 +120,8 @@ func TestVirtualService(t *testing.T) {
 }
 
 func TestNewIstioVirtualServiceSource(t *testing.T) {
+	t.Parallel()
+
 	for _, ti := range []struct {
 		title                    string
 		annotationFilter         string
@@ -156,7 +160,10 @@ func TestNewIstioVirtualServiceSource(t *testing.T) {
 			annotationFilter: "kubernetes.io/gateway.class=nginx",
 		},
 	} {
+		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
+
 			_, err := NewIstioVirtualServiceSource(
 				fake.NewSimpleClientset(),
 				istiofake.NewSimpleClientset(),
@@ -359,6 +366,8 @@ func testVirtualServiceBindsToGateway(t *testing.T) {
 }
 
 func testEndpointsFromVirtualServiceConfig(t *testing.T) {
+	t.Parallel()
+
 	for _, ti := range []struct {
 		title      string
 		lbServices []fakeIngressGatewayService
@@ -538,7 +547,10 @@ func testEndpointsFromVirtualServiceConfig(t *testing.T) {
 			},
 		},
 	} {
+		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
+
 			if source, err := newTestVirtualServiceSource(ti.lbServices, []fakeGatewayConfig{ti.gwconfig}); err != nil {
 				require.NoError(t, err)
 			} else if endpoints, err := source.endpointsFromVirtualService(context.Background(), ti.vsconfig.Config()); err != nil {
@@ -551,6 +563,8 @@ func testEndpointsFromVirtualServiceConfig(t *testing.T) {
 }
 
 func testVirtualServiceEndpoints(t *testing.T) {
+	t.Parallel()
+
 	namespace := "testing"
 	for _, ti := range []struct {
 		title                    string
@@ -1433,7 +1447,10 @@ func testVirtualServiceEndpoints(t *testing.T) {
 			fqdnTemplate: "{{.Name}}.ext-dns.test.com",
 		},
 	} {
+		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
+
 			var gateways []networkingv1alpha3.Gateway
 			var virtualservices []networkingv1alpha3.VirtualService
 

--- a/source/virtualservice_test.go
+++ b/source/virtualservice_test.go
@@ -70,17 +70,6 @@ func (suite *VirtualServiceSuite) SetupTest() {
 		suite.NoError(err, "should succeed")
 	}
 
-	suite.source, err = NewIstioVirtualServiceSource(
-		fakeKubernetesClient,
-		fakeIstioClient,
-		"",
-		"",
-		"{{.Name}}",
-		false,
-		false,
-	)
-	suite.NoError(err, "should initialize virtualservice source")
-
 	suite.gwconfig = (fakeGatewayConfig{
 		name:      "foo-gateway-with-targets",
 		namespace: "istio-system",
@@ -97,6 +86,17 @@ func (suite *VirtualServiceSuite) SetupTest() {
 	}).Config()
 	_, err = fakeIstioClient.NetworkingV1alpha3().VirtualServices(suite.vsconfig.Namespace).Create(context.Background(), &suite.vsconfig, metav1.CreateOptions{})
 	suite.NoError(err, "should succeed")
+
+	suite.source, err = NewIstioVirtualServiceSource(
+		fakeKubernetesClient,
+		fakeIstioClient,
+		"",
+		"",
+		"{{.Name}}",
+		false,
+		false,
+	)
+	suite.NoError(err, "should initialize virtualservice source")
 }
 
 func (suite *VirtualServiceSuite) TestResourceLabelIsSet() {

--- a/source/virtualservice_test.go
+++ b/source/virtualservice_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	istionetworking "istio.io/api/networking/v1alpha3"
 	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -47,7 +48,7 @@ type VirtualServiceSuite struct {
 
 func (suite *VirtualServiceSuite) SetupTest() {
 	fakeKubernetesClient := fake.NewSimpleClientset()
-	fakeIstioClient := NewFakeConfigStore()
+	fakeIstioClient := istiofake.NewSimpleClientset()
 	var err error
 
 	suite.lbServices = []*v1.Service{
@@ -158,7 +159,7 @@ func TestNewIstioVirtualServiceSource(t *testing.T) {
 		t.Run(ti.title, func(t *testing.T) {
 			_, err := NewIstioVirtualServiceSource(
 				fake.NewSimpleClientset(),
-				NewFakeConfigStore(),
+				istiofake.NewSimpleClientset(),
 				"",
 				ti.annotationFilter,
 				ti.fqdnTemplate,
@@ -1451,7 +1452,7 @@ func testVirtualServiceEndpoints(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			fakeIstioClient := NewFakeConfigStore()
+			fakeIstioClient := istiofake.NewSimpleClientset()
 
 			for _, gateway := range gateways {
 				_, err := fakeIstioClient.NetworkingV1alpha3().Gateways(gateway.Namespace).Create(context.Background(), &gateway, metav1.CreateOptions{})
@@ -1520,7 +1521,7 @@ func testGatewaySelectorMatchesService(t *testing.T) {
 
 func newTestVirtualServiceSource(loadBalancerList []fakeIngressGatewayService, gwList []fakeGatewayConfig) (*virtualServiceSource, error) {
 	fakeKubernetesClient := fake.NewSimpleClientset()
-	fakeIstioClient := NewFakeConfigStore()
+	fakeIstioClient := istiofake.NewSimpleClientset()
 
 	for _, lb := range loadBalancerList {
 		service := lb.Service()


### PR DESCRIPTION
**Description**

This makes Source tests run much faster and deterministically:
- When comparing lists of endpoints, those with the same DNS name but different targets are sorted consistently.
- When validating endpoints, compare ProviderSpecific and SetIdentifier fields.
- Test resources (services, ingresses, etc.) are created before the Source, which eliminates informer timing issues.
- Connector Source tests, which run a TCP server, pick any open port instead of using fixed ports which may be taken. Also close the listener.
- All Source tests that rely on informer synchronization have been parallelized. Locally, this drops the running time from 30s+ to ~5s.

Prelude to #2045

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated (N/A)
