### PR TITLE
WIP Fix handling of external IPv6 addresses for host-network pods

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -19,11 +19,13 @@ package controller
 import (
 	"context"
 	"errors"
-	"github.com/prometheus/client_golang/prometheus"
 	"math"
 	"reflect"
+	"sort"
 	"testing"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/internal/testutils"
@@ -82,36 +84,39 @@ func (p *errorMockProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, 
 
 // ApplyChanges validates that the passed in changes satisfy the assumptions.
 func (p *mockProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
-	if len(changes.Create) != len(p.ExpectChanges.Create) {
-		return errors.New("number of created records is wrong")
+	if err := verifyEndpoints(changes.Create, p.ExpectChanges.Create); err != nil {
+		return err
 	}
 
-	for i := range changes.Create {
-		if changes.Create[i].DNSName != p.ExpectChanges.Create[i].DNSName || !changes.Create[i].Targets.Same(p.ExpectChanges.Create[i].Targets) {
-			return errors.New("created record is wrong")
-		}
+	if err := verifyEndpoints(changes.UpdateNew, p.ExpectChanges.UpdateNew); err != nil {
+		return err
 	}
 
-	for i := range changes.UpdateNew {
-		if changes.UpdateNew[i].DNSName != p.ExpectChanges.UpdateNew[i].DNSName || !changes.UpdateNew[i].Targets.Same(p.ExpectChanges.UpdateNew[i].Targets) {
-			return errors.New("delete record is wrong")
-		}
+	if err := verifyEndpoints(changes.UpdateOld, p.ExpectChanges.UpdateOld); err != nil {
+		return err
 	}
 
-	for i := range changes.UpdateOld {
-		if changes.UpdateOld[i].DNSName != p.ExpectChanges.UpdateOld[i].DNSName || !changes.UpdateOld[i].Targets.Same(p.ExpectChanges.UpdateOld[i].Targets) {
-			return errors.New("delete record is wrong")
-		}
-	}
-
-	for i := range changes.Delete {
-		if changes.Delete[i].DNSName != p.ExpectChanges.Delete[i].DNSName || !changes.Delete[i].Targets.Same(p.ExpectChanges.Delete[i].Targets) {
-			return errors.New("delete record is wrong")
-		}
+	if err := verifyEndpoints(changes.Delete, p.ExpectChanges.Delete); err != nil {
+		return err
 	}
 
 	if !reflect.DeepEqual(ctx.Value(provider.RecordsContextKey), p.RecordsStore) {
 		return errors.New("context is wrong")
+	}
+	return nil
+}
+
+func verifyEndpoints(actual, expected []*endpoint.Endpoint) error {
+	if len(actual) != len(expected) {
+		return errors.New("number of records is wrong")
+	}
+	sort.Slice(actual, func(i, j int) bool {
+		return actual[i].DNSName < actual[j].DNSName
+	})
+	for i := range actual {
+		if actual[i].DNSName != expected[i].DNSName || !actual[i].Targets.Same(expected[i].Targets) {
+			return errors.New("record is wrong")
+		}
 	}
 	return nil
 }
@@ -131,7 +136,7 @@ func TestRunOnce(t *testing.T) {
 	// Fake some desired endpoints coming from our source.
 	source := new(testutils.MockSource)
 	cfg := externaldns.NewConfig()
-	cfg.ManagedDNSRecordTypes = []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME}
+	cfg.ManagedDNSRecordTypes = []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME}
 	source.On("Endpoints").Return([]*endpoint.Endpoint{
 		{
 			DNSName:    "create-record",
@@ -142,6 +147,16 @@ func TestRunOnce(t *testing.T) {
 			DNSName:    "update-record",
 			RecordType: endpoint.RecordTypeA,
 			Targets:    endpoint.Targets{"8.8.4.4"},
+		},
+		{
+			DNSName:    "create-aaaa-record",
+			RecordType: endpoint.RecordTypeAAAA,
+			Targets:    endpoint.Targets{"2001:DB8::1"},
+		},
+		{
+			DNSName:    "update-aaaa-record",
+			RecordType: endpoint.RecordTypeAAAA,
+			Targets:    endpoint.Targets{"2001:DB8::2"},
 		},
 	}, nil)
 
@@ -158,18 +173,32 @@ func TestRunOnce(t *testing.T) {
 				RecordType: endpoint.RecordTypeA,
 				Targets:    endpoint.Targets{"4.3.2.1"},
 			},
+			{
+				DNSName:    "update-aaaa-record",
+				RecordType: endpoint.RecordTypeAAAA,
+				Targets:    endpoint.Targets{"2001:DB8::3"},
+			},
+			{
+				DNSName:    "delete-aaaa-record",
+				RecordType: endpoint.RecordTypeAAAA,
+				Targets:    endpoint.Targets{"2001:DB8::4"},
+			},
 		},
 		&plan.Changes{
 			Create: []*endpoint.Endpoint{
+				{DNSName: "create-aaaa-record", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:DB8::1"}},
 				{DNSName: "create-record", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 			UpdateNew: []*endpoint.Endpoint{
+				{DNSName: "update-aaaa-record", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:DB8::2"}},
 				{DNSName: "update-record", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"8.8.4.4"}},
 			},
 			UpdateOld: []*endpoint.Endpoint{
+				{DNSName: "update-aaaa-record", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:DB8::3"}},
 				{DNSName: "update-record", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"8.8.8.8"}},
 			},
 			Delete: []*endpoint.Endpoint{
+				{DNSName: "delete-aaaa-record", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:DB8::4"}},
 				{DNSName: "delete-record", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"4.3.2.1"}},
 			},
 		},
@@ -192,6 +221,7 @@ func TestRunOnce(t *testing.T) {
 	source.AssertExpectations(t)
 	// check the verified records
 	assert.Equal(t, math.Float64bits(1), valueFromMetric(verifiedARecords))
+	assert.Equal(t, math.Float64bits(1), valueFromMetric(verifiedAAAARecords))
 }
 
 func valueFromMetric(metric prometheus.Gauge) uint64 {
@@ -241,7 +271,7 @@ func TestShouldRunOnce(t *testing.T) {
 func testControllerFiltersDomains(t *testing.T, configuredEndpoints []*endpoint.Endpoint, domainFilter endpoint.DomainFilterInterface, providerEndpoints []*endpoint.Endpoint, expectedChanges []*plan.Changes) {
 	t.Helper()
 	cfg := externaldns.NewConfig()
-	cfg.ManagedDNSRecordTypes = []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME}
+	cfg.ManagedDNSRecordTypes = []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME}
 
 	source := new(testutils.MockSource)
 	source.On("Endpoints").Return(configuredEndpoints, nil)
@@ -469,4 +499,83 @@ func TestVerifyARecords(t *testing.T) {
 		}},
 	)
 	assert.Equal(t, math.Float64bits(2), valueFromMetric(verifiedARecords))
+	assert.Equal(t, math.Float64bits(0), valueFromMetric(verifiedAAAARecords))
+}
+
+func TestVerifyAAAARecords(t *testing.T) {
+	testControllerFiltersDomains(
+		t,
+		[]*endpoint.Endpoint{
+			{
+				DNSName:    "create-record.used.tld",
+				RecordType: endpoint.RecordTypeAAAA,
+				Targets:    endpoint.Targets{"2001:DB8::1"},
+			},
+			{
+				DNSName:    "some-record.used.tld",
+				RecordType: endpoint.RecordTypeAAAA,
+				Targets:    endpoint.Targets{"2001:DB8::2"},
+			},
+		},
+		endpoint.NewDomainFilter([]string{"used.tld"}),
+		[]*endpoint.Endpoint{
+			{
+				DNSName:    "some-record.used.tld",
+				RecordType: endpoint.RecordTypeAAAA,
+				Targets:    endpoint.Targets{"2001:DB8::2"},
+			},
+			{
+				DNSName:    "create-record.used.tld",
+				RecordType: endpoint.RecordTypeAAAA,
+				Targets:    endpoint.Targets{"2001:DB8::1"},
+			},
+		},
+		[]*plan.Changes{},
+	)
+	assert.Equal(t, math.Float64bits(2), valueFromMetric(verifiedAAAARecords))
+
+	testControllerFiltersDomains(
+		t,
+		[]*endpoint.Endpoint{
+			{
+				DNSName:    "some-record.1.used.tld",
+				RecordType: endpoint.RecordTypeAAAA,
+				Targets:    endpoint.Targets{"2001:DB8::1"},
+			},
+			{
+				DNSName:    "some-record.2.used.tld",
+				RecordType: endpoint.RecordTypeAAAA,
+				Targets:    endpoint.Targets{"2001:DB8::2"},
+			},
+			{
+				DNSName:    "some-record.3.used.tld",
+				RecordType: endpoint.RecordTypeAAAA,
+				Targets:    endpoint.Targets{"2001:DB8::3"},
+			},
+		},
+		endpoint.NewDomainFilter([]string{"used.tld"}),
+		[]*endpoint.Endpoint{
+			{
+				DNSName:    "some-record.1.used.tld",
+				RecordType: endpoint.RecordTypeAAAA,
+				Targets:    endpoint.Targets{"2001:DB8::1"},
+			},
+			{
+				DNSName:    "some-record.2.used.tld",
+				RecordType: endpoint.RecordTypeAAAA,
+				Targets:    endpoint.Targets{"2001:DB8::2"},
+			},
+		},
+		[]*plan.Changes{{
+			Create: []*endpoint.Endpoint{
+				{
+					DNSName:    "some-record.3.used.tld",
+					RecordType: endpoint.RecordTypeAAAA,
+					Targets:    endpoint.Targets{"2001:DB8::3"},
+				},
+			},
+		}},
+	)
+	assert.Equal(t, math.Float64bits(0), valueFromMetric(verifiedARecords))
+	assert.Equal(t, math.Float64bits(2), valueFromMetric(verifiedAAAARecords))
 }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -178,15 +178,15 @@ You can use the host label in the metric to figure out if the request was agains
 
 Here is the full list of available metrics provided by ExternalDNS:
 
-| Name                                                | Description                                             | Type    |
-| --------------------------------------------------- | ------------------------------------------------------- | ------- |
-| external_dns_controller_last_sync_timestamp_seconds | Timestamp of last successful sync with the DNS provider | Gauge   |
-| external_dns_registry_endpoints_total               | Number of Endpoints in all sources                      | Gauge   |
-| external_dns_registry_errors_total                  | Number of Registry errors                               | Counter |
-| external_dns_source_endpoints_total                 | Number of Endpoints in the registry                     | Gauge   |
-| external_dns_source_errors_total                    | Number of Source errors                                 | Counter |
-| external_dns_controller_verified_records            | Number of DNS A-records that exists both in             | Gauge   |
-|                                                     | source & registry                                       |         |
+| Name                                                | Description                                                        | Type    |
+| --------------------------------------------------- | ------------------------------------------------------------------ | ------- |
+| external_dns_controller_last_sync_timestamp_seconds | Timestamp of last successful sync with the DNS provider            | Gauge   |
+| external_dns_registry_endpoints_total               | Number of Endpoints in all sources                                 | Gauge   |
+| external_dns_registry_errors_total                  | Number of Registry errors                                          | Counter |
+| external_dns_source_endpoints_total                 | Number of Endpoints in the registry                                | Gauge   |
+| external_dns_source_errors_total                    | Number of Source errors                                            | Counter |
+| external_dns_controller_verified_a_records          | Number of DNS A-records that exists both in source and registry    | Gauge   |
+| external_dns_controller_verified_aaaa_records       | Number of DNS AAAA-records that exists both in source and registry | Gauge   |
 
 ### How can I run ExternalDNS under a specific GCP Service Account, e.g. to access DNS records in other projects?
 

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -27,6 +27,8 @@ import (
 const (
 	// RecordTypeA is a RecordType enum value
 	RecordTypeA = "A"
+	// RecordTypeAAAA is a RecordType enum value
+	RecordTypeAAAA = "AAAA"
 	// RecordTypeCNAME is a RecordType enum value
 	RecordTypeCNAME = "CNAME"
 	// RecordTypeTXT is a RecordType enum value

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -130,7 +130,7 @@ type Endpoint struct {
 	DNSName string `json:"dnsName,omitempty"`
 	// The targets the DNS record points to
 	Targets Targets `json:"targets,omitempty"`
-	// RecordType type of record, e.g. CNAME, A, SRV, TXT etc
+	// RecordType type of record, e.g. CNAME, A, AAAA, SRV, TXT etc
 	RecordType string `json:"recordType,omitempty"`
 	// Identifier to distinguish multiple records with the same name and type (e.g. Route53 records with routing policies other than 'simple')
 	SetIdentifier string `json:"setIdentifier,omitempty"`

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -35,22 +35,6 @@ func TestNewEndpoint(t *testing.T) {
 	}
 }
 
-func TestNewEndpointWithIPv6(t *testing.T) {
-	e := NewEndpoint("example.org", "AAAA", "foo.com")
-	if e.DNSName != "example.org" || e.Targets[0] != "foo.com" || e.RecordType != "AAAA" {
-		t.Error("Endpoint is not initialized correctly")
-	}
-
-	if e.Labels == nil {
-		t.Error("Labels is not initialized")
-	}
-
-	w := NewEndpoint("example.org", "", "load-balancer.com.")
-	if w.DNSName != "example.org" || w.Targets[0] != "load-balancer.com" || w.RecordType != "" {
-		t.Error("Endpoint is not initialized correctly")
-	}
-}
-
 func TestTargetsSame(t *testing.T) {
 	tests := []Targets{
 		{""},

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -35,6 +35,22 @@ func TestNewEndpoint(t *testing.T) {
 	}
 }
 
+func TestNewEndpointWithIPv6(t *testing.T) {
+	e := NewEndpoint("example.org", "AAAA", "foo.com")
+	if e.DNSName != "example.com" || e.Targets[0] != "foo.com" || e.RecordType != "AAAA" {
+		t.Error("Endpoint is not initialized correctly")
+	}
+
+	if e.Labels == nil {
+		t.Error("Labels is not initialized")
+	}
+
+	w := NewEndpoint("example.org", "", "load-balancer.com.")
+	if w.DNSName != "example.org" || e.Targets[0] != "load-balancer.com" || w.RecordType != "" {
+		t.Error("Endpoint is not initialized correctly")
+	}
+}
+
 func TestTargetsSame(t *testing.T) {
 	tests := []Targets{
 		{""},

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -37,7 +37,7 @@ func TestNewEndpoint(t *testing.T) {
 
 func TestNewEndpointWithIPv6(t *testing.T) {
 	e := NewEndpoint("example.org", "AAAA", "foo.com")
-	if e.DNSName != "example.com" || e.Targets[0] != "foo.com" || e.RecordType != "AAAA" {
+	if e.DNSName != "example.org" || e.Targets[0] != "foo.com" || e.RecordType != "AAAA" {
 		t.Error("Endpoint is not initialized correctly")
 	}
 
@@ -46,7 +46,7 @@ func TestNewEndpointWithIPv6(t *testing.T) {
 	}
 
 	w := NewEndpoint("example.org", "", "load-balancer.com.")
-	if w.DNSName != "example.org" || e.Targets[0] != "load-balancer.com" || w.RecordType != "" {
+	if w.DNSName != "example.org" || w.Targets[0] != "load-balancer.com" || w.RecordType != "" {
 		t.Error("Endpoint is not initialized correctly")
 	}
 }

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -295,7 +295,7 @@ var defaultConfig = &Config{
 	TransIPAccountName:          "",
 	TransIPPrivateKeyFile:       "",
 	DigitalOceanAPIPageSize:     50,
-	ManagedDNSRecordTypes:       []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
+	ManagedDNSRecordTypes:       []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	GoDaddyAPIKey:               "",
 	GoDaddySecretKey:            "",
 	GoDaddyTTL:                  600,
@@ -381,7 +381,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("crd-source-apiversion", "API version of the CRD for crd source, e.g. `externaldns.k8s.io/v1alpha1`, valid only when using crd source").Default(defaultConfig.CRDSourceAPIVersion).StringVar(&cfg.CRDSourceAPIVersion)
 	app.Flag("crd-source-kind", "Kind of the CRD for the crd source in API group and version specified by crd-source-apiversion").Default(defaultConfig.CRDSourceKind).StringVar(&cfg.CRDSourceKind)
 	app.Flag("service-type-filter", "The service types to take care about (default: all, expected: ClusterIP, NodePort, LoadBalancer or ExternalName)").StringsVar(&cfg.ServiceTypeFilter)
-	app.Flag("managed-record-types", "Comma separated list of record types to manage (default: A, CNAME) (supported records: CNAME, A, NS").Default("A", "CNAME").StringsVar(&cfg.ManagedDNSRecordTypes)
+	app.Flag("managed-record-types", "Comma separated list of record types to manage (default: A, AAAA, CNAME) (supported records: CNAME, A, AAAA, NS").Default("A", "AAAA", "CNAME").StringsVar(&cfg.ManagedDNSRecordTypes)
 	app.Flag("default-targets", "Set globally default IP address that will apply as a target instead of source addresses. Specify multiple times for multiple targets (optional)").StringsVar(&cfg.DefaultTargets)
 
 	// Flags related to providers

--- a/pkg/apis/externaldns/types_test.go
+++ b/pkg/apis/externaldns/types_test.go
@@ -113,7 +113,7 @@ var (
 		TransIPAccountName:          "",
 		TransIPPrivateKeyFile:       "",
 		DigitalOceanAPIPageSize:     50,
-		ManagedDNSRecordTypes:       []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
+		ManagedDNSRecordTypes:       []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 		RFC2136BatchChangeSize:      50,
 		OCPRouterName:               "default",
 	}
@@ -209,7 +209,7 @@ var (
 		TransIPAccountName:          "transip",
 		TransIPPrivateKeyFile:       "/path/to/transip.key",
 		DigitalOceanAPIPageSize:     100,
-		ManagedDNSRecordTypes:       []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
+		ManagedDNSRecordTypes:       []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 		RFC2136BatchChangeSize:      100,
 	}
 )

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -76,12 +76,12 @@ bar.com |                | [->191.1.1.1, ->190.1.1.1]  |  = create (bar.com -> 1
 "=", i.e. result of calculation relies on supplied ConflictResolver
 */
 type planTable struct {
-	rows     map[string]map[string]*planTableRow
+	rows     map[string]map[string]map[string]*planTableRow
 	resolver ConflictResolver
 }
 
 func newPlanTable() planTable { //TODO: make resolver configurable
-	return planTable{map[string]map[string]*planTableRow{}, PerResource{}}
+	return planTable{map[string]map[string]map[string]*planTableRow{}, PerResource{}}
 }
 
 // planTableRow
@@ -99,23 +99,29 @@ func (t planTableRow) String() string {
 func (t planTable) addCurrent(e *endpoint.Endpoint) {
 	dnsName := normalizeDNSName(e.DNSName)
 	if _, ok := t.rows[dnsName]; !ok {
-		t.rows[dnsName] = make(map[string]*planTableRow)
+		t.rows[dnsName] = make(map[string]map[string]*planTableRow)
 	}
 	if _, ok := t.rows[dnsName][e.SetIdentifier]; !ok {
-		t.rows[dnsName][e.SetIdentifier] = &planTableRow{}
+		t.rows[dnsName][e.SetIdentifier] = make(map[string]*planTableRow)
 	}
-	t.rows[dnsName][e.SetIdentifier].current = e
+	if _, ok := t.rows[e.SetIdentifier][e.RecordType]; !ok {
+		t.rows[dnsName][e.SetIdentifier][e.RecordType] = &planTableRow{}
+	}
+	t.rows[dnsName][e.SetIdentifier][e.RecordType].current = e
 }
 
 func (t planTable) addCandidate(e *endpoint.Endpoint) {
 	dnsName := normalizeDNSName(e.DNSName)
 	if _, ok := t.rows[dnsName]; !ok {
-		t.rows[dnsName] = make(map[string]*planTableRow)
+		t.rows[dnsName] = make(map[string]map[string]*planTableRow)
 	}
 	if _, ok := t.rows[dnsName][e.SetIdentifier]; !ok {
-		t.rows[dnsName][e.SetIdentifier] = &planTableRow{}
+		t.rows[dnsName][e.SetIdentifier] = make(map[string]*planTableRow)
 	}
-	t.rows[dnsName][e.SetIdentifier].candidates = append(t.rows[dnsName][e.SetIdentifier].candidates, e)
+	if _, ok := t.rows[dnsName][e.SetIdentifier][e.RecordType]; !ok {
+		t.rows[dnsName][e.SetIdentifier][e.RecordType] = &planTableRow{}
+	}
+	t.rows[dnsName][e.SetIdentifier][e.RecordType].candidates = append(t.rows[dnsName][e.SetIdentifier][e.RecordType].candidates, e)
 }
 
 func (c *Changes) HasChanges() bool {
@@ -145,24 +151,26 @@ func (p *Plan) Calculate() *Plan {
 	changes := &Changes{}
 
 	for _, topRow := range t.rows {
-		for _, row := range topRow {
-			if row.current == nil { //dns name not taken
-				changes.Create = append(changes.Create, t.resolver.ResolveCreate(row.candidates))
-			}
-			if row.current != nil && len(row.candidates) == 0 {
-				changes.Delete = append(changes.Delete, row.current)
-			}
-
-			// TODO: allows record type change, which might not be supported by all dns providers
-			if row.current != nil && len(row.candidates) > 0 { //dns name is taken
-				update := t.resolver.ResolveUpdate(row.current, row.candidates)
-				// compare "update" to "current" to figure out if actual update is required
-				if shouldUpdateTTL(update, row.current) || targetChanged(update, row.current) || p.shouldUpdateProviderSpecific(update, row.current) {
-					inheritOwner(row.current, update)
-					changes.UpdateNew = append(changes.UpdateNew, update)
-					changes.UpdateOld = append(changes.UpdateOld, row.current)
+		for _, midRow := range topRow {
+			for _, row := range midRow {
+				if row.current == nil { //dns name not taken
+					changes.Create = append(changes.Create, t.resolver.ResolveCreate(row.candidates))
 				}
-				continue
+				if row.current != nil && len(row.candidates) == 0 {
+					changes.Delete = append(changes.Delete, row.current)
+				}
+
+				// TODO: allows record type change, which might not be supported by all dns providers
+				if row.current != nil && len(row.candidates) > 0 { //dns name is taken
+					update := t.resolver.ResolveUpdate(row.current, row.candidates)
+					// compare "update" to "current" to figure out if actual update is required
+					if shouldUpdateTTL(update, row.current) || targetChanged(update, row.current) || p.shouldUpdateProviderSpecific(update, row.current) {
+						inheritOwner(row.current, update)
+						changes.UpdateNew = append(changes.UpdateNew, update)
+						changes.UpdateOld = append(changes.UpdateOld, row.current)
+					}
+					continue
+				}
 			}
 		}
 	}
@@ -174,7 +182,7 @@ func (p *Plan) Calculate() *Plan {
 		Current:        p.Current,
 		Desired:        p.Desired,
 		Changes:        changes,
-		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
 	return plan

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -35,6 +35,9 @@ type PlanTestSuite struct {
 	fooV2CnameNoLabel                *endpoint.Endpoint
 	fooV3CnameSameResource           *endpoint.Endpoint
 	fooA5                            *endpoint.Endpoint
+	fooAAAA                          *endpoint.Endpoint
+	dsA                              *endpoint.Endpoint
+	dsAAAA                           *endpoint.Endpoint
 	bar127A                          *endpoint.Endpoint
 	bar127AWithTTL                   *endpoint.Endpoint
 	bar127AWithProviderSpecificTrue  *endpoint.Endpoint
@@ -101,6 +104,30 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "A",
 		Labels: map[string]string{
 			endpoint.ResourceLabelKey: "ingress/default/foo-5",
+		},
+	}
+	suite.fooAAAA = &endpoint.Endpoint{
+		DNSName:    "foo",
+		Targets:    endpoint.Targets{"2001:DB8::1"},
+		RecordType: "AAAA",
+		Labels: map[string]string{
+			endpoint.ResourceLabelKey: "ingress/default/foo-AAAA",
+		},
+	}
+	suite.dsA = &endpoint.Endpoint{
+		DNSName:    "ds",
+		Targets:    endpoint.Targets{"1.1.1.1"},
+		RecordType: "A",
+		Labels: map[string]string{
+			endpoint.ResourceLabelKey: "ingress/default/ds",
+		},
+	}
+	suite.dsAAAA = &endpoint.Endpoint{
+		DNSName:    "ds",
+		Targets:    endpoint.Targets{"1.1.1.1"},
+		RecordType: "AAAA",
+		Labels: map[string]string{
+			endpoint.ResourceLabelKey: "ingress/default/ds-AAAAA",
 		},
 	}
 	suite.bar127A = &endpoint.Endpoint{
@@ -420,9 +447,9 @@ func (suite *PlanTestSuite) TestIdempotency() {
 func (suite *PlanTestSuite) TestDifferentTypes() {
 	current := []*endpoint.Endpoint{suite.fooV1Cname}
 	desired := []*endpoint.Endpoint{suite.fooV2Cname, suite.fooA5}
-	expectedCreate := []*endpoint.Endpoint{}
+	expectedCreate := []*endpoint.Endpoint{suite.fooA5}
 	expectedUpdateOld := []*endpoint.Endpoint{suite.fooV1Cname}
-	expectedUpdateNew := []*endpoint.Endpoint{suite.fooA5}
+	expectedUpdateNew := []*endpoint.Endpoint{suite.fooV2Cname}
 	expectedDelete := []*endpoint.Endpoint{}
 
 	p := &Plan{
@@ -514,53 +541,6 @@ func (suite *PlanTestSuite) TestRemoveEndpointWithUpsert() {
 
 	p := &Plan{
 		Policies:       []Policy{&UpsertOnlyPolicy{}},
-		Current:        current,
-		Desired:        desired,
-		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
-	}
-
-	changes := p.Calculate().Changes
-	validateEntries(suite.T(), changes.Create, expectedCreate)
-	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
-	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
-	validateEntries(suite.T(), changes.Delete, expectedDelete)
-}
-
-//TODO: remove once multiple-target per endpoint is supported
-func (suite *PlanTestSuite) TestDuplicatedEndpointsForSameResourceReplace() {
-	current := []*endpoint.Endpoint{suite.fooV3CnameSameResource, suite.bar192A}
-	desired := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooV3CnameSameResource}
-	expectedCreate := []*endpoint.Endpoint{}
-	expectedUpdateOld := []*endpoint.Endpoint{suite.fooV3CnameSameResource}
-	expectedUpdateNew := []*endpoint.Endpoint{suite.fooV1Cname}
-	expectedDelete := []*endpoint.Endpoint{suite.bar192A}
-
-	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
-		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
-	}
-
-	changes := p.Calculate().Changes
-	validateEntries(suite.T(), changes.Create, expectedCreate)
-	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
-	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
-	validateEntries(suite.T(), changes.Delete, expectedDelete)
-}
-
-//TODO: remove once multiple-target per endpoint is supported
-func (suite *PlanTestSuite) TestDuplicatedEndpointsForSameResourceRetain() {
-
-	current := []*endpoint.Endpoint{suite.fooV1Cname, suite.bar192A}
-	desired := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooV3CnameSameResource}
-	expectedCreate := []*endpoint.Endpoint{}
-	expectedUpdateOld := []*endpoint.Endpoint{}
-	expectedUpdateNew := []*endpoint.Endpoint{}
-	expectedDelete := []*endpoint.Endpoint{suite.bar192A}
-
-	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
 		Current:        current,
 		Desired:        desired,
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
@@ -665,6 +645,39 @@ func (suite *PlanTestSuite) TestDomainFiltersUpdate() {
 	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
 	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
 	validateEntries(suite.T(), changes.Delete, expectedDelete)
+}
+
+func (suite *PlanTestSuite) TestAAAARecords() {
+
+	current := []*endpoint.Endpoint{}
+	desired := []*endpoint.Endpoint{suite.fooAAAA}
+	expectedCreate := []*endpoint.Endpoint{suite.fooAAAA}
+
+	p := &Plan{
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	changes := p.Calculate().Changes
+	validateEntries(suite.T(), changes.Create, expectedCreate)
+}
+
+func (suite *PlanTestSuite) TestDualStackRecords() {
+	current := []*endpoint.Endpoint{}
+	desired := []*endpoint.Endpoint{suite.dsA, suite.dsAAAA}
+	expectedCreate := []*endpoint.Endpoint{suite.dsA, suite.dsAAAA}
+
+	p := &Plan{
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	changes := p.Calculate().Changes
+	validateEntries(suite.T(), changes.Create, expectedCreate)
 }
 
 func TestPlan(t *testing.T) {

--- a/provider/pdns/pdns.go
+++ b/provider/pdns/pdns.go
@@ -315,7 +315,6 @@ func (p *PDNSProvider) ConvertEndpointsToZones(eps []*endpoint.Endpoint, changet
 					if ep.RecordType == "CNAME" {
 						t = provider.EnsureTrailingDot(t)
 					}
-
 					records = append(records, pgo.Record{Content: t})
 				}
 				rrset := pgo.RrSet{

--- a/provider/recordfilter.go
+++ b/provider/recordfilter.go
@@ -17,10 +17,10 @@ limitations under the License.
 package provider
 
 // SupportedRecordType returns true only for supported record types.
-// Currently A, CNAME, SRV, TXT and NS record types are supported.
+// Currently A, AAAA, CNAME, SRV, TXT and NS record types are supported.
 func SupportedRecordType(recordType string) bool {
 	switch recordType {
-	case "A", "CNAME", "SRV", "TXT", "NS":
+	case "A", "AAAA", "CNAME", "SRV", "TXT", "NS":
 		return true
 	default:
 		return false

--- a/provider/recordfilter_test.go
+++ b/provider/recordfilter_test.go
@@ -28,6 +28,10 @@ func TestRecordTypeFilter(t *testing.T) {
 			true,
 		},
 		{
+			"AAAA",
+			true,
+		},
+		{
 			"CNAME",
 			true,
 		},

--- a/provider/transip/transip_test.go
+++ b/provider/transip/transip_test.go
@@ -244,7 +244,7 @@ func TestProviderRecords(t *testing.T) {
 
 	endpoints, err := p.Records(context.TODO())
 	if assert.NoError(t, err) {
-		if assert.Equal(t, 2, len(endpoints)) {
+		if assert.Equal(t, 4, len(endpoints)) {
 			assert.Equal(t, "www.example.org", endpoints[0].DNSName)
 			assert.EqualValues(t, "@", endpoints[0].Targets[0])
 			assert.Equal(t, "CNAME", endpoints[0].RecordType)

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -99,6 +99,10 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 			newEndpointWithOwner("multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
 			newEndpointWithOwner("*.wildcard.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
 			newEndpointWithOwner("txt.wc.wildcard.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("dualstack.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA, ""),
+			newEndpointWithOwner("txt.dualstack.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("dualstack.test-zone.example.org", "2001:DB8::1", endpoint.RecordTypeAAAA, ""),
+			newEndpointWithOwner("txt.aaaadualstack.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""),
 		},
 	})
 	expectedRecords := []*endpoint.Endpoint{
@@ -179,6 +183,22 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 				endpoint.OwnerLabelKey: "owner",
 			},
 		},
+		{
+			DNSName:    "dualstack.test-zone.example.org",
+			Targets:    endpoint.Targets{"1.1.1.1"},
+			RecordType: endpoint.RecordTypeA,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
+		{
+			DNSName:    "dualstack.test-zone.example.org",
+			Targets:    endpoint.Targets{"2001:DB8::1"},
+			RecordType: endpoint.RecordTypeAAAA,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner-2",
+			},
+		},
 	}
 
 	r, _ := NewTXTRegistry(p, "txt.", "", "owner", time.Hour, "wc")
@@ -212,6 +232,10 @@ func testTXTRegistryRecordsSuffixed(t *testing.T) {
 			newEndpointWithOwner("multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-1"),
 			newEndpointWithOwner("multiple.test-zone.example.org", "lb2.loadbalancer.com", endpoint.RecordTypeCNAME, "").WithSetIdentifier("test-set-2"),
 			newEndpointWithOwner("multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
+			newEndpointWithOwner("dualstack.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA, ""),
+			newEndpointWithOwner("dualstack-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("dualstack.test-zone.example.org", "2001:DB8::1", endpoint.RecordTypeAAAA, ""),
+			newEndpointWithOwner("aaaadualstack-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""),
 		},
 	})
 	expectedRecords := []*endpoint.Endpoint{
@@ -284,6 +308,22 @@ func testTXTRegistryRecordsSuffixed(t *testing.T) {
 				endpoint.OwnerLabelKey: "",
 			},
 		},
+		{
+			DNSName:    "dualstack.test-zone.example.org",
+			Targets:    endpoint.Targets{"1.1.1.1"},
+			RecordType: endpoint.RecordTypeA,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
+		{
+			DNSName:    "dualstack.test-zone.example.org",
+			Targets:    endpoint.Targets{"2001:DB8::1"},
+			RecordType: endpoint.RecordTypeAAAA,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner-2",
+			},
+		},
 	}
 
 	r, _ := NewTXTRegistry(p, "", "-txt", "owner", time.Hour, "")
@@ -313,6 +353,10 @@ func testTXTRegistryRecordsNoPrefix(t *testing.T) {
 			newEndpointWithOwner("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
 			newEndpointWithOwner("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("dualstack.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA, ""),
+			newEndpointWithOwner("dualstack.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("dualstack.test-zone.example.org", "2001:DB8::1", endpoint.RecordTypeAAAA, ""),
+			newEndpointWithOwner("aaaadualstack.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""),
 		},
 	})
 	expectedRecords := []*endpoint.Endpoint{
@@ -363,6 +407,22 @@ func testTXTRegistryRecordsNoPrefix(t *testing.T) {
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "owner",
+			},
+		},
+		{
+			DNSName:    "dualstack.test-zone.example.org",
+			Targets:    endpoint.Targets{"1.1.1.1"},
+			RecordType: endpoint.RecordTypeA,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
+		{
+			DNSName:    "dualstack.test-zone.example.org",
+			Targets:    endpoint.Targets{"2001:DB8::1"},
+			RecordType: endpoint.RecordTypeAAAA,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner-2",
 			},
 		},
 	}
@@ -661,6 +721,7 @@ func TestCacheMethods(t *testing.T) {
 		newEndpointWithOwner("thing2.com", "1.2.3.4", "CNAME", "owner"),
 		newEndpointWithOwner("thing3.com", "1.2.3.4", "A", "owner"),
 		newEndpointWithOwner("thing4.com", "1.2.3.4", "A", "owner"),
+		newEndpointWithOwner("thing4.com", "2001:DB8::1", "AAAA", "owner"),
 		newEndpointWithOwner("thing5.com", "1.2.3.5", "A", "owner"),
 	}
 
@@ -671,6 +732,7 @@ func TestCacheMethods(t *testing.T) {
 		newEndpointWithOwner("thing4.com", "1.2.3.4", "A", "owner"),
 		newEndpointWithOwner("thing5.com", "1.2.3.5", "A", "owner"),
 		newEndpointWithOwner("thing.com", "1.2.3.6", "A", "owner2"),
+		newEndpointWithOwner("thing4.com", "2001:DB8::2", "AAAA", "owner"),
 	}
 
 	expectedCacheAfterDelete := []*endpoint.Endpoint{
@@ -681,6 +743,7 @@ func TestCacheMethods(t *testing.T) {
 		newEndpointWithOwner("thing5.com", "1.2.3.5", "A", "owner"),
 	}
 	// test add cache
+	registry.addToCache(newEndpointWithOwner("thing4.com", "2001:DB8::1", "AAAA", "owner"))
 	registry.addToCache(newEndpointWithOwner("thing5.com", "1.2.3.5", "A", "owner"))
 
 	if !reflect.DeepEqual(expectedCacheAfterAdd, registry.recordsCache) {
@@ -690,6 +753,8 @@ func TestCacheMethods(t *testing.T) {
 	// test update cache
 	registry.removeFromCache(newEndpointWithOwner("thing.com", "1.2.3.4", "A", "owner"))
 	registry.addToCache(newEndpointWithOwner("thing.com", "1.2.3.6", "A", "owner2"))
+	registry.removeFromCache(newEndpointWithOwner("thing4.com", "2001:DB8::1", "AAAA", "owner"))
+	registry.addToCache(newEndpointWithOwner("thing4.com", "2001:DB8::2", "AAAA", "owner"))
 	// ensure it was updated
 	if !reflect.DeepEqual(expectedCacheAfterUpdate, registry.recordsCache) {
 		t.Fatalf("expected endpoints should match endpoints from cache: expected %v, but got %v", expectedCacheAfterUpdate, registry.recordsCache)
@@ -697,6 +762,7 @@ func TestCacheMethods(t *testing.T) {
 
 	// test deleting a record
 	registry.removeFromCache(newEndpointWithOwner("thing.com", "1.2.3.6", "A", "owner2"))
+	registry.removeFromCache(newEndpointWithOwner("thing4.com", "2001:DB8::2", "AAAA", "owner"))
 	// ensure it was deleted
 	if !reflect.DeepEqual(expectedCacheAfterDelete, registry.recordsCache) {
 		t.Fatalf("expected endpoints should match endpoints from cache: expected %v, but got %v", expectedCacheAfterDelete, registry.recordsCache)

--- a/source/contour_httpproxy_test.go
+++ b/source/contour_httpproxy_test.go
@@ -218,8 +218,9 @@ func testEndpointsFromHTTPProxy(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 		},
@@ -233,8 +234,9 @@ func testEndpointsFromHTTPProxy(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 			},
 		},
@@ -249,12 +251,14 @@ func testEndpointsFromHTTPProxy(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"8.8.8.8", "127.0.0.1"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8", "127.0.0.1"},
 				},
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"elb.com", "alb.com"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"elb.com", "alb.com"},
 				},
 			},
 		},
@@ -340,20 +344,24 @@ func testHTTPProxyEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 				{
-					DNSName: "new.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "new.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "new.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "new.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 		},
@@ -378,20 +386,24 @@ func testHTTPProxyEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 				{
-					DNSName: "new.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "new.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "new.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "new.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 		},
@@ -416,12 +428,14 @@ func testHTTPProxyEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 		},
@@ -444,8 +458,9 @@ func testHTTPProxyEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 			},
 		},
@@ -507,8 +522,9 @@ func testHTTPProxyEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 			},
 		},
@@ -549,8 +565,9 @@ func testHTTPProxyEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 			},
 		},
@@ -591,12 +608,14 @@ func testHTTPProxyEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "fake1.ext-dns.test.com",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "fake1.ext-dns.test.com",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "fake1.ext-dns.test.com",
-					Targets: endpoint.Targets{"elb.com"},
+					DNSName:    "fake1.ext-dns.test.com",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"elb.com"},
 				},
 			},
 			fqdnTemplate: "{{.Name}}.ext-dns.test.com",
@@ -880,19 +899,22 @@ func testHTTPProxyEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName:   "example.org",
-					Targets:   endpoint.Targets{"httpproxy-target.com"},
-					RecordTTL: endpoint.TTL(6),
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"httpproxy-target.com"},
+					RecordTTL:  endpoint.TTL(6),
 				},
 				{
-					DNSName:   "example2.org",
-					Targets:   endpoint.Targets{"httpproxy-target.com"},
-					RecordTTL: endpoint.TTL(1),
+					DNSName:    "example2.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"httpproxy-target.com"},
+					RecordTTL:  endpoint.TTL(1),
 				},
 				{
-					DNSName:   "example3.org",
-					Targets:   endpoint.Targets{"httpproxy-target.com"},
-					RecordTTL: endpoint.TTL(10),
+					DNSName:    "example3.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"httpproxy-target.com"},
+					RecordTTL:  endpoint.TTL(10),
 				},
 			},
 		},
@@ -995,20 +1017,24 @@ func testHTTPProxyEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 				{
-					DNSName: "new.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "new.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "new.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "new.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 			ignoreHostnameAnnotation: true,

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -176,8 +176,9 @@ func testEndpointsFromIngress(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 		},
@@ -189,8 +190,9 @@ func testEndpointsFromIngress(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 			},
 		},
@@ -203,12 +205,14 @@ func testEndpointsFromIngress(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"8.8.8.8", "127.0.0.1"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8", "127.0.0.1"},
 				},
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"elb.com", "alb.com"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"elb.com", "alb.com"},
 				},
 			},
 		},
@@ -269,12 +273,14 @@ func testEndpointsFromIngressHostnameSourceAnnotation(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 				{
-					DNSName: "foo.baz",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "foo.baz",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 		},
@@ -286,8 +292,9 @@ func testEndpointsFromIngressHostnameSourceAnnotation(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 		},
@@ -300,12 +307,14 @@ func testEndpointsFromIngressHostnameSourceAnnotation(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 				{
-					DNSName: "foo.baz",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "foo.baz",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 		},
@@ -318,8 +327,9 @@ func testEndpointsFromIngressHostnameSourceAnnotation(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 		},
@@ -332,8 +342,9 @@ func testEndpointsFromIngressHostnameSourceAnnotation(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "foo.baz",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "foo.baz",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 		},
@@ -386,12 +397,14 @@ func testIngressEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "new.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "new.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 		},
@@ -434,12 +447,14 @@ func testIngressEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "new.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "new.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 		},
@@ -462,8 +477,9 @@ func testIngressEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 			},
 		},
@@ -484,8 +500,9 @@ func testIngressEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 			},
 		},
@@ -541,8 +558,9 @@ func testIngressEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 			},
 		},
@@ -579,8 +597,9 @@ func testIngressEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 			},
 		},
@@ -617,12 +636,14 @@ func testIngressEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "fake1.ext-dns.test.com",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "fake1.ext-dns.test.com",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "fake1.ext-dns.test.com",
-					Targets: endpoint.Targets{"elb.com"},
+					DNSName:    "fake1.ext-dns.test.com",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"elb.com"},
 				},
 			},
 			fqdnTemplate: "{{.Name}}.ext-dns.test.com",
@@ -972,19 +993,22 @@ func testIngressEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName:   "example.org",
-					Targets:   endpoint.Targets{"ingress-target.com"},
-					RecordTTL: endpoint.TTL(6),
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"ingress-target.com"},
+					RecordTTL:  endpoint.TTL(6),
 				},
 				{
-					DNSName:   "example2.org",
-					Targets:   endpoint.Targets{"ingress-target.com"},
-					RecordTTL: endpoint.TTL(1),
+					DNSName:    "example2.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"ingress-target.com"},
+					RecordTTL:  endpoint.TTL(1),
 				},
 				{
-					DNSName:   "example3.org",
-					Targets:   endpoint.Targets{"ingress-target.com"},
-					RecordTTL: endpoint.TTL(10),
+					DNSName:    "example3.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"ingress-target.com"},
+					RecordTTL:  endpoint.TTL(10),
 				},
 			},
 		},
@@ -1131,12 +1155,14 @@ func testIngressEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "new.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "new.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 		},
@@ -1168,8 +1194,9 @@ func testIngressEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"1.2.3.4"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"1.2.3.4"},
 				},
 			},
 		},
