### PR TITLE
helm: Don't suppress configuration for registries other than TXT

### DIFF
--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -78,7 +78,6 @@ spec:
             {{- end }}
             - --policy={{ .Values.policy }}
             - --registry={{ .Values.registry }}
-            {{- if eq .Values.registry "txt" }}
             {{- if .Values.txtOwnerId }}
             - --txt-owner-id={{ .Values.txtOwnerId }}
             {{- end }}
@@ -87,7 +86,6 @@ spec:
             {{- end }}
             {{- if and (eq .Values.txtPrefix "") (ne .Values.txtSuffix "") }}
             - --txt-suffix={{ .Values.txtSuffix }}
-            {{- end }}
             {{- end }}
             {{- if .Values.namespaced }}
             - --namespace={{ .Release.Namespace }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -162,9 +162,15 @@ sources:
 
 policy: upsert-only
 
+# Specifies the registry for storing ownership and labels.
+# Valid values are "aws-sd", "noop", "dynamodb", and "txt".
 registry: txt
+# When using a registry other than "noop", specifies a name that
+# uniquely identifies this instance of external-dns.
 txtOwnerId: ""
+# Specifies a prefix for the domain names of TXT records created by the "txt" registry. Optional.
 txtPrefix: ""
+# Specifies a suffix for the domain names of TXT records created by the "txt" registry. Optional.
 txtSuffix: ""
 
 domainFilters: []


### PR DESCRIPTION

**Description**

The "aws-sd" and "dynamodb" registries also consume txtOwnerId. The "dynamodb" registry will also soon be consuming txtPrefix and txtSuffix.

Also document these existing settings.

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
