### PR TITLE
Support for dnsendpoints in ClusterRole created by helm chart

### DIFF
--- a/charts/external-dns/templates/clusterrole.yaml
+++ b/charts/external-dns/templates/clusterrole.yaml
@@ -41,4 +41,13 @@ rules:
     resources: ["virtualservices"]
     verbs: ["get","watch","list"]
 {{- end }}
+
+{{- if has "crd" .Values.sources }}
+  - apiGroups: ["externaldns.k8s.io"]
+    resources: ["dnsendpoints"]
+    verbs: ["get","watch","list"]
+  - apiGroups: ["externaldns.k8s.io"]
+    resources: ["dnsendpoints/status"]
+    verbs: ["*"]
+{{- end }}
 {{- end }}


### PR DESCRIPTION
**Description**

This pr fixes the problem with RBAC (ClusterRole) created by helm chart not supporting DNSEndpoint CRD.