### PR TITLE
Remove UpdateOld changeset for Azure

### DIFF
--- a/provider/azure/azure.go
+++ b/provider/azure/azure.go
@@ -250,10 +250,6 @@ func (p *AzureProvider) mapChanges(zones []dns.Zone, changes *plan.Changes) (azu
 		mapChange(deleted, change)
 	}
 
-	for _, change := range changes.UpdateOld {
-		mapChange(deleted, change)
-	}
-
 	for _, change := range changes.Create {
 		mapChange(updated, change)
 	}

--- a/provider/azure/azure_private_dns.go
+++ b/provider/azure/azure_private_dns.go
@@ -237,10 +237,6 @@ func (p *AzurePrivateDNSProvider) mapChanges(zones []privatedns.PrivateZone, cha
 		mapChange(deleted, change)
 	}
 
-	for _, change := range changes.UpdateOld {
-		mapChange(deleted, change)
-	}
-
 	for _, change := range changes.Create {
 		mapChange(updated, change)
 	}

--- a/provider/azure/azure_privatedns_test.go
+++ b/provider/azure/azure_privatedns_test.go
@@ -342,11 +342,8 @@ func TestAzurePrivateDNSApplyChanges(t *testing.T) {
 	testAzurePrivateDNSApplyChangesInternal(t, false, &recordsClient)
 
 	validateAzureEndpoints(t, recordsClient.deletedEndpoints, []*endpoint.Endpoint{
-		endpoint.NewEndpoint("old.example.com", endpoint.RecordTypeA, ""),
-		endpoint.NewEndpoint("oldcname.example.com", endpoint.RecordTypeCNAME, ""),
 		endpoint.NewEndpoint("deleted.example.com", endpoint.RecordTypeA, ""),
 		endpoint.NewEndpoint("deletedcname.example.com", endpoint.RecordTypeCNAME, ""),
-		endpoint.NewEndpoint("oldmail.example.com", endpoint.RecordTypeMX, ""),
 	})
 
 	validateAzureEndpoints(t, recordsClient.updatedEndpoints, []*endpoint.Endpoint{

--- a/provider/azure/azure_test.go
+++ b/provider/azure/azure_test.go
@@ -349,11 +349,8 @@ func TestAzureApplyChanges(t *testing.T) {
 	testAzureApplyChangesInternal(t, false, &recordsClient)
 
 	validateAzureEndpoints(t, recordsClient.deletedEndpoints, []*endpoint.Endpoint{
-		endpoint.NewEndpoint("old.example.com", endpoint.RecordTypeA, ""),
-		endpoint.NewEndpoint("oldcname.example.com", endpoint.RecordTypeCNAME, ""),
 		endpoint.NewEndpoint("deleted.example.com", endpoint.RecordTypeA, ""),
 		endpoint.NewEndpoint("deletedcname.example.com", endpoint.RecordTypeCNAME, ""),
-		endpoint.NewEndpoint("oldmail.example.com", endpoint.RecordTypeMX, ""),
 	})
 
 	validateAzureEndpoints(t, recordsClient.updatedEndpoints, []*endpoint.Endpoint{
@@ -508,8 +505,6 @@ func TestAzureApplyChangesZoneName(t *testing.T) {
 	testAzureApplyChangesInternalZoneName(t, false, &recordsClient)
 
 	validateAzureEndpoints(t, recordsClient.deletedEndpoints, []*endpoint.Endpoint{
-		endpoint.NewEndpoint("old.foo.example.com", endpoint.RecordTypeA, ""),
-		endpoint.NewEndpoint("oldcname.foo.example.com", endpoint.RecordTypeCNAME, ""),
 		endpoint.NewEndpoint("deleted.foo.example.com", endpoint.RecordTypeA, ""),
 		endpoint.NewEndpoint("deletedcname.foo.example.com", endpoint.RecordTypeCNAME, ""),
 	})


### PR DESCRIPTION
**Description**

The underlying SDK uses `recordSetsClient.CreateOrUpdate()` [doc](https://docs.microsoft.com/en-us/rest/api/dns/record-sets/create-or-update) which allows us to exclusively rely on UpdateNew for record set updates. As a result, we're no longer running the risk of zone update failures causing outages as outlined in #2918

Fix https://github.com/kubernetes-sigs/external-dns/issues/2918
Supersedes https://github.com/kubernetes-sigs/external-dns/pull/3285

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
