### PR TITLE
Add missing test for overriding managed-record-types

### DIFF
--- a/pkg/apis/externaldns/types_test.go
+++ b/pkg/apis/externaldns/types_test.go
@@ -209,7 +209,7 @@ var (
 		TransIPAccountName:          "transip",
 		TransIPPrivateKeyFile:       "/path/to/transip.key",
 		DigitalOceanAPIPageSize:     100,
-		ManagedDNSRecordTypes:       []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
+		ManagedDNSRecordTypes:       []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME, endpoint.RecordTypeNS},
 		RFC2136BatchChangeSize:      100,
 	}
 )
@@ -330,6 +330,9 @@ func TestParseFlags(t *testing.T) {
 				"--transip-account=transip",
 				"--transip-keyfile=/path/to/transip.key",
 				"--digitalocean-api-page-size=100",
+				"--managed-record-types=A",
+				"--managed-record-types=CNAME",
+				"--managed-record-types=NS",
 				"--rfc2136-batch-change-size=100",
 			},
 			envVars:  map[string]string{},
@@ -429,6 +432,7 @@ func TestParseFlags(t *testing.T) {
 				"EXTERNAL_DNS_TRANSIP_ACCOUNT":                 "transip",
 				"EXTERNAL_DNS_TRANSIP_KEYFILE":                 "/path/to/transip.key",
 				"EXTERNAL_DNS_DIGITALOCEAN_API_PAGE_SIZE":      "100",
+				"EXTERNAL_DNS_MANAGED_RECORD_TYPES":            "A\nCNAME\nNS",
 				"EXTERNAL_DNS_RFC2136_BATCH_CHANGE_SIZE":       "100",
 			},
 			expected: overriddenConfig,


### PR DESCRIPTION

**Description**

Very little change that adds the test case that verifies that overriding the config works also for `managed-record-types` (env vars and cli params). The test file works as a good source of documentation for newcomers and it helped me to realise what's the env var name of the cli param and vice-versa. The `EXTERNAL_DNS_MANAGED_RECORD_TYPES` was missing here though so I was puzzled what to use..

<!-- Please provide a summary of the change here. -->


**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated (very minor change for this)

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>