### PR TITLE
feat(chart): Updated chart to ExternalDNS v0.13.4

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -7,16 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [v1.12.2] - UNRELEASED
-### Highlights
-### All Changes
-- Added RBAC for Gateway-API resources to clusterrole [#3499](https://github.com/kubernetes-sigs/external-dns/pull/3499). [@michaelvl](https://github.com/MichaelVL)
-
-## [v1.12.2] - UNRELEASED
+## [UNRELEASED]
 
 ### All Changes
 
-- Add RBAC to be able to support the F5 VirtualServer `Source` ([#3503](https://github.com/kubernetes-sigs/external-dns/pull/3503)) [@mikejoh](https://github.com/mikejoh)
+## [v1.12.2] - UNRELEASED
+
+### All Changes
+
+- Added support for ServiceMonitor relabelling. ([#3366](https://github.com/kubernetes-sigs/external-dns/pull/3366)) [@jkroepke](https://github.com/jkroepke)
+- Updated chart icon path. ([#3492](https://github.com/kubernetes-sigs/external-dns/pull/3494)) [kundan2707](https://github.com/kundan2707)
+- Added RBAC for Gateway-API resources to ClusterRole. ([#3499](https://github.com/kubernetes-sigs/external-dns/pull/3499)) [@michaelvl](https://github.com/MichaelVL)
+- Added RBAC for F5 VirtualServer to ClusterRole. ([#3503](https://github.com/kubernetes-sigs/external-dns/pull/3503)) [@mikejoh](https://github.com/mikejoh)
+- Added support for running ExternalDNS with namespaced scope. ([#3403](https://github.com/kubernetes-sigs/external-dns/pull/3403)) [@jkroepke](https://github.com/jkroepke)
+- Updated _ExternalDNS_ version to [v0.13.4](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.13.4). ([#3516](https://github.com/kubernetes-sigs/external-dns/pull/3516)) [@stevehipwell](https://github.com/stevehipwell)
 
 ## [v1.12.1] - 2023-02-06
 

--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: external-dns
 description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 type: application
-version: 1.12.1
-appVersion: 0.13.2
+version: 1.12.2
+appVersion: 0.13.4
 keywords:
   - kubernetes
   - externaldns
@@ -20,9 +20,15 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Updated ExternalDNS version to v0.13.2."
     - kind: added
-      description: "Added secretConfiguration.subPath to mount specific files from secret as a sub-path."
+      description: "Added support for ServiceMonitor relabelling."
     - kind: changed
-      description: "Changed to use registry.k8s.io instead of k8s.gcr.io."
+      description: "Updated chart icon path."
+    - kind: added
+      description: "Added RBAC for Gateway-API resources to ClusterRole."
+    - kind: added
+      description: "Added RBAC for F5 VirtualServer to ClusterRole."
+    - kind: added
+      description: "Added support for running ExternalDNS with namespaced scope."
+    - kind: changed
+      description: "Updated _ExternalDNS_ version to [v0.13.4](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.13.4)."


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR updates the Helm chart to use the latest ExternalDNS version ([v0.13.4](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.13.4)) and includes all the other improvements since the last release (see CHANGELOG).

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #3506

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
