### PR TITLE
Upgrade ExternalDNS to go 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
-        go-version: 1.20
+        go-version: '1.20'
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
-        go-version: 1.19
+        go-version: 1.20
       id: go
 
     - name: Check out code into the Go module directory
@@ -38,7 +38,7 @@ jobs:
             apt update
             apt install -y make gcc libc-dev git
       if: github.actor == 'nektos/act'
-  
+
     - name: Test
       run: make test
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install go version
       uses: actions/setup-go@v3
       with:
-        go-version: '^1.19'
+        go-version: '^1.20'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: ^1.20
+          go-version: '^1.20'
 
       - run: |
           pip install -r docs/scripts/requirements.txt

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: ^1.19
+          go-version: ^1.20
 
       - run: |
           pip install -r docs/scripts/requirements.txt

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,5 +31,5 @@ jobs:
 
     - name: Lint
       run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.53.2
         make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,6 @@ linters:
   # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
   disable-all: true
   enable:
-    - depguard
     - dogsled
     - gofmt
     - goimports

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 # builder image
 ARG ARCH
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 ARG ARCH
 
 WORKDIR /sigs.k8s.io/external-dns

--- a/Dockerfile.mini
+++ b/Dockerfile.mini
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 
 WORKDIR /sigs.k8s.io/external-dns
 

--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -1,7 +1,7 @@
 # Quick Start
 
 - [Git](https://git-scm.com/downloads)
-- [Go 1.19+](https://golang.org/dl/)
+- [Go 1.20+](https://golang.org/dl/)
 - [Go modules](https://github.com/golang/go/wiki/Modules)
 - [golangci-lint](https://github.com/golangci/golangci-lint)
 - [Docker](https://docs.docker.com/install/)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/external-dns
 
-go 1.19
+go 1.20
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3

--- a/provider/coredns/coredns.go
+++ b/provider/coredns/coredns.go
@@ -38,7 +38,7 @@ import (
 )
 
 func init() {
-	rand.Seed(time.Now().UnixNano())
+	rand.New(rand.NewSource(time.Now().UnixNano()))
 }
 
 const (

--- a/provider/coredns/coredns.go
+++ b/provider/coredns/coredns.go
@@ -37,10 +37,6 @@ import (
 	"sigs.k8s.io/external-dns/provider"
 )
 
-func init() {
-	rand.New(rand.NewSource(time.Now().UnixNano()))
-}
-
 const (
 	priority    = 10 // default priority when nothing is set
 	etcdTimeout = 5 * time.Second

--- a/provider/rdns/rdns.go
+++ b/provider/rdns/rdns.go
@@ -46,7 +46,7 @@ const (
 )
 
 func init() {
-	rand.Seed(time.Now().UnixNano())
+	rand.New(rand.NewSource(time.Now().UnixNano()))
 }
 
 // RDNSClient is an interface to work with Rancher DNS(RDNS) records in etcdv3 backend.

--- a/provider/tencentcloud/cloudapi/mockapi.go
+++ b/provider/tencentcloud/cloudapi/mockapi.go
@@ -34,7 +34,7 @@ type mockAPIService struct {
 }
 
 func NewMockService(privateZones []*privatedns.PrivateZone, privateZoneRecords map[string][]*privatedns.PrivateZoneRecord, dnspodDomains []*dnspod.DomainListItem, dnspodRecords map[string][]*dnspod.RecordListItem) *mockAPIService {
-	rand.Seed(time.Now().Unix())
+	rand.New(rand.NewSource(time.Now().Unix()))
 	return &mockAPIService{
 		privateZones:       privateZones,
 		privateZoneRecords: privateZoneRecords,

--- a/provider/tencentcloud/cloudapi/mockapi.go
+++ b/provider/tencentcloud/cloudapi/mockapi.go
@@ -18,7 +18,6 @@ package cloudapi
 
 import (
 	"math/rand"
-	"time"
 
 	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
 	dnspod "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod/v20210323"
@@ -34,7 +33,6 @@ type mockAPIService struct {
 }
 
 func NewMockService(privateZones []*privatedns.PrivateZone, privateZoneRecords map[string][]*privatedns.PrivateZoneRecord, dnspodDomains []*dnspod.DomainListItem, dnspodRecords map[string][]*dnspod.RecordListItem) *mockAPIService {
-	rand.New(rand.NewSource(time.Now().Unix()))
 	return &mockAPIService{
 		privateZones:       privateZones,
 		privateZoneRecords: privateZoneRecords,

--- a/source/fake.go
+++ b/source/fake.go
@@ -41,7 +41,7 @@ const (
 )
 
 func init() {
-	rand.Seed(time.Now().UnixNano())
+	rand.New(rand.NewSource(time.Now().UnixNano()))
 }
 
 // NewFakeSource creates a new fakeSource with the given config.

--- a/source/fake.go
+++ b/source/fake.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
-	"time"
 
 	"sigs.k8s.io/external-dns/endpoint"
 )
@@ -39,10 +38,6 @@ type fakeSource struct {
 const (
 	defaultFQDNTemplate = "example.com"
 )
-
-func init() {
-	rand.New(rand.NewSource(time.Now().UnixNano()))
-}
 
 // NewFakeSource creates a new fakeSource with the given config.
 func NewFakeSource(fqdnTemplate string) (Source, error) {


### PR DESCRIPTION
**Description**

This PR
- update ExternalDNS to go 1.20
   - Replace #3357,
   - Inspired by #3152
- update golangci-lint to v1.53.2 
   - Remove unconfigured depguard
   - Move to new way of using seed, cf [go 1.20 release notes](https://tip.golang.org/doc/go1.20)

**Checklist**

- [x]  Build and tests are green
