### PR TITLE
chore(chart): trigger release action

### DIFF
--- a/.github/workflows/lint-test-chart.yaml
+++ b/.github/workflows/lint-test-chart.yaml
@@ -37,7 +37,7 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --check-version-increment false
+        run: ct lint --check-version-increment=false
 
       - name: Create Kind cluster
         uses: helm/kind-action@v1.2.0

--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Allow specifying Service annotations"
+      description: "Allow specifying Service annotations."


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

This PR re-triggers a chart release that failed due to bad CI.

This PR also fixes https://github.com/helm/chart-testing/issues/363.

**Checklist**

- [ ] ~~Unit tests updated~~
- [ ] ~~End user documentation updated~~
