### PR TITLE
feat: add desec dns integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ ExternalDNS allows you to keep selected zones (via `--domain-filter`) synchroniz
 * [TencentCloud DNSPod](https://cloud.tencent.com/product/cns)
 * [Plural](https://www.plural.sh/)
 * [Pi-hole](https://pi-hole.net/)
+* [DeSec](https://desec.io)
 
 From this release, ExternalDNS can become aware of the records it is managing (enabled via `--registry=txt`), therefore ExternalDNS can safely manage non-empty hosted zones. We strongly encourage you to use `v0.5` (or greater) with `--registry=txt` enabled and `--txt-owner-id` set to a unique value that doesn't change for the lifetime of your cluster. You might also want to run ExternalDNS in a dry run mode (`--dry-run` flag) to see the changes to be submitted to your DNS Provider API.
 
@@ -124,6 +125,7 @@ The following table clarifies the current status of the providers according to t
 | TencentCloud | Alpha | @Hyzhou |
 | Plural | Alpha | @michaeljguarino |
 | Pi-hole | Alpha | @tinyzimmer |
+| Desec | Alpha | @ykorzikowski |
 
 ## Kubernetes version compatibility
 
@@ -196,6 +198,7 @@ The following tutorials are provided:
 * [TencentCloud](docs/tutorials/tencentcloud.md)
 * [Plural](docs/tutorials/plural.md)
 * [Pi-hole](docs/tutorials/pihole.md)
+* [Desec](docs/tutorials/desec.md)
 
 ### Running Locally
 

--- a/docs/tutorials/desec.md
+++ b/docs/tutorials/desec.md
@@ -1,0 +1,194 @@
+# Setting up ExternalDNS for Desec
+
+This tutorial describes how to setup ExternalDNS for usage within a Kubernetes cluster using Desec.
+
+Make sure to use **master** version of ExternalDNS for this tutorial.
+
+## Creating Desec Credentials
+
+A secret containing the a Desec API token is needed for this provider. You can get a token for your user [here](https://desec.io/tokens).
+
+To create the API token secret you can run `kubectl create secret generic desec-api-key --from-literal=EXTERNAL_DNS_DESEC_API_KEY=<replace-with-your-access-token>`.
+
+## Deploy ExternalDNS
+
+Connect your `kubectl` client to the cluster you want to test ExternalDNS with.
+
+Besides the API key, it is mandatory to provide a list of DNS zones you want ExternalDNS to manage. The hosted DNS zones will be provides via the `--domain-filter`.
+
+Then apply one of the following manifests file to deploy ExternalDNS.
+
+### Manifest (for clusters without RBAC enabled)
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      containers:
+      - name: external-dns
+        image: registry.k8s.io/external-dns/external-dns:latest
+        args:
+        - --source=service # ingress is also possible
+        - --provider=desec
+        - --domain-filter="example.com"
+        env:
+        - name: EXTERNAL_DNS_DESEC_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: EXTERNAL_DNS_DESEC_API_KEY
+              name: Desec-api-key
+
+```
+
+### Manifest (for clusters with RBAC enabled)
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups: [""]
+  resources: ["services","endpoints","pods"]
+  verbs: ["get","watch","list"]
+- apiGroups: ["extensions","networking.k8s.io"]
+  resources: ["ingresses"]
+  verbs: ["get","watch","list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+  namespace: default
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      serviceAccountName: external-dns
+      containers:
+      - name: external-dns
+        image: registry.k8s.io/external-dns/external-dns:latest
+        args:
+        - --source=service # ingress is also possible
+        - --provider=desec
+        - --domain-filter=example.com
+        env:
+        - name: EXTERNAL_DNS_DESEC_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: EXTERNAL_DNS_DESEC_API_KEY
+              name: Desec-api-key
+```
+
+## Deploying an Nginx Service
+
+Create a service file called 'nginx.yaml' with the following contents:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: example.com
+spec:
+  selector:
+    app: nginx
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+```
+
+Note the annotation on the service; use the same hostname as the Desec DNS zone created above. The annotation may also be a subdomain
+of the DNS zone (e.g. 'www.example.com').
+
+By setting the TTL annotation on the service, you have to pass a valid TTL, which must be 120 or above.
+This annotation is optional, if you won't set it, it will be 1 (automatic) which is 300.
+
+ExternalDNS uses this annotation to determine what services should be registered with DNS.  Removing the annotation
+will cause ExternalDNS to remove the corresponding DNS records.
+
+Create the deployment and service:
+
+```
+$ kubectl create -f nginx.yaml
+```
+
+Depending where you run your service it can take a little while for your cloud provider to create an external IP for the service.
+
+Once the service has an external IP assigned, ExternalDNS will notice the new service IP address and synchronize
+the Desec DNS records.
+
+## Verifying Desec DNS records
+
+Check your [Desec domain overview](https://desec.io/domains) to view the domains associated with your Desec account. There you can view the records for each domain.
+
+The records should show the external IP address of the service as the A record for your domain.
+
+## Cleanup
+
+Now that we have verified that ExternalDNS will automatically manage Desec DNS records, we can delete the tutorial's example:
+
+```
+$ kubectl delete -f nginx.yaml
+$ kubectl delete -f externaldns.yaml

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/miekg/dns v1.1.50
 	github.com/nesv/go-dynect v0.6.0
 	github.com/nic-at/rc0go v1.1.1
+	github.com/nrdcg/desec v0.7.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/openshift/api v0.0.0-20200605231317-fb2a6ca106ae
 	github.com/openshift/client-go v0.0.0-20200608144219-584632b8fc73

--- a/go.sum
+++ b/go.sum
@@ -862,6 +862,8 @@ github.com/nesv/go-dynect v0.6.0/go.mod h1:GHRBRKzTwjAMhosHJQq/KrZaFkXIFyJ5zRE7t
 github.com/nic-at/rc0go v1.1.1 h1:bf2gTwYecJEh7qmnOEuarXKueZn4A8N08U1Uop3K8+s=
 github.com/nic-at/rc0go v1.1.1/go.mod h1:KEa3H5fmDNXCaXSqOeAZxkKnG/8ggr1OHIG25Ve7fjU=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nrdcg/desec v0.7.0 h1:iuGhi4pstF3+vJWwt292Oqe2+AsSPKDynQna/eu1fDs=
+github.com/nrdcg/desec v0.7.0/go.mod h1:e1uRqqKv1mJdd5+SQROAhmy75lKMphLzWIuASLkpeFY=
 github.com/nwaples/rardecode v1.0.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ import (
 	"sigs.k8s.io/external-dns/provider/civo"
 	"sigs.k8s.io/external-dns/provider/cloudflare"
 	"sigs.k8s.io/external-dns/provider/coredns"
+	"sigs.k8s.io/external-dns/provider/desec"
 	"sigs.k8s.io/external-dns/provider/designate"
 	"sigs.k8s.io/external-dns/provider/digitalocean"
 	"sigs.k8s.io/external-dns/provider/dnsimple"
@@ -354,6 +355,8 @@ func main() {
 		p, err = plural.NewPluralProvider(cfg.PluralCluster, cfg.PluralProvider)
 	case "tencentcloud":
 		p, err = tencentcloud.NewTencentCloudProvider(domainFilter, zoneIDFilter, cfg.TencentCloudConfigFile, cfg.TencentCloudZoneType, cfg.DryRun)
+	case "desec":
+		p, err = desec.NewDesecProvider(domainFilter, cfg.DesecAPIKey, cfg.DryRun)
 	default:
 		log.Fatalf("unknown dns provider: %s", cfg.Provider)
 	}

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -198,6 +198,7 @@ type Config struct {
 	PiholeTLSInsecureSkipVerify       bool
 	PluralCluster                     string
 	PluralProvider                    string
+	DesecAPIKey                       string `secure:"yes"`
 }
 
 var defaultConfig = &Config{
@@ -429,7 +430,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("exclude-target-net", "Exclude target nets (optional)").StringsVar(&cfg.ExcludeTargetNets)
 
 	// Flags related to providers
-	providers := []string{"akamai", "alibabacloud", "aws", "aws-sd", "azure", "azure-dns", "azure-private-dns", "bluecat", "civo", "cloudflare", "coredns", "designate", "digitalocean", "dnsimple", "dyn", "exoscale", "gandi", "godaddy", "google", "ibmcloud", "infoblox", "inmemory", "linode", "ns1", "oci", "ovh", "pdns", "pihole", "plural", "rcodezero", "rdns", "rfc2136", "safedns", "scaleway", "skydns", "tencentcloud", "transip", "ultradns", "vinyldns", "vultr"}
+	providers := []string{"akamai", "alibabacloud", "aws", "aws-sd", "azure", "azure-dns", "azure-private-dns", "bluecat", "civo", "cloudflare", "coredns", "designate", "desec", "digitalocean", "dnsimple", "dyn", "exoscale", "gandi", "godaddy", "google", "ibmcloud", "infoblox", "inmemory", "linode", "ns1", "oci", "ovh", "pdns", "pihole", "plural", "rcodezero", "rdns", "rfc2136", "safedns", "scaleway", "skydns", "tencentcloud", "transip", "ultradns", "vinyldns", "vultr"}
 	app.Flag("provider", "The DNS provider where the DNS records will be created (required, options: "+strings.Join(providers, ", ")+")").Required().PlaceHolder("provider").EnumVar(&cfg.Provider, providers...)
 	app.Flag("domain-filter", "Limit possible target zones by a domain suffix; specify multiple times for multiple domains (optional)").Default("").StringsVar(&cfg.DomainFilter)
 	app.Flag("exclude-domains", "Exclude subdomains (optional)").Default("").StringsVar(&cfg.ExcludeDomains)
@@ -552,6 +553,9 @@ func (cfg *Config) ParseFlags(args []string) error {
 	// Flags related to the Plural provider
 	app.Flag("plural-cluster", "When using the plural provider, specify the cluster name you're running with").Default(defaultConfig.PluralCluster).StringVar(&cfg.PluralCluster)
 	app.Flag("plural-provider", "When using the plural provider, specify the provider name you're running with").Default(defaultConfig.PluralProvider).StringVar(&cfg.PluralProvider)
+
+	// Flags related to the Desec provider
+	app.Flag("desec-api-key", "When using the desec provider, specify the api key you're running with").Default(defaultConfig.DesecAPIKey).StringVar(&cfg.DesecAPIKey)
 
 	// Flags related to policies
 	app.Flag("policy", "Modify how DNS records are synchronized between sources and providers (default: sync, options: sync, upsert-only, create-only)").Default(defaultConfig.Policy).EnumVar(&cfg.Policy, "sync", "upsert-only", "create-only")

--- a/provider/desec/desec.go
+++ b/provider/desec/desec.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package desec
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/nrdcg/desec"
+	nc "github.com/nrdcg/desec"
+
+	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
+)
+
+// DesecProvider is an implementation of Provider for Desec DNS.
+type DesecProvider struct {
+	provider.BaseProvider
+	client       *nc.Client
+	domainFilter endpoint.DomainFilter
+	dryRun       bool
+}
+
+// DesecChange includes the changesets that need to be applied to the Desec CCP API
+type DesecChange struct {
+	Create    *[]nc.RRSet
+	UpdateNew *[]nc.RRSet
+	UpdateOld *[]nc.RRSet
+	Delete    *[]nc.RRSet
+}
+
+// NewDesecProvider creates a new provider including the Desec CCP API client
+func NewDesecProvider(domainFilter endpoint.DomainFilter, apiKey string, dryRun bool) (*DesecProvider, error) {
+	if !domainFilter.IsConfigured() {
+		return nil, fmt.Errorf("Desec provider requires at least one configured domain in the domainFilter")
+	}
+
+	if apiKey == "" {
+		return nil, fmt.Errorf("Desec provider requires an API Key")
+	}
+
+	client := desec.New(apiKey, desec.NewDefaultClientOptions())
+
+	return &DesecProvider{
+		client:       client,
+		domainFilter: domainFilter,
+		dryRun:       dryRun,
+	}, nil
+}
+
+// Records delivers the list of Endpoint records for all zones.
+func (p *DesecProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	endpoints := make([]*endpoint.Endpoint, 0)
+
+	if p.dryRun {
+		log.Debugf("dry run - skipping login")
+	} else {
+
+		for _, domain := range p.domainFilter.Filters {
+			records, err := p.client.Records.GetAll(ctx, domain, nil)
+			if err != nil {
+				return nil, fmt.Errorf("unable to query DNS Records for domain '%v': %v", domain, err)
+			}
+
+			for _, record := range records {
+				ep := endpoint.NewEndpointWithTTL(record.Name, record.Type, endpoint.TTL(record.TTL), record.Records...)
+				endpoints = append(endpoints, ep)
+			}
+		}
+	}
+	log.Debugf("Endpoints collected: %v", endpoints)
+	return endpoints, nil
+}
+
+// ApplyChanges applies a given set of changes in a given zone.
+func (p *DesecProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
+	if !changes.HasChanges() {
+		log.Debugf("no changes detected - nothing to do")
+		return nil
+	}
+
+	perZoneChanges := map[string]*plan.Changes{}
+
+	for _, zoneName := range p.domainFilter.Filters {
+		log.Debugf("zone detected - %s", zoneName)
+
+		perZoneChanges[zoneName] = &plan.Changes{}
+	}
+
+	for _, ep := range changes.Create {
+		zoneName := endpointZoneName(ep, p.domainFilter.Filters)
+		if zoneName == "" {
+			log.Debugf("create - ignoring change since %s did not match any zone", ep)
+			continue
+		}
+		log.Debugf("planning Create %v in %s", ep, zoneName)
+
+		perZoneChanges[zoneName].Create = append(perZoneChanges[zoneName].Create, ep)
+	}
+
+	for _, ep := range changes.UpdateOld {
+		zoneName := endpointZoneName(ep, p.domainFilter.Filters)
+		if zoneName == "" {
+			log.Debugf("updateOld - ignoring change since %v did not match any zone", ep)
+			continue
+		}
+		log.Debugf("planning UpdateOld %v in %s", ep, zoneName)
+
+		perZoneChanges[zoneName].UpdateOld = append(perZoneChanges[zoneName].UpdateOld, ep)
+	}
+
+	for _, ep := range changes.UpdateNew {
+		zoneName := endpointZoneName(ep, p.domainFilter.Filters)
+		if zoneName == "" {
+			log.Debugf("updateNew - ignoring change since %v did not match any zone", ep)
+			continue
+		}
+		log.Debugf("planning UpdateNew %v in %s", ep, zoneName)
+		perZoneChanges[zoneName].UpdateNew = append(perZoneChanges[zoneName].UpdateNew, ep)
+	}
+
+	for _, ep := range changes.Delete {
+		zoneName := endpointZoneName(ep, p.domainFilter.Filters)
+		if zoneName == "" {
+			log.Debugf("ignoring change since %v did not match any zone", ep)
+			continue
+		}
+		log.Debugf("planning Delete %v in %s", ep, zoneName)
+		perZoneChanges[zoneName].Delete = append(perZoneChanges[zoneName].Delete, ep)
+	}
+
+	if p.dryRun {
+		log.Infof("dry run - not applying changes")
+		return nil
+	}
+
+	// Assemble changes per zone and prepare it for the Desec API client
+	for zoneName, c := range perZoneChanges {
+
+		change := &DesecChange{
+			Create:    convertToDesecRecord(c.Create, zoneName),
+			UpdateNew: convertToDesecRecord(c.UpdateNew, zoneName),
+			UpdateOld: convertToDesecRecord(c.UpdateOld, zoneName),
+			Delete:    convertToDesecRecord(c.Delete, zoneName),
+		}
+
+		for _, cr := range *change.UpdateOld {
+			_, err := p.client.Records.Update(ctx, cr.Domain, cr.SubName, cr.Type, cr)
+			if err != nil {
+				return err
+			}
+		}
+
+		for _, cr := range *change.Delete {
+			err := p.client.Records.Delete(ctx, cr.Domain, cr.SubName, cr.Type)
+			if err != nil {
+				return err
+			}
+		}
+
+		for _, cr := range *change.Create {
+			_, err := p.client.Records.Create(ctx, cr)
+			if err != nil {
+				return err
+			}
+		}
+
+		for _, cr := range *change.UpdateNew {
+			_, err := p.client.Records.Update(ctx, cr.Domain, cr.SubName, cr.Type, cr)
+			if err != nil {
+				return err
+			}
+		}
+
+	}
+
+	log.Debugf("update completed")
+
+	return nil
+}
+
+func addTailingDotToRecordName(recordName string) string {
+	if recordName == "" {
+		return recordName
+	}
+
+	if !strings.HasSuffix(recordName, ".") {
+		recordName = recordName + "."
+	}
+
+	return recordName
+}
+
+// convertToDesecRecord transforms a list of endpoints into a list of Desec DNS Records
+// returns a pointer to a list of DNS Records
+func convertToDesecRecord(endpoints []*endpoint.Endpoint, zoneName string) *[]nc.RRSet {
+
+	records := make([]nc.RRSet, len(endpoints))
+
+	for i, ep := range endpoints {
+		ttl := 3600
+		if ep.RecordTTL.IsConfigured() {
+			ttl = int(ep.RecordTTL)
+		}
+
+		records[i] = nc.RRSet{
+			Name:    addTailingDotToRecordName(ep.DNSName),
+			Domain:  zoneName,
+			SubName: getSubnameDependingOnZonename(ep, zoneName),
+			Type:    ep.RecordType,
+			Records: ep.Targets,
+			TTL:     ttl,
+		}
+
+		fmt.Println(records[i])
+	}
+	return &records
+}
+
+func getSubnameDependingOnZonename(ep *endpoint.Endpoint, zoneName string) (subName string) {
+	if ep.DNSName != zoneName {
+		return extractSubname(ep.DNSName)
+	}
+
+	return ""
+}
+
+// extract the subname of fqdn. Example: foo.bar.org will return foo
+func extractSubname(DNSName string) (subname string) {
+	splitSubname := strings.Split(DNSName, ".")
+	sn := []string{}
+
+	for i, part := range splitSubname {
+		if i == len(splitSubname)-1 {
+			continue
+		}
+		if i == len(splitSubname)-2 {
+			continue
+		}
+		sn = append(sn, part)
+	}
+
+	return strings.Join(sn, ".")
+}
+
+// endpointZoneName determines zoneName for endpoint by taking longest suffix zoneName match in endpoint DNSName
+// returns empty string if no match found
+func endpointZoneName(endpoint *endpoint.Endpoint, zones []string) (zone string) {
+	var matchZoneName string = ""
+	for _, zoneName := range zones {
+		if strings.HasSuffix(endpoint.DNSName, zoneName) && len(zoneName) > len(matchZoneName) {
+			matchZoneName = zoneName
+		}
+	}
+	return matchZoneName
+}

--- a/provider/desec/desec_test.go
+++ b/provider/desec/desec_test.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package desec
+
+import (
+	"context"
+	"testing"
+
+	nc "github.com/nrdcg/desec"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+)
+
+func TestDesecProvider(t *testing.T) {
+	t.Run("ExtractSubname", testExtractSubname)
+	t.Run("EndpointZoneName", testEndpointZoneName)
+	t.Run("ConvertToDesecRecord", testConvertToDesecRecord)
+	t.Run("NewdesecProvider", testNewDesecProvider)
+	t.Run("ApplyChanges", testApplyChanges)
+	t.Run("Records", testRecords)
+
+}
+
+func testExtractSubname(t *testing.T) {
+	// given
+	fqdn1 := "foo.bar.org"
+	fqdn2 := "foo.foo-bar.bar.org"
+
+	// then
+	subName1 := extractSubname(fqdn1)
+	subName2 := extractSubname(fqdn2)
+
+	// assert
+	assert.Equal(t, "foo", subName1)
+	assert.Equal(t, "foo.foo-bar", subName2)
+}
+
+func testEndpointZoneName(t *testing.T) {
+	zoneList := []string{"bar.org", "baz.org"}
+
+	// in zone list
+	ep1 := endpoint.Endpoint{
+		DNSName:    "foo.bar.org",
+		Targets:    endpoint.Targets{"5.5.5.5"},
+		RecordType: endpoint.RecordTypeA,
+	}
+
+	// not in zone list
+	ep2 := endpoint.Endpoint{
+		DNSName:    "foo.foo.org",
+		Targets:    endpoint.Targets{"5.5.5.5"},
+		RecordType: endpoint.RecordTypeA,
+	}
+
+	// matches zone exactly
+	ep3 := endpoint.Endpoint{
+		DNSName:    "baz.org",
+		Targets:    endpoint.Targets{"5.5.5.5"},
+		RecordType: endpoint.RecordTypeA,
+	}
+
+	assert.Equal(t, endpointZoneName(&ep1, zoneList), "bar.org")
+	assert.Equal(t, endpointZoneName(&ep2, zoneList), "")
+	assert.Equal(t, endpointZoneName(&ep3, zoneList), "baz.org")
+}
+
+func testConvertToDesecRecord(t *testing.T) {
+
+	// given
+
+	// in zone list
+	ep1 := endpoint.Endpoint{
+		DNSName:    "foo.bar.org",
+		Targets:    endpoint.Targets{"5.5.5.5"},
+		RecordType: endpoint.RecordTypeA,
+	}
+
+	// matches zone exactly
+	ep2 := endpoint.Endpoint{
+		DNSName:    "bar.org",
+		Targets:    endpoint.Targets{"5.5.5.5"},
+		RecordType: endpoint.RecordTypeA,
+	}
+
+	// txt type
+	ep3 := endpoint.Endpoint{
+		DNSName:    "foo.bar.org",
+		Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=default,external-dns/resource=service/default/nginx\""},
+		RecordType: endpoint.RecordTypeTXT,
+	}
+
+	// cname ends with .
+	ep4 := endpoint.Endpoint{
+		DNSName:    "foofoo.bar.org",
+		Targets:    endpoint.Targets{"foo.bar.org."},
+		RecordType: endpoint.RecordTypeCNAME,
+	}
+
+	epList := []*endpoint.Endpoint{&ep1, &ep2, &ep3, &ep4}
+
+	nc1 := nc.RRSet{
+		Name:    "foo.bar.org.",
+		Domain:  "bar.org",
+		SubName: "foo",
+		Type:    "A",
+		Records: []string{"5.5.5.5"},
+		TTL:     3600,
+	}
+
+	nc2 := nc.RRSet{
+		Name:    "bar.org.",
+		Domain:  "bar.org",
+		SubName: "",
+		Type:    "A",
+		Records: []string{"5.5.5.5"},
+		TTL:     3600,
+	}
+
+	nc3 := nc.RRSet{
+		Name:    "foo.bar.org.",
+		Domain:  "bar.org",
+		SubName: "foo",
+		Type:    "TXT",
+		Records: []string{"\"heritage=external-dns,external-dns/owner=default,external-dns/resource=service/default/nginx\""},
+		TTL:     3600,
+	}
+
+	nc4 := nc.RRSet{
+		Name:    "foofoo.bar.org.",
+		Domain:  "bar.org",
+		SubName: "foofoo",
+		Type:    "CNAME",
+		Records: []string{"foo.bar.org."},
+		TTL:     3600,
+	}
+
+	ncRecordList := []nc.RRSet{nc1, nc2, nc3, nc4}
+
+	// then
+	convertedDesecRecords := convertToDesecRecord(epList, "bar.org")
+
+	// assert
+	assert.Equal(t, &ncRecordList, convertedDesecRecords)
+}
+
+func testNewDesecProvider(t *testing.T) {
+	p, err := NewDesecProvider(endpoint.NewDomainFilter([]string{"example.com"}), "KEY", true)
+	assert.NotNil(t, p.client)
+	assert.NoError(t, err)
+
+	_, err = NewDesecProvider(endpoint.NewDomainFilter([]string{"example.com"}), "", true)
+	assert.Error(t, err)
+
+	_, err = NewDesecProvider(endpoint.NewDomainFilter([]string{}), "KEY", true)
+	assert.Error(t, err)
+
+}
+
+func testApplyChanges(t *testing.T) {
+	p, _ := NewDesecProvider(endpoint.NewDomainFilter([]string{"example.com"}), "KEY", true)
+	changes1 := &plan.Changes{
+		Create:    []*endpoint.Endpoint{},
+		Delete:    []*endpoint.Endpoint{},
+		UpdateNew: []*endpoint.Endpoint{},
+		UpdateOld: []*endpoint.Endpoint{},
+	}
+
+	// No Changes
+	err := p.ApplyChanges(context.TODO(), changes1)
+	assert.NoError(t, err)
+
+	// Changes
+	changes2 := &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			{
+				DNSName:    "api.example.com",
+				RecordType: "A",
+			},
+			{
+				DNSName:    "api.baz.com",
+				RecordType: "TXT",
+			}},
+		Delete: []*endpoint.Endpoint{
+			{
+				DNSName:    "api.example.com",
+				RecordType: "A",
+			},
+			{
+				DNSName:    "api.baz.com",
+				RecordType: "TXT",
+			}},
+		UpdateNew: []*endpoint.Endpoint{
+			{
+				DNSName:    "api.example.com",
+				RecordType: "A",
+			},
+			{
+				DNSName:    "api.baz.com",
+				RecordType: "TXT",
+			}},
+		UpdateOld: []*endpoint.Endpoint{
+			{
+				DNSName:    "api.example.com",
+				RecordType: "A",
+			},
+			{
+				DNSName:    "api.baz.com",
+				RecordType: "TXT",
+			}},
+	}
+
+	err = p.ApplyChanges(context.TODO(), changes2)
+	assert.NoError(t, err)
+
+}
+
+func testRecords(t *testing.T) {
+	p, _ := NewDesecProvider(endpoint.NewDomainFilter([]string{"example.com"}), "KEY", true)
+	ep, err := p.Records(context.TODO())
+	assert.Equal(t, []*endpoint.Endpoint{}, ep)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
**Description**

This PR will add feature for desec.io dns provider. 

Fixes #3345

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
- [] Integration test on test cluster

I already did a test against the deSec API from my IDE, but I need to test it on a kubernetes setup. 