### PR TITLE
Add no-change info log for cloudflare provider

### DIFF
--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -297,6 +297,7 @@ func (p *CloudFlareProvider) PropertyValuesEqual(name string, previous string, c
 func (p *CloudFlareProvider) submitChanges(ctx context.Context, changes []*cloudFlareChange) error {
 	// return early if there is nothing to change
 	if len(changes) == 0 {
+		log.Info("All records are already up to date")
 		return nil
 	}
 


### PR DESCRIPTION
**Description**

Many providers including aws and google is logging "All records are already up to date" when there is no change. For cloudflare this PR is adding it. I.e when there is no such a log in external-dns with cloudflare provider and there is in external-dns with aws provider, it is a bit confusing for the end users who use them both.

**Checklist**

- [ ] ~~Unit tests updated~~
- [ ] ~~End user documentation updated~~
