### PR TITLE
feat: restrict rfc2136 kerberos password from being exposed in logs

### DIFF
--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -166,7 +166,7 @@ type Config struct {
 	RFC2136GSSTSIG                    bool
 	RFC2136KerberosRealm              string
 	RFC2136KerberosUsername           string
-	RFC2136KerberosPassword           string
+	RFC2136KerberosPassword           string `secure:"yes"`
 	RFC2136TSIGKeyName                string
 	RFC2136TSIGSecret                 string `secure:"yes"`
 	RFC2136TSIGSecretAlg              string


### PR DESCRIPTION
This PR simply changes the string output of a config such that the Kerberos RFC2136 sensitive values do not get logged on controller startup.

Signed-off-by: Dustin Scott <sdustin@vmware.com>

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR simply changes the string output of a config such that the Kerberos RFC2136 sensitive values do not get logged on controller startup.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2702 

**Checklist**

Unit tests and documentation update not required for this change.

- [ X ] Unit tests updated
- [ X ] End user documentation updated
