### PR TITLE
Publishing external-dns As A provider

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ import (
 	"sigs.k8s.io/external-dns/provider/dnsimple"
 	"sigs.k8s.io/external-dns/provider/dyn"
 	"sigs.k8s.io/external-dns/provider/exoscale"
+	externaldnsprovider "sigs.k8s.io/external-dns/provider/externaldns"
 	"sigs.k8s.io/external-dns/provider/gandi"
 	"sigs.k8s.io/external-dns/provider/godaddy"
 	"sigs.k8s.io/external-dns/provider/google"
@@ -230,6 +231,20 @@ func main() {
 		p, err = ovh.NewOVHProvider(ctx, domainFilter, cfg.OVHEndpoint, cfg.OVHApiRateLimit, cfg.DryRun)
 	case "linode":
 		p, err = linode.NewLinodeProvider(domainFilter, cfg.DryRun, externaldns.Version)
+	case "externaldns":
+		p, err = externaldnsprovider.NewExternalDns(&externaldnsprovider.ExternalDnsProviderConfig{
+			CaCrt:          cfg.ExternalDnsCaCrt,
+			CaCrtPath:      cfg.ExternalDnsCaCrtPath,
+			Namespace:      cfg.ExternalDnsNamespace,
+			NamespacePath:  cfg.ExternalDnsNamespacePath,
+			Token:          cfg.ExternalDnsToken,
+			TokenPath:      cfg.ExternalDnsTokenPath,
+			KubernetesHost: cfg.ExternalDnsKubernetesHost,
+			KubernetesPort: cfg.ExternalDnsKubernetesPort,
+			CrName:         cfg.ExternalDnsCrName,
+			CrdApiVersion:  cfg.CRDSourceAPIVersion,
+			CrdKind:        cfg.CRDSourceKind,
+		}, cfg.DryRun)
 	case "dnsimple":
 		p, err = dnsimple.NewDnsimpleProvider(domainFilter, zoneIDFilter, cfg.DryRun)
 	case "infoblox":

--- a/pkg/apis/externaldns/types_test.go
+++ b/pkg/apis/externaldns/types_test.go
@@ -124,6 +124,15 @@ var (
 		ManagedDNSRecordTypes:       []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 		RFC2136BatchChangeSize:      50,
 		OCPRouterName:               "default",
+		ExternalDnsCaCrt:            "",
+		ExternalDnsNamespace:        "",
+		ExternalDnsToken:            "",
+		ExternalDnsCaCrtPath:        "",
+		ExternalDnsNamespacePath:    "",
+		ExternalDnsTokenPath:        "",
+		ExternalDnsCrName:           "external-dns",
+		ExternalDnsKubernetesHost:   "127.0.0.1",
+		ExternalDnsKubernetesPort:   "443",
 	}
 
 	overriddenConfig = &Config{
@@ -227,6 +236,15 @@ var (
 		DigitalOceanAPIPageSize:     100,
 		ManagedDNSRecordTypes:       []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME, endpoint.RecordTypeNS},
 		RFC2136BatchChangeSize:      100,
+		ExternalDnsCaCrt:            "",
+		ExternalDnsNamespace:        "",
+		ExternalDnsToken:            "",
+		ExternalDnsCaCrtPath:        "",
+		ExternalDnsNamespacePath:    "",
+		ExternalDnsTokenPath:        "",
+		ExternalDnsCrName:           "external-dns",
+		ExternalDnsKubernetesHost:   "127.0.0.1",
+		ExternalDnsKubernetesPort:   "443",
 	}
 )
 
@@ -358,6 +376,9 @@ func TestParseFlags(t *testing.T) {
 				"--managed-record-types=CNAME",
 				"--managed-record-types=NS",
 				"--rfc2136-batch-change-size=100",
+				"--externaldns-kubernetes-host=127.0.0.1",
+				"--externaldns-kubernetes-port=443",
+				"--externaldns-resource-name=external-dns",
 			},
 			envVars:  map[string]string{},
 			expected: overriddenConfig,

--- a/provider/externaldns/README.md
+++ b/provider/externaldns/README.md
@@ -1,0 +1,143 @@
+# External-dns provider
+
+This provider uses the external-dns CRD in an external kubernetes cluster as the provider backend. The idea is that the management cluster is the one that has access to the real provider backend. It may use tools like OpenPolicyAgent Gatekeeper or other admission controllers to centrally govern policies of which DNS entries are allowed and which are not. A workload cluster runs external-dns and only needs a ServiceAccount on the management cluster, but doesn't need credentials to the "real" provider backend.
+
+## Development using Kind
+
+As we have a workload and a management cluster, we create 2 KIND clusters, and install the CRD in both.
+In the management cluster we install a external-dns with inmemory provider (strictly this isn't required)
+and also set up a ServiceAccount `workload1-external-dns` in namespace `workload1` which we give CRUD
+permissions to the DNSEndpoint of name `workload1`.
+
+```
+kind create cluster --name kind 
+kind create cluster --name mgmt 
+kubectl config use-context kind-kind
+
+kubectl --context kind-kind apply -f docs/contributing/crd-source/crd-manifest.yaml
+kubectl --context kind-mgmt apply -f docs/contributing/crd-source/crd-manifest.yaml
+kubectl --context kind-mgmt apply -f provider/externaldns/mgmt.yaml
+```
+
+Next we extract the various values we need to run external-dns:
+```
+secretName=$(kubectl --context kind-mgmt -n workload1 get sa workload1-external-dns '-ojsonpath={.secrets[0].name}')
+kubectl --context kind-mgmt -n workload1 get secret $secretName '-ojsonpath={.data.ca\.crt}' | base64 -D > .ca.crt
+kubectl --context kind-mgmt -n workload1 get secret $secretName '-ojsonpath={.data.namespace}' | base64 -D > .namespace
+kubectl --context kind-mgmt -n workload1 get secret $secretName '-ojsonpath={.data.token}' | base64 -D > .token
+
+server=$(kubectl --context kind-mgmt config view --minify | yq e '.clusters[0].cluster.server' - | sed 's;https://;;')
+k8shost=$(echo $server | awk -F":" '{print $1}')
+k8sport=$(echo $server | awk -F":" '{print $2}')
+```
+
+Now in one console we run external-dns against the workload cluster, pointing to the mgmt cluster as the target:
+```
+kubectl config use-context kind-kind
+make && build/external-dns --source=crd --provider=externaldns --externaldns-ca-cert-path=.ca.crt --externaldns-namespace-path=.namespace --externaldns-token-path=.token --externaldns-kubernetes-host=$k8shost --externaldns-kubernetes-port=$k8sport --externaldns-resource-name=workload1
+```
+
+And in a second console we change the state of workload cluster, and then check that it has been updated in the mgmt cluster:
+```
+kubectl --context kind-kind apply -f provider/externaldns/workload1.yaml
+sleep 60
+kubectl --context kind-mgmt -n workload1 get dnsendpoint foo -oyaml
+
+kubectl --context kind-kind apply -f provider/externaldns/workload1b.yaml
+sleep 60
+kubectl --context kind-mgmt -n workload1 get dnsendpoint foo -oyaml
+
+kubectl --context kind-kind delete -f provider/externaldns/workload1.yaml
+sleep 60
+kubectl --context kind-mgmt -n workload1 get dnsendpoint foo -oyaml
+
+kubectl --context kind-kind delete -f provider/externaldns/workload1b.yaml
+sleep 60
+kubectl --context kind-mgmt -n workload1 get dnsendpoint foo -oyaml
+```
+
+## Running in Workload Cluster
+
+### One time Management config
+
+To allow for this to work, we need to ensure the SV has the following additional configuration (only admins can do this):
+```
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cl-system-wc-manager-externaldns-role
+rules:
+- apiGroups: ["externaldns.k8s.io"]
+  resources: ["dnsendpoints"]
+  verbs: ["create", "update", "delete", "get","watch","list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cl-system-wc-manager-externaldns-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cl-system-wc-manager-externaldns-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: org-system-wc
+```
+
+We could also create this per TKC (using `Role` and `RoleBinding`), and then lock down the `resourceNames` in the `Role`.
+But it is likely not necessary, as this `ClusterRole` is assigned to the TKG manager, not to the TKC. The per-TKC permissions
+are handled below.
+
+### Management config for a Workload cluster
+
+Inside the same namespace as the TKC, create this CR, which 
+```
+apiVersion: run.tanzu.vmware.com/v1alpha1
+kind: ProviderServiceAccount
+metadata:
+  name: gc-cl-externaldns
+  namespace: cl-blog
+spec:
+  ref:
+    name: gc
+  rules:
+  - apiGroups: ["externaldns.k8s.io"]
+    resources: ["dnsendpoints"]
+    resourceNames: ["gc-external-dns"]
+    verbs: ["create", "update", "delete", "get","watch","list"]
+  targetNamespace: external-dns
+  targetSecretName: svcreds
+```
+
+### Inside the Workload Cluster
+
+See `workload-external-dns.yaml` for a more complete example of how to deploy external-dns, but the key is the `PodSpec`:
+```
+    spec:
+      serviceAccountName: external-dns
+      volumes:
+      - name: svcreds
+        secret:
+          secretName: svcreds
+      containers:
+      - name: external-dns
+        # XXX: Adjust this to the right image
+        image: k8s.gcr.io/external-dns/external-dns:v0.7.6
+        args:
+        - --source=crd
+        - --source=service
+        - --provider=externaldns
+        - --externaldns-ca-cert-path=/svcreds/ca.crt
+        - --externaldns-namespace-path=/svcreds/namespace
+        - --externaldns-token-path=/svcreds/token
+        - --externaldns-kubernetes-host="supervisor.default.svc"
+        - --externaldns-kubernetes-port="6443"
+        # XXX: Adjust this to match the name set up in ProviderServiceAccount in SV
+        - --externaldns-resource-name=gc-external-dns
+        volumeMounts:
+        - name: svcreds
+          mountPath: "/svcreds"
+          readOnly: true
+```
+

--- a/provider/externaldns/externaldns.go
+++ b/provider/externaldns/externaldns.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package externaldns
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
+	"sigs.k8s.io/external-dns/source"
+)
+
+type ExternalDnsProviderConfig struct {
+	// CaCrt should contain the value of the "ca.crt" field in a K8s ServiceAccount Secret
+	CaCrt string
+	// Namespace should contain the value of the "namespace" field in a K8s ServiceAccount Secret
+	Namespace string
+	// Token should contain the value of the "token" field in a K8s ServiceAccount Secret
+	Token string
+
+	// CaCrtPath should contain a filepath to the "ca.crt" field in a K8s ServiceAccount Secret. If set, will overwrite CaCrt
+	CaCrtPath string
+	// NamespacePath should contain a filepath to the "namespace" field in a K8s ServiceAccount Secret. If set, will overwrite Namespace
+	NamespacePath string
+	// TokenPath should contain a filepath to the "token" field in a K8s ServiceAccount Secret. If set, will overwrite Token
+	TokenPath string
+
+	// CrName is the name of the DNSEndpoint CR in the target cluster, it will reside in the Namespace namespace
+	CrName string
+
+	// KubernetesHost is the hostname of the target kubernetes cluster
+	KubernetesHost string
+
+	// KubernetesPort is the port (as string) of the target kubernetes cluster
+	KubernetesPort string
+
+	// CrdApiVersion is the APIVersion of the DNSEndpoint CRD we use
+	CrdApiVersion string
+	// CrdKind is the Kind of the DNSEndpoint CRD we use
+	CrdKind string
+}
+
+// ExternalDnsProvider - dns provider that uses the DNSEndpoint CRD in a (remote)
+// kubernetes cluster, e.g. a management cluster.
+// The design is simple. There is a single DNSEndpoint CR in the target cluster,
+// and it contains all the desired endpoints. Records() fetches this CR, returns
+// the endpoint list, and ApplyChanges() updates (or creates) the CR.
+type ExternalDnsProvider struct {
+	provider.BaseProvider
+
+	dryRun      bool
+	crdClient   *rest.RESTClient
+	scheme      *runtime.Scheme
+	cfg         *ExternalDnsProviderConfig
+	crdResource string
+}
+
+type ExternalDnsInterface interface {
+       GetCurrentDnsEndpointCr(ctx context.Context) (*endpoint.DNSEndpoint, error)
+}
+
+var (
+	Cp=invokeGetCurrentDnsEndpointCr
+	readFile=os.ReadFile
+	crdClient=source.NewCRDClientForAPIVersionKindWithConfig
+	makeReq=makeRequest
+)
+
+func invokeGetCurrentDnsEndpointCr(ctx context.Context, e ExternalDnsInterface) (*endpoint.DNSEndpoint, error) {
+	return e.GetCurrentDnsEndpointCr(ctx)
+}
+
+// getCurrentDnsEndpointCr fetches the current DNSEndpoint CR in the target cluster, without error handling
+func (p *ExternalDnsProvider) GetCurrentDnsEndpointCr(ctx context.Context) (*endpoint.DNSEndpoint, error) {
+	epCr := &endpoint.DNSEndpoint{}
+
+	err := p.crdClient.Get().
+		Namespace(p.cfg.Namespace).
+		Name(p.cfg.CrName).
+		Resource(p.crdResource).
+		VersionedParams(&metav1.GetOptions{}, runtime.NewParameterCodec(p.scheme)).
+		Do(ctx).
+		Into(epCr)
+	return epCr, err
+}
+
+func makeRequest(p *ExternalDnsProvider, epCr *endpoint.DNSEndpoint, req *rest.Request, ctx context.Context) error{
+	err := req.
+		Namespace(p.cfg.Namespace).
+		Name(epCr.Name).
+		Resource(p.crdResource).
+		VersionedParams(&metav1.UpdateOptions{}, runtime.NewParameterCodec(p.scheme)).
+		Body(epCr).
+		Do(ctx).
+		Error()
+	return err
+}
+
+// Records returns the list of endpoints
+func (p *ExternalDnsProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	epCr, err := Cp(ctx, p)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return []*endpoint.Endpoint{}, nil
+		}
+		return nil, err
+	}
+
+	return epCr.Spec.Endpoints, nil
+}
+
+// ApplyChanges simply passes the request to the DNSEndpoint CR in the target cluster, or creates it
+// create record - record should not exist
+// update/delete record - record should exist
+// create/update/delete lists should not have overlapping records
+func (p *ExternalDnsProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
+	create := false
+	//epCr, err := p.getCurrentDnsEndpointCr(ctx)
+	epCr, err := Cp(ctx, p)
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return fmt.Errorf("ApplyChanges: failed to get DNSEndpoint CR from target cluster: %s", err)
+		}
+		create = true
+		epCr = &endpoint.DNSEndpoint{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      p.cfg.CrName,
+				Namespace: p.cfg.Namespace,
+			},
+			Spec: endpoint.DNSEndpointSpec{
+				Endpoints: []*endpoint.Endpoint{},
+			},
+		}
+	}
+
+	epCr.Spec.Endpoints = append(epCr.Spec.Endpoints, changes.Create...)
+
+	toBeRemovedEpsSet := map[string]struct{}{}
+	for _, removeEp := range changes.UpdateOld {
+		toBeRemovedEpsSet[removeEp.String()] = struct{}{}
+	}
+	for _, removeEp := range changes.Delete {
+		toBeRemovedEpsSet[removeEp.String()] = struct{}{}
+	}
+
+	keepEndpoints := make([]*endpoint.Endpoint, 0)
+	for _, existEp := range epCr.Spec.Endpoints {
+		existEpStr := existEp.String()
+		_, remove := toBeRemovedEpsSet[existEpStr]
+		if !remove {
+			keepEndpoints = append(keepEndpoints, existEp)
+		}
+	}
+	epCr.Spec.Endpoints = keepEndpoints
+
+	epCr.Spec.Endpoints = append(epCr.Spec.Endpoints, changes.UpdateNew...)
+
+	if p.dryRun {
+		log.Infof("DryRun: ApplyChanges: Created/Updated DNSEndpoint CR in target cluster")
+		return nil
+	}
+
+	req := p.crdClient.Post()
+	if !create {
+		req = p.crdClient.Put()
+	}
+	/*err = req.
+		Namespace(p.cfg.Namespace).
+		Name(epCr.Name).
+		Resource(p.crdResource).
+		VersionedParams(&metav1.UpdateOptions{}, runtime.NewParameterCodec(p.scheme)).
+		Body(epCr).
+		Do(ctx).
+		Error()*/
+	err = makeReq(p, epCr, req, ctx)
+	if err != nil {
+		return fmt.Errorf("ApplyChanges: failed to create/update DNSEndpoint CR in target cluster: %s", err)
+	}
+	log.Infof("ApplyChanges: Created/Updated DNSEndpoint CR in target cluster")
+
+	return nil
+}
+
+// NewExternalDns returns ExternalDnsProvider DNS provider interface implementation
+func NewExternalDns(cfg *ExternalDnsProviderConfig, dryRun bool) (*ExternalDnsProvider, error) {
+	if cfg.NamespacePath != "" {
+		nsB, err := readFile(cfg.NamespacePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read namespace from file %s: %s", cfg.NamespacePath, err)
+		}
+		cfg.Namespace = string(nsB)
+	}
+	if cfg.CaCrtPath != "" {
+		caCrtB, err := readFile(cfg.CaCrtPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA cert from file %s: %s", cfg.CaCrtPath, err)
+		}
+		cfg.CaCrt = string(caCrtB)
+	}
+	if cfg.TokenPath != "" {
+		tokenB, err := readFile(cfg.TokenPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read token from file %s: %s", cfg.TokenPath, err)
+		}
+		cfg.Token = string(tokenB)
+	}
+
+	restConfig := &rest.Config{
+		Host: "https://" + net.JoinHostPort(cfg.KubernetesHost, cfg.KubernetesPort),
+		TLSClientConfig: rest.TLSClientConfig{
+			CAData: []byte(cfg.CaCrt),
+		},
+		BearerToken: cfg.Token,
+	}
+	k8sClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create k8s client: %s", err)
+	}
+	crdClient, scheme, err := crdClient(k8sClient, restConfig, cfg.CrdApiVersion, cfg.CrdKind)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get CRD k8s client: %s", err)
+	}
+	provider := &ExternalDnsProvider{
+		dryRun:      dryRun,
+		crdResource: strings.ToLower(cfg.CrdKind) + "s",
+		crdClient:   crdClient,
+		scheme:      scheme,
+		cfg: 		cfg,
+	}
+
+	return provider, nil
+}

