### PR TITLE
fix(gandi): allow grandi provider to support multiple TXT rsetvalues

### DIFF
--- a/provider/gandi/gandi.go
+++ b/provider/gandi/gandi.go
@@ -127,7 +127,7 @@ func (p *GandiProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, erro
 						"value":  v,
 						"ttl":    r.RrsetTTL,
 						"zone":   zone,
-					}).Info("Rerturning endpoint record")
+					}).Debug("Returning endpoint record")
 
 					endpoints = append(endpoints, endpoint.NewEndpoint(name, r.RrsetType, v))
 				}

--- a/provider/gandi/gandi.go
+++ b/provider/gandi/gandi.go
@@ -16,7 +16,6 @@ package gandi
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"strings"
 
@@ -121,11 +120,17 @@ func (p *GandiProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, erro
 					name = zone
 				}
 
-				if len(r.RrsetValues) > 1 {
-					return nil, fmt.Errorf("can't handle multiple values for rrset %s", name)
-				}
+				for _, v := range r.RrsetValues {
+					log.WithFields(log.Fields{
+						"record": r.RrsetName,
+						"type":   r.RrsetType,
+						"value":  v,
+						"ttl":    r.RrsetTTL,
+						"zone":   zone,
+					}).Info("Rerturning endpoint record")
 
-				endpoints = append(endpoints, endpoint.NewEndpoint(name, r.RrsetType, r.RrsetValues[0]))
+					endpoints = append(endpoints, endpoint.NewEndpoint(name, r.RrsetType, v))
+				}
 			}
 		}
 	}

--- a/provider/gandi/gandi_test.go
+++ b/provider/gandi/gandi_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/go-gandi/go-gandi/domain"
@@ -342,7 +341,7 @@ func TestGandiProvider_RecordsAppliesDomainFilter(t *testing.T) {
 	td.Cmp(t, expectedActions, mockedClient.Actions)
 }
 
-func TestGandiProvider_RecordsErrorOnMultipleValues(t *testing.T) {
+func TestGandiProvider_RecordsWithMultipleValues(t *testing.T) {
 	mockedClient := mockGandiClientNewWithRecords([]livedns.DomainRecord{
 		{
 			RrsetValues: []string{"foo", "bar"},
@@ -355,23 +354,11 @@ func TestGandiProvider_RecordsErrorOnMultipleValues(t *testing.T) {
 		LiveDNSClient: mockedClient,
 	}
 
-	expectedActions := []MockAction{
-		{
-			Name: "ListDomains",
-		},
-		{
-			Name: "GetDomainRecords",
-			FQDN: "example.com",
-		},
-	}
-
 	endpoints, err := mockedProvider.Records(context.Background())
-	if err == nil {
-		t.Errorf("expected to fail")
+	if err != nil {
+		t.Errorf("should not fail, %s", err)
 	}
-	assert.Equal(t, 0, len(endpoints))
-	assert.True(t, strings.HasPrefix(err.Error(), "can't handle multiple values for rrset"))
-	td.Cmp(t, expectedActions, mockedClient.Actions)
+	assert.Equal(t, 2, len(endpoints))
 }
 
 func TestGandiProvider_ApplyChangesEmpty(t *testing.T) {


### PR DESCRIPTION
**Description**

Gandi return all TXT records grouped by domain... So if you have multiple TXT (as SPF, various domain verifications, etc...) [this line](https://github.com/kubernetes-sigs/external-dns/blob/master/provider/gandi/gandi.go#L123) throw an error. 
This fix is simple, as all `rrset_values` returned from the gandi livedns api is an array, i simply add a for_each loop on each of these values.

Fixes #2451

**Checklist**

- [x] Unit tests updated
