### PR TITLE
Allow ambassador host source to get provider specific annotations

### DIFF
--- a/source/ambassador_host.go
+++ b/source/ambassador_host.go
@@ -161,8 +161,7 @@ func (sc *ambassadorHostSource) Endpoints(ctx context.Context) ([]*endpoint.Endp
 func (sc *ambassadorHostSource) endpointsFromHost(ctx context.Context, host *ambassador.Host, targets endpoint.Targets) ([]*endpoint.Endpoint, error) {
 	var endpoints []*endpoint.Endpoint
 
-	providerSpecific := endpoint.ProviderSpecific{}
-	setIdentifier := ""
+	providerSpecific, setIdentifier := getProviderSpecificAnnotations(host.Annotations)
 
 	annotations := host.Annotations
 	ttl, err := getTTLFromAnnotations(annotations)


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Allow ambassador host source to get provider specific annotations.

For example:
```
apiVersion: getambassador.io/v2
kind: Host
metadata:
  name: test
  annotations:
    external-dns.ambassador-service: ambassador/ambassador
    external-dns.alpha.kubernetes.io/aws-weight: "100" # aws route53 weights
    external-dns.alpha.kubernetes.io/set-identifier: mycluster # aws route53 weights
spec:
  hostname: test.com
```

In the current version external-dns is not able to use those provider specific annotations for ambassador hosts, this PR fix that.