### PR TITLE
New features: set migrate txt-owner

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -139,6 +139,10 @@ type Controller struct {
 	ManagedRecordTypes []string
 	// MinEventSyncInterval is used as window for batching events
 	MinEventSyncInterval time.Duration
+	// modify owner
+	TXTOwner string
+	// migrate txt-owner flag
+	TXTOwnerMigrate bool
 }
 
 // RunOnce runs a single iteration of a reconciliation loop.
@@ -171,11 +175,13 @@ func (c *Controller) RunOnce(ctx context.Context) error {
 		DomainFilter:       endpoint.MatchAllDomainFilters{c.DomainFilter, c.Registry.GetDomainFilter()},
 		PropertyComparator: c.Registry.PropertyValuesEqual,
 		ManagedRecords:     c.ManagedRecordTypes,
+		TXTOwner:           c.TXTOwner,
+		TXTOwnerMigrate:    c.TXTOwnerMigrate,
 	}
 
 	plan = plan.Calculate()
 
-	if plan.Changes.HasChanges() {
+	if plan.Changes.HasChanges() || plan.HasMig {
 		err = c.Registry.ApplyChanges(ctx, plan.Changes)
 		if err != nil {
 			registryErrorsTotal.Inc()

--- a/main.go
+++ b/main.go
@@ -88,6 +88,9 @@ func main() {
 	if cfg.DryRun {
 		log.Info("running in dry-run mode. No changes to DNS records will be made.")
 	}
+	if cfg.TXTOwnerMigrate {
+		log.Info("modify the previous txt-owner to the current txt-owner")
+	}
 
 	ll, err := log.ParseLevel(cfg.LogLevel)
 	if err != nil {
@@ -359,6 +362,8 @@ func main() {
 		DomainFilter:         domainFilter,
 		ManagedRecordTypes:   cfg.ManagedDNSRecordTypes,
 		MinEventSyncInterval: cfg.MinEventSyncInterval,
+		TXTOwner:             cfg.TXTOwnerID,
+		TXTOwnerMigrate:      cfg.TXTOwnerMigrate,
 	}
 
 	if cfg.Once {

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -129,6 +129,7 @@ type Config struct {
 	Policy                            string
 	Registry                          string
 	TXTOwnerID                        string
+	TXTOwnerMigrate                   bool
 	TXTPrefix                         string
 	TXTSuffix                         string
 	Interval                          time.Duration
@@ -255,6 +256,7 @@ var defaultConfig = &Config{
 	Policy:                      "sync",
 	Registry:                    "txt",
 	TXTOwnerID:                  "default",
+	TXTOwnerMigrate:             false,
 	TXTPrefix:                   "",
 	TXTSuffix:                   "",
 	TXTCacheInterval:            0,
@@ -488,6 +490,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	// Flags related to the registry
 	app.Flag("registry", "The registry implementation to use to keep track of DNS record ownership (default: txt, options: txt, noop, aws-sd)").Default(defaultConfig.Registry).EnumVar(&cfg.Registry, "txt", "noop", "aws-sd")
 	app.Flag("txt-owner-id", "When using the TXT registry, a name that identifies this instance of ExternalDNS (default: default)").Default(defaultConfig.TXTOwnerID).StringVar(&cfg.TXTOwnerID)
+	app.Flag("migrate-txt-owner", "When enabled, modify the previous txt-owner to the current txt-owner (default: disabled)").BoolVar(&cfg.TXTOwnerMigrate)
 	app.Flag("txt-prefix", "When using the TXT registry, a custom string that's prefixed to each ownership DNS record (optional). Mutual exclusive with txt-suffix!").Default(defaultConfig.TXTPrefix).StringVar(&cfg.TXTPrefix)
 	app.Flag("txt-suffix", "When using the TXT registry, a custom string that's suffixed to the host portion of each ownership DNS record (optional). Mutual exclusive with txt-prefix!").Default(defaultConfig.TXTSuffix).StringVar(&cfg.TXTSuffix)
 	app.Flag("txt-wildcard-replacement", "When using the TXT registry, a custom string that's used instead of an asterisk for TXT records corresponding to wildcard DNS records (optional)").Default(defaultConfig.TXTWildcardReplacement).StringVar(&cfg.TXTWildcardReplacement)


### PR DESCRIPTION

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
When changing --txt-owner-id on an existing external-dns resource, it does not update the existing TXT records it owns, therefore losing ownership. Meaning that we have to manually delete the records in order to have external-dns take ownership again. To solve this problem, I added the ability to update the original txt-owner by setting -- migrate-txt-owner to overwrite the old txt-owner.
<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE
https://github.com/kubernetes-sigs/external-dns/issues/2036
