### PR TITLE
Allow multiple records per A record in OpenStack Designate Provider

### DIFF
--- a/provider/designate/designate.go
+++ b/provider/designate/designate.go
@@ -415,6 +415,10 @@ func (p designateProvider) ApplyChanges(ctx context.Context, changes *plan.Chang
 	}
 
 	endpoints, err := p.Records(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch active records: %w", err)
+	}
+
 	recordSets := map[string]*recordSet{}
 	for _, ep := range changes.Create {
 		addEndpoint(ep, recordSets, endpoints, false)
@@ -429,9 +433,6 @@ func (p designateProvider) ApplyChanges(ctx context.Context, changes *plan.Chang
 		addEndpoint(ep, recordSets, endpoints, true)
 	}
 
-	if err != nil {
-		return fmt.Errorf("failed to fetch active records: %w", err)
-	}
 	for _, rs := range recordSets {
 		if err2 := p.upsertRecordSet(rs, managedZones); err == nil {
 			err = err2

--- a/provider/designate/designate.go
+++ b/provider/designate/designate.go
@@ -350,7 +350,7 @@ type recordSet struct {
 }
 
 // adds endpoint into recordset aggregation, loading original values from endpoint labels first
-func addEndpoint(ep *endpoint.Endpoint, recordSets map[string]*recordSet, delete bool) {
+func addEndpoint(ep *endpoint.Endpoint, recordSets map[string]*recordSet, oldEndpoints []*endpoint.Endpoint, delete bool) {
 	key := fmt.Sprintf("%s/%s", ep.DNSName, ep.RecordType)
 	rs := recordSets[key]
 	if rs == nil {
@@ -360,6 +360,9 @@ func addEndpoint(ep *endpoint.Endpoint, recordSets map[string]*recordSet, delete
 			names:      make(map[string]bool),
 		}
 	}
+
+	addDesignateIDLabelsFromExistingEndpoints(oldEndpoints, ep)
+
 	if rs.zoneID == "" {
 		rs.zoneID = ep.Labels[designateZoneID]
 	}
@@ -381,24 +384,53 @@ func addEndpoint(ep *endpoint.Endpoint, recordSets map[string]*recordSet, delete
 	recordSets[key] = rs
 }
 
+// addDesignateIDLabelsFromExistingEndpoints adds the labels identified by the constants designateZoneID and designateRecordSetID
+// to an Endpoint. Therefore, it searches all given existing endpoints for an endpoint with the same record type and record
+// value. If the given Endpoint already has the labels set, they are left untouched. This fixes an issue with the
+// TXTRegistry which generates new TXT entries instead of updating the old ones.
+func addDesignateIDLabelsFromExistingEndpoints(existingEndpoints []*endpoint.Endpoint, ep *endpoint.Endpoint) {
+	_, hasZoneIDLabel := ep.Labels[designateZoneID]
+	_, hasRecordSetIDLabel := ep.Labels[designateRecordSetID]
+	if hasZoneIDLabel && hasRecordSetIDLabel {
+		return
+	}
+	for _, oep := range existingEndpoints {
+		if ep.RecordType == oep.RecordType && ep.DNSName == oep.DNSName {
+			if !hasZoneIDLabel {
+				ep.Labels[designateZoneID] = oep.Labels[designateZoneID]
+			}
+			if !hasRecordSetIDLabel {
+				ep.Labels[designateRecordSetID] = oep.Labels[designateRecordSetID]
+			}
+			return
+		}
+	}
+}
+
 // ApplyChanges applies a given set of changes in a given zone.
 func (p designateProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
 	managedZones, err := p.getZones()
 	if err != nil {
 		return err
 	}
+
+	endpoints, err := p.Records(ctx)
 	recordSets := map[string]*recordSet{}
 	for _, ep := range changes.Create {
-		addEndpoint(ep, recordSets, false)
-	}
-	for _, ep := range changes.UpdateNew {
-		addEndpoint(ep, recordSets, false)
+		addEndpoint(ep, recordSets, endpoints, false)
 	}
 	for _, ep := range changes.UpdateOld {
-		addEndpoint(ep, recordSets, true)
+		addEndpoint(ep, recordSets, endpoints, true)
+	}
+	for _, ep := range changes.UpdateNew {
+		addEndpoint(ep, recordSets, endpoints, false)
 	}
 	for _, ep := range changes.Delete {
-		addEndpoint(ep, recordSets, true)
+		addEndpoint(ep, recordSets, endpoints, true)
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to fetch active records: %w", err)
 	}
 	for _, rs := range recordSets {
 		if err2 := p.upsertRecordSet(rs, managedZones); err == nil {

--- a/provider/designate/designate.go
+++ b/provider/designate/designate.go
@@ -322,13 +322,13 @@ func (p designateProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, e
 				if recordSet.Type != endpoint.RecordTypeA && recordSet.Type != endpoint.RecordTypeTXT && recordSet.Type != endpoint.RecordTypeCNAME {
 					return nil
 				}
-				for _, record := range recordSet.Records {
-					ep := endpoint.NewEndpoint(recordSet.Name, recordSet.Type, record)
-					ep.Labels[designateRecordSetID] = recordSet.ID
-					ep.Labels[designateZoneID] = recordSet.ZoneID
-					ep.Labels[designateOriginalRecords] = strings.Join(recordSet.Records, "\000")
-					result = append(result, ep)
-				}
+
+				ep := endpoint.NewEndpoint(recordSet.Name, recordSet.Type, recordSet.Records...)
+				ep.Labels[designateRecordSetID] = recordSet.ID
+				ep.Labels[designateZoneID] = recordSet.ZoneID
+				ep.Labels[designateOriginalRecords] = strings.Join(recordSet.Records, "\000")
+				result = append(result, ep)
+
 				return nil
 			},
 		)

--- a/provider/designate/designate_test.go
+++ b/provider/designate/designate_test.go
@@ -275,17 +275,7 @@ func TestDesignateRecords(t *testing.T) {
 		{
 			DNSName:    "srv.test.net",
 			RecordType: endpoint.RecordTypeA,
-			Targets:    endpoint.Targets{"10.2.1.1"},
-			Labels: map[string]string{
-				designateRecordSetID:     rs21ID,
-				designateZoneID:          zone2ID,
-				designateOriginalRecords: "10.2.1.1\00010.2.1.2",
-			},
-		},
-		{
-			DNSName:    "srv.test.net",
-			RecordType: endpoint.RecordTypeA,
-			Targets:    endpoint.Targets{"10.2.1.2"},
+			Targets:    endpoint.Targets{"10.2.1.1", "10.2.1.2"},
 			Labels: map[string]string{
 				designateRecordSetID:     rs21ID,
 				designateZoneID:          zone2ID,
@@ -337,6 +327,19 @@ func testDesignateCreateRecords(t *testing.T, client *fakeDesignateClient) []*re
 			Status: "ACTIVE",
 		})
 	}
+
+	_, err := client.CreateRecordSet("zone-1", recordsets.CreateOpts{
+		Name:        "www.example.com.",
+		Description: "",
+		Records:     []string{"foo"},
+		TTL:         60,
+		Type:        endpoint.RecordTypeTXT,
+	})
+
+	if err != nil {
+		t.Fatal("failed to prefil records")
+	}
+
 	endpoints := []*endpoint.Endpoint{
 		{
 			DNSName:    "www.example.com",
@@ -410,7 +413,7 @@ func testDesignateCreateRecords(t *testing.T, client *fakeDesignateClient) []*re
 	expectedCopy := make([]*recordsets.RecordSet, len(expected))
 	copy(expectedCopy, expected)
 
-	err := client.ToProvider().ApplyChanges(context.Background(), &plan.Changes{Create: endpoints})
+	err = client.ToProvider().ApplyChanges(context.Background(), &plan.Changes{Create: endpoints})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION

**Description**

Allow multiple records per A record. Therefore update the Delete and Create order so, we don't delete a single old record value.
Before this patch, external-dns alternated between two IPs as record values if upgraded from a single record to two A records.

Fetch labels from existing TXT records to fix https://github.com/kubernetes-sigs/external-dns/issues/

Fixes #603

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
