### PR TITLE
Allow annotation target override on gateway

### DIFF
--- a/docs/annotations/annotations.md
+++ b/docs/annotations/annotations.md
@@ -12,7 +12,7 @@ The following table documents which sources support which annotations:
 | CloudFoundry |            |          |                   |         |     |                     |
 | CRD          |            |          |                   |         |     |                     |
 | F5           |            |          |                   |         | Yes |                     |
-| Gateway      | Yes        | Yes[^1]  |                   |         | Yes | Yes                 |
+| Gateway      | Yes        | Yes[^1]  |                   | Yes[^4] | Yes | Yes                 |
 | Gloo         |            |          |                   |         | Yes | Yes                 |
 | Ingress      | Yes        | Yes[^1]  |                   | Yes     | Yes | Yes                 |
 | Istio        | Yes        | Yes[^1]  |                   | Yes     | Yes | Yes                 |
@@ -27,6 +27,7 @@ The following table documents which sources support which annotations:
 [^1]: Unless the `--ignore-hostname-annotation` flag is specified.
 [^2]: Only behaves differently than `hostname` for `Service`s of type `LoadBalancer`.
 [^3]: Also supported on `Pods` referenced from a headless `Service`'s `Endpoints`.
+[^4]: The annotation should be on the `Gateway`
 
 ## external-dns.alpha.kubernetes.io/access
 

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -354,7 +354,7 @@ func (c *gatewayRouteResolver) resolve(rt gatewayRoute) (map[string]endpoint.Tar
 				}
 				override := getTargetsFromTargetAnnotation(gw.gateway.Annotations)
 				hostTargets[host] = append(hostTargets[host], override...)
-				if override == nil {
+				if len(override) == 0 {
 					for _, addr := range gw.gateway.Status.Addresses {
 						hostTargets[host] = append(hostTargets[host], addr.Value)
 					}

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -352,8 +352,12 @@ func (c *gatewayRouteResolver) resolve(rt gatewayRoute) (map[string]endpoint.Tar
 				if !ok {
 					continue
 				}
-				for _, addr := range gw.gateway.Status.Addresses {
-					hostTargets[host] = append(hostTargets[host], addr.Value)
+				override := getTargetsFromTargetAnnotation(gw.gateway.Annotations)
+				hostTargets[host] = append(hostTargets[host], override...)
+				if override == nil {
+					for _, addr := range gw.gateway.Status.Addresses {
+						hostTargets[host] = append(hostTargets[host], addr.Value)
+					}
 				}
 				match = true
 			}

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -1033,6 +1033,128 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			}},
 			endpoints: nil,
 		},
