### PR TITLE
docs: add example for provider specific config

### DIFF
--- a/docs/contributing/crd-source/dnsendpoint-example.yaml
+++ b/docs/contributing/crd-source/dnsendpoint-example.yaml
@@ -9,3 +9,7 @@ spec:
     recordType: A
     targets:
     - 192.168.99.216
+    # Provider specific configurations are set like an annotation would on other sources
+    providerSpecific:
+      - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+        value: "true"


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This adds an example for provider specific configuration with the CRD source.

I read through the source code to find out why my annotations were not working, so I thought I'd spare the next person that time.
<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

**Checklist**

- [ ] Unit tests updated (not needed)
- [x] End user documentation updated
