### PR TITLE
feat: add support for external IP in ambassador host source

### DIFF
--- a/source/ambassador_host.go
+++ b/source/ambassador_host.go
@@ -184,11 +184,6 @@ func (sc *ambassadorHostSource) endpointsFromHost(ctx context.Context, host *amb
 }
 
 func (sc *ambassadorHostSource) targetsFromAmbassadorLoadBalancer(ctx context.Context, service string) (endpoint.Targets, error) {
-	var (
-		targets     endpoint.Targets
-		externalIPs endpoint.Targets
-	)
-
 	lbNamespace, lbName, err := parseAmbLoadBalancerService(service)
 	if err != nil {
 		return nil, err
@@ -199,24 +194,7 @@ func (sc *ambassadorHostSource) targetsFromAmbassadorLoadBalancer(ctx context.Co
 		return nil, err
 	}
 
-	for _, lb := range svc.Status.LoadBalancer.Ingress {
-		if lb.IP != "" {
-			targets = append(targets, lb.IP)
-		}
-		if lb.Hostname != "" {
-			targets = append(targets, lb.Hostname)
-		}
-	}
-
-	if svc.Spec.ExternalIPs != nil {
-		for _, ext := range svc.Spec.ExternalIPs {
-			externalIPs = append(externalIPs, ext)
-		}
-	}
-
-	if len(externalIPs) > 0 {
-		return externalIPs, nil
-	}
+	var targets = extractLoadBalancerTargets(svc, true)
 
 	return targets, nil
 }


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Hello!

I would like to submit a PR to add support for external IPs in Ambassador Host resources.
Most of the code has been shamelessly copied from the `Service` source implementation (https://github.com/kubernetes-sigs/external-dns/blob/master/source/service.go#L591).

I couldn't add any tests as the ones I currently see for Ambassador are rather basic (e.g. making sure the annotation format is correct) while in my case I would need to mock the Kubernetes API and I'm not sure how to do it -- happy to give it a try if somebody can guide me a bit.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Note this fixes #3733.

Let me know if anything is missing or if you have improvement ideas.

Thanks,
Fred

