### PR TITLE
Provider GoDaddy fix domain update

### DIFF
--- a/provider/godaddy/client.go
+++ b/provider/godaddy/client.go
@@ -23,9 +23,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
+	"strconv"
 	"time"
 
+	"golang.org/x/time/rate"
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 )
 
@@ -71,6 +74,9 @@ type Client struct {
 	// Client is the underlying HTTP client used to run the requests. It may be overloaded but a default one is instanciated in ``NewClient`` by default.
 	Client *http.Client
 
+	// GoDaddy limits to 60 requests per minute
+	Ratelimiter *rate.Limiter
+
 	// Logger is used to log HTTP requests and responses.
 	Logger Logger
 
@@ -115,6 +121,7 @@ func NewClient(useOTE bool, apiKey, apiSecret string) (*Client, error) {
 		APISecret:   apiSecret,
 		APIEndPoint: endpoint,
 		Client:      &http.Client{},
+		Ratelimiter: rate.NewLimiter(rate.Every(60*time.Second), 60),
 		Timeout:     DefaultTimeout,
 	}
 
@@ -216,7 +223,22 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	if c.Logger != nil {
 		c.Logger.LogRequest(req)
 	}
+
+	c.Ratelimiter.Wait(req.Context())
 	resp, err := c.Client.Do(req)
+	// In case of several clients behind NAT we still can hit rate limit
+	for i := 1; i < 3 && err == nil && resp.StatusCode == 429; i++ {
+		retryAfter, _ := strconv.ParseInt(resp.Header.Get("Retry-After"), 10, 0)
+
+		jitter := rand.Int63n(int64(retryAfter))
+		retryAfterSec := retryAfter + jitter/2
+
+		sleepTime := time.Duration(retryAfterSec) * time.Second
+		time.Sleep(sleepTime)
+
+		c.Ratelimiter.Wait(req.Context())
+		resp, err = c.Client.Do(req)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/provider/godaddy/client.go
+++ b/provider/godaddy/client.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"golang.org/x/time/rate"
+
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 )
 
@@ -230,7 +231,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	for i := 1; i < 3 && err == nil && resp.StatusCode == 429; i++ {
 		retryAfter, _ := strconv.ParseInt(resp.Header.Get("Retry-After"), 10, 0)
 
-		jitter := rand.Int63n(int64(retryAfter))
+		jitter := rand.Int63n(retryAfter)
 		retryAfterSec := retryAfter + jitter/2
 
 		sleepTime := time.Duration(retryAfterSec) * time.Second

--- a/provider/godaddy/godaddy.go
+++ b/provider/godaddy/godaddy.go
@@ -247,7 +247,7 @@ func (p *GDProvider) records(ctx *context.Context, zone string, all bool) (*gdRe
 
 			results.records = append(results.records, rec)
 		} else {
-			log.Infof("GoDaddy: Discard record %s for %s is %+v", rec.Name, zone, rec)
+			log.Infof("GoDaddy: Ignore record %s for %s is %+v", rec.Name, zone, rec)
 		}
 	}
 

--- a/provider/godaddy/godaddy.go
+++ b/provider/godaddy/godaddy.go
@@ -34,13 +34,13 @@ import (
 const (
 	gdMinimalTTL = 600
 	gdCreate     = 0
-	gdUpdate     = 1
+	gdReplace    = 1
 	gdDelete     = 2
 )
 
 var actionNames = []string{
 	"create",
-	"update",
+	"replace",
 	"delete",
 }
 
@@ -82,11 +82,9 @@ type gdRecordField struct {
 	Service  *string `json:"service,omitempty"`
 }
 
-type gdUpdateRecordField struct {
+type gdReplaceRecordField struct {
 	Data     string  `json:"data"`
-	Name     string  `json:"name"`
 	TTL      int64   `json:"ttl"`
-	Type     string  `json:"type"`
 	Port     *int    `json:"port,omitempty"`
 	Priority *int    `json:"priority,omitempty"`
 	Weight   *int64  `json:"weight,omitempty"`
@@ -356,28 +354,33 @@ func (p *GDProvider) changeAllRecords(endpoints []gdEndpoint, zoneRecords []*gdR
 				dnsName = "@"
 			}
 
-			for _, target := range e.endpoint.Targets {
-				change := gdRecordField{
-					Type: e.endpoint.RecordType,
-					Name: dnsName,
-					TTL:  p.ttl,
-					Data: target,
-				}
+			e.endpoint.RecordTTL = endpoint.TTL(maxOf(gdMinimalTTL, int64(e.endpoint.RecordTTL)))
 
-				if e.endpoint.RecordTTL.IsConfigured() {
-					change.TTL = maxOf(gdMinimalTTL, int64(e.endpoint.RecordTTL))
-				}
+			if err := zoneRecord.applyEndpoint(e.action, p.client, *e.endpoint, dnsName, p.DryRun); err != nil {
+				log.Errorf("Unable to apply change %s on record %s type %s, %v", actionNames[e.action], dnsName, e.endpoint.RecordType, err)
 
-				if err := zoneRecord.applyChange(e.action, p.client, change, p.DryRun); err != nil {
-					log.Errorf("Unable to apply change %s on record %s, %v", actionNames[e.action], change, err)
-
-					return err
-				}
+				return err
 			}
 		}
 	}
 
 	return nil
+}
+
+func (p *GDProvider) endpointEqual(l *endpoint.Endpoint, r *endpoint.Endpoint) bool {
+	if l.DNSName != r.DNSName || l.RecordType!= r.RecordType {
+		return false
+	}
+
+	if ! l.Targets.Same(r.Targets) {
+		return false
+	}
+
+	if l.RecordTTL != r.RecordTTL {
+		return false
+	}
+
+	return true
 }
 
 // ApplyChanges applies a given set of changes in a given zone.
@@ -397,11 +400,29 @@ func (p *GDProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) er
 		changedZoneRecords[i] = &records[i]
 	}
 
-	allChanges := make([]gdEndpoint, 0, countTargets(changes))
+	var allChanges []gdEndpoint
 
 	allChanges = p.appendChange(gdDelete, changes.Delete, allChanges)
-	allChanges = p.appendChange(gdDelete, changes.UpdateOld, allChanges)
-	allChanges = p.appendChange(gdUpdate, changes.UpdateNew, allChanges)
+
+	for _, recOld := range changes.UpdateOld {
+		for _, recNew := range changes.UpdateNew {
+			if recOld.DNSName != recNew.DNSName {
+                continue
+            }
+
+			if ! p.endpointEqual(recOld, recNew) {
+				DeleteEndpoints := []*endpoint.Endpoint{recOld}
+				PatchEndpoints := []*endpoint.Endpoint{recNew}
+				if recOld.RecordType == recNew.RecordType {
+					allChanges = p.appendChange(gdReplace, PatchEndpoints, allChanges)
+				} else {
+					allChanges = p.appendChange(gdDelete, DeleteEndpoints, allChanges)
+					allChanges = p.appendChange(gdCreate, PatchEndpoints, allChanges)
+				}
+			}
+		}
+	}
+
 	allChanges = p.appendChange(gdCreate, changes.Create, allChanges)
 
 	log.Infof("GoDaddy: %d changes will be done", len(allChanges))
@@ -413,18 +434,75 @@ func (p *GDProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) er
 	return nil
 }
 
