### PR TITLE
Update proposal for downgrading

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -9,6 +9,9 @@ Prefix and suffix are extended with %{record_type} template where the user can c
 
 In order to maintain compatibility, both records will be maintained for some time, in order to have downgrade possibility.
 
+If the implementation is to complete the downgrade, it should include the following modifications:
+  * A new flag `-skip-ipv6-targets-in-a-record` has been added to allow filtering of IPv6 targets in type A endpoints so that a double-stacked rollback version of a source resource does not cause other effects. This feature should be merged in a previous release. This is because some providers (e.g. aliyundns) currently update A-record IPv6 targets as if they were A-records, and then are bound to encounter failures, and if they do they will delete the A-record at the same time.
+
 Later on, the old format will be dropped and only the new format will be kept (<record_type>-<endpoint_name>).
 
 Cleanup will be done by controller itself.


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Ref #2461  #2157 . Some related changes to the migration proposal to ensure smooth migration and downgrade.
Version: `v0.11.1`

Source:
```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: a.dns-test.loulan.me
  creationTimestamp: "2022-04-29T15:33:04Z"
  name: nginx
  namespace: external-dns-2
spec:
  allocateLoadBalancerNodePorts: true
  clusterIP: 10.98.49.158
  clusterIPs:
  - 10.98.49.158
  - 2000:1::a7e3
  externalTrafficPolicy: Cluster
  internalTrafficPolicy: Cluster
  ipFamilies:
  - IPv4
  - IPv6
  ipFamilyPolicy: RequireDualStack
  ports:
  - nodePort: 31219
    port: 80
    protocol: TCP
    targetPort: 80
  selector:
    app: nginx
  sessionAffinity: None
  type: LoadBalancer
status:
  loadBalancer:
    ingress:
    - ip: 10.0.2.152
    - ip: fd00:100::98
```


Information about the current version with dual stack:
```json
{
    "dnsName":"a.dns-test.loulan.me",
    "targets":[
        "10.0.2.152",
        "fd00:100::98"
    ],
    "recordType":"A",
    "labels":{
        "owner":"default",
        "resource":"service/external-dns-2/nginx"
    }
}
```



- [x] Unit tests updated
- [x] End user documentation updated
