### PR TITLE
Don't create endpoint if attempting to create one with invalid dns name

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -190,6 +190,13 @@ func NewEndpointWithTTL(dnsName, recordType string, ttl TTL, targets ...string) 
 		cleanTargets[idx] = strings.TrimSuffix(target, ".")
 	}
 
+	for _, label := range strings.Split(dnsName, ".") {
+		if len(label) > 63 {
+			log.Errorf("label %s in %s is longer than 63 characters. Cannot create endpoint", label, dnsName)
+			return nil
+		}
+	}
+
 	return &Endpoint{
 		DNSName:    strings.TrimSuffix(dnsName, "."),
 		Targets:    cleanTargets,

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -195,8 +195,13 @@ func (im *TXTRegistry) generateTXTRecord(r *endpoint.Endpoint) []*endpoint.Endpo
 	txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
 	txt.ProviderSpecific = r.ProviderSpecific
 	// new TXT record format (containing record type)
-	txtNew := endpoint.NewEndpoint(im.mapper.toNewTXTName(r.DNSName, r.RecordType), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
-	txtNew.ProviderSpecific = r.ProviderSpecific
+	txtNew := endpoint.NewEndpoint(im.mapper.toNewTXTName(r.DNSName, r.RecordType), endpoint.RecordTypeTXT, r.Labels.Serialize(true))
+	if txtNew != nil {
+		txtNew.WithSetIdentifier(r.SetIdentifier)
+		txtNew.ProviderSpecific = r.ProviderSpecific
+	} else {
+		return []*endpoint.Endpoint{txt}
+	}
 
 	return []*endpoint.Endpoint{txt, txtNew}
 }

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -790,6 +790,8 @@ func testTXTRegistryMissingRecordsNoPrefix(t *testing.T) {
 			newEndpointWithOwner("oldformat-otherowner.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=otherowner\"", endpoint.RecordTypeTXT, ""),
 			endpoint.NewEndpoint("unmanaged1.test-zone.example.org", endpoint.RecordTypeA, "unmanaged1.loadbalancer.com"),
 			endpoint.NewEndpoint("unmanaged2.test-zone.example.org", endpoint.RecordTypeCNAME, "unmanaged2.loadbalancer.com"),
+			newEndpointWithOwner("this-is-a-63-characters-long-label-that-we-do-expect-will-work.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("this-is-a-63-characters-long-label-that-we-do-expect-will-work.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 		},
 	})
 	expectedRecords := []*endpoint.Endpoint{
@@ -846,6 +848,14 @@ func testTXTRegistryMissingRecordsNoPrefix(t *testing.T) {
 			DNSName:    "unmanaged2.test-zone.example.org",
 			Targets:    endpoint.Targets{"unmanaged2.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeCNAME,
+		},
+		{
+			DNSName:    "this-is-a-63-characters-long-label-that-we-do-expect-will-work.test-zone.example.org",
+			Targets:    endpoint.Targets{"foo.loadbalancer.com"},
+			RecordType: endpoint.RecordTypeCNAME,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+			},
 		},
 	}
 


### PR DESCRIPTION
**Description**

We should expect that 63 char labels works also with the txt registry. But as can be seen from https://github.com/kubernetes-sigs/external-dns/issues/2839 and others, this is not the case after introducing the new format.

This PR doesn't fix the underlying problem in any way, but it maintains backwards compatibility by ignoring the new format if it results in endpoint with too long name. This way, e.g route53 batch changes will keep working with the consequence of not migrating to the new format.

Note: This will also prevent subtle breakage in case e.g the service annotation contains invalid DNS labels.

**Checklist**

- [x] Unit tests updated
