### PR TITLE
Override provider-specific values for TXT registry.

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -138,6 +138,9 @@ type Endpoint struct {
 	// ProviderSpecific stores provider specific config
 	// +optional
 	ProviderSpecific ProviderSpecific `json:"providerSpecific,omitempty"`
+	// ProviderSpecificRegistry stores provider specific config specifically for the registry
+	// +optional
+	ProviderSpecificRegistry ProviderSpecific `json:"ProviderSpecificRegistry,omitempty"`
 }
 
 // NewEndpoint initialization method to be used to create an endpoint

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -592,6 +592,16 @@ func (p *AWSProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) []*endpoin
 				Value: fmt.Sprintf("%t", p.evaluateTargetHealth),
 			})
 		}
+
+		// adjust providerSpecificRegistry for cases where failover is set
+		var providerSpecificRegistry endpoint.ProviderSpecific
+		for _, i := range ep.ProviderSpecific {
+			if i.Name == providerSpecificFailover {
+				i.Name = providerSpecificMultiValueAnswer
+			}
+			providerSpecificRegistry = append(providerSpecificRegistry, i)
+		}
+		ep.ProviderSpecificRegistry = providerSpecificRegistry
 	}
 	return endpoints
 }

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -155,7 +155,7 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 		}
 		r.Labels[endpoint.OwnerLabelKey] = im.ownerID
 		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
-		txt.ProviderSpecific = r.ProviderSpecific
+		txt.ProviderSpecific = r.ProviderSpecificRegistry
 		filteredChanges.Create = append(filteredChanges.Create, txt)
 
 		if im.cacheInterval > 0 {
@@ -165,7 +165,7 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 
 	for _, r := range filteredChanges.Delete {
 		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
-		txt.ProviderSpecific = r.ProviderSpecific
+		txt.ProviderSpecific = r.ProviderSpecificRegistry
 
 		// when we delete TXT records for which value has changed (due to new label) this would still work because
 		// !!! TXT record value is uniquely generated from the Labels of the endpoint. Hence old TXT record can be uniquely reconstructed
@@ -179,8 +179,9 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 	// make sure TXT records are consistently updated as well
 	for _, r := range filteredChanges.UpdateOld {
 		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
-		txt.ProviderSpecific = r.ProviderSpecific
-		// when we updateOld TXT records for which value has changed (due to new label) this would still work because
+		txt.ProviderSpecific = r.ProviderSpecificRegistry
+
+		// when we update Old TXT records for which value has changed (due to new label) this would still work because
 		// !!! TXT record value is uniquely generated from the Labels of the endpoint. Hence old TXT record can be uniquely reconstructed
 		filteredChanges.UpdateOld = append(filteredChanges.UpdateOld, txt)
 		// remove old version of record from cache
@@ -192,7 +193,8 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 	// make sure TXT records are consistently updated as well
 	for _, r := range filteredChanges.UpdateNew {
 		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
-		txt.ProviderSpecific = r.ProviderSpecific
+		txt.ProviderSpecific = r.ProviderSpecificRegistry
+
 		filteredChanges.UpdateNew = append(filteredChanges.UpdateNew, txt)
 		// add new version of record to cache
 		if im.cacheInterval > 0 {


### PR DESCRIPTION
Current use case is for properly working failover records -- details are in https://github.com/kubernetes-sigs/external-dns/issues/1420 .

For failover records, the TXT records are created as multi-value answers, which allows them to happily exist (and co-exist with entries of the same name).

This is a resubmission of https://github.com/kubernetes-sigs/external-dns/pull/1423.

Fixes #1420

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