@@ -1188,8 +1215,9 @@ func testIngressEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 			},
 		},

--- a/source/istio_gateway_test.go
+++ b/source/istio_gateway_test.go
@@ -182,8 +182,9 @@ func testEndpointsFromGatewayConfig(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 		},
@@ -201,8 +202,9 @@ func testEndpointsFromGatewayConfig(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 		},
@@ -220,8 +222,9 @@ func testEndpointsFromGatewayConfig(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 			},
 		},
@@ -240,12 +243,14 @@ func testEndpointsFromGatewayConfig(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"8.8.8.8", "127.0.0.1"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8", "127.0.0.1"},
 				},
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"elb.com", "alb.com"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"elb.com", "alb.com"},
 				},
 			},
 		},
@@ -308,8 +313,9 @@ func testEndpointsFromGatewayConfig(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"lb.com", "lb2.com"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com", "lb2.com"},
 				},
 			},
 		},
@@ -374,20 +380,24 @@ func testGatewayEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 				{
-					DNSName: "new.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "new.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "new.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "new.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 		},
@@ -414,20 +424,24 @@ func testGatewayEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 				{
-					DNSName: "new.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "new.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "new.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "new.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 		},
@@ -450,12 +464,14 @@ func testGatewayEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 		},
@@ -480,8 +496,9 @@ func testGatewayEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 			},
 		},
