### PR TITLE
chore: Add AWS me-central-1 region

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -90,6 +90,7 @@ var canonicalHostedZones = map[string]string{
 	"cn-northwest-1.elb.amazonaws.com.cn": "ZM7IZAIOVVDZF",
 	"us-gov-west-1.elb.amazonaws.com":     "Z33AYJ8TM3BH4J",
 	"us-gov-east-1.elb.amazonaws.com":     "Z166TLBEWOO7G0",
+	"me-central-1.elb.amazonaws.com":      "Z08230872XQRWHG2XF6I",
 	"me-south-1.elb.amazonaws.com":        "ZS929ML54UICD",
 	"af-south-1.elb.amazonaws.com":        "Z268VQBMOI5EKX",
 	// Network Load Balancers
@@ -116,6 +117,7 @@ var canonicalHostedZones = map[string]string{
 	"elb.cn-northwest-1.amazonaws.com.cn": "ZQEIKTCZ8352D",
 	"elb.us-gov-west-1.amazonaws.com":     "ZMG1MZ2THAWF1",
 	"elb.us-gov-east-1.amazonaws.com":     "Z1ZSMQQ6Q24QQ8",
+	"elb.me-central-1.amazonaws.com":      "Z00282643NTTLPANJJG2P",
 	"elb.me-south-1.amazonaws.com":        "Z3QSRYVP46NYYV",
 	"elb.af-south-1.amazonaws.com":        "Z203XCE67M25HM",
 	// Global Accelerator


### PR DESCRIPTION
**Description**

Adding the AWS `me-central-1` region, as per the [Elastic Load Balancing endpoints and quotas
](https://docs.aws.amazon.com/general/latest/gr/elb.html) data.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
