### PR TITLE
[Google Provider] Additional logging when project detection fails

### DIFF
--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -149,6 +149,9 @@ func NewGoogleProvider(ctx context.Context, project string, domainFilter endpoin
 			log.Infof("Google project auto-detected: %s", mProject)
 			project = mProject
 		}
+		if mProject == "" {
+			log.Errorf("Google project still not detected, please run with --google-project flag.")
+		}
 	}
 
 	zoneTypeFilter := provider.NewZoneTypeFilter(zoneVisibility)


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Provides a helpful error message and exits when required field is not set.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2381 

