### PR TITLE
Suppress dependabot updates for OpenShift

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
       dev-dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "github.com/openshift/api"
+      - dependency-name: "github.com/openshift/client-go"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION


**Description**

Dependabot appears to be attempting to downgrade these dependencies to non-working versions.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
