### PR TITLE
Bump Cloudflare-Go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/aliyun/alibaba-cloud-sdk-go v1.61.357
 	github.com/aws/aws-sdk-go v1.40.38
 	github.com/bodgit/tsig v0.0.2
-	github.com/cloudflare/cloudflare-go v0.22.0
+	github.com/cloudflare/cloudflare-go v0.25.0
 	github.com/cloudfoundry-community/go-cfclient v0.0.0-20190201205600-f136f9222381
 	github.com/datawire/ambassador v1.6.0
 	github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/aliyun/alibaba-cloud-sdk-go v1.61.357
 	github.com/aws/aws-sdk-go v1.40.38
 	github.com/bodgit/tsig v0.0.2
-	github.com/cloudflare/cloudflare-go v0.13.2
+	github.com/cloudflare/cloudflare-go v0.22.0
 	github.com/cloudfoundry-community/go-cfclient v0.0.0-20190201205600-f136f9222381
 	github.com/datawire/ambassador v1.6.0
 	github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,7 @@ github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.10.1 h1:d2CL6F9k2O0Ux0w27LgogJ5UOzZRj6a/hDPFqPP68d8=
 github.com/cloudflare/cloudflare-go v0.10.1/go.mod h1:C0Y6eWnTJPMK2ceuOxx2pjh78UUHihcXeTTHb8r7QjU=
+github.com/cloudflare/cloudflare-go v0.13.2/go.mod h1:27kfc1apuifUmJhp069y0+hwlKDg4bd8LWlu7oKeZvM=
 github.com/cloudflare/cloudflare-go v0.22.0 h1:3TYbkyz/IBbM6XozrTKWiNpv7RjJGamALy9yu2SBqTo=
 github.com/cloudflare/cloudflare-go v0.22.0/go.mod h1:sPWL/lIC6biLEdyGZwBQ1rGQKF1FhM7N60fuNiFdYTI=
 github.com/cloudfoundry-community/go-cfclient v0.0.0-20190201205600-f136f9222381 h1:rdRS5BT13Iae9ssvcslol66gfOOXjaLYwqerEn/cl9s=
@@ -775,6 +776,7 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-oci8 v0.0.7/go.mod h1:wjDx6Xm9q7dFtHJvIlrI99JytznLw5wQ4R+9mNXJwGI=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-shellwords v1.0.10/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
@@ -849,6 +851,7 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.2/go.mod h1:rSAaSIOAGT9odnlyGlUfAJaoc5w2fSBUmeGDbRWPxyQ=
+github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.4.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -1074,6 +1077,8 @@ github.com/ultradns/ultradns-sdk-go v0.0.0-20200616202852-e62052662f60/go.mod h1
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,8 @@ github.com/cloudflare/cloudflare-go v0.10.1/go.mod h1:C0Y6eWnTJPMK2ceuOxx2pjh78U
 github.com/cloudflare/cloudflare-go v0.13.2/go.mod h1:27kfc1apuifUmJhp069y0+hwlKDg4bd8LWlu7oKeZvM=
 github.com/cloudflare/cloudflare-go v0.22.0 h1:3TYbkyz/IBbM6XozrTKWiNpv7RjJGamALy9yu2SBqTo=
 github.com/cloudflare/cloudflare-go v0.22.0/go.mod h1:sPWL/lIC6biLEdyGZwBQ1rGQKF1FhM7N60fuNiFdYTI=
+github.com/cloudflare/cloudflare-go v0.25.0 h1:GwyKwGq8ciGNjKiTpjj6RvU3+uJNuPBNjlUkeQRx0yU=
+github.com/cloudflare/cloudflare-go v0.25.0/go.mod h1:sPWL/lIC6biLEdyGZwBQ1rGQKF1FhM7N60fuNiFdYTI=
 github.com/cloudfoundry-community/go-cfclient v0.0.0-20190201205600-f136f9222381 h1:rdRS5BT13Iae9ssvcslol66gfOOXjaLYwqerEn/cl9s=
 github.com/cloudfoundry-community/go-cfclient v0.0.0-20190201205600-f136f9222381/go.mod h1:e5+USP2j8Le2M0Jo3qKPFnNhuo1wueU4nWHCXBOfQ14=
 github.com/cncf/udpa v0.0.0-20200324003616-bae28a880fdb/go.mod h1:HNVadOiXCy7Jk3R2knJ+qm++zkncJxxBMpjdGgJ+UJc=

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,10 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudflare/cloudflare-go v0.13.2 h1:bhMGoNhAg21DuqJjU9jQepRRft6vYfo6pejT3NN4V6A=
-github.com/cloudflare/cloudflare-go v0.13.2/go.mod h1:27kfc1apuifUmJhp069y0+hwlKDg4bd8LWlu7oKeZvM=
+github.com/cloudflare/cloudflare-go v0.10.1 h1:d2CL6F9k2O0Ux0w27LgogJ5UOzZRj6a/hDPFqPP68d8=
+github.com/cloudflare/cloudflare-go v0.10.1/go.mod h1:C0Y6eWnTJPMK2ceuOxx2pjh78UUHihcXeTTHb8r7QjU=
+github.com/cloudflare/cloudflare-go v0.22.0 h1:3TYbkyz/IBbM6XozrTKWiNpv7RjJGamALy9yu2SBqTo=
+github.com/cloudflare/cloudflare-go v0.22.0/go.mod h1:sPWL/lIC6biLEdyGZwBQ1rGQKF1FhM7N60fuNiFdYTI=
 github.com/cloudfoundry-community/go-cfclient v0.0.0-20190201205600-f136f9222381 h1:rdRS5BT13Iae9ssvcslol66gfOOXjaLYwqerEn/cl9s=
 github.com/cloudfoundry-community/go-cfclient v0.0.0-20190201205600-f136f9222381/go.mod h1:e5+USP2j8Le2M0Jo3qKPFnNhuo1wueU4nWHCXBOfQ14=
 github.com/cncf/udpa v0.0.0-20200324003616-bae28a880fdb/go.mod h1:HNVadOiXCy7Jk3R2knJ+qm++zkncJxxBMpjdGgJ+UJc=
