### PR TITLE
Avoid full reconciliation on RFC 2136 transfer error

### DIFF
--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -238,6 +238,7 @@ func (r rfc2136Provider) List() ([]dns.RR, error) {
 				log.Error("AXFR error: unexpected response received from the server")
 			} else {
 				log.Errorf("AXFR error: %v", e.Error)
+				return nil, fmt.Errorf("AXFR error: %v", e.Error)
 			}
 			continue
 		}


### PR DESCRIPTION
Addresses https://github.com/kubernetes-sigs/external-dns/issues/2071
