### PR TITLE
Handle the migration to the new TXT format: create missing records

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -167,6 +167,9 @@ func (c *Controller) RunOnce(ctx context.Context) error {
 		deprecatedRegistryErrors.Inc()
 		return err
 	}
+
+	missingRecords := c.Registry.MissingRecords()
+
 	registryEndpointsTotal.Set(float64(len(records)))
 	regARecords := filterARecords(records)
 	registryARecords.Set(float64(len(regARecords)))
@@ -189,6 +192,7 @@ func (c *Controller) RunOnce(ctx context.Context) error {
 		Policies:           []plan.Policy{c.Policy},
 		Current:            records,
 		Desired:            endpoints,
+		Missing:            missingRecords,
 		DomainFilter:       endpoint.MatchAllDomainFilters{c.DomainFilter, c.Registry.GetDomainFilter()},
 		PropertyComparator: c.Registry.PropertyValuesEqual,
 		ManagedRecords:     c.ManagedRecordTypes,

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -7,7 +7,8 @@ It contains record type it manages, e.g.:
 
 Prefix and suffix are extended with %{record_type} template where the user can control how prefixed/suffixed records should look like.
 
-In order to maintain compatibility, both records will be maintained for some time, in order to have downgrade possibility.
+In order to maintain compatibility, both records will be maintained for some time, in order to have downgrade possibility.  
+The controller will try to create the "new format" TXT records if they are not present to ease the migration from the versions < 0.12.0.
 
 Later on, the old format will be dropped and only the new format will be kept (<record_type>-<endpoint_name>).
 

--- a/main.go
+++ b/main.go
@@ -341,7 +341,7 @@ func main() {
 	case "noop":
 		r, err = registry.NewNoopRegistry(p)
 	case "txt":
-		r, err = registry.NewTXTRegistry(p, cfg.TXTPrefix, cfg.TXTSuffix, cfg.TXTOwnerID, cfg.TXTCacheInterval, cfg.TXTWildcardReplacement)
+		r, err = registry.NewTXTRegistry(p, cfg.TXTPrefix, cfg.TXTSuffix, cfg.TXTOwnerID, cfg.TXTCacheInterval, cfg.TXTWildcardReplacement, cfg.ManagedDNSRecordTypes)
 	case "aws-sd":
 		r, err = registry.NewAWSSDRegistry(p.(*awssd.AWSSDProvider), cfg.TXTOwnerID)
 	default:

--- a/registry/aws_sd_registry.go
+++ b/registry/aws_sd_registry.go
@@ -67,6 +67,11 @@ func (sdr *AWSSDRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, er
 	return records, nil
 }
 
+// MissingRecords returns nil because there is no missing records for AWSSD registry
+func (sdr *AWSSDRegistry) MissingRecords() []*endpoint.Endpoint {
+	return nil
+}
+
 // ApplyChanges filters out records not owned the External-DNS, additionally it adds the required label
 // inserted in the AWS SD instance as a CreateID field
 func (sdr *AWSSDRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) error {

--- a/registry/noop.go
+++ b/registry/noop.go
@@ -45,6 +45,11 @@ func (im *NoopRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, erro
 	return im.provider.Records(ctx)
 }
 
+// MissingRecords returns nil because there is no missing records for Noop registry
+func (im *NoopRegistry) MissingRecords() []*endpoint.Endpoint {
+	return nil
+}
+
 // ApplyChanges propagates changes to the dns provider
 func (im *NoopRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
 	return im.provider.ApplyChanges(ctx, changes)

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -35,6 +35,7 @@ type Registry interface {
 	PropertyValuesEqual(attribute string, previous string, current string) bool
 	AdjustEndpoints(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint
 	GetDomainFilter() endpoint.DomainFilterInterface
+	MissingRecords() []*endpoint.Endpoint
 }
 
 //TODO(ideahitme): consider moving this to Plan


### PR DESCRIPTION
**Description**
Handle the migration to the new TXT record format automatically by ExternalDNS.

Should help fixing issue https://github.com/kubernetes-sigs/external-dns/issues/2793.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
