### PR TITLE
Optionally add CRD manifest for DNSEndpoint as helm deliverables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,9 @@ lint: licensecheck go-lint
 # generates CRD using controller-gen
 crd: controller-gen
 	${CONTROLLER_GEN} crd:crdVersions=v1 paths="./endpoint/..." output:crd:stdout > docs/contributing/crd-source/crd-manifest.yaml
+	@echo -n "{{- if .Values.deployCrd }}" > charts/external-dns/templates/crd.yaml
+	cat docs/contributing/crd-source/crd-manifest.yaml >> charts/external-dns/templates/crd.yaml
+	@echo "{{- end }}"  >> charts/external-dns/templates/crd.yaml
 
 # The verify target runs tasks similar to the CI tasks, but without code coverage
 .PHONY: verify test

--- a/charts/external-dns/templates/crd.yaml
+++ b/charts/external-dns/templates/crd.yaml
@@ -1,4 +1,4 @@
-
+{{- if .Values.deployCrd }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -100,3 +100,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -21,6 +21,9 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# Specifies whether the custom resource definition of DNSEndpoint should be deployed
+deployCrd: false
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true

--- a/docs/contributing/crd-source.md
+++ b/docs/contributing/crd-source.md
@@ -88,6 +88,7 @@ Apply this to register the CRD
 $ kubectl apply --validate=false -f docs/contributing/crd-source/crd-manifest.yaml
 customresourcedefinition.apiextensions.k8s.io "dnsendpoints.externaldns.k8s.io" created
 ```
+Or alternatively deploy the external-dns helm chart with value `deployCrd=true`.
 
 Then you can create the dns-endpoint yaml similar to [dnsendpoint-example](crd-source/dnsendpoint-example.yaml)
 


### PR DESCRIPTION
**Description**

Since DNSEndpoint can be used as one of the sources for external-dns, it would be handy to be able
to deploy its definition file together with the main deployment.

More info about the implementation:
- piggy-backing on the make crd to create such template file under charts/external-dns/templates/
- by default it's the same as before and the CRD is not deployed using helm chart
- to enable the CRD deployment, one has to set helm value deployCrd=true

Result:
```
λ helm template charts/external-dns | grep DNSEndpointSpec # no match
λ helm template charts/external-dns --set deployCrd=true | grep DNSEndpointSpec
            description: DNSEndpointSpec defines the desired state of DNSEndpoint
```
<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2640

**Checklist**

- [ ] Unit tests updated (N/A - no tests for helm chart)
- [x] End user documentation updated

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>
