### PR TITLE
aws: match parent zones when listing hosted zones

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -245,7 +245,7 @@ func (p *AWSProvider) Zones(ctx context.Context) (map[string]*route53.HostedZone
 				continue
 			}
 
-			if !p.domainFilter.Match(aws.StringValue(zone.Name)) {
+			if !p.domainFilter.Match(aws.StringValue(zone.Name)) && !p.domainFilter.MatchParent(aws.StringValue(zone.Name)) {
 				continue
 			}
 

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -290,21 +290,25 @@ func TestAWSZones(t *testing.T) {
 
 	noZones := map[string]*route53.HostedZone{}
 
+	defaultDomainFilters := endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."})
+
 	for _, ti := range []struct {
 		msg            string
 		zoneIDFilter   provider.ZoneIDFilter
 		zoneTypeFilter provider.ZoneTypeFilter
 		zoneTagFilter  provider.ZoneTagFilter
+		domainFilters  endpoint.DomainFilter
 		expectedZones  map[string]*route53.HostedZone
 	}{
-		{"no filter", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), provider.NewZoneTagFilter([]string{}), allZones},
-		{"public filter", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter("public"), provider.NewZoneTagFilter([]string{}), publicZones},
-		{"private filter", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter("private"), provider.NewZoneTagFilter([]string{}), privateZones},
-		{"unknown filter", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter("unknown"), provider.NewZoneTagFilter([]string{}), noZones},
-		{"zone id filter", provider.NewZoneIDFilter([]string{"/hostedzone/zone-3.ext-dns-test-2.teapot.zalan.do."}), provider.NewZoneTypeFilter(""), provider.NewZoneTagFilter([]string{}), privateZones},
-		{"tag filter", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), provider.NewZoneTagFilter([]string{"zone=3"}), privateZones},
+		{"no filter", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), provider.NewZoneTagFilter([]string{}), defaultDomainFilters, allZones},
+		{"public filter", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter("public"), provider.NewZoneTagFilter([]string{}), defaultDomainFilters, publicZones},
+		{"private filter", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter("private"), provider.NewZoneTagFilter([]string{}), defaultDomainFilters, privateZones},
+		{"unknown filter", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter("unknown"), provider.NewZoneTagFilter([]string{}), defaultDomainFilters, noZones},
+		{"zone id filter", provider.NewZoneIDFilter([]string{"/hostedzone/zone-3.ext-dns-test-2.teapot.zalan.do."}), provider.NewZoneTypeFilter(""), provider.NewZoneTagFilter([]string{}), defaultDomainFilters, privateZones},
+		{"tag filter", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), provider.NewZoneTagFilter([]string{"zone=3"}), defaultDomainFilters, privateZones},
+		{"domain filter zone-1", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), provider.NewZoneTagFilter([]string{}), endpoint.NewDomainFilter([]string{"zone-1.ext-dns-test-2.teapot.zalan.do"}), map[string]*route53.HostedZone{"/hostedzone/zone-1.ext-dns-test-2.teapot.zalan.do.": allZones["/hostedzone/zone-1.ext-dns-test-2.teapot.zalan.do."]}},
 	} {
-		provider, _ := newAWSProviderWithTagFilter(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), ti.zoneIDFilter, ti.zoneTypeFilter, ti.zoneTagFilter, defaultEvaluateTargetHealth, false, []*endpoint.Endpoint{})
+		provider, _ := newAWSProviderWithTagFilter(t, ti.domainFilters, ti.zoneIDFilter, ti.zoneTypeFilter, ti.zoneTagFilter, defaultEvaluateTargetHealth, false, []*endpoint.Endpoint{})
 
 		zones, err := provider.Zones(context.Background())
 		require.NoError(t, err)


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2040 for AWS provider. 
The issue was already solved in #2113 for pdns, this PR is just also applying the same fix for AWS provider.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
