### PR TITLE
Bump external-dns image tag to v0.13.1

### DIFF
--- a/docs/tutorials/azure-private-dns.md
+++ b/docs/tutorials/azure-private-dns.md
@@ -172,7 +172,7 @@ spec:
     spec:
       containers:
       - name: externaldns
-        image: k8s.gcr.io/external-dns/external-dns:v0.8.0
+        image: k8s.gcr.io/external-dns/external-dns:v0.13.1
         args:
         - --source=service
         - --source=ingress
@@ -243,7 +243,7 @@ spec:
       serviceAccountName: externaldns
       containers:
       - name: externaldns
-        image: k8s.gcr.io/external-dns/external-dns:v0.8.0
+        image: k8s.gcr.io/external-dns/external-dns:v0.13.1
         args:
         - --source=service
         - --source=ingress
@@ -314,7 +314,7 @@ spec:
       serviceAccountName: externaldns
       containers:
       - name: externaldns
-        image: k8s.gcr.io/external-dns/external-dns:v0.8.0
+        image: k8s.gcr.io/external-dns/external-dns:v0.13.1
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
I tested the tutorial with:

```
image: k8s.gcr.io/external-dns/external-dns:v0.13.1
```
