### PR TITLE
Cloudflare provider - Removed incorrect log message

### DIFF
--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -382,10 +382,6 @@ func (p *CloudFlareProvider) newCloudFlareChange(action string, endpoint *endpoi
 		ttl = int(endpoint.RecordTTL)
 	}
 
-	if len(endpoint.Targets) > 1 {
-		log.Errorf("Updates should have just one target")
-	}
-
 	return &cloudFlareChange{
 		Action: action,
 		ResourceRecord: cloudflare.DNSRecord{


### PR DESCRIPTION
I don't understand the reasoning behind this log message, we had to disable the logging inside the external-dns container due to the extensive logging.

The `endpoint.Targets` can contain multiple targets, which should be fine.

We could probably remove this logging, or refactor the logic around `newCloudFlareChange` inside `ApplyChanges`.