### PR TITLE
Add Osaka (ap-northeast-3) Hosted Zone ID for AWS Network Load Balancers

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -101,6 +101,7 @@ var canonicalHostedZones = map[string]string{
 	"elb.ca-central-1.amazonaws.com":      "Z2EPGBW3API2WT",
 	"elb.ap-east-1.amazonaws.com":         "Z12Y7K3UBGUAD1",
 	"elb.ap-south-1.amazonaws.com":        "ZVDDRBQ08TROA",
+	"elb.ap-northeast-3.amazonaws.com":    "Z1GWIQ4HH19I5X",
 	"elb.ap-northeast-2.amazonaws.com":    "ZIBE1TIR4HY56",
 	"elb.ap-southeast-1.amazonaws.com":    "ZKVM4W9LS7TM",
 	"elb.ap-southeast-2.amazonaws.com":    "ZCT6FZBF4DROD",

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -1218,6 +1218,7 @@ func TestAWSCanonicalHostedZone(t *testing.T) {
 		{"foo.elb.ca-central-1.amazonaws.com", "Z2EPGBW3API2WT"},
 		{"foo.elb.ap-east-1.amazonaws.com", "Z12Y7K3UBGUAD1"},
 		{"foo.elb.ap-south-1.amazonaws.com", "ZVDDRBQ08TROA"},
+		{"foo.elb.ap-northeast-3.amazonaws.com", "Z1GWIQ4HH19I5X"},
 		{"foo.elb.ap-northeast-2.amazonaws.com", "ZIBE1TIR4HY56"},
 		{"foo.elb.ap-southeast-1.amazonaws.com", "ZKVM4W9LS7TM"},
 		{"foo.elb.ap-southeast-2.amazonaws.com", "ZCT6FZBF4DROD"},


### PR DESCRIPTION
**Description**
Add Osaka (ap-northeast-3) Hosted Zone ID for AWS Network Load Balancers based on the documentation: https://docs.aws.amazon.com/general/latest/gr/elb.html

Fixes #ISSUE
There is no issue opened on this topic.

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
