### PR TITLE
Use Go 1.17 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.17
+        go-version: 1.17
       id: go
 
     - name: Check out code into the Go module directory


### PR DESCRIPTION
**Description**

This PR fixes CI which was forcing to use Go version 1.17 or above. Our codebase is not compatible yet with Go 1.18 and our CI is failing since that was released.


