### PR TITLE
Split CI to speedup checks

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: Go
+name: Lint
 
 on:
   push:
@@ -29,21 +29,7 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
 
-    - name: Install CI
+    - name: Lint
       run: |
-        go get -v -t -d ./...
-
-    - name: Install additional CI for nektos/act
-      run: |
-            apt update
-            apt install -y make gcc libc-dev git
-      if: github.actor == 'nektos/act'
-  
-    - name: Test
-      run: make test
-
-    - name: Send coverage
-      uses: shogo82148/actions-goveralls@v1
-      with:
-        path-to-profile: profile.cov
-      if: github.actor != 'nektos/act'
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1
+        make lint


### PR DESCRIPTION
**Description**

This project's CI is way too slow. There are many things that we can do, but the first trivial one is to split the lint phase from the normal go tests. 

👇  5 and 4 minutes in parallel instead of a total of 9, this is a 4 minutes speedup for tests 🎉 

![Split CI to speedup checks by Raffo · Pull Request #3263 · kubernetes-sigsexternal-dns](https://user-images.githubusercontent.com/683988/209446148-b97c0282-0bf3-4a9a-9e8f-baad5063b5e0.png)
