### PR TITLE
Added automation to run GH actions on PRs with ok-to-test

### DIFF
--- a/.github/workflows/gh-workflow-approve.yaml
+++ b/.github/workflows/gh-workflow-approve.yaml
@@ -1,0 +1,40 @@
+name: Approve GH Workflows
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - synchronize
+    branches:
+      - master
+
+jobs:
+  approve:
+    name: Approve ok-to-test
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Update PR
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # v6.3.3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          debug: ${{ secrets.ACTIONS_RUNNER_DEBUG }}
+          script: |
+            const workflowRuns = await octokit.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event: "pull_request",
+              status: "action_required",
+              head_sha: context.sha,
+              per_page: 100
+            }).data.workflow_runs;
+
+            for (var run of workflowRuns) {
+              await github.rest.actions.approveWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id
+              });
+            }


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR adds a GH workflow to automatically approve running GH actions for first time contributors once the `ok-to-test` label has been added. This should significantly reduce the pressure on the maintainers with repo ownership. I've tested the logic works correctly but I've not used it as a GH action yet.

**IMPORTANT** - This has no impact on any repo code so can be merged without fixing flaking jobs.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
