### PR TITLE
If an error propagates all the way out, bail execution

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -292,7 +292,7 @@ func (c *Controller) Run(ctx context.Context) {
 	for {
 		if c.ShouldRunOnce(time.Now()) {
 			if err := c.RunOnce(ctx); err != nil {
-				log.Error(err)
+				log.Fatal(err)
 			}
 		}
 		select {


### PR DESCRIPTION
**Description**

~Related to #3008, when external-dns is configured with multiple sources and one of them fails, all other sources are skipped as well. This PR logs and continues rather than aborting completely and log.~

If an error propagates all the way out to the control loop, log and exit rather than log and carry on.
