### PR TITLE
[Infoblox] Disable always changed by defaulting TTL to 0

### DIFF
--- a/main.go
+++ b/main.go
@@ -237,19 +237,20 @@ func main() {
 	case "infoblox":
 		p, err = infoblox.NewInfobloxProvider(
 			infoblox.InfobloxConfig{
-				DomainFilter: domainFilter,
-				ZoneIDFilter: zoneIDFilter,
-				Host:         cfg.InfobloxGridHost,
-				Port:         cfg.InfobloxWapiPort,
-				Username:     cfg.InfobloxWapiUsername,
-				Password:     cfg.InfobloxWapiPassword,
-				Version:      cfg.InfobloxWapiVersion,
-				SSLVerify:    cfg.InfobloxSSLVerify,
-				View:         cfg.InfobloxView,
-				MaxResults:   cfg.InfobloxMaxResults,
-				DryRun:       cfg.DryRun,
-				FQDNRexEx:    cfg.InfobloxFQDNRegEx,
-				CreatePTR:    cfg.InfobloxCreatePTR,
+				DomainFilter:  domainFilter,
+				ZoneIDFilter:  zoneIDFilter,
+				Host:          cfg.InfobloxGridHost,
+				Port:          cfg.InfobloxWapiPort,
+				Username:      cfg.InfobloxWapiUsername,
+				Password:      cfg.InfobloxWapiPassword,
+				Version:       cfg.InfobloxWapiVersion,
+				SSLVerify:     cfg.InfobloxSSLVerify,
+				View:          cfg.InfobloxView,
+				MaxResults:    cfg.InfobloxMaxResults,
+				DryRun:        cfg.DryRun,
+				FQDNRexEx:     cfg.InfobloxFQDNRegEx,
+				CreatePTR:     cfg.InfobloxCreatePTR,
+				CacheDuration: cfg.InfobloxCacheDuration,
 			},
 		)
 	case "dyn":

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -112,6 +112,7 @@ type Config struct {
 	InfobloxMaxResults                int
 	InfobloxFQDNRegEx                 string
 	InfobloxCreatePTR                 bool
+	InfobloxCacheDuration             int
 	DynCustomerName                   string
 	DynUsername                       string
 	DynPassword                       string `secure:"yes"`
@@ -242,6 +243,7 @@ var defaultConfig = &Config{
 	InfobloxMaxResults:          0,
 	InfobloxFQDNRegEx:           "",
 	InfobloxCreatePTR:           false,
+	InfobloxCacheDuration:       0,
 	OCIConfigFile:               "/etc/kubernetes/oci.yaml",
 	InMemoryZones:               []string{},
 	OVHEndpoint:                 "ovh-eu",
@@ -431,6 +433,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("infoblox-max-results", "Add _max_results as query parameter to the URL on all API requests. The default is 0 which means _max_results is not set and the default of the server is used.").Default(strconv.Itoa(defaultConfig.InfobloxMaxResults)).IntVar(&cfg.InfobloxMaxResults)
 	app.Flag("infoblox-fqdn-regex", "Apply this regular expression as a filter for obtaining zone_auth objects. This is disabled by default.").Default(defaultConfig.InfobloxFQDNRegEx).StringVar(&cfg.InfobloxFQDNRegEx)
 	app.Flag("infoblox-create-ptr", "When using the Infoblox provider, create a ptr entry in addition to an entry").Default(strconv.FormatBool(defaultConfig.InfobloxCreatePTR)).BoolVar(&cfg.InfobloxCreatePTR)
+	app.Flag("infoblox-cache-duration", "When using the Infoblox provider, set the record TTL (0s to disable).").Default(strconv.Itoa(defaultConfig.InfobloxCacheDuration)).IntVar(&cfg.InfobloxCacheDuration)
 	app.Flag("dyn-customer-name", "When using the Dyn provider, specify the Customer Name").Default("").StringVar(&cfg.DynCustomerName)
 	app.Flag("dyn-username", "When using the Dyn provider, specify the Username").Default("").StringVar(&cfg.DynUsername)
 	app.Flag("dyn-password", "When using the Dyn provider, specify the password").Default("").StringVar(&cfg.DynPassword)


### PR DESCRIPTION
**Description**

Configuration to set TTL of the Endpoint of the Kubernetes side.

The kubernetes side TTL is always something and the Infoblox side is kept at 0 because of the default.

* https://github.com/kubernetes-sigs/external-dns/blob/375a5645c25975d08ef630fc1bd293cbfc6b7236/endpoint/endpoint.go#L147

This will always trigger `shouldUpdateTTL` and return `False`
We want it to trigger `targetChanged` if needed and do nothing if there are no changes.

* https://github.com/kubernetes-sigs/external-dns/blob/375a5645c25975d08ef630fc1bd293cbfc6b7236/plan/plan.go#L160
* https://github.com/kubernetes-sigs/external-dns/blob/375a5645c25975d08ef630fc1bd293cbfc6b7236/plan/plan.go#L197-L199   

In preference of #1521 (ordered):
1. #2500
1. #2496
1. #2502
1. #2501

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
