### PR TITLE
docs: Update deprecated apiVersions

### DIFF
--- a/docs/tutorials/civo.md
+++ b/docs/tutorials/civo.md
@@ -59,7 +59,7 @@ kind: ServiceAccount
 metadata:
   name: external-dns
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: external-dns
@@ -74,7 +74,7 @@ rules:
   resources: ["nodes"]
   verbs: ["list"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: external-dns-viewer

--- a/docs/tutorials/gandi.md
+++ b/docs/tutorials/gandi.md
@@ -56,7 +56,7 @@ kind: ServiceAccount
 metadata:
   name: external-dns
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: external-dns
@@ -71,7 +71,7 @@ rules:
   resources: ["nodes"]
   verbs: ["list","watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: external-dns-viewer

--- a/docs/tutorials/hostport.md
+++ b/docs/tutorials/hostport.md
@@ -114,7 +114,7 @@ spec:
 First lets deploy a Kafka Stateful set, a simple example(a lot of stuff is missing) with a headless service called `ksvc`
 
 ```yaml
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: kafka

--- a/docs/tutorials/public-private-route53.md
+++ b/docs/tutorials/public-private-route53.md
@@ -216,7 +216,7 @@ Consult [AWS ExternalDNS setup docs](aws.md) for installation guidelines.
 In ExternalDNS containers args, make sure to specify `aws-zone-type` and `ingress-class`:
 
 ```yaml
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -254,7 +254,7 @@ Consult [AWS ExternalDNS setup docs](aws.md) for installation guidelines.
 In ExternalDNS containers args, make sure to specify `aws-zone-type` and `ingress-class`:
 
 ```yaml
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

Was working on R53 today for a test setup and some of the manifests for AWS R53 were outdated. Here's a tiny PR to fix them.


**Description**

- update rbac.authorization apiVersion from `rbac.authorization.k8s.io/v1beta1` to `rbac.authorization.k8s.io/v1` as it was [deprecated in k8s 1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122)
- update deployment and statefulset apiVersion from `apps/v1beta` to `apps/v1` as it was [deprecated in k8s 1.16](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#deployment-v116)



**Checklist**

- [ ] Unit tests updated (N/A)
- [x] End user documentation updated
