### PR TITLE
Replace trivy scan coming from script with GitHub action

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,6 +1,7 @@
 name: trivy vulnerability scanner
 on:
   push:
+  pull_request:
 jobs:
   build:
     name: Build

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -11,7 +11,15 @@ jobs:
       - name: Build an image from Dockerfile
         run: |
           make build.docker
+      - name: Get tag
+        id: tag
+        run: echo "::set-output name=TAG::$(git describe --tags --always --dirty)"
       - name: Run trivy
-        run: |
-          ./scripts/run-trivy.sh 
-            
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:${{ steps.tag.outputs.TAG }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'


### PR DESCRIPTION
**Description**

This allows for getting automatic updates for the trivy tool, as well as
getting easier configuration through the supported GitHub action.

If the `master` tag would not be followed and we'd follow a specific tag
instead, we could get automated tag updates via dependabot or a similar
tool.


**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
