### PR TITLE
fix: filter peering zones in google provider

### DIFF
--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -177,11 +177,15 @@ func (p *GoogleProvider) Zones(ctx context.Context) (map[string]*dns.ManagedZone
 
 	f := func(resp *dns.ManagedZonesListResponse) error {
 		for _, zone := range resp.ManagedZones {
-			if p.domainFilter.Match(zone.DnsName) && p.zoneTypeFilter.Match(zone.Visibility) && (p.zoneIDFilter.Match(fmt.Sprintf("%v", zone.Id)) || p.zoneIDFilter.Match(fmt.Sprintf("%v", zone.Name))) {
-				zones[zone.Name] = zone
-				log.Debugf("Matched %s (zone: %s) (visibility: %s)", zone.DnsName, zone.Name, zone.Visibility)
+			if zone.PeeringConfig == nil {
+				if p.domainFilter.Match(zone.DnsName) && p.zoneTypeFilter.Match(zone.Visibility) && (p.zoneIDFilter.Match(fmt.Sprintf("%v", zone.Id)) || p.zoneIDFilter.Match(fmt.Sprintf("%v", zone.Name))) {
+					zones[zone.Name] = zone
+					log.Debugf("Matched %s (zone: %s) (visibility: %s)", zone.DnsName, zone.Name, zone.Visibility)
+				} else {
+					log.Debugf("Filtered %s (zone: %s) (visibility: %s)", zone.DnsName, zone.Name, zone.Visibility)
+				}
 			} else {
-				log.Debugf("Filtered %s (zone: %s) (visibility: %s)", zone.DnsName, zone.Name, zone.Visibility)
+				log.Debugf("Filtered peering zone %s (zone: %s) (visibility: %s)", zone.DnsName, zone.Name, zone.Visibility)
 			}
 		}
 

--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -237,6 +237,17 @@ func TestGoogleZonesVisibilityFilterPrivate(t *testing.T) {
 	})
 }
 
+func TestGoogleZonesVisibilityFilterPrivatePeering(t *testing.T) {
+	provider := newGoogleProviderZoneOverlap(t, endpoint.NewDomainFilter([]string{"svc.local."}), provider.NewZoneIDFilter([]string{""}), provider.NewZoneTypeFilter("private"), false, []*endpoint.Endpoint{})
+
+	zones, err := provider.Zones(context.Background())
+	require.NoError(t, err)
+	
+	validateZones(t, zones, map[string]*dns.ManagedZone{
+		"svc-local": {Name: "svc-local", DnsName: "svc.local.", Id: 1005, Visibility: "private"},
+	})
+}
+
 func TestGoogleZones(t *testing.T) {
 	provider := newGoogleProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), provider.NewZoneIDFilter([]string{""}), false, []*endpoint.Endpoint{})
 
@@ -744,6 +755,22 @@ func newGoogleProviderZoneOverlap(t *testing.T, domainFilter endpoint.DomainFilt
 		Visibility: "private",
 	})
 
+
+	createZone(t, provider, &dns.ManagedZone{
+		Name:       "svc-local",
+		DnsName:    "svc.local.",
+		Id:         10005,
+		Visibility: "private",
+	})
+
+	createZone(t, provider, &dns.ManagedZone{
+		Name:       "svc-local-peer",
+		DnsName:    "svc.local.",
+		Id:         10006,
+		Visibility: "private",
+		PeeringConfig: &dns.ManagedZonePeeringConfig{TargetNetwork: nil},
+	})
+	
 	provider.dryRun = dryRun
 
 	return provider


### PR DESCRIPTION
**Description**

Filters peering zones from the list of zones considered for creation of records by the google provider. This is needed because peering zones do not allow the creation of records, so if a peering zone matches a domain filter, external-dns tries to create records in it, causing the entire changeset to fail and no records to be created (even in other, valid zones).

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2947

**Checklist**

- [x] Unit tests updated
- [X] End user documentation updated

**Notes**

Changes to end user docs were not necessary.