### PR TITLE
Only add cluster role permissions for enabled sources

### DIFF
--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: external-dns
 description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 type: application
-version: 1.4.1
+version: 1.5.0
 appVersion: 0.10.1
 keywords:
   - kubernetes
@@ -18,4 +18,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update image to v0.10.1"
+      description: "Cluster role permissions are now only added for enabled sources"

--- a/charts/external-dns/templates/clusterrole.yaml
+++ b/charts/external-dns/templates/clusterrole.yaml
@@ -6,20 +6,36 @@ metadata:
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
 rules:
-  - apiGroups: [""]
-    resources: ["services","endpoints","pods"]
-    verbs: ["get","watch","list"]
-  - apiGroups: ["extensions","networking.k8s.io"]
-    resources: ["ingresses"]
-    verbs: ["get","watch","list"]
+{{- if or (has "node" .Values.sources) (has "pod" .Values.sources) (has "service" .Values.sources) }}
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["list","watch"]
+{{- end }}
+
+{{- if or (has "pod" .Values.sources) (has "service" .Values.sources) }}
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get","watch","list"]
+{{- end }}
+
+{{- if has "service" .Values.sources }}
+  - apiGroups: [""]
+    resources: ["services","endpoints"]
+    verbs: ["get","watch","list"]
+{{- end }}
+
+{{- if has "ingress" .Values.sources }}
+  - apiGroups: ["extensions","networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get","watch","list"]
+{{- end }}
+
 {{- if has "istio-gateway" .Values.sources }}
   - apiGroups: ["networking.istio.io"]
     resources: ["gateways"]
     verbs: ["get","watch","list"]
 {{- end }}
+
 {{- if has "istio-virtualservice" .Values.sources }}
   - apiGroups: ["networking.istio.io"]
     resources: ["virtualservices"]


### PR DESCRIPTION
Following up on [a previous discussion](https://github.com/kubernetes-sigs/external-dns/pull/2248#issuecomment-951773993), this PR changes the cluster role permissions to only include permissions for enabled sources. This doesn't require any additional configuration by the end user, because we know which permissions need to be added based on the sources selected in `.Values.sources`.

We run external-dns with only one source (`istio-gateway`), so we don't need to grant it permission to access endpoints, ingresses, nodes, pods, or services; the existing setup in the chart grants these permissions regardless.

I think it's beneficial to follow principle of least privilege here, and to be consistent with the setup for the Istio sources.