### PR TITLE
Updated Helm chart to use ExternalDNS v0.12.2

### DIFF
--- a/.github/workflows/lint-test-chart.yaml
+++ b/.github/workflows/lint-test-chart.yaml
@@ -9,33 +9,36 @@ jobs:
   lint-test:
     if: github.repository == 'kubernetes-sigs/external-dns'
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           fetch-depth: 0
 
       - name: Run Artifact Hub lint
-        shell: bash
         run: |
           set -euo pipefail
-          curl -Lo ah_linux_amd64.tar.gz https://github.com/artifacthub/hub/releases/download/v1.6.0/ah_1.6.0_linux_amd64.tar.gz
+          curl -Lo ah_linux_amd64.tar.gz https://github.com/artifacthub/hub/releases/download/v1.9.0/ah_1.9.0_linux_amd64.tar.gz
           tar -xzvf ah_linux_amd64.tar.gz ah
           ./ah lint --kind helm || exit 1
           rm -f ./ah ./ah_linux_amd64.tar.gz
 
-      - name: Set up Helm
-        uses: azure/setup-helm@v1
+      - name: Set-up Helm
+        uses: azure/setup-helm@b5b231a831f96336bbfeccc1329990f0005c5bb1
         with:
-          version: 3.*
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - name: Set-up Python
+        uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5
         with:
-          python-version: 3.7
+          python-version: "3.x"
 
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.2.1
+      - name: Set-up chart-testing
+        uses: helm/chart-testing-action@dae259e86a35ff09145c0805e2d7dd3f7207064a
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -48,8 +51,8 @@ jobs:
       - name: Run chart-testing (lint)
         run: ct lint --check-version-increment=false
 
-      - name: Create Kind cluster
-        uses: helm/kind-action@v1.2.0
+      - name: Set-up Kind cluster
+        uses: helm/kind-action@d08cf6ff1575077dee99962540d77ce91c62387d
         with:
           wait: 120s
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -11,15 +11,17 @@ jobs:
   release:
     if: github.repository == 'kubernetes-sigs/external-dns'
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           fetch-depth: 0
 
       - name: Get chart version
         id: chart_version
-        shell: bash
         run: |
           set -euo pipefail
           chart_version="$(grep -Po "(?<=^version: ).+" charts/external-dns/Chart.yaml)"
@@ -27,13 +29,12 @@ jobs:
 
       - name: Get changelog entry
         id: changelog_reader
-        uses: mindsers/changelog-reader-action@v2
+        uses: mindsers/changelog-reader-action@5bfb30f7871d5c4cde50cd897314f37578043394
         with:
           path: charts/external-dns/CHANGELOG.md
           version: "v${{ steps.chart_version.outputs.version }}"
 
       - name: Create release notes
-        shell: bash
         run: |
           set -euo pipefail
           cat <<"EOF" > charts/external-dns/_release-notes.md
@@ -45,13 +46,14 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Install Helm
-        uses: azure/setup-helm@v1
+      - name: Set-up Helm
+        uses: azure/setup-helm@b5b231a831f96336bbfeccc1329990f0005c5bb1
         with:
-          version: v3.6.3
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.3.0
+        uses: helm/chart-releaser-action@a3454e46a6f5ac4811069a381e646961dda2e1bf
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_RELEASE_NAME_TEMPLATE: "external-dns-helm-chart-{{ .Version }}"

--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -9,13 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ## [UNRELEASED]
 ### Added
-
-- Add support to configure dnsPolicy on the Helm chart deployment. [@michelzanini](https://github.com/michelzanini)
-
 ### Changed
 ### Fixed
 ### Deprecated
 ### Removed -->
+
+## [v1.11.0] - 2022-08-10
+
+### Added
+
+- Added support to configure `dnsPolicy` on the Helm chart deployment. [@michelzanini](https://github.com/michelzanini)
+- Added ability to customise the deployment strategy. [mac-chaffee](https://github.com/mac-chaffee)
+
+### Changed
+
+- Updated _ExternalDNS_ version to [v0.12.2](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.12.2). [@stevehipwell](https://github.com/stevehipwell)
+- Changed default deployment strategy to `Recreate`. [mac-chaffee](https://github.com/mac-chaffee)
 
 ## [v1.10.1] - 2022-07-11
 

--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: external-dns
 description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 type: application
-version: 1.10.1
-appVersion: 0.12.0
+version: 1.11.0
+appVersion: 0.12.2
 keywords:
   - kubernetes
   - externaldns
@@ -21,13 +21,10 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "Added commonLabels value to allow the addition of labels to all resources."
+      description: "Added support to configure dnsPolicy on the Helm chart deployment."
     - kind: added
-      description: "Added support for Process Namespace Sharing via the shareProcessNamespace value."
-      links:
-        - name: GitHub Issue #2715
-          url: https://github.com/kubernetes-sigs/external-dns/pull/2715
-        - name: Process Namespace Sharing
-          url: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+      description: "Added ability to customise the deployment strategy."
     - kind: changed
-      description: "Fixed incorrect addition of `namespace` to `ClusterRole` & `ClusterRoleBinding`."
+      description: "Updated ExternalDNS version to v0.12.2."
+    - kind: changed
+      description: "Changed default deployment strategy to Recreate."


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR updates the helm chart to use ExternalDNS `v0.12.2` and includes the merged PRs since the last release; it also includes updates to the GitHub actions used to release the chart which are locked down to specific commits so that a moved tag can't introduce different code.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2916

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
