### PR TITLE
Document usage of AWS env vars

### DIFF
--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -55,7 +55,7 @@ If your EKS-managed cluster is >= 1.13 and was created after 2019-09-04, refer
 to the [Amazon EKS
 documentation](https://docs.aws.amazon.com/eks/latest/userguide/create-service-account-iam-policy-and-role.html)
 for instructions on how to create the IAM Role. Otherwise, you will need to use
-kiam or kube2iam.
+kiam or kube2iam or set the environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY on the deployment.
 
 ### kiam
 


### PR DESCRIPTION
**Description**

Document the working method of using environment variables on the external-dns deployment to avoid the overhead of kiam or kube2iam when not using EKS

Fixes undocumented feature

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
- [x] AWS tutorial updated