### PR TITLE
Azure provider: Fix "Failed to extract targets" for Alias record sets

### DIFF
--- a/provider/azure/azure.go
+++ b/provider/azure/azure.go
@@ -432,5 +432,13 @@ func extractAzureTargets(recordSet *dns.RecordSet) []string {
 			return []string{(*values)[0]}
 		}
 	}
+
+	// Check for A, CNAME records with 'Alias record set' pointed to Azure resource
+	// https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/dns/dns-alias.md
+	targetResource := properties.TargetResource
+	if targetResource != nil && targetResource.ID != nil {
+		return []string{*targetResource.ID}
+	}
+
 	return []string{}
 }


### PR DESCRIPTION
**Description**

Fix Azure provider targets extraction for A/CNAME records with [Alias record set](https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/dns/dns-alias.md) option

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2613

Example of RecordSetProperties object with TargetResource.ID (A record with `alias record set`)

![exx](https://user-images.githubusercontent.com/2057180/154934883-eb1bdc85-025a-45f1-81dc-7c6d3234b2fa.png)

Before PR:
```
time="..." level=error msg="Failed to extract targets for 'some-record.example.domain' with type 'A'."
```

After PR:
```
time="..." level=debug msg="Found A record for 'some-record.example.domain' with target '/subscriptions/.../resourceGroups/.../providers/Microsoft.Network/frontdoors/afd-example'."
```

**Checklist**

- [x] Unit tests updated - _nothing to do_
- [x] End user documentation updated - _nothing to do_