@@ -549,8 +566,9 @@ func testGatewayEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 			},
 		},
@@ -595,8 +613,9 @@ func testGatewayEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 			},
 		},
@@ -641,12 +660,14 @@ func testGatewayEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "fake1.ext-dns.test.com",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "fake1.ext-dns.test.com",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "fake1.ext-dns.test.com",
-					Targets: endpoint.Targets{"elb.com"},
+					DNSName:    "fake1.ext-dns.test.com",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"elb.com"},
 				},
 			},
 			fqdnTemplate: "{{.Name}}.ext-dns.test.com",
@@ -946,19 +967,22 @@ func testGatewayEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName:   "example.org",
-					Targets:   endpoint.Targets{"gateway-target.com"},
-					RecordTTL: endpoint.TTL(6),
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"gateway-target.com"},
+					RecordTTL:  endpoint.TTL(6),
 				},
 				{
-					DNSName:   "example2.org",
-					Targets:   endpoint.Targets{"gateway-target.com"},
-					RecordTTL: endpoint.TTL(1),
+					DNSName:    "example2.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"gateway-target.com"},
+					RecordTTL:  endpoint.TTL(1),
 				},
 				{
-					DNSName:   "example3.org",
-					Targets:   endpoint.Targets{"gateway-target.com"},
-					RecordTTL: endpoint.TTL(10),
+					DNSName:    "example3.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"gateway-target.com"},
+					RecordTTL:  endpoint.TTL(10),
 				},
 			},
 		},
