### PR TITLE
rfc2136: remove deprecated MD5 key algorithm

### DIFF
--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -71,7 +71,6 @@ type rfc2136Provider struct {
 
 // Map of supported TSIG algorithms
 var tsigAlgs = map[string]string{
-	"hmac-md5":    dns.HmacMD5,
 	"hmac-sha1":   dns.HmacSHA1,
 	"hmac-sha224": dns.HmacSHA224,
 	"hmac-sha256": dns.HmacSHA256,


### PR DESCRIPTION
Signed-off-by: Jack Henschel <jack.henschel@cern.ch>

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This patch removes the deprecated `hmac-md5` TSIG algorithm from the supported list.
The `dns` library used by the RFC2136 provider no longer supports this algorithm: https://github.com/miekg/dns/pull/1187/files

Users are currently experiencing the following error message (at runtime!) when configuring external-dns with this algorithm:

```
failed to fetch records via AXFR: dns: bad key algorithm
```
<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
