### PR TITLE
Allow multiple hostnames in internal annotation for pods

### DIFF
--- a/source/pod.go
+++ b/source/pod.go
@@ -89,33 +89,46 @@ func (ps *podSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 			continue
 		}
 
-		if domain, ok := pod.Annotations[internalHostnameAnnotationKey]; ok {
-			addToEndpointMap(endpointMap, domain, suitableType(pod.Status.PodIP), pod.Status.PodIP)
-		}
-
-		if domain, ok := pod.Annotations[hostnameAnnotationKey]; ok {
-			node, _ := ps.nodeInformer.Lister().Get(pod.Spec.NodeName)
-			for _, address := range node.Status.Addresses {
-				recordType := suitableType(address.Address)
-				// IPv6 addresses are labeled as NodeInternalIP despite being usable externally as well.
-				if address.Type == corev1.NodeExternalIP || (address.Type == corev1.NodeInternalIP && recordType == endpoint.RecordTypeAAAA) {
-					addToEndpointMap(endpointMap, domain, recordType, address.Address)
-				}
-			}
-		}
-
-		if ps.compatibility == "kops-dns-controller" {
-			if domain, ok := pod.Annotations[kopsDNSControllerInternalHostnameAnnotationKey]; ok {
+		if domainAnnotation, ok := pod.Annotations[internalHostnameAnnotationKey]; ok {
+			domainList := splitHostnameAnnotation(domainAnnotation)
+			for _, domain := range domainList {
 				addToEndpointMap(endpointMap, domain, suitableType(pod.Status.PodIP), pod.Status.PodIP)
-			}
 
-			if domain, ok := pod.Annotations[kopsDNSControllerHostnameAnnotationKey]; ok {
+			}
+		}
+
+		if domainAnnotation, ok := pod.Annotations[hostnameAnnotationKey]; ok {
+			domainList := splitHostnameAnnotation(domainAnnotation)
+			for _, domain := range domainList {
 				node, _ := ps.nodeInformer.Lister().Get(pod.Spec.NodeName)
 				for _, address := range node.Status.Addresses {
 					recordType := suitableType(address.Address)
 					// IPv6 addresses are labeled as NodeInternalIP despite being usable externally as well.
 					if address.Type == corev1.NodeExternalIP || (address.Type == corev1.NodeInternalIP && recordType == endpoint.RecordTypeAAAA) {
 						addToEndpointMap(endpointMap, domain, recordType, address.Address)
+					}
+				}
+			}
+		}
+
+		if ps.compatibility == "kops-dns-controller" {
+			if domainAnnotation, ok := pod.Annotations[kopsDNSControllerInternalHostnameAnnotationKey]; ok {
+				domainList := splitHostnameAnnotation(domainAnnotation)
+				for _, domain := range domainList {
+					addToEndpointMap(endpointMap, domain, suitableType(pod.Status.PodIP), pod.Status.PodIP)
+				}
+			}
+
+			if domainAnnotation, ok := pod.Annotations[kopsDNSControllerHostnameAnnotationKey]; ok {
+				domainList := splitHostnameAnnotation(domainAnnotation)
+				for _, domain := range domainList {
+					node, _ := ps.nodeInformer.Lister().Get(pod.Spec.NodeName)
+					for _, address := range node.Status.Addresses {
+						recordType := suitableType(address.Address)
+						// IPv6 addresses are labeled as NodeInternalIP despite being usable externally as well.
+						if address.Type == corev1.NodeExternalIP || (address.Type == corev1.NodeInternalIP && recordType == endpoint.RecordTypeAAAA) {
+							addToEndpointMap(endpointMap, domain, recordType, address.Address)
+						}
 					}
 				}
 			}

--- a/source/pod.go
+++ b/source/pod.go
@@ -93,7 +93,6 @@ func (ps *podSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 			domainList := splitHostnameAnnotation(domainAnnotation)
 			for _, domain := range domainList {
 				addToEndpointMap(endpointMap, domain, suitableType(pod.Status.PodIP), pod.Status.PodIP)
-
 			}
 		}
 

--- a/source/pod_test.go
+++ b/source/pod_test.go
@@ -526,6 +526,46 @@ func TestPodSource(t *testing.T) {
 				},
 			},
 		},
+		{
+			"split record for internal hostname annotation",
+			"",
+			"",
+			[]*endpoint.Endpoint{
+				{DNSName: "internal.a.foo.example.org", Targets: endpoint.Targets{"10.0.1.1"}, RecordType: endpoint.RecordTypeA},
+				{DNSName: "internal.b.foo.example.org", Targets: endpoint.Targets{"10.0.1.1"}, RecordType: endpoint.RecordTypeA},
+			},
+			false,
+			[]*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-node1",
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{Type: corev1.NodeInternalIP, Address: "10.0.1.1"},
+						},
+					},
+				},
+			},
+			[]*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-pod1",
+						Namespace: "kube-system",
+						Annotations: map[string]string{
+							internalHostnameAnnotationKey: "internal.a.foo.example.org,internal.b.foo.example.org",
+						},
+					},
+					Spec: corev1.PodSpec{
+						HostNetwork: true,
+						NodeName:    "my-node1",
+					},
+					Status: corev1.PodStatus{
+						PodIP: "10.0.1.1",
+					},
+				},
+			},
+		},
 	} {
 		tc := tc
 		t.Run(tc.title, func(t *testing.T) {

--- a/source/source.go
+++ b/source/source.go
@@ -157,7 +157,7 @@ func getHostnamesFromAnnotations(annotations map[string]string) []string {
 	if !exists {
 		return nil
 	}
-	return strings.Split(strings.Replace(hostnameAnnotation, " ", "", -1), ",")
+	return splitHostnameAnnotation(hostnameAnnotation)
 }
 
 func getAccessFromAnnotations(annotations map[string]string) string {
@@ -173,7 +173,11 @@ func getInternalHostnamesFromAnnotations(annotations map[string]string) []string
 	if !exists {
 		return nil
 	}
-	return strings.Split(strings.Replace(internalHostnameAnnotation, " ", "", -1), ",")
+	return splitHostnameAnnotation(internalHostnameAnnotation)
+}
+
+func splitHostnameAnnotation(annotation string) []string {
+	return strings.Split(strings.Replace(annotation, " ", "", -1), ",")
 }
 
 func getAliasFromAnnotations(annotations map[string]string) bool {


### PR DESCRIPTION
**Description**

This PR allows multiple record names separated by commas in the internal-hostname annotation of pods, as is available for services.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
