### PR TITLE
GCP: handle failed project auto detection

### DIFF
--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -145,10 +145,11 @@ func NewGoogleProvider(ctx context.Context, project string, domainFilter endpoin
 
 	if project == "" {
 		mProject, mErr := metadata.ProjectID()
-		if mErr == nil {
-			log.Infof("Google project auto-detected: %s", mProject)
-			project = mProject
+		if mErr != nil {
+			return nil, fmt.Errorf("failed to auto-detect the project id: %w", mErr)
 		}
+		log.Infof("Google project auto-detected: %s", mProject)
+		project = mProject
 	}
 
 	zoneTypeFilter := provider.NewZoneTypeFilter(zoneVisibility)


### PR DESCRIPTION
**Description**
While using Google DNS provider you can end up in the situation when the auto detection of the project ID fails (when the metadata URL is not allowed, for instance). This PR helps to see the actual error and fail the instantiation of the provider if the no GCP project was provided/auto-detected.

Without this PR you can get the following not descriptive error if the project was not explicitly provided and the auto-detection failed:
```
level=error msg="googleapi: Error 400: Invalid resource field value in the request., invalidParameter"
```

With this PR external-dns fails and gives a more descriptive error :
```
level=fatal msg="failed to auto-detect the project id: Get \"http://169.254.169.254/computeMetadata/v1/project/project-id\": dial tcp 169.254.169.254:80: connect: connection refused"
```

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
