### PR TITLE
update ultradns sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/alexbrainman/sspi v0.0.0-20180613141037-e580b900e9f5 // indirect
 	github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 // indirect
+	github.com/ans-group/go-durationstring v1.2.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
@@ -144,7 +145,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/terra-farm/udnssdk v1.3.5 // indirect
-	github.com/ans-group/go-durationstring v1.2.0 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.2 // indirect
 	go.mongodb.org/mongo-driver v1.5.1 // indirect
 	go.opencensus.io v0.23.0 // indirect
@@ -201,6 +201,7 @@ require (
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/rs/zerolog v1.26.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/shettyvaishak/ultradns-sdk-go v1.3.8 // indirect
 	github.com/spf13/afero v1.8.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/cobra v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1284,6 +1284,8 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/shettyvaishak/ultradns-sdk-go v1.3.8 h1:kLKKb00gffZwyjcuphs4k2KiZ/+DQB9H0ib1pVafaXM=
+github.com/shettyvaishak/ultradns-sdk-go v1.3.8/go.mod h1:mth7Izn/IRwZsFrv230HW1i/HeSrLgChF7eE0+4jPn0=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=

--- a/provider/ultradns/ultradns_test.go
+++ b/provider/ultradns/ultradns_test.go
@@ -27,8 +27,8 @@ import (
 	_ "strings"
 	"testing"
 
+	udnssdk "github.com/shettyvaishak/ultradns-sdk-go"
 	"github.com/stretchr/testify/assert"
-	udnssdk "github.com/ultradns/ultradns-sdk-go"
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 )
@@ -37,7 +37,7 @@ type mockUltraDNSZone struct {
 	client *udnssdk.Client
 }
 
-func (m *mockUltraDNSZone) SelectWithOffsetWithLimit(k *udnssdk.ZoneKey, offset int, limit int) (zones []udnssdk.Zone, ResultInfo udnssdk.ResultInfo, resp *http.Response, err error) {
+func (m *mockUltraDNSZone) SelectWithOffsetWithLimit(k *udnssdk.ZoneKey, page string, limit int) (zones []udnssdk.Zone, CursorInfo udnssdk.CursorInfo, resp *http.Response, err error) {
 	zones = []udnssdk.Zone{}
 	zone := udnssdk.Zone{}
 	zoneJson := `
@@ -58,7 +58,7 @@ func (m *mockUltraDNSZone) SelectWithOffsetWithLimit(k *udnssdk.ZoneKey, offset 
 	}
 
 	zones = append(zones, zone)
-	return zones, udnssdk.ResultInfo{}, nil, nil
+	return zones, udnssdk.CursorInfo{}, nil, nil
 }
 
 type mockUltraDNSRecord struct {
@@ -131,7 +131,7 @@ func TestUltraDNSProvider_Zones(t *testing.T) {
 		AccountName: "teamrest",
 	}
 
-	expected, _, _, err := provider.client.Zone.SelectWithOffsetWithLimit(zoneKey, 0, 1000)
+	expected, _, _, err := provider.client.Zone.SelectWithOffsetWithLimit(zoneKey, "", 1000)
 	assert.Nil(t, err)
 	zones, err := provider.Zones(context.Background())
 	assert.Nil(t, err)
@@ -731,7 +731,7 @@ func TestUltraDNSProvider_DomainFilterZonesMocked(t *testing.T) {
 	}
 
 	// When AccountName not given
-	expected, _, _, err := provider.client.Zone.SelectWithOffsetWithLimit(zoneKey, 0, 1000)
+	expected, _, _, err := provider.client.Zone.SelectWithOffsetWithLimit(zoneKey, "", 1000)
 	assert.Nil(t, err)
 	zones, err := provider.Zones(context.Background())
 	assert.Nil(t, err)
@@ -750,7 +750,7 @@ func TestUltraDNSProvider_DomainFilterZonesMocked(t *testing.T) {
 		AccountName: "teamrest",
 	}
 
-	expected, _, _, err = provider.client.Zone.SelectWithOffsetWithLimit(zoneKey, 0, 1000)
+	expected, _, _, err = provider.client.Zone.SelectWithOffsetWithLimit(zoneKey, "", 1000)
 	assert.Nil(t, err)
 	zones, err = provider.Zones(context.Background())
 	assert.Nil(t, err)
@@ -767,7 +767,7 @@ func TestUltraDNSProvider_DomainFilterZonesMocked(t *testing.T) {
 		AccountName: "teamrest",
 	}
 
-	expected, _, _, err = provider.client.Zone.SelectWithOffsetWithLimit(zoneKey, 0, 1000)
+	expected, _, _, err = provider.client.Zone.SelectWithOffsetWithLimit(zoneKey, "", 1000)
 	assert.Nil(t, err)
 	zones, err = provider.Zones(context.Background())
 	assert.Nil(t, err)


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
/zones api is deprecated and replaced with v3/zones. There are also changes to the pagination model, api returns cursorInfo instead of resultInfo. cursorInfo has following fields: first, next, previous, last indicating subsequent page id's

Could not commit to the existing sdk repo so forked it and made the changes
https://github.com/shettyvaishak/ultradns-sdk-go

More details on the api change can be found here:
https://docs.ultradns.neustar/Content/REST%20API/Content/REST%20API/Zone%20API/Zone%20API.htm

Built the image locally using these changes and monitored for a week , all functionality seems to be working as expected
<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2780 

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
