### PR TITLE
loop through all hosted zones to match the domain record

### DIFF
--- a/provider/alibabacloud/alibaba_cloud.go
+++ b/provider/alibabacloud/alibaba_cloud.go
@@ -382,8 +382,7 @@ func (p *AlibabaCloudProvider) records() ([]alidns.Record, error) {
 		for _, zoneDomain := range hostedZoneDomains {
 			domainRecords, err := p.getDomainRecords(zoneDomain)
 			if err != nil {
-				log.Errorf("AlibabaCloudProvider getDomainRecords %q error %v", zoneDomain, err)
-				return nil, err
+				return nil, fmt.Errorf("getDomainRecords %q: %w", zoneDomain, err)
 			}
 			results = append(results, domainRecords...)
 		}
@@ -672,35 +671,17 @@ func (p *AlibabaCloudProvider) splitDNSName(dnsName string, hostedZoneDomains []
 		return strings.Count(hostedZoneDomains[i], ".") > strings.Count(hostedZoneDomains[j], ".")
 	})
 
-	found := false
-
 	for _, filter := range hostedZoneDomains {
 		if strings.HasSuffix(name, "."+filter) {
 			rr = name[0 : len(name)-len(filter)-1]
 			domain = filter
-			found = true
 			break
 		} else if name == filter {
 			domain = filter
 			rr = ""
-			found = true
 		}
 	}
 
-	if !found {
-		parts := strings.Split(name, ".")
-		if len(parts) < 2 {
-			rr = name
-			domain = ""
-		} else {
-			domain = parts[len(parts)-2] + "." + parts[len(parts)-1]
-			rrIndex := strings.Index(name, domain)
-			if rrIndex < 1 {
-				rrIndex = 1
-			}
-			rr = name[0 : rrIndex-1]
-		}
-	}
 	if rr == "" {
 		rr = nullHostAlibabaCloud
 	}

