### PR TITLE
add option to specify endpoint for AWS Provider

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -230,11 +230,16 @@ type AWSConfig struct {
 	PreferCNAME          bool
 	DryRun               bool
 	ZoneCacheDuration    time.Duration
+	Endpoint             string
 }
 
 // NewAWSProvider initializes a new AWS Route53 based Provider.
 func NewAWSProvider(awsConfig AWSConfig) (*AWSProvider, error) {
 	config := aws.NewConfig().WithMaxRetries(awsConfig.APIRetries)
+
+	if awsConfig.Endpoint != "" {
+		config.WithEndpoint(awsConfig.Endpoint)
+	}
 
 	config.WithHTTPClient(
 		instrumented_http.NewClient(config.HTTPClient, &instrumented_http.Callbacks{


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR adds a configuration option to the AWS provider to specify Endpoint for AWS Route53 client used in AWS Provider. It will help write more comprehensive e2e tests with tools such as Localstack or external stubs of Route53 API.
It does not change API or add configuration options exposed to the user.

<!-- Please provide a summary of the change here. -->
Add `Endpoint` configuration option for `AWSConfig` used by AWS Provider.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

**Checklist**

- [x] Unit tests updated - N/A
- [x] End user documentation updated - N/A