@@ -773,7 +775,7 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-oci8 v0.0.7/go.mod h1:wjDx6Xm9q7dFtHJvIlrI99JytznLw5wQ4R+9mNXJwGI=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
-github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-shellwords v1.0.10/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.12.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
@@ -847,7 +849,7 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.2/go.mod h1:rSAaSIOAGT9odnlyGlUfAJaoc5w2fSBUmeGDbRWPxyQ=
-github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.4.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -1072,8 +1074,7 @@ github.com/ultradns/ultradns-sdk-go v0.0.0-20200616202852-e62052662f60/go.mod h1
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
+github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
@@ -1267,6 +1268,7 @@ golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLd
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210928044308-7d9f5e0b762b h1:eB48h3HiRycXNy8E0Gf5e0hv7YT6Kt14L/D73G1fuwo=

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -186,24 +186,20 @@ func (p *CloudFlareProvider) Zones(ctx context.Context) ([]cloudflare.Zone, erro
 	}
 
 	log.Debugln("no zoneIDFilter configured, looking at all zones")
-	for {
-		zonesResponse, err := p.Client.ListZonesContext(ctx, cloudflare.WithPagination(p.PaginationOptions))
-		if err != nil {
-			return nil, err
-		}
 
-		for _, zone := range zonesResponse.Result {
-			if !p.domainFilter.Match(zone.Name) {
-				log.Debugf("zone %s not in domain filter", zone.Name)
-				continue
-			}
-			result = append(result, zone)
-		}
-		if p.PaginationOptions.Page == zonesResponse.ResultInfo.TotalPages {
-			break
-		}
-		p.PaginationOptions.Page++
+	zonesResponse, err := p.Client.ListZonesContext(ctx)
+	if err != nil {
+		return nil, err
 	}
+
+	for _, zone := range zonesResponse.Result {
+		if !p.domainFilter.Match(zone.Name) {
+			log.Debugf("zone %s not in domain filter", zone.Name)
+			continue
+		}
+		result = append(result, zone)
+	}
+
 	return result, nil
 }
 

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -46,11 +46,11 @@ const (
 // We have to use pointers to bools now, as the upstream cloudflare-go library requires them
 // see: https://github.com/cloudflare/cloudflare-go/pull/595
 
-// ProxyEnabled is a pointer to a bool true showing the record should be proxied through cloudflare
-var ProxyEnabled *bool = &[]bool{true}[0]
+// proxyEnabled is a pointer to a bool true showing the record should be proxied through cloudflare
+var proxyEnabled *bool = boolPtr(true)
 
-// ProxyDisabled is a pointer to a bool false showing the record should not be proxied through cloudflare
-var ProxyDisabled *bool = &[]bool{false}[0]
+// proxyDisabled is a pointer to a bool false showing the record should not be proxied through cloudflare
+var proxyDisabled *bool = boolPtr(false)
 
 var cloudFlareTypeNotSupported = map[string]bool{
 	"LOC": true,
@@ -460,4 +460,10 @@ func groupByNameAndType(records []cloudflare.DNSRecord) []*endpoint.Endpoint {
 	}
 
 	return endpoints
+}
+
+// boolPtr is used as a helper function to return a pointer to a boolean
+// Needed because some parameters require a pointer.
+func boolPtr(b bool) *bool {
+	return &b
 }

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -43,6 +43,15 @@ const (
 	defaultCloudFlareRecordTTL = 1
 )
 
+// We have to use pointers to bools now, as the upstream cloudflare-go library requires them
+// see: https://github.com/cloudflare/cloudflare-go/pull/595
+
+// ProxyEnabled is a pointer to a bool true showing the record should be proxied through cloudflare
+var ProxyEnabled *bool = &[]bool{true}[0]
+
+// ProxyDisabled is a pointer to a bool false showing the record should not be proxied through cloudflare
+var ProxyDisabled *bool = &[]bool{false}[0]
+
 var cloudFlareTypeNotSupported = map[string]bool{
 	"LOC": true,
 	"MX":  true,
@@ -54,53 +63,53 @@ var cloudFlareTypeNotSupported = map[string]bool{
 
 // cloudFlareDNS is the subset of the CloudFlare API that we actually use.  Add methods as required. Signatures must match exactly.
 type cloudFlareDNS interface {
-	UserDetails() (cloudflare.User, error)
+	UserDetails(ctx context.Context) (cloudflare.User, error)
 	ZoneIDByName(zoneName string) (string, error)
-	ListZones(zoneID ...string) ([]cloudflare.Zone, error)
+	ListZones(ctx context.Context, zoneID ...string) ([]cloudflare.Zone, error)
 	ListZonesContext(ctx context.Context, opts ...cloudflare.ReqOption) (cloudflare.ZonesResponse, error)
-	ZoneDetails(zoneID string) (cloudflare.Zone, error)
-	DNSRecords(zoneID string, rr cloudflare.DNSRecord) ([]cloudflare.DNSRecord, error)
-	CreateDNSRecord(zoneID string, rr cloudflare.DNSRecord) (*cloudflare.DNSRecordResponse, error)
-	DeleteDNSRecord(zoneID, recordID string) error
-	UpdateDNSRecord(zoneID, recordID string, rr cloudflare.DNSRecord) error
+	ZoneDetails(ctx context.Context, zoneID string) (cloudflare.Zone, error)
+	DNSRecords(ctx context.Context, zoneID string, rr cloudflare.DNSRecord) ([]cloudflare.DNSRecord, error)
+	CreateDNSRecord(ctx context.Context, zoneID string, rr cloudflare.DNSRecord) (*cloudflare.DNSRecordResponse, error)
+	DeleteDNSRecord(ctx context.Context, zoneID, recordID string) error
+	UpdateDNSRecord(ctx context.Context, zoneID, recordID string, rr cloudflare.DNSRecord) error
 }
 
 type zoneService struct {
 	service *cloudflare.API
 }
 
-func (z zoneService) UserDetails() (cloudflare.User, error) {
-	return z.service.UserDetails()
+func (z zoneService) UserDetails(ctx context.Context) (cloudflare.User, error) {
+	return z.service.UserDetails(ctx)
 }
 
-func (z zoneService) ListZones(zoneID ...string) ([]cloudflare.Zone, error) {
-	return z.service.ListZones(zoneID...)
+func (z zoneService) ListZones(ctx context.Context, zoneID ...string) ([]cloudflare.Zone, error) {
+	return z.service.ListZones(ctx, zoneID...)
 }
 
 func (z zoneService) ZoneIDByName(zoneName string) (string, error) {
 	return z.service.ZoneIDByName(zoneName)
 }
 
-func (z zoneService) CreateDNSRecord(zoneID string, rr cloudflare.DNSRecord) (*cloudflare.DNSRecordResponse, error) {
-	return z.service.CreateDNSRecord(zoneID, rr)
+func (z zoneService) CreateDNSRecord(ctx context.Context, zoneID string, rr cloudflare.DNSRecord) (*cloudflare.DNSRecordResponse, error) {
+	return z.service.CreateDNSRecord(ctx, zoneID, rr)
 }
 
-func (z zoneService) DNSRecords(zoneID string, rr cloudflare.DNSRecord) ([]cloudflare.DNSRecord, error) {
-	return z.service.DNSRecords(zoneID, rr)
+func (z zoneService) DNSRecords(ctx context.Context, zoneID string, rr cloudflare.DNSRecord) ([]cloudflare.DNSRecord, error) {
+	return z.service.DNSRecords(ctx, zoneID, rr)
 }
-func (z zoneService) UpdateDNSRecord(zoneID, recordID string, rr cloudflare.DNSRecord) error {
-	return z.service.UpdateDNSRecord(zoneID, recordID, rr)
+func (z zoneService) UpdateDNSRecord(ctx context.Context, zoneID, recordID string, rr cloudflare.DNSRecord) error {
+	return z.service.UpdateDNSRecord(ctx, zoneID, recordID, rr)
 }
-func (z zoneService) DeleteDNSRecord(zoneID, recordID string) error {
-	return z.service.DeleteDNSRecord(zoneID, recordID)
+func (z zoneService) DeleteDNSRecord(ctx context.Context, zoneID, recordID string) error {
+	return z.service.DeleteDNSRecord(ctx, zoneID, recordID)
 }
 
 func (z zoneService) ListZonesContext(ctx context.Context, opts ...cloudflare.ReqOption) (cloudflare.ZonesResponse, error) {
 	return z.service.ListZonesContext(ctx, opts...)
 }
 
-func (z zoneService) ZoneDetails(zoneID string) (cloudflare.Zone, error) {
-	return z.service.ZoneDetails(zoneID)
+func (z zoneService) ZoneDetails(ctx context.Context, zoneID string) (cloudflare.Zone, error) {
+	return z.service.ZoneDetails(ctx, zoneID)
 }
 
 // CloudFlareProvider is an implementation of Provider for CloudFlare DNS.
@@ -162,7 +171,7 @@ func (p *CloudFlareProvider) Zones(ctx context.Context) ([]cloudflare.Zone, erro
 		log.Debugln("zoneIDFilter configured. only looking up zone IDs defined")
 		for _, zoneID := range p.zoneIDFilter.ZoneIDs {
 			log.Debugf("looking up zone %s", zoneID)
-			detailResponse, err := p.Client.ZoneDetails(zoneID)
+			detailResponse, err := p.Client.ZoneDetails(ctx, zoneID)
 			if err != nil {
 				log.Errorf("zone %s lookup failed, %v", zoneID, err)
 				continue
@@ -207,7 +216,7 @@ func (p *CloudFlareProvider) Records(ctx context.Context) ([]*endpoint.Endpoint,
 
 	endpoints := []*endpoint.Endpoint{}
 	for _, zone := range zones {
-		records, err := p.Client.DNSRecords(zone.ID, cloudflare.DNSRecord{})
+		records, err := p.Client.DNSRecords(ctx, zone.ID, cloudflare.DNSRecord{})
 		if err != nil {
 			return nil, err
 		}
@@ -281,7 +290,7 @@ func (p *CloudFlareProvider) submitChanges(ctx context.Context, changes []*cloud
 	changesByZone := p.changesByZone(zones, changes)
 
 	for zoneID, changes := range changesByZone {
-		records, err := p.Client.DNSRecords(zoneID, cloudflare.DNSRecord{})
+		records, err := p.Client.DNSRecords(ctx, zoneID, cloudflare.DNSRecord{})
 		if err != nil {
 			return fmt.Errorf("could not fetch records from zone, %v", err)
 		}
@@ -306,7 +315,7 @@ func (p *CloudFlareProvider) submitChanges(ctx context.Context, changes []*cloud
 					log.WithFields(logFields).Errorf("failed to find previous record: %v", change.ResourceRecord)
 					continue
 				}
-				err := p.Client.UpdateDNSRecord(zoneID, recordID, change.ResourceRecord)
+				err := p.Client.UpdateDNSRecord(ctx, zoneID, recordID, change.ResourceRecord)
 				if err != nil {
 					log.WithFields(logFields).Errorf("failed to delete record: %v", err)
 				}
@@ -316,12 +325,12 @@ func (p *CloudFlareProvider) submitChanges(ctx context.Context, changes []*cloud
 					log.WithFields(logFields).Errorf("failed to find previous record: %v", change.ResourceRecord)
 					continue
 				}
-				err := p.Client.DeleteDNSRecord(zoneID, recordID)
+				err := p.Client.DeleteDNSRecord(ctx, zoneID, recordID)
 				if err != nil {
 					log.WithFields(logFields).Errorf("failed to delete record: %v", err)
 				}
 			} else if change.Action == cloudFlareCreate {
-				_, err := p.Client.CreateDNSRecord(zoneID, change.ResourceRecord)
+				_, err := p.Client.CreateDNSRecord(ctx, zoneID, change.ResourceRecord)
 				if err != nil {
 					log.WithFields(logFields).Errorf("failed to create record: %v", err)
 				}
@@ -391,7 +400,7 @@ func (p *CloudFlareProvider) newCloudFlareChange(action string, endpoint *endpoi
 		ResourceRecord: cloudflare.DNSRecord{
 			Name:    endpoint.DNSName,
 			TTL:     ttl,
-			Proxied: proxied,
+			Proxied: &proxied,
 			Type:    endpoint.RecordType,
 			Content: target,
 		},
@@ -450,7 +459,8 @@ func groupByNameAndType(records []cloudflare.DNSRecord) []*endpoint.Endpoint {
 				records[0].Type,
 				endpoint.TTL(records[0].TTL),
 				targets...).
-				WithProviderSpecific(source.CloudflareProxiedKey, strconv.FormatBool(records[0].Proxied)))
+				WithProviderSpecific(source.CloudflareProxiedKey, strconv.FormatBool(*records[0].Proxied)),
+		)
 	}
 
 	return endpoints

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -55,7 +55,7 @@ var ExampleDomain = []cloudflare.DNSRecord{
 		Type:    endpoint.RecordTypeA,
 		TTL:     120,
 		Content: "1.2.3.4",
-		Proxied: ProxyDisabled,
+		Proxied: proxyDisabled,
 	},
 	{
 		ID:      "2345678901",
@@ -64,7 +64,7 @@ var ExampleDomain = []cloudflare.DNSRecord{
 		Type:    endpoint.RecordTypeA,
 		TTL:     120,
 		Content: "3.4.5.6",
-		Proxied: ProxyDisabled,
+		Proxied: proxyDisabled,
 	},
 	{
 		ID:      "1231231233",
@@ -73,7 +73,7 @@ var ExampleDomain = []cloudflare.DNSRecord{
 		Type:    endpoint.RecordTypeA,
 		TTL:     1,
 		Content: "2.3.4.5",
-		Proxied: ProxyDisabled,
+		Proxied: proxyDisabled,
 	},
 }
 
@@ -292,7 +292,7 @@ func TestCloudflareA(t *testing.T) {
 				Name:    "bar.com",
 				Content: "127.0.0.1",
 				TTL:     1,
-				Proxied: ProxyDisabled,
+				Proxied: proxyDisabled,
 			},
 		},
 		{
@@ -303,7 +303,7 @@ func TestCloudflareA(t *testing.T) {
 				Name:    "bar.com",
 				Content: "127.0.0.2",
 				TTL:     1,
-				Proxied: ProxyDisabled,
+				Proxied: proxyDisabled,
 			},
 		},
 	},
@@ -330,7 +330,7 @@ func TestCloudflareCname(t *testing.T) {
 				Name:    "cname.bar.com",
 				Content: "google.com",
 				TTL:     1,
-				Proxied: ProxyDisabled,
+				Proxied: proxyDisabled,
 			},
 		},
 		{
@@ -341,7 +341,7 @@ func TestCloudflareCname(t *testing.T) {
 				Name:    "cname.bar.com",
 				Content: "facebook.com",
 				TTL:     1,
-				Proxied: ProxyDisabled,
+				Proxied: proxyDisabled,
 			},
 		},
 	},
@@ -368,7 +368,7 @@ func TestCloudflareCustomTTL(t *testing.T) {
 				Name:    "ttl.bar.com",
 				Content: "127.0.0.1",
 				TTL:     120,
-				Proxied: ProxyDisabled,
+				Proxied: proxyDisabled,
 			},
 		},
 	},
@@ -394,7 +394,7 @@ func TestCloudflareProxiedDefault(t *testing.T) {
 				Name:    "bar.com",
 				Content: "127.0.0.1",
 				TTL:     1,
-				Proxied: ProxyEnabled,
+				Proxied: proxyEnabled,
 			},
 		},
 	},
@@ -426,7 +426,7 @@ func TestCloudflareProxiedOverrideTrue(t *testing.T) {
 				Name:    "bar.com",
 				Content: "127.0.0.1",
 				TTL:     1,
-				Proxied: ProxyEnabled,
+				Proxied: proxyEnabled,
 			},
 		},
 	},
@@ -458,7 +458,7 @@ func TestCloudflareProxiedOverrideFalse(t *testing.T) {
 				Name:    "bar.com",
 				Content: "127.0.0.1",
 				TTL:     1,
-				Proxied: ProxyDisabled,
+				Proxied: proxyDisabled,
 			},
 		},
 	},
@@ -490,7 +490,7 @@ func TestCloudflareProxiedOverrideIllegal(t *testing.T) {
 				Name:    "bar.com",
 				Content: "127.0.0.1",
 				TTL:     1,
-				Proxied: ProxyEnabled,
+				Proxied: proxyEnabled,
 			},
 		},
 	},
@@ -499,8 +499,8 @@ func TestCloudflareProxiedOverrideIllegal(t *testing.T) {
 }
 
 func TestCloudflareSetProxied(t *testing.T) {
-	var proxied *bool = ProxyEnabled
-	var notProxied *bool = ProxyDisabled
+	var proxied *bool = proxyEnabled
+	var notProxied *bool = proxyDisabled
 	var testCases = []struct {
 		recordType string
 		domain     string
@@ -686,7 +686,7 @@ func TestCloudflareApplyChanges(t *testing.T) {
 				Name:    "new.bar.com",
 				Content: "target",
 				TTL:     1,
-				Proxied: ProxyDisabled,
+				Proxied: proxyDisabled,
 			},
 		},
 		{
@@ -696,7 +696,7 @@ func TestCloudflareApplyChanges(t *testing.T) {
 				Name:    "foobar.bar.com",
 				Content: "target-new",
 				TTL:     1,
-				Proxied: ProxyDisabled,
+				Proxied: proxyDisabled,
 			},
 		},
 	})
@@ -783,7 +783,7 @@ func TestCloudflareGroupByNameAndType(t *testing.T) {
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.1",
 					TTL:     defaultCloudFlareRecordTTL,
-					Proxied: ProxyDisabled,
+					Proxied: proxyDisabled,
 				},
 			},
 			ExpectedEndpoints: []*endpoint.Endpoint{
@@ -810,14 +810,14 @@ func TestCloudflareGroupByNameAndType(t *testing.T) {
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.1",
 					TTL:     defaultCloudFlareRecordTTL,
-					Proxied: ProxyDisabled,
+					Proxied: proxyDisabled,
 				},
 				{
 					Name:    "foo.com",
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.2",
 					TTL:     defaultCloudFlareRecordTTL,
-					Proxied: ProxyDisabled,
+					Proxied: proxyDisabled,
 				},
 			},
 			ExpectedEndpoints: []*endpoint.Endpoint{
@@ -844,28 +844,28 @@ func TestCloudflareGroupByNameAndType(t *testing.T) {
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.1",
 					TTL:     defaultCloudFlareRecordTTL,
-					Proxied: ProxyDisabled,
+					Proxied: proxyDisabled,
 				},
 				{
 					Name:    "foo.com",
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.2",
 					TTL:     defaultCloudFlareRecordTTL,
-					Proxied: ProxyDisabled,
+					Proxied: proxyDisabled,
 				},
 				{
 					Name:    "bar.de",
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.1",
 					TTL:     defaultCloudFlareRecordTTL,
-					Proxied: ProxyDisabled,
+					Proxied: proxyDisabled,
 				},
 				{
 					Name:    "bar.de",
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.2",
 					TTL:     defaultCloudFlareRecordTTL,
-					Proxied: ProxyDisabled,
+					Proxied: proxyDisabled,
 				},
 			},
 			ExpectedEndpoints: []*endpoint.Endpoint{
@@ -905,21 +905,21 @@ func TestCloudflareGroupByNameAndType(t *testing.T) {
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.1",
 					TTL:     defaultCloudFlareRecordTTL,
-					Proxied: ProxyDisabled,
+					Proxied: proxyDisabled,
 				},
 				{
 					Name:    "foo.com",
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.2",
 					TTL:     defaultCloudFlareRecordTTL,
-					Proxied: ProxyDisabled,
+					Proxied: proxyDisabled,
 				},
 				{
 					Name:    "bar.de",
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.1",
 					TTL:     defaultCloudFlareRecordTTL,
-					Proxied: ProxyDisabled,
+					Proxied: proxyDisabled,
 				},
 			},
 			ExpectedEndpoints: []*endpoint.Endpoint{
@@ -959,21 +959,21 @@ func TestCloudflareGroupByNameAndType(t *testing.T) {
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.1",
 					TTL:     defaultCloudFlareRecordTTL,
-					Proxied: ProxyDisabled,
+					Proxied: proxyDisabled,
 				},
 				{
 					Name:    "foo.com",
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.2",
 					TTL:     defaultCloudFlareRecordTTL,
-					Proxied: ProxyDisabled,
+					Proxied: proxyDisabled,
 				},
 				{
 					Name:    "bar.de",
 					Type:    "NOT SUPPORTED",
 					Content: "10.10.10.1",
 					TTL:     defaultCloudFlareRecordTTL,
-					Proxied: ProxyDisabled,
+					Proxied: proxyDisabled,
 				},
 			},
 			ExpectedEndpoints: []*endpoint.Endpoint{
@@ -1009,25 +1009,25 @@ func TestProviderPropertiesIdempotency(t *testing.T) {
 		{
 			Name:                     "ProxyDefault: false, ShouldBeProxied: false, ExpectUpdates: false",
 			ProviderProxiedByDefault: false,
-			RecordsAreProxied:        ProxyDisabled,
+			RecordsAreProxied:        proxyDisabled,
 			ShouldBeUpdated:          false,
 		},
 		{
 			Name:                     "ProxyDefault: true, ShouldBeProxied: true, ExpectUpdates: false",
 			ProviderProxiedByDefault: true,
-			RecordsAreProxied:        ProxyEnabled,
+			RecordsAreProxied:        proxyEnabled,
 			ShouldBeUpdated:          false,
 		},
 		{
 			Name:                     "ProxyDefault: true, ShouldBeProxied: false, ExpectUpdates: true",
 			ProviderProxiedByDefault: true,
-			RecordsAreProxied:        ProxyDisabled,
+			RecordsAreProxied:        proxyDisabled,
 			ShouldBeUpdated:          true,
 		},
 		{
 			Name:                     "ProxyDefault: false, ShouldBeProxied: true, ExpectUpdates: true",
 			ProviderProxiedByDefault: false,
-			RecordsAreProxied:        ProxyEnabled,
+			RecordsAreProxied:        proxyEnabled,
 			ShouldBeUpdated:          true,
 		},
 	}
@@ -1153,7 +1153,7 @@ func TestCloudflareComplexUpdate(t *testing.T) {
 				Type:    "A",
 				Content: "2.3.4.5",
 				TTL:     1,
-				Proxied: ProxyEnabled,
+				Proxied: proxyEnabled,
 			},
 		},
 		MockAction{
@@ -1165,7 +1165,7 @@ func TestCloudflareComplexUpdate(t *testing.T) {
 				Type:    "A",
 				Content: "1.2.3.4",
 				TTL:     1,
-				Proxied: ProxyEnabled,
+				Proxied: proxyEnabled,
 			},
 		},
 		MockAction{
@@ -1186,7 +1186,7 @@ func TestCustomTTLWithEnabledProxyNotChanged(t *testing.T) {
 				Type:    endpoint.RecordTypeA,
 				TTL:     1,
 				Content: "1.2.3.4",
-				Proxied: ProxyEnabled,
+				Proxied: proxyEnabled,
 			},
 		},
 	})

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -55,7 +55,7 @@ var ExampleDomain = []cloudflare.DNSRecord{
 		Type:    endpoint.RecordTypeA,
 		TTL:     120,
 		Content: "1.2.3.4",
-		Proxied: false,
+		Proxied: ProxyDisabled,
 	},
 	{
 		ID:      "2345678901",
@@ -64,7 +64,7 @@ var ExampleDomain = []cloudflare.DNSRecord{
 		Type:    endpoint.RecordTypeA,
 		TTL:     120,
 		Content: "3.4.5.6",
-		Proxied: false,
+		Proxied: ProxyDisabled,
 	},
 	{
 		ID:      "1231231233",
@@ -73,7 +73,7 @@ var ExampleDomain = []cloudflare.DNSRecord{
 		Type:    endpoint.RecordTypeA,
 		TTL:     1,
 		Content: "2.3.4.5",
-		Proxied: false,
+		Proxied: ProxyDisabled,
 	},
 }
 
@@ -105,7 +105,7 @@ func NewMockCloudFlareClientWithRecords(records map[string][]cloudflare.DNSRecor
 	return m
 }
 
-func (m *mockCloudFlareClient) CreateDNSRecord(zoneID string, rr cloudflare.DNSRecord) (*cloudflare.DNSRecordResponse, error) {
+func (m *mockCloudFlareClient) CreateDNSRecord(ctx context.Context, zoneID string, rr cloudflare.DNSRecord) (*cloudflare.DNSRecordResponse, error) {
 	m.Actions = append(m.Actions, MockAction{
 		Name:       "Create",
 		ZoneId:     zoneID,
@@ -118,7 +118,7 @@ func (m *mockCloudFlareClient) CreateDNSRecord(zoneID string, rr cloudflare.DNSR
 	return nil, nil
 }
 
-func (m *mockCloudFlareClient) DNSRecords(zoneID string, rr cloudflare.DNSRecord) ([]cloudflare.DNSRecord, error) {
+func (m *mockCloudFlareClient) DNSRecords(ctx context.Context, zoneID string, rr cloudflare.DNSRecord) ([]cloudflare.DNSRecord, error) {
 	if m.dnsRecordsError != nil {
 		return nil, m.dnsRecordsError
 	}
@@ -132,7 +132,7 @@ func (m *mockCloudFlareClient) DNSRecords(zoneID string, rr cloudflare.DNSRecord
 	return result, nil
 }
 
-func (m *mockCloudFlareClient) UpdateDNSRecord(zoneID, recordID string, rr cloudflare.DNSRecord) error {
+func (m *mockCloudFlareClient) UpdateDNSRecord(ctx context.Context, zoneID, recordID string, rr cloudflare.DNSRecord) error {
 	m.Actions = append(m.Actions, MockAction{
 		Name:       "Update",
 		ZoneId:     zoneID,
@@ -147,7 +147,7 @@ func (m *mockCloudFlareClient) UpdateDNSRecord(zoneID, recordID string, rr cloud
 	return nil
 }
 
-func (m *mockCloudFlareClient) DeleteDNSRecord(zoneID, recordID string) error {
+func (m *mockCloudFlareClient) DeleteDNSRecord(ctx context.Context, zoneID, recordID string) error {
 	m.Actions = append(m.Actions, MockAction{
 		Name:     "Delete",
 		ZoneId:   zoneID,
@@ -162,7 +162,7 @@ func (m *mockCloudFlareClient) DeleteDNSRecord(zoneID, recordID string) error {
 	return nil
 }
 
-func (m *mockCloudFlareClient) UserDetails() (cloudflare.User, error) {
+func (m *mockCloudFlareClient) UserDetails(ctx context.Context) (cloudflare.User, error) {
 	return m.User, nil
 }
 
@@ -176,7 +176,7 @@ func (m *mockCloudFlareClient) ZoneIDByName(zoneName string) (string, error) {
 	return "", errors.New("Unknown zone: " + zoneName)
 }
 
-func (m *mockCloudFlareClient) ListZones(zoneID ...string) ([]cloudflare.Zone, error) {
+func (m *mockCloudFlareClient) ListZones(ctx context.Context, zoneID ...string) ([]cloudflare.Zone, error) {
 	if m.listZonesError != nil {
 		return nil, m.listZonesError
 	}
@@ -216,7 +216,7 @@ func (m *mockCloudFlareClient) ListZonesContext(ctx context.Context, opts ...clo
 	}, nil
 }
 
-func (m *mockCloudFlareClient) ZoneDetails(zoneID string) (cloudflare.Zone, error) {
+func (m *mockCloudFlareClient) ZoneDetails(ctx context.Context, zoneID string) (cloudflare.Zone, error) {
 	for id, zoneName := range m.Zones {
 		if zoneID == id {
 			return cloudflare.Zone{
@@ -292,7 +292,7 @@ func TestCloudflareA(t *testing.T) {
 				Name:    "bar.com",
 				Content: "127.0.0.1",
 				TTL:     1,
-				Proxied: false,
+				Proxied: ProxyDisabled,
 			},
 		},
 		{
@@ -303,7 +303,7 @@ func TestCloudflareA(t *testing.T) {
 				Name:    "bar.com",
 				Content: "127.0.0.2",
 				TTL:     1,
-				Proxied: false,
+				Proxied: ProxyDisabled,
 			},
 		},
 	},
@@ -330,7 +330,7 @@ func TestCloudflareCname(t *testing.T) {
 				Name:    "cname.bar.com",
 				Content: "google.com",
 				TTL:     1,
-				Proxied: false,
+				Proxied: ProxyDisabled,
 			},
 		},
 		{
@@ -341,7 +341,7 @@ func TestCloudflareCname(t *testing.T) {
 				Name:    "cname.bar.com",
 				Content: "facebook.com",
 				TTL:     1,
-				Proxied: false,
+				Proxied: ProxyDisabled,
 			},
 		},
 	},
@@ -368,7 +368,7 @@ func TestCloudflareCustomTTL(t *testing.T) {
 				Name:    "ttl.bar.com",
 				Content: "127.0.0.1",
 				TTL:     120,
-				Proxied: false,
+				Proxied: ProxyDisabled,
 			},
 		},
 	},
@@ -394,7 +394,7 @@ func TestCloudflareProxiedDefault(t *testing.T) {
 				Name:    "bar.com",
 				Content: "127.0.0.1",
 				TTL:     1,
-				Proxied: true,
+				Proxied: ProxyEnabled,
 			},
 		},
 	},
@@ -426,7 +426,7 @@ func TestCloudflareProxiedOverrideTrue(t *testing.T) {
 				Name:    "bar.com",
 				Content: "127.0.0.1",
 				TTL:     1,
-				Proxied: true,
+				Proxied: ProxyEnabled,
 			},
 		},
 	},
@@ -458,7 +458,7 @@ func TestCloudflareProxiedOverrideFalse(t *testing.T) {
 				Name:    "bar.com",
 				Content: "127.0.0.1",
 				TTL:     1,
-				Proxied: false,
+				Proxied: ProxyDisabled,
 			},
 		},
 	},
@@ -490,7 +490,7 @@ func TestCloudflareProxiedOverrideIllegal(t *testing.T) {
 				Name:    "bar.com",
 				Content: "127.0.0.1",
 				TTL:     1,
-				Proxied: true,
+				Proxied: ProxyEnabled,
 			},
 		},
 	},
@@ -499,19 +499,21 @@ func TestCloudflareProxiedOverrideIllegal(t *testing.T) {
 }
 
 func TestCloudflareSetProxied(t *testing.T) {
+	var proxied *bool = ProxyEnabled
+	var notProxied *bool = ProxyDisabled
 	var testCases = []struct {
 		recordType string
 		domain     string
-		proxiable  bool
+		proxiable  *bool
 	}{
-		{"A", "bar.com", true},
-		{"CNAME", "bar.com", true},
-		{"TXT", "bar.com", false},
-		{"MX", "bar.com", false},
-		{"NS", "bar.com", false},
-		{"SPF", "bar.com", false},
-		{"SRV", "bar.com", false},
-		{"A", "*.bar.com", false},
+		{"A", "bar.com", proxied},
+		{"CNAME", "bar.com", proxied},
+		{"TXT", "bar.com", notProxied},
+		{"MX", "bar.com", notProxied},
+		{"NS", "bar.com", notProxied},
+		{"SPF", "bar.com", notProxied},
+		{"SRV", "bar.com", notProxied},
+		{"A", "*.bar.com", notProxied},
 	}
 
 	for _, testCase := range testCases {
@@ -684,6 +686,7 @@ func TestCloudflareApplyChanges(t *testing.T) {
 				Name:    "new.bar.com",
 				Content: "target",
 				TTL:     1,
+				Proxied: ProxyDisabled,
 			},
 		},
 		{
@@ -693,6 +696,7 @@ func TestCloudflareApplyChanges(t *testing.T) {
 				Name:    "foobar.bar.com",
 				Content: "target-new",
 				TTL:     1,
+				Proxied: ProxyDisabled,
 			},
 		},
 	})
@@ -779,6 +783,7 @@ func TestCloudflareGroupByNameAndType(t *testing.T) {
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.1",
 					TTL:     defaultCloudFlareRecordTTL,
+					Proxied: ProxyDisabled,
 				},
 			},
 			ExpectedEndpoints: []*endpoint.Endpoint{
@@ -805,12 +810,14 @@ func TestCloudflareGroupByNameAndType(t *testing.T) {
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.1",
 					TTL:     defaultCloudFlareRecordTTL,
+					Proxied: ProxyDisabled,
 				},
 				{
 					Name:    "foo.com",
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.2",
 					TTL:     defaultCloudFlareRecordTTL,
+					Proxied: ProxyDisabled,
 				},
 			},
 			ExpectedEndpoints: []*endpoint.Endpoint{
@@ -837,24 +844,28 @@ func TestCloudflareGroupByNameAndType(t *testing.T) {
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.1",
 					TTL:     defaultCloudFlareRecordTTL,
+					Proxied: ProxyDisabled,
 				},
 				{
 					Name:    "foo.com",
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.2",
 					TTL:     defaultCloudFlareRecordTTL,
+					Proxied: ProxyDisabled,
 				},
 				{
 					Name:    "bar.de",
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.1",
 					TTL:     defaultCloudFlareRecordTTL,
+					Proxied: ProxyDisabled,
 				},
 				{
 					Name:    "bar.de",
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.2",
 					TTL:     defaultCloudFlareRecordTTL,
+					Proxied: ProxyDisabled,
 				},
 			},
 			ExpectedEndpoints: []*endpoint.Endpoint{
@@ -894,18 +905,21 @@ func TestCloudflareGroupByNameAndType(t *testing.T) {
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.1",
 					TTL:     defaultCloudFlareRecordTTL,
+					Proxied: ProxyDisabled,
 				},
 				{
 					Name:    "foo.com",
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.2",
 					TTL:     defaultCloudFlareRecordTTL,
+					Proxied: ProxyDisabled,
 				},
 				{
 					Name:    "bar.de",
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.1",
 					TTL:     defaultCloudFlareRecordTTL,
+					Proxied: ProxyDisabled,
 				},
 			},
 			ExpectedEndpoints: []*endpoint.Endpoint{
@@ -945,18 +959,21 @@ func TestCloudflareGroupByNameAndType(t *testing.T) {
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.1",
 					TTL:     defaultCloudFlareRecordTTL,
+					Proxied: ProxyDisabled,
 				},
 				{
 					Name:    "foo.com",
 					Type:    endpoint.RecordTypeA,
 					Content: "10.10.10.2",
 					TTL:     defaultCloudFlareRecordTTL,
+					Proxied: ProxyDisabled,
 				},
 				{
 					Name:    "bar.de",
 					Type:    "NOT SUPPORTED",
 					Content: "10.10.10.1",
 					TTL:     defaultCloudFlareRecordTTL,
+					Proxied: ProxyDisabled,
 				},
 			},
 			ExpectedEndpoints: []*endpoint.Endpoint{
@@ -984,94 +1001,101 @@ func TestCloudflareGroupByNameAndType(t *testing.T) {
 
 func TestProviderPropertiesIdempotency(t *testing.T) {
 	testCases := []struct {
+		Name                     string
 		ProviderProxiedByDefault bool
-		RecordsAreProxied        bool
+		RecordsAreProxied        *bool
 		ShouldBeUpdated          bool
 	}{
 		{
+			Name:                     "ProxyDefault: false, ShouldBeProxied: false, ExpectUpdates: false",
 			ProviderProxiedByDefault: false,
-			RecordsAreProxied:        false,
+			RecordsAreProxied:        ProxyDisabled,
 			ShouldBeUpdated:          false,
 		},
 		{
+			Name:                     "ProxyDefault: true, ShouldBeProxied: true, ExpectUpdates: false",
 			ProviderProxiedByDefault: true,
-			RecordsAreProxied:        true,
+			RecordsAreProxied:        ProxyEnabled,
 			ShouldBeUpdated:          false,
 		},
 		{
+			Name:                     "ProxyDefault: true, ShouldBeProxied: false, ExpectUpdates: true",
 			ProviderProxiedByDefault: true,
-			RecordsAreProxied:        false,
+			RecordsAreProxied:        ProxyDisabled,
 			ShouldBeUpdated:          true,
 		},
 		{
+			Name:                     "ProxyDefault: false, ShouldBeProxied: true, ExpectUpdates: true",
 			ProviderProxiedByDefault: false,
-			RecordsAreProxied:        true,
+			RecordsAreProxied:        ProxyEnabled,
 			ShouldBeUpdated:          true,
 		},
 	}
 
 	for _, test := range testCases {
-		client := NewMockCloudFlareClientWithRecords(map[string][]cloudflare.DNSRecord{
-			"001": {
-				{
-					ID:      "1234567890",
-					ZoneID:  "001",
-					Name:    "foobar.bar.com",
-					Type:    endpoint.RecordTypeA,
-					TTL:     120,
-					Content: "1.2.3.4",
-					Proxied: test.RecordsAreProxied,
+		t.Run(test.Name, func(t *testing.T) {
+			client := NewMockCloudFlareClientWithRecords(map[string][]cloudflare.DNSRecord{
+				"001": {
+					{
+						ID:      "1234567890",
+						ZoneID:  "001",
+						Name:    "foobar.bar.com",
+						Type:    endpoint.RecordTypeA,
+						TTL:     120,
+						Content: "1.2.3.4",
+						Proxied: test.RecordsAreProxied,
+					},
 				},
-			},
-		})
-
-		provider := &CloudFlareProvider{
-			Client:           client,
-			proxiedByDefault: test.ProviderProxiedByDefault,
-		}
-		ctx := context.Background()
-
-		current, err := provider.Records(ctx)
-		if err != nil {
-			t.Errorf("should not fail, %s", err)
-		}
-		assert.Equal(t, 1, len(current))
-
-		desired := []*endpoint.Endpoint{}
-		for _, c := range current {
-			// Copy all except ProviderSpecific fields
-			desired = append(desired, &endpoint.Endpoint{
-				DNSName:       c.DNSName,
-				Targets:       c.Targets,
-				RecordType:    c.RecordType,
-				SetIdentifier: c.SetIdentifier,
-				RecordTTL:     c.RecordTTL,
-				Labels:        c.Labels,
 			})
-		}
 
-		plan := plan.Plan{
-			Current:            current,
-			Desired:            desired,
-			PropertyComparator: provider.PropertyValuesEqual,
-			ManagedRecords:     []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
-		}
+			provider := &CloudFlareProvider{
+				Client:           client,
+				proxiedByDefault: test.ProviderProxiedByDefault,
+			}
+			ctx := context.Background()
 
-		plan = *plan.Calculate()
-		assert.NotNil(t, plan.Changes, "should have plan")
-		if plan.Changes == nil {
-			return
-		}
-		assert.Equal(t, 0, len(plan.Changes.Create), "should not have creates")
-		assert.Equal(t, 0, len(plan.Changes.Delete), "should not have deletes")
+			current, err := provider.Records(ctx)
+			if err != nil {
+				t.Errorf("should not fail, %s", err)
+			}
+			assert.Equal(t, 1, len(current))
 
-		if test.ShouldBeUpdated {
-			assert.Equal(t, 1, len(plan.Changes.UpdateNew), "should not have new updates")
-			assert.Equal(t, 1, len(plan.Changes.UpdateOld), "should not have old updates")
-		} else {
-			assert.Equal(t, 0, len(plan.Changes.UpdateNew), "should not have new updates")
-			assert.Equal(t, 0, len(plan.Changes.UpdateOld), "should not have old updates")
-		}
+			desired := []*endpoint.Endpoint{}
+			for _, c := range current {
+				// Copy all except ProviderSpecific fields
+				desired = append(desired, &endpoint.Endpoint{
+					DNSName:       c.DNSName,
+					Targets:       c.Targets,
+					RecordType:    c.RecordType,
+					SetIdentifier: c.SetIdentifier,
+					RecordTTL:     c.RecordTTL,
+					Labels:        c.Labels,
+				})
+			}
+
+			plan := plan.Plan{
+				Current:            current,
+				Desired:            desired,
+				PropertyComparator: provider.PropertyValuesEqual,
+				ManagedRecords:     []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
+			}
+
+			plan = *plan.Calculate()
+			assert.NotNil(t, plan.Changes, "should have plan")
+			if plan.Changes == nil {
+				return
+			}
+			assert.Equal(t, 0, len(plan.Changes.Create), "should not have creates")
+			assert.Equal(t, 0, len(plan.Changes.Delete), "should not have deletes")
+
+			if test.ShouldBeUpdated {
+				assert.Equal(t, 1, len(plan.Changes.UpdateNew), "should not have new updates")
+				assert.Equal(t, 1, len(plan.Changes.UpdateOld), "should not have old updates")
+			} else {
+				assert.Equal(t, 0, len(plan.Changes.UpdateNew), "should not have new updates")
+				assert.Equal(t, 0, len(plan.Changes.UpdateOld), "should not have old updates")
+			}
+		})
 	}
 }
 
@@ -1129,7 +1153,7 @@ func TestCloudflareComplexUpdate(t *testing.T) {
 				Type:    "A",
 				Content: "2.3.4.5",
 				TTL:     1,
-				Proxied: true,
+				Proxied: ProxyEnabled,
 			},
 		},
 		MockAction{
@@ -1141,7 +1165,7 @@ func TestCloudflareComplexUpdate(t *testing.T) {
 				Type:    "A",
 				Content: "1.2.3.4",
 				TTL:     1,
-				Proxied: true,
+				Proxied: ProxyEnabled,
 			},
 		},
 		MockAction{
@@ -1162,7 +1186,7 @@ func TestCustomTTLWithEnabledProxyNotChanged(t *testing.T) {
 				Type:    endpoint.RecordTypeA,
 				TTL:     1,
 				Content: "1.2.3.4",
-				Proxied: true,
+				Proxied: ProxyEnabled,
 			},
 		},
 	})


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
In order for us to use some new features provided by cloudflare-go for
the cloudflare provider (mainly around Cloudflare Access, etc.) we need
to bump the version of cloudflare-go used.

The only real change that needed to be done was that the `Proxied` field
on `cloudflare.DNSRecord` structs changed from `bool` -> `*bool`.
Upstream did this because in certain cases, a user could not flip from
proxied -> DNS only (the library omitted sending `proxied = false` to
the API)

Other decent change was that most methods exported by the library now
require `context.Context` to be passed in. Was rather trivial to get up.

https://github.com/cloudflare/cloudflare-go/pull/595


Signed-off-by: Devon Mizelle <devon.mizelle@onepeloton.com>

**Checklist**

- [X] Unit tests updated
- [N/A] End user documentation updated
