### PR TITLE
feat: resolve LB-type Service hostname to create A/AAAA instead of CNAME

### DIFF
--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -83,16 +83,17 @@ The following table lists the configurable parameters of the _ExternalDNS_ chart
 | `secretConfiguration.mountPath`    | Mount path of secret configuration secret (this can be templated).                                                                                                                                                                                                                                                    | `""`                                        |
 | `secretConfiguration.data`         | Secret configuration secret data. Could be used to store DNS provider credentials.                                                                                                                                                                                                                                    | `{}`                                        |
 | `secretConfiguration.subPath`      | Sub-path of secret configuration secret (this can be templated).                                                                                                                                                                                                                                                      | `""`                                        |
+| `resolveLoadBalancerHostname`      | Resolve the hostname of LoadBalancer-type Service object to IP addresses in order to create DNS A/AAAA records instead of CNAMEs | `false`                                        |
 
 ## Namespaced scoped installation
 
-external-dns supports running on a namespaced only scope, too. 
+external-dns supports running on a namespaced only scope, too.
 If `namespaced=true` is defined, the helm chart will setup `Roles` and `RoleBindings` instead `ClusterRoles` and `ClusterRoleBindings`.
 
 ### Limited supported
 Not all sources are supported in namespaced scope, since some sources depends on cluster-wide resources.
 For example: Source `node` isn't supported, since `kind: Node` has scope `Cluster`.
-Sources like `istio-virtualservice` only work, if all resources like `Gateway` and `VirtualService` are present in the same 
+Sources like `istio-virtualservice` only work, if all resources like `Gateway` and `VirtualService` are present in the same
 namespaces as `external-dns`.
 
 The annotation `external-dns.alpha.kubernetes.io/endpoints-type: NodeExternalIP` is not supported.

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -83,7 +83,7 @@ The following table lists the configurable parameters of the _ExternalDNS_ chart
 | `secretConfiguration.mountPath`    | Mount path of secret configuration secret (this can be templated).                                                                                                                                                                                                                                                    | `""`                                        |
 | `secretConfiguration.data`         | Secret configuration secret data. Could be used to store DNS provider credentials.                                                                                                                                                                                                                                    | `{}`                                        |
 | `secretConfiguration.subPath`      | Sub-path of secret configuration secret (this can be templated).                                                                                                                                                                                                                                                      | `""`                                        |
-| `resolveLoadBalancerHostname`      | Resolve the hostname of LoadBalancer-type Service object to IP addresses in order to create DNS A/AAAA records instead of CNAMEs | `false`                                        |
+| `resolveServiceLoadBalancerHostname`      | Resolve the hostname of LoadBalancer-type Service object to IP addresses in order to create DNS A/AAAA records instead of CNAMEs | `false`                                        |
 
 ## Namespaced scoped installation
 

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -96,6 +96,9 @@ spec:
             - --domain-filter={{ . }}
             {{- end }}
             - --provider={{ tpl .Values.provider $ }}
+            {{- if .Values.resolveLoadBalancerHostname }}
+            - --resolve-load-balancer-hostname
+            {{- end }}
           {{- range .Values.extraArgs }}
             - {{ tpl . $ }}
           {{- end }}

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -96,8 +96,8 @@ spec:
             - --domain-filter={{ . }}
             {{- end }}
             - --provider={{ tpl .Values.provider $ }}
