### PR TITLE
gateway-api: patch route informer results with TypeMeta

### DIFF
--- a/source/gateway_udproute.go
+++ b/source/gateway_udproute.go
@@ -32,9 +32,9 @@ func NewGatewayUDPRouteSource(clients ClientGenerator, config *Config) (Source, 
 	})
 }
 
-type gatewayUDPRoute struct{ route *v1alpha2.UDPRoute }
+type gatewayUDPRoute struct{ route v1alpha2.UDPRoute } // NOTE: Must update TypeMeta in List when changing the APIVersion.
 
-func (rt *gatewayUDPRoute) Object() kubeObject             { return rt.route }
+func (rt *gatewayUDPRoute) Object() kubeObject             { return &rt.route }
 func (rt *gatewayUDPRoute) Metadata() *metav1.ObjectMeta   { return &rt.route.ObjectMeta }
 func (rt *gatewayUDPRoute) Hostnames() []v1beta1.Hostname  { return nil }
 func (rt *gatewayUDPRoute) Protocol() v1beta1.ProtocolType { return v1beta1.UDPProtocolType }
@@ -53,7 +53,14 @@ func (inf gatewayUDPRouteInformer) List(namespace string, selector labels.Select
 	}
 	routes := make([]gatewayRoute, len(list))
 	for i, rt := range list {
-		routes[i] = &gatewayUDPRoute{rt}
+		// List results are supposed to be treated as read-only.
+		// We make a shallow copy since we're only interested in setting the TypeMeta.
+		clone := *rt
+		clone.TypeMeta = metav1.TypeMeta{
+			APIVersion: v1alpha2.GroupVersion.String(),
+			Kind:       "UDPRoute",
+		}
+		routes[i] = &gatewayUDPRoute{clone}
 	}
 	return routes, nil
 }


### PR DESCRIPTION
**Description**

The informers are not always setting the TypeMeta (APIVersion and Kind) on objects. It's unclear to me why this is. Perhaps the API Server omits it as a wire optimization on watches and the client doesn't put it back? Whatever the reason, the Gateway API code depends on it existing. This explicitly adds TypeMeta to objects coming from the informers.

Fixes #3068