--- a/provider/externaldns/externaldns_test.go
+++ b/provider/externaldns/externaldns_test.go
@@ -1,0 +1,198 @@
+package externaldns
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+	"testing"
+)
+
+func GetCurrentDnsEndpointCr(ctx context.Context) (*endpoint.DNSEndpoint, error) {
+	dnsEndpoint := &endpoint.DNSEndpoint{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "test.k8s.io/v1alpha1",
+			Kind:       "DNSEndpoint",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "endpoints within a specific namespace",
+			Namespace: "test",
+			Generation: 1,
+		},
+		Spec: endpoint.DNSEndpointSpec{
+			Endpoints: []*endpoint.Endpoint{
+				{DNSName: "abc.example.org",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+					RecordTTL:  180,
+				},
+				{DNSName: "efg.example.org",
+					Targets:    endpoint.Targets{"11.22.33.44"},
+					RecordType: endpoint.RecordTypeA,
+					RecordTTL:  180,
+				},
+			},
+		},
+	}
+	return dnsEndpoint, nil
+}
+
+func GetCurrentDnsEndpointCr1(ctx context.Context) (*endpoint.DNSEndpoint, error) {
+	error := errors.New("Error while making k8s call")
+	return nil, error
+}
+
+
+func invokeGetCurrentDnsEndpointCr1(ctx context.Context, e ExternalDnsInterface) (*endpoint.DNSEndpoint, error) {
+	return GetCurrentDnsEndpointCr(ctx)
+}
+
+func invokeGetCurrentDnsEndpointCr2(ctx context.Context, e ExternalDnsInterface) (*endpoint.DNSEndpoint, error) {
+	return GetCurrentDnsEndpointCr1(ctx)
+}
+
+func readCaCertFile(name string) ([]byte, error) {
+	return nil,  errors.New("")
+}
+
+func readNSFile(name string) ([]byte, error) {
+	fmt.Println("came here......")
+	return nil, errors.New("")
+}
+
+func getCrdClient(client kubernetes.Interface, config *rest.Config, version string, kind string) (*rest.RESTClient, *runtime.Scheme, error) {
+	crdClient := &rest.RESTClient{}
+	return crdClient, nil, nil
+}
+
+func readEmptyfile(name string) ([]byte, error) {
+	bytes := make([]byte, 0)
+	return bytes, nil
+}
+
+
+func TestExternalDnsGetRecords(t *testing.T) {
+	ep := ExternalDnsProvider{}
+	Cp = invokeGetCurrentDnsEndpointCr1
+	endpoints, _ := ep.Records(context.Background())
+	assert.Equal(t, 2, len(endpoints))
+	assert.Equal(t, "abc.example.org", endpoints[0].DNSName)
+	assert.Equal(t, "efg.example.org", endpoints[1].DNSName)
+
+}
+
+func TestExternalDnsNilRecords(t *testing.T) {
+	ep := ExternalDnsProvider{}
+	Cp = invokeGetCurrentDnsEndpointCr2
+	var err error
+	endpoints, err := ep.Records(context.Background())
+	assert.Equal(t, 0, len(endpoints))
+	assert.NotNil(t, err)
+}
+
+func refFunction(p *ExternalDnsProvider, epCr *endpoint.DNSEndpoint, req *rest.Request, ctx context.Context) error {
+
+	for _, ep := range epCr.Spec.Endpoints {
+		fmt.Println(ep)
+	}
+	return nil
+}
+
+func TestExternalDnsApplyChanges(t *testing.T) {
+	plan := &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			{
+				DNSName:    "v1.foo.com",
+				RecordType: "A",
+				Targets:    []string{""},
+			},
+			{
+				DNSName:    "v1.foobar.com",
+				RecordType: "TXT",
+				Targets:    []string{""},
+			},
+		},
+		Delete: []*endpoint.Endpoint{
+			{
+				DNSName:    "abc.example.org",
+				RecordType: "A",
+				Targets:    []string{"1.2.3.4"},
+				RecordTTL:  180,
+			},
+		},
+		UpdateOld: []*endpoint.Endpoint{
+			{
+				DNSName:    "v1.foo.com",
+				RecordType: "A",
+				Targets:    []string{""},
+			},
+			{
+				DNSName:    "efg.example.org",
+				RecordType: "A",
+				Targets:    []string{""},
+			},
+		},
+		UpdateNew: []*endpoint.Endpoint{
+			{
+				DNSName:    "v1.foo.com",
+				RecordType: "A",
+				Targets:    []string{""},
+			},
+			{
+				DNSName:    "v1.foobar.com",
+				RecordType: "TXT",
+				Targets:    []string{""},
+			},
+		},
+	}
+	Cp = invokeGetCurrentDnsEndpointCr1
+	ep := ExternalDnsProvider{
+		crdClient: &rest.RESTClient{},
+	}
+	makeReq=refFunction
+	err := ep.ApplyChanges(context.Background(), plan)
+	assert.NoError(t, err)
+}
+
+func TestNewExternalDns(t *testing.T) {
+	config := &ExternalDnsProviderConfig{
+		Namespace: "namespace",
+		CaCrtPath: "CaCrtPath",
+		TokenPath: "TokenPath",
+	}
+	readFile = readEmptyfile
+	crdClient = getCrdClient
+	provider, _ := NewExternalDns(config, false)
+	assert.NotNil(t, provider)
+
+}
+
+func TestNewExternalDnsWithNSNotExisting(t *testing.T) {
+	config := &ExternalDnsProviderConfig{
+		Namespace: "namespace",
+		CaCrtPath: "CaCrtPath",
+		TokenPath: "TokenPath",
+	}
+	readFile = readNSFile
+	provider, _ := NewExternalDns(config, false)
+	assert.Nil(t, provider)
+
+}
+
+func TestNewExternalDnsWithCaCertNotExisting(t *testing.T) {
+	config := &ExternalDnsProviderConfig{
+		Namespace: "namespace",
+		CaCrtPath: "CaCrtPath",
+		TokenPath: "TokenPath",
+	}
+	readFile = readCaCertFile
+	provider, _ := NewExternalDns(config, false)
+	assert.Nil(t, provider)
+
+}

