### PR TITLE
reorder cloudflare updates to delete before create

### DIFF
--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -242,16 +242,16 @@ func (p *CloudFlareProvider) ApplyChanges(ctx context.Context, changes *plan.Cha
 
 		add, remove, leave := provider.Difference(current.Targets, desired.Targets)
 
+		for _, a := range remove {
+			cloudflareChanges = append(cloudflareChanges, p.newCloudFlareChange(cloudFlareDelete, current, a))
+		}
+
 		for _, a := range add {
 			cloudflareChanges = append(cloudflareChanges, p.newCloudFlareChange(cloudFlareCreate, desired, a))
 		}
 
 		for _, a := range leave {
 			cloudflareChanges = append(cloudflareChanges, p.newCloudFlareChange(cloudFlareUpdate, desired, a))
-		}
-
-		for _, a := range remove {
-			cloudflareChanges = append(cloudflareChanges, p.newCloudFlareChange(cloudFlareDelete, current, a))
 		}
 	}
 

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -1143,6 +1143,11 @@ func TestCloudflareComplexUpdate(t *testing.T) {
 
 	td.CmpDeeply(t, client.Actions, []MockAction{
 		{
+			Name:     "Delete",
+			ZoneId:   "001",
+			RecordId: "2345678901",
+		},
+		{
 			Name:   "Create",
 			ZoneId: "001",
 			RecordData: cloudflare.DNSRecord{
@@ -1164,11 +1169,6 @@ func TestCloudflareComplexUpdate(t *testing.T) {
 				TTL:     1,
 				Proxied: proxyEnabled,
 			},
-		},
-		{
-			Name:     "Delete",
-			ZoneId:   "001",
-			RecordId: "2345678901",
 		},
 	})
 }


### PR DESCRIPTION
**Description**
When an A or CNAME record must be changed, in the current state the provider attempts to create a record then delete the old record. The create fails due to there being an existing A/CNAME record with that name, and then the delete succeeds, leaving the name unresolvable until the next time the external-dns loop runs.

By doing the delete first, this issue is mitigated. While not as elegant as using UPDATE calls, it is a lot simpler.

Attempts to remediate https://github.com/kubernetes-sigs/external-dns/issues/2820 and (to some extent) https://github.com/kubernetes-sigs/external-dns/issues/2435

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
