### PR TITLE
minor fixes to the scaleway provider

### DIFF
--- a/provider/scaleway/scaleway.go
+++ b/provider/scaleway/scaleway.go
@@ -19,6 +19,7 @@ package scaleway
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -55,9 +56,19 @@ type ScalewayChange struct {
 
 // NewScalewayProvider initializes a new Scaleway DNS provider
 func NewScalewayProvider(ctx context.Context, domainFilter endpoint.DomainFilter, dryRun bool) (*ScalewayProvider, error) {
+	var err error
+	defaultPageSize := uint64(1000)
+	if envPageSize, ok := os.LookupEnv("SCW_DEFAULT_PAGE_SIZE"); ok {
+		defaultPageSize, err = strconv.ParseUint(envPageSize, 10, 32)
+		if err != nil {
+			log.Infof("Ignoring default page size %s, defaulting to 1000", envPageSize)
+			defaultPageSize = 1000
+		}
+	}
 	scwClient, err := scw.NewClient(
 		scw.WithEnv(),
 		scw.WithUserAgent("ExternalDNS/"+externaldns.Version),
+		scw.WithDefaultPageSize(uint32(defaultPageSize)),
 	)
 	if err != nil {
 		return nil, err
@@ -256,6 +267,10 @@ func (p *ScalewayProvider) generateApplyRequests(ctx context.Context, changes *p
 		req.Changes = append(req.Changes, &domain.RecordChange{
 			Add: recordsToAdd[zoneName],
 		})
+		// ignore sending empty update requests
+		if len(req.Changes) == 1 && len(req.Changes[0].Add.Records) == 0 {
+			continue
+		}
 		returnedRequests = append(returnedRequests, req)
 	}
 


### PR DESCRIPTION
Signed-off-by: Patrik Cyvoct <patrik@ptrk.io>

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Two small fixes for the Scaleway provider:
- defaults to a bigger page size for listing when there is a lot of domains
- avoid sending an empty update zone request