### PR TITLE
Fix incorrect arg in Oracle OCI tutorial

### DIFF
--- a/docs/tutorials/oracle.md
+++ b/docs/tutorials/oracle.md
@@ -60,7 +60,7 @@ E.g.:
 Allow dynamic-group <dynamic-group-name> to manage dns in compartment id <target-compartment-OCID>
 ```
 
-You'll also need to add the `--oci-instance-principals=true` flag to enable
+You'll also need to add the `--oci-auth-instance-principal` flag to enable
 this type of authentication. Finally, you'll need to add the
 `--oci-compartment-ocid=ocid1.compartment.oc1...` flag to provide the OCID of
 the compartment containing the zone to be managed.


### PR DESCRIPTION
**Description**

The recently-added support for Oracle's OCI IAM instance principal authentication included an incorrect arg name in the change to the Oracle tutorial.  This changes the tutorial to specify the correct arg name.  Thanks to joe.rosinski@oracle.com for spotting the problem.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes https://github.com/kubernetes-sigs/external-dns/issues/3545

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
