### PR TITLE
Revert "Install tzdata, so that time zone information is available."

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,6 @@ RUN make test build.$ARCH
 # final image
 FROM $ARCH/alpine:3.14
 
-RUN apk --no-cache add tzdata
-
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /bin/external-dns
 


### PR DESCRIPTION
This reverts commit 5554e0529e723c27c2cb3d855f052c7075e20b81 as it breaks multi arch builds. #2378 might fix that so we will look into reintroducing this feature after we made multi arch support better. We need this revert now so that we can release v0.10.1. 