### PR TITLE
 Define Labels type and JSON tags for ProviderSpecific fields 

### DIFF
--- a/docs/contributing/crd-source.md
+++ b/docs/contributing/crd-source.md
@@ -15,10 +15,11 @@ Here is typical example of [CRD API type](https://github.com/kubernetes-sigs/ext
 type TTL int64
 type Targets []string
 type ProviderSpecificProperty struct {
-	Name  string
-	Value string
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
 }
 type ProviderSpecific []ProviderSpecificProperty
+type Labels map[string]string
 
 type Endpoint struct {
 	// The hostname of the DNS record


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
The current example of CRD source is missing the `Labels` type
definition.  It also does not have the JSON tag for the `Name` and
`Value` fields of the `ProviderSpecificProperty` type.  As such,
creating a CRD from these types will result in errors.

This change fixes the two issues highlighted above.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #3455

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