@@ -1067,20 +1091,24 @@ func testGatewayEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 				{
-					DNSName: "new.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "new.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "new.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "new.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 			ignoreHostnameAnnotation: true,
@@ -1135,12 +1163,14 @@ func testGatewayEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "fake1.dns-through-hostname.com",
-					Targets: endpoint.Targets{"1.2.3.4"},
+					DNSName:    "fake1.dns-through-hostname.com",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"1.2.3.4"},
 				},
 				{
-					DNSName: "fake2.dns-through-hostname.com",
-					Targets: endpoint.Targets{"1.2.3.4"},
+					DNSName:    "fake2.dns-through-hostname.com",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"1.2.3.4"},
 				},
 			},
 		},

--- a/source/istio_virtualservice_test.go
+++ b/source/istio_virtualservice_test.go
@@ -392,8 +392,9 @@ func testEndpointsFromVirtualServiceConfig(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 		},
@@ -414,8 +415,9 @@ func testEndpointsFromVirtualServiceConfig(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 			},
 		},
@@ -437,12 +439,14 @@ func testEndpointsFromVirtualServiceConfig(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"8.8.8.8", "127.0.0.1"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8", "127.0.0.1"},
 				},
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"elb.com", "alb.com"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"elb.com", "alb.com"},
 				},
 			},
 		},
@@ -541,8 +545,9 @@ func testEndpointsFromVirtualServiceConfig(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "foo.bar",
-					Targets: endpoint.Targets{"elb.com", "alb.com"},
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"elb.com", "alb.com"},
 				},
 			},
 		},
@@ -616,20 +621,24 @@ func testVirtualServiceEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 				{
-					DNSName: "new.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "new.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "new.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "new.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 		},
@@ -663,8 +672,9 @@ func testVirtualServiceEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 			},
 		},
@@ -700,20 +710,24 @@ func testVirtualServiceEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 				{
-					DNSName: "new.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "new.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "new.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "new.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 		},
@@ -750,12 +764,14 @@ func testVirtualServiceEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 		},
@@ -788,8 +804,9 @@ func testVirtualServiceEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 			},
 		},
@@ -856,8 +873,9 @@ func testVirtualServiceEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 			},
 		},
@@ -915,12 +933,14 @@ func testVirtualServiceEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "vs1.ext-dns.test.com",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "vs1.ext-dns.test.com",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "vs1.ext-dns.test.com",
-					Targets: endpoint.Targets{"elb.com"},
+					DNSName:    "vs1.ext-dns.test.com",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"elb.com"},
 				},
 			},
 			fqdnTemplate: "{{.Name}}.ext-dns.test.com",
@@ -1204,14 +1224,16 @@ func testVirtualServiceEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName:   "example.org",
-					Targets:   endpoint.Targets{"8.8.8.8"},
-					RecordTTL: endpoint.TTL(6),
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
+					RecordTTL:  endpoint.TTL(6),
 				},
 				{
-					DNSName:   "example2.org",
-					Targets:   endpoint.Targets{"8.8.8.8"},
-					RecordTTL: endpoint.TTL(1),
+					DNSName:    "example2.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
+					RecordTTL:  endpoint.TTL(1),
 				},
 			},
 		},
@@ -1320,20 +1342,24 @@ func testVirtualServiceEndpoints(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "example.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 				{
-					DNSName: "new.org",
-					Targets: endpoint.Targets{"8.8.8.8"},
+					DNSName:    "new.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
 				},
 				{
-					DNSName: "new.org",
-					Targets: endpoint.Targets{"lb.com"},
+					DNSName:    "new.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
 				},
 			},
 			ignoreHostnameAnnotation: true,

