### PR TITLE
Fix alpine vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY . .
 RUN make test build.$ARCH
 
 # final image
-FROM $ARCH/alpine:3.13
+FROM $ARCH/alpine:3.14
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /bin/external-dns


### PR DESCRIPTION
This PR fixes CVE-2021-36159 by bumping to the next version of alpine.

Related to https://github.com/kubernetes-sigs/external-dns/issues/2211 

/cc @njuettner 