### PR TITLE
doc: add Kubernetes compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ The following table clarifies the current status of the providers according to t
 | GoDaddy | Alpha | |
 | Gandi | Alpha | @packi |
 
+## Kubernetes version compatibility
+
+| ExternalDNS        |      <= 0.9.x      |     >= 0.10.0      |
+| ------------------ | :----------------: | :----------------: |
+| Kubernetes <= 1.18 | :white_check_mark: |        :x:         |
+| Kubernetes >= 1.19 |        :x:         | :white_check_mark: |
+
 ## Running ExternalDNS:
 
 The are two ways of running ExternalDNS:

--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -4,6 +4,7 @@ description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses 
 type: application
 version: 1.4.0
 appVersion: 0.10.1
+kubeVersion: ">= 1.19.0"
 keywords:
   - kubernetes
   - external-dns

--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -4,7 +4,6 @@ description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses 
 type: application
 version: 1.4.0
 appVersion: 0.10.1
-kubeVersion: ">= 1.19.0"
 keywords:
   - kubernetes
   - external-dns


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

With the changes made in #2281, It breaks the backward compatibility to k8s 1.18. I think this field could be used to indicates that the chart now with default `appVersion: 0.10.0` only works with k8s version >= 1.19.0.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
