### PR TITLE
Restore support for exclusion-only domain filters for AWS provider

### DIFF
--- a/endpoint/domain_filter_test.go
+++ b/endpoint/domain_filter_test.go
@@ -379,15 +379,15 @@ func TestPrepareFiltersStripsWhitespaceAndDotSuffix(t *testing.T) {
 	}{
 		{
 			[]string{},
-			[]string{},
+			nil,
 		},
 		{
 			[]string{""},
-			[]string{""},
+			nil,
 		},
 		{
 			[]string{" ", "   ", ""},
-			[]string{"", "", ""},
+			nil,
 		},
 		{
 			[]string{"  foo   ", "  bar. ", "baz."},
@@ -429,7 +429,7 @@ func TestDomainFilterIsConfigured(t *testing.T) {
 		{
 			[]string{"", ""},
 			[]string{""},
-			true,
+			false,
 		},
 		{
 			[]string{" . "},
@@ -443,6 +443,11 @@ func TestDomainFilterIsConfigured(t *testing.T) {
 		},
 		{
 			[]string{" notempty.com "},
+			[]string{"  thisdoesntmatter.com "},
+			true,
+		},
+		{
+			[]string{""},
 			[]string{"  thisdoesntmatter.com "},
 			true,
 		},

--- a/provider/alibabacloud/alibaba_cloud.go
+++ b/provider/alibabacloud/alibaba_cloud.go
@@ -373,7 +373,7 @@ func (p *AlibabaCloudProvider) records() ([]alidns.Record, error) {
 	log.Infof("Retrieving Alibaba Cloud DNS Domain Records")
 	var results []alidns.Record
 
-	if len(p.domainFilter.Filters) == 1 && p.domainFilter.Filters[0] == "" {
+	if len(p.domainFilter.Filters) == 0 {
 		domainNames, tmpErr := p.getDomainList()
 		if tmpErr != nil {
 			log.Errorf("AlibabaCloudProvider getDomainList error %v", tmpErr)

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -188,17 +188,13 @@ func (p *GoogleProvider) Zones(ctx context.Context) (map[string]*dns.ManagedZone
 		return nil
 	}
 
-	log.Debugf("Matching zones against domain filters: %v", p.domainFilter.Filters)
+	log.Debugf("Matching zones against domain filters: %v", p.domainFilter)
 	if err := p.managedZonesClient.List(p.project).Pages(ctx, f); err != nil {
 		return nil, err
 	}
 
 	if len(zones) == 0 {
-		if p.domainFilter.IsConfigured() {
-			log.Warnf("No zones in the project, %s, match domain filters: %v", p.project, p.domainFilter.Filters)
-		} else {
-			log.Warnf("No zones found in the project, %s", p.project)
-		}
+		log.Warnf("No zones in the project, %s, match domain filters: %v", p.project, p.domainFilter)
 	}
 
 	for _, zone := range zones {

--- a/provider/ibmcloud/ibmcloud.go
+++ b/provider/ibmcloud/ibmcloud.go
@@ -218,7 +218,7 @@ func (c *ibmcloudConfig) Validate(authenticator core.Authenticator, domainFilter
 	var service ibmcloudService
 	isPrivate := false
 	log.Debugf("filters: %v, %v", domainFilter.Filters, zoneIDFilter.ZoneIDs)
-	if domainFilter.Filters[0] == "" && zoneIDFilter.ZoneIDs[0] == "" {
+	if (len(domainFilter.Filters) == 0 || domainFilter.Filters[0] == "") && zoneIDFilter.ZoneIDs[0] == "" {
 		return service, isPrivate, fmt.Errorf("at lease one of filters: 'domain-filter', 'zone-id-filter' needed")
 	}
 
@@ -253,7 +253,7 @@ func (c *ibmcloudConfig) Validate(authenticator core.Authenticator, domainFilter
 		}
 		for _, zone := range zonesResp.Result {
 			log.Debugf("zoneName: %s, zoneID: %s", *zone.Name, *zone.ID)
-			if len(domainFilter.Filters[0]) != 0 && domainFilter.Match(*zone.Name) {
+			if len(domainFilter.Filters) > 0 && domainFilter.Filters[0] != "" && domainFilter.Match(*zone.Name) {
 				log.Debugf("zone %s found.", *zone.ID)
 				zoneID = *zone.ID
 				break

--- a/provider/oci/oci.go
+++ b/provider/oci/oci.go
@@ -138,11 +138,7 @@ func (p *OCIProvider) zones(ctx context.Context) (map[string]dns.ZoneSummary, er
 	}
 
 	if len(zones) == 0 {
-		if p.domainFilter.IsConfigured() {
-			log.Warnf("No zones in compartment %q match domain filters %v", p.cfg.CompartmentID, p.domainFilter.Filters)
-		} else {
-			log.Warnf("No zones found in compartment %q", p.cfg.CompartmentID)
-		}
+		log.Warnf("No zones in compartment %q match domain filters %v", p.cfg.CompartmentID, p.domainFilter)
 	}
 
 	return zones, nil


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This aims to fix regression #2821.

I've tweaked `endpoint.DomainFilter.IsConfigured()` to pass for filters that only express exclusion rules (either regular expression-based exclusion or an explicit exclusion list). I've also tweaked some of the initialization to handle empty strings in explicit filter lists less ambiguously.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2821 

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
