### PR TITLE
feat: allow pod IPs even for non-hostNetwork pods

### DIFF
--- a/docs/annotations/annotations.md
+++ b/docs/annotations/annotations.md
@@ -64,6 +64,8 @@ Specifies the domain for the resource's DNS records.
 Multiple hostnames can be specified through a comma-separated list, e.g.
 `svc.mydomain1.com,svc.mydomain2.com`.
 
+For `Pods`, uses the `Pod`'s `Status.PodIP`, unless they are `hostNetwork: true` in which case the NodeExternalIP is used for IPv4 and NodeInternalIP for IPv6.
+
 ## external-dns.alpha.kubernetes.io/ingress-hostname-source
 
 Specifies where to get the domain for an `Ingress` resource.
@@ -80,7 +82,7 @@ Specifies the domain for the resource's DNS records that are for use from intern
 
 For `Services` of type `LoadBalancer`, uses the `Service`'s `ClusterIP`.
 
-For `Pods`, uses the `Pod`'s `Status.PodIP`.
+For `Pods`, uses the `Pod`'s `Status.PodIP`, unless they are `hostNetwork: true` in which case the NodeExternalIP is used for IPv4 and NodeInternalIP for IPv6.
 
 ## external-dns.alpha.kubernetes.io/target
 

--- a/docs/tutorials/kops-dns-controller.md
+++ b/docs/tutorials/kops-dns-controller.md
@@ -21,11 +21,9 @@ The DNS record mappings try to "do the right thing", but what this means is diff
 
 ### Pods
 
-For the external annotation, ExternalDNS will map a HostNetwork=true Pod to the external IPs of the Node.
+For the external annotation, ExternalDNS will map a Pod to the external IPs of the Node.
 
-For the internal annotation, ExternalDNS will map a HostNetwork=true Pod to the internal IPs of the Node.
-
-ExternalDNS ignore Pods that are not HostNetwork=true
+For the internal annotation, ExternalDNS will map a Pod to the internal IPs of the Node.
 
 Annotations added to Pods will always result in an A record being created.
 

