### PR TITLE
Remove broken link

### DIFF
--- a/docs/proposal/registry.md
+++ b/docs/proposal/registry.md
@@ -122,8 +122,4 @@ A single loop iteration of external-dns operation:
 1. DNS Provider should use batch operations
 2. DNS Provider should be called with CREATE operation (not UPSERT!) when the record does not yet exist!
 
-### Resources:
 
-1. Registry implementation draft: 
-
-[Flow](https://lh3.googleusercontent.com/BNUZZQ8XivYkXyYVPDgPCoZpwYv0pOyoyfBKbOnYJGsqueeB-EUXfzBZLk7xP-E_GDo7YHiTlA4XgPEs6ao_Ex0TY2SN66-yg5iRmn5Tc2EXVqs_yS9CtumhE1T4krZc4Z8_1gHOirDxCegU-Fk0K3fvg-J3UpzdKmGDG-JZwdzRyP4WyORWUQilJO9jErh-HP8AtM8p2ZjiqN9B3-VXdYuHbsiR6EHNFw43aOQAk52muDf2AgjqX2YUSbN9eO0Akt39ien3euT2HsZJlPvm5s8v2a_ZqTSW0DVcGaRhLQbZXcogSEP-ebbuGunuVbz45Ws8X6zJhZpASNQ-jknhGZEhZkSAQdwvihZpTsDdUuJx9RFDXNwA0lEaE_xediW119uJGywSNc6w8hnJZ6Xo49YQStuGbJKRAieQMvEhZXofiqCKyOUXSlsO7j9iE-rzis0JRSHWB8acA3AlcXqBj9D70AHfRHC_HfBLw9lcusy4dInmK2OCzGqXV11PoqibiZPqh-oNED31pToZQk4NB1xbOuUC_Tjf8UR_xAyhJ3yKzS09K898uCf-87Ra4iqRDCz3N35b=w2560-h1260)


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/external-dns/issues/2316 

This was pointing to a google resource that does not exist anymore. As it does not add much, I'm going to just remove the link.

/cc @njuettner 