### PR TITLE
[azure] remove dummy MSI_ENDPOINT

### DIFF
--- a/provider/azure/config.go
+++ b/provider/azure/config.go
@@ -19,7 +19,6 @@ package azure
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"strings"
 
 	"github.com/Azure/go-autorest/autorest/adal"
@@ -104,10 +103,6 @@ func getAccessToken(cfg config, environment azure.Environment) (*adal.ServicePri
 	// Try to retrieve token with MSI.
 	if cfg.UseManagedIdentityExtension {
 		log.Info("Using managed identity extension to retrieve access token for Azure API.")
-		os.Setenv("MSI_ENDPOINT", "http://dummy")
-		defer func() {
-			os.Unsetenv("MSI_ENDPOINT")
-		}()
 
 		if cfg.UserAssignedIdentityID != "" {
 			log.Infof("Resolving to user assigned identity, client id is %s.", cfg.UserAssignedIdentityID)


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

For some reason, code was added to set the MSI_ENDPOINT environment to a dummy value, which prevents the retrieval of an access token when using managed identities. This PR removes this code.
