### PR TITLE
feat(Azure): add support for workload identity

### DIFF
--- a/docs/tutorials/azure.md
+++ b/docs/tutorials/azure.md
@@ -323,29 +323,11 @@ kubectl patch deployment external-dns --namespace "default" --patch \
 
 ### Managed identity using Workload Identity
 
-For this process, we will create a [managed identity](https://docs.microsoft.com//azure/active-directory/managed-identities-azure-resources/overview) that will be explicitly used by the ExternalDNS container.  This process is somewhat similar to Pod Identity except that this managed identity is associated with a kubernetes service account.
-
-NOTE: after support for Workload Identity graduates to GA, this step will no longer be needed.
-
-#### Enable the Worload Identity feature
-
-To enable [Workload Identity](https://learn.microsoft.com/en-us/azure/aks/workload-identity-deploy-cluster) preview feature, use the following commands:
-
-```bash
-$ az extension add --name aks-preview
-$ az extension update --name aks-preview
-$ az feature register --namespace "Microsoft.ContainerService" --name "EnableWorkloadIdentityPreview"
-
-# After several minutes, the feature should become registered. You can check that by periodically running the following command
-$ az feature list -o table --query "[?contains(name, 'Microsoft.ContainerService/EnableWorkloadIdentityPreview')].{Name:name,State:properties.state}"
-
-# Once the process is completed, refresh the registration of resource provider
-$ az provider register --namespace Microsoft.ContainerService
-```
+For this process, we will create a [managed identity](https://docs.microsoft.com//azure/active-directory/managed-identities-azure-resources/overview) that will be explicitly used by the ExternalDNS container. This process is somewhat similar to Pod Identity except that this managed identity is associated with a kubernetes service account.
 
 #### Deploy OIDC issuer and Workload Identity services
 
-Once enabled, you can update your cluster and install needed services for the [Workload Identity](https://learn.microsoft.com/en-us/azure/aks/workload-identity-deploy-cluster) feature:
+Update your cluster to install [OIDC Issuer](https://learn.microsoft.com/en-us/azure/aks/use-oidc-issuer) and [Workload Identity](https://learn.microsoft.com/en-us/azure/aks/workload-identity-deploy-cluster):
 
 ```bash
 $ AZURE_AKS_RESOURCE_GROUP="my-aks-cluster-group" # name of resource group where aks cluster was created

--- a/docs/tutorials/azure.md
+++ b/docs/tutorials/azure.md
@@ -424,6 +424,8 @@ $ kubectl patch serviceaccount external-dns --namespace "default" --patch \
  "{\"metadata\": {\"labels\": {\"azure.workload.identity/use\": \"true\"}, \"annotations\": {\"azure.workload.identity/client-id\": \"${IDENTITY_CLIENT_ID}\"}}}"
 ```
 
+NOTE: it's also possible to specify (or override) ClientID through `UserAssignedIdentityID` field in `azure.json`.
+
 If a pod with external-dns is already running, you need to restart it:
 ```bash
 $ kubectl rollout restart deployment/external-dns

--- a/provider/azure/config.go
+++ b/provider/azure/config.go
@@ -169,7 +169,7 @@ func getWIToken(environment azure.Environment) (*adal.ServicePrincipalToken, err
 		return nil, fmt.Errorf("failed to read a file with a federated token: %v", err)
 	}
 
-	token, err := adal.NewServicePrincipalTokenFromFederatedToken(*oauthConfig, os.Getenv("AZURE_CLIENT_ID"), string(jwt), "https://management.azure.com")
+	token, err := adal.NewServicePrincipalTokenFromFederatedToken(*oauthConfig, os.Getenv("AZURE_CLIENT_ID"), string(jwt), environment.ResourceManagerEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a workload identity token: %v", err)
 	}

--- a/provider/azure/config.go
+++ b/provider/azure/config.go
@@ -121,7 +121,11 @@ func getAccessToken(cfg config, environment azure.Environment) (*adal.ServicePri
 			}
 
 			// Need to call Refresh(), otherwise .Token() will be empty
-			newWIToken.Refresh()
+			err = newWIToken.Refresh()
+			if err != nil {
+				return nil, err
+			}
+
 			accessToken := newWIToken.Token()
 
 			return &accessToken, nil

--- a/provider/azure/config_test.go
+++ b/provider/azure/config_test.go
@@ -17,13 +17,19 @@ limitations under the License.
 package azure
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"reflect"
 	"testing"
 
+	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetAzureEnvironmentConfig(t *testing.T) {
@@ -65,4 +71,117 @@ func TestGetAzureEnvironmentConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func populateFederatedToken(t *testing.T, filename string, content string) {
+	t.Helper()
+
+	f, err := os.Create(filename)
+	if err != nil {
+		assert.FailNow(t, err.Error())
+	}
+
+	if _, err := io.WriteString(f, content); err != nil {
+		assert.FailNow(t, err.Error())
+	}
+
+	if err := f.Close(); err != nil {
+		assert.FailNow(t, err.Error())
+	}
+}
+
+func TestGetAccessTokenWorkloadIdentity(t *testing.T) {
+	// Create a file that will be used to store a federated token
+	f, err := os.CreateTemp("", "")
+	if err != nil {
+		assert.FailNow(t, err.Error())
+	}
+	defer os.Remove(f.Name())
+
+	// Close the file to simplify logic within populateFederatedToken helper
+	if err := f.Close(); err != nil {
+		assert.FailNow(t, err.Error())
+	}
+
+	// The initial federated token is never used, so we don't care about the value yet
+	// Though, it's a requirement from adal to have a non-empty value set
+	populateFederatedToken(t, f.Name(), "random-jwt")
+
+	// Envs are described here: https://azure.github.io/azure-workload-identity/docs/installation/mutating-admission-webhook.html
+	t.Setenv("AZURE_TENANT_ID", "fakeTenantID")
+	t.Setenv("AZURE_CLIENT_ID", "fakeClientID")
+	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", f.Name())
+
+	t.Run("token refresh", func(t *testing.T) {
+		// Basically, we want one token to be exchanged for the other (key and value respectively)
+		tokens := map[string]string{
+			"initialFederatedToken":   "initialAccessToken",
+			"refreshedFederatedToken": "refreshedAccessToken",
+		}
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := r.ParseForm(); err != nil {
+				assert.FailNow(t, err.Error())
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			receivedFederatedToken := r.FormValue("client_assertion")
+			accessToken := adal.Token{AccessToken: tokens[receivedFederatedToken]}
+
+			if err := json.NewEncoder(w).Encode(accessToken); err != nil {
+				assert.FailNow(t, err.Error())
+			}
+
+			// Expected format: http://<server>/<tenant-ID>/oauth2/token?api-version=1.0
+			assert.Contains(t, r.RequestURI, os.Getenv("AZURE_TENANT_ID"), "URI should contain the tenant ID exposed through env variable")
+
+			assert.Equal(t, os.Getenv("AZURE_CLIENT_ID"), r.FormValue("client_id"), "client_id should match the value exposed through env variable")
+		}))
+		defer ts.Close()
+
+		env := azure.Environment{ActiveDirectoryEndpoint: ts.URL, ResourceManagerEndpoint: ts.URL}
+
+		cfg := config{
+			UseWorkloadIdentityExtension: true,
+		}
+
+		token, err := getAccessToken(cfg, env)
+		assert.NoError(t, err)
+
+		for federatedToken, accessToken := range tokens {
+			populateFederatedToken(t, f.Name(), federatedToken)
+			assert.NoError(t, token.Refresh(), "Token refresh failed")
+			assert.Equal(t, accessToken, token.Token().AccessToken, "Access token should have been set to a value returned by the webserver")
+		}
+	})
+
+	t.Run("clientID overrides through UserAssignedIdentityID section", func(t *testing.T) {
+		cfg := config{
+			UseWorkloadIdentityExtension: true,
+			UserAssignedIdentityID:       "overridenClientID",
+		}
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := r.ParseForm(); err != nil {
+				assert.FailNow(t, err.Error())
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			accessToken := adal.Token{AccessToken: "abc"}
+
+			if err := json.NewEncoder(w).Encode(accessToken); err != nil {
+				assert.FailNow(t, err.Error())
+			}
+
+			assert.Equal(t, cfg.UserAssignedIdentityID, r.FormValue("client_id"), "client_id should match the value passed through managedIdentity section")
+		}))
+		defer ts.Close()
+
+		env := azure.Environment{ActiveDirectoryEndpoint: ts.URL, ResourceManagerEndpoint: ts.URL}
+
+		token, err := getAccessToken(cfg, env)
+		assert.NoError(t, err)
+
+		assert.NoError(t, token.Refresh(), "Token refresh failed")
+	})
 }


### PR DESCRIPTION
## Description

### Context

In [Release 2022-10-10](https://github.com/Azure/AKS/blob/master/CHANGELOG.md#release-2022-10-10), AKS has brought support for [Workload Identity Federation](https://learn.microsoft.com/en-us/azure/active-directory/develop/workload-identity-federation) which will eventually replace Pod-Managed Identities.
This is an important change, because it resolves several limitations of Pod-Managed Identities described [here](https://azure.github.io/azure-workload-identity/docs/introduction.html).

As I see, there is a PR #2885 that tried to add the functionality, though it haven't got any traction since July. Plus, it doesn't tackle federated token renewal. Thus, I decided to come up with a different implementation to see if it finds any support.

### Implementation details

[adal package](https://github.com/Azure/go-autorest/tree/main/autorest/adal) has a function called `NewServicePrincipalTokenFromFederatedToken` which packs a federated token into a struct `&ServicePrincipalFederatedSecret{jwt: jwt,}` and passes it to `NewServicePrincipalTokenWithSecret` through `secret` field.

After that, we get an instance of `*adal.ServicePrincipalToken`. Unfortunately, it doesn't expose any methods to replace `jwt` in `secret`. So, suddenly, we have the following issue:
By default, the federated token is valid only for 1h, whereas the AAD token that is received in exchange for federated - for 24h ([docs](https://azure.github.io/azure-workload-identity/docs/topics/service-account-labels-and-annotations.html)). Thus, after roughly 24h, the implicitly called `.Refresh()` method for `*adal.ServicePrincipalToken` would start producing errors due to stale `jwt`.

`adal` doesn't seem to offer any native support for tracking changes in the file with federated token. The only sane method that I was able to find by looking through the library was taking advantage of `customRefreshFunc`, which is supposed to return a fresh access token or an error if any. To avoid having to reinvent the wheel, I wanted to reuse as many existing methods as possible.

The final logic is the following: whenever an access token is about to expire (or just empty right after an instance of `*adal.ServicePrincipalToken` is generated), the library would automatically call a wrapper function that would read the federated token from disk and use it to obtain a new access token by invoking the standard process through explicit call of `.Refresh()` method.

On one of my AKS clusters, I used the patched build of external-dns with an additional diagnostic message, which would highlight any attempts to refresh an access token, and everything worked well. So, I think we have a robust setup now.

The updated user documentation is based on a similar section that was written for Pod-Managed Identities. It might still be a bit rough, I could easily fix it in case of any issues.   

Fixes #2724 

### Extra information

The [adal package](https://github.com/Azure/go-autorest/tree/main/autorest/adal) that is currently used in Azure provider is scheduled to be deprecated by March 31 2023, so we'll eventually need to migrate away from it. Though that's a different question.

In case you're curious how the same is implemented in [the official sidecar proxy](https://learn.microsoft.com/en-us/azure/aks/workload-identity-migration-sidecar), you can have a look at the code [here](https://github.com/Azure/azure-workload-identity/blob/main/pkg/proxy/proxy.go).

### Checklist

- [ ] Unit tests updated
- [X] End user documentation updated
