### PR TITLE
fix: add missing TXT records correctly for multiple records with the same name

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -236,6 +236,10 @@ func (e *Endpoint) GetProviderSpecificProperty(key string) (ProviderSpecificProp
 	return ProviderSpecificProperty{}, false
 }
 
+func (e *Endpoint) Id() string {
+	return fmt.Sprintf("%s::%s", e.DNSName, e.SetIdentifier)
+}
+
 func (e *Endpoint) String() string {
 	return fmt.Sprintf("%s %d IN %s %s %s %s", e.DNSName, e.RecordTTL, e.RecordType, e.SetIdentifier, e.Targets, e.ProviderSpecific)
 }

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -123,9 +123,8 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 		if err != nil {
 			return nil, err
 		}
-		key := fmt.Sprintf("%s::%s", im.mapper.toEndpointName(record.DNSName), record.SetIdentifier)
-		labelMap[key] = labels
-		txtRecordsMap[record.DNSName] = struct{}{}
+		labelMap[fmt.Sprintf("%s::%s", im.mapper.toEndpointName(record.DNSName), record.SetIdentifier)] = labels
+		txtRecordsMap[record.Id()] = struct{}{}
 	}
 
 	for _, ep := range endpoints {
@@ -138,8 +137,7 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 			dnsNameSplit[0] = im.wildcardReplacement
 		}
 		dnsName := strings.Join(dnsNameSplit, ".")
