### PR TITLE
pre filter external owned services using coredns

### DIFF
--- a/docs/tutorials/coredns.md
+++ b/docs/tutorials/coredns.md
@@ -230,3 +230,7 @@ dnstools# dig @10.100.4.143 nginx.example.org +short
 10.0.2.15
 dnstools#
 ```
+
+## Pre filtering CoreDNS services based on ownerIDs
+
+If your are running external-dns in multi cluster, you can use `--coredns-pre-filter-external-owned-records` and `--txt-owner-id` to ignore external created services, for example from a different external-dns.

--- a/main.go
+++ b/main.go
@@ -275,7 +275,7 @@ func main() {
 			},
 		)
 	case "coredns", "skydns":
-		p, err = coredns.NewCoreDNSProvider(domainFilter, cfg.CoreDNSPrefix, cfg.DryRun)
+		p, err = coredns.NewCoreDNSProvider(domainFilter, cfg.CoreDNSPrefix, cfg.TXTOwnerID, cfg.CoreDNSPreFilterExternalOwnedRecords, cfg.DryRun)
 	case "rdns":
 		p, err = rdns.NewRDNSProvider(
 			rdns.RDNSConfig{

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -42,158 +42,159 @@ var Version = "unknown"
 
 // Config is a project-wide configuration
 type Config struct {
-	APIServerURL                      string
-	KubeConfig                        string
-	RequestTimeout                    time.Duration
-	DefaultTargets                    []string
-	ContourLoadBalancerService        string
-	GlooNamespace                     string
-	SkipperRouteGroupVersion          string
-	Sources                           []string
-	Namespace                         string
-	AnnotationFilter                  string
-	LabelFilter                       string
-	FQDNTemplate                      string
-	CombineFQDNAndAnnotation          bool
-	IgnoreHostnameAnnotation          bool
-	IgnoreIngressTLSSpec              bool
-	IgnoreIngressRulesSpec            bool
-	GatewayNamespace                  string
-	GatewayLabelFilter                string
-	Compatibility                     string
-	PublishInternal                   bool
-	PublishHostIP                     bool
-	AlwaysPublishNotReadyAddresses    bool
-	ConnectorSourceServer             string
-	Provider                          string
-	GoogleProject                     string
-	GoogleBatchChangeSize             int
-	GoogleBatchChangeInterval         time.Duration
-	GoogleZoneVisibility              string
-	DomainFilter                      []string
-	ExcludeDomains                    []string
-	RegexDomainFilter                 *regexp.Regexp
-	RegexDomainExclusion              *regexp.Regexp
-	ZoneNameFilter                    []string
-	ZoneIDFilter                      []string
-	TargetNetFilter                   []string
-	ExcludeTargetNets                 []string
-	AlibabaCloudConfigFile            string
-	AlibabaCloudZoneType              string
-	AWSZoneType                       string
-	AWSZoneTagFilter                  []string
-	AWSAssumeRole                     string
-	AWSAssumeRoleExternalID           string
-	AWSBatchChangeSize                int
-	AWSBatchChangeInterval            time.Duration
-	AWSEvaluateTargetHealth           bool
-	AWSAPIRetries                     int
-	AWSPreferCNAME                    bool
-	AWSZoneCacheDuration              time.Duration
-	AWSSDServiceCleanup               bool
-	AzureConfigFile                   string
-	AzureResourceGroup                string
-	AzureSubscriptionID               string
-	AzureUserAssignedIdentityClientID string
-	BluecatDNSConfiguration           string
-	BluecatConfigFile                 string
-	BluecatDNSView                    string
-	BluecatGatewayHost                string
-	BluecatRootZone                   string
-	BluecatDNSServerName              string
-	BluecatDNSDeployType              string
-	BluecatSkipTLSVerify              bool
-	CloudflareProxied                 bool
-	CloudflareZonesPerPage            int
-	CoreDNSPrefix                     string
-	RcodezeroTXTEncrypt               bool
-	AkamaiServiceConsumerDomain       string
-	AkamaiClientToken                 string
-	AkamaiClientSecret                string
-	AkamaiAccessToken                 string
-	AkamaiEdgercPath                  string
-	AkamaiEdgercSection               string
-	InfobloxGridHost                  string
-	InfobloxWapiPort                  int
-	InfobloxWapiUsername              string
-	InfobloxWapiPassword              string `secure:"yes"`
-	InfobloxWapiVersion               string
-	InfobloxSSLVerify                 bool
-	InfobloxView                      string
-	InfobloxMaxResults                int
-	InfobloxFQDNRegEx                 string
-	InfobloxCreatePTR                 bool
-	InfobloxCacheDuration             int
-	DynCustomerName                   string
-	DynUsername                       string
-	DynPassword                       string `secure:"yes"`
-	DynMinTTLSeconds                  int
-	OCIConfigFile                     string
-	InMemoryZones                     []string
-	OVHEndpoint                       string
-	OVHApiRateLimit                   int
-	PDNSServer                        string
-	PDNSAPIKey                        string `secure:"yes"`
-	PDNSTLSEnabled                    bool
-	TLSCA                             string
-	TLSClientCert                     string
-	TLSClientCertKey                  string
-	Policy                            string
-	Registry                          string
-	TXTOwnerID                        string
-	TXTPrefix                         string
-	TXTSuffix                         string
-	Interval                          time.Duration
-	MinEventSyncInterval              time.Duration
-	Once                              bool
-	DryRun                            bool
-	UpdateEvents                      bool
-	LogFormat                         string
-	MetricsAddress                    string
-	LogLevel                          string
-	TXTCacheInterval                  time.Duration
-	TXTWildcardReplacement            string
-	ExoscaleEndpoint                  string
-	ExoscaleAPIKey                    string `secure:"yes"`
-	ExoscaleAPISecret                 string `secure:"yes"`
-	CRDSourceAPIVersion               string
-	CRDSourceKind                     string
-	ServiceTypeFilter                 []string
-	CFAPIEndpoint                     string
-	CFUsername                        string
-	CFPassword                        string
-	RFC2136Host                       string
-	RFC2136Port                       int
-	RFC2136Zone                       string
-	RFC2136Insecure                   bool
-	RFC2136GSSTSIG                    bool
-	RFC2136KerberosRealm              string
-	RFC2136KerberosUsername           string
-	RFC2136KerberosPassword           string `secure:"yes"`
-	RFC2136TSIGKeyName                string
-	RFC2136TSIGSecret                 string `secure:"yes"`
-	RFC2136TSIGSecretAlg              string
-	RFC2136TAXFR                      bool
-	RFC2136MinTTL                     time.Duration
-	RFC2136BatchChangeSize            int
-	NS1Endpoint                       string
-	NS1IgnoreSSL                      bool
-	NS1MinTTLSeconds                  int
-	TransIPAccountName                string
-	TransIPPrivateKeyFile             string
-	DigitalOceanAPIPageSize           int
-	ManagedDNSRecordTypes             []string
-	GoDaddyAPIKey                     string `secure:"yes"`
-	GoDaddySecretKey                  string `secure:"yes"`
-	GoDaddyTTL                        int64
-	GoDaddyOTE                        bool
-	OCPRouterName                     string
-	IBMCloudProxied                   bool
-	IBMCloudConfigFile                string
-	TencentCloudConfigFile            string
-	TencentCloudZoneType              string
-	PluralCluster                     string
-	PluralProvider                    string
+	APIServerURL                         string
+	KubeConfig                           string
+	RequestTimeout                       time.Duration
+	DefaultTargets                       []string
+	ContourLoadBalancerService           string
+	GlooNamespace                        string
+	SkipperRouteGroupVersion             string
+	Sources                              []string
+	Namespace                            string
+	AnnotationFilter                     string
+	LabelFilter                          string
+	FQDNTemplate                         string
+	CombineFQDNAndAnnotation             bool
+	IgnoreHostnameAnnotation             bool
+	IgnoreIngressTLSSpec                 bool
+	IgnoreIngressRulesSpec               bool
+	GatewayNamespace                     string
+	GatewayLabelFilter                   string
+	Compatibility                        string
+	PublishInternal                      bool
+	PublishHostIP                        bool
+	AlwaysPublishNotReadyAddresses       bool
+	ConnectorSourceServer                string
+	Provider                             string
+	GoogleProject                        string
+	GoogleBatchChangeSize                int
+	GoogleBatchChangeInterval            time.Duration
+	GoogleZoneVisibility                 string
+	DomainFilter                         []string
+	ExcludeDomains                       []string
+	RegexDomainFilter                    *regexp.Regexp
+	RegexDomainExclusion                 *regexp.Regexp
+	ZoneNameFilter                       []string
+	ZoneIDFilter                         []string
+	TargetNetFilter                      []string
+	ExcludeTargetNets                    []string
+	AlibabaCloudConfigFile               string
+	AlibabaCloudZoneType                 string
+	AWSZoneType                          string
+	AWSZoneTagFilter                     []string
+	AWSAssumeRole                        string
+	AWSAssumeRoleExternalID              string
+	AWSBatchChangeSize                   int
+	AWSBatchChangeInterval               time.Duration
+	AWSEvaluateTargetHealth              bool
+	AWSAPIRetries                        int
+	AWSPreferCNAME                       bool
+	AWSZoneCacheDuration                 time.Duration
+	AWSSDServiceCleanup                  bool
+	AzureConfigFile                      string
+	AzureResourceGroup                   string
+	AzureSubscriptionID                  string
+	AzureUserAssignedIdentityClientID    string
+	BluecatDNSConfiguration              string
+	BluecatConfigFile                    string
+	BluecatDNSView                       string
+	BluecatGatewayHost                   string
+	BluecatRootZone                      string
+	BluecatDNSServerName                 string
+	BluecatDNSDeployType                 string
+	BluecatSkipTLSVerify                 bool
+	CloudflareProxied                    bool
+	CloudflareZonesPerPage               int
+	CoreDNSPrefix                        string
+	CoreDNSPreFilterExternalOwnedRecords bool
+	RcodezeroTXTEncrypt                  bool
+	AkamaiServiceConsumerDomain          string
+	AkamaiClientToken                    string
+	AkamaiClientSecret                   string
+	AkamaiAccessToken                    string
+	AkamaiEdgercPath                     string
+	AkamaiEdgercSection                  string
+	InfobloxGridHost                     string
+	InfobloxWapiPort                     int
+	InfobloxWapiUsername                 string
+	InfobloxWapiPassword                 string `secure:"yes"`
+	InfobloxWapiVersion                  string
+	InfobloxSSLVerify                    bool
+	InfobloxView                         string
+	InfobloxMaxResults                   int
+	InfobloxFQDNRegEx                    string
+	InfobloxCreatePTR                    bool
+	InfobloxCacheDuration                int
+	DynCustomerName                      string
+	DynUsername                          string
+	DynPassword                          string `secure:"yes"`
+	DynMinTTLSeconds                     int
+	OCIConfigFile                        string
+	InMemoryZones                        []string
+	OVHEndpoint                          string
+	OVHApiRateLimit                      int
+	PDNSServer                           string
+	PDNSAPIKey                           string `secure:"yes"`
+	PDNSTLSEnabled                       bool
+	TLSCA                                string
+	TLSClientCert                        string
+	TLSClientCertKey                     string
+	Policy                               string
+	Registry                             string
+	TXTOwnerID                           string
+	TXTPrefix                            string
+	TXTSuffix                            string
+	Interval                             time.Duration
+	MinEventSyncInterval                 time.Duration
+	Once                                 bool
+	DryRun                               bool
+	UpdateEvents                         bool
+	LogFormat                            string
+	MetricsAddress                       string
+	LogLevel                             string
+	TXTCacheInterval                     time.Duration
+	TXTWildcardReplacement               string
+	ExoscaleEndpoint                     string
+	ExoscaleAPIKey                       string `secure:"yes"`
+	ExoscaleAPISecret                    string `secure:"yes"`
+	CRDSourceAPIVersion                  string
+	CRDSourceKind                        string
+	ServiceTypeFilter                    []string
+	CFAPIEndpoint                        string
+	CFUsername                           string
+	CFPassword                           string
+	RFC2136Host                          string
+	RFC2136Port                          int
+	RFC2136Zone                          string
+	RFC2136Insecure                      bool
+	RFC2136GSSTSIG                       bool
+	RFC2136KerberosRealm                 string
+	RFC2136KerberosUsername              string
+	RFC2136KerberosPassword              string `secure:"yes"`
+	RFC2136TSIGKeyName                   string
+	RFC2136TSIGSecret                    string `secure:"yes"`
+	RFC2136TSIGSecretAlg                 string
+	RFC2136TAXFR                         bool
+	RFC2136MinTTL                        time.Duration
+	RFC2136BatchChangeSize               int
+	NS1Endpoint                          string
+	NS1IgnoreSSL                         bool
+	NS1MinTTLSeconds                     int
+	TransIPAccountName                   string
+	TransIPPrivateKeyFile                string
+	DigitalOceanAPIPageSize              int
+	ManagedDNSRecordTypes                []string
+	GoDaddyAPIKey                        string `secure:"yes"`
+	GoDaddySecretKey                     string `secure:"yes"`
+	GoDaddyTTL                           int64
+	GoDaddyOTE                           bool
+	OCPRouterName                        string
+	IBMCloudProxied                      bool
+	IBMCloudConfigFile                   string
+	TencentCloudConfigFile               string
+	TencentCloudZoneType                 string
+	PluralCluster                        string
+	PluralProvider                       string
 }
 
 var defaultConfig = &Config{
@@ -466,6 +467,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("cloudflare-proxied", "When using the Cloudflare provider, specify if the proxy mode must be enabled (default: disabled)").BoolVar(&cfg.CloudflareProxied)
 	app.Flag("cloudflare-zones-per-page", "When using the Cloudflare provider, specify how many zones per page listed, max. possible 50 (default: 50)").Default(strconv.Itoa(defaultConfig.CloudflareZonesPerPage)).IntVar(&cfg.CloudflareZonesPerPage)
 	app.Flag("coredns-prefix", "When using the CoreDNS provider, specify the prefix name").Default(defaultConfig.CoreDNSPrefix).StringVar(&cfg.CoreDNSPrefix)
+	app.Flag("coredns-pre-filter-external-owned-records", "When using the CoreDNS provider, services are pre filter based on the txt-owner-id (default: false)").BoolVar(&cfg.CoreDNSPreFilterExternalOwnedRecords)
 	app.Flag("akamai-serviceconsumerdomain", "When using the Akamai provider, specify the base URL (required when --provider=akamai and edgerc-path not specified)").Default(defaultConfig.AkamaiServiceConsumerDomain).StringVar(&cfg.AkamaiServiceConsumerDomain)
 	app.Flag("akamai-client-token", "When using the Akamai provider, specify the client token (required when --provider=akamai and edgerc-path not specified)").Default(defaultConfig.AkamaiClientToken).StringVar(&cfg.AkamaiClientToken)
 	app.Flag("akamai-client-secret", "When using the Akamai provider, specify the client secret (required when --provider=akamai and edgerc-path not specified)").Default(defaultConfig.AkamaiClientSecret).StringVar(&cfg.AkamaiClientSecret)

--- a/provider/coredns/coredns.go
+++ b/provider/coredns/coredns.go
@@ -62,6 +62,9 @@ type coreDNSProvider struct {
 	coreDNSPrefix string
 	domainFilter  endpoint.DomainFilter
 	client        coreDNSClient
+
+	ownerID                       string //refers to the owner id of the current instance
+	preFilterExternalOwnedRecords bool
 }
 
 // Service represents CoreDNS etcd record
@@ -246,7 +249,7 @@ func newETCDClient() (coreDNSClient, error) {
 }
 
 // NewCoreDNSProvider is a CoreDNS provider constructor
-func NewCoreDNSProvider(domainFilter endpoint.DomainFilter, prefix string, dryRun bool) (provider.Provider, error) {
+func NewCoreDNSProvider(domainFilter endpoint.DomainFilter, prefix, ownerID string, preFilterExternalOwnedRecords, dryRun bool) (provider.Provider, error) {
 	client, err := newETCDClient()
 	if err != nil {
 		return nil, err
@@ -257,6 +260,9 @@ func NewCoreDNSProvider(domainFilter endpoint.DomainFilter, prefix string, dryRu
 		dryRun:        dryRun,
 		coreDNSPrefix: prefix,
 		domainFilter:  domainFilter,
+
+		ownerID:                       ownerID,
+		preFilterExternalOwnedRecords: preFilterExternalOwnedRecords,
 	}, nil
 }
 
@@ -291,6 +297,14 @@ func (p coreDNSProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, err
 		return nil, err
 	}
 	for _, service := range services {
+		if p.preFilterExternalOwnedRecords && service.Text != "" {
+			if labels, err := endpoint.NewLabelsFromString(service.Text); err == nil && labels != nil {
+				if owner, exists := labels[endpoint.OwnerLabelKey]; exists && owner != p.ownerID {
+					log.Debugf(`Skipping coredns service %v because owner id does not match, found: "%s", required: "%s"`, service, owner, p.ownerID)
+					continue
+				}
+			}
+		}
 		domains := strings.Split(strings.TrimPrefix(service.Key, p.coreDNSPrefix), "/")
 		reverse(domains)
 		dnsName := strings.Join(domains[service.TargetStrip:], ".")


### PR DESCRIPTION
**Description**

Partially fixes #2156

Etcd entries are filter out based on the text content, if they are not originating from current owner-id. 

This solution is this locally in a multi cluster env.

@fusida Any feedback?

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
