### PR TITLE
bug: fix digital ocean provider not setting TTL

### DIFF
--- a/provider/digitalocean/digital_ocean.go
+++ b/provider/digitalocean/digital_ocean.go
@@ -172,7 +172,8 @@ func (p *DigitalOceanProvider) Records(ctx context.Context) ([]*endpoint.Endpoin
 					name = zone.Name
 				}
 
-				ep := endpoint.NewEndpoint(name, r.Type, r.Data)
+				ep := endpoint.NewEndpointWithTTL(name, r.Type, endpoint.TTL(r.TTL), r.Data)
+
 				endpoints = append(endpoints, ep)
 			}
 		}

--- a/provider/digitalocean/digital_ocean_test.go
+++ b/provider/digitalocean/digital_ocean_test.go
@@ -329,6 +329,17 @@ func TestDigitalOceanMakeDomainEditRequest(t *testing.T) {
 		Data: "bar.example.com.",
 		TTL:  digitalOceanRecordTTL,
 	}, r3)
+
+	// Ensure that custom TTLs can be set
+	customTTL := 600
+	r4 := makeDomainEditRequest("example.com", "foo.example.com", endpoint.RecordTypeCNAME,
+		"bar.example.com.", customTTL)
+	assert.Equal(t, &godo.DomainRecordEditRequest{
+		Type: endpoint.RecordTypeCNAME,
+		Name: "foo",
+		Data: "bar.example.com.",
+		TTL:  customTTL,
+	}, r4)
 }
 
 func TestDigitalOceanApplyChanges(t *testing.T) {


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
This PR should fix the issue where the Digital Ocean provider unnecessarily tries to update records,
due to the TTL comparison that happens [here](https://github.com/kubernetes-sigs/external-dns/blob/master/plan/plan.go#L197).
```go
func shouldUpdateTTL(desired, current *endpoint.Endpoint) bool {
	if !desired.RecordTTL.IsConfigured() {
		return false
	}
	return desired.RecordTTL != current.RecordTTL
}
```

The changes makes sure the TTL field is used when creating records.
<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2754

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated

Signed-off-by: Ismayil Mirzali <ismayilmirzeli@gmail.com>
