### PR TITLE
Explicitly set Helm chart resource namespaces & support common labels

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -13,18 +13,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed -->
 
-## [v1.9.0] - UNRELEASED
-
-### Changed
-
-- Update _ExternalDNS_ version to [v0.11.0](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.11.0).
-
-## [v1.8.0] - UNRELEASED
+## [UNRELEASED]
 
 ### Added
 
-- Add annotations to Deployment. [#2477](https://github.com/kubernetes-sigs/external-dns/pull/2477) from @beastob
+- Added `commonLabels` value to allow the addition of labels to all resources. [@stevehipwell](https://github.com/stevehipwell)
+- Added support for [Process Namespace Sharing](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/) via the `shareProcessNamespace`
+ value. ([#2715](https://github.com/kubernetes-sigs/external-dns/pull/2715)) [@wolffberg](https://github.com/wolffberg)
 
 ### Changed
 
-- Fix RBAC for `istio-virtualservice` source when `istio-gateway` isn't also added. [#2564](https://github.com/kubernetes-sigs/external-dns/pull/2564) from @mcwarman
+- Set resource namespaces to `{{ .Release.Namespace }}` in the templates instead of waiting until apply time for inference. [@stevehipwell](https://github.com/stevehipwell)
+- Fixed `rbac.additionalPermissions` default value.([#2796](https://github.com/kubernetes-sigs/external-dns/pull/2796)) [@tamalsaha](https://github.com/tamalsaha)
+
+## [v1.9.0] - 2022-04-19
+
+### Changed
+
+- Update _ExternalDNS_ version to [v0.11.0](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.11.0). ([#2690](https://github.com/kubernetes-sigs/external-dns/pull/2690)) [@stevehipwell](https://github.com/stevehipwell)
+
+## [v1.8.0] - 2022-04-13
+
+### Added
+
+- Add annotations to Deployment. ([#2477](https://github.com/kubernetes-sigs/external-dns/pull/2477)) [@beastob](https://github.com/beastob)
+
+### Changed
+
+- Fix RBAC for `istio-virtualservice` source when `istio-gateway` isn't also added. ([#2564](https://github.com/kubernetes-sigs/external-dns/pull/2564)) [@mcwarman](https://github.com/mcwarman)

--- a/charts/external-dns/templates/_helpers.tpl
+++ b/charts/external-dns/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "external-dns.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/external-dns/templates/clusterrole.yaml
+++ b/charts/external-dns/templates/clusterrole.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "external-dns.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
 rules:
@@ -11,25 +12,21 @@ rules:
     resources: ["nodes"]
     verbs: ["list","watch"]
 {{- end }}
-
 {{- if or (has "pod" .Values.sources) (has "service" .Values.sources) (has "contour-httpproxy" .Values.sources) (has "gloo-proxy" .Values.sources) (has "openshift-route" .Values.sources) (has "skipper-routegroup" .Values.sources) }}
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get","watch","list"]
 {{- end }}
-
 {{- if or (has "service" .Values.sources) (has "contour-httpproxy" .Values.sources) (has "gloo-proxy" .Values.sources) (has "istio-gateway" .Values.sources) (has "istio-virtualservice" .Values.sources) (has "openshift-route" .Values.sources) (has "skipper-routegroup" .Values.sources) }}
   - apiGroups: [""]
     resources: ["services","endpoints"]
     verbs: ["get","watch","list"]
 {{- end }}
-
 {{- if or (has "ingress" .Values.sources) (has "contour-httpproxy" .Values.sources) (has "openshift-route" .Values.sources) (has "skipper-routegroup" .Values.sources) }}
   - apiGroups: ["extensions","networking.k8s.io"]
     resources: ["ingresses"]
     verbs: ["get","watch","list"]
 {{- end }}
-
 {{- if or (has "istio-gateway" .Values.sources) (has "istio-virtualservice" .Values.sources) }}
   - apiGroups: ["networking.istio.io"]
     resources: ["gateways"]
@@ -41,25 +38,21 @@ rules:
     resources: ["virtualservices"]
     verbs: ["get","watch","list"]
 {{- end }}
-
 {{- if has "ambassador-host" .Values.sources }}
   - apiGroups: ["getambassador.io"]
     resources: ["hosts","ingresses"]
     verbs: ["get","watch","list"]
 {{- end }}
-
 {{- if has "contour-httpproxy" .Values.sources }}
   - apiGroups: ["projectcontour.io"]
     resources: ["httpproxies"]
     verbs: ["get","watch","list"]
 {{- end }}
-
 {{- if has "contour-ingressroute" .Values.sources }}
   - apiGroups: ["contour.heptio.com"]
     resources: ["ingressroutes"]
     verbs: ["get","watch","list"]
 {{- end }}
-
 {{- if has "crd" .Values.sources }}
   - apiGroups: ["externaldns.k8s.io"]
     resources: ["dnsendpoints"]
@@ -68,25 +61,21 @@ rules:
     resources: ["dnsendpoints/status"]
     verbs: ["*"]
 {{- end }}
-
 {{- if has "gloo-proxy" .Values.sources }}
   - apiGroups: ["gloo.solo.io","gateway.solo.io"]
     resources: ["proxies","virtualservices"]
     verbs: ["get","watch","list"]
 {{- end }}
-
 {{- if has "kong-tcpingress" .Values.sources }}
   - apiGroups: ["configuration.konghq.com"]
     resources: ["tcpingresses"]
     verbs: ["get","watch","list"]
 {{- end }}
-
 {{- if has "openshift-route" .Values.sources }}
   - apiGroups: ["route.openshift.io"]
     resources: ["routes"]
     verbs: ["get","watch","list"]
 {{- end }}
-
 {{- if has "skipper-routegroup" .Values.sources }}
   - apiGroups: ["zalando.org"]
     resources: ["routegroups"]
@@ -95,9 +84,7 @@ rules:
     resources: ["routegroups/status"]
     verbs: ["patch","update"]
 {{- end }}
-
 {{- with .Values.rbac.additionalPermissions }}
   {{- toYaml . | nindent 2 }}
 {{- end }}
-
 {{- end }}

--- a/charts/external-dns/templates/clusterrolebinding.yaml
+++ b/charts/external-dns/templates/clusterrolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ printf "%s-viewer" (include "external-dns.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
 roleRef:

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "external-dns.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
   {{- with .Values.deploymentAnnotations }}

--- a/charts/external-dns/templates/service.yaml
+++ b/charts/external-dns/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "external-dns.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}

--- a/charts/external-dns/templates/serviceaccount.yaml
+++ b/charts/external-dns/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "external-dns.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/external-dns/templates/servicemonitor.yaml
+++ b/charts/external-dns/templates/servicemonitor.yaml
@@ -3,11 +3,12 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "external-dns.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
-    {{- with .Values.serviceMonitor.additionalLabels }}
+  {{- with .Values.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- end }}
 spec:
   jobLabel: {{ .Release.Name }}
   namespaceSelector:

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -9,8 +9,11 @@ image:
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
+
 nameOverride: ""
 fullnameOverride: ""
+
+commonLabels: {}
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR changes the chart behaviour to explicitly set the resource namespace instead of inferring it at apply time and adds support for setting common labels on all resources. I've also tidied up the chart CHANGELOG which can hopefully be kept up to date.

Fixes #2672.

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
