### PR TITLE
Set logformat before logging config

### DIFF
--- a/docs/tutorials/gke.md
+++ b/docs/tutorials/gke.md
@@ -325,6 +325,7 @@ spec:
             - --source=ingress
             - --domain-filter=example.com # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
             - --provider=google
+            - --log-format=json # google cloud logs parses severity of the "text" log format incorrectly
     #        - --google-project=my-cloud-dns-project # Use this to specify a project different from the one external-dns is running inside
             - --google-zone-visibility=public # Use this to filter to only zones with this visibility. Set to either 'public' or 'private'. Omitting will match public and private zones
             - --policy=upsert-only # would prevent ExternalDNS from deleting any records, omit to enable full synchronization

--- a/main.go
+++ b/main.go
@@ -77,15 +77,15 @@ func main() {
 	if err := cfg.ParseFlags(os.Args[1:]); err != nil {
 		log.Fatalf("flag parsing error: %v", err)
 	}
+	if cfg.LogFormat == "json" {
+		log.SetFormatter(&log.JSONFormatter{})
+	}
 	log.Infof("config: %s", cfg)
 
 	if err := validation.ValidateConfig(cfg); err != nil {
 		log.Fatalf("config validation failed: %v", err)
 	}
 
-	if cfg.LogFormat == "json" {
-		log.SetFormatter(&log.JSONFormatter{})
-	}
 	if cfg.DryRun {
 		log.Info("running in dry-run mode. No changes to DNS records will be made.")
 	}


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Google Cloud Logging (AKA Stackdriver Logs) interprets the default
logrus log format as "error" severity even when `level=info` is
present in the log output: ensure that the normal startup log
is not parsed as an error by setting the JSON formatter first.

**Checklist**

- [X] Unit tests updated
- [X] End user documentation updated

Signed-off-by: Nathan J Mehl <n@oden.io>