### PR TITLE
Update All GitHub Actions to use Go 1.18

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install go version
       uses: actions/setup-go@v3
       with:
-        go-version: '^1.16'
+        go-version: '^1.18'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: ^1.17
+          go-version: ^1.18
 
       - run: |
           pip install -r docs/scripts/requirements.txt


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
All GitHub actions that use actions/setup-go are being updated to use Go
1.18. Now all CI tasks should be using hte same version of Go, 1.18.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes N/A

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
