### PR TITLE
CRD source: add event-handler support

### DIFF
--- a/main.go
+++ b/main.go
@@ -133,6 +133,7 @@ func main() {
 		RequestTimeout:                 cfg.RequestTimeout,
 		DefaultTargets:                 cfg.DefaultTargets,
 		OCPRouterName:                  cfg.OCPRouterName,
+		UpdateEvents:                   cfg.UpdateEvents,
 	}
 
 	// Lookup all the selected sources by names and pass them the desired configuration.

--- a/source/crd.go
+++ b/source/crd.go
@@ -108,7 +108,7 @@ func NewCRDClientForAPIVersionKind(client kubernetes.Interface, kubeConfig, apiS
 }
 
 // NewCRDSource creates a new crdSource with the given config.
-func NewCRDSource(crdClient rest.Interface, namespace, kind string, annotationFilter string, labelSelector labels.Selector, scheme *runtime.Scheme) (Source, error) {
+func NewCRDSource(crdClient rest.Interface, namespace, kind string, annotationFilter string, labelSelector labels.Selector, scheme *runtime.Scheme, startInformer bool) (Source, error) {
 	sourceCrd := crdSource{
 		crdResource:      strings.ToLower(kind) + "s",
 		namespace:        namespace,
@@ -117,43 +117,46 @@ func NewCRDSource(crdClient rest.Interface, namespace, kind string, annotationFi
 		crdClient:        crdClient,
 		codec:            runtime.NewParameterCodec(scheme),
 	}
-	// external-dns already runs its sync-handler periodically (controlled by `--interval` flag) to ensure any
-	// missed or dropped events are handled.  specify a resync period 0 to avoid unnecessary sync handler invocations.
-	informer := cache.NewSharedInformer(
-		&cache.ListWatch{
-			ListFunc: func(lo metav1.ListOptions) (result runtime.Object, err error) {
-				return sourceCrd.List(context.TODO(), &lo)
+	if startInformer {
+		// external-dns already runs its sync-handler periodically (controlled by `--interval` flag) to ensure any
+		// missed or dropped events are handled.  specify a resync period 0 to avoid unnecessary sync handler invocations.
+		informer := cache.NewSharedInformer(
+			&cache.ListWatch{
+				ListFunc: func(lo metav1.ListOptions) (result runtime.Object, err error) {
+					return sourceCrd.List(context.TODO(), &lo)
+				},
+				WatchFunc: func(lo metav1.ListOptions) (watch.Interface, error) {
+					return sourceCrd.watch(context.TODO(), &lo)
+				},
 			},
-			WatchFunc: func(lo metav1.ListOptions) (watch.Interface, error) {
-				return sourceCrd.watch(context.TODO(), &lo)
-			},
-		},
-		&endpoint.DNSEndpoint{},
-		0)
-	sourceCrd.informer = &informer
-	go informer.Run(wait.NeverStop)
+			&endpoint.DNSEndpoint{},
+			0)
+		sourceCrd.informer = &informer
+		go informer.Run(wait.NeverStop)
+	}
 	return &sourceCrd, nil
 }
 
 func (cs *crdSource) AddEventHandler(ctx context.Context, handler func()) {
-	log.Debug("Adding event handler for CRD")
-
-	// Right now there is no way to remove event handler from informer, see:
-	// https://github.com/kubernetes/kubernetes/issues/79610
-	informer := *cs.informer
-	informer.AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				handler()
+	if cs.informer != nil {
+		log.Debug("Adding event handler for CRD")
+		// Right now there is no way to remove event handler from informer, see:
+		// https://github.com/kubernetes/kubernetes/issues/79610
+		informer := *cs.informer
+		informer.AddEventHandler(
+			cache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {
+					handler()
+				},
+				UpdateFunc: func(old interface{}, new interface{}) {
+					handler()
+				},
+				DeleteFunc: func(obj interface{}) {
+					handler()
+				},
 			},
-			UpdateFunc: func(old interface{}, new interface{}) {
-				handler()
-			},
-			DeleteFunc: func(obj interface{}) {
-				handler()
-			},
-		},
-	)
+		)
+	}
 }
 
 // Endpoints returns endpoint objects.

--- a/source/crd.go
+++ b/source/crd.go
@@ -19,11 +19,12 @@ package source
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
+
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
-	"os"
-	"strings"
 
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -387,7 +387,12 @@ func testCRDSourceEndpoints(t *testing.T) {
 			labelSelector, err := labels.Parse(ti.labelFilter)
 			require.NoError(t, err)
 
-			cs, err := NewCRDSource(restClient, ti.namespace, ti.kind, ti.annotationFilter, labelSelector, scheme, false)
+			// At present, client-go's fake.RESTClient (used by crd_test.go) is known to cause race conditions when used
+			// with informers: https://github.com/kubernetes/kubernetes/issues/95372
+			// So don't start the informer during testing.
+			startInformer := false
+
+			cs, err := NewCRDSource(restClient, ti.namespace, ti.kind, ti.annotationFilter, labelSelector, scheme, startInformer)
 			require.NoError(t, err)
 
 			receivedEndpoints, err := cs.Endpoints(context.Background())

--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -387,7 +387,7 @@ func testCRDSourceEndpoints(t *testing.T) {
 			labelSelector, err := labels.Parse(ti.labelFilter)
 			require.NoError(t, err)
 
-			cs, err := NewCRDSource(restClient, ti.namespace, ti.kind, ti.annotationFilter, labelSelector, scheme)
+			cs, err := NewCRDSource(restClient, ti.namespace, ti.kind, ti.annotationFilter, labelSelector, scheme, false)
 			require.NoError(t, err)
 
 			receivedEndpoints, err := cs.Endpoints(context.Background())

--- a/source/store.go
+++ b/source/store.go
@@ -270,7 +270,8 @@ func BuildWithConfig(ctx context.Context, source string, p ClientGenerator, cfg 
 		if err != nil {
 			return nil, err
 		}
-		return NewCRDSource(crdClient, cfg.Namespace, cfg.CRDSourceKind, cfg.AnnotationFilter, cfg.LabelFilter, scheme, true)
+		startInformer := true
+		return NewCRDSource(crdClient, cfg.Namespace, cfg.CRDSourceKind, cfg.AnnotationFilter, cfg.LabelFilter, scheme, startInformer)
 	case "skipper-routegroup":
 		apiServerURL := cfg.APIServerURL
 		tokenPath := ""

--- a/source/store.go
+++ b/source/store.go
@@ -270,7 +270,7 @@ func BuildWithConfig(ctx context.Context, source string, p ClientGenerator, cfg 
 		if err != nil {
 			return nil, err
 		}
-		return NewCRDSource(crdClient, cfg.Namespace, cfg.CRDSourceKind, cfg.AnnotationFilter, cfg.LabelFilter, scheme)
+		return NewCRDSource(crdClient, cfg.Namespace, cfg.CRDSourceKind, cfg.AnnotationFilter, cfg.LabelFilter, scheme, true)
 	case "skipper-routegroup":
 		apiServerURL := cfg.APIServerURL
 		tokenPath := ""

--- a/source/store.go
+++ b/source/store.go
@@ -69,6 +69,7 @@ type Config struct {
 	RequestTimeout                 time.Duration
 	DefaultTargets                 []string
 	OCPRouterName                  string
+	UpdateEvents                   bool
 }
 
 // ClientGenerator provides clients
@@ -270,8 +271,7 @@ func BuildWithConfig(ctx context.Context, source string, p ClientGenerator, cfg 
 		if err != nil {
 			return nil, err
 		}
-		startInformer := true
-		return NewCRDSource(crdClient, cfg.Namespace, cfg.CRDSourceKind, cfg.AnnotationFilter, cfg.LabelFilter, scheme, startInformer)
+		return NewCRDSource(crdClient, cfg.Namespace, cfg.CRDSourceKind, cfg.AnnotationFilter, cfg.LabelFilter, scheme, cfg.UpdateEvents)
 	case "skipper-routegroup":
 		apiServerURL := cfg.APIServerURL
 		tokenPath := ""


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

When the `--events` flag is passed at startup, `Source.AddEventHandler()` is called
on each configured source.  Most sources provide `AddEventHandler()`
implementations that invoke the reconciliation loop when the configured source
changes, but the CRD source had a no-op implementation.  I.e. when a custom
resource was created, updated, or deleted, external-dns remained unware, and the
reconciliation loop would not fire until the configured interval had passed.

This change adds an informer (on the CRD specified by `--crd-source-apiversion`
and `--crd-source-kind=DNSEndpoint`), and a `Source.AddEventHandler()`
implementation that calls `Informer.AddEventHandler()`.  Now when a custom
resource is created, updated, or deleted, the reconciliation loop is invoked.

## Testing
I ran external-dns with the "inmemory" provider, the "noop" registry, and the `--events` flag with a CRD source, and observed normal startup:
```
host:~ user$ external-dns \
> --provider=inmemory \
> --inmemory-zone=example.com \
> --registry=noop \
> --source=crd \
> --crd-source-apiversion=example.com/v1 \
> --crd-source-kind=DNSEndpoint \
> --events \
> --interval=1800s
INFO[0000] config: {APIServerURL: KubeConfig: RequestTimeout:30s DefaultTargets:[] ContourLoadBalancerService:heptio-contour/contour GlooNamespace:gloo-system SkipperRouteGroupVersion:zalando.org/v1 Sources:[crd] Namespace: AnnotationFilter: LabelFilter: FQDNTemplate: CombineFQDNAndAnnotation:false IgnoreHostnameAnnotation:false IgnoreIngressTLSSpec:false IgnoreIngressRulesSpec:false Compatibility: PublishInternal:false PublishHostIP:false AlwaysPublishNotReadyAddresses:false ConnectorSourceServer:localhost:8080 Provider:inmemory GoogleProject: GoogleBatchChangeSize:1000 GoogleBatchChangeInterval:1s GoogleZoneVisibility: DomainFilter:[] ExcludeDomains:[] RegexDomainFilter: RegexDomainExclusion: ZoneNameFilter:[] ZoneIDFilter:[] AlibabaCloudConfigFile:/etc/kubernetes/alibaba-cloud.json AlibabaCloudZoneType: AWSZoneType: AWSZoneTagFilter:[] AWSAssumeRole: AWSBatchChangeSize:1000 AWSBatchChangeInterval:1s AWSEvaluateTargetHealth:true AWSAPIRetries:3 AWSPreferCNAME:false AWSZoneCacheDuration:0s AzureConfigFile:/etc/kubernetes/azure.json AzureResourceGroup: AzureSubscriptionID: AzureUserAssignedIdentityClientID: BluecatConfigFile:/etc/kubernetes/bluecat.json CloudflareProxied:false CloudflareZonesPerPage:50 CoreDNSPrefix:/skydns/ RcodezeroTXTEncrypt:false AkamaiServiceConsumerDomain: AkamaiClientToken: AkamaiClientSecret: AkamaiAccessToken: AkamaiEdgercPath: AkamaiEdgercSection: InfobloxGridHost: InfobloxWapiPort:443 InfobloxWapiUsername:admin InfobloxWapiPassword: InfobloxWapiVersion:2.3.1 InfobloxSSLVerify:true InfobloxView: InfobloxMaxResults:0 InfobloxFQDNRegEx: DynCustomerName: DynUsername: DynPassword: DynMinTTLSeconds:0 OCIConfigFile:/etc/kubernetes/oci.yaml InMemoryZones:[example.com] OVHEndpoint:ovh-eu OVHApiRateLimit:20 PDNSServer:http://localhost:8081 PDNSAPIKey: PDNSTLSEnabled:false TLSCA: TLSClientCert: TLSClientCertKey: Policy:sync Registry:noop TXTOwnerID:default TXTPrefix: TXTSuffix: Interval:30m0s MinEventSyncInterval:5s Once:false DryRun:false UpdateEvents:true LogFormat:text MetricsAddress::7979 LogLevel:info TXTCacheInterval:0s TXTWildcardReplacement: ExoscaleEndpoint:https://api.exoscale.ch/dns ExoscaleAPIKey: ExoscaleAPISecret: CRDSourceAPIVersion:example.com/v1 CRDSourceKind:DNSEndpoint ServiceTypeFilter:[] CFAPIEndpoint: CFUsername: CFPassword: RFC2136Host: RFC2136Port:0 RFC2136Zone: RFC2136Insecure:false RFC2136GSSTSIG:false RFC2136KerberosRealm: RFC2136KerberosUsername: RFC2136KerberosPassword: RFC2136TSIGKeyName: RFC2136TSIGSecret: RFC2136TSIGSecretAlg: RFC2136TAXFR:false RFC2136MinTTL:0s RFC2136BatchChangeSize:50 NS1Endpoint: NS1IgnoreSSL:false NS1MinTTLSeconds:0 TransIPAccountName: TransIPPrivateKeyFile: DigitalOceanAPIPageSize:50 ManagedDNSRecordTypes:[A CNAME] GoDaddyAPIKey: GoDaddySecretKey: GoDaddyTTL:0 GoDaddyOTE:false} 
INFO[0000] Instantiating new Kubernetes client          
INFO[0000] Using kubeConfig                             
INFO[0000] Created Kubernetes client https://138.1.18.242:6443 
INFO[0008] All records are already up to date
```
Then I used the following files to create new instances of my custom resource, one in the default namespace, and one in the "foo" namespace (to verify that the event handler logic handles namespaces correctly):
```
host:~ user$ cat dnsendpoint-default.yaml 
apiVersion: example.com/v1
kind: DNSEndpoint
metadata:
  name: in-default-namespace
  namespace: default
spec:
  endpoints:
  - dnsName: 'in-default.example.com'
    recordType: A
    targets:
    - 192.0.2.1
host:~ user$ cat dnsendpoint-foo.yaml 
apiVersion: example.com/v1
kind: DNSEndpoint
metadata:
  name: in-foo-namespace
  namespace: foo
spec:
  endpoints:
  - dnsName: 'in-foo.example.com'
    recordType: A
    targets:
    - 192.0.2.2
```
I applied the files to create the resources.  I added a `sleep 30` in between to see if there was a corresponding period between external-dns detecting the two creations:
```
host:~ user$ kubectl apply -f dnsendpoint-default.yaml 
dnsendpoint.example.com/in-default-namespace created
host:~ user$ sleep 30
host:~ user$ kubectl apply -f dnsendpoint-foo.yaml 
dnsendpoint.example.com/in-foo-namespace created
```
Then I observed the expected external-dns logging indicating the resource creations were detected, and processed, with the expected interval:
```
INFO[0035] CREATE: in-default.example.com 0 IN A  192.0.2.1 [] 
INFO[0041] All records are already up to date           
INFO[0078] CREATE: in-foo.example.com 0 IN A  192.0.2.2 [] 
INFO[0084] All records are already up to date           
```
Then I deleted the resources:
```
host:~ user$ kubectl delete dnsendpoint in-default-namespace
dnsendpoint.example.com "in-default-namespace" deleted
host:~ user$ sleep 30
host:~ user$ kubectl -n foo delete dnsendpoint in-foo-namespace
dnsendpoint.example.com "in-foo-namespace" deleted
```
... and observed logging output indicating the resource deletions were detected and processed:
```
INFO[0119] DELETE: in-default.example.com 0 IN A  192.0.2.1 [] 
INFO[0165] DELETE: in-foo.example.com 0 IN A  192.0.2.2 [] 
```
<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [ ] Unit tests updated - I couldn't think of a way to unit-test this yet
- [ ] End user documentation updated - will check
