### PR TITLE
add external-dns.alpha.kubernetes.io/traffic-policy

### DIFF
--- a/source/source.go
+++ b/source/source.go
@@ -40,6 +40,8 @@ import (
 const (
 	// The annotation used for figuring out which controller is responsible
 	controllerAnnotationKey = "external-dns.alpha.kubernetes.io/controller"
+	// The annotation use to ovverride the local traffic policy
+	trafficPolicyAnnotationKey = "external-dns.alpha.kubernetes.io/traffic-policy"
 	// The annotation used for defining the desired hostname
 	hostnameAnnotationKey = "external-dns.alpha.kubernetes.io/hostname"
 	// The annotation used for specifying whether the public or private interface address is used


### PR DESCRIPTION
**Description**

Adds an annotation to mimic `ExternalTrafficPolicy: Local` without changing the kubernetes behavour. This allows for increased reliability when DNS is cached.


Anotation: `external-dns.alpha.kubernetes.io/traffic-policy: local`

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated

Documentation to be updated if concept approved.