### PR TITLE
[TXT Registry] Fix handling of records produced by `toNewTXTName` in `toEndpoint`

### DIFF
--- a/registry/txt.go
+++ b/registry/txt.go
@@ -200,7 +200,7 @@ func (im *TXTRegistry) generateTXTRecord(r *endpoint.Endpoint) []*endpoint.Endpo
 
 	endpoints := make([]*endpoint.Endpoint, 0)
 
-	if r.RecordType != endpoint.RecordTypeAAAA {
+	if !im.mapper.recordTypeInAffix() && r.RecordType != endpoint.RecordTypeAAAA {
 		// old TXT record format
 		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true, im.txtEncryptEnabled, im.txtEncryptAESKey))
 		if txt != nil {
@@ -305,6 +305,7 @@ type nameMapper interface {
 	toEndpointName(string) (endpointName string, recordType string)
 	toTXTName(string) string
 	toNewTXTName(string, string) string
+	recordTypeInAffix() bool
 }
 
 type affixNameMapper struct {

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -334,11 +334,14 @@ func extractRecordTypeDefaultPosition(name string) (baseName, recordType string)
 // dropAffixExtractType strips TXT record to find an endpoint name it manages
 // it also returns the record type
 func (pr affixNameMapper) dropAffixExtractType(name string) (baseName, recordType string) {
+	prefix := pr.prefix
+	suffix := pr.suffix
+
 	if pr.recordTypeInAffix() {
 		for _, t := range getSupportedTypes() {
 			t = strings.ToLower(t)
-			iPrefix := strings.ReplaceAll(pr.prefix, recordTemplate, t)
-			iSuffix := strings.ReplaceAll(pr.suffix, recordTemplate, t)
+			iPrefix := strings.ReplaceAll(prefix, recordTemplate, t)
+			iSuffix := strings.ReplaceAll(suffix, recordTemplate, t)
 
 			if pr.isPrefix() && strings.HasPrefix(name, iPrefix) {
 				return strings.TrimPrefix(name, iPrefix), t
@@ -350,16 +353,16 @@ func (pr affixNameMapper) dropAffixExtractType(name string) (baseName, recordTyp
 		}
 
 		// handle old TXT records
-		pr.prefix = pr.dropAffixTemplate(pr.prefix)
-		pr.suffix = pr.dropAffixTemplate(pr.suffix)
+		prefix = pr.dropAffixTemplate(prefix)
+		suffix = pr.dropAffixTemplate(suffix)
 	}
 
-	if pr.isPrefix() && strings.HasPrefix(name, pr.prefix) {
-		return extractRecordTypeDefaultPosition(strings.TrimPrefix(name, pr.prefix))
+	if pr.isPrefix() && strings.HasPrefix(name, prefix) {
+		return extractRecordTypeDefaultPosition(strings.TrimPrefix(name, prefix))
 	}
 
-	if pr.isSuffix() && strings.HasSuffix(name, pr.suffix) {
-		return extractRecordTypeDefaultPosition(strings.TrimSuffix(name, pr.suffix))
+	if pr.isSuffix() && strings.HasSuffix(name, suffix) {
+		return extractRecordTypeDefaultPosition(strings.TrimSuffix(name, suffix))
 	}
 
 	return "", ""

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -350,13 +350,17 @@ func (pr affixNameMapper) dropAffixExtractType(name string) (string, string) {
 				return strings.TrimSuffix(name, iSuffix), t
 			}
 		}
+
+		// handle old TXT records
+		pr.prefix = pr.dropAffixTemplate(pr.prefix)
+		pr.suffix = pr.dropAffixTemplate(pr.suffix)
 	}
 
-	if strings.HasPrefix(name, pr.prefix) && pr.isPrefix() {
+	if pr.isPrefix() && strings.HasPrefix(name, pr.prefix) {
 		return extractRecordTypeDefaultPosition(strings.TrimPrefix(name, pr.prefix))
 	}
 
-	if strings.HasSuffix(name, pr.suffix) && pr.isSuffix() {
+	if pr.isSuffix() && strings.HasSuffix(name, pr.suffix) {
 		return extractRecordTypeDefaultPosition(strings.TrimSuffix(name, pr.suffix))
 	}
 

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -156,7 +156,7 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 		key := createKey(dnsName, ep.SetIdentifier)
 		keyType := createKey(key, ep.RecordType)
 		labels, labelsExist := labelMap[keyType]
-		if !labelsExist {
+		if !labelsExist && ep.RecordType != endpoint.RecordTypeAAAA {
 			labels, labelsExist = labelMap[key]
 		}
 		if labelsExist {

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -1172,6 +1172,7 @@ func TestExtractRecordTypeDefaultPosition(t *testing.T) {
 			expectedType: "",
 		},
 	}
+
 	for _, tc := range tests {
 		t.Run(tc.input, func(t *testing.T) {
 			actualName, actualType := extractRecordTypeDefaultPosition(tc.input)
@@ -1182,105 +1183,120 @@ func TestExtractRecordTypeDefaultPosition(t *testing.T) {
 }
 
 func TestToEndpointNameNewTXT(t *testing.T) {
-	type testCase struct {
+	tests := []struct {
 		name       string
 		mapper     affixNameMapper
 		domain     string
+		txtDomain  string
 		recordType string
-	}
-
-	testCases := []testCase{
+	}{
 		{
 			name:       "prefix",
 			mapper:     newaffixNameMapper("foo", "", ""),
 			domain:     "example.com",
 			recordType: "A",
+			txtDomain:  "fooa-example.com",
 		},
 		{
 			name:       "suffix",
 			mapper:     newaffixNameMapper("", "foo", ""),
 			domain:     "example.com",
 			recordType: "AAAA",
+			txtDomain:  "aaaa-examplefoo.com",
 		},
 		{
 			name:       "prefix with dash",
 			mapper:     newaffixNameMapper("foo-", "", ""),
 			domain:     "example.com",
 			recordType: "A",
+			txtDomain:  "foo-a-example.com",
 		},
 		{
 			name:       "suffix with dash",
 			mapper:     newaffixNameMapper("", "-foo", ""),
 			domain:     "example.com",
 			recordType: "CNAME",
+			txtDomain:  "cname-example-foo.com",
 		},
 		{
 			name:       "prefix with dot",
 			mapper:     newaffixNameMapper("foo.", "", ""),
 			domain:     "example.com",
 			recordType: "CNAME",
+			txtDomain:  "foo.cname-example.com",
 		},
 		{
 			name:       "suffix with dot",
 			mapper:     newaffixNameMapper("", ".foo", ""),
 			domain:     "example.com",
 			recordType: "CNAME",
+			txtDomain:  "cname-example.foo.com",
 		},
 		{
 			name:       "prefix with multiple dots",
 			mapper:     newaffixNameMapper("foo.bar.", "", ""),
 			domain:     "example.com",
 			recordType: "CNAME",
+			txtDomain:  "foo.bar.cname-example.com",
 		},
 		{
 			name:       "suffix with multiple dots",
 			mapper:     newaffixNameMapper("", ".foo.bar.test", ""),
 			domain:     "example.com",
 			recordType: "CNAME",
+			txtDomain:  "cname-example.foo.bar.test.com",
 		},
 		{
 			name:       "templated prefix",
 			mapper:     newaffixNameMapper("%{record_type}-foo", "", ""),
 			domain:     "example.com",
 			recordType: "A",
+			txtDomain:  "a-fooexample.com",
 		},
 		{
 			name:       "templated suffix",
 			mapper:     newaffixNameMapper("", "foo-%{record_type}", ""),
 			domain:     "example.com",
 			recordType: "A",
+			txtDomain:  "examplefoo-a.com",
 		},
 		{
 			name:       "templated prefix with dot",
 			mapper:     newaffixNameMapper("%{record_type}foo.", "", ""),
 			domain:     "example.com",
 			recordType: "CNAME",
+			txtDomain:  "cnamefoo.example.com",
 		},
 		{
 			name:       "templated suffix with dot",
 			mapper:     newaffixNameMapper("", ".foo%{record_type}", ""),
 			domain:     "example.com",
 			recordType: "A",
+			txtDomain:  "example.fooa.com",
 		},
 		{
 			name:       "templated prefix with multiple dots",
 			mapper:     newaffixNameMapper("bar.%{record_type}.foo.", "", ""),
 			domain:     "example.com",
 			recordType: "CNAME",
+			txtDomain:  "bar.cname.foo.example.com",
 		},
 		{
 			name:       "templated suffix with multiple dots",
 			mapper:     newaffixNameMapper("", ".foo%{record_type}.bar", ""),
 			domain:     "example.com",
 			recordType: "A",
+			txtDomain:  "example.fooa.bar.com",
 		},
 	}
 
-	for _, tc := range testCases {
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			txtName := tc.mapper.toNewTXTName(tc.domain, tc.recordType)
-			res, _ := tc.mapper.toEndpointName(txtName)
-			assert.Equal(t, tc.domain, res)
+			txtDomain := tc.mapper.toNewTXTName(tc.domain, tc.recordType)
+			assert.Equal(t, tc.txtDomain, txtDomain)
+
+			domain, _ := tc.mapper.toEndpointName(txtDomain)
+			assert.Equal(t, tc.domain, domain)
 		})
 	}
 }

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -216,13 +216,13 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 	r, _ := NewTXTRegistry(p, "txt.", "", "owner", time.Hour, "wc", []string{}, false, nil)
 	records, _ := r.Records(ctx)
 
-	assert.ElementsMatch(t, expectedRecords, records)
+	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
 
 	// Ensure prefix is case-insensitive
 	r, _ = NewTXTRegistry(p, "TxT.", "", "owner", time.Hour, "", []string{}, false, nil)
 	records, _ = r.Records(ctx)
 
-	assert.ElementsMatch(t, expectedRecords, records)
+	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
 }
 
 func testTXTRegistryRecordsSuffixed(t *testing.T) {

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -1112,24 +1112,39 @@ func TestCacheMethods(t *testing.T) {
 
 func TestDropPrefix(t *testing.T) {
 	mapper := newaffixNameMapper("foo-%{record_type}-", "", "")
-	cnameRecord := "foo-cname-test.example.com"
-	aRecord := "foo-a-test.example.com"
-	expectedCnameRecord := "test.example.com"
-	expectedARecord := "test.example.com"
-	actualCnameRecord, _ := mapper.dropAffixExtractType(cnameRecord)
-	actualARecord, _ := mapper.dropAffixExtractType(aRecord)
-	assert.Equal(t, expectedCnameRecord, actualCnameRecord)
-	assert.Equal(t, expectedARecord, actualARecord)
+	expectedOutput := "test.example.com"
+
+	tests := []string{
+		"foo-cname-test.example.com",
+		"foo-a-test.example.com",
+		"foo--test.example.com",
+	}
+
+	for _, tc := range tests {
+		t.Run(tc, func(t *testing.T) {
+			actualOutput, _ := mapper.dropAffixExtractType(tc)
+			assert.Equal(t, expectedOutput, actualOutput)
+		})
+	}
 }
 
 func TestDropSuffix(t *testing.T) {
 	mapper := newaffixNameMapper("", "-%{record_type}-foo", "")
-	aRecord := "test-a-foo.example.com"
-	expectedARecord := "test.example.com"
-	r := strings.SplitN(aRecord, ".", 2)
-	rClean, _ := mapper.dropAffixExtractType(r[0])
-	actualARecord := rClean + "." + r[1]
-	assert.Equal(t, expectedARecord, actualARecord)
+	expectedOutput := "test.example.com"
+
+	tests := []string{
+		"test-a-foo.example.com",
+		"test--foo.example.com",
+	}
+
+	for _, tc := range tests {
+		t.Run(tc, func(t *testing.T) {
+			r := strings.SplitN(tc, ".", 2)
+			rClean, _ := mapper.dropAffixExtractType(r[0])
+			actualOutput := rClean + "." + r[1]
+			assert.Equal(t, expectedOutput, actualOutput)
+		})
+	}
 }
 
 func TestExtractRecordTypeDefaultPosition(t *testing.T) {

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -583,7 +583,6 @@ func testTXTRegistryApplyChangesWithTemplatedPrefix(t *testing.T) {
 	expected := &plan.Changes{
 		Create: []*endpoint.Endpoint{
 			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress"),
-			newEndpointWithOwnerAndOwnedRecord("prefix.new-record-1.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress\"", endpoint.RecordTypeTXT, "", "new-record-1.test-zone.example.org"),
 			newEndpointWithOwnerAndOwnedRecord("prefixcname.new-record-1.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress\"", endpoint.RecordTypeTXT, "", "new-record-1.test-zone.example.org"),
 		},
 	}
@@ -628,7 +627,6 @@ func testTXTRegistryApplyChangesWithTemplatedSuffix(t *testing.T) {
 		Create: []*endpoint.Endpoint{
 			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress"),
 			newEndpointWithOwnerAndOwnedRecord("new-record-1-cnamesuffix.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress\"", endpoint.RecordTypeTXT, "", "new-record-1.test-zone.example.org"),
-			newEndpointWithOwnerAndOwnedRecord("new-record-1-suffix.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress\"", endpoint.RecordTypeTXT, "", "new-record-1.test-zone.example.org"),
 		},
 	}
 	p.OnApplyChanges = func(ctx context.Context, got *plan.Changes) {

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -1227,6 +1227,18 @@ func TestToEndpointNameNewTXT(t *testing.T) {
 			recordType: "CNAME",
 		},
 		{
+			name:       "prefix with multiple dots",
+			mapper:     newaffixNameMapper("foo.bar.", "", ""),
+			domain:     "example.com",
+			recordType: "CNAME",
+		},
+		{
+			name:       "suffix with multiple dots",
+			mapper:     newaffixNameMapper("", ".foo.bar.test", ""),
+			domain:     "example.com",
+			recordType: "CNAME",
+		},
+		{
 			name:       "templated prefix",
 			mapper:     newaffixNameMapper("%{record_type}-foo", "", ""),
 			domain:     "example.com",
@@ -1247,6 +1259,18 @@ func TestToEndpointNameNewTXT(t *testing.T) {
 		{
 			name:       "templated suffix with dot",
 			mapper:     newaffixNameMapper("", ".foo%{record_type}", ""),
+			domain:     "example.com",
+			recordType: "A",
+		},
+		{
+			name:       "templated prefix with multiple dots",
+			mapper:     newaffixNameMapper("bar.%{record_type}.foo.", "", ""),
+			domain:     "example.com",
+			recordType: "CNAME",
+		},
+		{
+			name:       "templated suffix with multiple dots",
+			mapper:     newaffixNameMapper("", ".foo%{record_type}.bar", ""),
 			domain:     "example.com",
 			recordType: "A",
 		},


### PR DESCRIPTION
The current implementation of the `toEndpoint` function is unable to handle records generated by the `toNewTXTName` function. As a result, domains created with a prefix such as `%{record_type}foo.` are not deleted after the associated CRD is removed.

This PR addresses this issue by improving the handling of records produced by the `toNewTXTName` function in the `toEndpoint` function. Additionally, it covers edge cases related to dashes or dots in the affix. A new test, `TestToEndpointNameNewTXT`, has been added to ensure the proper conversion between the output of `toNewTXTName` and its input using the `toEndpoint` function.

Additionally, this PR fixes the `testTXTRegistryRecordsPrefixed` test, which previously operated under the incorrect assumption that the output of `toNewTXTName` with the prefix `txt.` for `dualstack.test-zone.example.org` would be `aaaa-txt.dualstack.test-zone.example.org`. In reality when not using a templated record type, the type will be prepended to the domain rather than the affix.

```go
DNSName := strings.SplitN(endpointDNSName, ".", 2)

if !pr.recordTypeInAffix() {
	DNSName[0] = recordT + DNSName[0]
}
```

Here are the results of the new test before the change:

![](https://github.com/kubernetes-sigs/external-dns/assets/9078247/785447f0-23d5-4e5e-a60b-2d5d95b64c78)

Potentially fixes: https://github.com/kubernetes-sigs/external-dns/issues/3007  https://github.com/kubernetes-sigs/external-dns/issues/3186


**Checklist**

- [x] Unit tests updated