-func (p *gdRecords) addRecord(client gdClient, change gdRecordField, dryRun bool) error {
+func (p *gdRecords) addRecord(client gdClient, endpoint endpoint.Endpoint, dnsName string, dryRun bool) error {
+	var response GDErrorResponse
+	for _, target := range endpoint.Targets {
+		change := gdRecordField{
+			Type: endpoint.RecordType,
+			Name: dnsName,
+			TTL:  int64(endpoint.RecordTTL),
+			Data: target,
+		}
+
+		p.records = append(p.records, change)
+		p.changed = true
+
+		log.Debugf("GoDaddy: Add an entry %s to zone %s", change.String(), p.zone)
+		if dryRun {
+			log.Infof("[DryRun] - Add record %s.%s of type %s %s", change.Name, p.zone, change.Type, toString(change))
+		} else if err := client.Patch(fmt.Sprintf("/v1/domains/%s/records", p.zone), []gdRecordField{change}, &response); err != nil {
+			log.Errorf("Add record %s.%s of type %s failed: %s", change.Name, p.zone, change.Type, response)
+
+			return err
+		}
+
+	}
+
+	return nil
+}
+
+func (p *gdRecords) replaceRecord(client gdClient, endpoint endpoint.Endpoint, dnsName string, dryRun bool) error {
+	changed := []gdReplaceRecordField{}
+	records := []string{}
+
+	for _, target := range endpoint.Targets {
+		change := gdRecordField{
+			Type: endpoint.RecordType,
+			Name: dnsName,
+			TTL:  int64(endpoint.RecordTTL),
+			Data: target,
+		}
+
+		for index, record := range p.records {
+			if record.Type == change.Type && record.Name == change.Name {
+				p.records[index] = change
+				p.changed = true
+			}
+		}
+		records = append(records, target)
+		changed = append(changed, gdReplaceRecordField{
+			Data:     change.Data,
+			TTL:      change.TTL,
+			Port:     change.Port,
+			Priority: change.Priority,
+			Weight:   change.Weight,
+			Protocol: change.Protocol,
+			Service:  change.Service,
+		})
+	}
+
 	var response GDErrorResponse
 
-	log.Debugf("GoDaddy: Add an entry %s to zone %s", change.String(), p.zone)
-
-	p.records = append(p.records, change)
-	p.changed = true
 
 	if dryRun {
-		log.Infof("[DryRun] - Add record %s.%s of type %s %s", change.Name, p.zone, change.Type, toString(change))
-	} else if err := client.Patch(fmt.Sprintf("/v1/domains/%s/records", p.zone), []gdRecordField{change}, &response); err != nil {
-		log.Errorf("Add record %s.%s of type %s failed: %s", change.Name, p.zone, change.Type, response)
+		log.Infof("[DryRun] - Replace record %s.%s of type %s %s", dnsName, p.zone, endpoint.RecordType, records)
+
+		return nil
+	}
+
+	log.Debugf("Replace record %s.%s of type %s %s", dnsName, p.zone, endpoint.RecordType, records)
+	if err := client.Put(fmt.Sprintf("/v1/domains/%s/records/%s/%s", p.zone, endpoint.RecordType, dnsName), changed, &response); err != nil {
+		log.Errorf("Replace record %s.%s of type %s failed: %v", dnsName, p.zone, endpoint.RecordType, response)
 
 		return err
 	}
@@ -432,88 +510,63 @@ func (p *gdRecords) addRecord(client gdClient, change gdRecordField, dryRun bool
 	return nil
 }
 
-func (p *gdRecords) updateRecord(client gdClient, change gdRecordField, dryRun bool) error {
-	log.Debugf("GoDaddy: Update an entry %s to zone %s", change.String(), p.zone)
-
-	for index, record := range p.records {
-		if record.Type == change.Type && record.Name == change.Name {
-			var response GDErrorResponse
-
-			p.records[index] = change
-			p.changed = true
-
-			changed := []gdUpdateRecordField{{
-				Data:     change.Data,
-				Name:     change.Name,
-				TTL:      change.TTL,
-				Type:     change.Type,
-				Port:     change.Port,
-				Priority: change.Priority,
-				Weight:   change.Weight,
-				Protocol: change.Protocol,
-				Service:  change.Service,
-			}}
-
-			if dryRun {
-				log.Infof("[DryRun] - Update record %s.%s of type %s %s", change.Name, p.zone, change.Type, toString(changed))
-			} else if err := client.Patch(fmt.Sprintf("/v1/domains/%s/records", p.zone), changed, &response); err != nil {
-				log.Errorf("Update record %s.%s of type %s failed: %v", change.Name, p.zone, change.Type, response)
-
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
 // Remove one record from the record list
-func (p *gdRecords) deleteRecord(client gdClient, change gdRecordField, dryRun bool) error {
-	log.Debugf("GoDaddy: Delete an entry %s to zone %s", change.String(), p.zone)
+func (p *gdRecords) deleteRecord(client gdClient, endpoint endpoint.Endpoint, dnsName string, dryRun bool) error {
+	records := []string{}
 
-	deleteIndex := -1
-
-	for index, record := range p.records {
-		if record.Type == change.Type && record.Name == change.Name && record.Data == change.Data {
-			deleteIndex = index
-			break
+	for _, target := range endpoint.Targets {
+		change := gdRecordField{
+			Type: endpoint.RecordType,
+			Name: dnsName,
+			TTL:  int64(endpoint.RecordTTL),
+			Data: target,
 		}
-	}
+		records = append(records, target)
 
-	if deleteIndex >= 0 {
-		var response GDErrorResponse
+		log.Debugf("GoDaddy: Delete an entry %s from zone %s", change.String(), p.zone)
 
-		p.records[deleteIndex] = p.records[len(p.records)-1]
+		deleteIndex := -1
 
-		p.records = p.records[:len(p.records)-1]
-		p.changed = true
-
-		if dryRun {
-			log.Infof("[DryRun] - Delete record %s.%s of type %s %s", change.Name, p.zone, change.Type, toString(change))
-		} else if err := client.Delete(fmt.Sprintf("/v1/domains/%s/records/%s/%s", p.zone, change.Type, change.Name), &response); err != nil {
-			log.Errorf("Delete record %s.%s of type %s failed: %v", change.Name, p.zone, change.Type, response)
-
-			if strings.Contains(err.Error(), "RECORD_NOT_FOUND") {
-				log.Debugf("Handle not found - already deleted?")
-			} else {
-				return err
+		for index, record := range p.records {
+			if record.Type == change.Type && record.Name == change.Name && record.Data == change.Data {
+				deleteIndex = index
+				break
 			}
 		}
-	} else {
-		log.Warnf("GoDaddy: record in zone %s not found %s to delete", p.zone, change.String())
+
+		if deleteIndex >= 0 {
+			p.records[deleteIndex] = p.records[len(p.records)-1]
+
+			p.records = p.records[:len(p.records)-1]
+			p.changed = true
+		}
+
+	}
+
+	if dryRun {
+		log.Infof("[DryRun] - Delete record %s.%s of type %s %s", dnsName, p.zone, endpoint.RecordType, records)
+
+		return nil
+	}
+
+	var response GDErrorResponse
+	if err := client.Delete(fmt.Sprintf("/v1/domains/%s/records/%s/%s", p.zone, endpoint.RecordType, dnsName), &response); err != nil {
+		log.Errorf("Delete record %s.%s of type %s failed: %v", dnsName, p.zone, endpoint.RecordType, response)
+
+		return err
 	}
 
 	return nil
 }
 
-func (p *gdRecords) applyChange(action int, client gdClient, change gdRecordField, dryRun bool) error {
+func (p *gdRecords) applyEndpoint(action int, client gdClient, endpoint endpoint.Endpoint, dnsName string, dryRun bool) error {
 	switch action {
 	case gdCreate:
-		return p.addRecord(client, change, dryRun)
-	case gdUpdate:
-		return p.updateRecord(client, change, dryRun)
+		return p.addRecord(client, endpoint, dnsName, dryRun)
+	case gdReplace:
+		return p.replaceRecord(client, endpoint, dnsName, dryRun)
 	case gdDelete:
-		return p.deleteRecord(client, change, dryRun)
+		return p.deleteRecord(client, endpoint, dnsName, dryRun)
 	}
 
 	return nil


### PR DESCRIPTION
**Description**

(I'm not Go dev so sorry if I do it too wrong)
Fix handling of second-level domains like `example.com`
Handle it in an obvious way because the old check was not supposed for that.
GoDaddy API used in the right way: https://developer.godaddy.com/doc/endpoint/domains
Check changes and only apply what actually changed.
Use PUT for record replacement (API doesn't allow partial updates or deletes).

Additionally:
* some simple rate limit handling (I have much more than 60 domains, and just realize that while debugging).
* Fix misleading `Discard` message, because as an end-user I several times got bald
* Tested on my environments, docker image: `public.ecr.aws/xflow-ltd/external-dns:0.13.5`

Old log, with lost of TXT records and broken dns
```
time="2021-12-08T12:32:44Z" level=warning msg="GoDaddy: record in zone apvcascade.dev not found apvcascade.dev 600 IN A 54.74.22.121 to delete"
time="2021-12-08T12:32:45Z" level=error msg="Add record apvcascade.dev.apvcascade.dev of type A failed: {\"code\":\"\"}"
time="2021-12-08T12:32:45Z" level=error msg="Unable to apply change create on record apvcascade.dev 600 IN A 34.245.127.123, Error DUPLICATE_RECORD: \"Another record with the same attributes already exists\""
time="2021-12-08T12:32:45Z" level=error msg="Error DUPLICATE_RECORD: \"Another record with the same attributes already exists\""
time="2021-12-08T12:33:45Z" level=info msg="GoDaddy: 4 zones found"
```

New log:
```
{"level":"info","msg":"GoDaddy: 6 changes will be done","time":"2023-02-22T18:32:34+01:00"}
{"level":"debug","msg":"GoDaddy: Delete an entry @ 600 IN A 34.246.198.255 to zone hdomain.dev","time":"2023-02-22T18:32:34+01:00"}
{"level":"debug","msg":"GoDaddy: Delete an entry @ 600 IN A 54.155.26.162 to zone hdomain.dev","time":"2023-02-22T18:32:34+01:00"}
{"level":"error","msg":"Delete record @.hdomain.dev of type A failed: {\"code\":\"\"}","time":"2023-02-22T18:32:34+01:00"}
{"level":"debug","msg":"Handle not found - already deleted?","time":"2023-02-22T18:32:34+01:00"}
{"level":"debug","msg":"GoDaddy: Delete an entry @ 600 IN A 54.194.62.197 to zone hdomain.dev","time":"2023-02-22T18:32:34+01:00"}
{"level":"error","msg":"Delete record @.hdomain.dev of type A failed: {\"code\":\"\"}","time":"2023-02-22T18:32:35+01:00"}
{"level":"debug","msg":"Handle not found - already deleted?","time":"2023-02-22T18:32:35+01:00"}
{"level":"debug","msg":"GoDaddy: Delete an entry external-dns 600 IN TXT \"heritage=external-dns,external-dns/owner=eks-dev,external-dns/resource=ingress/med/clickhouse\" to zone hdomain.dev","time":"2023-02-22T18:32:35+01:00"}
{"level":"debug","msg":"Skipping record external-dns.a-hdomain.dev because no hosted zone matching record DNS Name was detected","time":"2023-02-22T18:32:35+01:00"}
{"level":"debug","msg":"GoDaddy: Update an entry @ 600 IN A 54.155.26.162 to zone hdomain.dev","time":"2023-02-22T18:32:35+01:00"}
{"level":"debug","msg":"GoDaddy: Update an entry @ 600 IN A 54.194.250.28 to zone hdomain.dev","time":"2023-02-22T18:32:35+01:00"}
{"level":"debug","msg":"GoDaddy: Update an entry @ 600 IN A 54.194.62.197 to zone hdomain.dev","time":"2023-02-22T18:32:35+01:00"}
{"level":"debug","msg":"GoDaddy: Update an entry external-dns 600 IN TXT \"heritage=external-dns,external-dns/owner=eks-dev,external-dns/resource=ingress/med/clickhouse\" to zone hdomain.dev","time":"2023-02-22T18:32:35+01:00"}
{"level":"debug","msg":"Skipping record external-dns.a-hdomain.dev because no hosted zone matching record DNS Name was detected","time":"2023-02-22T18:32:35+01:00"}
{"level":"debug","msg":"GoDaddy: hdomain.dev zone found","time":"2023-02-22T18:33:34+01:00"}
```

Fixes #2467

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