--- a/provider/externaldns/mgmt.yaml
+++ b/provider/externaldns/mgmt.yaml
@@ -1,0 +1,108 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups: ["externaldns.k8s.io"]
+  resources: ["dnsendpoints"]
+  verbs: ["get","watch","list"]
+# - apiGroups: [""]
+#   resources: ["services","endpoints","pods"]
+#   verbs: ["get","watch","list"]
+# - apiGroups: ["extensions","networking.k8s.io"]
+#   resources: ["ingresses"] 
+#   verbs: ["get","watch","list"]
+# - apiGroups: [""]
+#   resources: ["nodes"]
+#   verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+  namespace: default
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      serviceAccountName: external-dns
+      containers:
+      - name: external-dns
+        image: k8s.gcr.io/external-dns/external-dns:v0.7.6
+        args:
+        - --source=crd
+        - --provider=inmemory
+        # - --infoblox-grid-host=foo # (required) IP of the Infoblox Grid host.
+        # - --infoblox-wapi-port=443          # (optional) Infoblox WAPI port. The default is "443".
+        # - --infoblox-wapi-version=2.3.1     # (optional) Infoblox WAPI version. The default is "2.3.1"
+        # - --no-infoblox-ssl-verify             # (optional) Use --no-infoblox-ssl-verify to skip server certificate verification.
+        # env:
+        # - name: EXTERNAL_DNS_INFOBLOX_HTTP_POOL_CONNECTIONS
+        #   value: "10" # (optional) Infoblox WAPI request connection pool size. The default is "10".
+        # - name: EXTERNAL_DNS_INFOBLOX_HTTP_REQUEST_TIMEOUT
+        #   value: "60" # (optional) Infoblox WAPI request timeout in seconds. The default is "60".
+        # - name: EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME
+        #   value: Foo
+        # - name: EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD
+        #   value: Bar
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: workload1
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: workload1-external-dns
+  namespace: workload1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: workload1-external-dns
+  namespace: workload1
+rules:
+- apiGroups: ["externaldns.k8s.io"]
+  resources: ["dnsendpoints"]
+  resourceNames:
+  - workload1
+  verbs: ["create", "update", "delete", "get","watch","list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: workload1-external-dns
+  namespace: workload1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: workload1-external-dns
+subjects:
+- kind: ServiceAccount
+  name: workload1-external-dns
+  namespace: workload1

--- a/provider/externaldns/workload-external-dns.yaml
+++ b/provider/externaldns/workload-external-dns.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-dns
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+  namespace: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups: ["externaldns.k8s.io"]
+  resources: ["dnsendpoints"]
+  verbs: ["get","watch","list"]
+- apiGroups: [""]
+  resources: ["services","endpoints","pods"]
+  verbs: ["get","watch","list"]
+- apiGroups: ["extensions","networking.k8s.io"]
+  resources: ["ingresses"] 
+  verbs: ["get","watch","list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+  namespace: external-dns
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+  namespace: external-dns
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      serviceAccountName: external-dns
+      volumes:
+      - name: svcreds
+        secret:
+          secretName: calatrava-svcreds
+      containers:
+      - name: external-dns
+        image: k8s.gcr.io/external-dns/external-dns:v0.7.6
+        args:
+        - --source=crd
+        - --source=service
+        - --provider=externaldns
+        - --externaldns-ca-cert-path=/svcreds/ca.crt
+        - --externaldns-namespace-path=/svcreds/namespace
+        - --externaldns-token-path=/svcreds/token
+        - --externaldns-kubernetes-host="supervisor.default.svc"
+        - --externaldns-kubernetes-port="6443"
+        - --externaldns-resource-name=gc
+        volumeMounts:
+        - name: svcreds
+          mountPath: "/svcreds"
+          readOnly: true

--- a/provider/externaldns/workload1.yaml
+++ b/provider/externaldns/workload1.yaml
@@ -1,0 +1,11 @@
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: examplednsrecord
+spec:
+  endpoints:
+  - dnsName: foo.bar.com
+    recordTTL: 180
+    recordType: A
+    targets:
+    - 192.168.99.216

--- a/provider/externaldns/workload1b.yaml
+++ b/provider/externaldns/workload1b.yaml
@@ -1,0 +1,28 @@
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: examplednsrecord
+spec:
+  endpoints:
+  - dnsName: foo.bar.com
+    recordTTL: 180
+    recordType: A
+    targets:
+    - 192.168.99.216
+  - dnsName: bar.bar.com
+    recordTTL: 180
+    recordType: A
+    targets:
+    - 192.168.99.217
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: examplednsrecord2
+spec:
+  endpoints:
+  - dnsName: test1-foo.bar.com
+    recordTTL: 180
+    recordType: A
+    targets:
+    - 192.168.99.218

--- a/source/crd.go
+++ b/source/crd.go
@@ -243,3 +243,40 @@ func (cs *crdSource) filterByAnnotations(dnsendpoints *endpoint.DNSEndpointList)
 
 	return &filteredList, nil
 }
+
+// NewCRDClientForAPIVersionKind return rest client for the given apiVersion and kind of the CRD
+func NewCRDClientForAPIVersionKindWithConfig(client kubernetes.Interface, config *rest.Config, apiVersion, kind string) (*rest.RESTClient, *runtime.Scheme, error) {
+	groupVersion, err := schema.ParseGroupVersion(apiVersion)
+	if err != nil {
+		return nil, nil, err
+	}
+	apiResourceList, err := client.Discovery().ServerResourcesForGroupVersion(groupVersion.String())
+	if err != nil {
+		return nil, nil, fmt.Errorf("error listing resources in GroupVersion %q: %s", groupVersion.String(), err)
+	}
+
+	var crdAPIResource *metav1.APIResource
+	for _, apiResource := range apiResourceList.APIResources {
+		if apiResource.Kind == kind {
+			crdAPIResource = &apiResource
+			break
+		}
+	}
+	if crdAPIResource == nil {
+		return nil, nil, fmt.Errorf("unable to find Resource Kind %q in GroupVersion %q", kind, apiVersion)
+	}
+
+	scheme := runtime.NewScheme()
+	addKnownTypes(scheme, groupVersion)
+
+	config.ContentConfig.GroupVersion = &groupVersion
+	config.APIPath = "/apis"
+	config.NegotiatedSerializer = serializer.WithoutConversionCodecFactory{CodecFactory: serializer.NewCodecFactory(scheme)}
+
+	crdClient, err := rest.UnversionedRESTClientFor(config)
+	if err != nil {
+		return nil, nil, err
+	}
+	return crdClient, scheme, nil
+}
+


### PR DESCRIPTION
Publishing external-dns As A provider


**Description**

This provider uses the external-dns CRD in an external kubernetes cluster as the provider backend. The idea is that the management cluster is the one that has access to the real provider backend. It may use tools like OpenPolicyAgent Gatekeeper or other admission controllers to centrally govern policies of which DNS entries are allowed and which are not. A workload cluster runs external-dns and only needs a ServiceAccount on the management cluster, but doesn't need credentials to the "real" provider backend.

**Checklist**

- [X] Unit tests updated
- [X] End user documentation updated
