### PR TITLE
docker buildx and tester

### DIFF
--- a/.github/workflows/staging-image-tester.yml
+++ b/.github/workflows/staging-image-tester.yml
@@ -34,10 +34,4 @@ jobs:
         go get -v -t -d ./...
 
     - name: Test
-      run: make release.staging
-
-    - name: Send coverage
-      uses: shogo82148/actions-goveralls@v1
-      with:
-        path-to-profile: profile.cov
-      if: github.actor != 'nektos/act'
+      run: make build/multiarch

--- a/.github/workflows/staging-image-tester.yml
+++ b/.github/workflows/staging-image-tester.yml
@@ -3,6 +3,8 @@ name: Build all images
 on:
   push:
     branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 permissions:
   contents: read  #  to fetch code (actions/checkout)

--- a/.github/workflows/staging-image-tester.yml
+++ b/.github/workflows/staging-image-tester.yml
@@ -34,4 +34,4 @@ jobs:
         go get -v -t -d ./...
 
     - name: Test
-      run: make build/multiarch
+      run: make build.image/multiarch

--- a/.github/workflows/staging-image-tester.yml
+++ b/.github/workflows/staging-image-tester.yml
@@ -1,0 +1,41 @@
+name: Build all images
+
+on:
+  push:
+    branches: [ master ]
+
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
+jobs:
+
+  build:
+    permissions:
+      contents: read  #  to fetch code (actions/checkout)
+      checks: write  #  to create a new check based on the results (shogo82148/actions-goveralls)
+
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
+    - name: Install CI
+      run: |
+        go get -v -t -d ./...
+
+    - name: Test
+      run: make release.staging
+
+    - name: Send coverage
+      uses: shogo82148/actions-goveralls@v1
+      with:
+        path-to-profile: profile.cov
+      if: github.actor != 'nektos/act'

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ COPY go.sum .
 RUN go mod download
 
 COPY . .
-RUN make test build.$ARCH
 
 FROM alpine:3.17
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,7 @@ RUN go mod download
 COPY . .
 RUN make test build.$ARCH
 
