### PR TITLE
Force use of buildx

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,9 +9,11 @@ steps:
       - DOCKER_CLI_EXPERIMENTAL=enabled
       - VERSION=$_GIT_TAG
       - PULL_BASE_REF=$_PULL_BASE_REF
+      - HOME=/root
     args:
       - -c
       - |
+        /buildx-entrypoint version
         apk add musl-dev gcc
         make release.staging
 substitutions:


### PR DESCRIPTION
**Description**

Turns out buildx just doesn't work out of the box. This is another attempt at making it work based on this comment I found on slack: https://kubernetes.slack.com/archives/CCK68P2Q2/p1678186600549009?thread_ts=1678184220.721889&cid=CCK68P2Q2 .


