### PR TITLE
Add RBAC to be able to handle F5 VirtualServer source

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecated
 - Removed -->
 
+## [v1.12.2] - UNRELEASED
+
+### All Changes
+
+- Add RBAC to be able to support the F5 VirtualServer `Source` ([#3503](https://github.com/kubernetes-sigs/external-dns/pull/3503)) [@mikejoh](https://github.com/mikejoh)
+
 ## [v1.12.1] - 2023-02-06
 
 ### All Changes

--- a/charts/external-dns/templates/clusterrole.yaml
+++ b/charts/external-dns/templates/clusterrole.yaml
@@ -83,6 +83,11 @@ rules:
     resources: ["routegroups/status"]
     verbs: ["patch","update"]
 {{- end }}
+{{- if has "f5-virtualserver" .Values.sources }}
+  - apiGroups: ["cis.f5.com"]
+    resources: ["virtualservers"]
+    verbs: ["get","watch","list"]
+{{- end }}
 {{- with .Values.rbac.additionalPermissions }}
   {{- toYaml . | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
**Description**
Add RBAC to be able to handle F5 VirtualServer `Source`. Support for F5 VirtualServers were added here: https://github.com/kubernetes-sigs/external-dns/pull/3162.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
