### PR TITLE
Allow AWS Route53 routing policy change to/from simple to others.

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -437,7 +437,6 @@ func (p *AWSProvider) UpdateRecords(ctx context.Context, updates, current []*end
 
 // Identify if old and new endpoints require DELETE/CREATE instead of UPDATE.
 func (p *AWSProvider) requiresDeleteCreate(old *endpoint.Endpoint, new *endpoint.Endpoint) bool {
-
 	// a change of record type
 	if old.RecordType != new.RecordType {
 		return true
@@ -448,21 +447,21 @@ func (p *AWSProvider) requiresDeleteCreate(old *endpoint.Endpoint, new *endpoint
 		return true
 	}
 
+	// a set identifier change
+	if old.SetIdentifier != new.SetIdentifier {
+		return true
+	}
+
 	// a change of routing policy
 	// default to true for geolocation properties if any geolocation property exists in old/new but not the other
 	for _, propType := range [7]string{providerSpecificWeight, providerSpecificRegion, providerSpecificFailover,
 		providerSpecificFailover, providerSpecificGeolocationContinentCode, providerSpecificGeolocationCountryCode,
 		providerSpecificGeolocationSubdivisionCode} {
 		_, oldPolicy := old.GetProviderSpecificProperty(propType)
-		_, newPolicy := old.GetProviderSpecificProperty(propType)
+		_, newPolicy := new.GetProviderSpecificProperty(propType)
 		if oldPolicy != newPolicy {
 			return true
 		}
-	}
-
-	// a set identifier change
-	if old.SetIdentifier != new.SetIdentifier {
-		return true
 	}
 
 	return false

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -435,6 +435,39 @@ func (p *AWSProvider) UpdateRecords(ctx context.Context, updates, current []*end
 	return p.submitChanges(ctx, p.createUpdateChanges(updates, current), zones)
 }
 
+// Identify if old and new endpoints require DELETE/CREATE instead of UPDATE.
+func (p *AWSProvider) requiresDeleteCreate(old *endpoint.Endpoint, new *endpoint.Endpoint) bool {
+
+	// a change of record type
+	if old.RecordType != new.RecordType {
+		return true
+	}
+
+	// an ALIAS record change to/from a CNAME
+	if old.RecordType == endpoint.RecordTypeCNAME && useAlias(old, p.preferCNAME) != useAlias(new, p.preferCNAME) {
+		return true
+	}
+
+	// a change of routing policy
+	// default to true for geolocation properties if any geolocation property exists in old/new but not the other
+	for _, propType := range [7]string{providerSpecificWeight, providerSpecificRegion, providerSpecificFailover,
+		providerSpecificFailover, providerSpecificGeolocationContinentCode, providerSpecificGeolocationCountryCode,
+		providerSpecificGeolocationSubdivisionCode} {
+		_, oldPolicy := old.GetProviderSpecificProperty(propType)
+		_, newPolicy := old.GetProviderSpecificProperty(propType)
+		if oldPolicy != newPolicy {
+			return true
+		}
+	}
+
+	// a set identifier change
+	if old.SetIdentifier != new.SetIdentifier {
+		return true
+	}
+
+	return false
+}
+
 func (p *AWSProvider) createUpdateChanges(newEndpoints, oldEndpoints []*endpoint.Endpoint) []*route53.Change {
 	var deletes []*endpoint.Endpoint
 	var creates []*endpoint.Endpoint
@@ -442,12 +475,7 @@ func (p *AWSProvider) createUpdateChanges(newEndpoints, oldEndpoints []*endpoint
 
 	for i, new := range newEndpoints {
 		old := oldEndpoints[i]
-		if new.RecordType != old.RecordType ||
-			// Handle the case where an AWS ALIAS record is changing to/from a CNAME.
-			(old.RecordType == endpoint.RecordTypeCNAME && useAlias(old, p.preferCNAME) != useAlias(new, p.preferCNAME)) ||
-			// Handle the case where an AWS record is changing to/from simple to other routing policies
-			((old.SetIdentifier == "" && new.SetIdentifier != "") || (old.SetIdentifier != "" && new.SetIdentifier == "")) {
-			// The record type changed or the routing policy change, so UPSERT will fail. Instead perform a DELETE followed by a CREATE.
+		if p.requiresDeleteCreate(old, new) {
 			deletes = append(deletes, old)
 			creates = append(creates, new)
 		} else {

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -444,8 +444,10 @@ func (p *AWSProvider) createUpdateChanges(newEndpoints, oldEndpoints []*endpoint
 		old := oldEndpoints[i]
 		if new.RecordType != old.RecordType ||
 			// Handle the case where an AWS ALIAS record is changing to/from a CNAME.
-			(old.RecordType == endpoint.RecordTypeCNAME && useAlias(old, p.preferCNAME) != useAlias(new, p.preferCNAME)) {
-			// The record type changed, so UPSERT will fail. Instead perform a DELETE followed by a CREATE.
+			(old.RecordType == endpoint.RecordTypeCNAME && useAlias(old, p.preferCNAME) != useAlias(new, p.preferCNAME)) ||
+			// Handle the case where an AWS record is changing to/from simple to other routing policies
+			((old.SetIdentifier == "" && new.SetIdentifier != "") || (old.SetIdentifier != "" && new.SetIdentifier == "")) {
+			// The record type changed or the routing policy change, so UPSERT will fail. Instead perform a DELETE followed by a CREATE.
 			deletes = append(deletes, old)
 			creates = append(creates, new)
 		} else {

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -528,6 +528,7 @@ func TestAWSApplyChanges(t *testing.T) {
 			endpoint.NewEndpointWithTTL("delete-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4", "4.3.2.1"),
 			endpoint.NewEndpointWithTTL("weighted-to-simple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4").WithSetIdentifier("weighted-to-simple").WithProviderSpecific(providerSpecificWeight, "10"),
 			endpoint.NewEndpointWithTTL("simple-to-weighted.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4"),
+			endpoint.NewEndpointWithTTL("policy-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4").WithSetIdentifier("policy-change").WithProviderSpecific(providerSpecificWeight, "10"),
 		})
 
 		createRecords := []*endpoint.Endpoint{
@@ -548,6 +549,7 @@ func TestAWSApplyChanges(t *testing.T) {
 			endpoint.NewEndpoint("update-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8", "8.8.4.4"),
 			endpoint.NewEndpoint("weighted-to-simple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("weighted-to-simple").WithProviderSpecific(providerSpecificWeight, "10"),
 			endpoint.NewEndpoint("simple-to-weighted.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
+			endpoint.NewEndpoint("policy-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("policy-change").WithProviderSpecific(providerSpecificWeight, "10"),
 		}
 		updatedRecords := []*endpoint.Endpoint{
 			endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
@@ -559,6 +561,7 @@ func TestAWSApplyChanges(t *testing.T) {
 			endpoint.NewEndpoint("update-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4", "4.3.2.1"),
 			endpoint.NewEndpoint("weighted-to-simple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
 			endpoint.NewEndpoint("simple-to-weighted.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("simple-to-weighted").WithProviderSpecific(providerSpecificWeight, "10"),
+			endpoint.NewEndpoint("policy-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("policy-change").WithProviderSpecific(providerSpecificRegion, "us-east-1"),
 		}
 
 		deleteRecords := []*endpoint.Endpoint{

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -526,6 +526,8 @@ func TestAWSApplyChanges(t *testing.T) {
 			endpoint.NewEndpointWithTTL("delete-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL), "qux.elb.amazonaws.com"),
 			endpoint.NewEndpointWithTTL("update-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "8.8.8.8", "8.8.4.4"),
 			endpoint.NewEndpointWithTTL("delete-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4", "4.3.2.1"),
+			endpoint.NewEndpointWithTTL("weighted-to-simple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4").WithSetIdentifier("weighted-to-simple").WithProviderSpecific(providerSpecificWeight, "10"),
+			endpoint.NewEndpointWithTTL("simple-to-weighted.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4"),
 		})
 
 		createRecords := []*endpoint.Endpoint{
@@ -544,6 +546,8 @@ func TestAWSApplyChanges(t *testing.T) {
 			endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "bar.elb.amazonaws.com"),
 			endpoint.NewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "bar.elb.amazonaws.com"),
 			endpoint.NewEndpoint("update-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8", "8.8.4.4"),
+			endpoint.NewEndpoint("weighted-to-simple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("weighted-to-simple").WithProviderSpecific(providerSpecificWeight, "10"),
+			endpoint.NewEndpoint("simple-to-weighted.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
 		}
 		updatedRecords := []*endpoint.Endpoint{
 			endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
@@ -553,6 +557,8 @@ func TestAWSApplyChanges(t *testing.T) {
 			endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "baz.elb.amazonaws.com"),
 			endpoint.NewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "baz.elb.amazonaws.com"),
 			endpoint.NewEndpoint("update-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4", "4.3.2.1"),
+			endpoint.NewEndpoint("weighted-to-simple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
+			endpoint.NewEndpoint("simple-to-weighted.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("simple-to-weighted").WithProviderSpecific(providerSpecificWeight, "10"),
 		}
 
 		deleteRecords := []*endpoint.Endpoint{
@@ -596,6 +602,9 @@ func TestAWSApplyChanges(t *testing.T) {
 			endpoint.NewEndpointWithTTL("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL), "baz.elb.amazonaws.com"),
 			endpoint.NewEndpointWithTTL("create-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "8.8.8.8", "8.8.4.4"),
 			endpoint.NewEndpointWithTTL("update-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4", "4.3.2.1"),
+			endpoint.NewEndpointWithTTL("weighted-to-simple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4"),
+			endpoint.NewEndpointWithTTL("simple-to-weighted.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4").WithSetIdentifier("simple-to-weighted").WithProviderSpecific(providerSpecificWeight, "10"),
+			endpoint.NewEndpointWithTTL("policy-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4").WithSetIdentifier("policy-change").WithProviderSpecific(providerSpecificRegion, "us-east-1"),
 		})
 	}
 }

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -529,6 +529,8 @@ func TestAWSApplyChanges(t *testing.T) {
 			endpoint.NewEndpointWithTTL("weighted-to-simple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4").WithSetIdentifier("weighted-to-simple").WithProviderSpecific(providerSpecificWeight, "10"),
 			endpoint.NewEndpointWithTTL("simple-to-weighted.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4"),
 			endpoint.NewEndpointWithTTL("policy-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4").WithSetIdentifier("policy-change").WithProviderSpecific(providerSpecificWeight, "10"),
+			endpoint.NewEndpointWithTTL("set-identifier-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4").WithSetIdentifier("before").WithProviderSpecific(providerSpecificWeight, "10"),
+			endpoint.NewEndpointWithTTL("set-identifier-no-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4").WithSetIdentifier("no-change").WithProviderSpecific(providerSpecificWeight, "10"),
 		})
 
 		createRecords := []*endpoint.Endpoint{
@@ -550,6 +552,8 @@ func TestAWSApplyChanges(t *testing.T) {
 			endpoint.NewEndpoint("weighted-to-simple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("weighted-to-simple").WithProviderSpecific(providerSpecificWeight, "10"),
 			endpoint.NewEndpoint("simple-to-weighted.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
 			endpoint.NewEndpoint("policy-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("policy-change").WithProviderSpecific(providerSpecificWeight, "10"),
+			endpoint.NewEndpoint("set-identifier-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("before").WithProviderSpecific(providerSpecificWeight, "10"),
+			endpoint.NewEndpoint("set-identifier-no-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("no-change").WithProviderSpecific(providerSpecificWeight, "10"),
 		}
 		updatedRecords := []*endpoint.Endpoint{
 			endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
@@ -562,6 +566,8 @@ func TestAWSApplyChanges(t *testing.T) {
 			endpoint.NewEndpoint("weighted-to-simple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
 			endpoint.NewEndpoint("simple-to-weighted.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("simple-to-weighted").WithProviderSpecific(providerSpecificWeight, "10"),
 			endpoint.NewEndpoint("policy-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("policy-change").WithProviderSpecific(providerSpecificRegion, "us-east-1"),
+			endpoint.NewEndpoint("set-identifier-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("after").WithProviderSpecific(providerSpecificWeight, "10"),
+			endpoint.NewEndpoint("set-identifier-no-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("no-change").WithProviderSpecific(providerSpecificWeight, "20"),
 		}
 
 		deleteRecords := []*endpoint.Endpoint{
@@ -608,6 +614,8 @@ func TestAWSApplyChanges(t *testing.T) {
 			endpoint.NewEndpointWithTTL("weighted-to-simple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4"),
 			endpoint.NewEndpointWithTTL("simple-to-weighted.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4").WithSetIdentifier("simple-to-weighted").WithProviderSpecific(providerSpecificWeight, "10"),
 			endpoint.NewEndpointWithTTL("policy-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4").WithSetIdentifier("policy-change").WithProviderSpecific(providerSpecificRegion, "us-east-1"),
+			endpoint.NewEndpointWithTTL("set-identifier-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4").WithSetIdentifier("after").WithProviderSpecific(providerSpecificWeight, "10"),
+			endpoint.NewEndpointWithTTL("set-identifier-no-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4").WithSetIdentifier("no-change").WithProviderSpecific(providerSpecificWeight, "20"),
 		})
 	}
 }

--- a/provider/ovh/ovh.go
+++ b/provider/ovh/ovh.go
@@ -22,9 +22,9 @@ import (
 	"fmt"
 	"strings"
 
-	"golang.org/x/sync/errgroup"
 	"github.com/ovh/go-ovh/ovh"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

Signed-off-by:  @jessegonzalez 

**Description**

<!-- Please provide a summary of the change here. -->

This PR allows Route53 record updates to change the routing policy to/from simple from/to other routing policies. These record modifications do not support UPSERT, but instead, require DELETE/CREATE to succeed.

The AWS provider function createUpdateChanges has been updated with another conditional to test if one of the old/new set identifiers is the empty string and the other is not.

The AWS Provider test TestAWSApplyChanges has been updated to validate the change, and validated before PR submission. 

Original PR: #3159 did not include stashed changes.

<details>
  <summary>Local test output</summary>

```
❯ make test
go test -race -coverprofile=profile.cov ./...
?       sigs.k8s.io/external-dns        [no test files]
ok      sigs.k8s.io/external-dns/controller     5.706s  coverage: 75.9% of statements
?       sigs.k8s.io/external-dns/docs/scripts   [no test files]
ok      sigs.k8s.io/external-dns/endpoint       1.117s  coverage: 47.8% of statements
?       sigs.k8s.io/external-dns/internal/config        [no test files]
ok      sigs.k8s.io/external-dns/internal/testutils     1.045s  coverage: 31.7% of statements
ok      sigs.k8s.io/external-dns/pkg/apis/externaldns   4.749s  coverage: 98.9% of statements
ok      sigs.k8s.io/external-dns/pkg/apis/externaldns/validation        3.711s  coverage: 64.6% of statements
?       sigs.k8s.io/external-dns/pkg/tlsutils   [no test files]
ok      sigs.k8s.io/external-dns/plan   1.429s  coverage: 93.0% of statements
ok      sigs.k8s.io/external-dns/provider       2.278s  coverage: 87.7% of statements
ok      sigs.k8s.io/external-dns/provider/akamai        3.222s  coverage: 72.2% of statements
ok      sigs.k8s.io/external-dns/provider/alibabacloud  3.020s  coverage: 66.4% of statements
ok      sigs.k8s.io/external-dns/provider/aws   5.166s  coverage: 89.3% of statements
ok      sigs.k8s.io/external-dns/provider/awssd 6.545s  coverage: 77.0% of statements
ok      sigs.k8s.io/external-dns/provider/azure 4.419s  coverage: 77.2% of statements
ok      sigs.k8s.io/external-dns/provider/bluecat       4.703s  coverage: 71.5% of statements
ok      sigs.k8s.io/external-dns/provider/bluecat/gateway       1.946s  coverage: 31.2% of statements
ok      sigs.k8s.io/external-dns/provider/civo  6.563s  coverage: 85.1% of statements
ok      sigs.k8s.io/external-dns/provider/cloudflare    7.011s  coverage: 87.5% of statements
ok      sigs.k8s.io/external-dns/provider/coredns       3.852s  coverage: 50.2% of statements
ok      sigs.k8s.io/external-dns/provider/designate     5.009s  coverage: 73.6% of statements
ok      sigs.k8s.io/external-dns/provider/digitalocean  7.969s  coverage: 83.2% of statements
ok      sigs.k8s.io/external-dns/provider/dnsimple      8.855s  coverage: 76.6% of statements
ok      sigs.k8s.io/external-dns/provider/dyn   6.590s  coverage: 25.5% of statements
?       sigs.k8s.io/external-dns/provider/dyn/soap      [no test files]
ok      sigs.k8s.io/external-dns/provider/exoscale      6.727s  coverage: 70.5% of statements
ok      sigs.k8s.io/external-dns/provider/gandi 7.172s  coverage: 83.5% of statements
ok      sigs.k8s.io/external-dns/provider/godaddy       7.588s  coverage: 59.5% of statements
ok      sigs.k8s.io/external-dns/provider/google        7.178s  coverage: 80.1% of statements
ok      sigs.k8s.io/external-dns/provider/ibmcloud      7.675s  coverage: 75.0% of statements
ok      sigs.k8s.io/external-dns/provider/infoblox      6.701s  coverage: 75.3% of statements
ok      sigs.k8s.io/external-dns/provider/inmemory      6.430s  coverage: 82.6% of statements
ok      sigs.k8s.io/external-dns/provider/linode        6.966s  coverage: 84.3% of statements
ok      sigs.k8s.io/external-dns/provider/ns1   6.485s  coverage: 81.6% of statements
ok      sigs.k8s.io/external-dns/provider/oci   6.796s  coverage: 82.3% of statements
ok      sigs.k8s.io/external-dns/provider/ovh   10.195s coverage: 95.2% of statements
ok      sigs.k8s.io/external-dns/provider/pdns  6.118s  coverage: 63.2% of statements
ok      sigs.k8s.io/external-dns/provider/pihole        6.398s  coverage: 73.7% of statements
ok      sigs.k8s.io/external-dns/provider/plural        5.186s  coverage: 31.1% of statements
ok      sigs.k8s.io/external-dns/provider/rcode0        5.568s  coverage: 86.3% of statements
ok      sigs.k8s.io/external-dns/provider/rdns  4.673s  coverage: 46.8% of statements
ok      sigs.k8s.io/external-dns/provider/rfc2136       5.022s  coverage: 60.4% of statements
ok      sigs.k8s.io/external-dns/provider/safedns       4.806s  coverage: 87.2% of statements
ok      sigs.k8s.io/external-dns/provider/scaleway      4.541s  coverage: 70.3% of statements
ok      sigs.k8s.io/external-dns/provider/tencentcloud  3.930s  coverage: 84.3% of statements
?       sigs.k8s.io/external-dns/provider/tencentcloud/cloudapi [no test files]
ok      sigs.k8s.io/external-dns/provider/transip       4.064s  coverage: 40.7% of statements
ok      sigs.k8s.io/external-dns/provider/ultradns      3.857s  coverage: 81.9% of statements
ok      sigs.k8s.io/external-dns/provider/vinyldns      3.296s  coverage: 79.6% of statements
ok      sigs.k8s.io/external-dns/provider/vultr 3.905s  coverage: 77.1% of statements
ok      sigs.k8s.io/external-dns/registry       3.948s  coverage: 90.0% of statements
ok      sigs.k8s.io/external-dns/source 5.825s  coverage: 73.5% of statements
```
</details>

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #3144 

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
