### PR TITLE
kustomize: Grant watch nodes instead of get

### DIFF
--- a/kustomize/external-dns-clusterrole.yaml
+++ b/kustomize/external-dns-clusterrole.yaml
@@ -14,4 +14,4 @@ rules:
     verbs: ["get","watch","list"]
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["get", "list"]
+    verbs: ["watch", "list"]


### PR DESCRIPTION
**Description**

Getting `Failed to watch *v1.Node: unknown (get nodes)` before, fixed with this change.

Same as Helm:
https://github.com/kubernetes-sigs/external-dns/blob/79de6b590f321343cb1298c847ec059a973d84a3/charts/external-dns/templates/clusterrole.yaml#L15-L17

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
