### PR TITLE
feat(chart): updated chart to ExternalDNS v0.13.5

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### All Changes
 
-- Updated _ExternalDNS_ version to [v0.13.5](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.13.5). ([#TODO](https://github.com/kubernetes-sigs/external-dns/pull/TODO)) [@GMartinez-Sisti](https://github.com/GMartinez-Sisti)
+- Updated _ExternalDNS_ version to [v0.13.5](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.13.5). ([#3661](https://github.com/kubernetes-sigs/external-dns/pull/3661)) [@GMartinez-Sisti](https://github.com/GMartinez-Sisti)
 - Resolve LB-type Service hostname to create A/AAAA instead of CNAME. ([#3554](https://github.com/kubernetes-sigs/external-dns/pull/3554)) [@cxuu](https://github.com/cxuu)
 - Adding missing gateway-httproute cluster role permission. ([#3541](https://github.com/kubernetes-sigs/external-dns/pull/3541)) [@nicon89](https://github.com/nicon89)
 

--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -11,7 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### All Changes
 
-## [v1.12.2] - UNRELEASED
+## [v1.13.0] - 2023-03-30
+
+### All Changes
+
+- Updated _ExternalDNS_ version to [v0.13.5](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.13.5). ([#TODO](https://github.com/kubernetes-sigs/external-dns/pull/TODO)) [@GMartinez-Sisti](https://github.com/GMartinez-Sisti)
+- Resolve LB-type Service hostname to create A/AAAA instead of CNAME. ([#3554](https://github.com/kubernetes-sigs/external-dns/pull/3554)) [@cxuu](https://github.com/cxuu)
+- Adding missing gateway-httproute cluster role permission. ([#3541](https://github.com/kubernetes-sigs/external-dns/pull/3541)) [@nicon89](https://github.com/nicon89)
+
+## [v1.12.2] - 2023-03-30
 
 ### All Changes
 

--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### All Changes
 
 - Updated _ExternalDNS_ version to [v0.13.5](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.13.5). ([#3661](https://github.com/kubernetes-sigs/external-dns/pull/3661)) [@GMartinez-Sisti](https://github.com/GMartinez-Sisti)
-- Resolve LB-type Service hostname to create A/AAAA instead of CNAME. ([#3554](https://github.com/kubernetes-sigs/external-dns/pull/3554)) [@cxuu](https://github.com/cxuu)
 - Adding missing gateway-httproute cluster role permission. ([#3541](https://github.com/kubernetes-sigs/external-dns/pull/3541)) [@nicon89](https://github.com/nicon89)
 
 ## [v1.12.2] - 2023-03-30

--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -23,6 +23,4 @@ annotations:
     - kind: changed
       description: "Updated _ExternalDNS_ version to [v0.13.5](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.13.5)."
     - kind: changed
-      description: "Resolve LB-type Service hostname to create A/AAAA instead of CNAME."
-    - kind: changed
       description: "Adding missing gateway-httproute cluster role permission."

--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: external-dns
 description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 type: application
-version: 1.12.2
-appVersion: 0.13.4
+version: 1.13.0
+appVersion: 0.13.5
 keywords:
   - kubernetes
   - externaldns
@@ -20,15 +20,9 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "Added support for ServiceMonitor relabelling."
     - kind: changed
-      description: "Updated chart icon path."
-    - kind: added
-      description: "Added RBAC for Gateway-API resources to ClusterRole."
-    - kind: added
-      description: "Added RBAC for F5 VirtualServer to ClusterRole."
-    - kind: added
-      description: "Added support for running ExternalDNS with namespaced scope."
+      description: "Updated _ExternalDNS_ version to [v0.13.5](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.13.5)."
     - kind: changed
-      description: "Updated _ExternalDNS_ version to [v0.13.4](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.13.4)."
+      description: "Resolve LB-type Service hostname to create A/AAAA instead of CNAME."
+    - kind: changed
+      description: "Adding missing gateway-httproute cluster role permission."


### PR DESCRIPTION
This PR updates the Helm chart to use the latest ExternalDNS version ([v0.13.5](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.13.5)) and includes all the other improvements since the last release (see CHANGELOG).

Followed the same format as https://github.com/kubernetes-sigs/external-dns/pull/3516.

Fixes https://github.com/kubernetes-sigs/external-dns/issues/3644

@stevehipwell 😃 

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
