### PR TITLE
Add support for multiple namespace watch on external-dns service source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,7 @@ COPY go.sum .
 RUN go mod download
 
 COPY . .
-RUN make build.$ARCH
-# RUN make test build.$ARCH
+RUN make test build.$ARCH
 
 # final image
 FROM $ARCH/alpine:3.15

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ COPY go.sum .
 RUN go mod download
 
 COPY . .
-RUN make test build.$ARCH
+RUN make build.$ARCH
+# RUN make test build.$ARCH
 
 # final image
 FROM $ARCH/alpine:3.15

--- a/Makefile
+++ b/Makefile
@@ -145,3 +145,30 @@ release.staging:
 
 release.prod:
 	$(MAKE) build.push/multiarch
+
+# ================= Kind deployment
+
+KIND_CLUSTER="edns"
+
+kind-up:
+	kind create cluster \
+		--image kindest/node:v1.23.0@sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac \
+		--name $(KIND_CLUSTER) \
+		--config zarf/kind/kind-config.yaml
+	kubectl config set-context --current --namespace=default
+
+kind-down:
+	kind delete cluster --name $(KIND_CLUSTER)
+
+kind-load:
+	kind load docker-image "$(IMAGE):$(VERSION)" --name $(KIND_CLUSTER)
+
+kind-apply:
+	kubectl apply -f zarf/helm/rolebinding.yaml
+	helm template edns charts/external-dns -f zarf/helm/custom-values.yaml --set image.repository=$(IMAGE) --set image.tag=$(VERSION) | kubectl apply -f -
+	kubectl apply -f zarf/helm/service.yaml
+
+kind-update: build build.docker kind-load kind-apply
+
+kind-logs:
+	kubectl logs deployment/edns-external-dns -f

--- a/source/compatibility.go
+++ b/source/compatibility.go
@@ -138,30 +138,32 @@ func legacyEndpointsFromDNSControllerNodePortService(svc *v1.Service, sc *servic
 		return nil, nil
 	}
 
-	nodes, err := sc.nodeInformer.Lister().List(labels.Everything())
-	if err != nil {
-		return nil, err
-	}
+	for _, informer := range sc.informers {
+		nodes, err := informer.nodeInformer.Lister().List(labels.Everything())
+		if err != nil {
+			return nil, err
+		}
 
-	var hostnameList []string
-	if isExternal {
-		hostnameList = strings.Split(strings.Replace(hostnameAnnotation, " ", "", -1), ",")
-	} else {
-		hostnameList = strings.Split(strings.Replace(internalHostnameAnnotation, " ", "", -1), ",")
-	}
+		var hostnameList []string
+		if isExternal {
+			hostnameList = strings.Split(strings.Replace(hostnameAnnotation, " ", "", -1), ",")
+		} else {
+			hostnameList = strings.Split(strings.Replace(internalHostnameAnnotation, " ", "", -1), ",")
+		}
 
-	for _, hostname := range hostnameList {
-		for _, node := range nodes {
-			_, isNode := node.Labels["node-role.kubernetes.io/node"]
-			if !isNode {
-				continue
-			}
-			for _, address := range node.Status.Addresses {
-				if address.Type == v1.NodeExternalIP && isExternal {
-					endpoints = append(endpoints, endpoint.NewEndpoint(hostname, endpoint.RecordTypeA, address.Address))
+		for _, hostname := range hostnameList {
+			for _, node := range nodes {
+				_, isNode := node.Labels["node-role.kubernetes.io/node"]
+				if !isNode {
+					continue
 				}
-				if address.Type == v1.NodeInternalIP && isInternal {
-					endpoints = append(endpoints, endpoint.NewEndpoint(hostname, endpoint.RecordTypeA, address.Address))
+				for _, address := range node.Status.Addresses {
+					if address.Type == v1.NodeExternalIP && isExternal {
+						endpoints = append(endpoints, endpoint.NewEndpoint(hostname, endpoint.RecordTypeA, address.Address))
+					}
+					if address.Type == v1.NodeInternalIP && isInternal {
+						endpoints = append(endpoints, endpoint.NewEndpoint(hostname, endpoint.RecordTypeA, address.Address))
+					}
 				}
 			}
 		}

--- a/source/service.go
+++ b/source/service.go
@@ -76,9 +76,9 @@ func NewServiceSource(ctx context.Context, kubeClient kubernetes.Interface, name
 	// Set resync period to 0, to prevent processing when nothing has changed
 	informerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 0, kubeinformers.WithNamespace(namespace))
 	serviceInformer := informerFactory.Core().V1().Services()
-	endpointsInformer := informerFactory.Core().V1().Endpoints()
-	podInformer := informerFactory.Core().V1().Pods()
-	nodeInformer := informerFactory.Core().V1().Nodes()
+	// endpointsInformer := informerFactory.Core().V1().Endpoints()
+	// podInformer := informerFactory.Core().V1().Pods()
+	// nodeInformer := informerFactory.Core().V1().Nodes()
 
 	// Add default resource event handlers to properly initialize informer.
 	serviceInformer.Informer().AddEventHandler(
@@ -87,24 +87,24 @@ func NewServiceSource(ctx context.Context, kubeClient kubernetes.Interface, name
 			},
 		},
 	)
-	endpointsInformer.Informer().AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-			},
-		},
-	)
-	podInformer.Informer().AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-			},
-		},
-	)
-	nodeInformer.Informer().AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-			},
-		},
-	)
+	// endpointsInformer.Informer().AddEventHandler(
+	// 	cache.ResourceEventHandlerFuncs{
+	// 		AddFunc: func(obj interface{}) {
+	// 		},
+	// 	},
+	// )
+	// podInformer.Informer().AddEventHandler(
+	// 	cache.ResourceEventHandlerFuncs{
+	// 		AddFunc: func(obj interface{}) {
+	// 		},
+	// 	},
+	// )
+	// nodeInformer.Informer().AddEventHandler(
+	// 	cache.ResourceEventHandlerFuncs{
+	// 		AddFunc: func(obj interface{}) {
+	// 		},
+	// 	},
+	// )
 
 	informerFactory.Start(ctx.Done())
 
