### PR TITLE
use docker buildx for multi-arch docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY . .
 RUN make test build.$ARCH
 
 # final image
-FROM $ARCH/alpine:3.15
+FROM alpine:3.15
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /bin/external-dns

--- a/Makefile
+++ b/Makefile
@@ -90,24 +90,21 @@ IMAGE         ?= us.gcr.io/k8s-artifacts-prod/external-dns/$(BINARY)
 VERSION       ?= $(shell git describe --tags --always --dirty)
 BUILD_FLAGS   ?= -v
 LDFLAGS       ?= -X sigs.k8s.io/external-dns/pkg/apis/externaldns.Version=$(VERSION) -w -s
-ARCHS         = amd64 arm64v8 arm32v7
+LINUX_ARCHS	  = amd64 arm64 arm/v7
+ARCH 		  ?= amd64
 SHELL         = /bin/bash
-
+# The output type for `docker buildx build` could either be docker (local), or registry.
+OUTPUT_TYPE ?= docker
 
 build: build/$(BINARY)
 
 build/$(BINARY): $(SOURCES)
 	CGO_ENABLED=0 go build -o build/$(BINARY) $(BUILD_FLAGS) -ldflags "$(LDFLAGS)" .
 
-build.push/multiarch:
+build.push.all: $(addprefix build.push-,$(LINUX_ARCHS))
 	arch_specific_tags=()
-	for arch in $(ARCHS); do \
+	for arch in $(LINUX_ARCHS); do \
 		image="$(IMAGE):$(VERSION)-$${arch}" ;\
-		# pre-pull due to https://github.com/kubernetes-sigs/cluster-addons/pull/84/files ;\
-		docker pull $${arch}/alpine:3.14 ;\
-		docker pull golang:1.18 ;\
-		DOCKER_BUILDKIT=1 docker build --rm --tag $${image} --build-arg VERSION="$(VERSION)" --build-arg ARCH="$${arch}" . ;\
-		docker push $${image} ;\
 		arch_specific_tags+=( "--amend $${image}" ) ;\
 	done ;\
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create "$(IMAGE):$(VERSION)" $${arch_specific_tags[@]} ;\
@@ -116,20 +113,33 @@ build.push/multiarch:
 	done;\
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(IMAGE):$(VERSION)" \
 
-build.push: build.docker
-	docker push "$(IMAGE):$(VERSION)"
+build.push:
+	$(MAKE) ARCH=$(ARCH) OUTPUT_TYPE=registry build.docker
 
-build.arm64v8:
+build.push-%:
+	$(MAKE) ARCH=$* build.push
+
+build.arm64:
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o build/$(BINARY) $(BUILD_FLAGS) -ldflags "$(LDFLAGS)" .
 
 build.amd64:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o build/$(BINARY) $(BUILD_FLAGS) -ldflags "$(LDFLAGS)" .
 
-build.arm32v7:
+build.arm/v7:
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -o build/$(BINARY) $(BUILD_FLAGS) -ldflags "$(LDFLAGS)" .
 
-build.docker:
-	docker build --rm --tag "$(IMAGE):$(VERSION)" --build-arg VERSION="$(VERSION)" --build-arg ARCH="amd64" .
+build.setup:
+	docker buildx inspect img-builder > /dev/null || docker buildx create --name img-builder --use
+
+build.docker: build.setup build.$(ARCH)
+	image="$(IMAGE):$(VERSION)-$(ARCH)"; \
+	docker buildx build \
+		--pull \
+		--output=type=$(OUTPUT_TYPE) \
+		--platform linux/$(ARCH) \
+		--build-arg ARCH="$(ARCH)" \
+		--build-arg VERSION="$(VERSION)" \
+		--tag $${image} .
 
 build.mini:
 	docker build --rm --tag "$(IMAGE):$(VERSION)-mini" --build-arg VERSION="$(VERSION)" -f Dockerfile.mini .


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
Before this change, docker image is built with the arch the same as host node even after `ARCH` is specified. Using docker buildx helps us build cross-platform multi-arch docker images


<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