--- a/source/openshift_route_test.go
+++ b/source/openshift_route_test.go
@@ -200,7 +200,8 @@ func testOcpRouteSourceEndpoints(t *testing.T) {
 			ocpRouterName: "",
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "my-domain.com",
+					DNSName:    "my-domain.com",
+					RecordType: endpoint.RecordTypeCNAME,
 					Targets: []string{
 						"apps.my-domain.com",
 					},
@@ -235,7 +236,8 @@ func testOcpRouteSourceEndpoints(t *testing.T) {
 			ocpRouterName: "default",
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "my-domain.com",
+					DNSName:    "my-domain.com",
+					RecordType: endpoint.RecordTypeCNAME,
 					Targets: []string{
 						"router-default.my-domain.com",
 					},
@@ -274,7 +276,8 @@ func testOcpRouteSourceEndpoints(t *testing.T) {
 			ocpRouterName: "default",
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "my-domain.com",
+					DNSName:    "my-domain.com",
+					RecordType: endpoint.RecordTypeCNAME,
 					Targets: []string{
 						"router-default.my-domain.com",
 					},
@@ -313,7 +316,8 @@ func testOcpRouteSourceEndpoints(t *testing.T) {
 			ocpRouterName: "default",
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "my-domain.com",
+					DNSName:    "my-domain.com",
+					RecordType: endpoint.RecordTypeCNAME,
 					Targets: []string{
 						"router-default.my-domain.com",
 					},
@@ -361,7 +365,8 @@ func testOcpRouteSourceEndpoints(t *testing.T) {
 			ocpRouterName: "",
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "my-annotation-domain.com",
+					DNSName:    "my-annotation-domain.com",
+					RecordType: endpoint.RecordTypeCNAME,
 					Targets: []string{
 						"my.site.foo.com",
 					},
@@ -393,7 +398,8 @@ func testOcpRouteSourceEndpoints(t *testing.T) {
 			ocpRouterName: "",
 			expected: []*endpoint.Endpoint{
 				{
-					DNSName: "my-annotation-domain.com",
+					DNSName:    "my-annotation-domain.com",
+					RecordType: endpoint.RecordTypeCNAME,
 					Targets: []string{
 						"my.site.foo.com",
 					},

--- a/source/pod_test.go
+++ b/source/pod_test.go
@@ -46,7 +46,8 @@ func TestPodSource(t *testing.T) {
 			"",
 			[]*endpoint.Endpoint{
 				{DNSName: "a.foo.example.org", Targets: endpoint.Targets{"54.10.11.1", "54.10.11.2"}, RecordType: endpoint.RecordTypeA},
-				{DNSName: "internal.a.foo.example.org", Targets: endpoint.Targets{"10.0.1.1", "10.0.1.2"}, RecordType: endpoint.RecordTypeA},
+				{DNSName: "a.foo.example.org", Targets: endpoint.Targets{"2001:db8::1", "2001:db8::2"}, RecordType: endpoint.RecordTypeAAAA},
+				{DNSName: "internal.a.foo.example.org", Targets: endpoint.Targets{"10.0.1.1", "10.0.1.2", "10.0.1.3"}, RecordType: endpoint.RecordTypeA},
 			},
 			false,
 			[]*corev1.Node{
@@ -58,6 +59,7 @@ func TestPodSource(t *testing.T) {
 						Addresses: []corev1.NodeAddress{
 							{Type: corev1.NodeExternalIP, Address: "54.10.11.1"},
 							{Type: corev1.NodeInternalIP, Address: "10.0.1.1"},
+							{Type: corev1.NodeInternalIP, Address: "2001:db8::1"},
 						},
 					},
 				},
@@ -69,6 +71,16 @@ func TestPodSource(t *testing.T) {
 						Addresses: []corev1.NodeAddress{
 							{Type: corev1.NodeExternalIP, Address: "54.10.11.2"},
 							{Type: corev1.NodeInternalIP, Address: "10.0.1.2"},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-node3",
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{Type: corev1.NodeInternalIP, Address: "2001:db8::2"},
 						},
 					},
 				},
@@ -106,6 +118,23 @@ func TestPodSource(t *testing.T) {
 					},
 					Status: corev1.PodStatus{
 						PodIP: "10.0.1.2",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-pod3",
+						Namespace: "kube-system",
+						Annotations: map[string]string{
+							internalHostnameAnnotationKey: "internal.a.foo.example.org",
+							hostnameAnnotationKey:         "a.foo.example.org",
+						},
+					},
+					Spec: corev1.PodSpec{
+						HostNetwork: true,
+						NodeName:    "my-node3",
+					},
+					Status: corev1.PodStatus{
+						PodIP: "10.0.1.3",
 					},
 				},
 			},
@@ -116,7 +145,8 @@ func TestPodSource(t *testing.T) {
 			"kops-dns-controller",
 			[]*endpoint.Endpoint{
 				{DNSName: "a.foo.example.org", Targets: endpoint.Targets{"54.10.11.1", "54.10.11.2"}, RecordType: endpoint.RecordTypeA},
-				{DNSName: "internal.a.foo.example.org", Targets: endpoint.Targets{"10.0.1.1", "10.0.1.2"}, RecordType: endpoint.RecordTypeA},
+				{DNSName: "a.foo.example.org", Targets: endpoint.Targets{"2001:db8::1", "2001:db8::2"}, RecordType: endpoint.RecordTypeAAAA},
+				{DNSName: "internal.a.foo.example.org", Targets: endpoint.Targets{"10.0.1.1", "10.0.1.2", "10.0.1.3"}, RecordType: endpoint.RecordTypeA},
 			},
 			false,
 			[]*corev1.Node{
@@ -128,6 +158,7 @@ func TestPodSource(t *testing.T) {
 						Addresses: []corev1.NodeAddress{
 							{Type: corev1.NodeExternalIP, Address: "54.10.11.1"},
 							{Type: corev1.NodeInternalIP, Address: "10.0.1.1"},
+							{Type: corev1.NodeInternalIP, Address: "2001:db8::1"},
 						},
 					},
 				},
@@ -139,6 +170,16 @@ func TestPodSource(t *testing.T) {
 						Addresses: []corev1.NodeAddress{
 							{Type: corev1.NodeExternalIP, Address: "54.10.11.2"},
 							{Type: corev1.NodeInternalIP, Address: "10.0.1.2"},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-node3",
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{Type: corev1.NodeInternalIP, Address: "2001:db8::2"},
 						},
 					},
 				},
@@ -176,6 +217,23 @@ func TestPodSource(t *testing.T) {
 					},
 					Status: corev1.PodStatus{
 						PodIP: "10.0.1.2",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-pod3",
+						Namespace: "kube-system",
+						Annotations: map[string]string{
+							internalHostnameAnnotationKey: "internal.a.foo.example.org",
+							hostnameAnnotationKey:         "a.foo.example.org",
+						},
+					},
+					Spec: corev1.PodSpec{
+						HostNetwork: true,
+						NodeName:    "my-node3",
+					},
+					Status: corev1.PodStatus{
+						PodIP: "10.0.1.3",
 					},
 				},
 			},
@@ -249,7 +307,7 @@ func TestPodSource(t *testing.T) {
 			},
 		},
 		{
-			"pods with hostNetwore=false should be ignored",
+			"pods with hostNetwork=false should be ignored",
 			"",
 			"",
 			[]*endpoint.Endpoint{

--- a/source/service.go
+++ b/source/service.go
@@ -442,6 +442,14 @@ func (sc *serviceSource) generateEndpoints(svc *v1.Service, hostname string, pro
 		DNSName:    hostname,
 	}
 
+	eaAAAA := &endpoint.Endpoint{
+		RecordTTL:  ttl,
+		RecordType: endpoint.RecordTypeAAAA,
+		Labels:     endpoint.NewLabels(),
+		Targets:    make(endpoint.Targets, 0, defaultTargetsCapacity),
+		DNSName:    hostname,
+	}
+
 	epCNAME := &endpoint.Endpoint{
 		RecordTTL:  ttl,
 		RecordType: endpoint.RecordTypeCNAME,
@@ -483,6 +491,9 @@ func (sc *serviceSource) generateEndpoints(svc *v1.Service, hostname string, pro
 		if suitableType(t) == endpoint.RecordTypeA {
 			epA.Targets = append(epA.Targets, t)
 		}
+		if suitableType(t) == endpoint.RecordTypeAAAA {
+			eaAAAA.Targets = append(eaAAAA.Targets, t)
+		}
 		if suitableType(t) == endpoint.RecordTypeCNAME {
 			epCNAME.Targets = append(epCNAME.Targets, t)
 		}
@@ -490,6 +501,9 @@ func (sc *serviceSource) generateEndpoints(svc *v1.Service, hostname string, pro
 
 	if len(epA.Targets) > 0 {
 		endpoints = append(endpoints, epA)
+	}
+	if len(eaAAAA.Targets) > 0 {
+		endpoints = append(endpoints, eaAAAA)
 	}
 	if len(epCNAME.Targets) > 0 {
 		endpoints = append(endpoints, epCNAME)

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -1051,7 +1051,8 @@ func testServiceSourceEndpoints(t *testing.T) {
 			serviceTypesFilter: []string{},
 			annotations:        map[string]string{hostnameAnnotationKey: "foobar.example.org"},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foobar.example.org", Targets: endpoint.Targets{"1.1.1.1", "2001:db8::1"}},
+				{DNSName: "foobar.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1"}},
+				{DNSName: "foobar.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:db8::1"}},
 			},
 		},
 		{
@@ -1067,7 +1068,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			serviceTypesFilter: []string{},
 			annotations:        map[string]string{hostnameAnnotationKey: "foobar-v6.example.org"},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foobar-v6.example.org", Targets: endpoint.Targets{"2001:db8::2"}},
+				{DNSName: "foobar-v6.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:db8::2"}},
 			},
 		},
 	} {

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -185,6 +185,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 		labels                   map[string]string
 		annotations              map[string]string
 		clusterIP                string
+		ipFamilies               []v1.IPFamily
 		externalIPs              []string
 		lbs                      []string
 		serviceTypesFilter       []string
@@ -199,6 +200,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			svcType:            v1.ServiceTypeLoadBalancer,
 			labels:             map[string]string{},
 			annotations:        map[string]string{},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -212,6 +214,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			ignoreHostnameAnnotation: true,
 			labels:                   map[string]string{},
 			annotations:              map[string]string{},
+			ipFamilies:               []v1.IPFamily{"IPv4"},
 			externalIPs:              []string{},
 			lbs:                      []string{"1.2.3.4"},
 			serviceTypesFilter:       []string{},
@@ -226,6 +229,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -243,6 +247,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -257,6 +262,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			clusterIP:          "1.2.3.4",
 			externalIPs:        []string{},
 			lbs:                []string{},
@@ -271,6 +277,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			fqdnTemplate:       "{{.Name}}.fqdn.org,{{.Name}}.fqdn.com",
 			labels:             map[string]string{},
 			annotations:        map[string]string{},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -288,6 +295,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			ignoreHostnameAnnotation: true,
 			labels:                   map[string]string{},
 			annotations:              map[string]string{},
+			ipFamilies:               []v1.IPFamily{"IPv4"},
 			externalIPs:              []string{},
 			lbs:                      []string{"1.2.3.4"},
 			serviceTypesFilter:       []string{},
@@ -307,6 +315,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org., bar.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -329,6 +338,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org., bar.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -346,6 +356,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org., bar.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -363,6 +374,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org, bar.example.org",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -380,6 +392,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"lb.example.com"}, // Kubernetes omits the trailing dot
 			serviceTypesFilter: []string{},
@@ -396,6 +409,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org", // Trailing dot is omitted
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4", "lb.example.com"}, // Kubernetes omits the trailing dot
 			serviceTypesFilter: []string{},
@@ -414,6 +428,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				controllerAnnotationKey: controllerAnnotationValue,
 				hostnameAnnotationKey:   "foo.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -432,6 +447,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				controllerAnnotationKey: "some-other-tool",
 				hostnameAnnotationKey:   "foo.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -447,6 +463,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -464,6 +481,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -478,6 +496,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -496,6 +515,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey:                         "foo.example.org.",
 				"service.beta.kubernetes.io/external-traffic": "OnlyLocal",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -514,6 +534,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey:                         "foo.example.org.",
 				"service.beta.kubernetes.io/external-traffic": "SomethingElse",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -530,6 +551,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey:                         "foo.example.org.",
 				"service.beta.kubernetes.io/external-traffic": "OnlyLocal",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -547,6 +569,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey:                         "foo.example.org.",
 				"service.beta.kubernetes.io/external-traffic": "Global",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -565,6 +588,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey:                         "foo.example.org.",
 				"service.beta.kubernetes.io/external-traffic": "OnlyLocal",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -579,6 +603,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{},
 			serviceTypesFilter: []string{},
@@ -593,6 +618,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{"10.2.3.4", "11.2.3.4"},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -609,6 +635,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4", "8.8.8.8"},
 			serviceTypesFilter: []string{},
@@ -625,6 +652,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				"zalando.org/dnsname": "foo.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -640,6 +668,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				"zalando.org/dnsname": "foo.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -656,6 +685,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			labels: map[string]string{
 				"dns": "route53",
 			},
+			ipFamilies: []v1.IPFamily{"IPv4"},
 			annotations: map[string]string{
 				"domainName": "foo.example.org., bar.example.org",
 			},
@@ -677,6 +707,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				kopsDNSControllerInternalHostnameAnnotationKey: "internal.foo.example.org",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4", "lb.example.com"},
 			serviceTypesFilter: []string{},
@@ -695,6 +726,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				kopsDNSControllerInternalHostnameAnnotationKey: "internal.foo.example.org., internal.bar.example.org",
 				kopsDNSControllerHostnameAnnotationKey:         "foo.example.org., bar.example.org",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -713,6 +745,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			fqdnTemplate:       "{{.Name}}.bar.example.com",
 			labels:             map[string]string{},
 			annotations:        map[string]string{},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4", "elb.com"},
 			serviceTypesFilter: []string{},
@@ -731,6 +764,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4", "elb.com"},
 			serviceTypesFilter: []string{},
@@ -750,6 +784,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				"zalando.org/dnsname": "mate.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -765,6 +800,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			fqdnTemplate:       "{{.Calibre}}.bar.example.com",
 			labels:             map[string]string{},
 			annotations:        map[string]string{},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -780,6 +816,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -797,6 +834,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org.",
 				ttlAnnotationKey:      "foo",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -814,6 +852,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org.",
 				ttlAnnotationKey:      "10",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -831,6 +870,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org.",
 				ttlAnnotationKey:      "1m",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -848,6 +888,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org.",
 				ttlAnnotationKey:      "-10",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -864,6 +905,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{string(v1.ServiceTypeLoadBalancer)},
@@ -880,6 +922,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{string(v1.ServiceTypeLoadBalancer)},
@@ -894,6 +937,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				internalHostnameAnnotationKey: "foo.internal.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			clusterIP:          "1.1.1.1",
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
@@ -912,6 +956,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey:         "foo.example.org.",
 				internalHostnameAnnotationKey: "foo.internal.example.org.",
 			},
+			ipFamilies:         []v1.IPFamily{"IPv4"},
 			clusterIP:          "1.1.1.1",
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
@@ -929,6 +974,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			labels: map[string]string{
 				"app": "web-external",
 			},
+			ipFamilies:           []v1.IPFamily{"IPv4"},
 			clusterIP:            "1.1.1.1",
 			externalIPs:          []string{},
 			lbs:                  []string{"1.2.3.4"},
@@ -947,6 +993,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			labels: map[string]string{
 				"app": "web-external",
 			},
+			ipFamilies:           []v1.IPFamily{"IPv4"},
 			clusterIP:            "1.1.1.1",
 			externalIPs:          []string{},
 			lbs:                  []string{"1.2.3.4"},
@@ -965,6 +1012,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			labels: map[string]string{
 				"app": "web-internal",
 			},
+			ipFamilies:           []v1.IPFamily{"IPv4"},
 			clusterIP:            "1.1.1.1",
 			externalIPs:          []string{},
 			lbs:                  []string{"1.2.3.4"},
@@ -981,6 +1029,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			labels: map[string]string{
 				"app": "web-internal",
 			},
+			ipFamilies:           []v1.IPFamily{"IPv4"},
 			clusterIP:            "1.1.1.1",
 			externalIPs:          []string{},
 			lbs:                  []string{"1.2.3.4"},
@@ -988,6 +1037,38 @@ func testServiceSourceEndpoints(t *testing.T) {
 			serviceLabelSelector: "app=web-external",
 			annotations:          map[string]string{hostnameAnnotationKey: "annotation.bar.example.com"},
 			expected:             []*endpoint.Endpoint{},
+		},
+		{
+			title:              "dual-stack load-balancer service gets both addresses",
+			svcNamespace:       "testing",
+			svcName:            "foobar",
+			svcType:            v1.ServiceTypeLoadBalancer,
+			labels:             map[string]string{},
+			ipFamilies:         []v1.IPFamily{"IPv4", "IPv6"},
+			clusterIP:          "1.1.1.2,2001:db8::2",
+			externalIPs:        []string{},
+			lbs:                []string{"1.1.1.1", "2001:db8::1"},
+			serviceTypesFilter: []string{},
+			annotations:        map[string]string{hostnameAnnotationKey: "foobar.example.org"},
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foobar.example.org", Targets: endpoint.Targets{"1.1.1.1", "2001:db8::1"}},
+			},
+		},
+		{
+			title:              "IPv6-only load-balancer service gets IPv6 endpoint",
+			svcNamespace:       "testing",
+			svcName:            "foobar-v6",
+			svcType:            v1.ServiceTypeLoadBalancer,
+			labels:             map[string]string{},
+			ipFamilies:         []v1.IPFamily{"IPv6"},
+			clusterIP:          "2001:db8::1",
+			externalIPs:        []string{},
+			lbs:                []string{"2001:db8::2"},
+			serviceTypesFilter: []string{},
+			annotations:        map[string]string{hostnameAnnotationKey: "foobar-v6.example.org"},
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foobar-v6.example.org", Targets: endpoint.Targets{"2001:db8::2"}},
+			},
 		},
 	} {
 		tc := tc

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -230,7 +230,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
 		{
@@ -275,8 +275,8 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.fqdn.org", Targets: endpoint.Targets{"1.2.3.4"}},
-				{DNSName: "foo.fqdn.com", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.fqdn.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.fqdn.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
 		{
@@ -292,8 +292,8 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                      []string{"1.2.3.4"},
 			serviceTypesFilter:       []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.fqdn.org", Targets: endpoint.Targets{"1.2.3.4"}},
-				{DNSName: "foo.fqdn.com", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.fqdn.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.fqdn.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
 		{
@@ -311,10 +311,10 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
-				{DNSName: "bar.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
-				{DNSName: "foo.fqdn.org", Targets: endpoint.Targets{"1.2.3.4"}},
-				{DNSName: "foo.fqdn.com", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "bar.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.fqdn.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.fqdn.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
 		{
@@ -333,8 +333,8 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.fqdn.org", Targets: endpoint.Targets{"1.2.3.4"}},
-				{DNSName: "foo.fqdn.com", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.fqdn.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.fqdn.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
 		{
@@ -350,8 +350,8 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
-				{DNSName: "bar.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "bar.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
 		{
@@ -367,8 +367,8 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
-				{DNSName: "bar.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "bar.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
 		{
@@ -384,7 +384,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"lb.example.com"}, // Kubernetes omits the trailing dot
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"lb.example.com"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeCNAME, Targets: endpoint.Targets{"lb.example.com"}},
 			},
 		},
 		{
@@ -400,8 +400,8 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4", "lb.example.com"}, // Kubernetes omits the trailing dot
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"lb.example.com"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeCNAME, Targets: endpoint.Targets{"lb.example.com"}},
 			},
 		},
 		{
@@ -418,7 +418,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
 		{
@@ -451,7 +451,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
 		{
@@ -482,7 +482,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
 		{
@@ -500,7 +500,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
 		{
@@ -551,7 +551,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
 		{
@@ -597,7 +597,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"10.2.3.4", "11.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"10.2.3.4", "11.2.3.4"}},
 			},
 		},
 		{
@@ -613,7 +613,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4", "8.8.8.8"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4", "8.8.8.8"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4", "8.8.8.8"}},
 			},
 		},
 		{
@@ -644,7 +644,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
 		{
@@ -663,8 +663,8 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
-				{DNSName: "bar.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "bar.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
 		{
@@ -681,8 +681,8 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4", "lb.example.com"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "internal.foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
-				{DNSName: "internal.foo.example.org", Targets: endpoint.Targets{"lb.example.com"}},
+				{DNSName: "internal.foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "internal.foo.example.org", RecordType: endpoint.RecordTypeCNAME, Targets: endpoint.Targets{"lb.example.com"}},
 			},
 		}, {
 			title:         "load balancer services annotated with DNS Controller annotations return an endpoint with both annotations in compatibility mode",
@@ -699,10 +699,10 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
-				{DNSName: "bar.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
-				{DNSName: "internal.foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
-				{DNSName: "internal.bar.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "bar.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "internal.foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "internal.bar.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
 		{
@@ -717,8 +717,8 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4", "elb.com"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.bar.example.com", Targets: endpoint.Targets{"1.2.3.4"}},
-				{DNSName: "foo.bar.example.com", Targets: endpoint.Targets{"elb.com"}},
+				{DNSName: "foo.bar.example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.bar.example.com", RecordType: endpoint.RecordTypeCNAME, Targets: endpoint.Targets{"elb.com"}},
 			},
 		},
 		{
@@ -735,8 +735,8 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4", "elb.com"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"elb.com"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeCNAME, Targets: endpoint.Targets{"elb.com"}},
 			},
 		},
 		{
@@ -754,7 +754,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "mate.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "mate.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
 		{
@@ -784,7 +784,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}, RecordTTL: endpoint.TTL(0)},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}, RecordTTL: endpoint.TTL(0)},
 			},
 		},
 		{
@@ -801,7 +801,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}, RecordTTL: endpoint.TTL(0)},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}, RecordTTL: endpoint.TTL(0)},
 			},
 		},
 		{
@@ -818,7 +818,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}, RecordTTL: endpoint.TTL(10)},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}, RecordTTL: endpoint.TTL(10)},
 			},
 		},
 		{
@@ -835,7 +835,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}, RecordTTL: endpoint.TTL(60)},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}, RecordTTL: endpoint.TTL(60)},
 			},
 		},
 		{
@@ -852,7 +852,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}, RecordTTL: endpoint.TTL(0)},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}, RecordTTL: endpoint.TTL(0)},
 			},
 		},
 		{
@@ -868,7 +868,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{string(v1.ServiceTypeLoadBalancer)},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
 		{
@@ -899,7 +899,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.internal.example.org", Targets: endpoint.Targets{"1.1.1.1"}},
+				{DNSName: "foo.internal.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1"}},
 			},
 		},
 		{
@@ -917,8 +917,8 @@ func testServiceSourceEndpoints(t *testing.T) {
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.internal.example.org", Targets: endpoint.Targets{"1.1.1.1"}},
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.internal.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
 		{
@@ -936,7 +936,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			serviceLabelSelector: "app=web-external",
 			fqdnTemplate:         "{{.Name}}.bar.example.com",
 			expected: []*endpoint.Endpoint{
-				{DNSName: "fqdn.bar.example.com", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "fqdn.bar.example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
 		{
@@ -954,7 +954,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			serviceLabelSelector: "app=web-external",
 			annotations:          map[string]string{hostnameAnnotationKey: "annotation.bar.example.com"},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "annotation.bar.example.com", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "annotation.bar.example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
 		{
@@ -1108,7 +1108,7 @@ func testMultipleServicesEndpoints(t *testing.T) {
 			},
 			[]string{},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/foo1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/foo1.2.3.4"}},
 			},
 			false,
 		},
@@ -1132,7 +1132,7 @@ func testMultipleServicesEndpoints(t *testing.T) {
 			},
 			[]string{},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4", "1.2.3.5", "1.2.3.6"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/foo1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4", "1.2.3.5", "1.2.3.6"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/foo1.2.3.4"}},
 			},
 			false,
 		},
@@ -1160,9 +1160,9 @@ func testMultipleServicesEndpoints(t *testing.T) {
 			},
 			[]string{},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4", "1.2.3.5", "1.2.3.6"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/foo1.2.3.4"}},
-				{DNSName: "bar.example.org", Targets: endpoint.Targets{"10.1.1.1", "10.1.1.2", "10.1.1.3"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/foo10.1.1.1"}},
-				{DNSName: "foobar.example.org", Targets: endpoint.Targets{"20.1.1.1"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/foo20.1.1.1"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4", "1.2.3.5", "1.2.3.6"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/foo1.2.3.4"}},
+				{DNSName: "bar.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"10.1.1.1", "10.1.1.2", "10.1.1.3"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/foo10.1.1.1"}},
+				{DNSName: "foobar.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"20.1.1.1"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/foo20.1.1.1"}},
 			},
 			false,
 		},
@@ -1185,8 +1185,8 @@ func testMultipleServicesEndpoints(t *testing.T) {
 			},
 			[]string{},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"a.elb.com"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/fooa.elb.com"}, SetIdentifier: "a"},
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"b.elb.com"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/foob.elb.com"}, SetIdentifier: "b"},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeCNAME, Targets: endpoint.Targets{"a.elb.com"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/fooa.elb.com"}, SetIdentifier: "a"},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeCNAME, Targets: endpoint.Targets{"b.elb.com"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/foob.elb.com"}, SetIdentifier: "b"},
 			},
 			false,
 		},
