### PR TITLE
Restore cluster role permissions to read services when Istio sources are enabled

### DIFF
--- a/charts/external-dns/templates/clusterrole.yaml
+++ b/charts/external-dns/templates/clusterrole.yaml
@@ -18,7 +18,7 @@ rules:
     verbs: ["get","watch","list"]
 {{- end }}
 
-{{- if or (has "service" .Values.sources) (has "contour-httpproxy" .Values.sources) (has "gloo-proxy" .Values.sources) (has "openshift-route" .Values.sources) (has "skipper-routegroup" .Values.sources) }}
+{{- if or (has "service" .Values.sources) (has "contour-httpproxy" .Values.sources) (has "gloo-proxy" .Values.sources) (has "istio-gateway" .Values.sources) (has "istio-virtualservice" .Values.sources) (has "openshift-route" .Values.sources) (has "skipper-routegroup" .Values.sources) }}
   - apiGroups: [""]
     resources: ["services","endpoints"]
     verbs: ["get","watch","list"]


### PR DESCRIPTION
I totally forgot to check whether the Istio sources relied on any of the core APIs in #2413 😳 

Turns out that they need to have read permissions on services as well as the Istio custom resources.