### PR TITLE
cleanup: remove dead code (`(Create|Update|Delete)Records` functions in AWS, Google, DNSimple)

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -423,37 +423,6 @@ func (p *AWSProvider) records(ctx context.Context, zones map[string]*route53.Hos
 	return endpoints, nil
 }
 
-// CreateRecords creates a given set of DNS records in the given hosted zone.
-func (p *AWSProvider) CreateRecords(ctx context.Context, endpoints []*endpoint.Endpoint) error {
-	return p.doRecords(ctx, route53.ChangeActionCreate, endpoints)
-}
-
-// DeleteRecords deletes a given set of DNS records in a given zone.
-func (p *AWSProvider) DeleteRecords(ctx context.Context, endpoints []*endpoint.Endpoint) error {
-	return p.doRecords(ctx, route53.ChangeActionDelete, endpoints)
-}
-
-func (p *AWSProvider) doRecords(ctx context.Context, action string, endpoints []*endpoint.Endpoint) error {
-	zones, err := p.Zones(ctx)
-	if err != nil {
-		return errors.Wrapf(err, "failed to list zones, aborting %s doRecords action", action)
-	}
-
-	p.AdjustEndpoints(endpoints)
-
-	return p.submitChanges(ctx, p.newChanges(action, endpoints), zones)
-}
-
-// UpdateRecords updates a given set of old records to a new set of records in a given hosted zone.
-func (p *AWSProvider) UpdateRecords(ctx context.Context, updates, current []*endpoint.Endpoint) error {
-	zones, err := p.Zones(ctx)
-	if err != nil {
-		return errors.Wrapf(err, "failed to list zones, aborting UpdateRecords")
-	}
-
-	return p.submitChanges(ctx, p.createUpdateChanges(updates, current), zones)
-}
-
 // Identify if old and new endpoints require DELETE/CREATE instead of UPDATE.
 func (p *AWSProvider) requiresDeleteCreate(old *endpoint.Endpoint, new *endpoint.Endpoint) bool {
 	// a change of record type

--- a/provider/dnsimple/dnsimple.go
+++ b/provider/dnsimple/dnsimple.go
@@ -336,21 +336,6 @@ func dnsimpleSuitableZone(hostname string, zones map[string]dnsimple.Zone) *dnsi
 	return zone
 }
 
