### PR TITLE
Do not reschedule, if already scheduled in the next MinInterval

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -242,7 +242,11 @@ func filterARecords(endpoints []*endpoint.Endpoint) []string {
 func (c *Controller) ScheduleRunOnce(now time.Time) {
 	c.nextRunAtMux.Lock()
 	defer c.nextRunAtMux.Unlock()
-	c.nextRunAt = now.Add(c.MinEventSyncInterval)
+	// Shedule only if a reconciliation is not already planned
+	// to happen in the following c.MinEventSyncInterval
+	if !c.nextRunAt.Before(now.Add(c.MinEventSyncInterval)) {
+		c.nextRunAt = now.Add(c.MinEventSyncInterval)
+	}
 }
 
 func (c *Controller) ShouldRunOnce(now time.Time) bool {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -242,7 +242,7 @@ func filterARecords(endpoints []*endpoint.Endpoint) []string {
 func (c *Controller) ScheduleRunOnce(now time.Time) {
 	c.nextRunAtMux.Lock()
 	defer c.nextRunAtMux.Unlock()
-	// Shedule only if a reconciliation is not already planned
+	// schedule only if a reconciliation is not already planned
 	// to happen in the following c.MinEventSyncInterval
 	if !c.nextRunAt.Before(now.Add(c.MinEventSyncInterval)) {
 		c.nextRunAt = now.Add(c.MinEventSyncInterval)


### PR DESCRIPTION
**Description**

When cfg.UpdateEvents is true, any service or ingress change in the Source, is invoking ctrl.ScheduleRunOnce, allowing a reconciliation to be eventually scheduled earlier than cfg.Interval, but not more often than cfg.MinEventSyncInterval.

The **problem** happens in a scenario where services or ingresses changes happen more often than cfg.MinEventSyncInterval, because the Controller.nextRunAt is **recalculated** as now + cfg.MinEventSyncInterval, allowing the next reconciliation to be pushed forward, even if it is already planned to happen, eventually even further than cfg.Interval and virtually forever.

For the sake of the example, in a very busy K8s cluster, in which one service is updated once every second, while the cfg.MinEventSyncInterval set to something bigger than one second, the reconciliation never happens.

The change I am submitting for your review, blocks the Controller.nextRunAt from being recalculated, if a reconciliation is already planned to happen sooner than the cfg.MinEventSyncInterval.
Alternatively, the cfg.Interval could be used instead of cfg.MinEventSyncInterval, as a maximum amount of time that a reconciliation is allowed to be delayed.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE.
There is no issue opened on this topic.

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated - I found no documentation around this topic.

PS: This is my first PR. Looking forward for any feedback. Thanks!
