### PR TITLE
RFC2136: add NS record support

### DIFF
--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -176,6 +176,9 @@ OuterLoop:
 		case dns.TypeTXT:
 			rrValues = (rr.(*dns.TXT).Txt)
 			rrType = "TXT"
+		case dns.TypeNS:
+			rrValues = []string{rr.(*dns.NS).Ns}
+			rrType = "NS"
 		default:
 			continue // Unhandled record type
 		}

--- a/provider/rfc2136/rfc2136_test.go
+++ b/provider/rfc2136/rfc2136_test.go
@@ -172,6 +172,11 @@ func TestRfc2136ApplyChanges(t *testing.T) {
 				RecordType: "TXT",
 				Targets:    []string{"boom"},
 			},
+			{
+				DNSName:    "ns.foobar.com",
+				RecordType: "NS",
+				Targets:    []string{"boom"},
+			},
 		},
 		Delete: []*endpoint.Endpoint{
 			{
@@ -190,12 +195,15 @@ func TestRfc2136ApplyChanges(t *testing.T) {
 	err = provider.ApplyChanges(context.Background(), p)
 	assert.NoError(t, err)
 
-	assert.Equal(t, 2, len(stub.createMsgs))
+	assert.Equal(t, 3, len(stub.createMsgs))
 	assert.True(t, strings.Contains(stub.createMsgs[0].String(), "v1.foo.com"))
 	assert.True(t, strings.Contains(stub.createMsgs[0].String(), "1.2.3.4"))
 
 	assert.True(t, strings.Contains(stub.createMsgs[1].String(), "v1.foobar.com"))
 	assert.True(t, strings.Contains(stub.createMsgs[1].String(), "boom"))
+
+	assert.True(t, strings.Contains(stub.createMsgs[2].String(), "ns.foobar.com"))
+	assert.True(t, strings.Contains(stub.createMsgs[2].String(), "boom"))
 
 	assert.Equal(t, 2, len(stub.updateMsgs))
 	assert.True(t, strings.Contains(stub.updateMsgs[0].String(), "v2.foo.com"))


### PR DESCRIPTION
Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
This adds NS record support to rfc2136 provider

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
