### PR TITLE
Fix trivy workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,8 +1,6 @@
 name: trivy vulnerability scanner
 on:
   push:
-    branches:
-      - master
 jobs:
   build:
     name: Build

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,8 +1,8 @@
 name: trivy vulnerability scanner
 on:
   push:
-    # branches:
-    #   - master
+    branches:
+      - master
 jobs:
   build:
     name: Build

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,8 +1,8 @@
 name: trivy vulnerability scanner
 on:
   push:
-    branches:
-      - master
+    # branches:
+    #   - master
 jobs:
   build:
     name: Build

--- a/scripts/run-trivy.sh
+++ b/scripts/run-trivy.sh
@@ -2,6 +2,7 @@
 set -e
 
 # install trivy
+cd /tmp
 curl -LO https://github.com/aquasecurity/trivy/releases/download/v0.20.2/trivy_0.20.2_Linux-64bit.tar.gz 
 echo "38a6de48e21a34e0fa0d2cf63439c0afcbbae0e78fb3feada7a84a9cf6e7f60c trivy_0.20.2_Linux-64bit.tar.gz" | sha256sum -c 
 tar -xvf trivy_0.20.2_Linux-64bit.tar.gz

--- a/scripts/run-trivy.sh
+++ b/scripts/run-trivy.sh
@@ -9,4 +9,5 @@ tar -xvf trivy_0.20.2_Linux-64bit.tar.gz
 chmod +x trivy
 
 # run trivy
+cd - 
 ./trivy image --exit-code 1 us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:$(git describe --tags --always --dirty)

--- a/scripts/run-trivy.sh
+++ b/scripts/run-trivy.sh
@@ -10,4 +10,4 @@ chmod +x trivy
 
 # run trivy
 cd - 
-./trivy image --exit-code 1 us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:$(git describe --tags --always --dirty)
+/tmp/trivy image --exit-code 1 us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:$(git describe --tags --always --dirty)


### PR DESCRIPTION
The trivy workflow was still broken, the last fix didn't really fix it. This is an attempt at fixing the script for good to restore the image scanning functionality.

This also makes the workflow run all the time so that we can spot vulnerabilities before merging to the default branch.