### PR TITLE
[TXT Registry] Disable generation of old style txt records when encryption is enabled

### DIFF
--- a/registry/txt.go
+++ b/registry/txt.go
@@ -217,6 +217,11 @@ func (im *TXTRegistry) generateTXTRecord(r *endpoint.Endpoint) []*endpoint.Endpo
 		txtNew.Labels[endpoint.OwnedRecordLabelKey] = r.DNSName
 		txtNew.ProviderSpecific = r.ProviderSpecific
 		endpoints = append(endpoints, txtNew)
+
+		// TODO: Make it less hacky
+		if im.txtEncryptEnabled {
+			r.Labels["txt-encryption-nonce"] = strings.Trim(txtNew.Targets[0], "\"")[:16]
+		}
 	}
 
 	return endpoints

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -167,7 +167,7 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 
 		// Handle the migration of TXT records created before the new format (introduced in v0.12.0).
 		// The migration is done for the TXT records owned by this instance only.
-		if len(txtRecordsMap) > 0 && ep.Labels[endpoint.OwnerLabelKey] == im.ownerID {
+		if !im.txtEncryptEnabled && len(txtRecordsMap) > 0 && ep.Labels[endpoint.OwnerLabelKey] == im.ownerID {
 			if plan.IsManagedRecord(ep.RecordType, im.managedRecordTypes) {
 				// Get desired TXT records and detect the missing ones
 				desiredTXTs := im.generateTXTRecord(ep)
@@ -200,7 +200,7 @@ func (im *TXTRegistry) generateTXTRecord(r *endpoint.Endpoint) []*endpoint.Endpo
 
 	endpoints := make([]*endpoint.Endpoint, 0)
 
-	if r.RecordType != endpoint.RecordTypeAAAA {
+	if !im.txtEncryptEnabled && r.RecordType != endpoint.RecordTypeAAAA {
 		// old TXT record format
 		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true, im.txtEncryptEnabled, im.txtEncryptAESKey))
 		if txt != nil {

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -350,13 +350,17 @@ func (pr affixNameMapper) dropAffixExtractType(name string) (string, string) {
 				return strings.TrimSuffix(name, iSuffix), t
 			}
 		}
+
+		// handle old TXT records
+		pr.prefix = pr.dropAffixTemplate(pr.prefix)
+		pr.suffix = pr.dropAffixTemplate(pr.suffix)
 	}
 
-	if strings.HasPrefix(name, pr.prefix) && pr.isPrefix() {
+	if pr.isPrefix() && strings.HasPrefix(name, pr.prefix) {
 		return extractRecordTypeDefaultPosition(strings.TrimPrefix(name, pr.prefix))
 	}
 
-	if strings.HasSuffix(name, pr.suffix) && pr.isSuffix() {
+	if pr.isSuffix() && strings.HasSuffix(name, pr.suffix) {
 		return extractRecordTypeDefaultPosition(strings.TrimSuffix(name, pr.suffix))
 	}
 

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -1112,24 +1112,39 @@ func TestCacheMethods(t *testing.T) {
 
 func TestDropPrefix(t *testing.T) {
 	mapper := newaffixNameMapper("foo-%{record_type}-", "", "")
-	cnameRecord := "foo-cname-test.example.com"
-	aRecord := "foo-a-test.example.com"
-	expectedCnameRecord := "test.example.com"
-	expectedARecord := "test.example.com"
-	actualCnameRecord, _ := mapper.dropAffixExtractType(cnameRecord)
-	actualARecord, _ := mapper.dropAffixExtractType(aRecord)
-	assert.Equal(t, expectedCnameRecord, actualCnameRecord)
-	assert.Equal(t, expectedARecord, actualARecord)
+	expectedOutput := "test.example.com"
+
+	tests := []string{
+		"foo-cname-test.example.com",
+		"foo-a-test.example.com",
+		"foo--test.example.com",
+	}
+
+	for _, tc := range tests {
+		t.Run(tc, func(t *testing.T) {
+			actualOutput, _ := mapper.dropAffixExtractType(tc)
+			assert.Equal(t, expectedOutput, actualOutput)
+		})
+	}
 }
 
 func TestDropSuffix(t *testing.T) {
 	mapper := newaffixNameMapper("", "-%{record_type}-foo", "")
-	aRecord := "test-a-foo.example.com"
-	expectedARecord := "test.example.com"
-	r := strings.SplitN(aRecord, ".", 2)
-	rClean, _ := mapper.dropAffixExtractType(r[0])
-	actualARecord := rClean + "." + r[1]
-	assert.Equal(t, expectedARecord, actualARecord)
+	expectedOutput := "test.example.com"
+
+	tests := []string{
+		"test-a-foo.example.com",
+		"test--foo.example.com",
+	}
+
+	for _, tc := range tests {
+		t.Run(tc, func(t *testing.T) {
+			r := strings.SplitN(tc, ".", 2)
+			rClean, _ := mapper.dropAffixExtractType(r[0])
+			actualOutput := rClean + "." + r[1]
+			assert.Equal(t, expectedOutput, actualOutput)
+		})
+	}
 }
 
 func TestExtractRecordTypeDefaultPosition(t *testing.T) {


### PR DESCRIPTION
As mentioned in the issue, current behaviour is unable to work with AWS which requires the `Delete` change request to be called with the exact same record set that is currently present in Route53. This is currently not happening due to:

1. [generateTXTRecord](https://github.com/kubernetes-sigs/external-dns/blob/bd8658e89a1fe3e255621103091717b20f8312b8/registry/txt.go#L196) generates both the old and new format txt records. Each record ends up being encrypted with new random nonce.
2. [Records()](https://github.com/kubernetes-sigs/external-dns/blob/bd8658e89a1fe3e255621103091717b20f8312b8/registry/txt.go#L146C22-L146C22) will only store one these in the `labelsMap` when iterating through the TXT labels.
3. Call to [generateTXTRecord](https://github.com/kubernetes-sigs/external-dns/blob/bd8658e89a1fe3e255621103091717b20f8312b8/registry/txt.go#L175C26-L175C26) within `Records()` will [delete the nonce](https://github.com/kubernetes-sigs/external-dns/blob/bd8658e89a1fe3e255621103091717b20f8312b8/registry/txt.go#L207
) from the labels.
4. Final call to `generateTXTRecord` from within [ApplyChanges](https://github.com/kubernetes-sigs/external-dns/blob/bd8658e89a1fe3e255621103091717b20f8312b8/registry/txt.go#L253) will have to regenerate the nonce once again, ending up with an entirely different target.

This change disables the generation of the old style txt records and old to new migrations when encryption is enabled. 

Fixes #3668
Depends on #3724 

**Checklist**

- [x] Unit tests updated
