### PR TITLE
Small change to release notes tutorial

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -24,7 +24,7 @@ You must be an official maintainer of the project to be able to do a release.
 
 ### Steps
 
-- Run `scripts/releaser.sh` to create a new GitHub release.
+- Run `scripts/releaser.sh` to create a new GitHub release. Alternatively you can create a release in the GitHub UI making sure to click on the autogenerate release node feature.
 - The step above will trigger the Kubernetes based CI/CD system [Prow](https://prow.k8s.io/?repo=kubernetes-sigs%2Fexternal-dns). Verify that a new image was built and uploaded to `gcr.io/k8s-staging-external-dns/external-dns`.
 - Create a PR in the [k8s.io repo](https://github.com/kubernetes/k8s.io) (see https://github.com/kubernetes/k8s.io/pull/540 for reference) by taking the current staging image using the sha256 digest. Once the PR is merged, the image will be live with the corresponding tag specified in the PR.
 - Verify that the image is pullable with the given tag (i.e. `v0.7.5`).


### PR DESCRIPTION
Currently we require using a script for release that needs to be run locally with a fresh copy of the default branch. That works well enough, but the autogeneration of release notes that GitHub added is enough for us to stop doing that and just use the UI for that part. This PR adds additional information to offer both options.

/cc @njuettner 
