### PR TITLE
Handle the migration to the new TXT format: missing records to be created separately

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -188,11 +188,33 @@ func (c *Controller) RunOnce(ctx context.Context) error {
 	verifiedARecords.Set(float64(len(vRecords)))
 	endpoints = c.Registry.AdjustEndpoints(endpoints)
 
+	if len(missingRecords) > 0 {
+		// Add missing records before the actual plan is applied.
+		// This prevents the problems when the missing TXT record needs to be
+		// created and deleted/upserted in the same batch.
+		missingRecordsPlan := &plan.Plan{
+			Policies:           []plan.Policy{c.Policy},
+			Missing:            missingRecords,
+			DomainFilter:       endpoint.MatchAllDomainFilters{c.DomainFilter, c.Registry.GetDomainFilter()},
+			PropertyComparator: c.Registry.PropertyValuesEqual,
+			ManagedRecords:     c.ManagedRecordTypes,
+		}
+		missingRecordsPlan = missingRecordsPlan.Calculate()
+		if missingRecordsPlan.Changes.HasChanges() {
+			err = c.Registry.ApplyChanges(ctx, missingRecordsPlan.Changes)
+			if err != nil {
+				registryErrorsTotal.Inc()
+				deprecatedRegistryErrors.Inc()
+				return err
+			}
+			log.Info("All missing records are created")
+		}
+	}
+
 	plan := &plan.Plan{
 		Policies:           []plan.Policy{c.Policy},
 		Current:            records,
 		Desired:            endpoints,
-		Missing:            missingRecords,
 		DomainFilter:       endpoint.MatchAllDomainFilters{c.DomainFilter, c.Registry.GetDomainFilter()},
 		PropertyComparator: c.Registry.PropertyValuesEqual,
 		ManagedRecords:     c.ManagedRecordTypes,

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -270,6 +270,51 @@ func testControllerFiltersDomains(t *testing.T, configuredEndpoints []*endpoint.
 	}
 }
 
+type noopRegistryWithMissing struct {
+	*registry.NoopRegistry
+	missingRecords []*endpoint.Endpoint
+}
+
+func (r *noopRegistryWithMissing) MissingRecords() []*endpoint.Endpoint {
+	return r.missingRecords
+}
+
+func testControllerFiltersDomainsWithMissing(t *testing.T, configuredEndpoints []*endpoint.Endpoint, domainFilter endpoint.DomainFilterInterface, providerEndpoints, missingEndpoints []*endpoint.Endpoint, expectedChanges []*plan.Changes) {
+	t.Helper()
+	cfg := externaldns.NewConfig()
+	cfg.ManagedDNSRecordTypes = []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME}
+
+	source := new(testutils.MockSource)
+	source.On("Endpoints").Return(configuredEndpoints, nil)
+
+	// Fake some existing records in our DNS provider and validate some desired changes.
+	provider := &filteredMockProvider{
+		RecordsStore: providerEndpoints,
+	}
+	noop, err := registry.NewNoopRegistry(provider)
+	require.NoError(t, err)
+
+	r := &noopRegistryWithMissing{
+		NoopRegistry:   noop,
+		missingRecords: missingEndpoints,
+	}
+
+	ctrl := &Controller{
+		Source:             source,
+		Registry:           r,
+		Policy:             &plan.SyncPolicy{},
+		DomainFilter:       domainFilter,
+		ManagedRecordTypes: cfg.ManagedDNSRecordTypes,
+	}
+
+	assert.NoError(t, ctrl.RunOnce(context.Background()))
+	assert.Equal(t, 1, provider.RecordsCallCount)
+	require.Len(t, provider.ApplyChangesCalls, len(expectedChanges))
+	for i, change := range expectedChanges {
+		assert.Equal(t, *change, *provider.ApplyChangesCalls[i])
+	}
+}
+
 func TestControllerSkipsEmptyChanges(t *testing.T) {
 	testControllerFiltersDomains(
 		t,
@@ -516,4 +561,58 @@ func TestARecords(t *testing.T) {
 	)
 	assert.Equal(t, math.Float64bits(2), valueFromMetric(sourceARecords))
 	assert.Equal(t, math.Float64bits(1), valueFromMetric(registryARecords))
+}
+
+// TestMissingRecordsApply validates that the missing records result in the dedicated plan apply.
+func TestMissingRecordsApply(t *testing.T) {
+	testControllerFiltersDomainsWithMissing(
+		t,
+		[]*endpoint.Endpoint{
+			{
+				DNSName:    "record1.used.tld",
+				RecordType: endpoint.RecordTypeA,
+				Targets:    endpoint.Targets{"1.2.3.4"},
+			},
+			{
+				DNSName:    "record2.used.tld",
+				RecordType: endpoint.RecordTypeA,
+				Targets:    endpoint.Targets{"8.8.8.8"},
+			},
+		},
+		endpoint.NewDomainFilter([]string{"used.tld"}),
+		[]*endpoint.Endpoint{
+			{
+				DNSName:    "record1.used.tld",
+				RecordType: endpoint.RecordTypeA,
+				Targets:    endpoint.Targets{"1.2.3.4"},
+			},
+		},
+		[]*endpoint.Endpoint{
+			{
+				DNSName:    "a-record1.used.tld",
+				RecordType: endpoint.RecordTypeTXT,
+				Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=owner\""},
+			},
+		},
+		[]*plan.Changes{
+			// Missing record had its own plan applied.
+			{
+				Create: []*endpoint.Endpoint{
+					{
+						DNSName:    "a-record1.used.tld",
+						RecordType: endpoint.RecordTypeTXT,
+						Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=owner\""},
+					},
+				},
+			},
+			{
+				Create: []*endpoint.Endpoint{
+					{
+						DNSName:    "record2.used.tld",
+						RecordType: endpoint.RecordTypeA,
+						Targets:    endpoint.Targets{"8.8.8.8"},
+					},
+				},
+			},
+		})
 }


### PR DESCRIPTION
**Description**
Follow-up of https://github.com/kubernetes-sigs/external-dns/pull/2811. Aims at addressing the following error when the missing new format TXT record gets created and deleted in the same batch:
```
Applying provider record filter for domains: [external.dns. .external.dns.]"
time="2022-07-26T07:17:45Z" level=info msg="Desired change: UPSERT cname-externaldns-e2e.external.dns TXT [Id: /hostedzone/]"
time="2022-07-26T07:17:45Z" level=info msg="Desired change: UPSERT externaldns-e2e.external.dns A [Id: /hostedzone/]"
time="2022-07-26T07:17:45Z" level=info msg="Desired change: UPSERT externaldns-e2e.external.dns TXT [Id: /hostedzone/]"
time="2022-07-26T07:17:45Z" level=info msg="Desired change: CREATE cname-externaldns-e2e.external.dns TXT [Id: /hostedzone/]"
time="2022-07-26T07:17:46Z" level=error msg="Failure in zone external.dns. [Id: /hostedzone/]"
time="2022-07-26T07:17:46Z" level=error msg="InvalidChangeBatch: [The request contains an invalid set of changes for a resource record set 'TXT cname-externaldns-e2e.external.dns.']\n\tstatus code: 400, request id: "
```

This error may happen when the DNS record was created with the external-dns of version `< 0.12.0` then the target of the source changed (ClusterIP, LoadBalancer's DNS record, HostIP) and then the new (`> 0.12.0`) version kicks the migration logic. The migration code sees that there is a new format TXT record is missing and adds it as "to be created" however the target changed and A/CNAME record needs to be changed too along with its TXT records.

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
