### PR TITLE
feat: Add support to configure dnsPolicy on the Helm chart deployment

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ## [UNRELEASED]
 ### Added
+
+- Add support to configure dnsPolicy on the Helm chart deployment. [@michelzanini](https://github.com/michelzanini)
+
 ### Changed
 ### Fixed
 ### Deprecated

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -44,6 +44,9 @@ spec:
       {{- with .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ . }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end }}
       containers:
         - name: external-dns
           {{- with .Values.securityContext }}

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -44,8 +44,8 @@ spec:
       {{- with .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ . }}
       {{- end }}
-      {{- if .Values.dnsPolicy }}
-      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- with .Values.dnsPolicy }}
+      dnsPolicy: {{ . }}
       {{- end }}
       containers:
         - name: external-dns

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -49,6 +49,10 @@ securityContext:
   capabilities:
     drop: ["ALL"]
 
+# Defaults to `ClusterFirst`.
+# Valid values are: `ClusterFirstWithHostNet`, `ClusterFirst`, `Default` or `None`.
+dnsPolicy: ClusterFirst
+
 priorityClassName: ""
 
 terminationGracePeriodSeconds:

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -51,7 +51,7 @@ securityContext:
 
 # Defaults to `ClusterFirst`.
 # Valid values are: `ClusterFirstWithHostNet`, `ClusterFirst`, `Default` or `None`.
-dnsPolicy: ClusterFirst
+dnsPolicy:
 
 priorityClassName: ""
 


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Add support to configure dnsPolicy on the Helm chart deployment.
This allows us to set the `dnsPolicy` to `Default` and skip in-cluster DNS to improve performance.

