### PR TITLE
support external ips for istio

### DIFF
--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -28,6 +28,7 @@ import (
 	istioclient "istio.io/client-go/pkg/clientset/versioned"
 	istioinformers "istio.io/client-go/pkg/informers/externalversions"
 	networkingv1alpha3informer "istio.io/client-go/pkg/informers/externalversions/networking/v1alpha3"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kubeinformers "k8s.io/client-go/informers"
@@ -254,6 +255,12 @@ func (sc *gatewaySource) targetsFromGateway(gateway networkingv1alpha3.Gateway) 
 				targets = append(targets, lb.IP)
 			} else if lb.Hostname != "" {
 				targets = append(targets, lb.Hostname)
+			}
+		}
+
+		if service.Spec.Type == corev1.ServiceTypeLoadBalancer && service.Spec.ExternalIPs != nil {
+			for _, ext := range service.Spec.ExternalIPs {
+				targets = append(targets, ext)
 			}
 		}
 	}

--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -28,7 +28,6 @@ import (
 	istioclient "istio.io/client-go/pkg/clientset/versioned"
 	istioinformers "istio.io/client-go/pkg/informers/externalversions"
 	networkingv1alpha3informer "istio.io/client-go/pkg/informers/externalversions/networking/v1alpha3"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kubeinformers "k8s.io/client-go/informers"
@@ -258,7 +257,7 @@ func (sc *gatewaySource) targetsFromGateway(gateway networkingv1alpha3.Gateway) 
 			}
 		}
 
-		if service.Spec.Type == corev1.ServiceTypeLoadBalancer && service.Spec.ExternalIPs != nil {
+		if service.Spec.ExternalIPs != nil {
 			for _, ext := range service.Spec.ExternalIPs {
 				targets = append(targets, ext)
 			}

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -28,7 +28,6 @@ import (
 	istioclient "istio.io/client-go/pkg/clientset/versioned"
 	istioinformers "istio.io/client-go/pkg/informers/externalversions"
 	networkingv1alpha3informer "istio.io/client-go/pkg/informers/externalversions/networking/v1alpha3"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -456,11 +455,11 @@ func (sc *virtualServiceSource) targetsFromGateway(gateway *networkingv1alpha3.G
 			} else if lb.Hostname != "" {
 				targets = append(targets, lb.Hostname)
 			}
+		}
 
-			if service.Spec.Type == corev1.ServiceTypeLoadBalancer && service.Spec.ExternalIPs != nil {
-				for _, ext := range service.Spec.ExternalIPs {
-					targets = append(targets, ext)
-				}
+		if service.Spec.ExternalIPs != nil {
+			for _, ext := range service.Spec.ExternalIPs {
+				targets = append(targets, ext)
 			}
 		}
 	}

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -28,6 +28,7 @@ import (
 	istioclient "istio.io/client-go/pkg/clientset/versioned"
 	istioinformers "istio.io/client-go/pkg/informers/externalversions"
 	networkingv1alpha3informer "istio.io/client-go/pkg/informers/externalversions/networking/v1alpha3"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -454,6 +455,12 @@ func (sc *virtualServiceSource) targetsFromGateway(gateway *networkingv1alpha3.G
 				targets = append(targets, lb.IP)
 			} else if lb.Hostname != "" {
 				targets = append(targets, lb.Hostname)
+			}
+
+			if service.Spec.Type == corev1.ServiceTypeLoadBalancer && service.Spec.ExternalIPs != nil {
+				for _, ext := range service.Spec.ExternalIPs {
+					targets = append(targets, ext)
+				}
 			}
 		}
 	}

--- a/source/istio_virtualservice_test.go
+++ b/source/istio_virtualservice_test.go
@@ -557,6 +557,37 @@ func testEndpointsFromVirtualServiceConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			title: "service with externalIPs returns a single endpoint with a targets",
+			lbServices: []fakeIngressGatewayService{
+				{
+					externalIPs: []string{"1.2.3.4"},
+					namespace:   "",
+					name:        "service1",
+					selector: map[string]string{
+						"app": "myservice",
+					},
+				},
+			},
+			gwconfig: fakeGatewayConfig{
+				name:     "mygw",
+				dnsnames: [][]string{{"foo.bar"}},
+				selector: map[string]string{
+					"app": "myservice",
+				},
+			},
+			vsconfig: fakeVirtualServiceConfig{
+				gateways: []string{"mygw"},
+				dnsnames: []string{"foo.bar"},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"1.2.3.4"},
+				},
+			},
+		},
 	} {
 		ti := ti
 		t.Run(ti.title, func(t *testing.T) {


### PR DESCRIPTION
**Description**

When externalIPs of service which is loadbalancer type created, external-dns doesn't support for istio-gateway, istio-virtualservice.


**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
