### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/lint-test-chart.yaml
+++ b/.github/workflows/lint-test-chart.yaml
@@ -45,7 +45,7 @@ jobs:
         run: |
           changed=$(ct list-changed)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -29,7 +29,7 @@ jobs:
         run: |
           set -euo pipefail
           chart_version="$(grep -Po "(?<=^version: ).+" charts/external-dns/Chart.yaml)"
-          echo "::set-output name=version::${chart_version}"
+          echo "version=${chart_version}" >> $GITHUB_OUTPUT
 
       - name: Get changelog entry
         id: changelog_reader


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Resolve  #3696 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo "::set-output name=changed::true"
```

**TO-BE**

```yaml
echo "changed=true" >> $GITHUB_OUTPUT
```

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
