### PR TITLE
deduplicate targets after combine endpoints #1929

### DIFF
--- a/source/service.go
+++ b/source/service.go
@@ -232,10 +232,27 @@ func (sc *serviceSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, e
 	}
 
 	for _, ep := range endpoints {
+		deduplicateTargets(ep)
 		sort.Sort(ep.Targets)
 	}
 
 	return endpoints, nil
+}
+
+func deduplicateTargets(ep *endpoint.Endpoint) *endpoint.Endpoint {
+	deduppedTargets := map[string]struct{}{}
+	targets := []string{}
+	for _, target := range ep.Targets {
+		if _, ok := deduppedTargets[target]; ok {
+			log.Debugf(">>Removing duplicate target %s", target)
+			continue
+		}
+
+		deduppedTargets[target] = struct{}{}
+		targets = append(targets, target)
+	}
+	ep.Targets = targets
+	return ep
 }
 
 // extractHeadlessEndpoints extracts endpoints from a headless service using the "Endpoints" Kubernetes API resource


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
When using headless service with External-IP, if multiple PODs are scheduled on same k8s Node, the extractHeadlessEndpoints func will  return multiple endpoints of root domain with same external ip, after combining these endpoints in Endpoints func, the root domain will have same IPs in its targets. This is the reason why we got "Duplicate Resource Record" error.
When using shared service IP address, the issue is similar.
<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1929

**Checklist**
