### PR TITLE
Fixing issue preventing use of default version

### DIFF
--- a/charts/external-dns/templates/_helpers.tpl
+++ b/charts/external-dns/templates/_helpers.tpl
@@ -68,5 +68,5 @@ Create the name of the service account to use
 The image to use
 */}}
 {{- define "external-dns.image" -}}
-{{- printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) }}
+{{- printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.appVersion) .Values.image.tag) }}
 {{- end }}


### PR DESCRIPTION
**Description**
In "v1.11.0" and before was causing errors when image.tag was not defined 
```
"docker.io/k8s.gcr.io/external-dns/external-dns:": invalid reference format
```
I believe this is because of a typo (.AppVersion instead of .appVersion)