@@ -132,9 +132,9 @@ func NewServiceSource(ctx context.Context, kubeClient kubernetes.Interface, name
 		publishHostIP:                  publishHostIP,
 		alwaysPublishNotReadyAddresses: alwaysPublishNotReadyAddresses,
 		serviceInformer:                serviceInformer,
-		endpointsInformer:              endpointsInformer,
-		podInformer:                    podInformer,
-		nodeInformer:                   nodeInformer,
+		endpointsInformer:              nil,
+		podInformer:                    nil,
+		nodeInformer:                   nil,
 		serviceTypeFilter:              serviceTypes,
 		labelSelector:                  labelSelector,
 	}, nil

--- a/source/service.go
+++ b/source/service.go
@@ -57,12 +57,17 @@ type serviceSource struct {
 	publishInternal                bool
 	publishHostIP                  bool
 	alwaysPublishNotReadyAddresses bool
-	serviceInformer                coreinformers.ServiceInformer
-	endpointsInformer              coreinformers.EndpointsInformer
-	podInformer                    coreinformers.PodInformer
-	nodeInformer                   coreinformers.NodeInformer
+	informers                      []informersMap
 	serviceTypeFilter              map[string]struct{}
 	labelSelector                  labels.Selector
+}
+
+type informersMap struct {
+	namespace         string
+	serviceInformer   coreinformers.ServiceInformer
+	endpointsInformer coreinformers.EndpointsInformer
+	podInformer       coreinformers.PodInformer
+	nodeInformer      coreinformers.NodeInformer
 }
 
 // NewServiceSource creates a new serviceSource with the given config.
@@ -72,51 +77,75 @@ func NewServiceSource(ctx context.Context, kubeClient kubernetes.Interface, name
 		return nil, err
 	}
 
-	// Use shared informers to listen for add/update/delete of services/pods/nodes in the specified namespace.
-	// Set resync period to 0, to prevent processing when nothing has changed
-	informerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 0, kubeinformers.WithNamespace(namespace))
-	serviceInformer := informerFactory.Core().V1().Services()
-	endpointsInformer := informerFactory.Core().V1().Endpoints()
-	podInformer := informerFactory.Core().V1().Pods()
+	/*
+		Assume namespace can be "ns1,ns2,ns3"
+		Step 1:
+			Split by ','
+		Step 2:
+			Modify interface to return map[string]
+	*/
 
-	// Add default resource event handlers to properly initialize informer.
-	serviceInformer.Informer().AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-			},
-		},
-	)
-	endpointsInformer.Informer().AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-			},
-		},
-	)
-	podInformer.Informer().AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-			},
-		},
-	)
+	namespaces := removeDuplicateValues(strings.Split(namespace, ","))
+	var informers []informersMap
 
