### PR TITLE
 terminationGracePeriodSeconds  default value update

### DIFF
--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -51,7 +51,7 @@ securityContext:
 
 priorityClassName: ""
 
-terminationGracePeriodSeconds:
+terminationGracePeriodSeconds: null 
 
 serviceMonitor:
   enabled: false


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
 Updated terminationGracePeriodSeconds  default value as per document
<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2920 

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
