### PR TITLE
Update rfc2136.md

### DIFF
--- a/docs/tutorials/rfc2136.md
+++ b/docs/tutorials/rfc2136.md
@@ -20,7 +20,7 @@ key "externaldns-key" {
 };
 ```
 - If you are your own DNS administrator create a TSIG key. Use
-`tsig-keygen -a hmac-sha256 externaldns` or on older distributions
+`tsig-keygen -a hmac-sha256 externaldns-key` or on older distributions
 `dnssec-keygen -a HMAC-SHA256 -b 256 -n HOST externaldns`. You will end up with
 a key printed to standard out like above (or in the case of dnssec-keygen in a
 file called `Kexternaldns......key`).
@@ -62,7 +62,7 @@ following.
   - Create a zone file (k8s.zone):
   ```text
   $TTL 60 ; 1 minute
-  k8s.example.org         IN SOA  k8s.example.org. root.k8s.example.org. (
+  k8s.example.org.        IN SOA  k8s.example.org. root.k8s.example.org. (
                                   16         ; serial
                                   60         ; refresh (1 minute)
                                   60         ; retry (1 minute)


### PR DESCRIPTION
Fixing a few typos:
- set the name of the key to the `tsig-keygen` command to `externaldns-key`, to keep it in line with the rest of the document (I had no way of checking `dnssec-keygen`, but that perhaps needs a similar fix)
- append a dot to the SOA record name of the k8s.example.org zone, otherwise the domain is appended one extra time.

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR fixes two small typos in the Rfc2136 documentation.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->


