### PR TITLE
support cnames and aaaa for default-targets

### DIFF
--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -440,7 +440,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("crd-source-kind", "Kind of the CRD for the crd source in API group and version specified by crd-source-apiversion").Default(defaultConfig.CRDSourceKind).StringVar(&cfg.CRDSourceKind)
 	app.Flag("service-type-filter", "The service types to take care about (default: all, expected: ClusterIP, NodePort, LoadBalancer or ExternalName)").StringsVar(&cfg.ServiceTypeFilter)
 	app.Flag("managed-record-types", "Record types to manage; specify multiple times to include many; (default: A, AAAA, CNAME) (supported records: CNAME, A, AAAA, NS").Default("A", "AAAA", "CNAME").StringsVar(&cfg.ManagedDNSRecordTypes)
-	app.Flag("default-targets", "Set globally default IP address that will apply as a target instead of source addresses. Specify multiple times for multiple targets (optional)").StringsVar(&cfg.DefaultTargets)
+	app.Flag("default-targets", "Set globally default host/IP that will apply as a target instead of source addresses. Specify multiple times for multiple targets (optional)").StringsVar(&cfg.DefaultTargets)
 	app.Flag("target-net-filter", "Limit possible targets by a net filter; specify multiple times for multiple possible nets (optional)").StringsVar(&cfg.TargetNetFilter)
 	app.Flag("exclude-target-net", "Exclude target nets (optional)").StringsVar(&cfg.ExcludeTargetNets)
 

--- a/source/multisource.go
+++ b/source/multisource.go
@@ -39,10 +39,12 @@ func (ms *multiSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, err
 		}
 		if len(ms.defaultTargets) > 0 {
 			for i := range endpoints {
-				endpoints[i].Targets = ms.defaultTargets
+				eps := endpointsForHostname(endpoints[i].DNSName, ms.defaultTargets, endpoints[i].RecordTTL, endpoints[i].ProviderSpecific, endpoints[i].SetIdentifier)
+				result = append(result, eps...)
 			}
+		} else {
+			result = append(result, endpoints...)
 		}
-		result = append(result, endpoints...)
 	}
 
 	return result, nil

