### PR TITLE
feat(chart): Update chart to use v0.10.2

### DIFF
--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: external-dns
 description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 type: application
-version: 1.6.0
-appVersion: 0.10.1
+version: 1.7.0
+appVersion: 0.10.2
 keywords:
   - kubernetes
   - external-dns
@@ -17,5 +17,9 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
+    - kind: added
+      description: "Allow custom ClusterRole rules to be specified for sources without defaults."
     - kind: changed
-      description: "Allow specifying Service annotations."
+      description: "Update ExternalDNS version to v0.10.2."
+    - kind: changed
+      description: "Set ClusterRole rules based more enabled sources."


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
This PR will update the Helm chart to use the latest [v0.10.2](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.10.2) version of ExternalDNS. It will also include the changes in #2468 & #2415.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2475.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
