### PR TITLE
remove unused parameters in aws change submit method

### DIFF
--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -501,7 +501,7 @@ func TestAWSApplyChanges(t *testing.T) {
 		setup      func(p *AWSProvider) context.Context
 		listRRSets int
 	}{
-		{"no cache", func(p *AWSProvider) context.Context { return context.Background() }, 3},
+		{"no cache", func(p *AWSProvider) context.Context { return context.Background() }, 0},
 		{"cached", func(p *AWSProvider) context.Context {
 			ctx := context.Background()
 			records, err := p.Records(ctx)
@@ -781,7 +781,7 @@ func TestAWSsubmitChanges(t *testing.T) {
 	zones, _ := provider.Zones(ctx)
 	records, _ := provider.Records(ctx)
 	cs := make([]*route53.Change, 0, len(endpoints))
-	cs = append(cs, provider.newChanges(route53.ChangeActionCreate, endpoints, records, zones)...)
+	cs = append(cs, provider.newChanges(route53.ChangeActionCreate, endpoints)...)
 
 	require.NoError(t, provider.submitChanges(ctx, cs, zones))
 
@@ -798,11 +798,9 @@ func TestAWSsubmitChangesError(t *testing.T) {
 	ctx := context.Background()
 	zones, err := provider.Zones(ctx)
 	require.NoError(t, err)
-	records, err := provider.Records(ctx)
-	require.NoError(t, err)
 
 	ep := endpoint.NewEndpointWithTTL("fail.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.0.0.1")
-	cs := provider.newChanges(route53.ChangeActionCreate, []*endpoint.Endpoint{ep}, records, zones)
+	cs := provider.newChanges(route53.ChangeActionCreate, []*endpoint.Endpoint{ep})
 
 	require.Error(t, provider.submitChanges(ctx, cs, zones))
 }


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR removes unused parameter is the `newChange` logic. Using these unused parameters has led to the provider calling ListResourceRecords unnecessarily. This refactor should lead to some performance improvements

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [X] Unit tests updated
