### PR TITLE
Add Helm chart metadata

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,8 @@
+repositoryID: 0fe570c3-9992-4df2-acb5-ef1f1922dacb
+owners:
+  - name: K8s Steering Committee 1
+    email: sc1@kubernetes.io
+  - name: K8s Steering Committee 2
+    email: sc2@kubernetes.io
+  - name: K8s Steering Committee 3
+    email: sc3@kubernetes.io

--- a/index.yaml
+++ b/index.yaml
@@ -27,4 +27,76 @@ entries:
     urls:
     - https://github.com/kubernetes-sigs/external-dns/releases/download/external-dns-helm-chart-1.2.0/external-dns-1.2.0.tgz
     version: 1.2.0
-generated: "2021-08-19T16:41:48.848784158Z"
+  - annotations:
+      artifacthub.io/changes: |
+        - kind: added
+          description: Initial official release.
+    apiVersion: v2
+    appVersion: 0.10.0
+    description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with
+      DNS providers.
+    home: https://github.com/kubernetes-sigs/external-dns/
+    icon: https://github.com/kubernetes-sigs/external-dns/raw/master/img/external-dns.png
+    keywords:
+    - kubernetes
+    - external-dns
+    - dns
+    maintainers:
+    - email: steve.hipwell@gmail.com
+      name: stevehipwell
+    name: external-dns
+    sources:
+    - https://github.com/kubernetes-sigs/external-dns/
+    type: application
+    urls:
+    - https://github.com/kubernetes-sigs/external-dns/releases/download/external-dns-helm-chart-1.3.0/external-dns-1.3.0.tgz
+    version: 1.3.0
+  - annotations:
+      artifacthub.io/changes: |
+        - kind: added
+          description: Initial official release.
+    apiVersion: v2
+    appVersion: 0.10.0
+    description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with
+      DNS providers.
+    home: https://github.com/kubernetes-sigs/external-dns/
+    icon: https://github.com/kubernetes-sigs/external-dns/raw/master/img/external-dns.png
+    keywords:
+    - kubernetes
+    - external-dns
+    - dns
+    maintainers:
+    - email: steve.hipwell@gmail.com
+      name: stevehipwell
+    name: external-dns
+    sources:
+    - https://github.com/kubernetes-sigs/external-dns/
+    type: application
+    urls:
+    - https://github.com/kubernetes-sigs/external-dns/releases/download/external-dns-helm-chart-1.3.1/external-dns-1.3.1.tgz
+    version: 1.3.1
+  - annotations:
+      artifacthub.io/changes: |
+        - kind: added
+          description: Initial official release.
+    apiVersion: v2
+    appVersion: 0.10.0
+    description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with
+      DNS providers.
+    home: https://github.com/kubernetes-sigs/external-dns/
+    icon: https://github.com/kubernetes-sigs/external-dns/raw/master/img/external-dns.png
+    keywords:
+    - kubernetes
+    - external-dns
+    - dns
+    maintainers:
+    - email: steve.hipwell@gmail.com
+      name: stevehipwell
+    name: external-dns
+    sources:
+    - https://github.com/kubernetes-sigs/external-dns/
+    type: application
+    urls:
+    - https://github.com/kubernetes-sigs/external-dns/releases/download/external-dns-helm-chart-1.3.2/external-dns-1.3.2.tgz
+    version: 1.3.2
+generated: "2021-10-07T13:50:00.848784158Z"


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR makes the [Artifact Hub External DNS Repo](https://artifacthub.io/packages/search?repo=external-dns&sort=relevance&page=1) official and will allow an ownership claim to be made (https://github.com/kubernetes-sigs/external-dns/issues/2275) when the owner of the [Kubernetes SIGs Artifact Hub organisation](https://artifacthub.io/packages/search?org=kubernetes-sigs&sort=relevance&page=1) can be found.

The `gh-pages` branch is currently protected which is breaking Helm chart releases, this PR adds the charts manually but the branch needs un-protecting ASAP.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated


