### PR TITLE
designate: exclude internal labels

### DIFF
--- a/provider/designate/designate.go
+++ b/provider/designate/designate.go
@@ -340,6 +340,14 @@ func (p designateProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, e
 	return result, nil
 }
 
+func (p designateProvider) PropertyValuesEqual(name, previous, current string) bool {
+	if name == designateRecordSetID || name == designateZoneID || name == designateOriginalRecords {
+		return true
+	}
+
+	return previous == current
+}
+
 // temporary structure to hold recordset parameters so that we could aggregate endpoints into recordsets
 type recordSet struct {
 	dnsName     string


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

I have noticed that the designate records are constantly created and deleted because the compared records contain labels like ```designate-recordset-id``` but the endpoints that are collected by the service does not contain such labels therefore they are always be created and deleted. 

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
