### PR TITLE
Force updating libcrypto3 and libssl3 in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN make test build.$ARCH
 # final image
 FROM $ARCH/alpine:3.17
 
-RUN apk update && apk add -U libcrypto3 libssl3 && rm -rf /var/cache/apt/*
+RUN apk update && apk add --latest libcrypto3 libssl3 && rm -rf /var/cache/apt/*
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /bin/external-dns

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN make test build.$ARCH
 # final image
 FROM $ARCH/alpine:3.17
 
+RUN apk update && apk add libcrypto3 libssl3 && rm -rf /var/cache/apt/*
+
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /bin/external-dns
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN make test build.$ARCH
 # final image
 FROM $ARCH/alpine:3.17
 
-RUN apk update && apk add --latest libcrypto3 libssl3 && rm -rf /var/cache/apt/*
+RUN apk update && apk add "libcrypto3>=3.0.8-r0" "libssl3>=3.0.8-r0" && rm -rf /var/cache/apt/*
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /bin/external-dns

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN make test build.$ARCH
 # final image
 FROM $ARCH/alpine:3.17
 
-RUN apk update && apk add libcrypto3 libssl3 && rm -rf /var/cache/apt/*
+RUN apk update && apk add -U libcrypto3 libssl3 && rm -rf /var/cache/apt/*
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /bin/external-dns


### PR DESCRIPTION
**Description**

Fixes https://github.com/kubernetes-sigs/external-dns/issues/3385 by forcing updating `libcrypto3` and `libssl3`. There are patch versions released for alpine, but no new image tagged that contains those fixes. This change will force CI to update those, resolving the vulnerabilities.

