### PR TITLE
Use HasPrefix to check for ownerID

### DIFF
--- a/provider/awssd/aws_sd.go
+++ b/provider/awssd/aws_sd.go
@@ -504,7 +504,7 @@ func (p *AWSSDProvider) DeleteService(service *sd.Service) error {
 		label[endpoint.OwnerLabelKey] = p.ownerID
 		label[endpoint.AWSSDDescriptionLabel] = label.Serialize(false)
 
-		if aws.StringValue(service.Description) == label[endpoint.AWSSDDescriptionLabel] {
+		if strings.HasPrefix(aws.StringValue(service.Description), label[endpoint.AWSSDDescriptionLabel]) {
 			log.Infof("Deleting service \"%s\"", *service.Name)
 			_, err := p.client.DeleteService(&sd.DeleteServiceInput{
 				Id: aws.String(*service.Id),

--- a/provider/awssd/aws_sd_test.go
+++ b/provider/awssd/aws_sd_test.go
@@ -685,6 +685,12 @@ func TestAWSSDProvider_DeleteService(t *testing.T) {
 				Name:        aws.String("service2"),
 				NamespaceId: aws.String("private"),
 			},
+			"srv3": {
+				Id:          aws.String("srv3"),
+				Description: aws.String("heritage=external-dns,external-dns/owner=owner-id,external-dns/resource=virtualservice/grpc-server/validate-grpc-server"),
+				Name:        aws.String("service3"),
+				NamespaceId: aws.String("private"),
+			},
 		},
 	}
 
@@ -695,9 +701,14 @@ func TestAWSSDProvider_DeleteService(t *testing.T) {
 
 	provider := newTestAWSSDProvider(api, endpoint.NewDomainFilter([]string{}), "", "owner-id")
 
-	// delete fist service
+	// delete first service
 	err := provider.DeleteService(services["private"]["srv1"])
 	assert.NoError(t, err)
+	assert.Len(t, api.services["private"], 2)
+
+	// delete third service
+	err1 := provider.DeleteService(services["private"]["srv3"])
+	assert.NoError(t, err1)
 	assert.Len(t, api.services["private"], 1)
 
 	expectedServices := map[string]*sd.Service{


### PR DESCRIPTION
**Description**

Fix for https://github.com/kubernetes-sigs/external-dns/issues/2706 using HasPrefix to check for owner ship.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2706

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
