### PR TITLE
Fixing sub-optimal behavior when 'old' instances are unnecessarily de-registered

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -92,6 +92,23 @@ func (t Targets) Same(o Targets) bool {
 	return true
 }
 
+// Subtracts specified targets from current
+func (targets Targets) Sub(another Targets) Targets {
+	result := []string{}
+	anotherMap := make(map[string]bool)
+
+	for _, target := range another {
+		anotherMap[target] = true
+	}
+
+	for _, target := range targets {
+		if !anotherMap[target] {
+			result = append(result, target)
+		}
+	}
+	return Targets(result)
+}
+
 // IsLess should fulfill the requirement to compare two targets and choose the 'lesser' one.
 // In the past target was a simple string so simple string comparison could be used. Now we define 'less'
 // as either being the shorter list of targets or where the first entry is less.

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -76,7 +76,6 @@ func TestSameFailures(t *testing.T) {
 		}
 	}
 }
-
 func TestIsLess(t *testing.T) {
 	testsA := []Targets{
 		{""},
@@ -112,6 +111,33 @@ func TestIsLess(t *testing.T) {
 	for i, d := range testsA {
 		if d.IsLess(testsB[i]) != expected[i] {
 			t.Errorf("%v < %v is expected to be %v", d, testsB[i], expected[i])
+		}
+	}
+}
+func TestSub(t *testing.T) {
+	tests := []struct {
+		a        Targets
+		b        Targets
+		expected Targets
+	}{
+		{
+			[]string{"1.2.3.4"},
+			[]string{"4.3.2.1"},
+			[]string{"1.2.3.4"},
+		}, {
+			[]string{"1.2.3.4", "4.3.2.1"},
+			[]string{"1.2.3.4"},
+			[]string{"4.3.2.1"},
+		}, {
+			[]string{"1.2.3.4", "4.3.2.1"},
+			[]string{"1.2.3.4", "4.3.2.1"},
+			[]string{},
+		},
+	}
+
+	for _, d := range tests {
+		if d.a.Sub(d.b).Same(d.expected) == false {
+			t.Errorf("%#v difference with %#v should equal %#v", d.a, d.b, d.expected)
 		}
 	}
 }

--- a/provider/awssd/aws_sd.go
+++ b/provider/awssd/aws_sd.go
@@ -271,8 +271,10 @@ func (p *AWSSDProvider) updatesToCreates(changes *plan.Changes) (creates []*endp
 	for _, old := range changes.UpdateOld {
 		current := updateNewMap[old.DNSName]
 
-		if !old.Targets.Same(current.Targets) {
-			// when targets differ the old instances need to be de-registered first
+		// when targets differ no more needed old instances should be de-registered first
+		targetsToDelete := old.Targets.Sub(current.Targets)
+		if targetsToDelete.Len() > 0 {
+			old.Targets = targetsToDelete
 			deletes = append(deletes, old)
 		}
 

--- a/provider/awssd/aws_sd_test.go
+++ b/provider/awssd/aws_sd_test.go
@@ -352,9 +352,30 @@ func TestAWSSDProvider_ApplyChanges(t *testing.T) {
 	assert.True(t, testutils.SameEndpoints(expectedEndpoints, endpoints), "expected and actual endpoints don't match, expected=%v, actual=%v", expectedEndpoints, endpoints)
 
 	ctx = context.Background()
+
+	provider.ApplyChanges(ctx, &plan.Changes{
+		UpdateNew: []*endpoint.Endpoint{
+			{DNSName: "service1.private.com", Targets: endpoint.Targets{"1.2.3.4"}, RecordType: endpoint.RecordTypeA, RecordTTL: 60},
+		},
+		UpdateOld: []*endpoint.Endpoint{
+			{DNSName: "service1.private.com", Targets: endpoint.Targets{"1.2.3.4", "1.2.3.5"}, RecordType: endpoint.RecordTypeA, RecordTTL: 60},
+		},
+	})
+
+	endpointsAfterUpdate := []*endpoint.Endpoint{
+		{DNSName: "service1.private.com", Targets: endpoint.Targets{"1.2.3.4"}, RecordType: endpoint.RecordTypeA, RecordTTL: 60},
+		{DNSName: "service2.private.com", Targets: endpoint.Targets{"load-balancer.us-east-1.elb.amazonaws.com"}, RecordType: endpoint.RecordTypeCNAME, RecordTTL: 80},
+		{DNSName: "service3.private.com", Targets: endpoint.Targets{"cname.target.com"}, RecordType: endpoint.RecordTypeCNAME, RecordTTL: 100},
+	}
+
+	assert.NotNil(t, existingServices["service1"])
+	endpoints, _ = provider.Records(ctx)
+	assert.True(t, testutils.SameEndpoints(endpointsAfterUpdate, endpoints), "expected and actual endpoints don't match, expected=%v, actual=%v", endpointsAfterUpdate, endpoints)
+
+	ctx = context.Background()
 	// apply deletes
 	provider.ApplyChanges(ctx, &plan.Changes{
-		Delete: expectedEndpoints,
+		Delete: endpointsAfterUpdate,
 	})
 
 	// make sure all instances are gone


### PR DESCRIPTION

**Description**
Fixing sub-optimal behavior when 'old' instances are unnecessarily de-registered first (and then immediately re-registered again) despite the fact that they should be kept in 'current' target
The fix is to de-register only instances that is not be present in 'current' target. The calculation made by substitution the 'old' instances set with 'current' instances set. 

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated. No updates needed
