### PR TITLE
Replace all versions of docker images with latest in tutorial

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -205,7 +205,7 @@ $ docker run \
   -e EXTERNAL_DNS_SOURCE=$'service\ningress' \
   -e EXTERNAL_DNS_PROVIDER=google \
   -e EXTERNAL_DNS_DOMAIN_FILTER=$'foo.com\nbar.com' \
-  registry.k8s.io/external-dns/external-dns:v0.13.1
+  registry.k8s.io/external-dns/external-dns:v0.13.2
 time="2017-08-08T14:10:26Z" level=info msg="config: &{APIServerURL: KubeConfig: Sources:[service ingress] Namespace: ...
 ```
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -31,6 +31,7 @@ You must be an official maintainer of the project to be able to do a release.
 - Branch out from the default branch and run `scripts/kustomize-version-updater.sh` to update the image tag used in the kustomization.yaml.
 - Create an issue to release the corresponding Helm chart via the chart release process (below) assigned to a chart maintainer
 - Create a PR with the kustomize change.
+- Create a PR to replace all versions for docker images in the tutorials. A possible script to use is `sd registry.k8s.io/external-dns/external-dns:.* registry.k8s.io/external-dns/external-dns:v0.13.2 $(fd --type file)` which uses the `fd` and `sd` utilities.
 - Once the PR is merged, all is done :-)
 
 ## How to release a new chart version

--- a/docs/tutorials/ANS_Group_SafeDNS.md
+++ b/docs/tutorials/ANS_Group_SafeDNS.md
@@ -48,7 +48,7 @@ spec:
       - name: external-dns
         # You will need to check what the latest version is yourself:
         # https://github.com/kubernetes-sigs/external-dns/releases
-        image: registry.k8s.io/external-dns/external-dns:vX.Y.Z
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         # (optional) limit to only example.com domains; change to match the
@@ -114,7 +114,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         # (optional) limit to only example.com domains; change to match the

--- a/docs/tutorials/akamai-edgedns.md
+++ b/docs/tutorials/akamai-edgedns.md
@@ -57,7 +57,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service  # or ingress or both
         - --provider=akamai
@@ -143,7 +143,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service  # or ingress or both
         - --provider=akamai

--- a/docs/tutorials/alibabacloud.md
+++ b/docs/tutorials/alibabacloud.md
@@ -113,7 +113,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service
         - --source=ingress
@@ -187,7 +187,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service
         - --source=ingress

--- a/docs/tutorials/aws-sd.md
+++ b/docs/tutorials/aws-sd.md
@@ -81,7 +81,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         env:
           - name: AWS_REGION
             value: us-east-1 # put your CloudMap NameSpace region
@@ -148,7 +148,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         env:
           - name: AWS_REGION
             value: us-east-1 # put your CloudMap NameSpace region

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -413,7 +413,7 @@ spec:
     spec:
       containers:
         - name: external-dns
-          image: registry.k8s.io/external-dns/external-dns:v0.13.1
+          image: registry.k8s.io/external-dns/external-dns:v0.13.2
           args:
             - --source=service
             - --source=ingress
@@ -508,7 +508,7 @@ spec:
       serviceAccountName: external-dns
       containers:
         - name: external-dns
-          image: registry.k8s.io/external-dns/external-dns:v0.13.1
+          image: registry.k8s.io/external-dns/external-dns:v0.13.2
           args:
             - --source=service
             - --source=ingress
@@ -950,7 +950,7 @@ A simple way to implement randomised startup is with an init container:
     spec:
       initContainers:
       - name: init-jitter
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         command:
         - /bin/sh
         - -c

--- a/docs/tutorials/azure-private-dns.md
+++ b/docs/tutorials/azure-private-dns.md
@@ -130,7 +130,7 @@ spec:
     spec:
       containers:
       - name: externaldns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service
         - --source=ingress
@@ -201,7 +201,7 @@ spec:
       serviceAccountName: externaldns
       containers:
       - name: externaldns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service
         - --source=ingress
@@ -272,7 +272,7 @@ spec:
       serviceAccountName: externaldns
       containers:
       - name: externaldns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service
         - --source=ingress

--- a/docs/tutorials/azure.md
+++ b/docs/tutorials/azure.md
@@ -356,7 +356,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service
         - --source=ingress
@@ -424,7 +424,7 @@ spec:
       serviceAccountName: external-dns
       containers:
         - name: external-dns
-          image: registry.k8s.io/external-dns/external-dns:v0.13.1
+          image: registry.k8s.io/external-dns/external-dns:v0.13.2
           args:
             - --source=service
             - --source=ingress
@@ -495,7 +495,7 @@ spec:
       serviceAccountName: external-dns
       containers:
         - name: external-dns
-          image: registry.k8s.io/external-dns/external-dns:v0.13.1
+          image: registry.k8s.io/external-dns/external-dns:v0.13.2
           args:
             - --source=service
             - --source=ingress

--- a/docs/tutorials/bluecat.md
+++ b/docs/tutorials/bluecat.md
@@ -46,7 +46,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --log-level=debug
         - --source=service
@@ -136,7 +136,7 @@ spec:
             secretName: bluecatconfig
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         volumeMounts:
           - name: bluecatconfig
             mountPath: "/etc/external-dns/"

--- a/docs/tutorials/civo.md
+++ b/docs/tutorials/civo.md
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
@@ -105,7 +105,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.

--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
@@ -118,7 +118,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.

--- a/docs/tutorials/contour.md
+++ b/docs/tutorials/contour.md
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service
         - --source=ingress
@@ -102,7 +102,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service
         - --source=ingress

--- a/docs/tutorials/coredns.md
+++ b/docs/tutorials/coredns.md
@@ -108,7 +108,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=ingress
         - --provider=coredns
@@ -175,7 +175,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=ingress
         - --provider=coredns

--- a/docs/tutorials/designate.md
+++ b/docs/tutorials/designate.md
@@ -59,7 +59,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
@@ -136,7 +136,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.

--- a/docs/tutorials/digitalocean.md
+++ b/docs/tutorials/digitalocean.md
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
@@ -107,7 +107,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.

--- a/docs/tutorials/dnsimple.md
+++ b/docs/tutorials/dnsimple.md
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone you create in DNSimple.
@@ -100,7 +100,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone you create in DNSimple.

--- a/docs/tutorials/dyn.md
+++ b/docs/tutorials/dyn.md
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=ingress
         - --txt-prefix=_d

--- a/docs/tutorials/exoscale.md
+++ b/docs/tutorials/exoscale.md
@@ -41,7 +41,7 @@ spec:
       # serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=ingress # or service or both
         - --provider=exoscale

--- a/docs/tutorials/externalname.md
+++ b/docs/tutorials/externalname.md
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --log-level=debug
         - --source=service

--- a/docs/tutorials/gandi.md
+++ b/docs/tutorials/gandi.md
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
@@ -103,7 +103,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.

--- a/docs/tutorials/gateway-api.md
+++ b/docs/tutorials/gateway-api.md
@@ -72,7 +72,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         # Add desired Gateway API Route sources.
         - --source=gateway-httproute

--- a/docs/tutorials/gke.md
+++ b/docs/tutorials/gke.md
@@ -319,7 +319,7 @@ spec:
       serviceAccountName: external-dns
       containers:
         - name: external-dns
-          image: registry.k8s.io/external-dns/external-dns:v0.13.1
+          image: registry.k8s.io/external-dns/external-dns:v0.13.2
           args:
             - --source=service
             - --source=ingress

--- a/docs/tutorials/gloo-proxy.md
+++ b/docs/tutorials/gloo-proxy.md
@@ -22,7 +22,7 @@ spec:
       containers:
       - name: external-dns
         # update this to the desired external-dns version
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=gloo-proxy
         - --gloo-namespace=custom-gloo-system # gloo system namespace. Omit to use the default (gloo-system)
@@ -90,7 +90,7 @@ spec:
       containers:
       - name: external-dns
         # update this to the desired external-dns version
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=gloo-proxy
         - --gloo-namespace=custom-gloo-system # gloo system namespace. Omit to use the default (gloo-system)

--- a/docs/tutorials/godaddy.md
+++ b/docs/tutorials/godaddy.md
@@ -44,7 +44,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
@@ -115,7 +115,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.

--- a/docs/tutorials/hostport.md
+++ b/docs/tutorials/hostport.md
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --log-level=debug
         - --source=service
@@ -96,7 +96,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --log-level=debug
         - --source=service

--- a/docs/tutorials/ibmcloud.md
+++ b/docs/tutorials/ibmcloud.md
@@ -69,7 +69,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
@@ -142,7 +142,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.

--- a/docs/tutorials/infoblox.md
+++ b/docs/tutorials/infoblox.md
@@ -69,7 +69,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service
         - --domain-filter=example.com       # (optional) limit to only example.com domains.
@@ -150,7 +150,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service
         - --domain-filter=example.com       # (optional) limit to only example.com domains.

--- a/docs/tutorials/istio.md
+++ b/docs/tutorials/istio.md
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service
         - --source=ingress
@@ -98,7 +98,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service
         - --source=ingress

--- a/docs/tutorials/kong.md
+++ b/docs/tutorials/kong.md
@@ -22,7 +22,7 @@ spec:
       containers:
       - name: external-dns
         # update this to the desired external-dns version
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=kong-tcpingress
         - --provider=aws
@@ -86,7 +86,7 @@ spec:
       containers:
       - name: external-dns
         # update this to the desired external-dns version
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=kong-tcpingress
         - --provider=aws

--- a/docs/tutorials/linode.md
+++ b/docs/tutorials/linode.md
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
@@ -105,7 +105,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.

--- a/docs/tutorials/nginx-ingress.md
+++ b/docs/tutorials/nginx-ingress.md
@@ -273,7 +273,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=ingress
         - --domain-filter=external-dns-test.gcp.zalan.do
@@ -570,7 +570,7 @@ spec:
             - --google-project=zalando-external-dns-test
             - --registry=txt
             - --txt-owner-id=my-identifier
-          image: registry.k8s.io/external-dns/external-dns:v0.13.1
+          image: registry.k8s.io/external-dns/external-dns:v0.13.2
           name: external-dns
       securityContext:
         fsGroup: 65534

--- a/docs/tutorials/nodes.md
+++ b/docs/tutorials/nodes.md
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=node # will use nodes as source
         - --provider=aws
@@ -99,7 +99,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=node # will use nodes as source
         - --provider=aws

--- a/docs/tutorials/ns1.md
+++ b/docs/tutorials/ns1.md
@@ -61,7 +61,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
@@ -125,7 +125,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.

--- a/docs/tutorials/openshift.md
+++ b/docs/tutorials/openshift.md
@@ -66,7 +66,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=openshift-route
         - --domain-filter=external-dns-test.my-org.com # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
@@ -133,7 +133,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=openshift-route
         - --domain-filter=external-dns-test.my-org.com # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones

--- a/docs/tutorials/oracle.md
+++ b/docs/tutorials/oracle.md
@@ -93,7 +93,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service
         - --source=ingress

--- a/docs/tutorials/ovh.md
+++ b/docs/tutorials/ovh.md
@@ -86,7 +86,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
@@ -160,7 +160,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.

--- a/docs/tutorials/pdns.md
+++ b/docs/tutorials/pdns.md
@@ -42,7 +42,7 @@ spec:
       # serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # or ingress or both
         - --provider=pdns

--- a/docs/tutorials/pihole.md
+++ b/docs/tutorials/pihole.md
@@ -78,7 +78,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:latest
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         # If authentication is disabled and/or you didn't create
         # a secret, you can remove this block.
         envFrom:

--- a/docs/tutorials/plural.md
+++ b/docs/tutorials/plural.md
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
@@ -105,7 +105,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.

--- a/docs/tutorials/public-private-route53.md
+++ b/docs/tutorials/public-private-route53.md
@@ -243,7 +243,7 @@ spec:
         - --txt-owner-id=external-dns
         - --annotation-filter=kubernetes.io/ingress.class in (external-ingress)
         - --aws-zone-type=public
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         name: external-dns-public
 ```
 
