### PR TITLE
fix: additionalPermissions is an array not object

### DIFF
--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -24,7 +24,7 @@ serviceAccount:
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
-  additionalPermissions: {}
+  additionalPermissions: []
 
 # Annotations to add to the Deployment
 deploymentAnnotations: {}


### PR DESCRIPTION
Signed-off-by: Tamal Saha <tamal@appscode.com>

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
`additionalPermissions` is an array of PolicyRule not object 

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
