### PR TITLE
Improve gandi provider to support apex domain redirection to FQDN

### DIFF
--- a/docs/tutorials/gandi.md
+++ b/docs/tutorials/gandi.md
@@ -188,4 +188,5 @@ $ kubectl delete service -f externaldns.yaml
 
 # Additional options
 
-If you're using organizations to separate your domains, you can pass the organization's ID in an environment variable called `GANDI_SHARING_ID` to get access to it.
+ - If you're using organizations to separate your domains, you can pass the organization's ID in an environment variable called `GANDI_SHARING_ID` to get access to it.
+ - If you want to register an apex domain that redirect to an FQDN (aws alb, ect...) you can force usage of Gandi [ALIAS Record](https://docs.gandi.net/en/domain_names/faq/record_types/alias_record.html) whith a `GANDI_PREFER_ALIAS` variables.


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR allow gandi provider to redirect apex domain to an FQDN. 

From my understanding, CNAME record only can be used for subdomains and external-dns force CNAME if record value is an FQDN. To fill this gap some DNS provider introduce a new record type ALIAS. ALIAS record is a type of DNS record that points your domain name to a hostname instead of an IP address. The ALIAS record is similar to a CNAME record, which is used to point subdomains to a hostname. This allow us to register a record an apex domain `@` with a FQDN.

So back on this PR, the fix convert an CNAME to an ALIAS, if the `record.RrsetName == "@" and record.RrsetType == "CNAME"`. And env var (`GANDI_PREFER_ALIAS`) has been added to keep old things working as expected.

This fix has been tested in our preproduction environment and work as expected.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
