### PR TITLE
Remove namespace from cluster scoped resources

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -10,10 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ## [UNRELEASED]
 ### Added
 ### Changed
+### Fixed
 ### Deprecated
 ### Removed -->
 
-## [v1.10.0] - 2022-07-04
+## [v1.10.1] - 2022-07-11
+
+### Fixed
+
+- Fixed incorrect addition of `namespace` to `ClusterRole` & `ClusterRoleBinding`. [@stevehipwell](https://github.com/stevehipwell)
+
+## [v1.10.0] - 2022-07-08
 
 ### Added
 

--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: external-dns
 description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 type: application
-version: 1.10.0
+version: 1.10.1
 appVersion: 0.12.0
 keywords:
   - kubernetes
@@ -30,11 +30,4 @@ annotations:
         - name: Process Namespace Sharing
           url: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
     - kind: changed
-      description: "Update ExternalDNS version to v0.12.0"
-    - kind: changed
-      description: "Set resource namespaces to {{ .Release.Namespace }} in the templates instead of waiting until apply time for inference."
-    - kind: fixed
-      description: "Fixed rbac.additionalPermissions default value."
-      links:
-        - name: GitHub Issue #2796
-          url: https://github.com/kubernetes-sigs/external-dns/pull/2796
+      description: "Fixed incorrect addition of `namespace` to `ClusterRole` & `ClusterRoleBinding`."

--- a/charts/external-dns/templates/clusterrole.yaml
+++ b/charts/external-dns/templates/clusterrole.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "external-dns.fullname" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
 rules:

--- a/charts/external-dns/templates/clusterrolebinding.yaml
+++ b/charts/external-dns/templates/clusterrolebinding.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ printf "%s-viewer" (include "external-dns.fullname" .) }}
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
 roleRef:


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR removes the incorrectly added `namespace` field from the cluster scoped `ClusterRole` & `ClusterRoleBinding` resources and releases a chart patch.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
