### PR TITLE
feat(ovh): add cache based on DNS zone SOA value

### DIFF
--- a/docs/tutorials/ovh.md
+++ b/docs/tutorials/ovh.md
@@ -18,7 +18,7 @@ instructions for creating a zone.
 
 You first need to create an OVH application.
 
-Using the [OVH documentation](https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api/#creation-of-your-application-keys) you will have your `Application key` and `Application secret`
+Using the [OVH documentation](https://docs.ovh.com/gb/en/api/first-steps-with-ovh-api/#advanced-usage-pair-ovhcloud-apis-with-an-application_2) you will have your `Application key` and `Application secret`
 
 And you will need to generate your consumer key, here the permissions needed :
 - GET on `/domain/zone`
@@ -26,6 +26,7 @@ And you will need to generate your consumer key, here the permissions needed :
 - GET on `/domain/zone/*/record/*`
 - POST on `/domain/zone/*/record`
 - DELETE on `/domain/zone/*/record/*`
+- GET on `/domain/zone/*/soa`
 - POST on `/domain/zone/*/refresh`
 
 You can use the following `curl` request to generate & validated your `Consumer key`
@@ -36,6 +37,10 @@ curl -XPOST -H "X-Ovh-Application: <ApplicationKey>" -H "Content-type: applicati
     {
       "method": "GET",
       "path": "/domain/zone"
+    },
+    {
+      "method": "GET",
+      "path": "/domain/zone/*/soa"
     },
     {
       "method": "GET",

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20230607134213-3cd0021bbee3
 	github.com/oracle/oci-go-sdk/v65 v65.41.0
 	github.com/ovh/go-ovh v1.4.1
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/pluralsh/gqlclient v1.5.1
 	github.com/projectcontour/contour v1.25.0
@@ -157,7 +158,6 @@ require (
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/openshift/gssapi v0.0.0-20161010215902-5fb4217df13b // indirect
 	github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b // indirect
-	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
 	github.com/peterhellberg/link v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect


### PR DESCRIPTION
Hello external-dns maintainers, OVHcloud API team here :wave: 

**Description**
This pull-request patches the 'ovh' provider to add a small local cache of the fetched DNS records.

Context: we detected that numerous of our customers use your external-dns software to manage their DNS records, sending waves of API queries to our APIs. As these records are retrieved one by one, it generates a high amount of requests on our backend.

As we would like to keep allowing our customers using external-dns with the best experience, we leveraged the usage of the DNS zone SOA Serial to detect if the zone records might have changed since the last time we generated the cache.
This way, we spare all the calls to retrieve the records that have been kept in cache, and serve them directly, since the SOA Serial haven't changed, guaranteeing that the DNS zone hasn't changed on our side.

This will also add a speed-up once the cache is warm, as long as the zone doesn't change.

This should also prevent users of external-dns from being targeted by potential rate-limiting in case of high activity on our backend.

Thanks in advance for your review.
Romain

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated