### PR TITLE
[Rfc2136] Add message compression

### DIFF
--- a/docs/tutorials/rfc2136.md
+++ b/docs/tutorials/rfc2136.md
@@ -277,6 +277,24 @@ spec:
         - --domain-filter=k8s.example.org
 ```
 
+### Batch updates
+
+When facing large batch, bind may refuse processing the update and return a "too large message" error. One option to circumvent this problem is to enable compression while comunicating with the bind server. It can be enabled using the `--rfc2136-enable-compression`:
+
+```text
+...
+        - --provider=rfc2136
+        - --rfc2136-host=192.168.0.1
+        - --rfc2136-port=53
+        - --rfc2136-zone=k8s.example.org
+        - --rfc2136-insecure
+        - --rfc2136-tsig-axfr
+        - --rfc2136-enable-compression
+...
+```
+
+The other way is to use the new `--rfc2136-batch-change-size` option, which is by default set to `50` since `v0.9.0`. Users who want to revert to the `v0.5` behavior without batching support can set their batch size to `1`.
+
 ## Microsoft DNS (Insecure Updates)
 
 While `external-dns` was not developed or tested against Microsoft DNS, it can be configured to work against it. YMMV.

--- a/main.go
+++ b/main.go
@@ -297,7 +297,7 @@ func main() {
 			p, err = oci.NewOCIProvider(*config, domainFilter, zoneIDFilter, cfg.DryRun)
 		}
 	case "rfc2136":
-		p, err = rfc2136.NewRfc2136Provider(cfg.RFC2136Host, cfg.RFC2136Port, cfg.RFC2136Zone, cfg.RFC2136Insecure, cfg.RFC2136TSIGKeyName, cfg.RFC2136TSIGSecret, cfg.RFC2136TSIGSecretAlg, cfg.RFC2136TAXFR, domainFilter, cfg.DryRun, cfg.RFC2136MinTTL, cfg.RFC2136GSSTSIG, cfg.RFC2136KerberosUsername, cfg.RFC2136KerberosPassword, cfg.RFC2136KerberosRealm, cfg.RFC2136BatchChangeSize, nil)
+		p, err = rfc2136.NewRfc2136Provider(cfg.RFC2136Host, cfg.RFC2136Port, cfg.RFC2136Zone, cfg.RFC2136Insecure, cfg.RFC2136TSIGKeyName, cfg.RFC2136TSIGSecret, cfg.RFC2136TSIGSecretAlg, cfg.RFC2136TAXFR, domainFilter, cfg.DryRun, cfg.RFC2136MinTTL, cfg.RFC2136GSSTSIG, cfg.RFC2136KerberosUsername, cfg.RFC2136KerberosPassword, cfg.RFC2136KerberosRealm, cfg.RFC2136BatchChangeSize, cfg.RFC2136EnableCompression, nil)
 	case "ns1":
 		p, err = ns1.NewNS1Provider(
 			ns1.NS1Config{

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -147,6 +147,7 @@ type Config struct {
 	CFAPIEndpoint                     string
 	CFUsername                        string
 	CFPassword                        string
+	RFC2136EnableCompression          bool
 	RFC2136Host                       string
 	RFC2136Port                       int
 	RFC2136Zone                       string
@@ -271,6 +272,7 @@ var defaultConfig = &Config{
 	CFAPIEndpoint:               "",
 	CFUsername:                  "",
 	CFPassword:                  "",
+	RFC2136EnableCompression:    false,
 	RFC2136Host:                 "",
 	RFC2136Port:                 0,
 	RFC2136Zone:                 "",
@@ -456,6 +458,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("exoscale-apisecret", "Provide your API Secret for the Exoscale provider").Default(defaultConfig.ExoscaleAPISecret).StringVar(&cfg.ExoscaleAPISecret)
 
 	// Flags related to RFC2136 provider
+	app.Flag("rfc2136-enable-compression", "When using the RFC2136 provider, requires to use compression when sending message").Default(strconv.FormatBool(defaultConfig.RFC2136EnableCompression)).BoolVar(&cfg.RFC2136EnableCompression)
 	app.Flag("rfc2136-host", "When using the RFC2136 provider, specify the host of the DNS server").Default(defaultConfig.RFC2136Host).StringVar(&cfg.RFC2136Host)
 	app.Flag("rfc2136-port", "When using the RFC2136 provider, specify the port of the DNS server").Default(strconv.Itoa(defaultConfig.RFC2136Port)).IntVar(&cfg.RFC2136Port)
 	app.Flag("rfc2136-zone", "When using the RFC2136 provider, specify the zone entry of the DNS server to use").Default(defaultConfig.RFC2136Zone).StringVar(&cfg.RFC2136Zone)

--- a/provider/rfc2136/rfc2136_test.go
+++ b/provider/rfc2136/rfc2136_test.go
@@ -95,7 +95,7 @@ func (r *rfc2136Stub) IncomeTransfer(m *dns.Msg, a string) (env chan *dns.Envelo
 }
 
 func createRfc2136StubProvider(stub *rfc2136Stub) (provider.Provider, error) {
-	return NewRfc2136Provider("", 0, "", false, "key", "secret", "hmac-sha512", true, endpoint.DomainFilter{}, false, 300*time.Second, false, "", "", "", 50, stub)
+	return NewRfc2136Provider("", 0, "", false, "key", "secret", "hmac-sha512", true, endpoint.DomainFilter{}, false, 300*time.Second, false, "", "", "", 50, false, stub)
 }
 
 func extractAuthoritySectionFromMessage(msg fmt.Stringer) []string {


### PR DESCRIPTION
**Description**

When facing large messages, one can have its dns refusing the update due to "too large message" error. The DNS library used has an option to compress the message that is sent.

This commit exposes this feature. It adds a new command line option called `--rfc2136-enable-compression` and adds a new field to the configuration. The default value of the field is set to `false` to not change the current behavior.

We had this change pending locally on our side since a long time. As of today, an alternative would be to use the recent `batchChangeSize` option from #2127 to overcome the same issue.

Relates to #1322 #1164

**Checklist**

- [x] Unit tests updated (current tests should pass, we'll add dedicated tests soon)
- [x] End user documentation updated (also added some words for #2127)
