### PR TITLE
refactor: use always fmt.Errorf("...: %w", err), instead of %s or %v

### DIFF
--- a/pkg/tlsutils/tlsconfig.go
+++ b/pkg/tlsutils/tlsconfig.go
@@ -51,7 +51,7 @@ func NewTLSConfig(certPath, keyPath, caPath, serverName string, insecure bool, m
 	if certPath != "" {
 		cert, err := tls.LoadX509KeyPair(certPath, keyPath)
 		if err != nil {
-			return nil, fmt.Errorf("could not load TLS cert: %s", err)
+			return nil, fmt.Errorf("could not load TLS cert: %w", err)
 		}
 		certificates = append(certificates, cert)
 	}
@@ -78,11 +78,11 @@ func loadRoots(caPath string) (*x509.CertPool, error) {
 	roots := x509.NewCertPool()
 	pem, err := os.ReadFile(caPath)
 	if err != nil {
-		return nil, fmt.Errorf("error reading %s: %s", caPath, err)
+		return nil, fmt.Errorf("error reading %s: %w", caPath, err)
 	}
 	ok := roots.AppendCertsFromPEM(pem)
 	if !ok {
-		return nil, fmt.Errorf("could not read root certs: %s", err)
+		return nil, fmt.Errorf("could not read root certs: %w", err)
 	}
 	return roots, nil
 }

--- a/provider/akamai/akamai.go
+++ b/provider/akamai/akamai.go
@@ -426,7 +426,7 @@ func (p AkamaiProvider) deleteRecordsets(zoneNameIDMapper provider.ZoneIDName, e
 		rec, err := p.client.GetRecord(zoneName, recName, endpoint.RecordType)
 		if err != nil {
 			if _, ok := err.(*dns.RecordError); !ok {
-				return fmt.Errorf("endpoint deletion. record validation failed. error: %s", err.Error())
+				return fmt.Errorf("endpoint deletion. record validation failed. error: %w", err)
 			}
 			log.Infof("Endpoint deletion. Record doesn't exist. Name: %s, Type: %s", recName, endpoint.RecordType)
 			continue

--- a/provider/coredns/coredns.go
+++ b/provider/coredns/coredns.go
@@ -112,7 +112,7 @@ func (c etcdClient) GetServices(prefix string) ([]*Service, error) {
 	for _, n := range r.Kvs {
 		svc := new(Service)
 		if err := json.Unmarshal(n.Value, svc); err != nil {
-			return nil, fmt.Errorf("%s: %s", n.Key, err.Error())
+			return nil, fmt.Errorf("%s: %w", n.Key, err)
 		}
 		b := Service{Host: svc.Host, Port: svc.Port, Priority: svc.Priority, Weight: svc.Weight, Text: svc.Text, Key: string(n.Key)}
 		if _, ok := bx[b]; ok {
@@ -166,7 +166,7 @@ func newTLSConfig(certPath, keyPath, caPath, serverName string, insecure bool) (
 	if certPath != "" {
 		cert, err := tls.LoadX509KeyPair(certPath, keyPath)
 		if err != nil {
-			return nil, fmt.Errorf("could not load TLS cert: %s", err)
+			return nil, fmt.Errorf("could not load TLS cert: %w", err)
 		}
 		certificates = append(certificates, cert)
 	}
@@ -192,11 +192,11 @@ func loadRoots(caPath string) (*x509.CertPool, error) {
 	roots := x509.NewCertPool()
 	pem, err := os.ReadFile(caPath)
 	if err != nil {
-		return nil, fmt.Errorf("error reading %s: %s", caPath, err)
+		return nil, fmt.Errorf("error reading %s: %w", caPath, err)
 	}
 	ok := roots.AppendCertsFromPEM(pem)
 	if !ok {
-		return nil, fmt.Errorf("could not read root certs: %s", err)
+		return nil, fmt.Errorf("could not read root certs: %w", err)
 	}
 	return roots, nil
 }

--- a/provider/infoblox/infoblox.go
+++ b/provider/infoblox/infoblox.go
@@ -187,7 +187,7 @@ func NewInfobloxProvider(ibStartupCfg StartupConfig) (*ProviderConfig, error) {
 func (p *ProviderConfig) Records(ctx context.Context) (endpoints []*endpoint.Endpoint, err error) {
 	zones, err := p.zones()
 	if err != nil {
-		return nil, fmt.Errorf("could not fetch zones: %s", err)
+		return nil, fmt.Errorf("could not fetch zones: %w", err)
 	}
 
 	for _, zone := range zones {
@@ -211,7 +211,7 @@ func (p *ProviderConfig) Records(ctx context.Context) (endpoints []*endpoint.End
 		objA.Zone = zone.Fqdn
 		err = p.client.GetObject(objA, "", searchParams, &resA)
 		if err != nil && !isNotFoundError(err) {
-			return nil, fmt.Errorf("could not fetch A records from zone '%s': %s", zone.Fqdn, err)
+			return nil, fmt.Errorf("could not fetch A records from zone '%s': %w", zone.Fqdn, err)
 		}
 		for _, res := range resA {
 			// Check if endpoint already exists and add to existing endpoint if it does
@@ -257,7 +257,7 @@ func (p *ProviderConfig) Records(ctx context.Context) (endpoints []*endpoint.End
 		objH.Zone = zone.Fqdn
 		err = p.client.GetObject(objH, "", searchParams, &resH)
 		if err != nil && !isNotFoundError(err) {
-			return nil, fmt.Errorf("could not fetch host records from zone '%s': %s", zone.Fqdn, err)
+			return nil, fmt.Errorf("could not fetch host records from zone '%s': %w", zone.Fqdn, err)
 		}
 		for _, res := range resH {
 			for _, ip := range res.Ipv4Addrs {
@@ -279,7 +279,7 @@ func (p *ProviderConfig) Records(ctx context.Context) (endpoints []*endpoint.End
 		objC.Zone = zone.Fqdn
 		err = p.client.GetObject(objC, "", searchParams, &resC)
 		if err != nil && !isNotFoundError(err) {
-			return nil, fmt.Errorf("could not fetch CNAME records from zone '%s': %s", zone.Fqdn, err)
+			return nil, fmt.Errorf("could not fetch CNAME records from zone '%s': %w", zone.Fqdn, err)
 		}
 		for _, res := range resC {
 			logrus.Debugf("Record='%s' CNAME:'%s'", res.Name, res.Canonical)
@@ -298,7 +298,7 @@ func (p *ProviderConfig) Records(ctx context.Context) (endpoints []*endpoint.End
 				objP.View = p.view
 				err = p.client.GetObject(objP, "", searchParams, &resP)
 				if err != nil && !isNotFoundError(err) {
-					return nil, fmt.Errorf("could not fetch PTR records from zone '%s': %s", zone.Fqdn, err)
+					return nil, fmt.Errorf("could not fetch PTR records from zone '%s': %w", zone.Fqdn, err)
 				}
 				for _, res := range resP {
 					endpoints = append(endpoints, endpoint.NewEndpoint(res.PtrdName, endpoint.RecordTypePTR, res.Ipv4Addr))
@@ -315,7 +315,7 @@ func (p *ProviderConfig) Records(ctx context.Context) (endpoints []*endpoint.End
 		)
 		err = p.client.GetObject(objT, "", searchParams, &resT)
 		if err != nil && !isNotFoundError(err) {
-			return nil, fmt.Errorf("could not fetch TXT records from zone '%s': %s", zone.Fqdn, err)
+			return nil, fmt.Errorf("could not fetch TXT records from zone '%s': %w", zone.Fqdn, err)
 		}
 		for _, res := range resT {
 			// The Infoblox API strips enclosing double quotes from TXT records lacking whitespace.

--- a/provider/rdns/rdns.go
+++ b/provider/rdns/rdns.go
@@ -295,7 +295,7 @@ func newEtcdv3Client() (RDNSClient, error) {
 		if cert != "" {
 			cert, err := tls.LoadX509KeyPair(cert, key)
 			if err != nil {
-				return nil, fmt.Errorf("could not load TLS cert: %s", err)
+				return nil, fmt.Errorf("could not load TLS cert: %w", err)
 			}
 			certificates = append(certificates, cert)
 		}
@@ -310,11 +310,11 @@ func newEtcdv3Client() (RDNSClient, error) {
 			roots := x509.NewCertPool()
 			pem, err := os.ReadFile(ca)
 			if err != nil {
-				return nil, fmt.Errorf("error reading %s: %s", ca, err)
+				return nil, fmt.Errorf("error reading %s: %w", ca, err)
 			}
 			ok := roots.AppendCertsFromPEM(pem)
 			if !ok {
-				return nil, fmt.Errorf("could not read root certs: %s", err)
+				return nil, fmt.Errorf("could not read root certs: %w", err)
 			}
 			config.RootCAs = roots
 		}
@@ -347,7 +347,7 @@ func (c etcdv3Client) Get(key string) ([]RDNSRecord, error) {
 	for _, v := range result.Kvs {
 		r := new(RDNSRecord)
 		if err := json.Unmarshal(v.Value, r); err != nil {
-			return nil, fmt.Errorf("%s: %s", v.Key, err.Error())
+			return nil, fmt.Errorf("%s: %w", v.Key, err)
 		}
 		r.Key = string(v.Key)
 		rs = append(rs, *r)
@@ -412,7 +412,7 @@ func (c etcdv3Client) aggregationRecords(result *clientv3.GetResponse) ([]RDNSRe
 	for _, n := range result.Kvs {
 		r := new(RDNSRecord)
 		if err := json.Unmarshal(n.Value, r); err != nil {
-			return nil, fmt.Errorf("%s: %s", n.Key, err.Error())
+			return nil, fmt.Errorf("%s: %w", n.Key, err)
 		}
 
 		r.Key = string(n.Key)

--- a/provider/transip/transip.go
+++ b/provider/transip/transip.go
@@ -72,7 +72,7 @@ func NewTransIPProvider(accountName, privateKeyFile string, domainFilter endpoin
 		Mode:           apiMode,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("could not setup TransIP API client: %s", err.Error())
+		return nil, fmt.Errorf("could not setup TransIP API client: %w", err)
 	}
 
 	// return TransIPProvider struct

--- a/source/crd.go
+++ b/source/crd.go
@@ -79,7 +79,7 @@ func NewCRDClientForAPIVersionKind(client kubernetes.Interface, kubeConfig, apiS
 	}
 	apiResourceList, err := client.Discovery().ServerResourcesForGroupVersion(groupVersion.String())
 	if err != nil {
-		return nil, nil, fmt.Errorf("error listing resources in GroupVersion %q: %s", groupVersion.String(), err)
+		return nil, nil, fmt.Errorf("error listing resources in GroupVersion %q: %w", groupVersion.String(), err)
 	}
 
 	var crdAPIResource *metav1.APIResource

--- a/source/node.go
+++ b/source/node.go
@@ -130,7 +130,7 @@ func (ns *nodeSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, erro
 
 		addrs, err := ns.nodeAddresses(node)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get node address from %s: %s", node.Name, err.Error())
+			return nil, fmt.Errorf("failed to get node address from %s: %w", node.Name, err)
 		}
 
 		ep.Labels = endpoint.NewLabels()


### PR DESCRIPTION
refactor: use always fmt.Errorf("...: %w", err), instead of %s or %v
