### PR TITLE
chore(deps): bump libcrypto3 and libssl3 3.0.8-r4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY . .
 
 FROM alpine:3.18
 
-RUN apk update && apk add "libcrypto3>=3.0.8-r1" "libssl3>=3.0.8-r1" && rm -rf /var/cache/apt/*
+RUN apk update && apk add "libcrypto3>=3.0.8-r4" "libssl3>=3.0.8-r4" && rm -rf /var/cache/apt/*
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /bin/external-dns


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Previous PR was the last PR and solved some CVEs.

- https://github.com/kubernetes-sigs/external-dns/pull/3500

This should resolve CVE-2023-1255 and CVE-2023-0465 by bumping libcrypto3 and libssl3 to 3.0.8-r4

```
~ docker run -u root -it --rm --entrypoint sh registry.k8s.io/external-dns/external-dns:v0.13.4 -c \
    'apk update && apk add "libcrypto3>=3.0.8-r4" "libssl3>=3.0.8-r4" && apk info libcrypto3'

fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/main/aarch64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/community/aarch64/APKINDEX.tar.gz
v3.17.3-202-gc3b7872ff80 [https://dl-cdn.alpinelinux.org/alpine/v3.17/main]
v3.17.3-195-gc5298d215ef [https://dl-cdn.alpinelinux.org/alpine/v3.17/community]
OK: 17694 distinct packages available
(1/2) Upgrading libcrypto3 (3.0.8-r1 -> 3.0.8-r4)
(2/2) Upgrading libssl3 (3.0.8-r1 -> 3.0.8-r4)
OK: 7 MiB in 15 packages
libcrypto3-3.0.8-r4 description:
Crypto library from openssl

libcrypto3-3.0.8-r4 webpage:
https://www.openssl.org/

libcrypto3-3.0.8-r4 installed size:
4100 KiB
```

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

**Checklist**

- ~Unit tests updated~
- ~End user documentation updated~