--- a/source/pod.go
+++ b/source/pod.go
@@ -85,7 +85,7 @@ func (ps *podSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 	for _, pod := range pods {
 		targets := getTargetsFromTargetAnnotation(pod.Annotations)
 
-		// accept hostname annotations that point to the pod's IP, no matter if the pod spec uses the host network
+		// accept internal hostname annotations that point to the pod's IP
 		if domainAnnotation, ok := pod.Annotations[internalHostnameAnnotationKey]; ok {
 			domainList := splitHostnameAnnotation(domainAnnotation)
 			for _, domain := range domainList {
@@ -99,46 +99,44 @@ func (ps *podSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 			}
 		}
 
-		// accept annotations that point to the node's external IP (or IPv6 NodeInternalIP) only for pods using the host network
-		if pod.Spec.HostNetwork {
-			if domainAnnotation, ok := pod.Annotations[hostnameAnnotationKey]; ok {
-				domainList := splitHostnameAnnotation(domainAnnotation)
-				for _, domain := range domainList {
-					if len(targets) == 0 {
-						node, _ := ps.nodeInformer.Lister().Get(pod.Spec.NodeName)
-						for _, address := range node.Status.Addresses {
-							recordType := suitableType(address.Address)
-							// IPv6 addresses are labeled as NodeInternalIP despite being usable externally as well.
-							if address.Type == corev1.NodeExternalIP || (address.Type == corev1.NodeInternalIP && recordType == endpoint.RecordTypeAAAA) {
-								addToEndpointMap(endpointMap, domain, recordType, address.Address)
-							}
+		// accept internal hostname annotations that point to the pod's IP (or IPv6 NodeInternalIP)
+		if domainAnnotation, ok := pod.Annotations[hostnameAnnotationKey]; ok {
+			domainList := splitHostnameAnnotation(domainAnnotation)
+			for _, domain := range domainList {
+				if len(targets) == 0 {
+					node, _ := ps.nodeInformer.Lister().Get(pod.Spec.NodeName)
+					for _, address := range node.Status.Addresses {
+						recordType := suitableType(address.Address)
+						// IPv6 addresses are labeled as NodeInternalIP despite being usable externally as well.
+						if address.Type == corev1.NodeExternalIP || (address.Type == corev1.NodeInternalIP && recordType == endpoint.RecordTypeAAAA) {
+							addToEndpointMap(endpointMap, domain, recordType, address.Address)
 						}
-					} else {
-						for _, target := range targets {
-							addToEndpointMap(endpointMap, domain, suitableType(target), target)
-						}
+					}
+				} else {
+					for _, target := range targets {
+						addToEndpointMap(endpointMap, domain, suitableType(target), target)
 					}
 				}
 			}
+		}
 
-			if ps.compatibility == "kops-dns-controller" {
-				if domainAnnotation, ok := pod.Annotations[kopsDNSControllerInternalHostnameAnnotationKey]; ok {
-					domainList := splitHostnameAnnotation(domainAnnotation)
-					for _, domain := range domainList {
-						addToEndpointMap(endpointMap, domain, suitableType(pod.Status.PodIP), pod.Status.PodIP)
-					}
+		if ps.compatibility == "kops-dns-controller" {
+			if domainAnnotation, ok := pod.Annotations[kopsDNSControllerInternalHostnameAnnotationKey]; ok {
+				domainList := splitHostnameAnnotation(domainAnnotation)
+				for _, domain := range domainList {
+					addToEndpointMap(endpointMap, domain, suitableType(pod.Status.PodIP), pod.Status.PodIP)
 				}
+			}
 
-				if domainAnnotation, ok := pod.Annotations[kopsDNSControllerHostnameAnnotationKey]; ok {
-					domainList := splitHostnameAnnotation(domainAnnotation)
-					for _, domain := range domainList {
-						node, _ := ps.nodeInformer.Lister().Get(pod.Spec.NodeName)
-						for _, address := range node.Status.Addresses {
-							recordType := suitableType(address.Address)
-							// IPv6 addresses are labeled as NodeInternalIP despite being usable externally as well.
-							if address.Type == corev1.NodeExternalIP || (address.Type == corev1.NodeInternalIP && recordType == endpoint.RecordTypeAAAA) {
-								addToEndpointMap(endpointMap, domain, recordType, address.Address)
-							}
+			if domainAnnotation, ok := pod.Annotations[kopsDNSControllerHostnameAnnotationKey]; ok {
+				domainList := splitHostnameAnnotation(domainAnnotation)
+				for _, domain := range domainList {
+					node, _ := ps.nodeInformer.Lister().Get(pod.Spec.NodeName)
+					for _, address := range node.Status.Addresses {
+						recordType := suitableType(address.Address)
+						// IPv6 addresses are labeled as NodeInternalIP despite being usable externally as well.
+						if address.Type == corev1.NodeExternalIP || (address.Type == corev1.NodeInternalIP && recordType == endpoint.RecordTypeAAAA) {
+							addToEndpointMap(endpointMap, domain, recordType, address.Address)
 						}
 					}
 				}
@@ -159,6 +157,13 @@ func addToEndpointMap(endpointMap map[endpoint.EndpointKey][]string, domain stri
 	}
 	if _, ok := endpointMap[key]; !ok {
 		endpointMap[key] = []string{}
+	}
+
+	// check that only unique addresses are added
+	for _, existingAddress := range endpointMap[key] {
+		if existingAddress == address {
+			return
+		}
 	}
 	endpointMap[key] = append(endpointMap[key], address)
 }

--- a/source/pod_test.go
+++ b/source/pod_test.go
@@ -116,7 +116,7 @@ func TestPodSource(t *testing.T) {
 			"kops-dns-controller",
 			[]*endpoint.Endpoint{
 				{DNSName: "a.foo.example.org", Targets: endpoint.Targets{"54.10.11.1", "54.10.11.2"}, RecordType: endpoint.RecordTypeA},
-				{DNSName: "internal.a.foo.example.org", Targets: endpoint.Targets{"10.0.1.1", "10.0.1.2"}, RecordType: endpoint.RecordTypeA},
+				{DNSName: "internal.a.foo.example.org", Targets: endpoint.Targets{"10.0.1.1", "10.0.1.2", "10.0.1.3"}, RecordType: endpoint.RecordTypeA},
 			},
 			false,
 			[]*corev1.Node{
@@ -178,7 +178,9 @@ func TestPodSource(t *testing.T) {
 						PodIP: "10.0.1.2",
 					},
 				},
-				// this pod must be ignored because it's not in the host network and kops requires this
+				// non-HostNetwork pod
+				// - internal hostname annotation will use the PodIP
+				// - external hostname annotation will use the NodeExternalIP
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "my-pod3",
@@ -264,7 +266,9 @@ func TestPodSource(t *testing.T) {
 						PodIP: "2001:DB8::2",
 					},
 				},
-				// this pod's internal hostname annotation must not be ignored even though it's not in the host network
+				// this pod's hostname annotations (both internal and not) must not be ignored even though it's not in the host network
+				// - internal hostname annotation uses the PodIP
+				// - external hostname annotation uses the NodeInternalIP
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "my-pod3",
@@ -290,7 +294,7 @@ func TestPodSource(t *testing.T) {
 			"kops-dns-controller",
 			[]*endpoint.Endpoint{
 				{DNSName: "a.foo.example.org", Targets: endpoint.Targets{"2001:DB8::1", "2001:DB8::2"}, RecordType: endpoint.RecordTypeAAAA},
-				{DNSName: "internal.a.foo.example.org", Targets: endpoint.Targets{"2001:DB8::1", "2001:DB8::2"}, RecordType: endpoint.RecordTypeAAAA},
+				{DNSName: "internal.a.foo.example.org", Targets: endpoint.Targets{"2001:DB8::1", "2001:DB8::2", "2001:DB8::3"}, RecordType: endpoint.RecordTypeAAAA},
 			},
 			false,
 			[]*corev1.Node{
@@ -350,7 +354,9 @@ func TestPodSource(t *testing.T) {
 						PodIP: "2001:DB8::2",
 					},
 				},
-				// this pod must be ignored because it's not in the host network and kops requires this (no matter the type of hostname annotation)
+				// this pod's hostname annotations (both internal and not) must not be ignored even though it's not in the host network
+				// - internal hostname annotation uses the PodIP
+				// - external hostname annotation uses the NodeInternalIP
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "my-pod3",
@@ -375,7 +381,7 @@ func TestPodSource(t *testing.T) {
 			"",
 			"",
 			[]*endpoint.Endpoint{
-				{DNSName: "a.foo.example.org", Targets: endpoint.Targets{"208.1.2.1", "208.1.2.2"}, RecordType: endpoint.RecordTypeA},
+				{DNSName: "a.foo.example.org", Targets: endpoint.Targets{"208.1.2.1", "208.1.2.2", "208.1.2.3"}, RecordType: endpoint.RecordTypeA},
 				{DNSName: "internal.a.foo.example.org", Targets: endpoint.Targets{"208.1.2.1", "208.1.2.2", "208.1.2.3"}, RecordType: endpoint.RecordTypeA},
 			},
 			false,
@@ -440,7 +446,7 @@ func TestPodSource(t *testing.T) {
 						PodIP: "10.0.1.2",
 					},
 				},
-				// this pod's internal hostname annotation must not be ignored even though it's not in the host network (even when using a custom target annotation)
+				// test non-HostNetwork pod
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "my-pod3",
@@ -532,11 +538,11 @@ func TestPodSource(t *testing.T) {
 			},
 		},
 		{
-			"internal hostname annotations of pods with hostNetwore=false should still be added as valid records",
+			"hostname annotations of pods with hostNetwork=false should still be added as valid records",
 			"",
 			"",
 			[]*endpoint.Endpoint{
-				{DNSName: "a.foo.example.org", Targets: endpoint.Targets{"54.10.11.1"}, RecordType: endpoint.RecordTypeA},
+				{DNSName: "a.foo.example.org", Targets: endpoint.Targets{"54.10.11.1", "54.10.11.2"}, RecordType: endpoint.RecordTypeA},
 				{DNSName: "internal.a.foo.example.org", Targets: endpoint.Targets{"10.0.1.1", "100.0.1.2"}, RecordType: endpoint.RecordTypeA},
 				// this annotation is part of a comma separated hostname list in the annotation
 				{DNSName: "internal.b.foo.example.org", Targets: endpoint.Targets{"10.0.1.1"}, RecordType: endpoint.RecordTypeA},


### PR DESCRIPTION
but only for the internalHostnameAnnotationKey which doesn't use the node's IP anyway

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Pod IPs and node IPs can be used for hostname annotations on pods.

The existing implementation worked this way:
- check if the pod has nodeNetwork: true
- if no -> skip
- otherwise:
  - for the internal hostname annotation -> use the pod' IP
  - for the regular hostname annotation -> use the node's IP
  - special handling for kops-dns-controller

I would like to change the implementation to cover a case, where Pod IPs can be exposed as names, but with pods where hostNetwork == false. This is a typical use case with CNI plugins like Calico CNI, where pod IPs are exposed as BGP routes directly to the ToR router/switch. So there is basically no service in front of the pod and the pod is directly exposed to the outside world of the cluster, most commonly with an internet-routable public IP, but could also be a private IP that is justed routed internally. The usefulness of this change addresses both those cases.

Since the pod's IP is already used for the internal hostname annotation, there is no need to actually limit this behavor to pods with nodeNetwork: true.

I can add public documentation for this, since the whole pod annotation part is not publicly documented yet, it might be a topic for a separate PR though.

There is no github issue for this yet.

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
