### PR TITLE
New provider-specific properties support when updating DNS records

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -212,8 +212,8 @@ func (p *Plan) shouldUpdateProviderSpecific(desired, current *endpoint.Endpoint)
 	currentProperties := map[string]endpoint.ProviderSpecificProperty{}
 
 	if current.ProviderSpecific != nil {
-		for _, d := range current.ProviderSpecific {
-			currentProperties[d.Name] = d
+		for _, c := range current.ProviderSpecific {
+			currentProperties[c.Name] = c
 		}
 	}
 
@@ -229,7 +229,7 @@ func (p *Plan) shouldUpdateProviderSpecific(desired, current *endpoint.Endpoint)
 				}
 			} else {
 				if p.PropertyComparator != nil {
-					if !p.PropertyComparator(c.Name, "", d.Value) {
+					if !p.PropertyComparator(d.Name, "", d.Value) {
 						return true
 					}
 				} else if d.Value != "" {


### PR DESCRIPTION
shouldUpdateProviderSpecific seems to be iterating over just the current properties that were previously set, not taking into consideration for planning changes when additional ProviderSpecific properties were just set.

The previous code version only iterates over current ProviderSpecific properties. This new version iterates over desired properties, including those that were just set.

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes an issue with the previous PR #3177 

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