--- a/provider/alibabacloud/alibaba_cloud.go
+++ b/provider/alibabacloud/alibaba_cloud.go
@@ -475,7 +475,6 @@ func (p *AlibabaCloudProvider) applyChangesForDNS(changes *plan.Changes) error {
 	recordMap := p.groupRecords(records)
 
 	hostedZoneDomains, err := p.getDomainList()
-
 	if err != nil {
 		return fmt.Errorf("getting domain list: %w", err)
 	}

--- a/provider/alibabacloud/alibaba_cloud.go
+++ b/provider/alibabacloud/alibaba_cloud.go
@@ -376,14 +376,15 @@ func (p *AlibabaCloudProvider) records() ([]alidns.Record, error) {
 	var results []alidns.Record
 	hostedZoneDomains, err := p.getDomainList()
 	if err != nil {
-		return results, fmt.Errorf("getDomainList: %w", err)
+		log.Errorf("getDomainList: %v", err)
+		return results, err
 	}
 	if !p.domainFilter.IsConfigured() {
 		for _, zoneDomain := range hostedZoneDomains {
 			domainRecords, err := p.getDomainRecords(zoneDomain)
 			if err != nil {
 				log.Errorf("AlibabaCloudProvider getDomainRecords %q error %v", zoneDomain, err)
-				continue
+				return nil, err
 			}
 			results = append(results, domainRecords...)
 		}

--- a/provider/alibabacloud/alibaba_cloud_test.go
+++ b/provider/alibabacloud/alibaba_cloud_test.go
@@ -18,9 +18,10 @@ package alibabacloud
 
 import (
 	"context"
+	"testing"
+
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/alidns"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/pvtz"
-	"testing"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
@@ -430,6 +431,13 @@ func TestAlibabaCloudProvider_splitDNSName(t *testing.T) {
 	rr, domain = p.splitDNSName(endpoint.DNSName)
 	if rr != "a.b.c" || domain != "container-service.top" {
 		t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
+	}
+	p.domainFilter.Filters = []string{"a.b.c.container-service.top", "container-service.top"}
+	for _, endpoint.DNSName = range p.domainFilter.Filters {
+		rr, domain = p.splitDNSName(endpoint.DNSName)
+		if domain != "container-service.top" {
+			t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
+		}
 	}
 }
 

--- a/provider/alibabacloud/alibaba_cloud_test.go
+++ b/provider/alibabacloud/alibaba_cloud_test.go
@@ -392,43 +392,45 @@ func TestAlibabaCloudProvider_ApplyChanges_PrivateZone(t *testing.T) {
 func TestAlibabaCloudProvider_splitDNSName(t *testing.T) {
 	p := newTestAlibabaCloudProvider(false)
 	endpoint := &endpoint.Endpoint{}
+	hostedZoneDomains := []string{"container-service.top", "example.org"}
+
 	endpoint.DNSName = "www.example.org"
-	rr, domain := p.splitDNSName(endpoint.DNSName, nil)
+	rr, domain := p.splitDNSName(endpoint.DNSName, hostedZoneDomains)
 	if rr != "www" || domain != "example.org" {
 		t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
 	}
 	endpoint.DNSName = ".example.org"
-	rr, domain = p.splitDNSName(endpoint.DNSName, nil)
+	rr, domain = p.splitDNSName(endpoint.DNSName, hostedZoneDomains)
 	if rr != "@" || domain != "example.org" {
 		t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
 	}
 	endpoint.DNSName = "www"
-	rr, domain = p.splitDNSName(endpoint.DNSName, nil)
+	rr, domain = p.splitDNSName(endpoint.DNSName, hostedZoneDomains)
 	if rr != "www" || domain != "" {
 		t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
 	}
 	endpoint.DNSName = ""
-	rr, domain = p.splitDNSName(endpoint.DNSName, nil)
+	rr, domain = p.splitDNSName(endpoint.DNSName, hostedZoneDomains)
 	if rr != "@" || domain != "" {
 		t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
 	}
 	endpoint.DNSName = "_30000._tcp.container-service.top"
-	rr, domain = p.splitDNSName(endpoint.DNSName, nil)
+	rr, domain = p.splitDNSName(endpoint.DNSName, hostedZoneDomains)
 	if rr != "_30000._tcp" || domain != "container-service.top" {
 		t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
 	}
 	endpoint.DNSName = "container-service.top"
-	rr, domain = p.splitDNSName(endpoint.DNSName, nil)
+	rr, domain = p.splitDNSName(endpoint.DNSName, hostedZoneDomains)
 	if rr != "@" || domain != "container-service.top" {
 		t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
 	}
 	endpoint.DNSName = "a.b.container-service.top"
-	rr, domain = p.splitDNSName(endpoint.DNSName, nil)
+	rr, domain = p.splitDNSName(endpoint.DNSName, hostedZoneDomains)
 	if rr != "a.b" || domain != "container-service.top" {
 		t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
 	}
 	endpoint.DNSName = "a.b.c.container-service.top"
-	rr, domain = p.splitDNSName(endpoint.DNSName, nil)
+	rr, domain = p.splitDNSName(endpoint.DNSName, hostedZoneDomains)
 	if rr != "a.b.c" || domain != "container-service.top" {
 		t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
 	}

--- a/provider/alibabacloud/alibaba_cloud_test.go
+++ b/provider/alibabacloud/alibaba_cloud_test.go
@@ -98,6 +98,9 @@ func (m *MockAlibabaCloudDNSAPI) DescribeDomains(request *alidns.DescribeDomains
 	for _, record := range m.records {
 		domain := alidns.Domain{}
 		domain.DomainName = record.DomainName
+		result.Domain = append(result.Domain, alidns.DomainInDescribeDomains{
+			DomainName: domain.DomainName,
+		})
 	}
 	response = alidns.CreateDescribeDomainsResponse()
 	response.Domains = result
@@ -406,7 +409,7 @@ func TestAlibabaCloudProvider_splitDNSName(t *testing.T) {
 	}
 	endpoint.DNSName = "www"
 	rr, domain = p.splitDNSName(endpoint.DNSName, hostedZoneDomains)
-	if rr != "www" || domain != "" {
+	if rr != "@" || domain != "" {
 		t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
 	}
 	endpoint.DNSName = ""

--- a/provider/alibabacloud/alibaba_cloud_test.go
+++ b/provider/alibabacloud/alibaba_cloud_test.go
@@ -393,51 +393,55 @@ func TestAlibabaCloudProvider_splitDNSName(t *testing.T) {
 	p := newTestAlibabaCloudProvider(false)
 	endpoint := &endpoint.Endpoint{}
 	endpoint.DNSName = "www.example.org"
-	rr, domain := p.splitDNSName(endpoint.DNSName)
+	rr, domain := p.splitDNSName(endpoint.DNSName, nil)
 	if rr != "www" || domain != "example.org" {
 		t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
 	}
 	endpoint.DNSName = ".example.org"
-	rr, domain = p.splitDNSName(endpoint.DNSName)
+	rr, domain = p.splitDNSName(endpoint.DNSName, nil)
 	if rr != "@" || domain != "example.org" {
 		t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
 	}
 	endpoint.DNSName = "www"
-	rr, domain = p.splitDNSName(endpoint.DNSName)
+	rr, domain = p.splitDNSName(endpoint.DNSName, nil)
 	if rr != "www" || domain != "" {
 		t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
 	}
 	endpoint.DNSName = ""
-	rr, domain = p.splitDNSName(endpoint.DNSName)
+	rr, domain = p.splitDNSName(endpoint.DNSName, nil)
 	if rr != "@" || domain != "" {
 		t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
 	}
 	endpoint.DNSName = "_30000._tcp.container-service.top"
-	rr, domain = p.splitDNSName(endpoint.DNSName)
+	rr, domain = p.splitDNSName(endpoint.DNSName, nil)
 	if rr != "_30000._tcp" || domain != "container-service.top" {
 		t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
 	}
 	endpoint.DNSName = "container-service.top"
-	rr, domain = p.splitDNSName(endpoint.DNSName)
+	rr, domain = p.splitDNSName(endpoint.DNSName, nil)
 	if rr != "@" || domain != "container-service.top" {
 		t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
 	}
 	endpoint.DNSName = "a.b.container-service.top"
-	rr, domain = p.splitDNSName(endpoint.DNSName)
+	rr, domain = p.splitDNSName(endpoint.DNSName, nil)
 	if rr != "a.b" || domain != "container-service.top" {
 		t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
 	}
 	endpoint.DNSName = "a.b.c.container-service.top"
-	rr, domain = p.splitDNSName(endpoint.DNSName)
+	rr, domain = p.splitDNSName(endpoint.DNSName, nil)
 	if rr != "a.b.c" || domain != "container-service.top" {
 		t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
 	}
-	p.domainFilter.Filters = []string{"a.b.c.container-service.top", "container-service.top"}
-	for _, endpoint.DNSName = range p.domainFilter.Filters {
-		rr, domain = p.splitDNSName(endpoint.DNSName)
-		if domain != "container-service.top" {
-			t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
-		}
+	endpoint.DNSName = "a.b.c.container-service.top"
+	rr, domain = p.splitDNSName(endpoint.DNSName, []string{"c.container-service.top"})
+	if rr != "a.b" || domain != "c.container-service.top" {
+		t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
+	}
+
+	endpoint.DNSName = "a.b.c.container-service.top"
+	rr, domain = p.splitDNSName(endpoint.DNSName, []string{"container-service.top", "c.container-service.top"})
+	if rr != "a.b" || domain != "c.container-service.top" {
+		t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
 	}
 }
 


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
loop through all domains to match the domain record

<!-- Please provide a summary of the change here. -->

instead of matching domain records with filter query, the idea is to first match the record with the hosted zones. If there is no match, splitDNS method then proceeds to split the domain to it's respective rr and Domain Name

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes https://github.com/kubernetes-sigs/external-dns/issues/3625

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
