### PR TITLE
Revert "fix: New provider specific update"

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -209,17 +209,16 @@ func shouldUpdateTTL(desired, current *endpoint.Endpoint) bool {
 }
 
 func (p *Plan) shouldUpdateProviderSpecific(desired, current *endpoint.Endpoint) bool {
-	currentProperties := map[string]endpoint.ProviderSpecificProperty{}
-
-	if current.ProviderSpecific != nil {
-		for _, d := range current.ProviderSpecific {
-			currentProperties[d.Name] = d
-		}
-	}
+	desiredProperties := map[string]endpoint.ProviderSpecificProperty{}
 
 	if desired.ProviderSpecific != nil {
 		for _, d := range desired.ProviderSpecific {
-			if c, ok := currentProperties[d.Name]; ok {
+			desiredProperties[d.Name] = d
+		}
+	}
+	if current.ProviderSpecific != nil {
+		for _, c := range current.ProviderSpecific {
+			if d, ok := desiredProperties[c.Name]; ok {
 				if p.PropertyComparator != nil {
 					if !p.PropertyComparator(c.Name, c.Value, d.Value) {
 						return true
@@ -229,10 +228,10 @@ func (p *Plan) shouldUpdateProviderSpecific(desired, current *endpoint.Endpoint)
 				}
 			} else {
 				if p.PropertyComparator != nil {
-					if !p.PropertyComparator(c.Name, "", d.Value) {
+					if !p.PropertyComparator(c.Name, c.Value, "") {
 						return true
 					}
-				} else if d.Value != "" {
+				} else if c.Value != "" {
 					return true
 				}
 			}


### PR DESCRIPTION
Reverts kubernetes-sigs/external-dns#3177. This PR has broken tests in master.