### PR TITLE
Rebuild of the ConflictResolver

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -229,7 +229,12 @@ func (c *Controller) RunOnce(ctx context.Context) error {
 			PropertyComparator: c.Registry.PropertyValuesEqual,
 			ManagedRecords:     c.ManagedRecordTypes,
 		}
-		missingRecordsPlan = missingRecordsPlan.Calculate()
+		missingRecordsPlan, err = missingRecordsPlan.CalculateWithError()
+		if err != nil {
+			sourceErrorsTotal.Inc()
+			deprecatedSourceErrors.Inc()
+			return err
+		}
 		if missingRecordsPlan.Changes.HasChanges() {
 			err = c.Registry.ApplyChanges(ctx, missingRecordsPlan.Changes)
 			if err != nil {
@@ -250,7 +255,12 @@ func (c *Controller) RunOnce(ctx context.Context) error {
 		ManagedRecords:     c.ManagedRecordTypes,
 	}
 
-	plan = plan.Calculate()
+	plan, err = plan.CalculateWithError()
+	if err != nil {
+		sourceErrorsTotal.Inc()
+		deprecatedSourceErrors.Inc()
+		return err
+	}
 
 	if plan.Changes.HasChanges() {
 		err = c.Registry.ApplyChanges(ctx, plan.Changes)

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -433,6 +433,9 @@ func TestWhenMultipleControllerConsidersAllFilteredComain(t *testing.T) {
 				DNSName:    "some-record.used.tld",
 				RecordType: endpoint.RecordTypeA,
 				Targets:    endpoint.Targets{"1.1.1.1"},
+				Labels: map[string]string{
+					"owner": "me",
+				},
 			},
 			{
 				DNSName:    "create-record.unused.tld",
@@ -462,7 +465,6 @@ func TestWhenMultipleControllerConsidersAllFilteredComain(t *testing.T) {
 						DNSName:    "some-record.used.tld",
 						RecordType: endpoint.RecordTypeA,
 						Targets:    endpoint.Targets{"8.8.8.8"},
-						Labels:     endpoint.Labels{},
 					},
 				},
 				UpdateNew: []*endpoint.Endpoint{
@@ -470,8 +472,9 @@ func TestWhenMultipleControllerConsidersAllFilteredComain(t *testing.T) {
 						DNSName:    "some-record.used.tld",
 						RecordType: endpoint.RecordTypeA,
 						Targets:    endpoint.Targets{"1.1.1.1"},
+						// this ne new resolver will transfer existing labels
 						Labels: endpoint.Labels{
-							"owner": "",
+							"owner": "me",
 						},
 					},
 				},

--- a/plan/conflict.go
+++ b/plan/conflict.go
@@ -17,7 +17,9 @@ limitations under the License.
 package plan
 
 import (
+	"fmt"
 	"sort"
+	"strings"
 
 	"sigs.k8s.io/external-dns/endpoint"
 )
@@ -25,46 +27,501 @@ import (
 // ConflictResolver is used to make a decision in case of two or more different kubernetes resources
 // are trying to acquire same DNS name
 type ConflictResolver interface {
-	ResolveCreate(candidates []*endpoint.Endpoint) *endpoint.Endpoint
-	ResolveUpdate(current *endpoint.Endpoint, candidates []*endpoint.Endpoint) *endpoint.Endpoint
+	Resolve(currents []*endpoint.Endpoint, candidates []*endpoint.Endpoint) (changes Changes, err error)
 }
 
 // PerResource allows only one resource to own a given dns name
 type PerResource struct{}
 
-// ResolveCreate is invoked when dns name is not owned by any resource
-// ResolveCreate takes "minimal" (string comparison of Target) endpoint to acquire the DNS record
-func (s PerResource) ResolveCreate(candidates []*endpoint.Endpoint) *endpoint.Endpoint {
-	var min *endpoint.Endpoint
-	for _, ep := range candidates {
-		if min == nil || s.less(ep, min) {
-			min = ep
-		}
-	}
-	return min
-}
-
 // ResolveUpdate is invoked when dns name is already owned by "current" endpoint
 // ResolveUpdate uses "current" record as base and updates it accordingly with new version of same resource
 // if it doesn't exist then pick min
-func (s PerResource) ResolveUpdate(current *endpoint.Endpoint, candidates []*endpoint.Endpoint) *endpoint.Endpoint {
-	currentResource := current.Labels[endpoint.ResourceLabelKey] // resource which has already acquired the DNS
-	// TODO: sort candidates only needed because we can still have two endpoints from same resource here. We sort for consistency
-	// TODO: remove once single endpoint can have multiple targets
-	sort.SliceStable(candidates, func(i, j int) bool {
-		return s.less(candidates[i], candidates[j])
-	})
-	for _, ep := range candidates {
-		if ep.Labels[endpoint.ResourceLabelKey] == currentResource {
-			return ep
+
+type wrapEndpoint struct {
+	endpoint  *endpoint.Endpoint
+	isCurrent bool
+	targetIdx int
+	order     int
+}
+
+func (w wrapEndpoint) target() string {
+	return w.endpoint.Targets[w.targetIdx]
+}
+
+func (w wrapEndpoint) setIdentifier() string {
+	return w.endpoint.SetIdentifier
+}
+
+func (w wrapEndpoint) recordTTL() endpoint.TTL {
+	return w.endpoint.RecordTTL
+}
+
+func (w wrapEndpoint) recordType() string {
+	return w.endpoint.RecordType
+}
+
+func (w wrapEndpoint) dnsName() string {
+	return w.endpoint.DNSName
+}
+
+type wrapEndpoints []wrapEndpoint
+
+func (ws wrapEndpoints) Len() int {
+	return len(ws)
+}
+
+// this sorts the same target in the input order
+func (ws wrapEndpoints) Less(i, j int) bool {
+	wi := ws[i]
+	wj := ws[j]
+	// we don't care about dnsName, recordType, setIdentifier
+	// they must be the same
+	val := strings.Compare(wi.dnsName(), wj.dnsName())
+	if val != 0 {
+		return val < 0
+	}
+	val = strings.Compare(wi.recordType(), wj.recordType())
+	if val != 0 {
+		return val < 0
+	}
+	val = strings.Compare(wi.setIdentifier(), wj.setIdentifier())
+	if val != 0 {
+		return val < 0
+	}
+	val = strings.Compare(wi.target(), wj.target())
+	if val != 0 {
+		return val < 0
+	}
+	// this sorts the same targets in the input order
+	// to have a defined marge behavior
+	return wi.order < wj.order
+}
+
+func (ws wrapEndpoints) Swap(i, j int) {
+	ws[i], ws[j] = ws[j], ws[i]
+}
+
+func toWrapEndpoints(ep *endpoint.Endpoint, order int, isCurrent bool) wrapEndpoints {
+	result := wrapEndpoints{}
+	workingEp := ep.DeepCopy()
+	// there is a situation where we have more than 65536 endpoints
+	// but i think that will break the dns provider
+	order = order << 16
+	for idx, _ := range ep.Targets {
+		result = append(result, wrapEndpoint{
+			endpoint:  workingEp,
+			isCurrent: isCurrent,
+			targetIdx: idx,
+			order:     order + idx,
+		})
+	}
+	return result
+}
+
+// func equalWrapNameType(a, b *wrapEndpoint) bool {
+// 	if a.dnsName() != b.dnsName() {
+// 		return false
+// 	}
+// 	if a.recordType() != b.recordType() {
+// 		return false
+// 	}
+// 	return true
+// }
+
+func equalWrapEndpoint(a, b *wrapEndpoint) bool {
+	if a.dnsName() != b.dnsName() {
+		return false
+	}
+	if a.recordType() != b.recordType() {
+		return false
+	}
+	if a.setIdentifier() != b.setIdentifier() {
+		return false
+	}
+	if a.recordTTL() != b.recordTTL() {
+		return false
+	}
+	if a.target() != b.target() {
+		return false
+	}
+	return true
+}
+
+func uniqueWrapEndpoints(ws wrapEndpoints) wrapEndpoints {
+	// sort by dnsName, recordType, target and order to have a defined merge behavior
+	sort.Sort(ws)
+	result := make(wrapEndpoints, 0, len(ws))
+	for i := 0; i < len(ws); i++ {
+		if i == 0 {
+			result = append(result, ws[i])
+			continue
+		}
+		if equalWrapEndpoint(&ws[i], &ws[i-1]) {
+			// mergeSetIdentifier(ws[i-1].endpoint, ws[i].endpoint)
+			ws[i-1].endpoint.Labels = srcWinsMergeLabels(ws[i-1].endpoint.Labels, ws[i].endpoint.Labels)
+			mergeProviderSpecific(ws[i-1].endpoint, ws[i].endpoint)
+			continue
+		}
+		result = append(result, ws[i])
+	}
+	return result
+}
+
+func mergeCurrentAndCandidates(ws wrapEndpoints) wrapEndpoints {
+	sort.Sort(ws)
+	currents := findCurrents(ws)
+	candidates := uniqueWrapEndpoints(findCandidates(ws))
+	return append(currents, candidates...)
+}
+
+func hasCurrentAndCandidate(ws wrapEndpoints) bool {
+	current := false
+	candidate := false
+	for _, wep := range ws {
+		if wep.isCurrent {
+			current = true
+		} else {
+			candidate = true
 		}
 	}
-	return s.ResolveCreate(candidates)
+	return current && candidate
+}
+
+func labels2ProviderSpecific(lbs endpoint.Labels) endpoint.ProviderSpecific {
+	ret := make(endpoint.ProviderSpecific, 0, len(lbs))
+	for k, v := range lbs {
+		ret = append(ret, endpoint.ProviderSpecificProperty{
+			Name:  k,
+			Value: v,
+		})
+	}
+	return ret
+}
+
+type myProviderSpecific endpoint.ProviderSpecific
+
+func (ps myProviderSpecific) Len() int {
+	return len(ps)
+}
+
+func (ps myProviderSpecific) Less(i, j int) bool {
+	x := strings.Compare(ps[i].Name, ps[j].Name)
+	if x < 0 {
+		return true
+	} else if x == 0 {
+		if strings.Compare(ps[i].Value, ps[j].Value) < 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (ps myProviderSpecific) Swap(i, j int) {
+	ps[i], ps[j] = ps[j], ps[i]
+}
+
+func equalProviderSpecific(ps1, ps2 endpoint.ProviderSpecific) bool {
+	if len(ps1) != len(ps2) {
+		return false
+	}
+	sort.Sort(myProviderSpecific(ps1))
+	sort.Sort(myProviderSpecific(ps2))
+	for i := 0; i < len(ps1); i++ {
+		if ps1[i].Name != ps2[i].Name || ps1[i].Value != ps2[i].Value {
+			return false
+		}
+	}
+	return true
+}
+
+func equalLabels(l1, l2 endpoint.Labels) bool {
+	if len(l1) != len(l2) {
+		return false
+	}
+	return equalProviderSpecific(labels2ProviderSpecific(l1), labels2ProviderSpecific(l2))
+}
+
+func onlyCurrent(ws wrapEndpoints) bool {
+	ret := true
+	for _, wep := range ws {
+		ret = ret && wep.isCurrent
+	}
+	return ret
+}
+
+func findCandidates(ws wrapEndpoints) wrapEndpoints {
+	ret := wrapEndpoints{}
+	for _, wep := range ws {
+		if !wep.isCurrent {
+			ret = append(ret, wep)
+		}
+	}
+	return ret
+}
+
+// func findCandidate(ws wrapEndpoints) *wrapEndpoint {
+// 	return &findCandidates(ws)[0]
+// }
+
+func findCurrents(ws wrapEndpoints) wrapEndpoints {
+	ret := wrapEndpoints{}
+	for _, wep := range ws {
+		if wep.isCurrent {
+			ret = append(ret, wep)
+		}
+	}
+	return ret
+}
+
+func findCurrentEndpoints(ws wrapEndpoints) []*endpoint.Endpoint {
+	sort.Sort(ws)
+	weps := map[string]wrapEndpoint{}
+	for _, wep := range findCurrents(ws) {
+		weps[fmt.Sprintf("%p", wep.endpoint)] = wep
+	}
+	orderWeps := make(wrapEndpoints, 0, len(weps))
+	for _, wep := range weps {
+		orderWeps = append(orderWeps, wep)
+	}
+	sort.Slice(orderWeps, func(i, j int) bool {
+		return orderWeps[i].order < orderWeps[j].order
+	})
+	ret := make([]*endpoint.Endpoint, 0, len(weps))
+	for _, wep := range orderWeps {
+		ret = append(ret, wep.endpoint)
+	}
+	return ret
+}
+
+// func findCurrent(ws wrapEndpoints) *wrapEndpoint {
+// 	return &findCurrents(ws)[0]
+// }
+
+func equalEndpointKey(a, b *endpoint.Endpoint) bool {
+	return a.DNSName == b.DNSName && a.RecordType == b.RecordType && a.SetIdentifier == b.SetIdentifier
+}
+
+func (wes wrapEndpoints) append(ep *endpoint.Endpoint, isCurrent bool) (wrapEndpoints, error) {
+	if len(wes) != 0 {
+		prev := wes[len(wes)-1]
+		// ensure that the group is homogeneous
+		if !equalEndpointKey(prev.endpoint, ep) {
+			return wes, fmt.Errorf("cannot append endpoint %v to group %v", ep, wes)
+		}
+	}
+	order := len(wes)
+	return append(wes, toWrapEndpoints(ep, order, isCurrent)...), nil
+}
+
+// func mergeSetIdentifier(dest, src *endpoint.Endpoint) {
+// 	if src.SetIdentifier != "" {
+// 		dest.SetIdentifier = src.SetIdentifier
+// 	}
+// }
+
+// func destWinsMergeLabels(dest, src *endpoint.Endpoint) {
+// 	if src.Labels == nil {
+// 		return
+// 	}
+// 	if dest.Labels == nil {
+// 		dest.Labels = make(endpoint.Labels)
+// 	}
+// 	for k, v := range src.Labels {
+// 		_, found := dest.Labels[k]
+// 		if found {
+// 			continue
+// 		}
+// 		dest.Labels[k] = v
+// 	}
+// }
+
+func srcWinsMergeLabels(dst, src map[string]string) map[string]string {
+	if src == nil || len(src) == 0 {
+		return dst
+	}
+	if dst == nil {
+		dst = make(map[string]string)
+	}
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func mergeProviderSpecific(dest, src *endpoint.Endpoint) {
+	destMap := make(map[string]string)
+	for _, p := range dest.ProviderSpecific {
+		destMap[p.Name] = p.Value
+	}
+	for _, p := range src.ProviderSpecific {
+		_, found := destMap[p.Name]
+		if found {
+			continue
+		}
+		dest.ProviderSpecific = append(dest.ProviderSpecific, p)
+	}
+}
+
+func equalEndpointWithoutLabels(e1, e2 *endpoint.Endpoint) bool {
+	if e1.DNSName != e2.DNSName {
+		return false
+	}
+	if !e1.Targets.Same(e2.Targets) {
+		return false
+	}
+	if e1.RecordType != e2.RecordType {
+		return false
+	}
+	if e1.SetIdentifier != e2.SetIdentifier {
+		return false
+	}
+	if e1.RecordTTL != e2.RecordTTL {
+		return false
+	}
+	if !equalProviderSpecific(e1.ProviderSpecific, e2.ProviderSpecific) {
+		return false
+	}
+	return true
+}
+
+func equalEndpoint(e1, e2 *endpoint.Endpoint) bool {
+	if !equalEndpointWithoutLabels(e1, e2) {
+		return false
+	}
+	if !equalLabels(e1.Labels, e2.Labels) {
+		return false
+	}
+	return true
+}
+
+func mergeEndpointTargets(ep *endpoint.Endpoint) error {
+	if len(ep.Targets) == 0 {
+		return fmt.Errorf("empty targets are not allowed")
+	}
+	switch ep.RecordType {
+	case endpoint.RecordTypePTR:
+		for i := 1; i < len(ep.Targets); i++ {
+			if ep.Targets[i] != ep.Targets[0] {
+				return fmt.Errorf("inconsistent targets for PTR record")
+			}
+		}
+		ep.Targets = []string{ep.Targets[0]}
+	case endpoint.RecordTypeCNAME:
+		for i := 1; i < len(ep.Targets); i++ {
+			if ep.Targets[i] != ep.Targets[0] {
+				return fmt.Errorf("inconsistent targets for CNAME record")
+			}
+		}
+		ep.Targets = []string{ep.Targets[0]}
+
+	default:
+		// we don't merge targets for other record types
+	}
+	return nil
+}
+
+func toEndpoint(ws wrapEndpoints) (*endpoint.Endpoint, error) {
+	if len(ws) == 0 {
+		return nil, fmt.Errorf("empty wrapEndpoints")
+	}
+	// sort by target
+	sort.Sort(ws)
+
+	ret := ws[0].endpoint.DeepCopy()
+	ret.Targets = []string{ws[0].target()}
+	for i := 1; i < len(ws); i++ {
+		wep := ws[i]
+		if ret.DNSName != wep.dnsName() {
+			return nil, fmt.Errorf("inconsistent DNSName")
+		}
+		if ret.RecordType != wep.recordType() {
+			return nil, fmt.Errorf("inconsistent RecordType")
+		}
+		if ret.SetIdentifier != wep.setIdentifier() {
+			return nil, fmt.Errorf("inconsistent SetIdentifier")
+		}
+		if ret.RecordTTL != wep.recordTTL() {
+			return nil, fmt.Errorf("inconsistent RecordTTL")
+		}
+		// check if target is duplicated
+		if ws[i-1].target() != wep.target() {
+			ret.Targets = append(ret.Targets, wep.target())
+		}
+		// src wins merge
+		ret.Labels = srcWinsMergeLabels(ret.Labels, wep.endpoint.Labels)
+		mergeProviderSpecific(ret, wep.endpoint)
+	}
+	err := mergeEndpointTargets(ret)
+
+	return ret, err
+}
+
+func (s PerResource) Resolve(currents []*endpoint.Endpoint, candidates []*endpoint.Endpoint) (changes Changes, err error) {
+	wes := make(wrapEndpoints, 0, len(currents)+len(candidates))
+	for _, ep := range currents {
+		wes, err = wes.append(ep, true)
+		if err != nil {
+			return
+		}
+	}
+	for _, ep := range candidates {
+		wes, err = wes.append(ep, false)
+		if err != nil {
+			return
+		}
+	}
+
+	mcac := mergeCurrentAndCandidates(wes)
+	var ep *endpoint.Endpoint
+	if onlyCurrent(mcac) {
+		// ep, err = toEndpoint(mcac)
+		// if err != nil {
+		// 	return
+		// }
+		changes.Delete = append(changes.Delete, findCurrentEndpoints(mcac)...)
+		return
+	}
+	if hasCurrentAndCandidate(mcac) {
+		currents := findCurrents(mcac)
+		sort.Sort(currents) // sort by target
+		var currentMergedLabels map[string]string
+		for _, current := range currents {
+			currentMergedLabels = srcWinsMergeLabels(currentMergedLabels, current.endpoint.Labels)
+		}
+		candidates := findCandidates(mcac)
+		sort.Sort(candidates) // sort by target
+
+		var candidateEP *endpoint.Endpoint
+		candidateEP, err = toEndpoint(candidates)
+		if err != nil {
+			return
+		}
+		candidateEP.Labels = srcWinsMergeLabels(currentMergedLabels, candidateEP.Labels)
+		oldEPs := findCurrentEndpoints(mcac)
+		foundCandidate := false
+		for _, oldEp := range oldEPs {
+			if equalEndpoint(oldEp, candidateEP) {
+				foundCandidate = true
+				continue
+			}
+			changes.UpdateOld = append(changes.UpdateOld, oldEp)
+		}
+		if !foundCandidate {
+			changes.UpdateNew = append(changes.UpdateNew, candidateEP)
+		}
+		return
+	}
+	ep, err = toEndpoint(mcac)
+	if err != nil {
+		return
+	}
+	changes.Create = append(changes.Create, ep)
+	return // s.ResolveCreate(candidates)
 }
 
 // less returns true if endpoint x is less than y
-func (s PerResource) less(x, y *endpoint.Endpoint) bool {
-	return x.Targets.IsLess(y.Targets)
-}
+// func (s PerResource) less(x, y *endpoint.Endpoint) bool {
+// 	return x.Targets.IsLess(y.Targets)
+// }
 
 // TODO: with cross-resource/cross-cluster setup alternative variations of ConflictResolver can be used

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -1860,7 +1860,8 @@ func TestAWSHealthTargetAnnotation(tt *testing.T) {
 				PropertyComparator: provider.PropertyValuesEqual,
 				ManagedRecords:     []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 			}
-			plan = plan.Calculate()
+			plan, err := plan.CalculateWithError()
+			assert.NoError(t, err)
 			assert.Equal(t, test.shouldUpdate, len(plan.Changes.UpdateNew) == 1)
 		})
 	}


### PR DESCRIPTION


**Description**

After discovering that the conflictresolver and plan only working with a few recordtypes. I decided to build i complete new.  

I know it's a bigger change but I tried to fix the existing one and it failed --- mainly the merging and sorting had not been there. And the lack of that prevents the merging of targets and labels. To create a defined or for merging a internal switch to a wrapEndpoint which only have one Target instead of a list of targets.

I had to change the api(plan.Calculate) due to that there are some cases where the conflict resolver is not able to resolve. These are mainly if the input data are not valid like having multiple targets on CNAME's or
PTR's recordtypes.  The change of the api and the behavior causes that i had to change the tests in plan and cloudflare_test.go.


**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
