### PR TITLE
Adding `NS` support for Azure DNS

### DIFF
--- a/docs/tutorials/azure.md
+++ b/docs/tutorials/azure.md
@@ -9,6 +9,17 @@ This tutorial uses [Azure CLI 2.0](https://docs.microsoft.com/en-us/cli/azure/in
 Azure commands and assumes that the Kubernetes cluster was created via Azure Container Services and `kubectl` commands
 are being run on an orchestration node.
 
+## Supported Record types
+
+Note: Not all record types, which are available in Azure DNS, are currently implemented in external-dns. 
+
+Only the following types are currently supported:
+
+- A
+- CNAME
+- TXT
+- NS
+
 ## Creating an Azure DNS zone
 
 The Azure provider for ExternalDNS will find suitable zones for domains it manages; it will not automatically create zones.

--- a/docs/tutorials/azure.md
+++ b/docs/tutorials/azure.md
@@ -20,6 +20,8 @@ Only the following types are currently supported:
 - TXT
 - NS
 
+**Note:** To manage `NS` records, you need to explicitly enable those through the [managed-record-types](https://github.com/kubernetes-sigs/external-dns/blob/master/pkg/apis/externaldns/types.go#L426) switch.
+
 ## Creating an Azure DNS zone
 
 The Azure provider for ExternalDNS will find suitable zones for domains it manages; it will not automatically create zones.


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

This adds support for managing NS records in Azure DNS as well. Not sure if there was a particular reason why this wasn't already there. 
Required in k8gb https://github.com/k8gb-io/k8gb/pull/912

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2826

I did update the unit tests but I do need some help on updating the one for deletion. I am not sure what is still missing but it's still failing:

```
--- FAIL: TestAzureApplyChangesZoneName (0.00s)
    azure_test.go:271: 
                Error Trace:    azure_test.go:271
                                                        azure_test.go:512
                Error:          Should be true
                Test:           TestAzureApplyChangesZoneName
                Messages:       expected and actual endpoints don't match. [deleted.foo.example.com 0 IN A   [] deletedcname.foo.example.com 0 IN CNAME   [] old.foo.example.com 0 IN A   [] oldcname.foo.example.com 0 IN CNAME   []]:[old.foo.example.com 0 IN A   [] oldcname.foo.example.com 0 IN CNAME   [] ns-old.nope.example.com 0 IN NS   [] deleted.foo.example.com 0 IN A   [] deletedcname.foo.example.com 0 IN CNAME   []]
FAIL
```

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
