### PR TITLE
Added filtering of IPv6 addresses from source endpoints

### DIFF
--- a/main.go
+++ b/main.go
@@ -154,6 +154,10 @@ func main() {
 	// Combine multiple sources into a single, deduplicated source.
 	endpointsSource := source.NewDedupSource(source.NewMultiSource(sources, sourceCfg.DefaultTargets))
 
+	if cfg.SuppressIPv6 {
+		endpointsSource = source.NewSuppressedSource(endpointsSource)
+	}
+
 	// RegexDomainFilter overrides DomainFilter
 	var domainFilter endpoint.DomainFilter
 	if cfg.RegexDomainFilter.String() != "" {

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -185,6 +185,7 @@ type Config struct {
 	GoDaddyTTL                        int64
 	GoDaddyOTE                        bool
 	OCPRouterName                     string
+	SuppressIPv6                      bool
 }
 
 var defaultConfig = &Config{
@@ -312,6 +313,7 @@ var defaultConfig = &Config{
 	GoDaddySecretKey:            "",
 	GoDaddyTTL:                  600,
 	GoDaddyOTE:                  false,
+	SuppressIPv6:                false,
 }
 
 // NewConfig returns new Config object
@@ -528,6 +530,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("log-format", "The format in which log messages are printed (default: text, options: text, json)").Default(defaultConfig.LogFormat).EnumVar(&cfg.LogFormat, "text", "json")
 	app.Flag("metrics-address", "Specify where to serve the metrics and health check endpoint (default: :7979)").Default(defaultConfig.MetricsAddress).StringVar(&cfg.MetricsAddress)
 	app.Flag("log-level", "Set the level of logging. (default: info, options: panic, debug, info, warning, error, fatal").Default(defaultConfig.LogLevel).EnumVar(&cfg.LogLevel, allLogLevelsAsStrings()...)
+	app.Flag("suppress-ipv6", "Filter out IPv6 addresses from source endpoints to avoid compatibility issues").Default("false").BoolVar(&cfg.SuppressIPv6)
 
 	_, err := app.Parse(args)
 	if err != nil {

--- a/source/suppress_ipv6.go
+++ b/source/suppress_ipv6.go
@@ -1,0 +1,57 @@
+package source
+
+import (
+	"context"
+	log "github.com/sirupsen/logrus"
+	"net"
+	"sigs.k8s.io/external-dns/endpoint"
+)
+
+type suppressedSource struct {
+	unfiltered Source
+}
+
+func NewSuppressedSource(original Source) Source {
+	return &suppressedSource{
+		unfiltered: original,
+	}
+}
+
+func getIp4Targets(targets endpoint.Targets) endpoint.Targets {
+	result := []string{}
+	for _, target := range targets {
+		ip := net.ParseIP(target)
+		if ip != nil && ip.To4() != nil {
+			// This is an IPv4
+			result = append(result, target)
+		} else {
+			log.Debugf("Suppressed %s, not IPv4 address", target)
+		}
+	}
+	return result
+}
+
+func (s *suppressedSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	endpoints, err := s.unfiltered.Endpoints(ctx)
+	if err != nil {
+		return endpoints, err
+	}
+	results := []*endpoint.Endpoint{}
+	for _, endpoint := range endpoints {
+		targets := getIp4Targets(endpoint.Targets)
+		if len(targets) > 0 {
+			endpointCopy := *endpoint
+			endpointCopy.Targets = targets
+
+			results = append(results, &endpointCopy)
+		} else {
+			log.Debugf("Suppressed %s. No IPv4 targets", endpoint.DNSName)
+		}
+	}
+
+	return results, nil
+}
+
+func (s *suppressedSource) AddEventHandler(ctx context.Context, f func()) {
+	s.unfiltered.AddEventHandler(ctx, f)
+}

--- a/source/suppress_ipv6_test.go
+++ b/source/suppress_ipv6_test.go
@@ -1,0 +1,82 @@
+package source
+
+import (
+	"context"
+	"github.com/stretchr/testify/suite"
+	"sigs.k8s.io/external-dns/endpoint"
+	"testing"
+)
+
+type mockSource struct {
+	endpoints []*endpoint.Endpoint
+}
+
+func (m *mockSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	return m.endpoints, nil
+}
+
+func (m mockSource) AddEventHandler(ctx context.Context, f func()) {
+	// NOP
+}
+
+func MockSource(endpoints []*endpoint.Endpoint) Source {
+	return &mockSource{
+		endpoints: endpoints,
+	}
+}
+
+type SuppressIPv6TestSuite struct {
+	suite.Suite
+}
+
+func TestSuppressIPv6(t *testing.T) {
+	suite.Run(t, new(SuppressIPv6TestSuite))
+}
+
+func (s *SuppressIPv6TestSuite) TestGetIPv4Targets() {
+	s.Len(getIp4Targets([]string{"xxx.biz", "::1"}), 0)
+
+	s.Equal([]string{"192.168.113.1"}, []string(
+		getIp4Targets([]string{
+			"192.168.113.1",
+			"2001:470:1f09:370:b73b:1902:5ab9:e7d",
+		},
+		),
+	))
+}
+
+func (s *SuppressIPv6TestSuite) TestEndpointsRemoved() {
+	endpoints := []*endpoint.Endpoint{
+		&endpoint.Endpoint{
+			DNSName:    "notargets.tailify.com",
+			Targets:    []string{"2001::1", "2002::2"},
+			RecordType: "A",
+			RecordTTL:  300,
+		},
+		&endpoint.Endpoint{
+			DNSName:    "targets.tailify.com",
+			Targets:    []string{"2001::1", "8.8.8.8"},
+			RecordType: "A",
+			RecordTTL:  300,
+		},
+	}
+	ms := MockSource(endpoints)
+
+	ss := NewSuppressedSource(ms)
+
+	expected := []*endpoint.Endpoint{
+		&endpoint.Endpoint{
+			DNSName:    "targets.tailify.com",
+			Targets:    []string{"8.8.8.8"},
+			RecordType: "A",
+			RecordTTL:  300,
+		},
+	}
+
+	ctx := context.TODO()
+
+	endps, err := ss.Endpoints(ctx)
+	s.Nil(err)
+	s.Equal(expected, endps)
+
+}


### PR DESCRIPTION
Signed-off-by: Alexey Kharlamov <alexey@kharlamov.biz>

**Description**
While a Kubernetes cluster can work in IPv4 model only, external load balancers may have IPv6 addresses. Thus, external-dns providers may not work correctly. 

`--suppress-ipv6` command-line argument must be provided to enable the functionality.

Fixes #2300 by filtering out all IPv6 addresses provided by sources. 

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