-            {{- if .Values.resolveLoadBalancerHostname }}
-            - --resolve-load-balancer-hostname
+            {{- if .Values.resolveServiceLoadBalancerHostname }}
+            - --resolve-service-load-balancer-hostname
             {{- end }}
           {{- range .Values.extraArgs }}
             - {{ tpl . $ }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -15,6 +15,8 @@ fullnameOverride: ""
 
 commonLabels: {}
 
+resolveLoadBalancerHostname: false
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -15,7 +15,7 @@ fullnameOverride: ""
 
 commonLabels: {}
 
-resolveLoadBalancerHostname: false
+resolveServiceLoadBalancerHostname: false
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/main.go
+++ b/main.go
@@ -141,7 +141,7 @@ func main() {
 		DefaultTargets:                 cfg.DefaultTargets,
 		OCPRouterName:                  cfg.OCPRouterName,
 		UpdateEvents:                   cfg.UpdateEvents,
-		ResolveLoadBalancerHostname:    cfg.ResolveLoadBalancerHostname,
+		ResolveLoadBalancerHostname:    cfg.ResolveServiceLoadBalancerHostname,
 	}
 
 	// Lookup all the selected sources by names and pass them the desired configuration.

--- a/main.go
+++ b/main.go
@@ -141,6 +141,7 @@ func main() {
 		DefaultTargets:                 cfg.DefaultTargets,
 		OCPRouterName:                  cfg.OCPRouterName,
 		UpdateEvents:                   cfg.UpdateEvents,
+		ResolveLoadBalancerHostname:    cfg.ResolveLoadBalancerHostname,
 	}
 
 	// Lookup all the selected sources by names and pass them the desired configuration.

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -166,6 +166,7 @@ type Config struct {
 	CFAPIEndpoint                     string
 	CFUsername                        string
 	CFPassword                        string
+	ResolveLoadBalancerHostname       bool
 	RFC2136Host                       string
 	RFC2136Port                       int
 	RFC2136Zone                       string
@@ -390,6 +391,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("server", "The Kubernetes API server to connect to (default: auto-detect)").Default(defaultConfig.APIServerURL).StringVar(&cfg.APIServerURL)
 	app.Flag("kubeconfig", "Retrieve target cluster configuration from a Kubernetes configuration file (default: auto-detect)").Default(defaultConfig.KubeConfig).StringVar(&cfg.KubeConfig)
 	app.Flag("request-timeout", "Request timeout when calling Kubernetes APIs. 0s means no timeout").Default(defaultConfig.RequestTimeout.String()).DurationVar(&cfg.RequestTimeout)
+	app.Flag("resolve-lb-hostname", "Resolve the hostname of LoadBalancer-type Service object to IP addresses in order to create DNS A/AAAA records instead of CNAMEs").BoolVar(&cfg.ResolveLoadBalancerHostname)
 
 	// Flags related to cloud foundry
 	app.Flag("cf-api-endpoint", "The fully-qualified domain name of the cloud foundry instance you are targeting").Default(defaultConfig.CFAPIEndpoint).StringVar(&cfg.CFAPIEndpoint)

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -43,165 +43,165 @@ var Version = "unknown"
 
 // Config is a project-wide configuration
 type Config struct {
-	APIServerURL                      string
-	KubeConfig                        string
-	RequestTimeout                    time.Duration
-	DefaultTargets                    []string
-	ContourLoadBalancerService        string
-	GlooNamespace                     string
-	SkipperRouteGroupVersion          string
-	Sources                           []string
-	Namespace                         string
-	AnnotationFilter                  string
-	LabelFilter                       string
-	FQDNTemplate                      string
-	CombineFQDNAndAnnotation          bool
-	IgnoreHostnameAnnotation          bool
-	IgnoreIngressTLSSpec              bool
-	IgnoreIngressRulesSpec            bool
-	GatewayNamespace                  string
-	GatewayLabelFilter                string
-	Compatibility                     string
-	PublishInternal                   bool
-	PublishHostIP                     bool
-	AlwaysPublishNotReadyAddresses    bool
-	ConnectorSourceServer             string
-	Provider                          string
-	GoogleProject                     string
-	GoogleBatchChangeSize             int
-	GoogleBatchChangeInterval         time.Duration
-	GoogleZoneVisibility              string
-	DomainFilter                      []string
-	ExcludeDomains                    []string
-	RegexDomainFilter                 *regexp.Regexp
-	RegexDomainExclusion              *regexp.Regexp
-	ZoneNameFilter                    []string
-	ZoneIDFilter                      []string
-	TargetNetFilter                   []string
-	ExcludeTargetNets                 []string
-	AlibabaCloudConfigFile            string
-	AlibabaCloudZoneType              string
-	AWSZoneType                       string
-	AWSZoneTagFilter                  []string
-	AWSAssumeRole                     string
-	AWSAssumeRoleExternalID           string
-	AWSBatchChangeSize                int
-	AWSBatchChangeInterval            time.Duration
-	AWSEvaluateTargetHealth           bool
-	AWSAPIRetries                     int
-	AWSPreferCNAME                    bool
-	AWSZoneCacheDuration              time.Duration
-	AWSSDServiceCleanup               bool
-	AzureConfigFile                   string
-	AzureResourceGroup                string
-	AzureSubscriptionID               string
-	AzureUserAssignedIdentityClientID string
-	BluecatDNSConfiguration           string
-	BluecatConfigFile                 string
-	BluecatDNSView                    string
-	BluecatGatewayHost                string
-	BluecatRootZone                   string
-	BluecatDNSServerName              string
-	BluecatDNSDeployType              string
-	BluecatSkipTLSVerify              bool
-	CloudflareProxied                 bool
-	CloudflareDNSRecordsPerPage       int
-	CoreDNSPrefix                     string
-	RcodezeroTXTEncrypt               bool
-	AkamaiServiceConsumerDomain       string
-	AkamaiClientToken                 string
-	AkamaiClientSecret                string
-	AkamaiAccessToken                 string
-	AkamaiEdgercPath                  string
-	AkamaiEdgercSection               string
-	InfobloxGridHost                  string
-	InfobloxWapiPort                  int
-	InfobloxWapiUsername              string
-	InfobloxWapiPassword              string `secure:"yes"`
-	InfobloxWapiVersion               string
-	InfobloxSSLVerify                 bool
-	InfobloxView                      string
-	InfobloxMaxResults                int
-	InfobloxFQDNRegEx                 string
-	InfobloxNameRegEx                 string
-	InfobloxCreatePTR                 bool
-	InfobloxCacheDuration             int
-	DynCustomerName                   string
-	DynUsername                       string
-	DynPassword                       string `secure:"yes"`
-	DynMinTTLSeconds                  int
-	OCIConfigFile                     string
-	OCICompartmentOCID                string
-	OCIAuthInstancePrincipal          bool
-	InMemoryZones                     []string
-	OVHEndpoint                       string
-	OVHApiRateLimit                   int
-	PDNSServer                        string
-	PDNSAPIKey                        string `secure:"yes"`
-	PDNSTLSEnabled                    bool
-	TLSCA                             string
-	TLSClientCert                     string
-	TLSClientCertKey                  string
-	Policy                            string
-	Registry                          string
-	TXTOwnerID                        string
-	TXTPrefix                         string
-	TXTSuffix                         string
-	Interval                          time.Duration
-	MinEventSyncInterval              time.Duration
-	Once                              bool
-	DryRun                            bool
-	UpdateEvents                      bool
-	LogFormat                         string
-	MetricsAddress                    string
-	LogLevel                          string
-	TXTCacheInterval                  time.Duration
-	TXTWildcardReplacement            string
-	ExoscaleEndpoint                  string
-	ExoscaleAPIKey                    string `secure:"yes"`
-	ExoscaleAPISecret                 string `secure:"yes"`
-	CRDSourceAPIVersion               string
-	CRDSourceKind                     string
-	ServiceTypeFilter                 []string
-	CFAPIEndpoint                     string
-	CFUsername                        string
-	CFPassword                        string
-	ResolveLoadBalancerHostname       bool
-	RFC2136Host                       string
-	RFC2136Port                       int
-	RFC2136Zone                       string
-	RFC2136Insecure                   bool
-	RFC2136GSSTSIG                    bool
-	RFC2136KerberosRealm              string
-	RFC2136KerberosUsername           string
-	RFC2136KerberosPassword           string `secure:"yes"`
-	RFC2136TSIGKeyName                string
-	RFC2136TSIGSecret                 string `secure:"yes"`
-	RFC2136TSIGSecretAlg              string
-	RFC2136TAXFR                      bool
-	RFC2136MinTTL                     time.Duration
-	RFC2136BatchChangeSize            int
-	NS1Endpoint                       string
-	NS1IgnoreSSL                      bool
-	NS1MinTTLSeconds                  int
-	TransIPAccountName                string
-	TransIPPrivateKeyFile             string
-	DigitalOceanAPIPageSize           int
-	ManagedDNSRecordTypes             []string
-	GoDaddyAPIKey                     string `secure:"yes"`
-	GoDaddySecretKey                  string `secure:"yes"`
-	GoDaddyTTL                        int64
-	GoDaddyOTE                        bool
-	OCPRouterName                     string
-	IBMCloudProxied                   bool
-	IBMCloudConfigFile                string
-	TencentCloudConfigFile            string
-	TencentCloudZoneType              string
-	PiholeServer                      string
-	PiholePassword                    string `secure:"yes"`
-	PiholeTLSInsecureSkipVerify       bool
-	PluralCluster                     string
-	PluralProvider                    string
+	APIServerURL                       string
+	KubeConfig                         string
+	RequestTimeout                     time.Duration
+	DefaultTargets                     []string
+	ContourLoadBalancerService         string
+	GlooNamespace                      string
+	SkipperRouteGroupVersion           string
+	Sources                            []string
+	Namespace                          string
+	AnnotationFilter                   string
+	LabelFilter                        string
+	FQDNTemplate                       string
+	CombineFQDNAndAnnotation           bool
+	IgnoreHostnameAnnotation           bool
+	IgnoreIngressTLSSpec               bool
+	IgnoreIngressRulesSpec             bool
+	GatewayNamespace                   string
+	GatewayLabelFilter                 string
+	Compatibility                      string
+	PublishInternal                    bool
+	PublishHostIP                      bool
+	AlwaysPublishNotReadyAddresses     bool
+	ConnectorSourceServer              string
+	Provider                           string
+	GoogleProject                      string
+	GoogleBatchChangeSize              int
+	GoogleBatchChangeInterval          time.Duration
+	GoogleZoneVisibility               string
+	DomainFilter                       []string
+	ExcludeDomains                     []string
+	RegexDomainFilter                  *regexp.Regexp
+	RegexDomainExclusion               *regexp.Regexp
+	ZoneNameFilter                     []string
+	ZoneIDFilter                       []string
+	TargetNetFilter                    []string
+	ExcludeTargetNets                  []string
+	AlibabaCloudConfigFile             string
+	AlibabaCloudZoneType               string
+	AWSZoneType                        string
+	AWSZoneTagFilter                   []string
+	AWSAssumeRole                      string
+	AWSAssumeRoleExternalID            string
+	AWSBatchChangeSize                 int
+	AWSBatchChangeInterval             time.Duration
+	AWSEvaluateTargetHealth            bool
+	AWSAPIRetries                      int
+	AWSPreferCNAME                     bool
+	AWSZoneCacheDuration               time.Duration
+	AWSSDServiceCleanup                bool
+	AzureConfigFile                    string
+	AzureResourceGroup                 string
+	AzureSubscriptionID                string
+	AzureUserAssignedIdentityClientID  string
+	BluecatDNSConfiguration            string
+	BluecatConfigFile                  string
+	BluecatDNSView                     string
+	BluecatGatewayHost                 string
+	BluecatRootZone                    string
+	BluecatDNSServerName               string
+	BluecatDNSDeployType               string
+	BluecatSkipTLSVerify               bool
+	CloudflareProxied                  bool
+	CloudflareDNSRecordsPerPage        int
+	CoreDNSPrefix                      string
+	RcodezeroTXTEncrypt                bool
+	AkamaiServiceConsumerDomain        string
+	AkamaiClientToken                  string
+	AkamaiClientSecret                 string
+	AkamaiAccessToken                  string
+	AkamaiEdgercPath                   string
+	AkamaiEdgercSection                string
+	InfobloxGridHost                   string
+	InfobloxWapiPort                   int
+	InfobloxWapiUsername               string
+	InfobloxWapiPassword               string `secure:"yes"`
+	InfobloxWapiVersion                string
+	InfobloxSSLVerify                  bool
+	InfobloxView                       string
+	InfobloxMaxResults                 int
+	InfobloxFQDNRegEx                  string
+	InfobloxNameRegEx                  string
+	InfobloxCreatePTR                  bool
+	InfobloxCacheDuration              int
+	DynCustomerName                    string
+	DynUsername                        string
+	DynPassword                        string `secure:"yes"`
+	DynMinTTLSeconds                   int
+	OCIConfigFile                      string
+	OCICompartmentOCID                 string
+	OCIAuthInstancePrincipal           bool
+	InMemoryZones                      []string
+	OVHEndpoint                        string
+	OVHApiRateLimit                    int
+	PDNSServer                         string
+	PDNSAPIKey                         string `secure:"yes"`
+	PDNSTLSEnabled                     bool
+	TLSCA                              string
+	TLSClientCert                      string
+	TLSClientCertKey                   string
+	Policy                             string
+	Registry                           string
+	TXTOwnerID                         string
+	TXTPrefix                          string
+	TXTSuffix                          string
+	Interval                           time.Duration
+	MinEventSyncInterval               time.Duration
+	Once                               bool
+	DryRun                             bool
+	UpdateEvents                       bool
+	LogFormat                          string
+	MetricsAddress                     string
+	LogLevel                           string
+	TXTCacheInterval                   time.Duration
+	TXTWildcardReplacement             string
+	ExoscaleEndpoint                   string
+	ExoscaleAPIKey                     string `secure:"yes"`
+	ExoscaleAPISecret                  string `secure:"yes"`
+	CRDSourceAPIVersion                string
+	CRDSourceKind                      string
+	ServiceTypeFilter                  []string
+	CFAPIEndpoint                      string
+	CFUsername                         string
+	CFPassword                         string
+	ResolveServiceLoadBalancerHostname bool
+	RFC2136Host                        string
+	RFC2136Port                        int
+	RFC2136Zone                        string
+	RFC2136Insecure                    bool
+	RFC2136GSSTSIG                     bool
+	RFC2136KerberosRealm               string
+	RFC2136KerberosUsername            string
+	RFC2136KerberosPassword            string `secure:"yes"`
+	RFC2136TSIGKeyName                 string
+	RFC2136TSIGSecret                  string `secure:"yes"`
+	RFC2136TSIGSecretAlg               string
+	RFC2136TAXFR                       bool
+	RFC2136MinTTL                      time.Duration
+	RFC2136BatchChangeSize             int
+	NS1Endpoint                        string
+	NS1IgnoreSSL                       bool
+	NS1MinTTLSeconds                   int
+	TransIPAccountName                 string
+	TransIPPrivateKeyFile              string
+	DigitalOceanAPIPageSize            int
+	ManagedDNSRecordTypes              []string
+	GoDaddyAPIKey                      string `secure:"yes"`
+	GoDaddySecretKey                   string `secure:"yes"`
+	GoDaddyTTL                         int64
+	GoDaddyOTE                         bool
+	OCPRouterName                      string
+	IBMCloudProxied                    bool
+	IBMCloudConfigFile                 string
+	TencentCloudConfigFile             string
+	TencentCloudZoneType               string
+	PiholeServer                       string
+	PiholePassword                     string `secure:"yes"`
+	PiholeTLSInsecureSkipVerify        bool
+	PluralCluster                      string
+	PluralProvider                     string
 }
 
 var defaultConfig = &Config{
@@ -391,7 +391,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("server", "The Kubernetes API server to connect to (default: auto-detect)").Default(defaultConfig.APIServerURL).StringVar(&cfg.APIServerURL)
 	app.Flag("kubeconfig", "Retrieve target cluster configuration from a Kubernetes configuration file (default: auto-detect)").Default(defaultConfig.KubeConfig).StringVar(&cfg.KubeConfig)
 	app.Flag("request-timeout", "Request timeout when calling Kubernetes APIs. 0s means no timeout").Default(defaultConfig.RequestTimeout.String()).DurationVar(&cfg.RequestTimeout)
-	app.Flag("resolve-lb-hostname", "Resolve the hostname of LoadBalancer-type Service object to IP addresses in order to create DNS A/AAAA records instead of CNAMEs").BoolVar(&cfg.ResolveLoadBalancerHostname)
+	app.Flag("resolve-service-load-balancer-hostname", "Resolve the hostname of LoadBalancer-type Service object to IP addresses in order to create DNS A/AAAA records instead of CNAMEs").BoolVar(&cfg.ResolveServiceLoadBalancerHostname)
 
 	// Flags related to cloud foundry
 	app.Flag("cf-api-endpoint", "The fully-qualified domain name of the cloud foundry instance you are targeting").Default(defaultConfig.CFAPIEndpoint).StringVar(&cfg.CFAPIEndpoint)

--- a/source/store.go
+++ b/source/store.go
@@ -73,6 +73,7 @@ type Config struct {
 	DefaultTargets                 []string
 	OCPRouterName                  string
 	UpdateEvents                   bool
+	ResolveLoadBalancerHostname    bool
 }
 
 // ClientGenerator provides clients
@@ -215,7 +216,7 @@ func BuildWithConfig(ctx context.Context, source string, p ClientGenerator, cfg 
 		if err != nil {
 			return nil, err
 		}
-		return NewServiceSource(ctx, client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.Compatibility, cfg.PublishInternal, cfg.PublishHostIP, cfg.AlwaysPublishNotReadyAddresses, cfg.ServiceTypeFilter, cfg.IgnoreHostnameAnnotation, cfg.LabelFilter)
+		return NewServiceSource(ctx, client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.Compatibility, cfg.PublishInternal, cfg.PublishHostIP, cfg.AlwaysPublishNotReadyAddresses, cfg.ServiceTypeFilter, cfg.IgnoreHostnameAnnotation, cfg.LabelFilter, cfg.ResolveLoadBalancerHostname)
 	case "ingress":
 		client, err := p.KubeClient()
 		if err != nil {


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR adds an optional feature (turned off by default).

On EKS for example, the LoadBalancer-type Service object will not have external IP addresses but external hostnames. In this case, external-dns will always create an `Endpoint` (an external-dns concept, see its go [struct](https://pkg.go.dev/sigs.k8s.io/external-dns/endpoint#Endpoint)) whose `RecordType` is `CNAME`. But the user might want to create `A` or `AAAA` records instead, and perhaps on a different DNS provider (e.g. Cloudflare) than the cluster provider (e.g. AWS). 

This PR adds an optional feature that allows external-dns to resolve the LB hostname into IP addresses before creating the `Endpoint` struct.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
