### PR TITLE
Fix null pointer on generateTxtRecord

### DIFF
--- a/registry/txt.go
+++ b/registry/txt.go
@@ -191,19 +191,26 @@ func (im *TXTRegistry) generateTXTRecord(r *endpoint.Endpoint) []*endpoint.Endpo
 	if r.RecordType == endpoint.RecordTypeTXT {
 		return nil
 	}
+
+	endpoints := make([]*endpoint.Endpoint, 0)
+
 	// old TXT record format
-	txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
-	txt.ProviderSpecific = r.ProviderSpecific
+	txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true))
+	if txt != nil {
+		txt.WithSetIdentifier(r.SetIdentifier)
+		txt.ProviderSpecific = r.ProviderSpecific
+		endpoints = append(endpoints, txt)
+	}
+
 	// new TXT record format (containing record type)
 	txtNew := endpoint.NewEndpoint(im.mapper.toNewTXTName(r.DNSName, r.RecordType), endpoint.RecordTypeTXT, r.Labels.Serialize(true))
 	if txtNew != nil {
 		txtNew.WithSetIdentifier(r.SetIdentifier)
 		txtNew.ProviderSpecific = r.ProviderSpecific
-	} else {
-		return []*endpoint.Endpoint{txt}
+		endpoints = append(endpoints, txtNew)
 	}
 
-	return []*endpoint.Endpoint{txt, txtNew}
+	return endpoints
 }
 
 // ApplyChanges updates dns provider with the changes

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -1169,6 +1169,23 @@ func TestGenerateTXT(t *testing.T) {
 	assert.Equal(t, expectedTXT, gotTXT)
 }
 
+func TestFailGenerateTXT(t *testing.T) {
+
+	cnameRecord := &endpoint.Endpoint{
+		DNSName:    "foo-some-really-big-name-not-supported-and-will-fail-000000000000000000.test-zone.example.org",
+		Targets:    endpoint.Targets{"new-foo.loadbalancer.com"},
+		RecordType: endpoint.RecordTypeCNAME,
+		Labels:     map[string]string{},
+	}
+	// A bad DNS name returns empty expected TXT
+	expectedTXT := []*endpoint.Endpoint{}
+	p := inmemory.NewInMemoryProvider()
+	p.CreateZone(testZone)
+	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour, "", []string{})
+	gotTXT := r.generateTXTRecord(cnameRecord)
+	assert.Equal(t, expectedTXT, gotTXT)
+}
+
 /**
 
 helper methods


### PR DESCRIPTION
**Description**
The generateTXTRecord uses a subsequent call, assuming the return from NewEndpoint wont ever be null.

It happens that if the first name is bigger than 63 characters, it will be null and get a null pointer.

This PR fixes this specific part of the code.

**Checklist**

- [X] Unit tests updated
- [ ] End user documentation updated
