### PR TITLE
feat: Add Root Domain Record

### DIFF
--- a/source/service.go
+++ b/source/service.go
@@ -324,10 +324,16 @@ func (sc *serviceSource) extractHeadlessEndpoints(svc *v1.Service, hostname stri
 	}
 
 	headlessDomains := []string{}
+	for headlessDomain := range targetsByHeadlessDomain {
+		headlessDomains = append(headlessDomains, headlessDomain)
+	}
+	sort.Strings(headlessDomains)
+
 	allTargetsRoot := make([]string, 0)
 	for _, headlessDomain := range headlessDomains {
 		allTargets := targetsByHeadlessDomain[headlessDomain]
 		targets := []string{}
+
 		deduppedTargets := map[string]struct{}{}
 		for _, target := range allTargets {
 			if _, ok := deduppedTargets[target]; ok {

--- a/source/service.go
+++ b/source/service.go
@@ -340,9 +340,11 @@ func (sc *serviceSource) extractHeadlessEndpoints(svc *v1.Service, hostname stri
 				log.Debugf("Removing duplicate target %s", target)
 				continue
 			}
+
 			deduppedTargets[target] = struct{}{}
 			targets = append(targets, target)
 		}
+
 		if ttl.IsConfigured() {
 			endpoints = append(endpoints, endpoint.NewEndpointWithTTL(headlessDomain, endpoint.RecordTypeA, ttl, targets...))
 		} else {


### PR DESCRIPTION
Description
Added annotation to support headless root domain that contains all of the sub addresses in the DNS record to communicate with a single DNS record for example when using Kafka.

Annotation:
external-dns.alpha.kubernetes.io/headless-root-domain-record

Fixes #2832 

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
