### PR TITLE
provider hetzner: Refactor to support > 1 targets

### DIFF
--- a/provider/hetzner/hetzner_test.go
+++ b/provider/hetzner/hetzner_test.go
@@ -244,7 +244,7 @@ func TestHetznerProvider_ApplyChanges(t *testing.T) {
 		{DNSName: "blindage.org", Targets: endpoint.Targets{"target"}},
 		{DNSName: "test.blindage.org", Targets: endpoint.Targets{"target"}, RecordTTL: 666},
 	}
-	changes.UpdateNew = []*endpoint.Endpoint{{DNSName: "test.blindage.org", Targets: endpoint.Targets{"target-new"}, RecordType: "A", RecordTTL: 777}}
+	changes.UpdateNew = []*endpoint.Endpoint{{DNSName: "test.blindage.org", Targets: endpoint.Targets{"target", "target-new"}, RecordType: "A", RecordTTL: 777}}
 	changes.Delete = []*endpoint.Endpoint{{DNSName: "test.blindage.org", Targets: endpoint.Targets{"target"}, RecordType: "A"}}
 
 	err := mockedProvider.ApplyChanges(context.Background(), changes)
@@ -289,7 +289,7 @@ func TestHetznerProvider_ApplyChangesCreateUpdateCname(t *testing.T) {
 			},
 		},
 		{
-			Name: "UpdateRecord",
+			Name: "CreateRecord",
 			RecordData: hclouddns.HCloudRecord{
 				RecordType: "CNAME",
 				ID:         "",


### PR DESCRIPTION
provider hetzner: Refactor to support > 1 targets

Test suite adapted to match the actions of the changed implementation.
Most prominently, a requested update is not neccessarily translated to a
DNS update, but depends on existing records.

**Description**
The current implementation of the hetzner provider only supports a single target per endpoint. That leads to unexpected interactions whenever multiple targets are created on an endpoint which may result in constantly switching the record's value to the targets in turn.

This PR fixes that by translating 1:N endpoints to 1:1 records for the provider's API.

Some of the transformations done probably rather belong into Plan. If other providers work like this as well (a multi-valued record represented as multiple single-valued records), it would be nice to export this as a trait on the provider and have the Plan take care of it while it calculates changes anyway.

Fixes #2232 
Obsoletes #2233

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
