### PR TITLE
feat: add AdguardHome provider

### DIFF
--- a/docs/tutorials/adguardhome.md
+++ b/docs/tutorials/adguardhome.md
@@ -1,0 +1,183 @@
+# Setting up ExternalDNS for AdguardHome
+
+This tutorial describes how to setup ExternalDNS for usage within a Kubernetes cluster using AdguardHome.
+
+## Deploy ExternalDNS
+
+Connect your `kubectl` client to the cluster you want to test ExternalDNS with.
+Then apply one of the following manifests file to deploy ExternalDNS.
+
+### Manifest (for clusters without RBAC enabled)
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: external-dns
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      containers:
+      - name: external-dns
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
+        args:
+        - --source=service # ingress is also possible
+        - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
+        - --provider=adguardhome
+        env:
+        - name: ADGUARD_HOME_URL
+          value: "YOUR_ADGUARD_HOME_URL" # Note: URL should be in the format of http://adguard.home:3000/control/
+        - name: ADGUARD_HOME_PASS
+          value: "YOUR_ADGUARD_HOME_PASSWORD"
+        - name: ADGUARD_HOME_USER
+          value: "YOUR_ADGUARD_HOME_USER"
+
+```
+
+### Manifest (for clusters with RBAC enabled)
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups: [""]
+  resources: ["services","endpoints","pods"]
+  verbs: ["get","watch","list"]
+- apiGroups: ["extensions","networking.k8s.io"]
+  resources: ["ingresses"] 
+  verbs: ["get","watch","list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+  namespace: default
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: external-dns
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      containers:
+        - name: external-dns
+          image: registry.k8s.io/external-dns/external-dns:v0.13.2
+          args:
+            - --source=service # ingress is also possible
+            - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
+            - --provider=adguardhome
+          env:
+            - name: ADGUARD_HOME_URL
+              value: "YOUR_ADGUARD_HOME_URL" # Note: URL should be in the format of http://adguard.home:3000/control/
+            - name: ADGUARD_HOME_PASS
+              value: "YOUR_ADGUARD_HOME_PASSWORD"
+            - name: ADGUARD_HOME_USER
+              value: "YOUR_ADGUARD_HOME_USER"
+```
+
+
+## Deploying an Nginx Service
+
+Create a service file called 'nginx.yaml' with the following contents:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: my-app.example.com
+spec:
+  selector:
+    app: nginx
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+```
+
+ExternalDNS uses `external-dns.alpha.kubernetes.io/hostname` annotation to determine what services should be registered with DNS. Removing the annotation will cause ExternalDNS to remove the corresponding DNS records.
+
+Create the deployment and service:
+
+```console
+$ kubectl create -f nginx.yaml
+```
+
+Depending where you run your service it can take a little while for your cloud provider to create an external IP for the service.
+
+Once the service has an external IP assigned, ExternalDNS will notice the new service IP address and synchronize the AdguardHome DNS records.
+
+## Verifying AdguardHome DNS records
+
+Check your AdguardHome DNS records to see if the new record was created.
+
+Click on the zone for the one created above if a different domain was used.
+
+Click on "Filters" and then "Custom filtering rules"
+
+This should show the external IP address of the service as the "Answer" for your domain.
+
+## Cleanup
+
+Now that we have verified that ExternalDNS will automatically manage AdguardHome DNS records, we can delete the tutorial's example:
+
+```
+$ kubectl delete service -f nginx.yaml
+$ kubectl delete service -f externaldns.yaml
+```

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/labels"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"sigs.k8s.io/external-dns/provider/adguardhome"
 
 	"sigs.k8s.io/external-dns/controller"
 	"sigs.k8s.io/external-dns/endpoint"
@@ -178,6 +179,11 @@ func main() {
 
 	var p provider.Provider
 	switch cfg.Provider {
+	case "adguardhome":
+		p, err = adguardhome.NewAdguardHomeProvider(
+			domainFilter,
+			cfg.DryRun,
+		)
 	case "akamai":
 		p, err = akamai.NewAkamaiProvider(
 			akamai.AkamaiConfig{

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -429,7 +429,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("exclude-target-net", "Exclude target nets (optional)").StringsVar(&cfg.ExcludeTargetNets)
 
 	// Flags related to providers
-	providers := []string{"akamai", "alibabacloud", "aws", "aws-sd", "azure", "azure-dns", "azure-private-dns", "bluecat", "civo", "cloudflare", "coredns", "designate", "digitalocean", "dnsimple", "dyn", "exoscale", "gandi", "godaddy", "google", "ibmcloud", "infoblox", "inmemory", "linode", "ns1", "oci", "ovh", "pdns", "pihole", "plural", "rcodezero", "rdns", "rfc2136", "safedns", "scaleway", "skydns", "tencentcloud", "transip", "ultradns", "vinyldns", "vultr"}
+	providers := []string{"adguardhome", "akamai", "alibabacloud", "aws", "aws-sd", "azure", "azure-dns", "azure-private-dns", "bluecat", "civo", "cloudflare", "coredns", "designate", "digitalocean", "dnsimple", "dyn", "exoscale", "gandi", "godaddy", "google", "ibmcloud", "infoblox", "inmemory", "linode", "ns1", "oci", "ovh", "pdns", "pihole", "plural", "rcodezero", "rdns", "rfc2136", "safedns", "scaleway", "skydns", "tencentcloud", "transip", "ultradns", "vinyldns", "vultr"}
 	app.Flag("provider", "The DNS provider where the DNS records will be created (required, options: "+strings.Join(providers, ", ")+")").Required().PlaceHolder("provider").EnumVar(&cfg.Provider, providers...)
 	app.Flag("domain-filter", "Limit possible target zones by a domain suffix; specify multiple times for multiple domains (optional)").Default("").StringsVar(&cfg.DomainFilter)
 	app.Flag("exclude-domains", "Exclude subdomains (optional)").Default("").StringsVar(&cfg.ExcludeDomains)

--- a/provider/adguardhome/adguardhome.go
+++ b/provider/adguardhome/adguardhome.go
@@ -1,0 +1,361 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adguardhome
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
+)
+
+var (
+	notManagedError = fmt.Errorf("rule is managed by external-dns")
+)
+
+const (
+	managedBy = "$managed by external-dns"
+
+	envURL      = "ADGUARD_HOME_URL"
+	envPassword = "ADGUARD_HOME_PASS"
+	envUser     = "ADGUARD_HOME_USER"
+)
+
+// Client is an interface for the AdguardHome API.
+// See OpenAPI spec for details: https://raw.githubusercontent.com/AdguardTeam/AdGuardHome/master/openapi/openapi.yaml
+type Client interface {
+	GetFilteringRules(ctx context.Context) ([]string, error)
+	SaveFilteringRules(ctx context.Context, rules []string) error
+}
+
+type AdguardHomeProvider struct {
+	provider.BaseProvider
+
+	client Client
+
+	domainFilter endpoint.DomainFilter
+}
+
+// NewAdguardHomeProvider initializes a new Vultr BNS based provider
+func NewAdguardHomeProvider(domainFilter endpoint.DomainFilter, dryRun bool) (*AdguardHomeProvider, error) {
+	adguardHomeURL, adguardHomeUrlOk := os.LookupEnv(envURL)
+	if !adguardHomeUrlOk {
+		return nil, fmt.Errorf("no url was found in environment variable ADGUARD_HOME_URL")
+	}
+
+	// Adjust the URL to match the API requirements
+	if !strings.HasSuffix(adguardHomeURL, "/") {
+		adguardHomeURL = adguardHomeURL + "/"
+	}
+
+	if !strings.HasSuffix(adguardHomeURL, "control/") {
+		adguardHomeURL = adguardHomeURL + "control/"
+	}
+
+	adguardHomeUser, adguardHomeUserOk := os.LookupEnv(envUser)
+	if !adguardHomeUserOk {
+		return nil, fmt.Errorf("no user was found in environment variable ADGUARD_HOME_USER")
+	}
+
+	adguardHomePass, adguardHomePassOk := os.LookupEnv(envPassword)
+	if !adguardHomePassOk {
+		return nil, fmt.Errorf("no password was found in environment variable ADGUARD_HOME_PASS")
+	}
+
+	c, err := newAdguardHomeClient(adguardHomeURL, adguardHomeUser, adguardHomePass, dryRun)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the adguard home api hс: %w", err)
+	}
+
+	p := &AdguardHomeProvider{
+		client:       c,
+		domainFilter: domainFilter,
+	}
+
+	return p, nil
+}
+
+// ApplyChanges implements Provider, syncing desired state with the AdguardHome server Local DNS.
+func (p *AdguardHomeProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
+	originalRules, err := p.client.GetFilteringRules(ctx)
+	if err != nil {
+		return err
+	}
+
+	resultingRules := make([]string, 0)
+	endpoints := make([]*endpoint.Endpoint, 0)
+	endpointsAExists := make(map[string]*endpoint.Endpoint)
+	for _, rule := range originalRules {
+		e, err := parseRule(rule)
+		if err != nil {
+			// Keep rules not managed by external-dns as-is
+			if err == notManagedError {
+				resultingRules = append(resultingRules, rule)
+				continue
+			}
+			return fmt.Errorf("failed to parse rule %s: %w", rule, err)
+		}
+
+		if endpointsAExists[e.DNSName] != nil {
+			endpointsAExists[e.DNSName].Targets = append(endpointsAExists[e.DNSName].Targets, e.Targets...)
+		} else {
+			endpoints = append(endpoints, e)
+			endpointsAExists[e.DNSName] = e
+		}
+	}
+
+	for _, deleteEndpoint := range append(changes.UpdateOld, changes.Delete...) {
+		for _, target := range deleteEndpoint.Targets {
+			for endpointIndex, endpointValue := range endpoints {
+				if endpointValue.DNSName == deleteEndpoint.DNSName && endpointValue.RecordType == deleteEndpoint.RecordType && endpointValue.Targets[0] == target {
+					endpoints = append(endpoints[:endpointIndex], endpoints[endpointIndex+1:]...)
+					log.Debugf("delete custom rule %s", deleteEndpoint)
+					break
+				}
+			}
+		}
+	}
+
+	for _, createEndpoint := range append(changes.Create, changes.UpdateNew...) {
+		if !endpointSupported(createEndpoint) {
+			continue
+		}
+
+		for _, target := range createEndpoint.Targets {
+			endpoints = append(endpoints, &endpoint.Endpoint{
+				DNSName:    createEndpoint.DNSName,
+				Targets:    endpoint.Targets{target},
+				RecordType: createEndpoint.RecordType,
+			})
+		}
+		log.Debugf("add custom rule %s", createEndpoint)
+	}
+
+	for _, e := range endpoints {
+		s := endpointToString(e)
+		resultingRules = append(resultingRules, s)
+	}
+
+	return p.client.SaveFilteringRules(ctx, resultingRules)
+}
+
+// Records implements Provider, populating a slice of endpoints from
+// AdguardHome local DNS.
+func (p *AdguardHomeProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	resp, err := p.client.GetFilteringRules(ctx)
+	if err != nil {
+		log.Errorf("Error %s", err)
+		return nil, err
+	}
+
+	log.WithFields(log.Fields{
+		"func":  "records",
+		"rules": resp,
+	}).Debugf("retrieved AdguardHome rules")
+
+	var ret []*endpoint.Endpoint
+	endpointsAExists := make(map[string]*endpoint.Endpoint)
+	for _, rule := range resp {
+		e, err := parseRule(rule)
+		if err != nil {
+			if err == notManagedError {
+				continue
+			}
+			return nil, err
+		}
+
+		if !p.domainFilter.Match(e.DNSName) {
+			continue
+		}
+		if endpointsAExists[e.DNSName] != nil {
+			endpointsAExists[e.DNSName].Targets = append(endpointsAExists[e.DNSName].Targets, e.Targets...)
+		} else {
+			ret = append(ret, e)
+			endpointsAExists[e.DNSName] = e
+		}
+	}
+
+	return ret, nil
+}
+
+// endpointSupported returns true if the endpoint is supported by the provider
+// it is only possible to store A and TXT records in AdguardHome
+func endpointSupported(e *endpoint.Endpoint) bool {
+	return e.RecordType == endpoint.RecordTypeA || e.RecordType == endpoint.RecordTypeTXT
+}
+
+func parseRule(rule string) (*endpoint.Endpoint, error) {
+	if !strings.Contains(rule, managedBy) {
+		return nil, notManagedError
+	}
+
+	if strings.HasPrefix(rule, "#") {
+		r := &endpoint.Endpoint{
+			RecordType: endpoint.RecordTypeTXT,
+		}
+		parts := strings.SplitN(rule, " ", 4)
+		if len(parts) != 4 {
+			return nil, fmt.Errorf("invalid rule: %s", rule)
+		}
+		r.DNSName = parts[2]
+		r.Targets = endpoint.Targets{strings.ReplaceAll(parts[1], fmt.Sprintf("%s", managedBy), "")}
+
+		return r, nil
+	}
+
+	parts := strings.SplitN(rule, " ", 3)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid rule: %s", rule)
+	}
+
+	r := &endpoint.Endpoint{
+		RecordType: endpoint.RecordTypeA,
+		DNSName:    parts[1],
+		Targets:    endpoint.Targets{parts[0]},
+	}
+
+	return r, nil
+}
+
+func endpointToString(e *endpoint.Endpoint) string {
+	if e.RecordType == endpoint.RecordTypeTXT {
+		return fmt.Sprintf("# %s %s %s", e.Targets[0], e.DNSName, managedBy)
+	}
+
+	return fmt.Sprintf("%s %s #%s", e.Targets[0], e.DNSName, managedBy)
+}
+
+type client struct {
+	hc *http.Client
+
+	endpoint string
+	user     string
+	pass     string
+	dryRun   bool
+}
+
+type filteringStatus struct {
+	UserRules []string `json:"user_rules"`
+}
+
+type setRules struct {
+	Rules []string `json:"rules"`
+}
+
+func (c *client) doRequest(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.endpoint+path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.SetBasicAuth(c.user, c.pass)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
+	}
+
+	return resp, nil
+}
+
+func (c *client) status(ctx context.Context) error {
+	if c.dryRun {
+		return nil
+	}
+
+	r, err := c.doRequest(ctx, http.MethodGet, "status", nil)
+	if err != nil {
+		return err
+	}
+	_ = r.Body.Close()
+	return nil
+}
+
+func (c *client) GetFilteringRules(ctx context.Context) ([]string, error) {
+	if c.dryRun {
+		return []string{}, nil
+	}
+
+	r, err := c.doRequest(ctx, http.MethodGet, "filtering/status", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+
+	var resp filteringStatus
+	err = json.NewDecoder(r.Body).Decode(&resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.UserRules, nil
+}
+
+func (c *client) SaveFilteringRules(ctx context.Context, rules []string) error {
+	if c.dryRun {
+		return nil
+	}
+
+	body := setRules{Rules: rules}
+
+	b := bytes.NewBuffer(nil)
+	err := json.NewEncoder(b).Encode(body)
+	if err != nil {
+		return err
+	}
+
+	r, err := c.doRequest(ctx, http.MethodPost, "filtering/set_rules", b)
+	if err != nil {
+		return err
+	}
+	_ = r.Body.Close()
+	return nil
+}
+
+func newAdguardHomeClient(endpoint, user, pass string, dryRun bool) (*client, error) {
+	hc := http.Client{}
+	c := &client{
+		hc:       &hc,
+		endpoint: endpoint,
+		user:     user,
+		pass:     pass,
+
+		dryRun: dryRun,
+	}
+
+	err := c.status(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}

--- a/provider/adguardhome/adguardhome_test.go
+++ b/provider/adguardhome/adguardhome_test.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package adguardhome
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
+)
+
+type mockAdguardClient struct {
+	rules []string
+}
+
+func (m *mockAdguardClient) GetFilteringRules(_ context.Context) ([]string, error) {
+	return m.rules, nil
+}
+
+func (m *mockAdguardClient) SaveFilteringRules(_ context.Context, rules []string) error {
+	m.rules = rules
+	return nil
+}
+
+func newMockClient() *mockAdguardClient {
+	return &mockAdguardClient{
+		rules: []string{
+			"# I am not for external-dns",
+			"1.1.1.1 example.com #$managed by external-dns",
+			"# myresponse notexample.com $managed by external-dns",
+		},
+	}
+}
+
+func TestAdguardHomeProvider_ApplyChanges(t *testing.T) {
+	p := &AdguardHomeProvider{
+		client: newMockClient(),
+	}
+
+	create := []*endpoint.Endpoint{
+		{
+			DNSName:    "example.com",
+			RecordType: endpoint.RecordTypeA,
+			Targets:    endpoint.Targets{"2.2.2.2"},
+		},
+	}
+
+	updateNew := []*endpoint.Endpoint{
+		{
+			DNSName:    "example.com",
+			RecordType: endpoint.RecordTypeA,
+			Targets:    endpoint.Targets{"3.3.3.3"},
+		},
+	}
+
+	changes := &plan.Changes{
+		Create:    create,
+		UpdateNew: updateNew,
+		UpdateOld: []*endpoint.Endpoint{
+			{
+				DNSName:    "notexample.com",
+				RecordType: endpoint.RecordTypeTXT,
+				Targets:    endpoint.Targets{"myresponse"},
+			},
+		},
+		Delete: []*endpoint.Endpoint{
+			{
+				DNSName:    "example.com",
+				RecordType: endpoint.RecordTypeA,
+				Targets:    endpoint.Targets{"1.1.1.1"},
+			},
+		},
+	}
+
+	err := p.ApplyChanges(context.Background(), changes)
+	if err != nil {
+		t.Errorf("failed to apply changes: %v", err)
+	}
+
+	r, err := p.Records(context.Background())
+	if err != nil {
+		t.Errorf("failed to fetch records: %v", err)
+	}
+
+	expected := []*endpoint.Endpoint{
+		{
+			DNSName:    "example.com",
+			RecordType: endpoint.RecordTypeA,
+			Targets:    endpoint.Targets{"2.2.2.2", "3.3.3.3"},
+		},
+	}
+	if !reflect.DeepEqual(r, expected) {
+		t.Errorf("records do not match: got: %v, expected: %v", r, expected)
+	}
+
+	// Ensure original rules were kept in place
+	expectedRules := []string{
+		"# I am not for external-dns",
+		"2.2.2.2 example.com #$managed by external-dns",
+		"3.3.3.3 example.com #$managed by external-dns",
+	}
+
+	if !reflect.DeepEqual(p.client.(*mockAdguardClient).rules, expectedRules) {
+		t.Errorf("rules do not match: got: %v, expected: %v", p.client.(*mockAdguardClient).rules, expectedRules)
+	}
+}
+
+func TestAdguardHomeProvider_Records(t *testing.T) {
+	type fields struct {
+		BaseProvider provider.BaseProvider
+		client       Client
+		domainFilter endpoint.DomainFilter
+		DryRun       bool
+	}
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []*endpoint.Endpoint
+		wantErr bool
+	}{
+		{
+			name: "test fetches records",
+			fields: fields{
+				client: newMockClient(),
+			},
+			args: args{
+				ctx: context.Background(),
+			},
+			want: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.com",
+					RecordType: "A",
+					Targets:    endpoint.Targets{"1.1.1.1"},
+				},
+				{
+					DNSName:    "notexample.com",
+					RecordType: "TXT",
+					Targets:    endpoint.Targets{"myresponse"},
+				},
+			},
+		},
+		{
+			name: "applies domain filter",
+			fields: fields{
+				client: newMockClient(),
+				domainFilter: endpoint.NewDomainFilter(
+					[]string{"example.com"},
+				),
+			},
+			args: args{
+				ctx: context.Background(),
+			},
+			want: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.com",
+					RecordType: "A",
+					Targets:    endpoint.Targets{"1.1.1.1"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &AdguardHomeProvider{
+				BaseProvider: tt.fields.BaseProvider,
+				client:       tt.fields.client,
+				domainFilter: tt.fields.domainFilter,
+			}
+			got, err := p.Records(tt.args.ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AdguardHomeProvider.Records() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AdguardHomeProvider.Records() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewAdguardHomeProvider(t *testing.T) {
+	got, err := NewAdguardHomeProvider(endpoint.NewDomainFilter([]string{"example.com"}), true)
+	if err == nil {
+		t.Errorf("NewAdguardHomeProvider() error = %v", err)
+		return
+	}
+
+	if got != nil {
+		t.Errorf("NewAdguardHomeProvider() = %v, want %v", got, "not nil")
+	}
+
+	_ = os.Setenv(envURL, "http://localhost:3000")
+	_ = os.Setenv(envUser, "pw")
+	_ = os.Setenv(envPassword, "user")
+
+	got, err = NewAdguardHomeProvider(endpoint.NewDomainFilter([]string{"example.com"}), true)
+	if err != nil {
+		t.Errorf("NewAdguardHomeProvider() error = %v", err)
+	}
+}
+
+func TestAdguardHomeProvider_MergeRecords(t *testing.T) {
+	c := newMockClient()
+	p := &AdguardHomeProvider{
+		client: c,
+	}
+
+	c.rules = []string{
+		"1.1.1.1 example.com #$managed by external-dns",
+		"1.2.1.1 example.com #$managed by external-dns",
+		"1.3.1.1 example.com #$managed by external-dns",
+		"1.4.1.1 example.com #$managed by external-dns",
+	}
+
+	got, err := p.Records(context.Background())
+	if err != nil {
+		t.Errorf("failed to fetch records: %v", err)
+	}
+
+	expected := []*endpoint.Endpoint{
+		{
+			DNSName:    "example.com",
+			RecordType: "A",
+			Targets: endpoint.Targets{
+				"1.1.1.1",
+				"1.2.1.1",
+				"1.3.1.1",
+				"1.4.1.1",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("records do not match: got: %v, expected: %v", got, expected)
+	}
+}


### PR DESCRIPTION
**Description**

This PR adds the adguard home provider. With this provider you can manage records in adguard home.

"AdGuard Home is a network-wide software for blocking ads and tracking. After you set it up, it'll cover ALL your home devices, and you don't need any client-side software for that. It operates as a DNS server that re-routes tracking domains to a “black hole”, thus preventing your devices from connecting to those servers. It's based on software we use for our public [AdGuard DNS](https://adguard-dns.io/) servers, and both share a lot of code."
from [adguard home](https://github.com/AdguardTeam/AdGuardHome)

Fixes https://github.com/kubernetes-sigs/external-dns/issues/3243

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
