### PR TITLE
Fix Helm chart CHANGELOG for v1.10.0

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed -->
 
-## [UNRELEASED]
+## [v1.10.0] - 2022-07-04
 
 ### Added
 

--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -6,6 +6,7 @@ version: 1.10.0
 appVersion: 0.12.0
 keywords:
   - kubernetes
+  - externaldns
   - external-dns
   - dns
   - service


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR fixes the [broken chart release](https://github.com/kubernetes-sigs/external-dns/runs/7049733823?check_suite_focus=true) for `v1.10.0` caused by a missing CHANGELOG entry in #2777.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