-	var nodeInformer coreinformers.NodeInformer
+	for _, entry := range namespaces {
+		// Use shared informers to listen for add/update/delete of services/pods/nodes in the specified namespace.
+		// Set resync period to 0, to prevent processing when nothing has changed
+		informerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 0, kubeinformers.WithNamespace(entry))
+		serviceInformer := informerFactory.Core().V1().Services()
+		endpointsInformer := informerFactory.Core().V1().Endpoints()
+		podInformer := informerFactory.Core().V1().Pods()
 
-	if contains(serviceTypeFilter, "NodePort") || len(serviceTypeFilter) == 0 {
-		nodeInformer = informerFactory.Core().V1().Nodes()
-
-		nodeInformer.Informer().AddEventHandler(
+		// Add default resource event handlers to properly initialize informer.
+		serviceInformer.Informer().AddEventHandler(
 			cache.ResourceEventHandlerFuncs{
 				AddFunc: func(obj interface{}) {
 				},
 			},
 		)
-	}
+		endpointsInformer.Informer().AddEventHandler(
+			cache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {
+				},
+			},
+		)
+		podInformer.Informer().AddEventHandler(
+			cache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {
+				},
+			},
+		)
 
-	informerFactory.Start(ctx.Done())
+		var nodeInformer coreinformers.NodeInformer
 
-	// wait for the local cache to be populated.
-	if err := waitForCacheSync(context.Background(), informerFactory); err != nil {
-		return nil, err
+		if contains(serviceTypeFilter, "NodePort") || len(serviceTypeFilter) == 0 {
+			nodeInformer = informerFactory.Core().V1().Nodes()
+
+			nodeInformer.Informer().AddEventHandler(
+				cache.ResourceEventHandlerFuncs{
+					AddFunc: func(obj interface{}) {
+					},
+				},
+			)
+		}
+
+		informersMap := informersMap{
+			namespace:         entry,
+			serviceInformer:   serviceInformer,
+			endpointsInformer: endpointsInformer,
+			podInformer:       podInformer,
+			nodeInformer:      nodeInformer,
+		}
+
+		informers = append(informers, informersMap)
+
+		informerFactory.Start(ctx.Done())
+
+		// wait for the local cache to be populated.
+		if err := waitForCacheSync(context.Background(), informerFactory); err != nil {
+			return nil, err
+		}
+
 	}
 
 	// Transform the slice into a map so it will
@@ -137,10 +166,7 @@ func NewServiceSource(ctx context.Context, kubeClient kubernetes.Interface, name
 		publishInternal:                publishInternal,
 		publishHostIP:                  publishHostIP,
 		alwaysPublishNotReadyAddresses: alwaysPublishNotReadyAddresses,
-		serviceInformer:                serviceInformer,
-		endpointsInformer:              endpointsInformer,
-		podInformer:                    podInformer,
-		nodeInformer:                   nodeInformer,
+		informers:                      informers,
 		serviceTypeFilter:              serviceTypes,
 		labelSelector:                  labelSelector,
 	}, nil
