### PR TITLE
Add istio-gateway permissions on source istio-virtualservice

### DIFF
--- a/charts/external-dns/templates/clusterrole.yaml
+++ b/charts/external-dns/templates/clusterrole.yaml
@@ -30,7 +30,7 @@ rules:
     verbs: ["get","watch","list"]
 {{- end }}
 
-{{- if has "istio-gateway" .Values.sources }}
+{{- if or (has "istio-gateway" .Values.sources) (has "istio-virtualservice" .Values.sources) }}
   - apiGroups: ["networking.istio.io"]
     resources: ["gateways"]
     verbs: ["get","watch","list"]


### PR DESCRIPTION
**Description**

The source `istio-virtualservice` relies on accessing the [`istio-gateway`](https://github.com/kubernetes-sigs/external-dns/blob/master/source/istio_virtualservice.go#L295). This change enables access to the `networking.istio.io/gateways` when running `istio-virtualservice`.