### PR TITLE
fix: nodePort #2704 - publish ready endpoints

### DIFF
--- a/source/service_test.go
+++ b/source/service_test.go
@@ -1632,6 +1632,7 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 		phases                   []v1.PodPhase
 		conditions               []v1.PodCondition
 		labelSelector            labels.Selector
+		deletionTimestamp        []*metav1.Time
 	}{
 		{
 			title:            "annotated NodePort services return an endpoint with IP addresses of the cluster's nodes",
@@ -1818,7 +1819,8 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 			podNames:  []string{"pod-0"},
 			nodeIndex: []int{1},
 			phases:    []v1.PodPhase{v1.PodRunning},
-			conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+			conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionFalse}},
+			deletionTimestamp: []*metav1.Time{{}},
 		},
 		{
 			title:            "annotated NodePort services with ExternalTrafficPolicy=Local and multiple pods on a single node return an endpoint with unique IP addresses of the cluster's nodes where pods is running only",
@@ -1862,9 +1864,10 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 			nodeIndex: []int{1, 1},
 			phases:    []v1.PodPhase{v1.PodRunning, v1.PodRunning},
 			conditions: []v1.PodCondition{
-				{Type: v1.PodReady, Status: v1.ConditionTrue},
-				{Type: v1.PodReady, Status: v1.ConditionTrue},
+				{Type: v1.PodReady, Status: v1.ConditionFalse},
+				{Type: v1.PodReady, Status: v1.ConditionFalse},
 			},
+			deletionTimestamp: []*metav1.Time{{},{}},
 		},
 		{
 			title:            "annotated NodePort services with ExternalTrafficPolicy=Local return pods in Ready & Running state",
@@ -1908,6 +1911,62 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 				{Type: v1.PodReady, Status: v1.ConditionTrue},
 				{Type: v1.PodReady, Status: v1.ConditionFalse},
 			},
+			deletionTimestamp: []*metav1.Time{{},{}},
+		},
+		{
+			title:            "annotated NodePort services with ExternalTrafficPolicy=Local return pods in Ready & Running state & not in Terminating",
+			svcNamespace:     "testing",
+			svcName:          "foo",
+			svcType:          v1.ServiceTypeNodePort,
+			svcTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+			labels:           map[string]string{},
+			annotations: map[string]string{
+				hostnameAnnotationKey: "foo.example.org.",
+			},
+			expected: []*endpoint.Endpoint{
+				{DNSName: "_foo._tcp.foo.example.org", Targets: endpoint.Targets{"0 50 30192 foo.example.org"}, RecordType: endpoint.RecordTypeSRV},
+				{DNSName: "foo.example.org", Targets: endpoint.Targets{"54.10.11.1"}, RecordType: endpoint.RecordTypeA},
+			},
+			nodes: []*v1.Node{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{Type: v1.NodeExternalIP, Address: "54.10.11.1"},
+						{Type: v1.NodeInternalIP, Address: "10.0.1.1"},
+					},
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node2",
+				},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{Type: v1.NodeExternalIP, Address: "54.10.11.2"},
+						{Type: v1.NodeInternalIP, Address: "10.0.1.2"},
+					},
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node3",
+				},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{Type: v1.NodeExternalIP, Address: "54.10.11.3"},
+						{Type: v1.NodeInternalIP, Address: "10.0.1.3"},
+					},
+				},
+			}},
+			podNames:  []string{"pod-0", "pod-1", "pod-2"},
+			nodeIndex: []int{0, 1, 2},
+			phases:    []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodRunning},
+			conditions: []v1.PodCondition{
+				{Type: v1.PodReady, Status: v1.ConditionTrue},
+				{Type: v1.PodReady, Status: v1.ConditionFalse},
+				{Type: v1.PodReady, Status: v1.ConditionTrue},
+			},
+			deletionTimestamp: []*metav1.Time{nil, nil, {}},
 		},
 		{
 			title:            "access=private annotation NodePort services return an endpoint with private IP addresses of the cluster's nodes",
@@ -2199,6 +2258,7 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 						Name:        podname,
 						Labels:      tc.labels,
 						Annotations: tc.annotations,
+						DeletionTimestamp: tc.deletionTimestamp[i],
 					},
 					Status: v1.PodStatus{
 						Phase: tc.phases[i],

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -1630,6 +1630,7 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 		podNames                 []string
 		nodeIndex                []int
 		phases                   []v1.PodPhase
+		conditions               []v1.PodCondition
 		labelSelector            labels.Selector
 	}{
 		{
@@ -1817,6 +1818,7 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 			podNames:  []string{"pod-0"},
 			nodeIndex: []int{1},
 			phases:    []v1.PodPhase{v1.PodRunning},
+			conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
 		},
 		{
 			title:            "annotated NodePort services with ExternalTrafficPolicy=Local and multiple pods on a single node return an endpoint with unique IP addresses of the cluster's nodes where pods is running only",
@@ -1859,6 +1861,53 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 			podNames:  []string{"pod-0", "pod-1"},
 			nodeIndex: []int{1, 1},
 			phases:    []v1.PodPhase{v1.PodRunning, v1.PodRunning},
+			conditions: []v1.PodCondition{
+				{Type: v1.PodReady, Status: v1.ConditionTrue},
+				{Type: v1.PodReady, Status: v1.ConditionTrue},
+			},
+		},
+		{
+			title:            "annotated NodePort services with ExternalTrafficPolicy=Local return pods in Ready & Running state",
+			svcNamespace:     "testing",
+			svcName:          "foo",
+			svcType:          v1.ServiceTypeNodePort,
+			svcTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+			labels:           map[string]string{},
+			annotations: map[string]string{
+				hostnameAnnotationKey: "foo.example.org.",
+			},
+			expected: []*endpoint.Endpoint{
+				{DNSName: "_foo._tcp.foo.example.org", Targets: endpoint.Targets{"0 50 30192 foo.example.org"}, RecordType: endpoint.RecordTypeSRV},
+				{DNSName: "foo.example.org", Targets: endpoint.Targets{"54.10.11.1"}, RecordType: endpoint.RecordTypeA},
+			},
+			nodes: []*v1.Node{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{Type: v1.NodeExternalIP, Address: "54.10.11.1"},
+						{Type: v1.NodeInternalIP, Address: "10.0.1.1"},
+					},
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node2",
+				},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{Type: v1.NodeExternalIP, Address: "54.10.11.2"},
+						{Type: v1.NodeInternalIP, Address: "10.0.1.2"},
+					},
+				},
+			}},
+			podNames:  []string{"pod-0", "pod-1"},
+			nodeIndex: []int{0, 1},
+			phases:    []v1.PodPhase{v1.PodRunning, v1.PodRunning},
+			conditions: []v1.PodCondition{
+				{Type: v1.PodReady, Status: v1.ConditionTrue},
+				{Type: v1.PodReady, Status: v1.ConditionFalse},
+			},
 		},
 		{
 			title:            "access=private annotation NodePort services return an endpoint with private IP addresses of the cluster's nodes",
@@ -2153,6 +2202,7 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					},
 					Status: v1.PodStatus{
 						Phase: tc.phases[i],
+						Conditions: []v1.PodCondition{tc.conditions[i]},
 					},
 				}
 


### PR DESCRIPTION
**Description**
External-dns handles nodePort differently to Service endpoints - Ignore pod status
Implement logic to check pod status and publish only ready & running pods instead of all.

Fixes #2704 

Additionally:
* Tested on my environments, docker image: `public.ecr.aws/xflow-ltd/external-dns:0.13.5`

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