@@ -148,65 +174,67 @@ func NewServiceSource(ctx context.Context, kubeClient kubernetes.Interface, name
 
 // Endpoints returns endpoint objects for each service that should be processed.
 func (sc *serviceSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error) {
-	services, err := sc.serviceInformer.Lister().Services(sc.namespace).List(sc.labelSelector)
-	if err != nil {
-		return nil, err
-	}
-	services, err = sc.filterByAnnotations(services)
-	if err != nil {
-		return nil, err
-	}
-
-	// filter on service types if at least one has been provided
-	if len(sc.serviceTypeFilter) > 0 {
-		services = sc.filterByServiceType(services)
-	}
-
 	endpoints := []*endpoint.Endpoint{}
+	for _, informer := range sc.informers {
 
-	for _, svc := range services {
-		// Check controller annotation to see if we are responsible.
-		controller, ok := svc.Annotations[controllerAnnotationKey]
-		if ok && controller != controllerAnnotationValue {
-			log.Debugf("Skipping service %s/%s because controller value does not match, found: %s, required: %s",
-				svc.Namespace, svc.Name, controller, controllerAnnotationValue)
-			continue
+		services, err := informer.serviceInformer.Lister().Services(informer.namespace).List(sc.labelSelector)
+		if err != nil {
+			return nil, err
 		}
 
-		svcEndpoints := sc.endpoints(svc)
+		services, err = sc.filterByAnnotations(services)
+		if err != nil {
+			return nil, err
+		}
 
-		// process legacy annotations if no endpoints were returned and compatibility mode is enabled.
-		if len(svcEndpoints) == 0 && sc.compatibility != "" {
-			svcEndpoints, err = legacyEndpointsFromService(svc, sc)
-			if err != nil {
-				return nil, err
+		// filter on service types if at least one has been provided
+		if len(sc.serviceTypeFilter) > 0 {
+			services = sc.filterByServiceType(services)
+		}
+
+		for _, svc := range services {
+			// Check controller annotation to see if we are responsible.
+			controller, ok := svc.Annotations[controllerAnnotationKey]
+			if ok && controller != controllerAnnotationValue {
+				log.Debugf("Skipping service %s/%s because controller value does not match, found: %s, required: %s",
+					svc.Namespace, svc.Name, controller, controllerAnnotationValue)
+				continue
 			}
-		}
 
-		// apply template if none of the above is found
-		if (sc.combineFQDNAnnotation || len(svcEndpoints) == 0) && sc.fqdnTemplate != nil {
-			sEndpoints, err := sc.endpointsFromTemplate(svc)
-			if err != nil {
-				return nil, err
+			svcEndpoints := sc.endpoints(svc)
+
+			// process legacy annotations if no endpoints were returned and compatibility mode is enabled.
+			if len(svcEndpoints) == 0 && sc.compatibility != "" {
+				svcEndpoints, err = legacyEndpointsFromService(svc, sc)
+				if err != nil {
+					return nil, err
+				}
 			}
 
-			if sc.combineFQDNAnnotation {
-				svcEndpoints = append(svcEndpoints, sEndpoints...)
-			} else {
-				svcEndpoints = sEndpoints
+			// apply template if none of the above is found
+			if (sc.combineFQDNAnnotation || len(svcEndpoints) == 0) && sc.fqdnTemplate != nil {
+				sEndpoints, err := sc.endpointsFromTemplate(svc)
+				if err != nil {
+					return nil, err
+				}
+
+				if sc.combineFQDNAnnotation {
+					svcEndpoints = append(svcEndpoints, sEndpoints...)
+				} else {
+					svcEndpoints = sEndpoints
+				}
 			}
-		}
 
-		if len(svcEndpoints) == 0 {
-			log.Debugf("No endpoints could be generated from service %s/%s", svc.Namespace, svc.Name)
-			continue
-		}
+			if len(svcEndpoints) == 0 {
+				log.Debugf("No endpoints could be generated from service %s/%s", svc.Namespace, svc.Name)
+				continue
+			}
 
-		log.Debugf("Endpoints generated from service: %s/%s: %v", svc.Namespace, svc.Name, svcEndpoints)
-		sc.setResourceLabel(svc, svcEndpoints)
-		endpoints = append(endpoints, svcEndpoints...)
+			log.Debugf("Endpoints generated from service: %s/%s: %v", svc.Namespace, svc.Name, svcEndpoints)
+			sc.setResourceLabel(svc, svcEndpoints)
+			endpoints = append(endpoints, svcEndpoints...)
+		}
 	}
-
 	// this sorting is required to make merging work.
 	// after we merge endpoints that have same DNS, we want to ensure that we end up with the same service being an "owner"
 	// of all those records, as otherwise each time we update, we will end up with a different service that gets data merged in
@@ -257,13 +285,17 @@ func (sc *serviceSource) extractHeadlessEndpoints(svc *v1.Service, hostname stri
 		return nil
 	}
 
-	endpointsObject, err := sc.endpointsInformer.Lister().Endpoints(svc.Namespace).Get(svc.GetName())
+	// TO DO: treat no namespace given
+	// extract the informer for the specific namespace
+	informer := getInformerByNamespace(sc.informers, svc.Namespace)
+
+	endpointsObject, err := informer.endpointsInformer.Lister().Endpoints(svc.Namespace).Get(svc.GetName())
 	if err != nil {
 		log.Errorf("Get endpoints of service[%s] error:%v", svc.GetName(), err)
 		return endpoints
 	}
 
-	pods, err := sc.podInformer.Lister().Pods(svc.Namespace).List(selector)
+	pods, err := informer.podInformer.Lister().Pods(svc.Namespace).List(selector)
 	if err != nil {
 		log.Errorf("List Pods of service[%s] error:%v", svc.GetName(), err)
 		return endpoints
@@ -554,6 +586,9 @@ func (sc *serviceSource) extractNodePortTargets(svc *v1.Service) (endpoint.Targe
 		err         error
 	)
 
+	// extract the informer for the specific namespace
+	informer := getInformerByNamespace(sc.informers, svc.Namespace)
+
 	switch svc.Spec.ExternalTrafficPolicy {
 	case v1.ServiceExternalTrafficPolicyTypeLocal:
 		nodesMap := map[*v1.Node]struct{}{}
@@ -565,14 +600,14 @@ func (sc *serviceSource) extractNodePortTargets(svc *v1.Service) (endpoint.Targe
 		if err != nil {
 			return nil, err
 		}
-		pods, err := sc.podInformer.Lister().Pods(svc.Namespace).List(selector)
+		pods, err := informer.podInformer.Lister().Pods(svc.Namespace).List(selector)
 		if err != nil {
 			return nil, err
 		}
 
 		for _, v := range pods {
 			if v.Status.Phase == v1.PodRunning {
-				node, err := sc.nodeInformer.Lister().Get(v.Spec.NodeName)
+				node, err := informer.nodeInformer.Lister().Get(v.Spec.NodeName)
 				if err != nil {
 					log.Debugf("Unable to find node where Pod %s is running", v.Spec.Hostname)
 					continue
@@ -584,7 +619,7 @@ func (sc *serviceSource) extractNodePortTargets(svc *v1.Service) (endpoint.Targe
 			}
 		}
 	default:
-		nodes, err = sc.nodeInformer.Lister().List(labels.Everything())
+		nodes, err = informer.nodeInformer.Lister().List(labels.Everything())
 		if err != nil {
 			return nil, err
 		}
@@ -656,9 +691,11 @@ func (sc *serviceSource) extractNodePortEndpoints(svc *v1.Service, nodeTargets e
 func (sc *serviceSource) AddEventHandler(ctx context.Context, handler func()) {
 	log.Debug("Adding event handler for service")
 
-	// Right now there is no way to remove event handler from informer, see:
-	// https://github.com/kubernetes/kubernetes/issues/79610
-	sc.serviceInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
+	for _, informer := range sc.informers {
+		// Right now there is no way to remove event handler from informer, see:
+		// https://github.com/kubernetes/kubernetes/issues/79610
+		informer.serviceInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
+	}
 }
 
 func contains(s []string, str string) bool {
@@ -669,4 +706,32 @@ func contains(s []string, str string) bool {
 	}
 
 	return false
+}
+
+func removeDuplicateValues(strSlice []string) []string {
+	keys := make(map[string]bool)
+	list := []string{}
+
+	// If the key(values of the slice) is not equal
+	// to the already present value in new slice (list)
+	// then we append it. else we jump on another element.
+	for _, entry := range strSlice {
+		if _, value := keys[entry]; !value {
+			keys[entry] = true
+			list = append(list, entry)
+		}
+	}
+	return list
+}
+
+func getInformerByNamespace(informers []informersMap, namespace string) informersMap {
+	var informer informersMap
+	for _, entry := range informers {
+		if entry.namespace == namespace || entry.namespace == "" {
+			informer = entry
+			break
+		}
+	}
+
+	return informer
 }

--- a/zarf/helm/custom-values.yaml
+++ b/zarf/helm/custom-values.yaml
@@ -1,0 +1,15 @@
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: false
+
+sources:
+  - service
+
+interval: 10s
+logLevel: debug
+extraArgs:
+  - --domain-filter=test.domain.net
+  - --namespace=default
+  - --service-type-filter=ExternalName
+
+provider: inmemory

--- a/zarf/helm/rolebinding.yaml
+++ b/zarf/helm/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rb-external-dns
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: edns-external-dns
+  namespace: default

--- a/zarf/helm/service.yaml
+++ b/zarf/helm/service.yaml
@@ -1,0 +1,9 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: inmemory-service2
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: my-dns-test.test.domain.net
+spec:
+  type: ExternalName
+  externalName: 192.168.10.10

--- a/zarf/kind/kind-config.yaml
+++ b/zarf/kind/kind-config.yaml
@@ -1,0 +1,17 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 3000
+    hostPort: 3000
+  - containerPort: 3001
+    hostPort: 3001
+  - containerPort: 4000
+    hostPort: 4000
+  - containerPort: 4001
+    hostPort: 4001
+  - containerPort: 9411
+    hostPort: 9411
+  - containerPort: 5432
+    hostPort: 5432


### PR DESCRIPTION
**Description**
Added zarf folder to hold kind config and helm testing values.
Added Makefile commands for kind.
Made nodeInformer be active only when using either no service-type-filter (aka all) or when using NodePorts.
Added support for multinamespace watch (service only source for now).

**Checklist**

- [X] Unit tests updated
- [X] End user documentation updated
