### PR TITLE
Add the canonical hosted zone for Cloudfront

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -119,6 +119,8 @@ var (
 		"elb.af-south-1.amazonaws.com":        "Z203XCE67M25HM",
 		// Global Accelerator
 		"awsglobalaccelerator.com": "Z2BJ6XQ5FK7U4H",
+		// Cloudfront
+		"cloudfront.net": "Z2FDTNDATAQYW2",
 	}
 )
 


### PR DESCRIPTION
**Description**

allows the use of cloudfront aliases with the alias annotation the same way it was done for global Accelerator.

code changes made by @georgebuckerfield

The value for the canonical hosted zone was taken from the AWS docs [here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-aliastarget.html).

Fixes #2426