### PR TITLE
Update helm chart to use v0.10.1

### DIFF
--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: external-dns
 description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 type: application
-version: 1.3.2
-appVersion: 0.10.0
+version: 1.4.0
+appVersion: 0.10.1
 keywords:
   - kubernetes
   - external-dns
@@ -17,5 +17,5 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Initial official release.
+    - kind: changed
+      description: "Update image to v0.10.1"


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
This PR updates the [Helm chart](https://artifacthub.io/packages/helm/external-dns/external-dns) to use the latest [v0.10.1](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.10.1) release.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
