### PR TITLE
Support proxying wildcard records

### DIFF
--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	log "github.com/sirupsen/logrus"
@@ -52,7 +51,7 @@ var proxyEnabled *bool = boolPtr(true)
 // proxyDisabled is a pointer to a bool false showing the record should not be proxied through cloudflare
 var proxyDisabled *bool = boolPtr(false)
 
-var cloudFlareTypeNotSupported = map[string]bool{
+var recordTypeProxyNotSupported = map[string]bool{
 	"LOC": true,
 	"MX":  true,
 	"NS":  true,
@@ -414,7 +413,7 @@ func shouldBeProxied(endpoint *endpoint.Endpoint, proxiedByDefault bool) bool {
 		}
 	}
 
-	if cloudFlareTypeNotSupported[endpoint.RecordType] || strings.Contains(endpoint.DNSName, "*") {
+	if recordTypeProxyNotSupported[endpoint.RecordType] {
 		proxied = false
 	}
 	return proxied

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -513,7 +513,8 @@ func TestCloudflareSetProxied(t *testing.T) {
 		{"NS", "bar.com", notProxied},
 		{"SPF", "bar.com", notProxied},
 		{"SRV", "bar.com", notProxied},
-		{"A", "*.bar.com", notProxied},
+		{"A", "*.bar.com", proxied},
+		{"CNAME", "*.docs.bar.com", proxied},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Supersedes #2354

Cloudflare provider doesn't allow proxied DNS records if the records contains wildcard (*) as part of the hostname, irrespective of the zone's plan. A while ago, [Cloudflare announced](https://blog.cloudflare.com/wildcard-proxy-for-everyone/) availability of wildcard proxy in all tiers

This PR updates the `shouldBeProxied` validation, so that it no longer skips wildcard record when checking for proxied status

Other Changes

Fixes https://github.com/kubernetes-sigs/external-dns/issues/1810
Relates https://github.com/kubernetes-sigs/external-dns/pull/1542

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
