### PR TITLE
AWSSD: Add rudimentary support for RegisterInstance with port

### DIFF
--- a/provider/awssd/aws_sd.go
+++ b/provider/awssd/aws_sd.go
@@ -49,6 +49,7 @@ const (
 	sdInstanceAttrIPV4  = "AWS_INSTANCE_IPV4"
 	sdInstanceAttrCname = "AWS_INSTANCE_CNAME"
 	sdInstanceAttrAlias = "AWS_ALIAS_DNS_NAME"
+	sdInstanceAttrPort  = "AWS_INSTANCE_PORT"
 )
 
 var (
@@ -489,6 +490,7 @@ func (p *AWSSDProvider) RegisterInstance(service *sd.Service, ep *endpoint.Endpo
 		log.Infof("Registering a new instance \"%s\" for service \"%s\" (%s)", target, *service.Name, *service.Id)
 
 		attr := make(map[string]*string)
+		defaultPort := "443"
 
 		if ep.RecordType == endpoint.RecordTypeCNAME {
 			if p.isAWSLoadBalancer(target) {
@@ -498,6 +500,7 @@ func (p *AWSSDProvider) RegisterInstance(service *sd.Service, ep *endpoint.Endpo
 			}
 		} else if ep.RecordType == endpoint.RecordTypeA {
 			attr[sdInstanceAttrIPV4] = aws.String(target)
+			attr[sdInstanceAttrPort] = &defaultPort
 		} else {
 			return fmt.Errorf("invalid endpoint type (%v)", ep)
 		}

--- a/provider/awssd/aws_sd_test.go
+++ b/provider/awssd/aws_sd_test.go
@@ -706,6 +706,7 @@ func TestAWSSDProvider_RegisterInstance(t *testing.T) {
 	provider := newTestAWSSDProvider(api, endpoint.NewDomainFilter([]string{}), "")
 
 	expectedInstances := make(map[string]*sd.Instance)
+	defaultPort := "443"
 
 	// IP-based instance
 	provider.RegisterInstance(services["private"]["a-srv"], &endpoint.Endpoint{
@@ -718,12 +719,14 @@ func TestAWSSDProvider_RegisterInstance(t *testing.T) {
 		Id: aws.String("1.2.3.4"),
 		Attributes: map[string]*string{
 			sdInstanceAttrIPV4: aws.String("1.2.3.4"),
+			sdInstanceAttrPort: &defaultPort,
 		},
 	}
 	expectedInstances["1.2.3.5"] = &sd.Instance{
 		Id: aws.String("1.2.3.5"),
 		Attributes: map[string]*string{
 			sdInstanceAttrIPV4: aws.String("1.2.3.5"),
+			sdInstanceAttrPort: &defaultPort,
 		},
 	}
 


### PR DESCRIPTION
**Description**

When using AWS SD services with healthchecks, external-dns isn't able to register any instances (`RegisterInstance`) of said services - it doesn't provide a default port to AWS API, and this parameter is required.

This PR will result in external-dns AWS SD  provider always using port 443 when registering instances, however it a) won't break anything since when no healthchecks are configured in AWS, the port isn't used and b) adds at least some support for registering instances with healthchecks while there was previously none.

* Added a default port (443) to `RegisterInstance` in aws_sd.go.
* Updated aws_sd_test.go to reflect the changes.

Tested on a cluster for a few days, external-dns is able to successfully register instances of an AWS SD service with healthchecks enabled.

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