-# final image
-FROM $ARCH/alpine:3.17
+FROM alpine:3.17
 
 RUN apk update && apk add "libcrypto3>=3.0.8-r0" "libssl3>=3.0.8-r0" && rm -rf /var/cache/apt/*
 

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ build.push/multiarch: $(addprefix build.push-,$(ARCHS))
 	done;\
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(IMAGE):$(VERSION)" \
 
-build/multiarch: $(addprefix build.push-,$(ARCHS))
+build.local/multiarch: $(addprefix build.local-,$(ARCHS))
 	arch_specific_tags=()
 	for arch in $(ARCHS); do \
 		image="$(IMAGE):$(VERSION)-$${arch}" ;\
@@ -124,6 +124,9 @@ build/multiarch: $(addprefix build.push-,$(ARCHS))
 	for arch in $(ARCHS); do \
 		DOCKER_CLI_EXPERIMENTAL=enabled docker manifest annotate --arch $${arch} "$(IMAGE):$(VERSION)" "$(IMAGE):$(VERSION)-$${arch}" ;\
 	done;\
+
+build.local:
+	$(MAKE) ARCH=$(ARCH) OUTPUT_TYPE=local build.docker
 
 build.push:
 	$(MAKE) ARCH=$(ARCH) OUTPUT_TYPE=registry build.docker

--- a/Makefile
+++ b/Makefile
@@ -128,15 +128,26 @@ build.image/multiarch: $(addprefix build.image-,$(ARCHS))
 build.image:
 	$(MAKE) ARCH=$(ARCH) OUTPUT_TYPE=image build.docker
 
-build.image-%:
-	$(MAKE) ARCH=$* build.image
+build.image-amd64:
+	$(MAKE) ARCH=amd64 build.image
 
+build.image-arm64:
+	$(MAKE) ARCH=arm64 build.image
+
+build.image-arm/v7:
+	$(MAKE) ARCH=arm/v7 build.image
 
 build.push:
 	$(MAKE) ARCH=$(ARCH) OUTPUT_TYPE=registry build.docker
 
-build.push-%:
-	$(MAKE) ARCH=$* build.push
+build.push-amd64:
+	$(MAKE) ARCH=amd64 build.push
+
+build.push-arm64:
+	$(MAKE) ARCH=arm64 build.push
+
+build.push-arm/v7:
+	$(MAKE) ARCH=arm/b7 build.push
 
 build.arm64:
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o build/$(BINARY) $(BUILD_FLAGS) -ldflags "$(LDFLAGS)" .

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ build.push/multiarch: $(addprefix build.push-,$(ARCHS))
 	done ;\
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create "$(IMAGE):$(VERSION)" $${arch_specific_tags[@]} ;\
 	for arch in $(ARCHS); do \
-		DOCKER_CLI_EXPERIMENTAL=enabled docker manifest annotate --arch $${arch} "$(IMAGE):$(VERSION)" "$(IMAGE):$(VERSION)-$${arch}" ;\
+		DOCKER_CLI_EXPERIMENTAL=enabled docker manifest annotate --arch $${arch} "$(IMAGE):$(VERSION)" "$(IMAGE):$(VERSION)" ;\
 	done;\
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(IMAGE):$(VERSION)" \
 
@@ -122,7 +122,7 @@ build.image/multiarch: $(addprefix build.image-,$(ARCHS))
 	done ;\
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create "$(IMAGE):$(VERSION)" $${arch_specific_tags[@]} ;\
 	for arch in $(ARCHS); do \
-		DOCKER_CLI_EXPERIMENTAL=enabled docker manifest annotate --arch $${arch} "$(IMAGE):$(VERSION)" "$(IMAGE):$(VERSION)-$${arch}" ;\
+		DOCKER_CLI_EXPERIMENTAL=enabled docker manifest annotate --arch $${arch} "$(IMAGE):$(VERSION)" "$(IMAGE):$(VERSION)" ;\
 	done;\
 
 build.image:

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,10 @@ build.local/multiarch: $(addprefix build.local-,$(ARCHS))
 build.local:
 	$(MAKE) ARCH=$(ARCH) OUTPUT_TYPE=local build.docker
 
+build.local-%:
+	$(MAKE) ARCH=$* build.local
+
+
 build.push:
 	$(MAKE) ARCH=$(ARCH) OUTPUT_TYPE=registry build.docker
 

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,17 @@ build.push/multiarch: $(addprefix build.push-,$(ARCHS))
 	done;\
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(IMAGE):$(VERSION)" \
 
+build/multiarch: $(addprefix build.push-,$(ARCHS))
+	arch_specific_tags=()
+	for arch in $(ARCHS); do \
+		image="$(IMAGE):$(VERSION)-$${arch}" ;\
+		arch_specific_tags+=( "--amend $${image}" ) ;\
+	done ;\
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create "$(IMAGE):$(VERSION)" $${arch_specific_tags[@]} ;\
+	for arch in $(ARCHS); do \
+		DOCKER_CLI_EXPERIMENTAL=enabled docker manifest annotate --arch $${arch} "$(IMAGE):$(VERSION)" "$(IMAGE):$(VERSION)-$${arch}" ;\
+	done;\
+
 build.push:
 	$(MAKE) ARCH=$(ARCH) OUTPUT_TYPE=registry build.docker
 

--- a/Makefile
+++ b/Makefile
@@ -90,9 +90,11 @@ IMAGE         ?= us.gcr.io/k8s-artifacts-prod/external-dns/$(BINARY)
 VERSION       ?= $(shell git describe --tags --always --dirty)
 BUILD_FLAGS   ?= -v
 LDFLAGS       ?= -X sigs.k8s.io/external-dns/pkg/apis/externaldns.Version=$(VERSION) -w -s
-ARCHS         = amd64 arm64 arm/v7
-DEFAULT_ARCH  = amd64
-SHELL         = /bin/bash
+ARCHS          = amd64 arm64 arm/v7
+ARCH          ?= amd64
+DEFAULT_ARCH   = amd64
+SHELL          = /bin/bash
+OUTPUT_TYPE   ?= docker
 
 
 build: build/$(BINARY)

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ build.image/multiarch: $(addprefix build.image-,$(ARCHS))
 	done;\
 
 build.image:
-	$(MAKE) ARCH=$(ARCH) OUTPUT_TYPE=image build.docker
+	$(MAKE) ARCH=$(ARCH) OUTPUT_TYPE=docker build.docker
 
 build.image-amd64:
 	$(MAKE) ARCH=amd64 build.image

--- a/Makefile
+++ b/Makefile
@@ -105,24 +105,24 @@ build/$(BINARY): $(SOURCES)
 build.push/multiarch: $(addprefix build.push-,$(ARCHS))
 	arch_specific_tags=()
 	for arch in $(ARCHS); do \
-		image="$(IMAGE):$(VERSION)-$${arch}" ;\
+		image="$(IMAGE):$(VERSION)-$(subst /,-,$${arch})" ;\
 		arch_specific_tags+=( "--amend $${image}" ) ;\
 	done ;\
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create "$(IMAGE):$(VERSION)" $${arch_specific_tags[@]} ;\
 	for arch in $(ARCHS); do \
-		DOCKER_CLI_EXPERIMENTAL=enabled docker manifest annotate --arch $${arch} "$(IMAGE):$(VERSION)" "$(IMAGE):$(VERSION)" ;\
+		DOCKER_CLI_EXPERIMENTAL=enabled docker manifest annotate --arch $${arch} "$(IMAGE):$(VERSION)" "$(IMAGE):$(VERSION)-$(subst /,-,$${arch})" ;\
 	done;\
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(IMAGE):$(VERSION)" \
 
 build.image/multiarch: $(addprefix build.image-,$(ARCHS))
 	arch_specific_tags=()
 	for arch in $(ARCHS); do \
-		image="$(IMAGE):$(VERSION)-$${arch}" ;\
+		image="$(IMAGE):$(VERSION)-$(subst /,-,$${arch})" ;\
 		arch_specific_tags+=( "--amend $${image}" ) ;\
 	done ;\
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create "$(IMAGE):$(VERSION)" $${arch_specific_tags[@]} ;\
 	for arch in $(ARCHS); do \
-		DOCKER_CLI_EXPERIMENTAL=enabled docker manifest annotate --arch $${arch} "$(IMAGE):$(VERSION)" "$(IMAGE):$(VERSION)" ;\
+		DOCKER_CLI_EXPERIMENTAL=enabled docker manifest annotate --arch $${arch} "$(IMAGE):$(VERSION)" "$(IMAGE):$(VERSION)-$(subst /,-,$${arch})" ;\
 	done;\
 
 build.image:
@@ -147,7 +147,7 @@ build.push-arm64:
 	$(MAKE) ARCH=arm64 build.push
 
 build.push-arm/v7:
-	$(MAKE) ARCH=arm/b7 build.push
+	$(MAKE) ARCH=arm/v7 build.push
 
 build.arm64:
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o build/$(BINARY) $(BUILD_FLAGS) -ldflags "$(LDFLAGS)" .
@@ -163,7 +163,7 @@ build.setup:
 
 build.docker: build.setup build.$(ARCH)
 	docker build --rm --tag "$(IMAGE):$(VERSION)" --build-arg VERSION="$(VERSION)" --build-arg ARCH="amd64" .
-	image="$(IMAGE):$(VERSION)-$(ARCH)"; \
+	image="$(IMAGE):$(VERSION)-$(subst /,-,$(ARCH))"; \
 	docker buildx build \
 		--pull \
 		--output=type=$(OUTPUT_TYPE) \

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 cover:
 	go get github.com/wadey/gocovmerge
 	$(eval PKGS := $(shell go list ./... | grep -v /vendor/))
-	$(eval PKGS_DELIM := $(shell echo $(PKGS) | sed -e 's/ /,/g'))
+	$(eval PKGS_DELIM := $(shell echo $(PKGS) | tr / -'))
 	go list -f '{{if or (len .TestGoFiles) (len .XTestGoFiles)}}go test -test.v -test.timeout=120s -covermode=count -coverprofile={{.Name}}_{{len .Imports}}_{{len .Deps}}.coverprofile -coverpkg $(PKGS_DELIM) {{.ImportPath}}{{end}}' $(PKGS) | xargs -0 sh -c
 	gocovmerge `ls *.coverprofile` > cover.out
 	rm *.coverprofile
@@ -105,12 +105,12 @@ build/$(BINARY): $(SOURCES)
 build.push/multiarch: $(addprefix build.push-,$(ARCHS))
 	arch_specific_tags=()
 	for arch in $(ARCHS); do \
-		image="$(IMAGE):$(VERSION)-$$(echo $$arch | sed 's/\//-/g')" ;\
+		image="$(IMAGE):$(VERSION)-$$(echo $$arch | tr / -)" ;\
 		arch_specific_tags+=( "--amend $${image}" ) ;\
 	done ;\
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create "$(IMAGE):$(VERSION)" $${arch_specific_tags[@]} ;\
 	for arch in $(ARCHS); do \
-		image="$(IMAGE):$(VERSION)-$$(echo $$arch | sed 's/\//-/g')" ;\
+		image="$(IMAGE):$(VERSION)-$$(echo $$arch | tr / -)" ;\
 		DOCKER_CLI_EXPERIMENTAL=enabled docker manifest annotate --arch $${arch} "$(IMAGE):$(VERSION)" "$${image}" ;\
 	done;\
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(IMAGE):$(VERSION)" \

--- a/Makefile
+++ b/Makefile
@@ -173,8 +173,8 @@ clean:
  # Builds and push container images to the staging bucket.
 .PHONY: release.staging
 
-release.staging:
+release.staging: test
 	IMAGE=$(IMAGE_STAGING) $(MAKE) build.push/multiarch
 
-release.prod:
+release.prod: test
 	$(MAKE) build.push/multiarch

--- a/Makefile
+++ b/Makefile
@@ -105,25 +105,17 @@ build/$(BINARY): $(SOURCES)
 build.push/multiarch: $(addprefix build.push-,$(ARCHS))
 	arch_specific_tags=()
 	for arch in $(ARCHS); do \
-		image="$(IMAGE):$(VERSION)-$(subst /,-,$${arch})" ;\
+		image="$(IMAGE):$(VERSION)-$$(echo $$arch | sed 's/\//-/g')" ;\
 		arch_specific_tags+=( "--amend $${image}" ) ;\
 	done ;\
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create "$(IMAGE):$(VERSION)" $${arch_specific_tags[@]} ;\
 	for arch in $(ARCHS); do \
-		DOCKER_CLI_EXPERIMENTAL=enabled docker manifest annotate --arch $${arch} "$(IMAGE):$(VERSION)" "$(IMAGE):$(VERSION)-$(subst /,-,$${arch})" ;\
+		image="$(IMAGE):$(VERSION)-$$(echo $$arch | sed 's/\//-/g')" ;\
+		DOCKER_CLI_EXPERIMENTAL=enabled docker manifest annotate --arch $${arch} "$(IMAGE):$(VERSION)" "$${image}" ;\
 	done;\
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(IMAGE):$(VERSION)" \
 
 build.image/multiarch: $(addprefix build.image-,$(ARCHS))
-	arch_specific_tags=()
-	for arch in $(ARCHS); do \
-		image="$(IMAGE):$(VERSION)-$(subst /,-,$${arch})" ;\
-		arch_specific_tags+=( "--amend $${image}" ) ;\
-	done ;\
-	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create "$(IMAGE):$(VERSION)" $${arch_specific_tags[@]} ;\
-	for arch in $(ARCHS); do \
-		DOCKER_CLI_EXPERIMENTAL=enabled docker manifest annotate --arch $${arch} "$(IMAGE):$(VERSION)" "$(IMAGE):$(VERSION)-$(subst /,-,$${arch})" ;\
-	done;\
 
 build.image:
 	$(MAKE) ARCH=$(ARCH) OUTPUT_TYPE=docker build.docker

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ build.image:
 	$(MAKE) ARCH=$(ARCH) OUTPUT_TYPE=image build.docker
 
 build.image-%:
-	$(MAKE) ARCH=$* build.local
+	$(MAKE) ARCH=$* build.image
 
 
 build.push:

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ build.push/multiarch: $(addprefix build.push-,$(ARCHS))
 	done;\
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(IMAGE):$(VERSION)" \
 
-build.local/multiarch: $(addprefix build.local-,$(ARCHS))
+build.image/multiarch: $(addprefix build.image-,$(ARCHS))
 	arch_specific_tags=()
 	for arch in $(ARCHS); do \
 		image="$(IMAGE):$(VERSION)-$${arch}" ;\
@@ -125,10 +125,10 @@ build.local/multiarch: $(addprefix build.local-,$(ARCHS))
 		DOCKER_CLI_EXPERIMENTAL=enabled docker manifest annotate --arch $${arch} "$(IMAGE):$(VERSION)" "$(IMAGE):$(VERSION)-$${arch}" ;\
 	done;\
 
-build.local:
-	$(MAKE) ARCH=$(ARCH) OUTPUT_TYPE=local build.docker
+build.image:
+	$(MAKE) ARCH=$(ARCH) OUTPUT_TYPE=image build.docker
 
-build.local-%:
+build.image-%:
 	$(MAKE) ARCH=$* build.local
 
 


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This introduces docker buildx so that we can more properly build multiarch images. Until today, we relied on a hack and that caused the builds to be slow and to stop building once that we had the requirement to actually have at least a `RUN` instruction in the Dockerfile. 
It also introduces a new github action that actually builds the images in CI without needing to merge so that we can test if images are building all time time.

Possible risks: we have no way to try this against kubernetes' CI other than merging, so we have to try and merge this and in the worst case iterate on it incrementally. 

