### PR TITLE
infoblox paging

### DIFF
--- a/provider/infoblox/infoblox.go
+++ b/provider/infoblox/infoblox.go
@@ -748,7 +748,6 @@ func PagingGetObject[T any](
 	queryParams map[string]string,
 	res *[]T,
 ) (err error) {
-
 	pagingResponse := pagingResponseStruct[T]{
 		NextPageId: "",
 		Result:     *res,
@@ -769,9 +768,9 @@ func PagingGetObject[T any](
 	if err != nil {
 		logrus.Errorf("could not fetch object: %s", err)
 		return err
-	} else {
-		pagingResult = append(pagingResult, pagingResponse.Result...)
 	}
+
+	pagingResult = append(pagingResult, pagingResponse.Result...)
 
 	for {
 		if pagingResponse.NextPageId == "" {

--- a/provider/infoblox/infoblox_test.go
+++ b/provider/infoblox/infoblox_test.go
@@ -115,6 +115,19 @@ func (client *mockIBConnector) CreateObject(obj ibclient.IBObject) (ref string, 
 }
 
 func (client *mockIBConnector) GetObject(obj ibclient.IBObject, ref string, queryParams *ibclient.QueryParams, res interface{}) (err error) {
+	isPagingType := false
+	switch res.(type) {
+	case *pagingResponseStruct[ibclient.RecordA]:
+		isPagingType = true
+	case *pagingResponseStruct[ibclient.HostRecord]:
+		isPagingType = true
+	case *pagingResponseStruct[ibclient.RecordTXT]:
+		isPagingType = true
+	case *pagingResponseStruct[ibclient.RecordPTR]:
+		isPagingType = true
+	case *pagingResponseStruct[ibclient.RecordCNAME]:
+		isPagingType = true
+	}
 	switch obj.ObjectType() {
 	case "record:a":
 		var result []ibclient.RecordA
@@ -131,7 +144,11 @@ func (client *mockIBConnector) GetObject(obj ibclient.IBObject, ref string, quer
 				result = append(result, *object.(*ibclient.RecordA))
 			}
 		}
-		*res.(*[]ibclient.RecordA) = result
+		if isPagingType {
+			res.(*pagingResponseStruct[ibclient.RecordA]).Result = result
+		} else {
+			*res.(*[]ibclient.RecordA) = result
+		}
 	case "record:cname":
 		var result []ibclient.RecordCNAME
 		for _, object := range *client.mockInfobloxObjects {
@@ -147,7 +164,11 @@ func (client *mockIBConnector) GetObject(obj ibclient.IBObject, ref string, quer
 				result = append(result, *object.(*ibclient.RecordCNAME))
 			}
 		}
-		*res.(*[]ibclient.RecordCNAME) = result
+		if isPagingType {
+			res.(*pagingResponseStruct[ibclient.RecordCNAME]).Result = result
+		} else {
+			*res.(*[]ibclient.RecordCNAME) = result
+		}
 	case "record:host":
 		var result []ibclient.HostRecord
 		for _, object := range *client.mockInfobloxObjects {
@@ -163,7 +184,11 @@ func (client *mockIBConnector) GetObject(obj ibclient.IBObject, ref string, quer
 				result = append(result, *object.(*ibclient.HostRecord))
 			}
 		}
-		*res.(*[]ibclient.HostRecord) = result
+		if isPagingType {
+			res.(*pagingResponseStruct[ibclient.HostRecord]).Result = result
+		} else {
+			*res.(*[]ibclient.HostRecord) = result
+		}
 	case "record:txt":
 		var result []ibclient.RecordTXT
 		for _, object := range *client.mockInfobloxObjects {
@@ -179,7 +204,11 @@ func (client *mockIBConnector) GetObject(obj ibclient.IBObject, ref string, quer
 				result = append(result, *object.(*ibclient.RecordTXT))
 			}
 		}
-		*res.(*[]ibclient.RecordTXT) = result
+		if isPagingType {
+			res.(*pagingResponseStruct[ibclient.RecordTXT]).Result = result
+		} else {
+			*res.(*[]ibclient.RecordTXT) = result
+		}
 	case "record:ptr":
 		var result []ibclient.RecordPTR
 		for _, object := range *client.mockInfobloxObjects {
@@ -195,7 +224,11 @@ func (client *mockIBConnector) GetObject(obj ibclient.IBObject, ref string, quer
 				result = append(result, *object.(*ibclient.RecordPTR))
 			}
 		}
-		*res.(*[]ibclient.RecordPTR) = result
+		if isPagingType {
+			res.(*pagingResponseStruct[ibclient.RecordPTR]).Result = result
+		} else {
+			*res.(*[]ibclient.RecordPTR) = result
+		}
 	case "zone_auth":
 		*res.(*[]ibclient.ZoneAuth) = *client.mockInfobloxZones
 	}


### PR DESCRIPTION
**Description**

If your infoblox zone has more than 1000 records in it, infoblox will return an error, and external-dns cannot retrieve the records it needs. Currently you can set the maximum number of results to return, however this just truncates the records and doesn't work how external-dns is expecting.

With this change `--infoblox-max-results` is used to determine the page size, and all of the records are retrieved from the zone.

The issue is mentioned [here](https://github.com/infobloxopen/infoblox-go-client/issues/75), however the infoblox team has not added it to the client.

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
