### PR TITLE
Add option to set extensible attributes necessary for cloud infoblox instances to infoblox provider

### DIFF
--- a/main.go
+++ b/main.go
@@ -284,6 +284,9 @@ func main() {
 				NameRegEx:     cfg.InfobloxNameRegEx,
 				CreatePTR:     cfg.InfobloxCreatePTR,
 				CacheDuration: cfg.InfobloxCacheDuration,
+				TenantId:      cfg.InfobloxTenantId,
+				CloudApiOwned: cfg.InfobloxCloudApiOwned,
+				CMPType:       cfg.InfobloxCMPType,
 			},
 		)
 	case "dyn":

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -128,6 +128,9 @@ type Config struct {
 	InfobloxNameRegEx                  string
 	InfobloxCreatePTR                  bool
 	InfobloxCacheDuration              int
+	InfobloxTenantId                   string
+	InfobloxCloudApiOwned              string
+	InfobloxCMPType                    string
 	DynCustomerName                    string
 	DynUsername                        string
 	DynPassword                        string `secure:"yes"`
@@ -283,6 +286,9 @@ var defaultConfig = &Config{
 	InfobloxFQDNRegEx:           "",
 	InfobloxCreatePTR:           false,
 	InfobloxCacheDuration:       0,
+	InfobloxTenantId:            "",
+	InfobloxCloudApiOwned:       "",
+	InfobloxCMPType:             "",
 	OCIConfigFile:               "/etc/kubernetes/oci.yaml",
 	InMemoryZones:               []string{},
 	OVHEndpoint:                 "ovh-eu",
@@ -503,6 +509,9 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("infoblox-name-regex", "Apply this regular expression as a filter on the name field for obtaining infoblox records. This is disabled by default.").Default(defaultConfig.InfobloxNameRegEx).StringVar(&cfg.InfobloxNameRegEx)
 	app.Flag("infoblox-create-ptr", "When using the Infoblox provider, create a ptr entry in addition to an entry").Default(strconv.FormatBool(defaultConfig.InfobloxCreatePTR)).BoolVar(&cfg.InfobloxCreatePTR)
 	app.Flag("infoblox-cache-duration", "When using the Infoblox provider, set the record TTL (0s to disable).").Default(strconv.Itoa(defaultConfig.InfobloxCacheDuration)).IntVar(&cfg.InfobloxCacheDuration)
+	app.Flag("infoblox-tenant-id", "When using the Infoblox provider, add Tenant Id as an extensible attribute. This is disabled by default.").Default(defaultConfig.InfobloxTenantId).StringVar(&cfg.InfobloxTenantId)
+	app.Flag("infoblox-cloudapi-owned", "When using the Infoblox provider, add Cloud Api Owned flag as an extensible attribute. Can be 'True' or 'False'. This is disabled by default.").Default(defaultConfig.InfobloxCloudApiOwned).StringVar(&cfg.InfobloxCloudApiOwned)
+	app.Flag("infoblox-cmp-type", "When using the Infoblox provider, add the CMP Type as an extensible attribute. This is disabled by default.").Default(defaultConfig.InfobloxCMPType).StringVar(&cfg.InfobloxCMPType)
 	app.Flag("dyn-customer-name", "When using the Dyn provider, specify the Customer Name").Default("").StringVar(&cfg.DynCustomerName)
 	app.Flag("dyn-username", "When using the Dyn provider, specify the Username").Default("").StringVar(&cfg.DynUsername)
 	app.Flag("dyn-password", "When using the Dyn provider, specify the password").Default("").StringVar(&cfg.DynPassword)

--- a/provider/infoblox/infoblox_test.go
+++ b/provider/infoblox/infoblox_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -900,6 +901,33 @@ func TestExtendedRequestMaxResultsBuilder(t *testing.T) {
 	req, _ = requestBuilder.BuildRequest(ibclient.CREATE, obj, "", &ibclient.QueryParams{})
 
 	assert.True(t, req.URL.Query().Get("_max_results") == "")
+}
+
+func TestNewExtensibleAttributes(t *testing.T) {
+
+	startupConfig := StartupConfig{
+		TenantId:      "myTenantId",
+		CloudApiOwned: "True",
+		CMPType:       "myCloudManagedPlatform",
+	}
+	eas, _ := parseExtensibleAttributes(startupConfig)
+	expectedEas := ibclient.EA{
+		"Tenant ID":       "myTenantId",
+		"Cloud API Owned": "True",
+		"CMP Type":        "myCloudManagedPlatform",
+	}
+	equal := reflect.DeepEqual(eas, expectedEas)
+	assert.True(t, equal == true)
+
+	startupConfig = StartupConfig{
+		TenantId:      "",
+		CloudApiOwned: "",
+		CMPType:       "",
+	}
+	eas, _ = parseExtensibleAttributes(startupConfig)
+	expectedEas = ibclient.EA{}
+	equal = reflect.DeepEqual(eas, expectedEas)
+	assert.True(t, equal == true)
 }
 
 func TestGetObject(t *testing.T) {


### PR DESCRIPTION
**Description**


Added flags to the infoblox provider in order to set the mandatory "extensible attributes" required for infoblox using a "cloud network automation" setup. The MR proposes to:

- Add three separate flags for the three mandatory extensibile attributes that need to be sent to the infoblox api when the "cloud network automation" feature is enabled.
- Accept all extensible attribute flags only as strings.
- Only include the extensible attributes in the infoblox api calls when they are explicitly set and not empty.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes https://github.com/kubernetes-sigs/external-dns/issues/3582

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated (N/A imo)
