### PR TITLE
Enable dependabot grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,23 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*" 
   - package-ecosystem: "docker" # Keep Docker dependencies up to date
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
**Description**

This PR enables dependabot grouped updates. This is a new alpha feature of dependabot that is exclusively enabled for this project and that should create grouped PRs to help ship the dependabot PRs. 

