### PR TITLE
Consider ProviderSpecific when sorting Endpoints

### DIFF
--- a/internal/testutils/endpoint.go
+++ b/internal/testutils/endpoint.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testutils
 
 import (
+	"fmt"
 	"reflect"
 	"sort"
 
@@ -42,7 +43,11 @@ func (b byAllFields) Less(i, j int) bool {
 	if b[i].DNSName == b[j].DNSName {
 		// This rather bad, we need a more complex comparison for Targets, which considers all elements
 		if b[i].Targets.Same(b[j].Targets) {
-			return b[i].RecordType <= b[j].RecordType
+			if b[i].RecordType != b[j].RecordType {
+				return b[i].RecordType < b[j].RecordType
+			}
+
+			return fmt.Sprintf("%v", b[i].ProviderSpecific) <= fmt.Sprintf("%v", b[j].ProviderSpecific)
 		}
 		return b[i].Targets.String() <= b[j].Targets.String()
 	}


### PR DESCRIPTION
**Description**

I had the master branch failing tests due to being on the wrong end of the unstable sorting:

```
$ go test sigs.k8s.io/external-dns/internal/testutils            
--- FAIL: ExampleSameEndpoints (0.00s)
got:
abc.com 0 IN A test-set-1 1.2.3.4 []
abc.com 0 IN TXT  something []
bbc.com 0 IN CNAME  foo.com []
cbc.com 60 IN CNAME  foo.com []
example.org 0 IN   load-balancer.org [{foo bar}]
example.org 0 IN   load-balancer.org []
example.org 0 IN TXT  load-balancer.org []
want:
abc.com 0 IN A test-set-1 1.2.3.4 []
abc.com 0 IN TXT  something []
bbc.com 0 IN CNAME  foo.com []
cbc.com 60 IN CNAME  foo.com []
example.org 0 IN   load-balancer.org []
example.org 0 IN   load-balancer.org [{foo bar}]
example.org 0 IN TXT  load-balancer.org []
FAIL
FAIL    sigs.k8s.io/external-dns/internal/testutils     0.003s
FAIL
```

There is a test that verifies Endpoints with ProviderSpecific is sorted after those that don't. Since we use unstable sorting, we need to consider ProviderSpecific to ensure intended behavior


**Checklist**

- [x] Unit tests updated (fixed anyway)
