### PR TITLE
Fix controller tests

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -223,6 +223,9 @@ func TestShouldRunOnce(t *testing.T) {
 
 func testControllerFiltersDomains(t *testing.T, configuredEndpoints []*endpoint.Endpoint, domainFilter endpoint.DomainFilterInterface, providerEndpoints []*endpoint.Endpoint, expectedChanges []*plan.Changes) {
 	t.Helper()
+	cfg := externaldns.NewConfig()
+	cfg.ManagedDNSRecordTypes = []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME}
+
 	source := new(testutils.MockSource)
 	source.On("Endpoints").Return(configuredEndpoints, nil)
 
@@ -235,10 +238,11 @@ func testControllerFiltersDomains(t *testing.T, configuredEndpoints []*endpoint.
 	require.NoError(t, err)
 
 	ctrl := &Controller{
-		Source:       source,
-		Registry:     r,
-		Policy:       &plan.SyncPolicy{},
-		DomainFilter: domainFilter,
+		Source:             source,
+		Registry:           r,
+		Policy:             &plan.SyncPolicy{},
+		DomainFilter:       domainFilter,
+		ManagedRecordTypes: cfg.ManagedDNSRecordTypes,
 	}
 
 	assert.NoError(t, ctrl.RunOnce(context.Background()))


### PR DESCRIPTION
8d6f29b8a09ddc245a712c370f1ed9de97426198 commit breaks
TestWhenNoFilterControllerConsidersAllComain and
TestWhenMultipleControllerConsidersAllFilteredComain tests,
lets fix them

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes https://github.com/kubernetes-sigs/external-dns/issues/2196

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