--- a/source/multisource.go
+++ b/source/multisource.go
@@ -40,6 +40,9 @@ func (ms *multiSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, err
 		if len(ms.defaultTargets) > 0 {
 			for i := range endpoints {
 				eps := endpointsForHostname(endpoints[i].DNSName, ms.defaultTargets, endpoints[i].RecordTTL, endpoints[i].ProviderSpecific, endpoints[i].SetIdentifier)
+				for _, ep := range eps {
+					ep.Labels = endpoints[i].Labels
+				}
 				result = append(result, eps...)
 			}
 		} else {

--- a/source/multisource_test.go
+++ b/source/multisource_test.go
@@ -129,13 +129,17 @@ func testMultiSourceEndpointsWithError(t *testing.T) {
 func testMultiSourceEndpointsDefaultTargets(t *testing.T) {
 	// Create the expected default targets
 	defaultTargetsA := []string{"127.0.0.1", "127.0.0.2"}
+	defaultTargetsAAAA := []string{"2001:db8::1"}
 	defaultTargetsCName := []string{"foo.example.org"}
 	defaultTargets := append(defaultTargetsA, defaultTargetsCName...)
+	defaultTargets = append(defaultTargets, defaultTargetsAAAA...)
 
 	// Create the expected endpoints
 	expectedEndpoints := []*endpoint.Endpoint{
 		{DNSName: "foo", Targets: defaultTargetsA, RecordType: "A"},
 		{DNSName: "bar", Targets: defaultTargetsA, RecordType: "A"},
+		{DNSName: "foo", Targets: defaultTargetsAAAA, RecordType: "AAAA"},
+		{DNSName: "bar", Targets: defaultTargetsAAAA, RecordType: "AAAA"},
 		{DNSName: "foo", Targets: defaultTargetsCName, RecordType: "CNAME"},
 		{DNSName: "bar", Targets: defaultTargetsCName, RecordType: "CNAME"},
 	}

--- a/source/multisource_test.go
+++ b/source/multisource_test.go
@@ -133,21 +133,22 @@ func testMultiSourceEndpointsDefaultTargets(t *testing.T) {
 	defaultTargetsCName := []string{"foo.example.org"}
 	defaultTargets := append(defaultTargetsA, defaultTargetsCName...)
 	defaultTargets = append(defaultTargets, defaultTargetsAAAA...)
+	labels := endpoint.Labels{"foo": "bar"}
 
 	// Create the expected endpoints
 	expectedEndpoints := []*endpoint.Endpoint{
-		{DNSName: "foo", Targets: defaultTargetsA, RecordType: "A"},
-		{DNSName: "bar", Targets: defaultTargetsA, RecordType: "A"},
-		{DNSName: "foo", Targets: defaultTargetsAAAA, RecordType: "AAAA"},
-		{DNSName: "bar", Targets: defaultTargetsAAAA, RecordType: "AAAA"},
-		{DNSName: "foo", Targets: defaultTargetsCName, RecordType: "CNAME"},
-		{DNSName: "bar", Targets: defaultTargetsCName, RecordType: "CNAME"},
+		{DNSName: "foo", Targets: defaultTargetsA, RecordType: "A", Labels: labels},
+		{DNSName: "bar", Targets: defaultTargetsA, RecordType: "A", Labels: labels},
+		{DNSName: "foo", Targets: defaultTargetsAAAA, RecordType: "AAAA", Labels: labels},
+		{DNSName: "bar", Targets: defaultTargetsAAAA, RecordType: "AAAA", Labels: labels},
+		{DNSName: "foo", Targets: defaultTargetsCName, RecordType: "CNAME", Labels: labels},
+		{DNSName: "bar", Targets: defaultTargetsCName, RecordType: "CNAME", Labels: labels},
 	}
 
 	// Create the source endpoints with different targets
 	sourceEndpoints := []*endpoint.Endpoint{
-		{DNSName: "foo", Targets: endpoint.Targets{"8.8.8.8"}},
-		{DNSName: "bar", Targets: endpoint.Targets{"8.8.4.4"}},
+		{DNSName: "foo", Targets: endpoint.Targets{"8.8.8.8"}, Labels: labels},
+		{DNSName: "bar", Targets: endpoint.Targets{"8.8.4.4"}, Labels: labels},
 	}
 
 	// Create a mocked source returning source targets

--- a/source/multisource_test.go
+++ b/source/multisource_test.go
@@ -128,12 +128,16 @@ func testMultiSourceEndpointsWithError(t *testing.T) {
 
 func testMultiSourceEndpointsDefaultTargets(t *testing.T) {
 	// Create the expected default targets
-	defaultTargets := []string{"127.0.0.1", "127.0.0.2"}
+	defaultTargetsA := []string{"127.0.0.1", "127.0.0.2"}
+	defaultTargetsCName := []string{"foo.example.org"}
+	defaultTargets := append(defaultTargetsA, defaultTargetsCName...)
 
 	// Create the expected endpoints
 	expectedEndpoints := []*endpoint.Endpoint{
-		{DNSName: "foo", Targets: defaultTargets},
-		{DNSName: "bar", Targets: defaultTargets},
+		{DNSName: "foo", Targets: defaultTargetsA, RecordType: "A"},
+		{DNSName: "bar", Targets: defaultTargetsA, RecordType: "A"},
+		{DNSName: "foo", Targets: defaultTargetsCName, RecordType: "CNAME"},
+		{DNSName: "bar", Targets: defaultTargetsCName, RecordType: "CNAME"},
 	}
 
 	// Create the source endpoints with different targets


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
add support to allow to add cnames and aaaa records to default-targets, similar to `external-dns.alpha.kubernetes.io/target` annotation.

#2244 

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
