### PR TITLE
Remove extraneous namespace on cluster-scoped resources

### DIFF
--- a/charts/external-dns/templates/clusterrole.yaml
+++ b/charts/external-dns/templates/clusterrole.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "external-dns.fullname" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
 rules:

--- a/charts/external-dns/templates/clusterrolebinding.yaml
+++ b/charts/external-dns/templates/clusterrolebinding.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ printf "%s-viewer" (include "external-dns.fullname" .) }}
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
 roleRef:


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Cluster-scoped resources should not have a namespace, and any namespace
argument provided will not render in the hydrated manifests.

Declaring a namespace also breaks [Config Sync](https://github.com/GoogleContainerTools/kpt-config-sync), which throws an
[error](https://cloud.google.com/anthos-config-management/docs/reference/errors#knv1052) when a cluster-scoped resource contains a namespace.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

Both of these seem N/A, but:

- [x] Unit tests updated
- [x] End user documentation updated
