### PR TITLE
Route53 update configuration of target health checks

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -222,11 +222,7 @@ func (e *Endpoint) WithSetIdentifier(setIdentifier string) *Endpoint {
 // warrant its own field on the Endpoint object itself. It differs from Labels in the fact that it's
 // not persisted in the Registry but only kept in memory during a single record synchronization.
 func (e *Endpoint) WithProviderSpecific(key, value string) *Endpoint {
-	if e.ProviderSpecific == nil {
-		e.ProviderSpecific = ProviderSpecific{}
-	}
-
-	e.ProviderSpecific = append(e.ProviderSpecific, ProviderSpecificProperty{Name: key, Value: value})
+	e.SetProviderSpecificProperty(key, value)
 	return e
 }
 
@@ -238,6 +234,30 @@ func (e *Endpoint) GetProviderSpecificProperty(key string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// SetProviderSpecificProperty sets the value of a ProviderSpecificProperty.
+func (e *Endpoint) SetProviderSpecificProperty(key string, value string) {
+	for i, providerSpecific := range e.ProviderSpecific {
+		if providerSpecific.Name == key {
+			e.ProviderSpecific[i] = ProviderSpecificProperty{
+				Name:  key,
+				Value: value,
+			}
+			return
+		}
+	}
+
+	e.ProviderSpecific = append(e.ProviderSpecific, ProviderSpecificProperty{Name: key, Value: value})
+}
+
+func (e *Endpoint) DeleteProviderSpecificProperty(key string) {
+	for i, providerSpecific := range e.ProviderSpecific {
+		if providerSpecific.Name == key {
+			e.ProviderSpecific = append(e.ProviderSpecific[:i], e.ProviderSpecific[i+1:]...)
+			return
+		}
+	}
 }
 
 func (e *Endpoint) String() string {

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -251,6 +251,7 @@ func (e *Endpoint) SetProviderSpecificProperty(key string, value string) {
 	e.ProviderSpecific = append(e.ProviderSpecific, ProviderSpecificProperty{Name: key, Value: value})
 }
 
+// DeleteProviderSpecificProperty deletes any ProviderSpecificProperty of the specified name.
 func (e *Endpoint) DeleteProviderSpecificProperty(key string) {
 	for i, providerSpecific := range e.ProviderSpecific {
 		if providerSpecific.Name == key {

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -230,14 +230,14 @@ func (e *Endpoint) WithProviderSpecific(key, value string) *Endpoint {
 	return e
 }
 
-// GetProviderSpecificProperty returns a ProviderSpecificProperty if the property exists.
-func (e *Endpoint) GetProviderSpecificProperty(key string) (ProviderSpecificProperty, bool) {
+// GetProviderSpecificProperty returns the value of a ProviderSpecificProperty if the property exists.
+func (e *Endpoint) GetProviderSpecificProperty(key string) (string, bool) {
 	for _, providerSpecific := range e.ProviderSpecific {
 		if providerSpecific.Name == key {
-			return providerSpecific, true
+			return providerSpecific.Value, true
 		}
 	}
-	return ProviderSpecificProperty{}, false
+	return "", false
 }
 
 func (e *Endpoint) String() string {

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -47,10 +47,12 @@ const (
 	// As we are using the standard AWS client, this should already be compliant.
 	// Hence, ifever AWS decides to raise this limit, we will automatically reduce the pressure on rate limits
 	route53PageSize = "300"
-	// provider specific key that designates whether an AWS ALIAS record has the EvaluateTargetHealth
-	// field set to true.
-	providerSpecificAlias                      = "alias"
-	providerSpecificTargetHostedZone           = "aws/target-hosted-zone"
+	// providerSpecificAlias specifies whether a CNAME endpoint maps to an AWS ALIAS record.
+	providerSpecificAlias            = "alias"
+	providerSpecificTargetHostedZone = "aws/target-hosted-zone"
+	// providerSpecificEvaluateTargetHealth specifies whether an AWS ALIAS record
+	// has the EvaluateTargetHealth field set to true. Present iff the endpoint
+	// has a `providerSpecificAlias` value of `true`.
 	providerSpecificEvaluateTargetHealth       = "aws/evaluate-target-health"
 	providerSpecificWeight                     = "aws/weight"
 	providerSpecificRegion                     = "aws/region"
@@ -283,13 +285,6 @@ func NewAWSProvider(awsConfig AWSConfig) (*AWSProvider, error) {
 	return provider, nil
 }
 
-func (p *AWSProvider) PropertyValuesEqual(name string, previous string, current string) bool {
-	if name == "aws/evaluate-target-health" {
-		return true
-	}
-	return p.BaseProvider.PropertyValuesEqual(name, previous, current)
-}
-
 // Zones returns the list of hosted zones.
 func (p *AWSProvider) Zones(ctx context.Context) (map[string]*route53.HostedZone, error) {
 	if p.zonesCache.zones != nil && time.Since(p.zonesCache.age) < p.zonesCache.duration {
@@ -390,7 +385,11 @@ func (p *AWSProvider) records(ctx context.Context, zones map[string]*route53.Hos
 					targets[idx] = aws.StringValue(rr.Value)
 				}
 
-				newEndpoints = append(newEndpoints, endpoint.NewEndpointWithTTL(wildcardUnescape(aws.StringValue(r.Name)), aws.StringValue(r.Type), ttl, targets...))
+				ep := endpoint.NewEndpointWithTTL(wildcardUnescape(aws.StringValue(r.Name)), aws.StringValue(r.Type), ttl, targets...)
+				if aws.StringValue(r.Type) == endpoint.RecordTypeCNAME {
+					ep = ep.WithProviderSpecific(providerSpecificAlias, "false")
+				}
+				newEndpoints = append(newEndpoints, ep)
 			}
 
 			if r.AliasTarget != nil {
@@ -466,8 +465,12 @@ func (p *AWSProvider) requiresDeleteCreate(old *endpoint.Endpoint, new *endpoint
 	}
 
 	// an ALIAS record change to/from a CNAME
-	if old.RecordType == endpoint.RecordTypeCNAME && useAlias(old, p.preferCNAME) != useAlias(new, p.preferCNAME) {
-		return true
+	if old.RecordType == endpoint.RecordTypeCNAME {
+		oldAlias, _ := old.GetProviderSpecificProperty(providerSpecificAlias)
+		newAlias, _ := new.GetProviderSpecificProperty(providerSpecificAlias)
+		if oldAlias != newAlias {
+			return true
+		}
 	}
 
 	// a set identifier change
@@ -667,23 +670,29 @@ func (p *AWSProvider) newChanges(action string, endpoints []*endpoint.Endpoint) 
 func (p *AWSProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint {
 	for _, ep := range endpoints {
 		alias := false
-		if aliasString, ok := ep.GetProviderSpecificProperty(providerSpecificAlias); ok {
+		if ep.RecordType != endpoint.RecordTypeCNAME {
+			ep.DeleteProviderSpecificProperty(providerSpecificAlias)
+		} else if aliasString, ok := ep.GetProviderSpecificProperty(providerSpecificAlias); ok {
 			alias = aliasString == "true"
-		} else if useAlias(ep, p.preferCNAME) {
-			alias = true
-			log.Debugf("Modifying endpoint: %v, setting %s=true", ep, providerSpecificAlias)
-			ep.ProviderSpecific = append(ep.ProviderSpecific, endpoint.ProviderSpecificProperty{
-				Name:  providerSpecificAlias,
-				Value: "true",
-			})
+			if !alias && aliasString != "false" {
+				ep.SetProviderSpecificProperty(providerSpecificAlias, "false")
+			}
+		} else {
+			alias = useAlias(ep, p.preferCNAME)
+			log.Debugf("Modifying endpoint: %v, setting %s=%v", ep, providerSpecificAlias, alias)
+			ep.SetProviderSpecificProperty(providerSpecificAlias, strconv.FormatBool(alias))
 		}
 
-		if _, ok := ep.GetProviderSpecificProperty(providerSpecificEvaluateTargetHealth); alias && !ok {
-			log.Debugf("Modifying endpoint: %v, setting %s=%t", ep, providerSpecificEvaluateTargetHealth, p.evaluateTargetHealth)
-			ep.ProviderSpecific = append(ep.ProviderSpecific, endpoint.ProviderSpecificProperty{
-				Name:  providerSpecificEvaluateTargetHealth,
-				Value: fmt.Sprintf("%t", p.evaluateTargetHealth),
-			})
+		if alias {
+			if prop, ok := ep.GetProviderSpecificProperty(providerSpecificEvaluateTargetHealth); ok {
+				if prop != "true" && prop != "false" {
+					ep.SetProviderSpecificProperty(providerSpecificEvaluateTargetHealth, "false")
+				}
+			} else {
+				ep.SetProviderSpecificProperty(providerSpecificEvaluateTargetHealth, strconv.FormatBool(p.evaluateTargetHealth))
+			}
+		} else {
+			ep.DeleteProviderSpecificProperty(providerSpecificEvaluateTargetHealth)
 		}
 	}
 	return endpoints

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -30,6 +30,13 @@ type Provider interface {
 	Records(ctx context.Context) ([]*endpoint.Endpoint, error)
 	ApplyChanges(ctx context.Context, changes *plan.Changes) error
 	PropertyValuesEqual(name string, previous string, current string) bool
+	// AdjustEndpoints canonicalizes a set of candidate endpoints.
+	// It is called with a set of candidate endpoints obtained from the various sources.
+	// It returns a set modified as required by the provider. The provider is responsible for
+	// adding, removing, and modifying the ProviderSpecific properties to match
+	// the endpoints that the provider returns in `Records` so that the change plan will not have
+	// unnecessary (potentially failing) changes. It may also modify other fields, add, or remove
+	// Endpoints. It is permitted to modify the supplied endpoints.
 	AdjustEndpoints(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint
 	GetDomainFilter() endpoint.DomainFilterInterface
 }

--- a/provider/scaleway/scaleway.go
+++ b/provider/scaleway/scaleway.go
@@ -278,9 +278,9 @@ func endpointToScalewayRecords(zoneName string, ep *endpoint.Endpoint) []*domain
 	}
 	priority := scalewayDefaultPriority
 	if prop, ok := ep.GetProviderSpecificProperty(scalewayPriorityKey); ok {
-		prio, err := strconv.ParseUint(prop.Value, 10, 32)
+		prio, err := strconv.ParseUint(prop, 10, 32)
 		if err != nil {
-			log.Errorf("Failed parsing value of %s: %s: %v; using priority of %d", scalewayPriorityKey, prop.Value, err, scalewayDefaultPriority)
+			log.Errorf("Failed parsing value of %s: %s: %v; using priority of %d", scalewayPriorityKey, prop, err, scalewayDefaultPriority)
 		} else {
 			priority = uint32(prio)
 		}


### PR DESCRIPTION

**Description**

Fixes the Route53 provider so that it will reconcile changes to the configuration of target health checks on alias records.

Fixes the canonicalization of the `alias` provider-specific property so that the planner will not schedule unnecessary changes.

Prepares the Route53 provider for subsequent removal of the `provider.PropertyValuesEqual()` interface method.

**Checklist**

- [x] Unit tests updated
- [ ] ~~End user documentation updated~~
