### PR TITLE
Update to ExternalDNS v0.11.0

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed -->
 
+## [v1.9.0] - UNRELEASED
+
+### Changed
+
+- Update _ExternalDNS_ version to [v0.11.0](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.11.0).
+
 ## [v1.8.0] - UNRELEASED
 
 ### Added

--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: external-dns
 description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 type: application
-version: 1.8.0
-appVersion: 0.10.2
+version: 1.9.0
+appVersion: 0.11.0
 keywords:
   - kubernetes
   - external-dns
@@ -19,7 +19,5 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "Add annotations to Deployment."
     - kind: changed
-      description: "Fix RBAC for istio-virtualservice source when istio-gateway isn't also added."
+      description: "Update ExternalDNS version to v0.11.0"


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR updates the Helm chart to use the latest v0.11.0 version of ExternalDNS.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2664.

Depends on #2689 being merged first.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