@@ -1299,7 +1299,7 @@ func TestClusterIpServices(t *testing.T) {
 			},
 			clusterIP: "1.2.3.4",
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
 		{
@@ -1322,7 +1322,7 @@ func TestClusterIpServices(t *testing.T) {
 			fqdnTemplate: "{{.Name}}.bar.example.com",
 			clusterIP:    "4.5.6.7",
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.bar.example.com", Targets: endpoint.Targets{"4.5.6.7"}},
+				{DNSName: "foo.bar.example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"4.5.6.7"}},
 			},
 		},
 		{
@@ -1342,7 +1342,7 @@ func TestClusterIpServices(t *testing.T) {
 			labels:       map[string]string{"app": "web-internal"},
 			clusterIP:    "4.5.6.7",
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.bar.example.com", Targets: endpoint.Targets{"4.5.6.7"}},
+				{DNSName: "foo.bar.example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"4.5.6.7"}},
 			},
 			labelSelector: "app=web-internal",
 		},
@@ -1742,8 +1742,8 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 				kopsDNSControllerInternalHostnameAnnotationKey: "internal.foo.example.org., internal.bar.example.org",
 			},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "internal.foo.example.org", Targets: endpoint.Targets{"10.0.1.1"}},
-				{DNSName: "internal.bar.example.org", Targets: endpoint.Targets{"10.0.1.1"}},
+				{DNSName: "internal.foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"10.0.1.1"}},
+				{DNSName: "internal.bar.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"10.0.1.1"}},
 			},
 			nodes: []*v1.Node{{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1784,8 +1784,8 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 				kopsDNSControllerInternalHostnameAnnotationKey: "internal.foo.example.org., internal.bar.example.org",
 			},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "internal.foo.example.org", Targets: endpoint.Targets{"10.0.1.1", "10.0.1.2"}},
-				{DNSName: "internal.bar.example.org", Targets: endpoint.Targets{"10.0.1.1", "10.0.1.2"}},
+				{DNSName: "internal.foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"10.0.1.1", "10.0.1.2"}},
+				{DNSName: "internal.bar.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"10.0.1.1", "10.0.1.2"}},
 			},
 			nodes: []*v1.Node{{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1826,8 +1826,8 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 				kopsDNSControllerHostnameAnnotationKey: "foo.example.org., bar.example.org",
 			},
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"54.10.11.1", "54.10.11.2"}},
-				{DNSName: "bar.example.org", Targets: endpoint.Targets{"54.10.11.1", "54.10.11.2"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"54.10.11.1", "54.10.11.2"}},
+				{DNSName: "bar.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"54.10.11.1", "54.10.11.2"}},
 			},
 			nodes: []*v1.Node{{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2038,9 +2038,9 @@ func TestHeadlessServices(t *testing.T) {
 			[]bool{true, true},
 			false,
 			[]*endpoint.Endpoint{
-				{DNSName: "foo-0.service.example.org", Targets: endpoint.Targets{"1.1.1.1"}},
-				{DNSName: "foo-1.service.example.org", Targets: endpoint.Targets{"1.1.1.2"}},
-				{DNSName: "service.example.org", Targets: endpoint.Targets{"1.1.1.1", "1.1.1.2"}},
+				{DNSName: "foo-0.service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1"}},
+				{DNSName: "foo-1.service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.2"}},
+				{DNSName: "service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1", "1.1.1.2"}},
 			},
 			false,
 		},
