### PR TITLE
Add cache at provider level

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -175,7 +175,7 @@ type Controller struct {
 	// The interval between individual synchronizations
 	Interval time.Duration
 	// The DomainFilter defines which DNS records to keep or exclude
-	DomainFilter endpoint.DomainFilter
+	DomainFilter endpoint.DomainFilterInterface
 	// The nextRunAt used for throttling and batching reconciliation
 	nextRunAt time.Time
 	// The nextRunAtMux is for atomic updating of nextRunAt
@@ -221,7 +221,7 @@ func (c *Controller) RunOnce(ctx context.Context) error {
 		Policies:       []plan.Policy{c.Policy},
 		Current:        records,
 		Desired:        endpoints,
-		DomainFilter:   endpoint.MatchAllDomainFilters{&c.DomainFilter, &registryFilter},
+		DomainFilter:   endpoint.MatchAllDomainFilters{c.DomainFilter, registryFilter},
 		ManagedRecords: c.ManagedRecordTypes,
 	}
 

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -57,7 +57,7 @@ type errorMockProvider struct {
 	mockProvider
 }
 
-func (p *filteredMockProvider) GetDomainFilter() endpoint.DomainFilter {
+func (p *filteredMockProvider) GetDomainFilter() endpoint.DomainFilterInterface {
 	return p.domainFilter
 }
 

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -930,6 +930,8 @@ Route53 has a [5 API requests per second per account hard quota](https://docs.aw
 Running several fast polling ExternalDNS instances in a given account can easily hit that limit. Some ways to reduce the request rate include:
 * Reduce the polling loop's synchronization interval at the possible cost of slower change propagation (but see `--events` below to reduce the impact).
   * `--interval=5m` (default `1m`)
+* Cache the results of the zone at the possible cost of slower propagation when the zone gets modified from other sources
+  * `--provider-cache-time=15m` (default `0m`)
 * Trigger the polling loop on changes to K8s objects, rather than only at `interval`, to have responsive updates with long poll intervals
   * `--events`
 * Limit the [sources watched](https://github.com/kubernetes-sigs/external-dns/blob/master/pkg/apis/externaldns/types.go#L364) when the `--events` flag is specified to specific types, namespaces, labels, or annotations

--- a/endpoint/domain_filter.go
+++ b/endpoint/domain_filter.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 )
 
-type MatchAllDomainFilters []*DomainFilter
+type MatchAllDomainFilters []DomainFilterInterface
 
 func (f MatchAllDomainFilters) Match(domain string) bool {
 	for _, filter := range f {
@@ -39,6 +39,10 @@ func (f MatchAllDomainFilters) Match(domain string) bool {
 	return true
 }
 
+type DomainFilterInterface interface {
+	Match(domain string) bool
+}
+
 // DomainFilter holds a lists of valid domain names
 type DomainFilter struct {
 	// Filters define what domains to match
@@ -50,6 +54,8 @@ type DomainFilter struct {
 	// regexExclusion defines a regular expression to exclude the domains matched
 	regexExclusion *regexp.Regexp
 }
+
+var _ DomainFilterInterface = &DomainFilter{}
 
 // domainFilterSerde is a helper type for serializing and deserializing DomainFilter.
 type domainFilterSerde struct {

--- a/main.go
+++ b/main.go
@@ -429,7 +429,7 @@ func main() {
 	case "txt":
 		r, err = registry.NewTXTRegistry(p, cfg.TXTPrefix, cfg.TXTSuffix, cfg.TXTOwnerID, cfg.TXTCacheInterval, cfg.TXTWildcardReplacement, cfg.ManagedDNSRecordTypes, cfg.TXTEncryptEnabled, []byte(cfg.TXTEncryptAESKey))
 	case "aws-sd":
-		r, err = registry.NewAWSSDRegistry(p.(*awssd.AWSSDProvider), cfg.TXTOwnerID)
+		r, err = registry.NewAWSSDRegistry(p, cfg.TXTOwnerID)
 	default:
 		log.Fatalf("unknown registry: %s", cfg.Registry)
 	}

--- a/main.go
+++ b/main.go
@@ -409,6 +409,13 @@ func main() {
 		log.Fatal(err)
 	}
 
+	if cfg.ProviderCacheTime > 0 {
+		p = &provider.CachedProvider{
+			Provider:     p,
+			RefreshDelay: cfg.ProviderCacheTime,
+		}
+	}
+
 	var r registry.Registry
 	switch cfg.Registry {
 	case "dynamodb":

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -67,7 +67,7 @@ type Config struct {
 	AlwaysPublishNotReadyAddresses     bool
 	ConnectorSourceServer              string
 	Provider                           string
-	ProviderCacheTime                  int
+	ProviderCacheTime                  time.Duration
 	GoogleProject                      string
 	GoogleBatchChangeSize              int
 	GoogleBatchChangeInterval          time.Duration

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -67,6 +67,7 @@ type Config struct {
 	AlwaysPublishNotReadyAddresses     bool
 	ConnectorSourceServer              string
 	Provider                           string
+	ProviderCacheTime                  int
 	GoogleProject                      string
 	GoogleBatchChangeSize              int
 	GoogleBatchChangeInterval          time.Duration
@@ -234,6 +235,7 @@ var defaultConfig = &Config{
 	PublishHostIP:               false,
 	ConnectorSourceServer:       "localhost:8080",
 	Provider:                    "",
+	ProviderCacheTime:           0,
 	GoogleProject:               "",
 	GoogleBatchChangeSize:       1000,
 	GoogleBatchChangeInterval:   time.Second,
@@ -445,6 +447,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	// Flags related to providers
 	providers := []string{"akamai", "alibabacloud", "aws", "aws-sd", "azure", "azure-dns", "azure-private-dns", "bluecat", "civo", "cloudflare", "coredns", "designate", "digitalocean", "dnsimple", "dyn", "exoscale", "gandi", "godaddy", "google", "ibmcloud", "infoblox", "inmemory", "linode", "ns1", "oci", "ovh", "pdns", "pihole", "plural", "rcodezero", "rdns", "rfc2136", "safedns", "scaleway", "skydns", "tencentcloud", "transip", "ultradns", "vinyldns", "vultr"}
 	app.Flag("provider", "The DNS provider where the DNS records will be created (required, options: "+strings.Join(providers, ", ")+")").Required().PlaceHolder("provider").EnumVar(&cfg.Provider, providers...)
+	app.Flag("provider-cache-time", "The time to cache the DNS provider record list requests.").Default(defaultConfig.ProviderCacheTime.String()).DurationVar(&cfg.ProviderCacheTime)
 	app.Flag("domain-filter", "Limit possible target zones by a domain suffix; specify multiple times for multiple domains (optional)").Default("").StringsVar(&cfg.DomainFilter)
 	app.Flag("exclude-domains", "Exclude subdomains (optional)").Default("").StringsVar(&cfg.ExcludeDomains)
 	app.Flag("regex-domain-filter", "Limit possible domains and target zones by a Regex filter; Overrides domain-filter (optional)").Default(defaultConfig.RegexDomainFilter.String()).RegexpVar(&cfg.RegexDomainFilter)

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -510,7 +510,7 @@ func (p *AWSProvider) createUpdateChanges(newEndpoints, oldEndpoints []*endpoint
 }
 
 // GetDomainFilter generates a filter to exclude any domain that is not controlled by the provider
-func (p *AWSProvider) GetDomainFilter() endpoint.DomainFilter {
+func (p *AWSProvider) GetDomainFilter() endpoint.DomainFilterInterface {
 	zones, err := p.Zones(context.Background())
 	if err != nil {
 		log.Errorf("failed to list zones: %v", err)

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -316,10 +316,10 @@ func TestAWSZones(t *testing.T) {
 func TestAWSRecordsFilter(t *testing.T) {
 	provider, _ := newAWSProvider(t, endpoint.DomainFilter{}, provider.ZoneIDFilter{}, provider.ZoneTypeFilter{}, false, false, nil)
 	domainFilter := provider.GetDomainFilter()
-	assert.NotNil(t, domainFilter)
+	require.NotNil(t, domainFilter)
 	require.IsType(t, endpoint.DomainFilter{}, domainFilter)
 	count := 0
-	filters := domainFilter.Filters
+	filters := domainFilter.(endpoint.DomainFilter).Filters
 	for _, tld := range []string{
 		"zone-4.ext-dns-test-3.teapot.zalan.do",
 		".zone-4.ext-dns-test-3.teapot.zalan.do",

--- a/provider/cached_provider.go
+++ b/provider/cached_provider.go
@@ -72,6 +72,7 @@ func (c *CachedProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, err
 }
 func (c *CachedProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
 	if !changes.HasChanges() {
+		log.Info("Records cache provider: no changes to be applied")
 		return nil
 	}
 	c.Reset()

--- a/provider/cached_provider.go
+++ b/provider/cached_provider.go
@@ -1,0 +1,73 @@
+package provider
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+)
+
+var (
+	cachedRecordsCallsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "external_dns",
+			Subsystem: "provider",
+			Name:      "cache_records_calls",
+			Help:      "Number of calls to the provider cache Records list.",
+		},
+		[]string{
+			"from_cache",
+		},
+	)
+	cachedApplyChangesCallsTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "external_dns",
+			Subsystem: "provider",
+			Name:      "cache_apply_changes_calls",
+			Help:      "Number of calls to the provider cache ApplyChanges.",
+		},
+	)
+)
+
+type CachedProvider struct {
+	Provider
+	RefreshDelay time.Duration
+	err          error
+	lastRead     time.Time
+	cache        []*endpoint.Endpoint
+}
+
+func (c *CachedProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	if c.needRefresh() {
+		c.cache, c.err = c.Provider.Records(ctx)
+		c.lastRead = time.Now()
+		cachedRecordsCallsTotal.WithLabelValues("false").Inc()
+	} else {
+		cachedRecordsCallsTotal.WithLabelValues("true").Inc()
+	}
+	return c.cache, c.err
+}
+func (c *CachedProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
+	c.Reset()
+	cachedApplyChangesCallsTotal.Inc()
+	return c.Provider.ApplyChanges(ctx, changes)
+}
+
+func (c *CachedProvider) Reset() {
+	c.err = nil
+	c.cache = nil
+	c.lastRead = time.Time{}
+}
+
+func (c *CachedProvider) needRefresh() bool {
+	if c.cache == nil || c.err != nil {
+		return true
+	}
+	return time.Now().After(c.lastRead.Add(c.RefreshDelay))
+}
+
+func init() {
+	prometheus.MustRegister(cachedRecordsCallsTotal)
+}

--- a/provider/cached_provider.go
+++ b/provider/cached_provider.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
+
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 )

--- a/provider/cached_provider.go
+++ b/provider/cached_provider.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package provider
 
 import (

--- a/provider/cached_provider_test.go
+++ b/provider/cached_provider_test.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package provider
 
 import (

--- a/provider/cached_provider_test.go
+++ b/provider/cached_provider_test.go
@@ -1,0 +1,164 @@
+package provider
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+)
+
+type testProviderFunc struct {
+	records             func(ctx context.Context) ([]*endpoint.Endpoint, error)
+	applyChanges        func(ctx context.Context, changes *plan.Changes) error
+	propertyValuesEqual func(name string, previous string, current string) bool
+	adjustEndpoints     func(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint
+	getDomainFilter     func() endpoint.DomainFilterInterface
+}
+
+func (p *testProviderFunc) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	return p.records(ctx)
+}
+
+func (p *testProviderFunc) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
+	return p.applyChanges(ctx, changes)
+}
+
+func (p *testProviderFunc) PropertyValuesEqual(name string, previous string, current string) bool {
+	return p.propertyValuesEqual(name, previous, current)
+}
+
+func (p *testProviderFunc) AdjustEndpoints(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint {
+	return p.adjustEndpoints(endpoints)
+}
+
+func (p *testProviderFunc) GetDomainFilter() endpoint.DomainFilterInterface {
+	return p.getDomainFilter()
+}
+
+func recordsNotCalled(t *testing.T) func(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	return func(ctx context.Context) ([]*endpoint.Endpoint, error) {
+		t.Errorf("unexpected call to Records")
+		return nil, nil
+	}
+}
+
+func applyChangesNotCalled(t *testing.T) func(ctx context.Context, changes *plan.Changes) error {
+	return func(ctx context.Context, changes *plan.Changes) error {
+		t.Errorf("unexpected call to ApplyChanges")
+		return nil
+	}
+}
+
+func propertyValuesEqualNotCalled(t *testing.T) func(name string, previous string, current string) bool {
+	return func(name string, previous string, current string) bool {
+		t.Errorf("unexpected call to PropertyValuesEqual")
+		return false
+	}
+}
+
+func adjustEndpointsNotCalled(t *testing.T) func(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint {
+	return func(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint {
+		t.Errorf("unexpected call to AdjustEndpoints")
+		return endpoints
+	}
+}
+
+func newTestProviderFunc(t *testing.T) *testProviderFunc {
+	return &testProviderFunc{
+		records:             recordsNotCalled(t),
+		applyChanges:        applyChangesNotCalled(t),
+		propertyValuesEqual: propertyValuesEqualNotCalled(t),
+		adjustEndpoints:     adjustEndpointsNotCalled(t),
+	}
+}
+
+func TestCachedProviderCallsProviderOnFirstCall(t *testing.T) {
+	testProvider := newTestProviderFunc(t)
+	testProvider.records = func(ctx context.Context) ([]*endpoint.Endpoint, error) {
+		return []*endpoint.Endpoint{{DNSName: "domain.fqdn"}}, nil
+	}
+	provider := CachedProvider{
+		Provider: testProvider,
+	}
+	endpoints, err := provider.Records(context.Background())
+	assert.NoError(t, err)
+	require.NotNil(t, endpoints)
+	require.Len(t, endpoints, 1)
+	require.NotNil(t, endpoints[0])
+	assert.Equal(t, "domain.fqdn", endpoints[0].DNSName)
+}
+
+func TestCachedProviderUsesCacheWhileValid(t *testing.T) {
+	testProvider := newTestProviderFunc(t)
+	testProvider.records = func(ctx context.Context) ([]*endpoint.Endpoint, error) {
+		return []*endpoint.Endpoint{{DNSName: "domain.fqdn"}}, nil
+	}
+	provider := CachedProvider{
+		RefreshDelay: 30 * time.Second,
+		Provider:     testProvider,
+	}
+	_, err := provider.Records(context.Background())
+	require.NoError(t, err)
+
+	t.Run("With consecutive calls within the caching time frame", func(t *testing.T) {
+		testProvider.records = recordsNotCalled(t)
+		endpoints, err := provider.Records(context.Background())
+		assert.NoError(t, err)
+		require.NotNil(t, endpoints)
+		require.Len(t, endpoints, 1)
+		require.NotNil(t, endpoints[0])
+		assert.Equal(t, "domain.fqdn", endpoints[0].DNSName)
+	})
+
+	t.Run("When the caching time frame is exceeded", func(t *testing.T) {
+		testProvider.records = func(ctx context.Context) ([]*endpoint.Endpoint, error) {
+			return []*endpoint.Endpoint{{DNSName: "new.domain.fqdn"}}, nil
+		}
+		provider.lastRead = time.Now().Add(-20 * time.Minute)
+		endpoints, err := provider.Records(context.Background())
+		assert.NoError(t, err)
+		require.NotNil(t, endpoints)
+		require.Len(t, endpoints, 1)
+		require.NotNil(t, endpoints[0])
+		assert.Equal(t, "new.domain.fqdn", endpoints[0].DNSName)
+	})
+}
+
+func TestCachedProviderForcesCacheRefreshOnUpdate(t *testing.T) {
+	testProvider := newTestProviderFunc(t)
+	testProvider.records = func(ctx context.Context) ([]*endpoint.Endpoint, error) {
+		return []*endpoint.Endpoint{{DNSName: "domain.fqdn"}}, nil
+	}
+	provider := CachedProvider{
+		RefreshDelay: 30 * time.Second,
+		Provider:     testProvider,
+	}
+	_, err := provider.Records(context.Background())
+	require.NoError(t, err)
+
+	t.Run("When the caching time frame is exceeded", func(t *testing.T) {
+		testProvider.records = recordsNotCalled(t)
+		testProvider.applyChanges = func(ctx context.Context, changes *plan.Changes) error {
+			return nil
+		}
+		err := provider.ApplyChanges(context.Background(), &plan.Changes{})
+		assert.NoError(t, err)
+		t.Run("Next call to Records is not cached", func(t *testing.T) {
+			testProvider.applyChanges = applyChangesNotCalled(t)
+			testProvider.records = func(ctx context.Context) ([]*endpoint.Endpoint, error) {
+				return []*endpoint.Endpoint{{DNSName: "new.domain.fqdn"}}, nil
+			}
+			endpoints, err := provider.Records(context.Background())
+
+			assert.NoError(t, err)
+			require.NotNil(t, endpoints)
+			require.Len(t, endpoints, 1)
+			require.NotNil(t, endpoints[0])
+			assert.Equal(t, "new.domain.fqdn", endpoints[0].DNSName)
+		})
+	})
+}

--- a/provider/inmemory/inmemory.go
+++ b/provider/inmemory/inmemory.go
@@ -46,7 +46,7 @@ var (
 // initialized as dns provider with no records
 type InMemoryProvider struct {
 	provider.BaseProvider
-	domain         endpoint.DomainFilter
+	domain         endpoint.DomainFilterInterface
 	client         *inMemoryClient
 	filter         *filter
 	OnApplyChanges func(ctx context.Context, changes *plan.Changes)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -37,7 +37,7 @@ type Provider interface {
 	// unnecessary (potentially failing) changes. It may also modify other fields, add, or remove
 	// Endpoints. It is permitted to modify the supplied endpoints.
 	AdjustEndpoints(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint
-	GetDomainFilter() endpoint.DomainFilter
+	GetDomainFilter() endpoint.DomainFilterInterface
 }
 
 type BaseProvider struct{}
@@ -46,7 +46,7 @@ func (b BaseProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) []*endpoin
 	return endpoints
 }
 
-func (b BaseProvider) GetDomainFilter() endpoint.DomainFilter {
+func (b BaseProvider) GetDomainFilter() endpoint.DomainFilterInterface {
 	return endpoint.DomainFilter{}
 }
 

--- a/registry/aws_sd_registry.go
+++ b/registry/aws_sd_registry.go
@@ -42,7 +42,7 @@ func NewAWSSDRegistry(provider provider.Provider, ownerID string) (*AWSSDRegistr
 	}, nil
 }
 
-func (sdr *AWSSDRegistry) GetDomainFilter() endpoint.DomainFilter {
+func (sdr *AWSSDRegistry) GetDomainFilter() endpoint.DomainFilterInterface {
 	return sdr.provider.GetDomainFilter()
 }
 

--- a/registry/dynamodb.go
+++ b/registry/dynamodb.go
@@ -100,7 +100,7 @@ func NewDynamoDBRegistry(provider provider.Provider, ownerID string, dynamodbAPI
 	}, nil
 }
 
-func (im *DynamoDBRegistry) GetDomainFilter() endpoint.DomainFilter {
+func (im *DynamoDBRegistry) GetDomainFilter() endpoint.DomainFilterInterface {
 	return im.provider.GetDomainFilter()
 }
 

--- a/registry/noop.go
+++ b/registry/noop.go
@@ -36,7 +36,7 @@ func NewNoopRegistry(provider provider.Provider) (*NoopRegistry, error) {
 	}, nil
 }
 
-func (im *NoopRegistry) GetDomainFilter() endpoint.DomainFilter {
+func (im *NoopRegistry) GetDomainFilter() endpoint.DomainFilterInterface {
 	return im.provider.GetDomainFilter()
 }
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -33,7 +33,7 @@ type Registry interface {
 	Records(ctx context.Context) ([]*endpoint.Endpoint, error)
 	ApplyChanges(ctx context.Context, changes *plan.Changes) error
 	AdjustEndpoints(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint
-	GetDomainFilter() endpoint.DomainFilter
+	GetDomainFilter() endpoint.DomainFilterInterface
 }
 
 // TODO(ideahitme): consider moving this to Plan

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -93,7 +93,7 @@ func getSupportedTypes() []string {
 	return []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME, endpoint.RecordTypeNS}
 }
 
-func (im *TXTRegistry) GetDomainFilter() endpoint.DomainFilter {
+func (im *TXTRegistry) GetDomainFilter() endpoint.DomainFilterInterface {
 	return im.provider.GetDomainFilter()
 }
 


### PR DESCRIPTION
**Description**

In the current implementation, DNS providers are called to list all records on every loop. This is expensive in terms of number of requests to the provider and may result in being rate limited, as reported in 1293 and 3397.

In our case, we have approximately 20,000 records in our AWS Hosted Zone. The ListResourceRecordSets API call allows a maximum of 300 items per call. That requires 67 API calls per external-dns deployment during every sync period

With this, we introduce an optional generic caching mechanism at the provider level, that re-uses the latest known list of records for a given time.

This prevents from expensive Provider calls to list all records for each object modification that does not change the actual record (annotations, statuses, ingress routing, ...)

This introduces 2 trade-offs:

1. Any changes or corruption directly on the provider side will be longer to detect and to resolve, up to the cache time

2. Any conflicting records in the DNS provider (such as a different external-dns instance) injected during the cache validity will cause the first iteration of the next reconcile loop to fail, and hence add a delay until the next retry

**Checklist**

- [X] Unit tests updated
- [X] End user documentation updated


