### PR TITLE
Log as Error for throttling rate exceeded

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -412,7 +413,11 @@ func main() {
 	if cfg.Once {
 		err := ctrl.RunOnce(ctx)
 		if err != nil {
-			log.Fatal(err)
+			if strings.Contains(err.Error(), "Throttling: Rate exceeded") {
+				log.Error(err)
+			} else {
+				log.Fatal(err)
+			}
 		}
 
 		os.Exit(0)


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
This changes the error severity from `Fatal` to `Error` for cases when `external-dns` experiences rate limit throttling from the cloud provider. Since record sync continues to happen despite the throttle, the problem is not fatal and severity of `Error` can be used to allow `external-dns` to continue to work.
<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
