### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,16 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
 
   build:
+    permissions:
+      contents: read  #  to fetch code (actions/checkout)
+      checks: write  #  to create a new check based on the results (shogo82148/actions-goveralls)
+
     name: Build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,8 +5,12 @@ on:
     tags:
       - "v*"
 
+permissions: {}
 jobs:
   release_docs:
+    permissions:
+      contents: write  #  for mike to push
+
     name: Release Docs
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -7,8 +7,13 @@ on:
     paths:
       - "charts/external-dns/Chart.yaml"
 
+permissions: {}
 jobs:
   release:
+
+    permissions:
+      contents: write  #  to push chart release and create a release (helm/chart-releaser-action)
+
     if: github.repository == 'kubernetes-sigs/external-dns'
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,6 +1,10 @@
 name: trivy vulnerability scanner
 on:
   push:
+
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

**Checklist**

- [NA] Unit tests updated
- [NA] End user documentation update
