### PR TITLE
Fixed AWS-SD endpoints deregister

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -89,6 +89,28 @@ func (t Targets) Same(o Targets) bool {
 	return true
 }
 
+// Checks if targets constain specified target (case-insensitive)
+func (targets Targets) Contains(target string) bool {
+	for _, t := range targets {
+		if strings.EqualFold(target, t) {
+			return true
+		}
+	}
+	return false
+}
+
+// Subtracts specified targets from current
+func (targets Targets) Sub(another Targets) Targets {
+	result := []string{}
+
+	for _, target := range targets {
+		if !another.Contains(target) {
+			result = append(result, target)
+		}
+	}
+	return Targets(result)
+}
+
 // IsLess should fulfill the requirement to compare two targets and choose the 'lesser' one.
 // In the past target was a simple string so simple string comparison could be used. Now we define 'less'
 // as either being the shorter list of targets or where the first entry is less.

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -76,3 +76,31 @@ func TestSameFailures(t *testing.T) {
 		}
 	}
 }
+
+func TestSub(t *testing.T) {
+	tests := []struct {
+		a        Targets
+		b        Targets
+		expected Targets
+	}{
+		{
+			[]string{"1.2.3.4"},
+			[]string{"4.3.2.1"},
+			[]string{"1.2.3.4"},
+		}, {
+			[]string{"1.2.3.4", "4.3.2.1"},
+			[]string{"1.2.3.4"},
+			[]string{"4.3.2.1"},
+		}, {
+			[]string{"1.2.3.4", "4.3.2.1"},
+			[]string{"1.2.3.4", "4.3.2.1"},
+			[]string{},
+		},
+	}
+
+	for _, d := range tests {
+		if d.a.Sub(d.b).Same(d.expected) == false {
+			t.Errorf("%#v difference with %#v should equal %#v", d.a, d.b, d.expected)
+		}
+	}
+}

--- a/provider/awssd/aws_sd.go
+++ b/provider/awssd/aws_sd.go
@@ -252,8 +252,9 @@ func (p *AWSSDProvider) updatesToCreates(changes *plan.Changes) (creates []*endp
 	for _, old := range changes.UpdateOld {
 		current := updateNewMap[old.DNSName]
 
-		if !old.Targets.Same(current.Targets) {
-			// when targets differ the old instances need to be de-registered first
+		targetsToDelete := old.Targets.Sub(current.Targets)
+		if targetsToDelete.Len() > 0 {
+			old.Targets = targetsToDelete
 			deletes = append(deletes, old)
 		}
 

--- a/provider/awssd/aws_sd_test.go
+++ b/provider/awssd/aws_sd_test.go
@@ -337,9 +337,30 @@ func TestAWSSDProvider_ApplyChanges(t *testing.T) {
 	assert.True(t, testutils.SameEndpoints(expectedEndpoints, endpoints), "expected and actual endpoints don't match, expected=%v, actual=%v", expectedEndpoints, endpoints)
 
 	ctx = context.Background()
+
+	provider.ApplyChanges(ctx, &plan.Changes{
+		UpdateNew: []*endpoint.Endpoint{
+			{DNSName: "service1.private.com", Targets: endpoint.Targets{"1.2.3.4"}, RecordType: endpoint.RecordTypeA, RecordTTL: 60},
+		},
+		UpdateOld: []*endpoint.Endpoint{
+			{DNSName: "service1.private.com", Targets: endpoint.Targets{"1.2.3.4", "1.2.3.5"}, RecordType: endpoint.RecordTypeA, RecordTTL: 60},
+		},
+	})
+
+	endpointsAfterUpdate := []*endpoint.Endpoint{
+		{DNSName: "service1.private.com", Targets: endpoint.Targets{"1.2.3.4"}, RecordType: endpoint.RecordTypeA, RecordTTL: 60},
+		{DNSName: "service2.private.com", Targets: endpoint.Targets{"load-balancer.us-east-1.elb.amazonaws.com"}, RecordType: endpoint.RecordTypeCNAME, RecordTTL: 80},
+		{DNSName: "service3.private.com", Targets: endpoint.Targets{"cname.target.com"}, RecordType: endpoint.RecordTypeCNAME, RecordTTL: 100},
+	}
+
+	assert.NotNil(t, existingServices["service1"])
+	endpoints, _ = provider.Records(ctx)
+	assert.True(t, testutils.SameEndpoints(endpointsAfterUpdate, endpoints), "expected and actual endpoints don't match, expected=%v, actual=%v", endpointsAfterUpdate, endpoints)
+
+	ctx = context.Background()
 	// apply deletes
 	provider.ApplyChanges(ctx, &plan.Changes{
-		Delete: expectedEndpoints,
+		Delete: endpointsAfterUpdate,
 	})
 
 	// make sure all instances are gone


### PR DESCRIPTION
We use extdns with AWS SD provider. If one of our instances for the particular service becomes stale, all instance are deleted and re-registered:
```
{"level":"info","msg":"De-registering an instance \"<ip-1>\" for service \"<svc>\" (srv-...)","time":"..."}
{"level":"info","msg":"De-registering an instance \"<ip-2>\" for service \"<svc>\" (srv-...)","time":"..."}
{"level":"info","msg":"De-registering an instance \"<ip-3>\" for service \"<svc>\" (srv-...)","time":"..."}
{"level":"info","msg":"De-registering an instance \"<ip-4>\" for service \"<svc>\" (srv-...)","time":"..."}
{"level":"info","msg":"Registering a new instance \"<ip-2>\" for service \"<svc>\" (srv-...)","time":"..."}
{"level":"info","msg":"Registering a new instance \"<ip-3>\" for service \"<svc>\" (srv-...)","time":"..."}
{"level":"info","msg":"Registering a new instance \"<ip-1>\" for service \"<svc>\" (srv-...)","time":"..."}
```

This may affect user experience due to possible delay between de-register and register requests. These changes prevent instances that didn't change from deregistering. Code was deployed into production for several weeks and worked as expected