@@ -281,7 +281,7 @@ spec:
         - --txt-owner-id=dev.k8s.nexus
         - --annotation-filter=kubernetes.io/ingress.class in (internal-ingress)
         - --aws-zone-type=private
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         name: external-dns-private
 ```
 

--- a/docs/tutorials/rcodezero.md
+++ b/docs/tutorials/rcodezero.md
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
@@ -120,7 +120,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.

--- a/docs/tutorials/rdns.md
+++ b/docs/tutorials/rdns.md
@@ -54,7 +54,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=ingress
         - --provider=rdns
@@ -123,7 +123,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=ingress
         - --provider=rdns

--- a/docs/tutorials/rfc2136.md
+++ b/docs/tutorials/rfc2136.md
@@ -218,7 +218,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --registry=txt
         - --txt-prefix=external-dns-
@@ -260,7 +260,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --registry=txt
         - --txt-prefix=external-dns-

--- a/docs/tutorials/scaleway.md
+++ b/docs/tutorials/scaleway.md
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
@@ -121,7 +121,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.

--- a/docs/tutorials/security-context.md
+++ b/docs/tutorials/security-context.md
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - ... # your arguments here
         securityContext:

--- a/docs/tutorials/tencentcloud.md
+++ b/docs/tutorials/tencentcloud.md
@@ -129,7 +129,7 @@ spec:
         - --policy=sync # set `upsert-only` would prevent ExternalDNS from deleting any records
         - --tencent-cloud-zone-type=private # only look at private hosted zones. set `public` to use the public dns service.
         - --tencent-cloud-config-file=/etc/kubernetes/tencent-cloud.json
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         imagePullPolicy: Always
         name: external-dns
         resources: {}

--- a/docs/tutorials/transip.md
+++ b/docs/tutorials/transip.md
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains
@@ -107,7 +107,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains

--- a/docs/tutorials/ultradns.md
+++ b/docs/tutorials/ultradns.md
@@ -44,7 +44,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service 
         - --source=ingress # ingress is also possible
@@ -116,7 +116,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service 
         - --source=ingress

--- a/docs/tutorials/vinyldns.md
+++ b/docs/tutorials/vinyldns.md
@@ -66,7 +66,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --provider=vinyldns
         - --source=service
@@ -137,7 +137,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --provider=vinyldns
         - --source=service

--- a/docs/tutorials/vultr.md
+++ b/docs/tutorials/vultr.md
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
@@ -106,7 +106,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.1
+        image: registry.k8s.io/external-dns/external-dns:v0.13.2
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.


### PR DESCRIPTION
**Description**

This PR:

- replaces all the occurrences of the docker images with the latest.
- add an info on an example of how to do that at release time, avoiding the use of `sed` and friends which are different on different architectures.

/cc @njuettner


