### PR TITLE
chore(chart): Reverted chart changes to args

### DIFF
--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -83,7 +83,6 @@ The following table lists the configurable parameters of the _ExternalDNS_ chart
 | `secretConfiguration.mountPath`    | Mount path of secret configuration secret (this can be templated).                                                                                                                                                                                                                                                    | `""`                                        |
 | `secretConfiguration.data`         | Secret configuration secret data. Could be used to store DNS provider credentials.                                                                                                                                                                                                                                    | `{}`                                        |
 | `secretConfiguration.subPath`      | Sub-path of secret configuration secret (this can be templated).                                                                                                                                                                                                                                                      | `""`                                        |
-| `resolveServiceLoadBalancerHostname`      | Resolve the hostname of LoadBalancer-type Service object to IP addresses in order to create DNS A/AAAA records instead of CNAMEs | `false`                                        |
 
 ## Namespaced scoped installation
 

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -96,9 +96,6 @@ spec:
             - --domain-filter={{ . }}
             {{- end }}
             - --provider={{ tpl .Values.provider $ }}
-            {{- if .Values.resolveServiceLoadBalancerHostname }}
-            - --resolve-service-load-balancer-hostname
-            {{- end }}
           {{- range .Values.extraArgs }}
             - {{ tpl . $ }}
           {{- end }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -15,8 +15,6 @@ fullnameOverride: ""
 
 commonLabels: {}
 
-resolveServiceLoadBalancerHostname: false
-
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR reverts the changes made to the Helm chart in #3554 as we don't try to duplicate the binary args as structure chart values and instead recommend the use of `extraArgs`.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
