### PR TITLE
[awssd] Only de-register removed targets

### DIFF
--- a/provider/awssd/aws_sd_test.go
+++ b/provider/awssd/aws_sd_test.go
@@ -47,6 +47,9 @@ type AWSSDClientStub struct {
 
 	// map[service_id] => map[inst_id]instance
 	instances map[string]map[string]*sd.Instance
+
+	// []inst_id
+	deregistered []string
 }
 
 func (s *AWSSDClientStub) CreateService(input *sd.CreateServiceInput) (*sd.CreateServiceOutput, error) {
@@ -74,6 +77,7 @@ func (s *AWSSDClientStub) CreateService(input *sd.CreateServiceInput) (*sd.Creat
 func (s *AWSSDClientStub) DeregisterInstance(input *sd.DeregisterInstanceInput) (*sd.DeregisterInstanceOutput, error) {
 	serviceInstances := s.instances[*input.ServiceId]
 	delete(serviceInstances, *input.InstanceId)
+	s.deregistered = append(s.deregistered, *input.InstanceId)
 
 	return &sd.DeregisterInstanceOutput{}, nil
 }
@@ -358,6 +362,60 @@ func TestAWSSDProvider_ApplyChanges(t *testing.T) {
 	// make sure all instances are gone
 	endpoints, _ = provider.Records(ctx)
 	assert.Empty(t, endpoints)
+}
+
+func TestAWSSDProvider_ApplyChanges_Update(t *testing.T) {
+	namespaces := map[string]*sd.Namespace{
+		"private": {
+			Id:   aws.String("private"),
+			Name: aws.String("private.com"),
+			Type: aws.String(sd.NamespaceTypeDnsPrivate),
+		},
+	}
+
+	api := &AWSSDClientStub{
+		namespaces: namespaces,
+		services:   make(map[string]map[string]*sd.Service),
+		instances:  make(map[string]map[string]*sd.Instance),
+	}
+
+	oldEndpoints := []*endpoint.Endpoint{
+		{DNSName: "service1.private.com", Targets: endpoint.Targets{"1.2.3.4", "1.2.3.5"}, RecordType: endpoint.RecordTypeA, RecordTTL: 60},
+	}
+
+	newEndpoints := []*endpoint.Endpoint{
+		{DNSName: "service1.private.com", Targets: endpoint.Targets{"1.2.3.4", "1.2.3.6"}, RecordType: endpoint.RecordTypeA, RecordTTL: 60},
+	}
+
+	provider := newTestAWSSDProvider(api, endpoint.NewDomainFilter([]string{}), "", "")
+
+	ctx := context.Background()
+
+	// apply creates
+	provider.ApplyChanges(ctx, &plan.Changes{
+		Create: oldEndpoints,
+	})
+
+	ctx = context.Background()
+
+	// apply update
+	provider.ApplyChanges(ctx, &plan.Changes{
+		UpdateOld: oldEndpoints,
+		UpdateNew: newEndpoints,
+	})
+
+	// make sure services were created
+	assert.Len(t, api.services["private"], 1)
+	existingServices, _ := provider.ListServicesByNamespaceID(namespaces["private"].Id)
+	assert.NotNil(t, existingServices["service1"])
+
+	// make sure instances were registered
+	endpoints, _ := provider.Records(ctx)
+	assert.True(t, testutils.SameEndpoints(newEndpoints, endpoints), "expected and actual endpoints don't match, expected=%v, actual=%v", newEndpoints, endpoints)
+
+	// make sure only one instance is de-registered
+	assert.Len(t, api.deregistered, 1)
+	assert.Equal(t, api.deregistered[0], "1.2.3.5", "wrong target de-registered")
 }
 
 func TestAWSSDProvider_ListNamespaces(t *testing.T) {


### PR DESCRIPTION
**Description**

This change improves how "Instances" are managed in AWS Cloud Map (aka. `aws servicediscovery`). This is especially a problem for [headless services](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) currently.

Without the fix, if we roll a single pod out of a 3 replicas deployment, which is fronted by a headless service utlizing the `awssd` provider in `external-dns`, it causes the controller to de-register all pod IPs first, then adding unchanged ones back:

```
{"level":"info","msg":"De-registering an instance \"10.0.134.229\" for service \"ost\" (srv-2y3ehwcmz55pudjy)","time":"2022-10-31T14:53:02Z"}
{"level":"info","msg":"De-registering an instance \"10.0.137.231\" for service \"ost\" (srv-2y3ehwcmz55pudjy)","time":"2022-10-31T14:53:02Z"}
{"level":"info","msg":"De-registering an instance \"10.0.146.215\" for service \"ost\" (srv-2y3ehwcmz55pudjy)","time":"2022-10-31T14:53:02Z"}
{"level":"info","msg":"Registering a new instance \"10.0.134.229\" for service \"ost\" (srv-2y3ehwcmz55pudjy)","time":"2022-10-31T14:53:02Z"}
```

This has been causing intermittent disruptions on services that should have been highly available. (edit: I don't have the logs anymore, but following this there are errors when again registering just de-registered instances, I believe that is the actual cause of "downtime" - the controller has to wait until AWS API has processed the de-register call before it can register unchanged instances again). This change uses a rather crude loop to filter out unchanged targets from de-register calls, thus preventing "downtime" in terms of DNS discovery:

```
{"level":"info","msg":"De-registering an instance \"10.0.134.229\" for service \"ost\" (srv-2y3ehwcmz55pudjy)","time":"2022-10-31T14:55:11Z"}
{"level":"info","msg":"Registering a new instance \"10.0.137.231\" for service \"ost\" (srv-2y3ehwcmz55pudjy)","time":"2022-10-31T14:55:12Z"}
{"level":"info","msg":"Registering a new instance \"10.0.149.134\" for service \"ost\" (srv-2y3ehwcmz55pudjy)","time":"2022-10-31T14:55:12Z"}
```

Note with the change in this PR there's only 1 de-register instead of it happening for all 3 pod IPs. I've also added a test to specifically check the number of de-register calls.

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