@@ -2095,9 +2095,9 @@ func TestHeadlessServices(t *testing.T) {
 			[]bool{true, true},
 			false,
 			[]*endpoint.Endpoint{
-				{DNSName: "foo-0.service.example.org", Targets: endpoint.Targets{"1.1.1.1"}, RecordTTL: endpoint.TTL(1)},
-				{DNSName: "foo-1.service.example.org", Targets: endpoint.Targets{"1.1.1.2"}, RecordTTL: endpoint.TTL(1)},
-				{DNSName: "service.example.org", Targets: endpoint.Targets{"1.1.1.1", "1.1.1.2"}, RecordTTL: endpoint.TTL(1)},
+				{DNSName: "foo-0.service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1"}, RecordTTL: endpoint.TTL(1)},
+				{DNSName: "foo-1.service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.2"}, RecordTTL: endpoint.TTL(1)},
+				{DNSName: "service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1", "1.1.1.2"}, RecordTTL: endpoint.TTL(1)},
 			},
 			false,
 		},
@@ -2125,8 +2125,8 @@ func TestHeadlessServices(t *testing.T) {
 			[]bool{true, false},
 			false,
 			[]*endpoint.Endpoint{
-				{DNSName: "foo-0.service.example.org", Targets: endpoint.Targets{"1.1.1.1"}},
-				{DNSName: "service.example.org", Targets: endpoint.Targets{"1.1.1.1"}},
+				{DNSName: "foo-0.service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1"}},
+				{DNSName: "service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1"}},
 			},
 			false,
 		},
@@ -2154,9 +2154,9 @@ func TestHeadlessServices(t *testing.T) {
 			[]bool{true, false},
 			true,
 			[]*endpoint.Endpoint{
-				{DNSName: "foo-0.service.example.org", Targets: endpoint.Targets{"1.1.1.1"}},
-				{DNSName: "foo-1.service.example.org", Targets: endpoint.Targets{"1.1.1.2"}},
-				{DNSName: "service.example.org", Targets: endpoint.Targets{"1.1.1.1", "1.1.1.2"}},
+				{DNSName: "foo-0.service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1"}},
+				{DNSName: "foo-1.service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.2"}},
+				{DNSName: "service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1", "1.1.1.2"}},
 			},
 			false,
 		},
@@ -2184,7 +2184,7 @@ func TestHeadlessServices(t *testing.T) {
 			[]bool{true, true},
 			false,
 			[]*endpoint.Endpoint{
-				{DNSName: "service.example.org", Targets: endpoint.Targets{"1.1.1.1", "1.1.1.2"}},
+				{DNSName: "service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1", "1.1.1.2"}},
 			},
 			false,
 		},
@@ -2212,7 +2212,7 @@ func TestHeadlessServices(t *testing.T) {
 			[]bool{true, true, true},
 			false,
 			[]*endpoint.Endpoint{
-				{DNSName: "service.example.org", Targets: endpoint.Targets{"1.1.1.1", "1.1.1.2"}},
+				{DNSName: "service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1", "1.1.1.2"}},
 			},
 			false,
 		},
@@ -2378,9 +2378,9 @@ func TestHeadlessServicesHostIP(t *testing.T) {
 			},
 			false,
 			[]*endpoint.Endpoint{
-				{DNSName: "foo-0.service.example.org", Targets: endpoint.Targets{"1.1.1.1"}},
-				{DNSName: "foo-1.service.example.org", Targets: endpoint.Targets{"1.1.1.2"}},
-				{DNSName: "service.example.org", Targets: endpoint.Targets{"1.1.1.1", "1.1.1.2"}},
+				{DNSName: "foo-0.service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1"}},
+				{DNSName: "foo-1.service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.2"}},
+				{DNSName: "service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1", "1.1.1.2"}},
 			},
 			false,
 		},
@@ -2443,9 +2443,9 @@ func TestHeadlessServicesHostIP(t *testing.T) {
 			},
 			false,
 			[]*endpoint.Endpoint{
-				{DNSName: "foo-0.service.example.org", Targets: endpoint.Targets{"1.1.1.1"}, RecordTTL: endpoint.TTL(1)},
-				{DNSName: "foo-1.service.example.org", Targets: endpoint.Targets{"1.1.1.2"}, RecordTTL: endpoint.TTL(1)},
-				{DNSName: "service.example.org", Targets: endpoint.Targets{"1.1.1.1", "1.1.1.2"}, RecordTTL: endpoint.TTL(1)},
+				{DNSName: "foo-0.service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1"}, RecordTTL: endpoint.TTL(1)},
+				{DNSName: "foo-1.service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.2"}, RecordTTL: endpoint.TTL(1)},
+				{DNSName: "service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1", "1.1.1.2"}, RecordTTL: endpoint.TTL(1)},
 			},
 			false,
 		},
@@ -2477,8 +2477,8 @@ func TestHeadlessServicesHostIP(t *testing.T) {
 			},
 			false,
 			[]*endpoint.Endpoint{
-				{DNSName: "foo-0.service.example.org", Targets: endpoint.Targets{"1.1.1.1"}},
-				{DNSName: "service.example.org", Targets: endpoint.Targets{"1.1.1.1"}},
+				{DNSName: "foo-0.service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1"}},
+				{DNSName: "service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1"}},
 			},
 			false,
 		},
@@ -2510,9 +2510,9 @@ func TestHeadlessServicesHostIP(t *testing.T) {
 			},
 			true,
 			[]*endpoint.Endpoint{
-				{DNSName: "foo-0.service.example.org", Targets: endpoint.Targets{"1.1.1.1"}},
-				{DNSName: "foo-1.service.example.org", Targets: endpoint.Targets{"1.1.1.2"}},
-				{DNSName: "service.example.org", Targets: endpoint.Targets{"1.1.1.1", "1.1.1.2"}},
+				{DNSName: "foo-0.service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1"}},
+				{DNSName: "foo-1.service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.2"}},
+				{DNSName: "service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1", "1.1.1.2"}},
 			},
 			false,
 		},
@@ -2544,7 +2544,7 @@ func TestHeadlessServicesHostIP(t *testing.T) {
 			},
 			false,
 			[]*endpoint.Endpoint{
-				{DNSName: "service.example.org", Targets: endpoint.Targets{"1.1.1.1", "1.1.1.2"}},
+				{DNSName: "service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.1.1.1", "1.1.1.2"}},
 			},
 			false,
 		},

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -185,7 +185,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 		labels                   map[string]string
 		annotations              map[string]string
 		clusterIP                string
-		ipFamilies               []v1.IPFamily
 		externalIPs              []string
 		lbs                      []string
 		serviceTypesFilter       []string
@@ -200,7 +199,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			svcType:            v1.ServiceTypeLoadBalancer,
 			labels:             map[string]string{},
 			annotations:        map[string]string{},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -214,7 +212,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			ignoreHostnameAnnotation: true,
 			labels:                   map[string]string{},
 			annotations:              map[string]string{},
-			ipFamilies:               []v1.IPFamily{"IPv4"},
 			externalIPs:              []string{},
 			lbs:                      []string{"1.2.3.4"},
 			serviceTypesFilter:       []string{},
@@ -229,7 +226,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -247,7 +243,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -262,7 +257,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			clusterIP:          "1.2.3.4",
 			externalIPs:        []string{},
 			lbs:                []string{},
@@ -277,7 +271,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			fqdnTemplate:       "{{.Name}}.fqdn.org,{{.Name}}.fqdn.com",
 			labels:             map[string]string{},
 			annotations:        map[string]string{},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -295,7 +288,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			ignoreHostnameAnnotation: true,
 			labels:                   map[string]string{},
 			annotations:              map[string]string{},
-			ipFamilies:               []v1.IPFamily{"IPv4"},
 			externalIPs:              []string{},
 			lbs:                      []string{"1.2.3.4"},
 			serviceTypesFilter:       []string{},
@@ -315,7 +307,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org., bar.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -338,7 +329,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org., bar.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -356,7 +346,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org., bar.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -374,7 +363,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org, bar.example.org",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -392,7 +380,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"lb.example.com"}, // Kubernetes omits the trailing dot
 			serviceTypesFilter: []string{},
@@ -409,7 +396,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org", // Trailing dot is omitted
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4", "lb.example.com"}, // Kubernetes omits the trailing dot
 			serviceTypesFilter: []string{},
@@ -428,7 +414,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 				controllerAnnotationKey: controllerAnnotationValue,
 				hostnameAnnotationKey:   "foo.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -447,7 +432,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 				controllerAnnotationKey: "some-other-tool",
 				hostnameAnnotationKey:   "foo.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -463,7 +447,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -481,7 +464,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -496,7 +478,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -515,7 +496,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey:                         "foo.example.org.",
 				"service.beta.kubernetes.io/external-traffic": "OnlyLocal",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -534,7 +514,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey:                         "foo.example.org.",
 				"service.beta.kubernetes.io/external-traffic": "SomethingElse",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -551,7 +530,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey:                         "foo.example.org.",
 				"service.beta.kubernetes.io/external-traffic": "OnlyLocal",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -569,7 +547,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey:                         "foo.example.org.",
 				"service.beta.kubernetes.io/external-traffic": "Global",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -588,7 +565,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey:                         "foo.example.org.",
 				"service.beta.kubernetes.io/external-traffic": "OnlyLocal",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -603,7 +579,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{},
 			serviceTypesFilter: []string{},
@@ -618,7 +593,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{"10.2.3.4", "11.2.3.4"},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -635,7 +609,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4", "8.8.8.8"},
 			serviceTypesFilter: []string{},
@@ -652,7 +625,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				"zalando.org/dnsname": "foo.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -668,7 +640,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				"zalando.org/dnsname": "foo.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -685,7 +656,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			labels: map[string]string{
 				"dns": "route53",
 			},
-			ipFamilies: []v1.IPFamily{"IPv4"},
 			annotations: map[string]string{
 				"domainName": "foo.example.org., bar.example.org",
 			},
@@ -707,7 +677,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				kopsDNSControllerInternalHostnameAnnotationKey: "internal.foo.example.org",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4", "lb.example.com"},
 			serviceTypesFilter: []string{},
@@ -726,7 +695,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 				kopsDNSControllerInternalHostnameAnnotationKey: "internal.foo.example.org., internal.bar.example.org",
 				kopsDNSControllerHostnameAnnotationKey:         "foo.example.org., bar.example.org",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -745,7 +713,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			fqdnTemplate:       "{{.Name}}.bar.example.com",
 			labels:             map[string]string{},
 			annotations:        map[string]string{},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4", "elb.com"},
 			serviceTypesFilter: []string{},
@@ -764,7 +731,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4", "elb.com"},
 			serviceTypesFilter: []string{},
@@ -784,7 +750,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				"zalando.org/dnsname": "mate.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -800,7 +765,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			fqdnTemplate:       "{{.Calibre}}.bar.example.com",
 			labels:             map[string]string{},
 			annotations:        map[string]string{},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -816,7 +780,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -834,7 +797,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org.",
 				ttlAnnotationKey:      "foo",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -852,7 +814,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org.",
 				ttlAnnotationKey:      "10",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -870,7 +831,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org.",
 				ttlAnnotationKey:      "1m",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -888,7 +848,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey: "foo.example.org.",
 				ttlAnnotationKey:      "-10",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{},
@@ -905,7 +864,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{string(v1.ServiceTypeLoadBalancer)},
@@ -922,7 +880,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{string(v1.ServiceTypeLoadBalancer)},
@@ -937,7 +894,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				internalHostnameAnnotationKey: "foo.internal.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			clusterIP:          "1.1.1.1",
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
@@ -956,7 +912,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 				hostnameAnnotationKey:         "foo.example.org.",
 				internalHostnameAnnotationKey: "foo.internal.example.org.",
 			},
-			ipFamilies:         []v1.IPFamily{"IPv4"},
 			clusterIP:          "1.1.1.1",
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
@@ -974,7 +929,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			labels: map[string]string{
 				"app": "web-external",
 			},
-			ipFamilies:           []v1.IPFamily{"IPv4"},
 			clusterIP:            "1.1.1.1",
 			externalIPs:          []string{},
 			lbs:                  []string{"1.2.3.4"},
@@ -993,7 +947,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			labels: map[string]string{
 				"app": "web-external",
 			},