-// CreateRecords creates records for a given slice of endpoints
-func (p *dnsimpleProvider) CreateRecords(ctx context.Context, endpoints []*endpoint.Endpoint) error {
-	return p.submitChanges(ctx, newDnsimpleChanges(dnsimpleCreate, endpoints))
-}
-
-// DeleteRecords deletes records for a given slice of endpoints
-func (p *dnsimpleProvider) DeleteRecords(ctx context.Context, endpoints []*endpoint.Endpoint) error {
-	return p.submitChanges(ctx, newDnsimpleChanges(dnsimpleDelete, endpoints))
-}
-
-// UpdateRecords updates records for a given slice of endpoints
-func (p *dnsimpleProvider) UpdateRecords(ctx context.Context, endpoints []*endpoint.Endpoint) error {
-	return p.submitChanges(ctx, newDnsimpleChanges(dnsimpleUpdate, endpoints))
-}
-
 // ApplyChanges applies a given set of changes
 func (p *dnsimpleProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
 	combinedChanges := make([]*dnsimpleChange, 0, len(changes.Create)+len(changes.UpdateNew)+len(changes.Delete))

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -231,34 +231,6 @@ func (p *GoogleProvider) Records(ctx context.Context) (endpoints []*endpoint.End
 	return endpoints, nil
 }
 
-// CreateRecords creates a given set of DNS records in the given hosted zone.
-func (p *GoogleProvider) CreateRecords(endpoints []*endpoint.Endpoint) error {
-	change := &dns.Change{}
-
-	change.Additions = append(change.Additions, p.newFilteredRecords(endpoints)...)
-
-	return p.submitChange(p.ctx, change)
-}
-
-// UpdateRecords updates a given set of old records to a new set of records in a given hosted zone.
-func (p *GoogleProvider) UpdateRecords(records, oldRecords []*endpoint.Endpoint) error {
-	change := &dns.Change{}
-
-	change.Additions = append(change.Additions, p.newFilteredRecords(records)...)
-	change.Deletions = append(change.Deletions, p.newFilteredRecords(oldRecords)...)
-
-	return p.submitChange(p.ctx, change)
-}
-
-// DeleteRecords deletes a given set of DNS records in a given zone.
-func (p *GoogleProvider) DeleteRecords(endpoints []*endpoint.Endpoint) error {
-	change := &dns.Change{}
-
-	change.Deletions = append(change.Deletions, p.newFilteredRecords(endpoints)...)
-
-	return p.submitChange(p.ctx, change)
-}
-
 // ApplyChanges applies a given set of changes in a given zone.
 func (p *GoogleProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
 	change := &dns.Change{}

--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -300,76 +300,15 @@ func TestGoogleRecordsFilter(t *testing.T) {
 		endpoint.NewEndpoint("filter-delete-test.zone-3.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.2"),
 	}
 
-	require.NoError(t, provider.CreateRecords(ignoredEndpoints))
+	require.NoError(t, provider.ApplyChanges(context.Background(), &plan.Changes{
+		Create: ignoredEndpoints,
+	}))
 
 	records, err := provider.Records(context.Background())
 	require.NoError(t, err)
 
 	// assert that due to filtering no changes were made.
 	validateEndpoints(t, records, originalEndpoints)
-}
-
-func TestGoogleCreateRecords(t *testing.T) {
-	provider := newGoogleProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), provider.NewZoneIDFilter([]string{""}), false, []*endpoint.Endpoint{})
-
-	records := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
-		endpoint.NewEndpointWithTTL("create-test-ttl.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, endpoint.TTL(15), "8.8.8.8"),
-		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, "foo.elb.amazonaws.com"),
-	}
-
-	require.NoError(t, provider.CreateRecords(records))
-
-	records, err := provider.Records(context.Background())
-	require.NoError(t, err)
-
-	validateEndpoints(t, records, []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("create-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, googleRecordTTL, "1.2.3.4"),
-		endpoint.NewEndpointWithTTL("create-test-ttl.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, endpoint.TTL(15), "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("create-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, googleRecordTTL, "foo.elb.amazonaws.com"),
-	})
-}
-
-func TestGoogleUpdateRecords(t *testing.T) {
-	currentRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, googleRecordTTL, "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("update-test-ttl.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, endpoint.TTL(15), "8.8.4.4"),
-		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, googleRecordTTL, "foo.elb.amazonaws.com"),
-	}
-	provider := newGoogleProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), provider.NewZoneIDFilter([]string{""}), false, currentRecords)
-	updatedRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
-		endpoint.NewEndpointWithTTL("update-test-ttl.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, endpoint.TTL(25), "4.3.2.1"),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, "bar.elb.amazonaws.com"),
-	}
-
-	require.NoError(t, provider.UpdateRecords(updatedRecords, currentRecords))
-
-	records, err := provider.Records(context.Background())
-	require.NoError(t, err)
-
-	validateEndpoints(t, records, []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, googleRecordTTL, "1.2.3.4"),
-		endpoint.NewEndpointWithTTL("update-test-ttl.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, endpoint.TTL(25), "4.3.2.1"),
-		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, googleRecordTTL, "bar.elb.amazonaws.com"),
-	})
-}
-
-func TestGoogleDeleteRecords(t *testing.T) {
-	originalEndpoints := []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, googleRecordTTL, "1.2.3.4"),
-		endpoint.NewEndpointWithTTL("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, googleRecordTTL, "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, googleRecordTTL, "baz.elb.amazonaws.com"),
-	}
-
-	provider := newGoogleProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), provider.NewZoneIDFilter([]string{""}), false, originalEndpoints)
-
-	require.NoError(t, provider.DeleteRecords(originalEndpoints))
-
-	records, err := provider.Records(context.Background())
-	require.NoError(t, err)
-
-	validateEndpoints(t, records, []*endpoint.Endpoint{})
 }
 
 func TestGoogleApplyChanges(t *testing.T) {
@@ -807,7 +746,9 @@ func setupGoogleRecords(t *testing.T, provider *GoogleProvider, endpoints []*end
 
 	validateEndpoints(t, records, []*endpoint.Endpoint{})
 
-	require.NoError(t, provider.CreateRecords(endpoints))
+	require.NoError(t, provider.ApplyChanges(context.Background(), &plan.Changes{
+		Create: endpoints,
+	}))
 
 	records, err = provider.Records(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

These functions where exported but unused; only `CreateRecords` was used in some tests, but its use can be replaced with `AdjustEndpoints` and `ApplyChanges`.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

**Checklist**

- [X] Unit tests updated
- [x] ~End user documentation updated~ unneeded
