### PR TITLE
fix: remove split of host/port

### DIFF
--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -134,12 +134,8 @@ func (r rfc2136Provider) KeyData() (keyName string, handle *gss.Client, err erro
 		return keyName, handle, err
 	}
 
-	rawHost, _, err := net.SplitHostPort(r.nameserver)
-	if err != nil {
-		return keyName, handle, err
-	}
+	keyName, _, err = handle.NegotiateContextWithCredentials(r.nameserver, r.krb5Realm, r.krb5Username, r.krb5Password)
 
-	keyName, _, err = handle.NegotiateContextWithCredentials(rawHost, r.krb5Realm, r.krb5Username, r.krb5Password)
 	return keyName, handle, err
 }
 


### PR DESCRIPTION
This commit removes the need to split the host and port as the
dns client configuration was refactored in v0.12.0 to no longer
require this.

Signed-off-by: Dustin Scott <sdustin@vmware.com>

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

This removes the need to split the host and port.  The refactor that went into v0.12.0 changed the methodology that was used to create the handle and now no longer requires the hostname separated from the port.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2778

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated

**NOTE:** docs not required to be updated.  Unit tests are sufficiently complex that it would not make sense to put it in this PR (unit tests require a functional KDC server to interact with) - opened issue https://github.com/kubernetes-sigs/external-dns/issues/2784 to address this.
