### PR TITLE
bluecat docs: JSON configuration file is not deprecated

### DIFF
--- a/docs/tutorials/bluecat.md
+++ b/docs/tutorials/bluecat.md
@@ -7,8 +7,9 @@ Install the BlueCat Gateway product and deploy the [community gateway workflows]
 
 ## Configuration Options
 
-There are two ways to pass configuration options to the Bluecat Provider JSON configuration file and command line flags. The JSON configuration file option
-is deprecated and will eventually be removed.
+There are two ways to pass configuration options to the Bluecat Provider JSON configuration file and command line flags. Currently if a valid configuration file is used all
+BlueCat provider configurations will be taken from the configuration file. If a configuraiton file is not provided or cannot be read then all BlueCat provider configurations will
+be taken from the command line flags. In the future an enhancement will be made to merge configuration options from the configuration file and command line flags if both are provided.
 
 BlueCat provider supports getting the proxy URL from the environment variables. The format is the one specified by golang's [http.ProxyFromEnvironment](https://pkg.go.dev/net/http#ProxyFromEnvironment).
 
@@ -71,7 +72,7 @@ kubectl apply -f ~/bluecat.yml -n bluecat-example
 ```
 
 
-### Using JSON Configuration file (DEPRECATED)
+### Using JSON Configuration File
 The options for configuring the Bluecat Provider are available through the JSON file provided to External-DNS via the flag `--bluecat-config-file`.
 
 | Key               | Required           |


### PR DESCRIPTION

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
Based on feedback having both the configuration file and command line
flags for the BlueCat provider will be used. Therefore update the
documentaiton to reflect that the JSON configuration file for the
BlueCat provider is not deprecated.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes N/A

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
