### PR TITLE
Add test for filtering Cloud DNS peering zones

### DIFF
--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -237,6 +237,17 @@ func TestGoogleZonesVisibilityFilterPrivate(t *testing.T) {
 	})
 }
 
+func TestGoogleZonesVisibilityFilterPrivatePeering(t *testing.T) {
+	provider := newGoogleProviderZoneOverlap(t, endpoint.NewDomainFilter([]string{"svc.local."}), provider.NewZoneIDFilter([]string{""}), provider.NewZoneTypeFilter("private"), false, []*endpoint.Endpoint{})
+
+	zones, err := provider.Zones(context.Background())
+	require.NoError(t, err)
+	
+	validateZones(t, zones, map[string]*dns.ManagedZone{
+		"svc-local": {Name: "svc-local", DnsName: "svc.local.", Id: 1005, Visibility: "private"},
+	})
+}
+
 func TestGoogleZones(t *testing.T) {
 	provider := newGoogleProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), provider.NewZoneIDFilter([]string{""}), false, []*endpoint.Endpoint{})
 
@@ -744,6 +755,22 @@ func newGoogleProviderZoneOverlap(t *testing.T, domainFilter endpoint.DomainFilt
 		Visibility: "private",
 	})
 
+
+	createZone(t, provider, &dns.ManagedZone{
+		Name:       "svc-local",
+		DnsName:    "svc.local.",
+		Id:         10005,
+		Visibility: "private",
+	})
+
+	createZone(t, provider, &dns.ManagedZone{
+		Name:       "svc-local-peer",
+		DnsName:    "svc.local.",
+		Id:         10006,
+		Visibility: "private",
+		PeeringConfig: &dns.ManagedZonePeeringConfig{TargetNetwork: nil},
+	})
+	
 	provider.dryRun = dryRun
 
 	return provider


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
Originally was planning to raise a PR to add filtering for Cloud DNS peering zones but have noticed #3690 was raised a few days ago so raising a PR to add a test for the filter to that PR.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Relates to fixing #2947, adding tests to #3690

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
