### PR TITLE
feat: pods can have hostPorts without hostNetwork

### DIFF
--- a/docs/tutorials/kops-dns-controller.md
+++ b/docs/tutorials/kops-dns-controller.md
@@ -21,11 +21,9 @@ The DNS record mappings try to "do the right thing", but what this means is diff
 
 ### Pods
 
-For the external annotation, ExternalDNS will map a HostNetwork=true Pod to the external IPs of the Node.
+For the external annotation, ExternalDNS will map a Pod to the external IPs of the Node.
 
-For the internal annotation, ExternalDNS will map a HostNetwork=true Pod to the internal IPs of the Node.
-
-ExternalDNS ignore Pods that are not HostNetwork=true
+For the internal annotation, ExternalDNS will map a Pod to the internal IPs of the Node.
 
 Annotations added to Pods will always result in an A record being created.
 

--- a/source/pod.go
+++ b/source/pod.go
@@ -21,7 +21,6 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 
-	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kubeinformers "k8s.io/client-go/informers"
@@ -84,11 +83,6 @@ func (ps *podSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 
 	endpointMap := make(map[endpoint.EndpointKey][]string)
 	for _, pod := range pods {
-		if !pod.Spec.HostNetwork {
-			log.Debugf("skipping pod %s. hostNetwork=false", pod.Name)
-			continue
-		}
-
 		targets := getTargetsFromTargetAnnotation(pod.Annotations)
 
 		if domainAnnotation, ok := pod.Annotations[internalHostnameAnnotationKey]; ok {

--- a/source/pod_test.go
+++ b/source/pod_test.go
@@ -459,12 +459,14 @@ func TestPodSource(t *testing.T) {
 			},
 		},
 		{
-			"pods with hostNetwore=false should be ignored",
+			"pods with hostNetwore=false should not be ignored",
 			"",
 			"",
 			[]*endpoint.Endpoint{
 				{DNSName: "a.foo.example.org", Targets: endpoint.Targets{"54.10.11.1"}, RecordType: endpoint.RecordTypeA},
 				{DNSName: "internal.a.foo.example.org", Targets: endpoint.Targets{"10.0.1.1"}, RecordType: endpoint.RecordTypeA},
+				{DNSName: "b.foo.example.org", Targets: endpoint.Targets{"54.10.11.2"}, RecordType: endpoint.RecordTypeA},
+				{DNSName: "internal.b.foo.example.org", Targets: endpoint.Targets{"10.0.1.2"}, RecordType: endpoint.RecordTypeA},
 			},
 			false,
 			[]*corev1.Node{
@@ -514,8 +516,8 @@ func TestPodSource(t *testing.T) {
 						Name:      "my-pod2",
 						Namespace: "kube-system",
 						Annotations: map[string]string{
-							internalHostnameAnnotationKey: "internal.a.foo.example.org",
-							hostnameAnnotationKey:         "a.foo.example.org",
+							internalHostnameAnnotationKey: "internal.b.foo.example.org",
+							hostnameAnnotationKey:         "b.foo.example.org",
 						},
 					},
 					Spec: corev1.PodSpec{
@@ -523,7 +525,7 @@ func TestPodSource(t *testing.T) {
 						NodeName:    "my-node2",
 					},
 					Status: corev1.PodStatus{
-						PodIP: "100.0.1.2",
+						PodIP: "10.0.1.2",
 					},
 				},
 			},


### PR DESCRIPTION
**Description**

Pods can have hostPorts without hostNetwork.
I propose to remove the check that prevent checking annotations on pods that are not on hostNetwork.

**Checklist**

- [X] Unit tests updated
- [X] End user documentation updated
