### PR TITLE
fix: New provider specific update

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -209,16 +209,17 @@ func shouldUpdateTTL(desired, current *endpoint.Endpoint) bool {
 }
 
 func (p *Plan) shouldUpdateProviderSpecific(desired, current *endpoint.Endpoint) bool {
-	desiredProperties := map[string]endpoint.ProviderSpecificProperty{}
+	currentProperties := map[string]endpoint.ProviderSpecificProperty{}
+
+	if current.ProviderSpecific != nil {
+		for _, d := range current.ProviderSpecific {
+			currentProperties[d.Name] = d
+		}
+	}
 
 	if desired.ProviderSpecific != nil {
 		for _, d := range desired.ProviderSpecific {
-			desiredProperties[d.Name] = d
-		}
-	}
-	if current.ProviderSpecific != nil {
-		for _, c := range current.ProviderSpecific {
-			if d, ok := desiredProperties[c.Name]; ok {
+			if c, ok := currentProperties[d.Name]; ok {
 				if p.PropertyComparator != nil {
 					if !p.PropertyComparator(c.Name, c.Value, d.Value) {
 						return true
@@ -228,10 +229,10 @@ func (p *Plan) shouldUpdateProviderSpecific(desired, current *endpoint.Endpoint)
 				}
 			} else {
 				if p.PropertyComparator != nil {
-					if !p.PropertyComparator(c.Name, c.Value, "") {
+					if !p.PropertyComparator(c.Name, "", d.Value) {
 						return true
 					}
-				} else if c.Value != "" {
+				} else if d.Value != "" {
 					return true
 				}
 			}


### PR DESCRIPTION
The previous code version only iterates over current ProviderSpecific properties. This new version iterates over desired properties, including those that were just set.

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

[shouldUpdateProviderSpecific](https://github.com/kubernetes-sigs/external-dns/blob/master/plan/plan.go#L211) seems to be iterating over just the current properties that were previously set, not taking into consideration for planning changes when additional ProviderSpecific properties were just set. 

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2953 

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
