### PR TITLE
provider/ovh: Fix lint

### DIFF
--- a/provider/ovh/ovh.go
+++ b/provider/ovh/ovh.go
@@ -22,9 +22,9 @@ import (
 	"fmt"
 	"strings"
 
-	"golang.org/x/sync/errgroup"
 	"github.com/ovh/go-ovh/ovh"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"


### PR DESCRIPTION


**Description**

provider/ovh/ovh.go:25: File is not `gofmt`-ed with `-s` (gofmt)
cfabcad9bcd89c8f5d0abc958b1efd35a1ff137b wasn't linted properly.
