### PR TITLE
Update references to UK Fast after merge with ANS group

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ ExternalDNS allows you to keep selected zones (via `--domain-filter`) synchroniz
 * [Akamai Edge DNS](https://learn.akamai.com/en-us/products/cloud_security/edge_dns.html)
 * [GoDaddy](https://www.godaddy.com)
 * [Gandi](https://www.gandi.net)
-* [UKFast SafeDNS](https://my.ukfast.co.uk/safedns/)
+* [ANS Group SafeDNS](https://portal.ans.co.uk/safedns/)
 * [IBM Cloud DNS](https://www.ibm.com/cloud/dns)
 
 From this release, ExternalDNS can become aware of the records it is managing (enabled via `--registry=txt`), therefore ExternalDNS can safely manage non-empty hosted zones. We strongly encourage you to use `v0.5` (or greater) with `--registry=txt` enabled and `--txt-owner-id` set to a unique value that doesn't change for the lifetime of your cluster. You might also want to run ExternalDNS in a dry run mode (`--dry-run` flag) to see the changes to be submitted to your DNS Provider API.

--- a/docs/tutorials/ANS_Group_SafeDNS.md
+++ b/docs/tutorials/ANS_Group_SafeDNS.md
@@ -1,4 +1,4 @@
-# Setting up ExternalDNS for Services on UKFast's SafeDNS
+# Setting up ExternalDNS for Services on ANS Group's SafeDNS
 
 This tutorial describes how to setup ExternalDNS for usage within a Kubernetes cluster using SafeDNS.
 
@@ -9,14 +9,14 @@ Make sure to use **>=0.11.0** version of ExternalDNS for this tutorial.
 If you want to learn about how to use the SafeDNS service read the following tutorials:
 To learn more about the use of SafeDNS in general, see the following page:
 
-[UKFast's SafeDNS documentation](https://docs.ukfast.co.uk/domains/safedns/index.html).
+[ANS Group's SafeDNS documentation](https://docs.ukfast.co.uk/domains/safedns/index.html).
 
 ## Creating SafeDNS credentials
 
 Generate a fresh API token for use with ExternalDNS, following the instructions
-at the UKFast developer [Getting-Started](https://developers.ukfast.io/getting-started)
+at the ANS Group developer [Getting-Started](https://developers.ukfast.io/getting-started)
 page. You will need to grant read/write access to the SafeDNS API. No access to
-any other UKFast service is required.
+any other ANS Group service is required.
 
 The environment variable `SAFEDNS_TOKEN` must have a value of this token to run
 ExternalDNS with SafeDNS integration.

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/alecthomas/colour v0.1.0 // indirect
 	github.com/alecthomas/kingpin v2.2.5+incompatible
 	github.com/aliyun/alibaba-cloud-sdk-go v1.61.1483
+	github.com/ans-group/sdk-go v1.7.0
 	github.com/aws/aws-sdk-go v1.42.52
 	github.com/bodgit/tsig v1.2.0
 	github.com/cloudflare/cloudflare-go v0.25.0
@@ -51,7 +52,6 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	github.com/transip/gotransip/v6 v6.14.0
-	github.com/ukfast/sdk-go v1.4.34
 	github.com/ultradns/ultradns-sdk-go v0.0.0-20200616202852-e62052662f60
 	github.com/vinyldns/go-vinyldns v0.0.0-20200211145900-fe8a3d82e556
 	github.com/vultr/govultr/v2 v2.14.1
@@ -144,7 +144,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/terra-farm/udnssdk v1.3.5 // indirect
-	github.com/ukfast/go-durationstring v1.1.0 // indirect
+	github.com/ans-group/go-durationstring v1.2.0 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.2 // indirect
 	go.mongodb.org/mongo-driver v1.5.1 // indirect
 	go.opencensus.io v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -187,6 +187,10 @@ github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9or
 github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129/go.mod h1:rFgpPQZYZ8vdbc+48xibu8ALc3yeyd64IhHS+PU6Yyg=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v0.0.0-20190621154722-5f990b63d2d6/go.mod h1:+lx6/Aqd1kLJ1GQfkvOnaZ1WGmLpMpbprPuIOOZX30U=
+github.com/ans-group/go-durationstring v1.2.0 h1:UJIuQATkp0t1rBvZsHRwki33YHV9E+Ulro+3NbMB7MM=
+github.com/ans-group/go-durationstring v1.2.0/go.mod h1:QGF9Mdpq9058QXaut8r55QWu6lcHX6i/GvF1PZVkV6o=
+github.com/ans-group/sdk-go v1.7.0 h1:Riy6MwVf6fkmQvxPPA1UfrBoqo3GYghXV9MhCzlCPg8=
+github.com/ans-group/sdk-go v1.7.0/go.mod h1:XSKXEDfKobnDtZoyia5DhJxxaDMcCjr76e1KJ9dU/xc=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
 github.com/aokoli/goutils v1.1.0/go.mod h1:SijmP0QR8LtwsmDs8Yii5Z/S4trXFGFC2oO5g9DP+DQ=

--- a/provider/safedns/safedns.go
+++ b/provider/safedns/safedns.go
@@ -21,10 +21,10 @@ import (
 	"fmt"
 	"os"
 
-	log "github.com/sirupsen/logrus"
-	ukfClient "github.com/ans-group/sdk-go/pkg/client"
-	ukfConnection "github.com/ans-group/sdk-go/pkg/connection"
+	ansClient "github.com/ans-group/sdk-go/pkg/client"
+	ansConnection "github.com/ans-group/sdk-go/pkg/connection"
 	"github.com/ans-group/sdk-go/pkg/service/safedns"
+	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
@@ -38,8 +38,8 @@ type SafeDNS interface {
 	DeleteZoneRecord(zoneName string, recordID int) error
 	GetZone(zoneName string) (safedns.Zone, error)
 	GetZoneRecord(zoneName string, recordID int) (safedns.Record, error)
-	GetZoneRecords(zoneName string, parameters ukfConnection.APIRequestParameters) ([]safedns.Record, error)
-	GetZones(parameters ukfConnection.APIRequestParameters) ([]safedns.Zone, error)
+	GetZoneRecords(zoneName string, parameters ansConnection.APIRequestParameters) ([]safedns.Record, error)
+	GetZones(parameters ansConnection.APIRequestParameters) ([]safedns.Zone, error)
 	PatchZoneRecord(zoneName string, recordID int, patch safedns.PatchRecordRequest) (int, error)
 	UpdateZoneRecord(zoneName string, record safedns.Record) (int, error)
 }
@@ -51,7 +51,7 @@ type SafeDNSProvider struct {
 	// Only consider hosted zones managing domains ending in this suffix
 	domainFilter     endpoint.DomainFilter
 	DryRun           bool
-	APIRequestParams ukfConnection.APIRequestParameters
+	APIRequestParams ansConnection.APIRequestParameters
 }
 
 // ZoneRecord is a datatype to simplify management of a record in a zone.
@@ -70,15 +70,15 @@ func NewSafeDNSProvider(domainFilter endpoint.DomainFilter, dryRun bool) (*SafeD
 		return nil, fmt.Errorf("no SAFEDNS_TOKEN found in environment")
 	}
 
-	ukfAPIConnection := ukfConnection.NewAPIKeyCredentialsAPIConnection(token)
-	ukfClient := ukfClient.NewClient(ukfAPIConnection)
-	safeDNS := ukfClient.SafeDNSService()
+	ukfAPIConnection := ansConnection.NewAPIKeyCredentialsAPIConnection(token)
+	ansClient := ansClient.NewClient(ukfAPIConnection)
+	safeDNS := ansClient.SafeDNSService()
 
 	provider := &SafeDNSProvider{
 		Client:           safeDNS,
 		domainFilter:     domainFilter,
 		DryRun:           dryRun,
-		APIRequestParams: *ukfConnection.NewAPIRequestParameters(),
+		APIRequestParams: *ansConnection.NewAPIRequestParameters(),
 	}
 	return provider, nil
 }

--- a/provider/safedns/safedns.go
+++ b/provider/safedns/safedns.go
@@ -22,9 +22,9 @@ import (
 	"os"
 
 	log "github.com/sirupsen/logrus"
-	ukfClient "github.com/ukfast/sdk-go/pkg/client"
-	ukfConnection "github.com/ukfast/sdk-go/pkg/connection"
-	"github.com/ukfast/sdk-go/pkg/service/safedns"
+	ukfClient "github.com/ans-group/sdk-go/pkg/client"
+	ukfConnection "github.com/ans-group/sdk-go/pkg/connection"
+	"github.com/ans-group/sdk-go/pkg/service/safedns"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"

--- a/provider/safedns/safedns_test.go
+++ b/provider/safedns/safedns_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	ukfConnection "github.com/ukfast/sdk-go/pkg/connection"
-	"github.com/ukfast/sdk-go/pkg/service/safedns"
+	ukfConnection "github.com/ans-group/sdk-go/pkg/connection"
+	"github.com/ans-group/sdk-go/pkg/service/safedns"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"

--- a/provider/safedns/safedns_test.go
+++ b/provider/safedns/safedns_test.go
@@ -21,11 +21,11 @@ import (
 	"os"
 	"testing"
 
+	ansConnection "github.com/ans-group/sdk-go/pkg/connection"
+	"github.com/ans-group/sdk-go/pkg/service/safedns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	ukfConnection "github.com/ans-group/sdk-go/pkg/connection"
-	"github.com/ans-group/sdk-go/pkg/service/safedns"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
@@ -56,12 +56,12 @@ func (m *MockSafeDNSService) GetZoneRecord(zoneName string, recordID int) (safed
 	return args.Get(0).(safedns.Record), args.Error(1)
 }
 
-func (m *MockSafeDNSService) GetZoneRecords(zoneName string, parameters ukfConnection.APIRequestParameters) ([]safedns.Record, error) {
+func (m *MockSafeDNSService) GetZoneRecords(zoneName string, parameters ansConnection.APIRequestParameters) ([]safedns.Record, error) {
 	args := m.Called(zoneName, parameters)
 	return args.Get(0).([]safedns.Record), args.Error(1)
 }
 
-func (m *MockSafeDNSService) GetZones(parameters ukfConnection.APIRequestParameters) ([]safedns.Zone, error) {
+func (m *MockSafeDNSService) GetZones(parameters ansConnection.APIRequestParameters) ([]safedns.Zone, error) {
 	args := m.Called(parameters)
 	return args.Get(0).([]safedns.Zone), args.Error(1)
 }


### PR DESCRIPTION
**Description**

Following the UKFast merge with ANS group, the URL for GitHub repositories has been changed. While GitHub will redirect to the correct place, it makes sense to update references to avoid confusion going forward.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
