### PR TITLE
Changes to add count of A records of source and registry as metrics

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -187,6 +187,8 @@ Here is the full list of available metrics provided by ExternalDNS:
 | external_dns_source_errors_total                    | Number of Source errors                                 | Counter |
 | external_dns_controller_verified_records            | Number of DNS A-records that exists both in             | Gauge   |
 |                                                     | source & registry                                       |         |
+| external_dns_registry_a_records                     | Number of A records in registry                         | Gauge   |
+| external_dns_source_a_records                       | Number of A records in source                           | Gauge   |
 
 ### How can I run ExternalDNS under a specific GCP Service Account, e.g. to access DNS records in other projects?
 


### PR DESCRIPTION
Changes to count of add A records of registry and source as gauge metric 
`external_dns_registry_a_records, external_dns_source_a_records`

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

The existing metrics -
`external_dns_registry_endpoints_total & external_dns_source_endpoints_total` gives a cumulative count of records all records (A, SRV, CNAME, TXT).

We have a metric - external_dns_controller_verified_records which gives the intersection of A records between source & regsitry. However, in order to determined how many records are yet to be synced to registry, we need count of total A records in registry & source.

Testing - Tested the changes.
[](url)

**Checklist**

- [X] Unit tests updated
- [X] End user documentation updated
