### PR TITLE
istio-gateway: Add debug logging when endpoints missing

### DIFF
--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -172,6 +172,11 @@ func (sc *gatewaySource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, e
 			return nil, err
 		}
 
+		if len(gwEndpoints) == 0 {
+			log.Debugf("No endpoints could be generated from gateway %s/%s", gateway.Namespace, gateway.Name)
+			continue
+		}
+
 		log.Debugf("Endpoints generated from gateway: %s/%s: %v", gateway.Namespace, gateway.Name, gwEndpoints)
 		sc.setResourceLabel(gateway, gwEndpoints)
 		endpoints = append(endpoints, gwEndpoints...)


### PR DESCRIPTION
**Description**

Add debug logging to `istio-gateway` for when an endpoint is missing, this adds logging parity to [`istio-virtualservice`](https://github.com/kubernetes-sigs/external-dns/blob/master/source/istio_virtualservice.go#L169-L172).
