### PR TITLE
feat[chart]: apply tpl func to shared part between subcharts

### DIFF
--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
             - --registry={{ .Values.registry }}
             {{- if eq .Values.registry "txt" }}
             {{- if .Values.txtOwnerId }}
-            - --txt-owner-id={{ .Values.txtOwnerId }}
+            - --txt-owner-id={{ tpl (.Values.txtOwnerId) . }}
             {{- end }}
             {{- if .Values.txtPrefix }}
             - --txt-prefix={{ .Values.txtPrefix }}

--- a/charts/external-dns/templates/serviceaccount.yaml
+++ b/charts/external-dns/templates/serviceaccount.yaml
@@ -7,6 +7,6 @@ metadata:
     {{- include "external-dns.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
This PR will update the Helm chart to use the helm 'tpl' function. tpl is a function that allows user to pass a template in a value file.
https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function

It works like this:
### value file
```yaml
global:
  test: ttttest2
serviceAccount:
  annotations:
    key: "{{ .Values.global.test }}-annotation"
txtOwnerId: "{{ .Values.global.test }}"
```
### result:
```yaml
# Source: external-dns/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: test-external-dns
  labels:
    helm.sh/chart: external-dns-1.8.0
    app.kubernetes.io/name: external-dns
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "0.10.2"
    app.kubernetes.io/managed-by: Helm
  annotations:
    key: 'ttttest2-annotation'
```
<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
No related issue.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
