### PR TITLE
kubernetes v1.22: Update controller to use networking.k8s.io/v1 Ingress.

### DIFF
--- a/docs/tutorials/ultradns.md
+++ b/docs/tutorials/ultradns.md
@@ -237,7 +237,7 @@ spec:
 ```
 - Then, create service file called 'expose-apple-banana-app.yaml' to expose the services. For more information to deploy ingress controller, refer to (https://kubernetes.github.io/ingress-nginx/deploy/)
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: example-ingress
@@ -252,8 +252,10 @@ spec:
       paths:
         - path: /apple
           backend:
-            serviceName: example-service
-            servicePort: 5678
+            service:
+              name: example-service
+              port:
+                number: 5678
 ```
 - Then, create the deployment and service:
 ```console
@@ -298,7 +300,7 @@ $ kubectl delete -f external-dns.yaml
       ports:
         - port: 5678 # Default port for image
     ---
-    apiVersion: extensions/v1beta1
+    apiVersion: networking.k8s.io/v1
     kind: Ingress
     metadata:
       name: example-ingress
@@ -313,8 +315,10 @@ $ kubectl delete -f external-dns.yaml
           paths:
             - path: /apple
               backend:
-                serviceName: example-service
-                servicePort: 5678
+                service:
+                  name: example-service
+                  port:
+                    number: 5678
     ```
     - _Config File Example – Kubernetes cluster service from different cloud vendors_
     ```yaml
@@ -434,7 +438,7 @@ $ kubectl delete -f external-dns.yaml
       ports:
         - port: 5680 # Default port for image
     ---
-    apiVersion: extensions/v1beta1
+    apiVersion: networking.k8s.io/v1
     kind: Ingress
     metadata:
       name: example-ingress
@@ -449,10 +453,12 @@ $ kubectl delete -f external-dns.yaml
           paths:
             - path: /apple
               backend:
-                serviceName: example-service
-                servicePort: 5678
+                service:
+                  name: example-service
+                  port:
+                    number: 5678
     ---
-    apiVersion: extensions/v1beta1
+    apiVersion: networking.k8s.io/v1
     kind: Ingress
     metadata:
       name: example-ingress1
@@ -467,10 +473,12 @@ $ kubectl delete -f external-dns.yaml
           paths:
             - path: /apple
               backend:
-                serviceName: example-service1
-                servicePort: 5679
+                service:
+                  name: example-service1
+                  port:
+                    number: 5679
     ---
-    apiVersion: extensions/v1beta1
+    apiVersion: networking.k8s.io/v1
     kind: Ingress
     metadata:
       name: example-ingress2
@@ -485,8 +493,10 @@ $ kubectl delete -f external-dns.yaml
           paths:
             - path: /apple
               backend:
-                serviceName: example-service2
-                servicePort: 5680
+                service:
+                  name: example-service2
+                  port:
+                    number: 5680
     ```
     - _Config File Example – Kubernetes cluster service from different cloud vendors_
     ```yaml
@@ -572,6 +582,7 @@ $ kubectl delete -f external-dns.yaml
       ports:
         - port: 5679 # Default port for image
     ---
+    apiVersion: networking.k8s.io/v1
     kind: Ingress
     metadata:
       name: example-ingress
@@ -586,10 +597,12 @@ $ kubectl delete -f external-dns.yaml
           paths:
             - path: /apple
               backend:
-                serviceName: example-service
-                servicePort: 5678
+                service:
+                  name: example-service
+                  port:
+                    number: 5678
     ---
-    apiVersion: extensions/v1beta1
+    apiVersion: networking.k8s.io/v1
     kind: Ingress
     metadata:
       name: example-ingress1
@@ -604,8 +617,10 @@ $ kubectl delete -f external-dns.yaml
           paths:
             - path: /apple
               backend:
-                serviceName: example-service1
-                servicePort: 5679
+                service:
+                  name: example-service1
+                  port:
+                    number: 5679
     ```
 - Then, create the deployment and service:
 ```console

--- a/scripts/update_route53_k8s_txt_owner.py
+++ b/scripts/update_route53_k8s_txt_owner.py
@@ -54,7 +54,7 @@ if external_dns_manages_services:
             k8s_domains.extend(annotations['domainName'].split(','))
 
 if external_dns_manages_ingresses:
-    ev1 = client.ExtensionsV1beta1Api()
+    ev1 = client.NetworkingV1Api()
     ings = ev1.list_ingress_for_all_namespaces()
     for i in ings.items:
         for r in i.spec.rules:

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	networkv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -37,7 +37,7 @@ var _ Source = &ingressSource{}
 type IngressSuite struct {
 	suite.Suite
 	sc             Source
-	fooWithTargets *v1beta1.Ingress
+	fooWithTargets *networkv1.Ingress
 }
 
 func (suite *IngressSuite) SetupTest() {
@@ -51,7 +51,7 @@ func (suite *IngressSuite) SetupTest() {
 		hostnames:   []string{"v1"},
 		annotations: map[string]string{ALBDualstackAnnotationKey: ALBDualstackAnnotationValue},
 	}).Ingress()
-	_, err := fakeClient.ExtensionsV1beta1().Ingresses(suite.fooWithTargets.Namespace).Create(context.Background(), suite.fooWithTargets, metav1.CreateOptions{})
+	_, err := fakeClient.NetworkingV1().Ingresses(suite.fooWithTargets.Namespace).Create(context.Background(), suite.fooWithTargets, metav1.CreateOptions{})
 	suite.NoError(err, "should succeed")
 
 	suite.sc, err = NewIngressSource(
@@ -1177,7 +1177,7 @@ func testIngressEndpoints(t *testing.T) {
 			fakeClient := fake.NewSimpleClientset()
 			for _, item := range ti.ingressItems {
 				ingress := item.Ingress()
-				_, err := fakeClient.ExtensionsV1beta1().Ingresses(ingress.Namespace).Create(context.Background(), ingress, metav1.CreateOptions{})
+				_, err := fakeClient.NetworkingV1().Ingresses(ingress.Namespace).Create(context.Background(), ingress, metav1.CreateOptions{})
 				require.NoError(t, err)
 			}
 			source, _ := NewIngressSource(
@@ -1213,29 +1213,29 @@ type fakeIngress struct {
 	annotations map[string]string
 }
 
-func (ing fakeIngress) Ingress() *v1beta1.Ingress {
-	ingress := &v1beta1.Ingress{
+func (ing fakeIngress) Ingress() *networkv1.Ingress {
+	ingress := &networkv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   ing.namespace,
 			Name:        ing.name,
 			Annotations: ing.annotations,
 		},
-		Spec: v1beta1.IngressSpec{
-			Rules: []v1beta1.IngressRule{},
+		Spec: networkv1.IngressSpec{
+			Rules: []networkv1.IngressRule{},
 		},
-		Status: v1beta1.IngressStatus{
+		Status: networkv1.IngressStatus{
 			LoadBalancer: v1.LoadBalancerStatus{
 				Ingress: []v1.LoadBalancerIngress{},
 			},
 		},
 	}
 	for _, dnsname := range ing.dnsnames {
-		ingress.Spec.Rules = append(ingress.Spec.Rules, v1beta1.IngressRule{
+		ingress.Spec.Rules = append(ingress.Spec.Rules, networkv1.IngressRule{
 			Host: dnsname,
 		})
 	}
 	for _, hosts := range ing.tlsdnsnames {
-		ingress.Spec.TLS = append(ingress.Spec.TLS, v1beta1.IngressTLS{
+		ingress.Spec.TLS = append(ingress.Spec.TLS, networkv1.IngressTLS{
 			Hosts: hosts,
 		})
 	}


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR should fix the problem of external-dns not running in v1.22. It does not provide backwards compatibility for extensions/v1beta1 ingresses as this should still be backwards compatible going back to v1.19 without any other code; I don't know the typical policy for this SIG, but given that v1beta1 Ingress has been removed, this seems safe enough (and much simpler).

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2168

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