-		key := fmt.Sprintf("%s::%s", dnsName, ep.SetIdentifier)
-		if labels, ok := labelMap[key]; ok {
+		if labels, ok := labelMap[fmt.Sprintf("%s::%s", dnsName, ep.SetIdentifier)]; ok {
 			for k, v := range labels {
 				ep.Labels[k] = v
 			}
@@ -153,7 +151,7 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 				desiredTXTs := im.generateTXTRecord(ep)
 				missingDesiredTXTs := []*endpoint.Endpoint{}
 				for _, desiredTXT := range desiredTXTs {
-					if _, exists := txtRecordsMap[desiredTXT.DNSName]; !exists {
+					if _, exists := txtRecordsMap[desiredTXT.Id()]; !exists {
 						missingDesiredTXTs = append(missingDesiredTXTs, desiredTXT)
 					}
 				}

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -784,6 +784,11 @@ func testTXTRegistryMissingRecordsNoPrefix(t *testing.T) {
 			newEndpointWithOwner("oldformat.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("oldformat2.test-zone.example.org", "bar.loadbalancer.com", endpoint.RecordTypeA, ""),
 			newEndpointWithOwner("oldformat2.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("oldformat3.test-zone.example.org", "bar1.loadbalancer.com", endpoint.RecordTypeA, "").WithSetIdentifier("one"),
+			newEndpointWithOwner("oldformat3.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("one"),
+			newEndpointWithOwner("oldformat3.test-zone.example.org", "bar2.loadbalancer.com", endpoint.RecordTypeA, "").WithSetIdentifier("two"),
+			newEndpointWithOwner("oldformat3.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=some-other-owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("two"),
+			newEndpointWithOwner("a-oldformat3.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=some-other-owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("two"),
 			newEndpointWithOwner("newformat.test-zone.example.org", "foobar.nameserver.com", endpoint.RecordTypeNS, ""),
 			newEndpointWithOwner("ns-newformat.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("newformat.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
@@ -815,6 +820,15 @@ func testTXTRegistryMissingRecordsNoPrefix(t *testing.T) {
 			},
 		},
 		{
+			DNSName:       "oldformat3.test-zone.example.org",
+			SetIdentifier: "one",
+			Targets:       endpoint.Targets{"bar1.loadbalancer.com"},
+			RecordType:    endpoint.RecordTypeA,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
+		{
 			DNSName:    "newformat.test-zone.example.org",
 			Targets:    endpoint.Targets{"foobar.nameserver.com"},
 			RecordType: endpoint.RecordTypeNS,
@@ -839,6 +853,16 @@ func testTXTRegistryMissingRecordsNoPrefix(t *testing.T) {
 			Labels: map[string]string{
 				// Records() retrieves all the records of the zone, no matter the owner
 				endpoint.OwnerLabelKey: "otherowner",
+			},
+		},
+		{
+			DNSName:       "oldformat3.test-zone.example.org",
+			SetIdentifier: "two",
+			Targets:       endpoint.Targets{"bar2.loadbalancer.com"},
+			RecordType:    endpoint.RecordTypeA,
+			Labels: map[string]string{
+				// Records() retrieves all the records of the zone, no matter the owner
+				endpoint.OwnerLabelKey: "some-other-owner",
 			},
 		},
 		{
@@ -879,6 +903,15 @@ func testTXTRegistryMissingRecordsNoPrefix(t *testing.T) {
 				endpoint.OwnedRecordLabelKey: "oldformat2.test-zone.example.org",
 			},
 		},
+		{
+			DNSName:       "a-oldformat3.test-zone.example.org",
+			SetIdentifier: "one",
+			Targets:       endpoint.Targets{"\"heritage=external-dns,external-dns/owner=owner\""},
+			RecordType:    endpoint.RecordTypeTXT,
+			Labels: endpoint.Labels{
+				endpoint.OwnedRecordLabelKey: "oldformat3.test-zone.example.org",
+			},
+		},
 	}
 
 	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour, "wc", []string{endpoint.RecordTypeCNAME, endpoint.RecordTypeA, endpoint.RecordTypeNS})
@@ -899,6 +932,11 @@ func testTXTRegistryMissingRecordsWithPrefix(t *testing.T) {
 			newEndpointWithOwner("txt.oldformat.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("oldformat2.test-zone.example.org", "bar.loadbalancer.com", endpoint.RecordTypeA, ""),
 			newEndpointWithOwner("txt.oldformat2.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("oldformat3.test-zone.example.org", "bar1.loadbalancer.com", endpoint.RecordTypeA, "").WithSetIdentifier("one"),
+			newEndpointWithOwner("txt.oldformat3.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("one"),
+			newEndpointWithOwner("oldformat3.test-zone.example.org", "bar2.loadbalancer.com", endpoint.RecordTypeA, "").WithSetIdentifier("two"),
+			newEndpointWithOwner("txt.oldformat3.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=some-other-owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("two"),
+			newEndpointWithOwner("txt.a-oldformat3.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=some-other-owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("two"),
 			newEndpointWithOwner("newformat.test-zone.example.org", "foobar.nameserver.com", endpoint.RecordTypeNS, ""),
 			newEndpointWithOwner("txt.ns-newformat.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("txt.newformat.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
@@ -925,6 +963,25 @@ func testTXTRegistryMissingRecordsWithPrefix(t *testing.T) {
 			RecordType: endpoint.RecordTypeA,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "owner",
+			},
+		},
+		{
+			DNSName:       "oldformat3.test-zone.example.org",
+			SetIdentifier: "one",
+			Targets:       endpoint.Targets{"bar1.loadbalancer.com"},
+			RecordType:    endpoint.RecordTypeA,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
+		{
+			DNSName:       "oldformat3.test-zone.example.org",
+			SetIdentifier: "two",
+			Targets:       endpoint.Targets{"bar2.loadbalancer.com"},
+			RecordType:    endpoint.RecordTypeA,
+			Labels: map[string]string{
+				// All the records of the zone are retrieved, no matter the owner
+				endpoint.OwnerLabelKey: "some-other-owner",
 			},
 		},
 		{
@@ -981,6 +1038,15 @@ func testTXTRegistryMissingRecordsWithPrefix(t *testing.T) {
 			RecordType: endpoint.RecordTypeTXT,
 			Labels: endpoint.Labels{
 				endpoint.OwnedRecordLabelKey: "oldformat2.test-zone.example.org",
+			},
+		},
+		{
+			DNSName:       "txt.a-oldformat3.test-zone.example.org",
+			SetIdentifier: "one",
+			Targets:       endpoint.Targets{"\"heritage=external-dns,external-dns/owner=owner\""},
+			RecordType:    endpoint.RecordTypeTXT,
+			Labels: endpoint.Labels{
+				endpoint.OwnedRecordLabelKey: "oldformat3.test-zone.example.org",
 			},
 		},
 	}


### PR DESCRIPTION
**Description**

Previously, if multiple records with the same name (but different `SetIdentifier`) were used, a missing TXT record with the new format was only added for one of these records.

**Checklist**

- [x] Unit tests updated
- [ ] ~End user documentation updated~
