### PR TITLE
Ignore ambassador-hosts with invalid annotations

### DIFF
--- a/source/ambassador_host.go
+++ b/source/ambassador_host.go
@@ -134,12 +134,14 @@ func (sc *ambassadorHostSource) Endpoints(ctx context.Context) ([]*endpoint.Endp
 
 		targets, err := sc.targetsFromAmbassadorLoadBalancer(ctx, service)
 		if err != nil {
-			return nil, err
+			log.Warningf("Could not find targets for service %s for Host %s: %v", service, fullname, err)
+			continue
 		}
 
 		hostEndpoints, err := sc.endpointsFromHost(ctx, host, targets)
 		if err != nil {
-			return nil, err
+			log.Warningf("Could not get endpoints for Host %s", err)
+			continue
 		}
 		if len(hostEndpoints) == 0 {
 			log.Debugf("No endpoints could be generated from Host %s", fullname)


### PR DESCRIPTION
**Description**

If e.g the ambassador service annotation points to an nonexisting service, external-dns will not update any DNS records. This PR makes external-dns ignore the host and carry on instead.

Didn't provide any unit tests as this code didn't seem to have anything like a fake client that knows about ambassador hosts. Did however validate the logic in a live cluster.