### PR TITLE
Add Istio permissions to cluster role

### DIFF
--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: external-dns
 description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 type: application
-version: 1.4.0
+version: 1.4.1
 appVersion: 0.10.1
 keywords:
   - kubernetes

--- a/charts/external-dns/templates/clusterrole.yaml
+++ b/charts/external-dns/templates/clusterrole.yaml
@@ -15,4 +15,14 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["list","watch"]
+{{- if has "istio-gateway" .Values.sources }}
+  - apiGroups: ["networking.istio.io"]
+    resources: ["gateways"]
+    verbs: ["get","watch","list"]
+{{- end }}
+{{- if has "istio-virtualservice" .Values.sources }}
+  - apiGroups: ["networking.istio.io"]
+    resources: ["virtualservices"]
+    verbs: ["get","watch","list"]
+{{- end }}
 {{- end }}


### PR DESCRIPTION
**Description**

Add the permissions shown [here](https://github.com/kubernetes-sigs/external-dns/blob/2f1aff4fe46c68cd0bceb2b6b7498f0c678c0ede/docs/tutorials/istio.md#manifest-for-clusters-with-rbac-enabled) to the cluster role created by the Helm chart, so that it can work with Istio.

**Checklist**

- [ ] ~Unit tests updated~
- [ ] ~End user documentation updated~
