### PR TITLE
create an alias when record in a zone another than the target

### DIFF
--- a/provider/pdns/pdns.go
+++ b/provider/pdns/pdns.go
@@ -258,6 +258,7 @@ func NewPDNSProvider(ctx context.Context, config PDNSConfig) (*PDNSProvider, err
 func (p *PDNSProvider) convertRRSetToEndpoints(rr pgo.RrSet) (endpoints []*endpoint.Endpoint, _ error) {
 	endpoints = []*endpoint.Endpoint{}
 	targets := []string{}
+	rrType_ := rr.Type_
 
 	for _, record := range rr.Records {
 		// If a record is "Disabled", it's not supposed to be "visible"
@@ -265,8 +266,10 @@ func (p *PDNSProvider) convertRRSetToEndpoints(rr pgo.RrSet) (endpoints []*endpo
 			targets = append(targets, record.Content)
 		}
 	}
-
-	endpoints = append(endpoints, endpoint.NewEndpointWithTTL(rr.Name, rr.Type_, endpoint.TTL(rr.Ttl), targets...))
+	if rr.Type_ == "ALIAS" {
+		rrType_ = "CNAME"
+	}
+	endpoints = append(endpoints, endpoint.NewEndpointWithTTL(rr.Name, rrType_, endpoint.TTL(rr.Ttl), targets...))
 	return endpoints, nil
 }
 
@@ -311,16 +314,20 @@ func (p *PDNSProvider) ConvertEndpointsToZones(eps []*endpoint.Endpoint, changet
 				// per (ep.DNSName, ep.RecordType) tuple, which holds true for
 				// external-dns v5.0.0-alpha onwards
 				records := []pgo.Record{}
+				RecordType_ := ep.RecordType
 				for _, t := range ep.Targets {
-					if ep.RecordType == "CNAME" {
+					if ep.RecordType == "CNAME" || ep.RecordType == "ALIAS" {
 						t = provider.EnsureTrailingDot(t)
+						if t != zone.Name && !strings.HasSuffix(t, "."+zone.Name) {
+							RecordType_ = "ALIAS"
+						}
 					}
 
 					records = append(records, pgo.Record{Content: t})
 				}
 				rrset := pgo.RrSet{
 					Name:       dnsname,
-					Type_:      ep.RecordType,
+					Type_:      RecordType_,
 					Records:    records,
 					Changetype: string(changetype),
 				}

--- a/provider/pdns/pdns_test.go
+++ b/provider/pdns/pdns_test.go
@@ -82,9 +82,19 @@ var (
 		Type_: "CNAME",
 		Ttl:   300,
 		Records: []pgo.Record{
-			{Content: "example.by.any.other.name.com", Disabled: false, SetPtr: false},
+			{Content: "example.com.", Disabled: false, SetPtr: false},
 		},
 	}
+
+	RRSetALIASRecord = pgo.RrSet{
+		Name:  "alias.example.com.",
+		Type_: "ALIAS",
+		Ttl:   300,
+		Records: []pgo.Record{
+			{Content: "example.by.any.other.name.com.", Disabled: false, SetPtr: false},
+		},
+	}
+
 	RRSetTXTRecord = pgo.RrSet{
 		Name:  "example.com.",
 		Type_: "TXT",
@@ -129,9 +139,10 @@ var (
 	}
 
 	endpointsMixedRecords = []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("cname.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(300), "example.by.any.other.name.com"),
+		endpoint.NewEndpointWithTTL("cname.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(300), "example.com"),
 		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "'would smell as sweet'"),
 		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8", "8.8.4.4", "4.4.4.4"),
+		endpoint.NewEndpointWithTTL("alias.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(300), "example.by.any.other.name.com"),
 	}
 
 	endpointsMultipleZones = []*endpoint.Endpoint{
@@ -215,7 +226,7 @@ var (
 		Type_:  "Zone",
 		Url:    "/api/v1/servers/localhost/zones/example.com.",
 		Kind:   "Native",
-		Rrsets: []pgo.RrSet{RRSetCNAMERecord, RRSetTXTRecord, RRSetMultipleRecords},
+		Rrsets: []pgo.RrSet{RRSetCNAMERecord, RRSetTXTRecord, RRSetMultipleRecords, RRSetALIASRecord},
 	}
 
 	ZoneEmptyToSimplePatch = pgo.Zone{
@@ -909,7 +920,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSConvertEndpointsToZones() {
 
 	for _, z := range zlist {
 		for _, rs := range z.Rrsets {
-			if "CNAME" == rs.Type_ {
+			if rs.Type_ == "CNAME" {
 				for _, r := range rs.Records {
 					assert.Equal(suite.T(), uint8(0x2e), r.Content[len(r.Content)-1])
 				}


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
DNS cannot work with cname whose target is another domain.
**Example** (This cname does not work.):
`ads.localhost in google.com CNAME`

But PowerDNS can create [ALIAS](https://doc.powerdns.com/authoritative/guides/alias.html)
This PR changes the pdns provider to create aliases for such entries. This is required when k8s uses alb/nld on AWS etc.
<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
