### PR TITLE
support externalIPs of loadbalancer type for istio

### DIFF
--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -28,6 +28,7 @@ import (
 	istioclient "istio.io/client-go/pkg/clientset/versioned"
 	istioinformers "istio.io/client-go/pkg/informers/externalversions"
 	networkingv1alpha3informer "istio.io/client-go/pkg/informers/externalversions/networking/v1alpha3"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kubeinformers "k8s.io/client-go/informers"
@@ -256,6 +257,13 @@ func (sc *gatewaySource) targetsFromGateway(gateway networkingv1alpha3.Gateway) 
 				targets = append(targets, lb.Hostname)
 			}
 		}
+
+		if service.Spec.Type == corev1.ServiceTypeLoadBalancer && service.Spec.ExternalIPs != nil {
+			for _, ext := range service.Spec.ExternalIPs {
+				targets = append(targets, ext)
+			}
+		}
+
 	}
 
 	return

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -28,6 +28,7 @@ import (
 	istioclient "istio.io/client-go/pkg/clientset/versioned"
 	istioinformers "istio.io/client-go/pkg/informers/externalversions"
 	networkingv1alpha3informer "istio.io/client-go/pkg/informers/externalversions/networking/v1alpha3"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -456,6 +457,13 @@ func (sc *virtualServiceSource) targetsFromGateway(gateway *networkingv1alpha3.G
 				targets = append(targets, lb.Hostname)
 			}
 		}
+
+		if service.Spec.Type == corev1.ServiceTypeLoadBalancer && service.Spec.ExternalIPs != nil {
+			for _, ext := range service.Spec.ExternalIPs {
+				targets = append(targets, ext)
+			}
+		}
+
 	}
 
 	return


### PR DESCRIPTION

**Description**
- When externalIPs of service which is loadbalancer type created,  external-dns doesn't support for istio-gateway, istio-virtualservice.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
