### PR TITLE
Install tzdata, so that time zone information is available.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN make test build.$ARCH
 # final image
 FROM $ARCH/alpine:3.14
 
+RUN apk --no-cache add tzdata
+
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /bin/external-dns
 


### PR DESCRIPTION
**Description**

This PR installs the tzdata Alpine package in the final external-dns container, so that timezone data is available for external-dns and its dependencies.

Fixes #2284 

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
