### PR TITLE
Added traefik-proxy rules to helm chart

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### All Changes
 
 - Disallowed privilege escalation in container security context and set the seccomp profile type to `RuntimeDefault`. ([#3689](https://github.com/kubernetes-sigs/external-dns/pull/3689)) [@nrvnrvn](https://github.com/nrvnrvn)
+- Added RBAC for Traefik to ClusterRole. ([#3325](https://github.com/kubernetes-sigs/external-dns/pull/3325)) [@ThomasK33](https://github.com/thomask33)
 
 ## [v1.13.0] - 2023-03-30
 

--- a/charts/external-dns/templates/clusterrole.yaml
+++ b/charts/external-dns/templates/clusterrole.yaml
@@ -106,7 +106,7 @@ rules:
     verbs: ["get","watch","list"]
 {{- end }}
 {{- if has "traefik-proxy" .Values.sources }}
-  - apiGroups: ["traefik.containo.us"]
+  - apiGroups: ["traefik.containo.us", "traefik.io"]
     resources: ["ingressroutes", "ingressroutetcps", "ingressrouteudps"]
     verbs: ["get","watch","list"]
 {{- end }}

--- a/charts/external-dns/templates/clusterrole.yaml
+++ b/charts/external-dns/templates/clusterrole.yaml
@@ -105,6 +105,11 @@ rules:
     resources: ["tcpingresses"]
     verbs: ["get","watch","list"]
 {{- end }}
+{{- if has "traefik-proxy" .Values.sources }}
+  - apiGroups: ["traefik.containo.us"]
+    resources: ["ingressroutes", "ingressroutetcps", "ingressrouteudps"]
+    verbs: ["get","watch","list"]
+{{- end }}
 {{- if has "openshift-route" .Values.sources }}
   - apiGroups: ["route.openshift.io"]
     resources: ["routes"]


### PR DESCRIPTION
As a follow-up to #3055, as suggested by @stevehipwell.
Only merge this once #3055 is merged onto the master.
