### PR TITLE
fix the helm chart installation command line

### DIFF
--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -13,7 +13,7 @@ helm repo add external-dns https://kubernetes-sigs.github.io/external-dns/
 After you've installed the repo you can install the chart.
 
 ```shell
-helm upgrade --install external-dns/external-dns
+helm upgrade --install external-dns external-dns/external-dns
 ```
 
 ## Configuration


### PR DESCRIPTION
**Description**

the release name was missing in the helm chart installation command line

Fixes N/A

**Checklist**

- [ N/A] Unit tests updated
- [ N/A] End user documentation updated
