### PR TITLE
fix clean apk cache directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY . .
 
 FROM alpine:3.18
 
-RUN apk update && apk add "libcrypto3>=3.0.8-r4" "libssl3>=3.0.8-r4" && rm -rf /var/cache/apt/*
+RUN apk update && apk add "libcrypto3>=3.0.8-r4" "libssl3>=3.0.8-r4" && rm -rf /var/cache/apk/*
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /bin/external-dns


### PR DESCRIPTION
alpine uses /var/cache/apk, not apt

**Description**

Haven't opened an issue, the problem is obvious and fix is trivial. Correctly cleaning up APKINDEX saves ~1.8M from the built alpine image.

Alternative solution, which is less verbose, would be to just use
`apk add --no-cache "libcrypto3>=3.0.8-r4" "libssl3>=3.0.8-r4"`

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
