### PR TITLE
Remove an obsolete TODO comment

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -314,9 +314,6 @@ func (p *AWSProvider) records(ctx context.Context, zones map[string]*route53.Hos
 		for _, r := range resp.ResourceRecordSets {
 			newEndpoints := make([]*endpoint.Endpoint, 0)
 
-			// TODO(linki, ownership): Remove once ownership system is in place.
-			// See: https://github.com/kubernetes-sigs/external-dns/pull/122/files/74e2c3d3e237411e619aefc5aab694742001cdec#r109863370
-
 			if !provider.SupportedRecordType(aws.StringValue(r.Type)) {
 				continue
 			}


### PR DESCRIPTION
This is a very small PR.

While trying to understand how AAAA records are handled, I stumbled upon this comment, because I believed that it refers to the if statement below:

```
if !provider.SupportedRecordType(aws.StringValue(r.Type))
```

However, it turns out that the comment is unrelated. It was introduced in https://github.com/kubernetes-sigs/external-dns/commit/b0f437a43833c325a0fdd2ce3288c900538562b3 and references a switch statement that has been removed (I guess the ownership system is in place now).