+		{
+			title: "AnnotationOverride",
+			config: Config{
+				GatewayNamespace: "gateway-namespace",
+			},
+			namespaces: namespaces("gateway-namespace", "route-namespace"),
+			gateways: []*v1beta1.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "overriden-gateway",
+						Namespace: "gateway-namespace",
+						Annotations: map[string]string{
+							targetAnnotationKey: "4.3.2.1",
+						},
+					},
+					Spec: v1beta1.GatewaySpec{
+						Listeners: []v1beta1.Listener{{
+							Protocol:      v1beta1.HTTPProtocolType,
+							AllowedRoutes: allowAllNamespaces,
+						}},
+					},
+					Status: gatewayStatus("1.2.3.4"),
+				},
+			},
+			routes: []*v1beta1.HTTPRoute{{
+				ObjectMeta: objectMeta("route-namespace", "test"),
+				Spec: v1beta1.HTTPRouteSpec{
+					Hostnames: hostnames("test.example.internal"),
+				},
+				Status: httpRouteStatus( // The route is attached to both gateways.
+					gatewayParentRef("gateway-namespace", "overriden-gateway"),
+				),
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("test.example.internal", "A", "4.3.2.1"),
+			},
+		},
+		{
+			title: "AnnotationOverrideMultipleStatusAddresses",
+			config: Config{
+				GatewayNamespace: "gateway-namespace",
+			},
+			namespaces: namespaces("gateway-namespace", "route-namespace"),
+			gateways: []*v1beta1.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "overriden-gateway",
+						Namespace: "gateway-namespace",
+						Annotations: map[string]string{
+							targetAnnotationKey: "4.3.2.1",
+						},
+					},
+					Spec: v1beta1.GatewaySpec{
+						Listeners: []v1beta1.Listener{{
+							Protocol:      v1beta1.HTTPProtocolType,
+							AllowedRoutes: allowAllNamespaces,
+						}},
+					},
+					Status: gatewayStatus("1.2.3.4", "2.3.4.5"),
+				},
+			},
+			routes: []*v1beta1.HTTPRoute{{
+				ObjectMeta: objectMeta("route-namespace", "test"),
+				Spec: v1beta1.HTTPRouteSpec{
+					Hostnames: hostnames("test.example.internal"),
+				},
+				Status: httpRouteStatus( // The route is attached to both gateways.
+					gatewayParentRef("gateway-namespace", "overriden-gateway"),
+				),
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("test.example.internal", "A", "4.3.2.1"),
+			},
+		},
+		{
+			title: "MutlipleGatewaysOneAnnotationOverride",
+			config: Config{
+				GatewayNamespace: "gateway-namespace",
+			},
+			namespaces: namespaces("gateway-namespace", "route-namespace"),
+			gateways: []*v1beta1.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "overriden-gateway",
+						Namespace: "gateway-namespace",
+						Annotations: map[string]string{
+							targetAnnotationKey: "4.3.2.1",
+						},
+					},
+					Spec: v1beta1.GatewaySpec{
+						Listeners: []v1beta1.Listener{{
+							Protocol:      v1beta1.HTTPProtocolType,
+							AllowedRoutes: allowAllNamespaces,
+						}},
+					},
+					Status: gatewayStatus("1.2.3.4"),
+				},
+				{
+					ObjectMeta: objectMeta("gateway-namespace", "test"),
+					Spec: v1beta1.GatewaySpec{
+						Listeners: []v1beta1.Listener{{
+							Protocol:      v1beta1.HTTPProtocolType,
+							AllowedRoutes: allowAllNamespaces,
+						}},
+					},
+					Status: gatewayStatus("2.3.4.5"),
+				},
+			},
+			routes: []*v1beta1.HTTPRoute{{
+				ObjectMeta: objectMeta("route-namespace", "test"),
+				Spec: v1beta1.HTTPRouteSpec{
+					Hostnames: hostnames("test.example.internal"),
+				},
+				Status: httpRouteStatus( // The route is attached to both gateways.
+					gatewayParentRef("gateway-namespace", "overriden-gateway"),
+					gatewayParentRef("gateway-namespace", "test"),
+				),
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("test.example.internal", "A", "4.3.2.1", "2.3.4.5"),
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -1071,43 +1071,6 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			},
 		},
 		{
-			title: "AnnotationOverrideMultipleStatusAddresses",
-			config: Config{
-				GatewayNamespace: "gateway-namespace",
-			},
-			namespaces: namespaces("gateway-namespace", "route-namespace"),
-			gateways: []*v1beta1.Gateway{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "overriden-gateway",
-						Namespace: "gateway-namespace",
-						Annotations: map[string]string{
-							targetAnnotationKey: "4.3.2.1",
-						},
-					},
-					Spec: v1beta1.GatewaySpec{
-						Listeners: []v1beta1.Listener{{
-							Protocol:      v1beta1.HTTPProtocolType,
-							AllowedRoutes: allowAllNamespaces,
-						}},
-					},
-					Status: gatewayStatus("1.2.3.4", "2.3.4.5"),
-				},
-			},
-			routes: []*v1beta1.HTTPRoute{{
-				ObjectMeta: objectMeta("route-namespace", "test"),
-				Spec: v1beta1.HTTPRouteSpec{
-					Hostnames: hostnames("test.example.internal"),
-				},
-				Status: httpRouteStatus( // The route is attached to both gateways.
-					gatewayParentRef("gateway-namespace", "overriden-gateway"),
-				),
-			}},
-			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("test.example.internal", "A", "4.3.2.1"),
-			},
-		},
-		{
 			title: "MutlipleGatewaysOneAnnotationOverride",
 			config: Config{
 				GatewayNamespace: "gateway-namespace",


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
This allows the `external-dns.alpha.kubernetes.io/target` annotation to work for gateway api resources

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [X] Unit tests updated
- [X] End user documentation updated
