### PR TITLE
Cloudflare wildcard records in enterprise plan

### DIFF
--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -367,13 +367,13 @@ func (p *CloudFlareProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) []*
 }
 
 func (p *CloudFlareProvider) enhanceEndpoint(record *endpoint.Endpoint, zoneNameIDMapper provider.ZoneIDName, idToZoneMapper map[string]cloudflare.Zone) error {
-	zoneId, zoneName := zoneNameIDMapper.FindZone(record.DNSName)
+	zoneID, zoneName := zoneNameIDMapper.FindZone(record.DNSName)
 
-	if zoneId == "" || zoneName == "" {
-		return errors.New("Could not find cloudflare zone associated with record")
+	if zoneID == "" || zoneName == "" {
+		return errors.New("could not find cloudflare zone associated with record")
 	}
 
-	zone, _ := idToZoneMapper[zoneId]
+	zone := idToZoneMapper[zoneID]
 
 	record.ProviderSpecific = append(record.ProviderSpecific, endpoint.ProviderSpecificProperty{
 		Name:  planKeyword,

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -347,7 +347,7 @@ func (p *CloudFlareProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) []*
 	if err != nil {
 		log.WithFields(log.Fields{
 			"endpoints": endpoints,
-		}).WithError(err).Errorf("Cannot adjust endpoints because zone mapping failed")
+		}).WithError(err).Debugf("Cannot adjust endpoints because zone mapping failed")
 
 		return endpoints
 	}
@@ -356,7 +356,7 @@ func (p *CloudFlareProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) []*
 		if err := p.enhanceEndpoint(e, zoneNameIDMapper, idToZoneMapper); err != nil {
 			log.WithFields(log.Fields{
 				"endpoint": e,
-			}).WithError(err).Errorf("Cannot enhance endpoint to include plan information")
+			}).WithError(err).Debugf("Cannot enhance endpoint to include plan information")
 		}
 		if shouldBeProxied(e, p.proxiedByDefault) {
 			e.RecordTTL = 0

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -229,7 +229,7 @@ func (m *mockCloudFlareClient) ListZonesContext(ctx context.Context, opts ...clo
 		return cloudflare.ZonesResponse{}, m.listZonesError
 	}
 
-	result, err := m.ListZones()
+	result, err := m.ListZones(ctx)
 	if err != nil {
 		return cloudflare.ZonesResponse{}, m.listZonesError
 	}
@@ -530,6 +530,8 @@ func TestCloudflareProxiedOverrideIllegal(t *testing.T) {
 }
 
 func TestCloudflareSetProxied(t *testing.T) {
+	var proxied *bool = proxyEnabled
+	var notProxied *bool = proxyDisabled
 	type zoneInfo struct {
 		id   string
 		plan string
@@ -540,24 +542,24 @@ func TestCloudflareSetProxied(t *testing.T) {
 		proxiable  *bool
 		zone       zoneInfo
 	}{
-		{"A", "foo.com", true, zoneInfo{"002", "Pro"}},
-		{"A", "tar.com", true, zoneInfo{"004", "Enterprise"}},
-		{"CNAME", "bar.com", true, zoneInfo{"001", "Free"}},
-		{"CNAME", "tar.com", true, zoneInfo{"004", "Enterprise"}},
-		{"TXT", "bar.com", false, zoneInfo{"001", "Free"}},
-		{"TXT", "tar.com", false, zoneInfo{"004", "Enterprise"}},
-		{"MX", "foo.com", false, zoneInfo{"002", "Pro"}},
-		{"MX", "tar.com", false, zoneInfo{"004", "Enterprise"}},
-		{"NS", "baz.com", false, zoneInfo{"003", "Business"}},
-		{"NS", "tar.com", false, zoneInfo{"004", "Enterprise"}},
-		{"SPF", "bar.com", false, zoneInfo{"001", "Free"}},
-		{"SPF", "tar.com", false, zoneInfo{"004", "Enterprise"}},
-		{"SRV", "baz.com", false, zoneInfo{"003", "Business"}},
-		{"SRV", "tar.com", false, zoneInfo{"004", "Enterprise"}},
-		{"A", "*.bar.com", false, zoneInfo{"001", "Free"}},
-		{"A", "*.foo.com", false, zoneInfo{"002", "Pro"}},
-		{"A", "*.baz.com", false, zoneInfo{"003", "Business"}},
-		{"A", "*.tar.com", true, zoneInfo{"004", "Enterprise"}},
+		{"A", "foo.com", proxied, zoneInfo{"002", "Pro"}},
+		{"A", "tar.com", proxied, zoneInfo{"004", "Enterprise"}},
+		{"CNAME", "bar.com", proxied, zoneInfo{"001", "Free"}},
+		{"CNAME", "tar.com", proxied, zoneInfo{"004", "Enterprise"}},
+		{"TXT", "bar.com", notProxied, zoneInfo{"001", "Free"}},
+		{"TXT", "tar.com", notProxied, zoneInfo{"004", "Enterprise"}},
+		{"MX", "foo.com", notProxied, zoneInfo{"002", "Pro"}},
+		{"MX", "tar.com", notProxied, zoneInfo{"004", "Enterprise"}},
+		{"NS", "baz.com", notProxied, zoneInfo{"003", "Business"}},
+		{"NS", "tar.com", notProxied, zoneInfo{"004", "Enterprise"}},
+		{"SPF", "bar.com", notProxied, zoneInfo{"001", "Free"}},
+		{"SPF", "tar.com", notProxied, zoneInfo{"004", "Enterprise"}},
+		{"SRV", "baz.com", notProxied, zoneInfo{"003", "Business"}},
+		{"SRV", "tar.com", notProxied, zoneInfo{"004", "Enterprise"}},
+		{"A", "*.bar.com", notProxied, zoneInfo{"001", "Free"}},
+		{"A", "*.foo.com", notProxied, zoneInfo{"002", "Pro"}},
+		{"A", "*.baz.com", notProxied, zoneInfo{"003", "Business"}},
+		{"A", "*.tar.com", proxied, zoneInfo{"004", "Enterprise"}},
 	}
 
 	for _, testCase := range testCases {
@@ -1117,7 +1119,7 @@ func TestProviderPropertiesIdempotency(t *testing.T) {
 				})
 			}
 
-		desired = provider.AdjustEndpoints(desired)
+			desired = provider.AdjustEndpoints(desired)
 
 			plan := plan.Plan{
 				Current:            current,


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Cloudflare provider doesn't allow proxied DNS records if the records contains wildcard (`*`) as part of the hostname, irrespective of the zone's plan. While wildcard DNS records **can be proxied**  in zones under the **Enterprise** plan.

This PR updates the `shouldBeProxied` validation to take into account the plan name when deciding whether to proxy wildcard records or not. For this, it leverages the `ProviderSpecificProperty` capabilities to add the plan name in the `AdjustEndpoints` method in the cloudflare provider, which is invoked before `plan.Calculate` in the controller loop

**Other Changes**

* Enhance cloudflare tests suite to have instances of the 4 different types of zones.
* Update cloudflare tests to run `AdjustEndpoint` before invoking `plan.Calculate` to match what the controller does
* Increase parameterized test cases in `TestCloudflareSetProxied`, including validating that proxied status is set accordingly for wildcard records depending on the zone plan

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1810
Relates #1542

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated (No need)
