### PR TITLE
Update to golangci-lint v1.45.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Lint
       run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2
         make lint
   
     - name: Test


### PR DESCRIPTION
Running golangci-lint v1.30.0 at commit 6d7f4650 produces the below
error when running "make lint" via GitHub Actions. Not sure exactly
when this error started happening, but it is broken now.

```
Run curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0
  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0
  make lint
  shell: /usr/bin/bash -e {0}
  env:
    GOROOT: /opt/hostedtoolcache/go/1.18.0/x64
golangci/golangci-lint info checking GitHub for tag 'v1.30.0'
golangci/golangci-lint info found version: 1.30.0 for v1.30.0/linux/amd64
golangci/golangci-lint info installed /home/runner/go/bin/golangci-lint
>> checking license header
golangci-lint run --timeout=15m ./...
Error: level=warning msg="[runner] Can't run linter goanalysis_metalinter: goprintffuncname: failed prerequisites: [inspect@sigs.k8s.io/external-dns/pkg/tlsutils: analysis skipped: errors in package: [/home/runner/work/external-dns/external-dns/pkg/tlsutils/tlsconfig.go:20:2: could not import crypto/tls (/opt/hostedtoolcache/go/1.18.0/x64/src/crypto/tls/alert.go:7:8: could not import strconv (/opt/hostedtoolcache/go/1.18.0/x64/src/strconv/atof.go:13:8: could not import math (/opt/hostedtoolcache/go/1.18.0/x64/src/math/exp_amd64.go:9:8: could not import internal/cpu (-: could not load export data: cannot import \"internal/cpu\" (unknown iexport format version 2), export data is newer version - update tool)))) /home/runner/work/external-dns/external-dns/pkg/tlsutils/tlsconfig.go:21:2: could not import crypto/x509 (/opt/hostedtoolcache/go/1.18.0/x64/src/crypto/x509/cert_pool.go:8:2: could not import bytes (/opt/hostedtoolcache/go/1.18.0/x64/src/bytes/buffer.go:10:2: could not import errors (/opt/hostedtoolcache/go/1.18.0/x64/src/errors/wrap.go:8:2: could not import internal/reflectlite (/opt/hostedtoolcache/go/1.18.0/x64/src/internal/reflectlite/swapper.go:8:2: could not import internal/goarch (-: could not load export data: cannot import \"internal/goarch\" (unknown iexport format version 2), export data is newer version - update tool))))) /home/runner/work/external-dns/external-dns/pkg/tlsutils/tlsconfig.go:22:2: could not import errors (/opt/hostedtoolcache/go/1.18.0/x64/src/errors/wrap.go:8:2: could not import internal/reflectlite (/opt/hostedtoolcache/go/1.18.0/x64/src/internal/reflectlite/swapper.go:8:2: could not import internal/goarch (-: could not load export data: cannot import \"internal/goarch\" (unknown iexport format version 2), export data is newer version - update tool))) /home/runner/work/external-dns/external-dns/pkg/tlsutils/tlsconfig.go:23:2: could not import fmt (/opt/hostedtoolcache/go/1.18.0/x64/src/fmt/errors.go:7:8: could not import errors (/opt/hostedtoolcache/go/1.18.0/x64/src/errors/wrap.go:8:2: could not import internal/reflectlite (/opt/hostedtoolcache/go/1.18.0/x64/src/internal/reflectlite/swapper.go:8:2: could not import internal/goarch (-: could not load export data: cannot import \"internal/goarch\" (unknown iexport format version 2), export data is newer version - update tool)))) /home/runner/work/external-dns/external-dns/pkg/tlsutils/tlsconfig.go:24:2: could not import io/ioutil (/opt/hostedtoolcache/go/1.18.0/x64/src/io/ioutil/ioutil.go:14:2: could not import io (/opt/hostedtoolcache/go/1.18.0/x64/src/io/io.go:16:2: could not import errors (/opt/hostedtoolcache/go/1.18.0/x64/src/errors/wrap.go:8:2: could not import internal/reflectlite (/opt/hostedtoolcache/go/1.18.0/x64/src/internal/reflectlite/swapper.go:8:2: could not import internal/goarch (-: could not load export data: cannot import \"internal/goarch\" (unknown iexport format version 2), export data is newer version - update tool))))) /home/runner/work/external-dns/external-dns/pkg/tlsutils/tlsconfig.go:25:2: could not import os (/opt/hostedtoolcache/go/1.18.0/x64/src/os/dir.go:8:2: could not import io/fs (/opt/hostedtoolcache/go/1.18.0/x64/src/io/fs/fs.go:11:2: could not import internal/oserror (/opt/hostedtoolcache/go/1.18.0/x64/src/internal/oserror/errors.go:10:8: could not import errors (/opt/hostedtoolcache/go/1.18.0/x64/src/errors/wrap.go:8:2: could not import internal/reflectlite (/opt/hostedtoolcache/go/1.18.0/x64/src/internal/reflectlite/swapper.go:8:2: could not import internal/goarch (-: could not load export data: cannot import \"internal/goarch\" (unknown iexport format version 2), export data is newer version - update tool)))))) /home/runner/work/external-dns/external-dns/pkg/tlsutils/tlsconfig.go:26:2: could not import strings (/opt/hostedtoolcache/go/1.18.0/x64/src/strings/builder.go:8:2: could not import unicode/utf8 (-: could not load export data: cannot import \"unicode/utf8\" (unknown iexport format version 2), export data is newer version - update tool))]]"
level=warning msg="[runner] Can't run linter unused: buildir: failed to load package goarch: could not load export data: cannot import \"internal/goarch\" (unknown iexport format version 2), export data is newer version - update tool"
level=error msg="Running error: buildir: failed to load package goarch: could not load export data: cannot import \"internal/goarch\" (unknown iexport format version 2), export data is newer version - update tool"
make: *** [Makefile:51: go-lint] Error 3
Error: Process completed with exit code 2.
```

Update from golangci-lint v1.30.0 to v1.45.2 to fix the error.