### PR TITLE
Retry failed batch by shortening it

### DIFF
--- a/plan/policy.go
+++ b/plan/policy.go
@@ -26,6 +26,8 @@ var Policies = map[string]Policy{
 	"sync":        &SyncPolicy{},
 	"upsert-only": &UpsertOnlyPolicy{},
 	"create-only": &CreateOnlyPolicy{},
+	"first-half":  &FirstHalfChangesPolicy{},
+	"last-half":   &LastHalfChangesPolicy{},
 }
 
 // SyncPolicy allows for full synchronization of DNS records.
@@ -56,4 +58,64 @@ func (p *CreateOnlyPolicy) Apply(changes *Changes) *Changes {
 	return &Changes{
 		Create: changes.Create,
 	}
+}
+
+// FirstHalfChangesPolicy allows limiting amount of records modified.
+type FirstHalfChangesPolicy struct{}
+
+// Apply applies the first half changes policy which limits change list to its first half.
+func (p *FirstHalfChangesPolicy) Apply(changes *Changes) *Changes {
+	if len(changes.Create) > 0 {
+		halfChanges := len(changes.Create) / 2
+		return &Changes{
+			Create: changes.Create[:halfChanges],
+		}
+	}
+
+	if len(changes.UpdateOld) > 0 && len(changes.UpdateNew) > 0 {
+		halfChanges := len(changes.UpdateNew) / 2
+		return &Changes{
+			UpdateOld: changes.UpdateOld[:halfChanges],
+			UpdateNew: changes.UpdateNew[:halfChanges],
+		}
+	}
+
+	if len(changes.Delete) > 0 {
+		halfChanges := len(changes.Delete) / 2
+		return &Changes{
+			Delete: changes.Delete[:halfChanges],
+		}
+	}
+
+	return &Changes{}
+}
+
+// LastHalfChangesPolicy allows limiting amount of records modified.
+type LastHalfChangesPolicy struct{}
+
+// Apply applies the last half changes policy which limits change list to its last half.
+func (p *LastHalfChangesPolicy) Apply(changes *Changes) *Changes {
+	if len(changes.Create) > 0 {
+		halfChanges := len(changes.Create) / 2
+		return &Changes{
+			Create: changes.Create[halfChanges:],
+		}
+	}
+
+	if len(changes.UpdateOld) > 0 && len(changes.UpdateNew) > 0 {
+		halfChanges := len(changes.UpdateNew) / 2
+		return &Changes{
+			UpdateOld: changes.UpdateOld[halfChanges:],
+			UpdateNew: changes.UpdateNew[halfChanges:],
+		}
+	}
+
+	if len(changes.Delete) > 0 {
+		halfChanges := len(changes.Delete) / 2
+		return &Changes{
+			Delete: changes.Delete[halfChanges:],
+		}
+	}
+
+	return &Changes{}
 }


### PR DESCRIPTION
**Description**
Given an error is returned on `Registry.ApplyChanges`, retry batch with different strategies to get more chances of finding and processing correct records, therefore preventing that the whole process fails indefinitely.

First by splitting the batch into batch actions and retrying each action separately. When that fails, split the action batch into halves and retrying with each.

![Screenshot 2022-11-23 at 10 12 30](https://user-images.githubusercontent.com/1137200/203508809-fce5c707-0944-4b11-bb91-647e62b72f7b.png)

Fixes [#421](https://github.com/kubernetes-sigs/external-dns/issues/421)

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
