### PR TITLE
feat[chart]: Update to ExternalDNS v0.12.0

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update _ExternalDNS_ version to [v0.12.0](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.12.0). [@vojtechmares](https://github.com/vojtechmares)
 - Set resource namespaces to `{{ .Release.Namespace }}` in the templates instead of waiting until apply time for inference. [@stevehipwell](https://github.com/stevehipwell)
 - Fixed `rbac.additionalPermissions` default value.([#2796](https://github.com/kubernetes-sigs/external-dns/pull/2796)) [@tamalsaha](https://github.com/tamalsaha)
 

--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: external-dns
 description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 type: application
-version: 1.9.0
-appVersion: 0.11.0
+version: 1.10.0
+appVersion: 0.12.0
 keywords:
   - kubernetes
   - external-dns
@@ -19,5 +19,21 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
+    - kind: added
+      description: "Added commonLabels value to allow the addition of labels to all resources."
+    - kind: added
+      description: "Added support for Process Namespace Sharing via the shareProcessNamespace value."
+      links:
+        - name: GitHub Issue #2715
+          url: https://github.com/kubernetes-sigs/external-dns/pull/2715
+        - name: Process Namespace Sharing
+          url: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
     - kind: changed
-      description: "Update ExternalDNS version to v0.11.0"
+      description: "Update ExternalDNS version to v0.12.0"
+    - kind: changed
+      description: "Set resource namespaces to {{ .Release.Namespace }} in the templates instead of waiting until apply time for inference."
+    - kind: fixed
+      description: "Fixed rbac.additionalPermissions default value."
+      links:
+        - name: GitHub Issue #2796
+          url: https://github.com/kubernetes-sigs/external-dns/pull/2796


### PR DESCRIPTION
Updating Helm chart to ExternalDNS v0.12.0

I've inspired myself with last commit updating the helm chart from v0.10.2 to v0.11.0 (https://github.com/kubernetes-sigs/external-dns/commit/a26ac538664e766cf3ba15b9db4e442aaed1c9d0)

Closes #2776 