### PR TITLE
Fix log message if a cloudflare update fails

### DIFF
--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -308,7 +308,7 @@ func (p *CloudFlareProvider) submitChanges(ctx context.Context, changes []*cloud
 				}
 				err := p.Client.UpdateDNSRecord(zoneID, recordID, change.ResourceRecord)
 				if err != nil {
-					log.WithFields(logFields).Errorf("failed to delete record: %v", err)
+					log.WithFields(logFields).Errorf("failed to update record: %v", err)
 				}
 			} else if change.Action == cloudFlareDelete {
 				recordID := p.getRecordID(records, change.ResourceRecord)


### PR DESCRIPTION
**Description**

If a Cloudflare DNS record update fails, the log erroneously claimed
that it failed to delete the record. This fixes the log to claim that
it failed to update the record.

**Checklist**
(neither are updated as they are irrelevant to this PR)
- [ ] Unit tests updated
- [ ] End user documentation updated