### PR TITLE
Fix Scaleway provider uint parsing

### DIFF
--- a/provider/scaleway/scaleway.go
+++ b/provider/scaleway/scaleway.go
@@ -278,7 +278,7 @@ func endpointToScalewayRecords(zoneName string, ep *endpoint.Endpoint) []*domain
 	}
 	var priority = scalewayDefaultPriority
 	if prop, ok := ep.GetProviderSpecificProperty(scalewayPriorityKey); ok {
-		prio, err := strconv.ParseUint(prop.Value, 10, 64)
+		prio, err := strconv.ParseUint(prop.Value, 10, 32)
 		if err != nil {
 			log.Errorf("Failed parsing value of %s: %s: %v; using priority of %d", scalewayPriorityKey, prop.Value, err, scalewayDefaultPriority)
 		} else {


### PR DESCRIPTION
This PR fixes the incorrect parsing on integer that lead to a security vulnerability as reported in https://github.com/kubernetes-sigs/external-dns/security/code-scanning/1?query=ref%3Arefs%2Fheads%2Fmaster 