-			ipFamilies:           []v1.IPFamily{"IPv4"},
 			clusterIP:            "1.1.1.1",
 			externalIPs:          []string{},
 			lbs:                  []string{"1.2.3.4"},
@@ -1012,7 +965,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			labels: map[string]string{
 				"app": "web-internal",
 			},
-			ipFamilies:           []v1.IPFamily{"IPv4"},
 			clusterIP:            "1.1.1.1",
 			externalIPs:          []string{},
 			lbs:                  []string{"1.2.3.4"},
@@ -1029,7 +981,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			labels: map[string]string{
 				"app": "web-internal",
 			},
-			ipFamilies:           []v1.IPFamily{"IPv4"},
 			clusterIP:            "1.1.1.1",
 			externalIPs:          []string{},
 			lbs:                  []string{"1.2.3.4"},
@@ -1044,7 +995,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			svcName:            "foobar",
 			svcType:            v1.ServiceTypeLoadBalancer,
 			labels:             map[string]string{},
-			ipFamilies:         []v1.IPFamily{"IPv4", "IPv6"},
 			clusterIP:          "1.1.1.2,2001:db8::2",
 			externalIPs:        []string{},
 			lbs:                []string{"1.1.1.1", "2001:db8::1"},
@@ -1061,7 +1011,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			svcName:            "foobar-v6",
 			svcType:            v1.ServiceTypeLoadBalancer,
 			labels:             map[string]string{},
-			ipFamilies:         []v1.IPFamily{"IPv6"},
 			clusterIP:          "2001:db8::1",
 			externalIPs:        []string{},
 			lbs:                []string{"2001:db8::2"},

--- a/source/shared_test.go
+++ b/source/shared_test.go
@@ -79,7 +79,7 @@ func validateEndpoint(t *testing.T, endpoint, expected *endpoint.Endpoint) {
 	}
 
 	// if non-empty record type is expected, check that it matches.
-	if expected.RecordType != "" && endpoint.RecordType != expected.RecordType {
+	if endpoint.RecordType != expected.RecordType {
 		t.Errorf("RecordType expected %q, got %q", expected.RecordType, endpoint.RecordType)
 	}
 

--- a/source/skipper_routegroup_test.go
+++ b/source/skipper_routegroup_test.go
@@ -90,8 +90,9 @@ func TestEndpointsFromRouteGroups(t *testing.T) {
 			}),
 			want: []*endpoint.Endpoint{
 				{
-					DNSName: "rg1.k8s.example",
-					Targets: endpoint.Targets([]string{"lb.example.org"}),
+					DNSName:    "rg1.k8s.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
 				},
 			},
 		},
@@ -113,12 +114,14 @@ func TestEndpointsFromRouteGroups(t *testing.T) {
 			),
 			want: []*endpoint.Endpoint{
 				{
-					DNSName: "rg1.k8s.example",
-					Targets: endpoint.Targets([]string{"lb.example.org"}),
+					DNSName:    "rg1.k8s.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
 				},
 				{
-					DNSName: "my.example",
-					Targets: endpoint.Targets([]string{"lb.example.org"}),
+					DNSName:    "my.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
 				},
 			},
 		},
@@ -140,8 +143,9 @@ func TestEndpointsFromRouteGroups(t *testing.T) {
 			),
 			want: []*endpoint.Endpoint{
 				{
-					DNSName: "rg1.k8s.example",
-					Targets: endpoint.Targets([]string{"lb.example.org"}),
+					DNSName:    "rg1.k8s.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
 				},
 			},
 		},
@@ -163,9 +167,10 @@ func TestEndpointsFromRouteGroups(t *testing.T) {
 			),
 			want: []*endpoint.Endpoint{
 				{
-					DNSName:   "rg1.k8s.example",
-					Targets:   endpoint.Targets([]string{"lb.example.org"}),
-					RecordTTL: endpoint.TTL(2189),
+					DNSName:    "rg1.k8s.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
+					RecordTTL:  endpoint.TTL(2189),
 				},
 			},
 		},
@@ -185,8 +190,9 @@ func TestEndpointsFromRouteGroups(t *testing.T) {
 			),
 			want: []*endpoint.Endpoint{
 				{
-					DNSName: "rg1.k8s.example",
-					Targets: endpoint.Targets([]string{"1.5.1.4"}),
+					DNSName:    "rg1.k8s.example",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets([]string{"1.5.1.4"}),
 				},
 			},
 		},
@@ -207,12 +213,14 @@ func TestEndpointsFromRouteGroups(t *testing.T) {
 			),
 			want: []*endpoint.Endpoint{
 				{
-					DNSName: "rg1.k8s.example",
-					Targets: endpoint.Targets([]string{"1.5.1.4"}),
+					DNSName:    "rg1.k8s.example",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets([]string{"1.5.1.4"}),
 				},
 				{
-					DNSName: "rg1.k8s.example",
-					Targets: endpoint.Targets([]string{"lb.example.org"}),
+					DNSName:    "rg1.k8s.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
 				},
 			},
 		}} {
@@ -278,8 +286,9 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 			},
 			want: []*endpoint.Endpoint{
 				{
-					DNSName: "rg1.k8s.example",
-					Targets: endpoint.Targets([]string{"lb.example.org"}),
+					DNSName:    "rg1.k8s.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
 				},
 			},
 		},
@@ -308,12 +317,14 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 			},
 			want: []*endpoint.Endpoint{
 				{
-					DNSName: "rg1.k8s.example",
-					Targets: endpoint.Targets([]string{"lb.example.org"}),
+					DNSName:    "rg1.k8s.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
 				},
 				{
-					DNSName: "rg1.namespace1.example",
-					Targets: endpoint.Targets([]string{"lb.example.org"}),
+					DNSName:    "rg1.namespace1.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
 				},
 			},
 		},
@@ -341,8 +352,9 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 			},
 			want: []*endpoint.Endpoint{
 				{
-					DNSName: "rg1.namespace1.example",
-					Targets: endpoint.Targets([]string{"lb.example.org"}),
+					DNSName:    "rg1.namespace1.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
 				},
 			},
 		},
@@ -370,8 +382,9 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 			},
 			want: []*endpoint.Endpoint{
 				{
-					DNSName: "rg1.k8s.example",
-					Targets: endpoint.Targets([]string{"lb.example.org"}),
+					DNSName:    "rg1.k8s.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
 				},
 			},
 		},
@@ -400,9 +413,10 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 			},
 			want: []*endpoint.Endpoint{
 				{
-					DNSName:   "rg1.k8s.example",
-					Targets:   endpoint.Targets([]string{"lb.example.org"}),
-					RecordTTL: endpoint.TTL(2189),
+					DNSName:    "rg1.k8s.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
+					RecordTTL:  endpoint.TTL(2189),
 				},
 			},
 		},
@@ -430,12 +444,14 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 			},
 			want: []*endpoint.Endpoint{
 				{
-					DNSName: "rg1.k8s.example",
-					Targets: endpoint.Targets([]string{"1.5.1.4"}),
+					DNSName:    "rg1.k8s.example",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets([]string{"1.5.1.4"}),
 				},
 				{
-					DNSName: "rg1.k8s.example",
-					Targets: endpoint.Targets([]string{"lb.example.org"}),
+					DNSName:    "rg1.k8s.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
 				},
 			},
 		},
@@ -495,20 +511,24 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 			},
 			want: []*endpoint.Endpoint{
 				{
-					DNSName: "rg1.k8s.example",
-					Targets: endpoint.Targets([]string{"lb.example.org"}),
+					DNSName:    "rg1.k8s.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
 				},
 				{
-					DNSName: "rg2.k8s.example",
-					Targets: endpoint.Targets([]string{"lb.example.org"}),
+					DNSName:    "rg2.k8s.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
 				},
 				{
-					DNSName: "rg3.k8s.example",
-					Targets: endpoint.Targets([]string{"lb.example.org"}),
+					DNSName:    "rg3.k8s.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
 				},
 				{
-					DNSName: "rg.k8s.example",
-					Targets: endpoint.Targets([]string{"lb2.example.org"}),
+					DNSName:    "rg.k8s.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb2.example.org"}),
 				},
 			},
 		},
@@ -575,8 +595,9 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 			},
 			want: []*endpoint.Endpoint{
 				{
-					DNSName: "rg1.k8s.example",
-					Targets: endpoint.Targets([]string{"lb.example.org"}),
+					DNSName:    "rg1.k8s.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
 				},
 			},
 		},
@@ -643,12 +664,14 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 			},
 			want: []*endpoint.Endpoint{
 				{
-					DNSName: "rg1.k8s.example",
-					Targets: endpoint.Targets([]string{"lb.example.org"}),
+					DNSName:    "rg1.k8s.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
 				},
 				{
-					DNSName: "rg2.k8s.example",
-					Targets: endpoint.Targets([]string{"lb.example.org"}),
+					DNSName:    "rg2.k8s.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
 				},
 			},
 		},
@@ -701,12 +724,14 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 			},
 			want: []*endpoint.Endpoint{
 				{
-					DNSName: "rg1.k8s.example",
-					Targets: endpoint.Targets([]string{"lb.example.org"}),
+					DNSName:    "rg1.k8s.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
 				},
 				{
-					DNSName: "rg3.k8s.example",
-					Targets: endpoint.Targets([]string{"lb.example.org"}),
+					DNSName:    "rg3.k8s.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
 				},
 			},
 		}} {

--- a/source/source.go
+++ b/source/source.go
@@ -222,8 +222,10 @@ func getTargetsFromTargetAnnotation(annotations map[string]string) endpoint.Targ
 // suitableType returns the DNS resource record type suitable for the target.
 // In this case type A for IPs and type CNAME for everything else.
 func suitableType(target string) string {
-	if net.ParseIP(target) != nil {
+	if net.ParseIP(target) != nil && net.ParseIP(target).To4() != nil {
 		return endpoint.RecordTypeA
+	} else if net.ParseIP(target) != nil && net.ParseIP(target).To16() != nil {
+		return endpoint.RecordTypeAAAA
 	}
 	return endpoint.RecordTypeCNAME
 }
@@ -233,12 +235,23 @@ func endpointsForHostname(hostname string, targets endpoint.Targets, ttl endpoin
 	var endpoints []*endpoint.Endpoint
 
 	var aTargets endpoint.Targets
+	var aaaaTargets endpoint.Targets
 	var cnameTargets endpoint.Targets
 
 	for _, t := range targets {
 		switch suitableType(t) {
 		case endpoint.RecordTypeA:
-			aTargets = append(aTargets, t)
+			if !isIPv6String(t) {
+				aTargets = append(aTargets, t)
+			} else {
+				continue
+			}
+		case endpoint.RecordTypeAAAA:
+			if isIPv6String(t) {
+				aaaaTargets = append(aaaaTargets, t)
+			} else {
+				continue
+			}
 		default:
 			cnameTargets = append(cnameTargets, t)
 		}
@@ -257,6 +270,19 @@ func endpointsForHostname(hostname string, targets endpoint.Targets, ttl endpoin
 		endpoints = append(endpoints, epA)
 	}
 
+	if len(aaaaTargets) > 0 {
+		epAAAA := &endpoint.Endpoint{
+			DNSName:          strings.TrimSuffix(hostname, "."),
+			Targets:          aaaaTargets,
+			RecordTTL:        ttl,
+			RecordType:       endpoint.RecordTypeAAAA,
+			Labels:           endpoint.NewLabels(),
+			ProviderSpecific: providerSpecific,
+			SetIdentifier:    setIdentifier,
+		}
+		endpoints = append(endpoints, epAAAA)
+	}
+
 	if len(cnameTargets) > 0 {
 		epCNAME := &endpoint.Endpoint{
 			DNSName:          strings.TrimSuffix(hostname, "."),
@@ -269,7 +295,6 @@ func endpointsForHostname(hostname string, targets endpoint.Targets, ttl endpoin
 		}
 		endpoints = append(endpoints, epCNAME)
 	}
-
 	return endpoints
 }
 
@@ -330,4 +355,10 @@ func waitForDynamicCacheSync(ctx context.Context, factory dynamicInformerFactory
 		}
 	}
 	return nil
+}
+
+// isIPv6String returns if ip is IPv6.
+func isIPv6String(ip string) bool {
+	netIP := net.ParseIP(ip)
+	return netIP != nil && netIP.To4() == nil
 }

--- a/source/source_test.go
+++ b/source/source_test.go
@@ -94,6 +94,7 @@ func TestSuitableType(t *testing.T) {
 		target, recordType, expected string
 	}{
 		{"8.8.8.8", "", "A"},
+		{"2001:db8::1", "", "AAAA"},
 		{"foo.example.org", "", "CNAME"},
 		{"bar.eu-central-1.elb.amazonaws.com", "", "CNAME"},
 	} {


### PR DESCRIPTION

**Description**

Fix the handling of external IPv6 addresses for host-network pods.

This corresponds to kubernetes/kops#12608, plus adds some missing IPv6 handling.

Fixing the handling of internal IPv6 addresses will be for a follow-up PR.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated (Not Applicable)
