### PR TITLE
Fix planning for multi-cluster dual stack record types

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -222,6 +222,7 @@ func (c *Controller) RunOnce(ctx context.Context) error {
 		Desired:        endpoints,
 		DomainFilter:   endpoint.MatchAllDomainFilters{c.DomainFilter, c.Registry.GetDomainFilter()},
 		ManagedRecords: c.ManagedRecordTypes,
+		OwnerID:        c.Registry.OwnerID(),
 	}
 
 	plan = plan.Calculate()

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -281,6 +281,44 @@ func (e *Endpoint) String() string {
 	return fmt.Sprintf("%s %d IN %s %s %s %s", e.DNSName, e.RecordTTL, e.RecordType, e.SetIdentifier, e.Targets, e.ProviderSpecific)
 }
 
+// EndpointFilterInterface matches endpoints
+type EndpointFilterInterface interface {
+	// Match returns true if the endpoint matches the filter, false otherwise
+	Match(ep *Endpoint) bool
+}
+
+// Apply filter to slice of endpoints and return new filtered slice that includes
+// only endpoints that match.
+func ApplyEndpointFilter(filter EndpointFilterInterface, eps []*Endpoint) []*Endpoint {
+	filtered := []*Endpoint{}
+	for _, ep := range eps {
+		if filter.Match(ep) {
+			filtered = append(filtered, ep)
+		}
+	}
+
+	return filtered
+}
+
+// NewOwnedRecordFilter returns endpoint filter that matches records with a owner
+// label that matches the given owner id.
+func NewOwnedRecordFilter(ownerID string) EndpointFilterInterface {
+	return ownedRecordFilter{ownerID: ownerID}
+}
+
+type ownedRecordFilter struct {
+	ownerID string
+}
+
+func (f ownedRecordFilter) Match(ep *Endpoint) bool {
+	if endpointOwner, ok := ep.Labels[OwnerLabelKey]; !ok || endpointOwner != f.ownerID {
+		log.Debugf(`Skipping endpoint %v because owner id does not match, found: "%s", required: "%s"`, ep, endpointOwner, f.ownerID)
+		return false
+	} else {
+		return true
+	}
+}
+
 // DNSEndpointSpec defines the desired state of DNSEndpoint
 type DNSEndpointSpec struct {
 	Endpoints []*Endpoint `json:"endpoints,omitempty"`

--- a/plan/conflict_test.go
+++ b/plan/conflict_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package plan
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-
 	"sigs.k8s.io/external-dns/endpoint"
 )
 
@@ -34,6 +34,7 @@ type ResolverSuite struct {
 	fooV2Cname          *endpoint.Endpoint
 	fooV2CnameDuplicate *endpoint.Endpoint
 	fooA5               *endpoint.Endpoint
+	fooAAA5             *endpoint.Endpoint
 	bar127A             *endpoint.Endpoint
 	bar192A             *endpoint.Endpoint
 	bar127AAnother      *endpoint.Endpoint
@@ -72,6 +73,14 @@ func (suite *ResolverSuite) SetupTest() {
 		DNSName:    "foo",
 		Targets:    endpoint.Targets{"5.5.5.5"},
 		RecordType: "A",
+		Labels: map[string]string{
+			endpoint.ResourceLabelKey: "ingress/default/foo-5",
+		},
+	}
+	suite.fooAAA5 = &endpoint.Endpoint{
+		DNSName:    "foo",
+		Targets:    endpoint.Targets{"2001:DB8::1"},
+		RecordType: "AAAA",
 		Labels: map[string]string{
 			endpoint.ResourceLabelKey: "ingress/default/foo-5",
 		},
@@ -131,6 +140,156 @@ func (suite *ResolverSuite) TestStrictResolver() {
 	// legacy record's resource value will not match any candidates resource label
 	// therefore pick minimum again
 	suite.Equal(suite.bar127A, suite.perResource.ResolveUpdate(suite.legacyBar192A, []*endpoint.Endpoint{suite.bar127A, suite.bar192A}), " legacy record's resource value will not match, should pick minimum")
+}
+
+func (suite *ResolverSuite) TestPerResource_ResolveRecordTypes() {
+	type args struct {
+		key planKey
+		row *planTableRow
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]*domainEndpoints
+	}{
+		{
+			name: "no conflict: cname record",
+			args: args{
+				key: planKey{dnsName: "foo"},
+				row: &planTableRow{
+					candidates: []*endpoint.Endpoint{suite.fooV1Cname},
+					records: map[string]*domainEndpoints{
+						endpoint.RecordTypeCNAME: {
+							candidates: []*endpoint.Endpoint{suite.fooV1Cname},
+						},
+					},
+				},
+			},
+			want: map[string]*domainEndpoints{
+				endpoint.RecordTypeCNAME: {
+					candidates: []*endpoint.Endpoint{suite.fooV1Cname},
+				},
+			},
+		},
+		{
+			name: "no conflict: a record",
+			args: args{
+				key: planKey{dnsName: "foo"},
+				row: &planTableRow{
+					current:    []*endpoint.Endpoint{suite.fooA5},
+					candidates: []*endpoint.Endpoint{suite.fooA5},
+					records: map[string]*domainEndpoints{
+						endpoint.RecordTypeA: {
+							current:    suite.fooA5,
+							candidates: []*endpoint.Endpoint{suite.fooA5},
+						},
+					},
+				},
+			},
+			want: map[string]*domainEndpoints{
+				endpoint.RecordTypeA: {
+					current:    suite.fooA5,
+					candidates: []*endpoint.Endpoint{suite.fooA5},
+				},
+			},
+		},
+		{
+			name: "no conflict: a and aaa records",
+			args: args{
+				key: planKey{dnsName: "foo"},
+				row: &planTableRow{
+					candidates: []*endpoint.Endpoint{suite.fooA5, suite.fooAAA5},
+					records: map[string]*domainEndpoints{
+						endpoint.RecordTypeA: {
+							candidates: []*endpoint.Endpoint{suite.fooA5},
+						},
+						endpoint.RecordTypeAAAA: {
+							candidates: []*endpoint.Endpoint{suite.fooAAA5},
+						},
+					},
+				},
+			},
+			want: map[string]*domainEndpoints{
+				endpoint.RecordTypeA: {
+					candidates: []*endpoint.Endpoint{suite.fooA5},
+				},
+				endpoint.RecordTypeAAAA: {
+					candidates: []*endpoint.Endpoint{suite.fooAAA5},
+				},
+			},
+		},
+		{
+			name: "conflict: cname and a records",
+			args: args{
+				key: planKey{dnsName: "foo"},
+				row: &planTableRow{
+					current:    []*endpoint.Endpoint{suite.fooA5},
+					candidates: []*endpoint.Endpoint{suite.fooV1Cname, suite.fooA5},
+					records: map[string]*domainEndpoints{
+						endpoint.RecordTypeCNAME: {
+							candidates: []*endpoint.Endpoint{suite.fooV1Cname},
+						},
+						endpoint.RecordTypeA: {
+							current:    suite.fooA5,
+							candidates: []*endpoint.Endpoint{suite.fooA5},
+						},
+					},
+				},
+			},
+			want: map[string]*domainEndpoints{
+				endpoint.RecordTypeCNAME: {
+					candidates: []*endpoint.Endpoint{suite.fooV1Cname},
+				},
+				endpoint.RecordTypeA: {
+					current:    suite.fooA5,
+					candidates: []*endpoint.Endpoint{},
+				},
+			},
+		},
+		{
+			name: "conflict: cname, a, and aaa records",
+			args: args{
+				key: planKey{dnsName: "foo"},
+				row: &planTableRow{
+					current:    []*endpoint.Endpoint{suite.fooA5, suite.fooAAA5},
+					candidates: []*endpoint.Endpoint{suite.fooV1Cname, suite.fooA5, suite.fooAAA5},
+					records: map[string]*domainEndpoints{
+						endpoint.RecordTypeCNAME: {
+							candidates: []*endpoint.Endpoint{suite.fooV1Cname},
+						},
+						endpoint.RecordTypeA: {
+							current:    suite.fooA5,
+							candidates: []*endpoint.Endpoint{},
+						},
+						endpoint.RecordTypeAAAA: {
+							current:    suite.fooAAA5,
+							candidates: []*endpoint.Endpoint{},
+						},
+					},
+				},
+			},
+			want: map[string]*domainEndpoints{
+				endpoint.RecordTypeCNAME: {
+					candidates: []*endpoint.Endpoint{suite.fooV1Cname},
+				},
+				endpoint.RecordTypeA: {
+					current:    suite.fooA5,
+					candidates: []*endpoint.Endpoint{},
+				},
+				endpoint.RecordTypeAAAA: {
+					current:    suite.fooAAA5,
+					candidates: []*endpoint.Endpoint{},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			if got := suite.perResource.ResolveRecordTypes(tt.args.key, tt.args.row); !reflect.DeepEqual(got, tt.want) {
+				suite.T().Errorf("PerResource.ResolveRecordTypes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestConflictResolver(t *testing.T) {

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -97,9 +97,9 @@ func newPlanTable() planTable { // TODO: make resolver configurable
 
 // planTableRow represents a set of current and desired domain resource records.
 type planTableRow struct {
-	// current corresponds to the records currently occupying dns name on the dns provider. More than 1 record may
-	// be represented here, for example A and AAAA. If current domain record is CNAME, no other record types are allowed
-	// per [RFC 1034 3.6.2]
+	// current corresponds to the records currently occupying dns name on the dns provider. More than one record may
+	// be represented here: for example A and AAAA. If the current domain record is a CNAME, no other record types
+	// are allowed per [RFC 1034 3.6.2]
 	//
 	// [RFC 1034 3.6.2]: https://datatracker.ietf.org/doc/html/rfc1034#autoid-15
 	current []*endpoint.Endpoint

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -609,23 +609,22 @@ func (suite *PlanTestSuite) TestConflictingCurrentNoDesired() {
 
 // TestCurrentWithConflictingDesired simulates where the desired records result in conflicting records types.
 // This could be the result of multiple sources generating conflicting records types. In this case the conflict
-// resolver should prefer the CNAME record candidate and delete the other records.
+// resolver should prefer the A and AAAA record candidate and delete the other records.
 func (suite *PlanTestSuite) TestCurrentWithConflictingDesired() {
-	suite.fooA5.Labels[endpoint.OwnerLabelKey] = "nerf"
-	suite.fooAAAA.Labels[endpoint.OwnerLabelKey] = "nerf"
-	current := []*endpoint.Endpoint{suite.fooA5, suite.fooAAAA}
+	suite.fooV1Cname.Labels[endpoint.OwnerLabelKey] = "nerf"
+	current := []*endpoint.Endpoint{suite.fooV1Cname}
 	desired := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooA5, suite.fooAAAA}
-	expectedCreate := []*endpoint.Endpoint{suite.fooV1Cname}
+	expectedCreate := []*endpoint.Endpoint{suite.fooA5, suite.fooAAAA}
 	expectedUpdateOld := []*endpoint.Endpoint{}
 	expectedUpdateNew := []*endpoint.Endpoint{}
-	expectedDelete := []*endpoint.Endpoint{suite.fooA5, suite.fooAAAA}
+	expectedDelete := []*endpoint.Endpoint{suite.fooV1Cname}
 
 	p := &Plan{
 		Policies:       []Policy{&SyncPolicy{}},
 		Current:        current,
 		Desired:        desired,
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
-		OwnerID:        suite.fooA5.Labels[endpoint.OwnerLabelKey],
+		OwnerID:        suite.fooV1Cname.Labels[endpoint.OwnerLabelKey],
 	}
 
 	changes := p.Calculate().Changes
@@ -637,11 +636,11 @@ func (suite *PlanTestSuite) TestCurrentWithConflictingDesired() {
 
 // TestNoCurrentWithConflictingDesired simulates where the desired records result in conflicting records types.
 // This could be the result of multiple sources generating conflicting records types. In this case there the
-// conflict resolver should prefer the CNAME record and drop the other candidate record types.
+// conflict resolver should prefer the A and AAAA record and drop the other candidate record types.
 func (suite *PlanTestSuite) TestNoCurrentWithConflictingDesired() {
 	current := []*endpoint.Endpoint{}
 	desired := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooA5, suite.fooAAAA}
-	expectedCreate := []*endpoint.Endpoint{suite.fooV1Cname}
+	expectedCreate := []*endpoint.Endpoint{suite.fooA5, suite.fooAAAA}
 	expectedUpdateOld := []*endpoint.Endpoint{}
 	expectedUpdateNew := []*endpoint.Endpoint{}
 	expectedDelete := []*endpoint.Endpoint{}

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -461,11 +461,11 @@ func (suite *PlanTestSuite) TestRecordTypeChange() {
 	expectedDelete := []*endpoint.Endpoint{suite.fooV1Cname}
 
 	p := &Plan{
-		Policies:          []Policy{&SyncPolicy{}},
-		Current:           current,
-		Desired:           desired,
-		ManagedRecords:    []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
-		OwnedRecordFilter: endpoint.NewOwnedRecordFilter(suite.fooV1Cname.Labels[endpoint.OwnerLabelKey]),
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+		OwnerID:        suite.fooV1Cname.Labels[endpoint.OwnerLabelKey],
 	}
 
 	changes := p.Calculate().Changes
@@ -484,11 +484,11 @@ func (suite *PlanTestSuite) TestExistingCNameWithDualStackDesired() {
 	expectedDelete := []*endpoint.Endpoint{suite.fooV1Cname}
 
 	p := &Plan{
-		Policies:          []Policy{&SyncPolicy{}},
-		Current:           current,
-		Desired:           desired,
-		ManagedRecords:    []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
-		OwnedRecordFilter: endpoint.NewOwnedRecordFilter(suite.fooV1Cname.Labels[endpoint.OwnerLabelKey]),
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+		OwnerID:        suite.fooV1Cname.Labels[endpoint.OwnerLabelKey],
 	}
 
 	changes := p.Calculate().Changes
@@ -509,11 +509,11 @@ func (suite *PlanTestSuite) TestExistingDualStackWithCNameDesired() {
 	expectedDelete := []*endpoint.Endpoint{suite.fooA5, suite.fooAAAA}
 
 	p := &Plan{
-		Policies:          []Policy{&SyncPolicy{}},
-		Current:           current,
-		Desired:           desired,
-		ManagedRecords:    []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
-		OwnedRecordFilter: endpoint.NewOwnedRecordFilter(suite.fooA5.Labels[endpoint.OwnerLabelKey]),
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+		OwnerID:        suite.fooA5.Labels[endpoint.OwnerLabelKey],
 	}
 
 	changes := p.Calculate().Changes
@@ -537,11 +537,11 @@ func (suite *PlanTestSuite) TestExistingOwnerNotMatchingDualStackDesired() {
 	expectedDelete := []*endpoint.Endpoint{}
 
 	p := &Plan{
-		Policies:          []Policy{&SyncPolicy{}},
-		Current:           current,
-		Desired:           desired,
-		ManagedRecords:    []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
-		OwnedRecordFilter: endpoint.NewOwnedRecordFilter("pwner"),
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+		OwnerID:        "pwner",
 	}
 
 	changes := p.Calculate().Changes
@@ -565,11 +565,11 @@ func (suite *PlanTestSuite) TestConflictingCurrentNonConflictingDesired() {
 	expectedDelete := []*endpoint.Endpoint{suite.fooV1Cname}
 
 	p := &Plan{
-		Policies:          []Policy{&SyncPolicy{}},
-		Current:           current,
-		Desired:           desired,
-		ManagedRecords:    []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
-		OwnedRecordFilter: endpoint.NewOwnedRecordFilter(suite.fooV1Cname.Labels[endpoint.OwnerLabelKey]),
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+		OwnerID:        suite.fooV1Cname.Labels[endpoint.OwnerLabelKey],
 	}
 
 	changes := p.Calculate().Changes
@@ -593,11 +593,11 @@ func (suite *PlanTestSuite) TestConflictingCurrentNoDesired() {
 	expectedDelete := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooA5}
 
 	p := &Plan{
-		Policies:          []Policy{&SyncPolicy{}},
-		Current:           current,
-		Desired:           desired,
-		ManagedRecords:    []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
-		OwnedRecordFilter: endpoint.NewOwnedRecordFilter(suite.fooV1Cname.Labels[endpoint.OwnerLabelKey]),
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+		OwnerID:        suite.fooV1Cname.Labels[endpoint.OwnerLabelKey],
 	}
 
 	changes := p.Calculate().Changes
@@ -621,11 +621,11 @@ func (suite *PlanTestSuite) TestCurrentWithConflictingDesired() {
 	expectedDelete := []*endpoint.Endpoint{}
 
 	p := &Plan{
-		Policies:          []Policy{&SyncPolicy{}},
-		Current:           current,
-		Desired:           desired,
-		ManagedRecords:    []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
-		OwnedRecordFilter: endpoint.NewOwnedRecordFilter(suite.fooA5.Labels[endpoint.OwnerLabelKey]),
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+		OwnerID:        suite.fooA5.Labels[endpoint.OwnerLabelKey],
 	}
 
 	changes := p.Calculate().Changes

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -928,14 +928,6 @@ func validateEntries(t *testing.T, entries, expected []*endpoint.Endpoint) {
 	}
 }
 
-func validateOwner(t *testing.T, entries []*endpoint.Endpoint, owner string) {
-	for _, entry := range entries {
-		if entry.Labels[endpoint.OwnerLabelKey] != owner {
-			t.Fatalf("expected owner label %q to match %q", entry.Labels[endpoint.OwnerLabelKey], owner)
-		}
-	}
-}
-
 func TestNormalizeDNSName(t *testing.T) {
 	records := []struct {
 		dnsName string

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -124,7 +124,7 @@ func (suite *PlanTestSuite) SetupTest() {
 	}
 	suite.dsAAAA = &endpoint.Endpoint{
 		DNSName:    "ds",
-		Targets:    endpoint.Targets{"1.1.1.1"},
+		Targets:    endpoint.Targets{"2001:DB8::1"},
 		RecordType: "AAAA",
 		Labels: map[string]string{
 			endpoint.ResourceLabelKey: "ingress/default/ds-AAAAA",
@@ -452,19 +452,205 @@ func (suite *PlanTestSuite) TestIdempotency() {
 	validateEntries(suite.T(), changes.Delete, expectedDelete)
 }
 
-func (suite *PlanTestSuite) TestDifferentTypes() {
+func (suite *PlanTestSuite) TestRecordTypeChange() {
 	current := []*endpoint.Endpoint{suite.fooV1Cname}
-	desired := []*endpoint.Endpoint{suite.fooV2Cname, suite.fooA5}
+	desired := []*endpoint.Endpoint{suite.fooA5}
 	expectedCreate := []*endpoint.Endpoint{suite.fooA5}
-	expectedUpdateOld := []*endpoint.Endpoint{suite.fooV1Cname}
-	expectedUpdateNew := []*endpoint.Endpoint{suite.fooV2Cname}
+	expectedUpdateOld := []*endpoint.Endpoint{}
+	expectedUpdateNew := []*endpoint.Endpoint{}
+	expectedDelete := []*endpoint.Endpoint{suite.fooV1Cname}
+
+	p := &Plan{
+		Policies:          []Policy{&SyncPolicy{}},
+		Current:           current,
+		Desired:           desired,
+		ManagedRecords:    []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+		OwnedRecordFilter: endpoint.NewOwnedRecordFilter(suite.fooV1Cname.Labels[endpoint.OwnerLabelKey]),
+	}
+
+	changes := p.Calculate().Changes
+	validateEntries(suite.T(), changes.Create, expectedCreate)
+	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
+	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
+	validateEntries(suite.T(), changes.Delete, expectedDelete)
+}
+
+func (suite *PlanTestSuite) TestExistingCNameWithDualStackDesired() {
+	current := []*endpoint.Endpoint{suite.fooV1Cname}
+	desired := []*endpoint.Endpoint{suite.fooA5, suite.fooAAAA}
+	expectedCreate := []*endpoint.Endpoint{suite.fooA5, suite.fooAAAA}
+	expectedUpdateOld := []*endpoint.Endpoint{}
+	expectedUpdateNew := []*endpoint.Endpoint{}
+	expectedDelete := []*endpoint.Endpoint{suite.fooV1Cname}
+
+	p := &Plan{
+		Policies:          []Policy{&SyncPolicy{}},
+		Current:           current,
+		Desired:           desired,
+		ManagedRecords:    []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+		OwnedRecordFilter: endpoint.NewOwnedRecordFilter(suite.fooV1Cname.Labels[endpoint.OwnerLabelKey]),
+	}
+
+	changes := p.Calculate().Changes
+	validateEntries(suite.T(), changes.Create, expectedCreate)
+	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
+	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
+	validateEntries(suite.T(), changes.Delete, expectedDelete)
+}
+
+func (suite *PlanTestSuite) TestExistingDualStackWithCNameDesired() {
+	suite.fooA5.Labels[endpoint.OwnerLabelKey] = "nerf"
+	suite.fooAAAA.Labels[endpoint.OwnerLabelKey] = "nerf"
+	current := []*endpoint.Endpoint{suite.fooA5, suite.fooAAAA}
+	desired := []*endpoint.Endpoint{suite.fooV2Cname}
+	expectedCreate := []*endpoint.Endpoint{suite.fooV2Cname}
+	expectedUpdateOld := []*endpoint.Endpoint{}
+	expectedUpdateNew := []*endpoint.Endpoint{}
+	expectedDelete := []*endpoint.Endpoint{suite.fooA5, suite.fooAAAA}
+
+	p := &Plan{
+		Policies:          []Policy{&SyncPolicy{}},
+		Current:           current,
+		Desired:           desired,
+		ManagedRecords:    []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+		OwnedRecordFilter: endpoint.NewOwnedRecordFilter(suite.fooA5.Labels[endpoint.OwnerLabelKey]),
+	}
+
+	changes := p.Calculate().Changes
+	validateEntries(suite.T(), changes.Create, expectedCreate)
+	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
+	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
+	validateEntries(suite.T(), changes.Delete, expectedDelete)
+}
+
+// TestExistingOwnerNotMatchingDualStackDesired validates that if there is an existing
+// record for a domain but there is no ownership claim over it and there are desired
+// records no changes are planed. Only domains that have explicit ownership claims should
+// be updated.
+func (suite *PlanTestSuite) TestExistingOwnerNotMatchingDualStackDesired() {
+	suite.fooA5.Labels = nil
+	current := []*endpoint.Endpoint{suite.fooA5}
+	desired := []*endpoint.Endpoint{suite.fooV2Cname}
+	expectedCreate := []*endpoint.Endpoint{}
+	expectedUpdateOld := []*endpoint.Endpoint{}
+	expectedUpdateNew := []*endpoint.Endpoint{}
+	expectedDelete := []*endpoint.Endpoint{}
+
+	p := &Plan{
+		Policies:          []Policy{&SyncPolicy{}},
+		Current:           current,
+		Desired:           desired,
+		ManagedRecords:    []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+		OwnedRecordFilter: endpoint.NewOwnedRecordFilter("pwner"),
+	}
+
+	changes := p.Calculate().Changes
+	validateEntries(suite.T(), changes.Create, expectedCreate)
+	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
+	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
+	validateEntries(suite.T(), changes.Delete, expectedDelete)
+}
+
+// TestConflictingCurrentNonConflictingDesired is a bit of a corner case as it would indicate
+// that the provider is not following valid DNS rules or there may be some
+// caching issues. In this case since the desired records are not conflicting
+// the updates will end up with the conflict resolved.
+func (suite *PlanTestSuite) TestConflictingCurrentNonConflictingDesired() {
+	suite.fooA5.Labels[endpoint.OwnerLabelKey] = suite.fooV1Cname.Labels[endpoint.OwnerLabelKey]
+	current := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooA5}
+	desired := []*endpoint.Endpoint{suite.fooA5}
+	expectedCreate := []*endpoint.Endpoint{}
+	expectedUpdateOld := []*endpoint.Endpoint{}
+	expectedUpdateNew := []*endpoint.Endpoint{}
+	expectedDelete := []*endpoint.Endpoint{suite.fooV1Cname}
+
+	p := &Plan{
+		Policies:          []Policy{&SyncPolicy{}},
+		Current:           current,
+		Desired:           desired,
+		ManagedRecords:    []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+		OwnedRecordFilter: endpoint.NewOwnedRecordFilter(suite.fooV1Cname.Labels[endpoint.OwnerLabelKey]),
+	}
+
+	changes := p.Calculate().Changes
+	validateEntries(suite.T(), changes.Create, expectedCreate)
+	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
+	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
+	validateEntries(suite.T(), changes.Delete, expectedDelete)
+}
+
+// TestConflictingCurrentNoDesired is a bit of a corner case as it would indicate
+// that the provider is not following valid DNS rules or there may be some
+// caching issues. In this case there are no desired enpoint candidates so plan
+// on deleting the records.
+func (suite *PlanTestSuite) TestConflictingCurrentNoDesired() {
+	suite.fooA5.Labels[endpoint.OwnerLabelKey] = suite.fooV1Cname.Labels[endpoint.OwnerLabelKey]
+	current := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooA5}
+	desired := []*endpoint.Endpoint{}
+	expectedCreate := []*endpoint.Endpoint{}
+	expectedUpdateOld := []*endpoint.Endpoint{}
+	expectedUpdateNew := []*endpoint.Endpoint{}
+	expectedDelete := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooA5}
+
+	p := &Plan{
+		Policies:          []Policy{&SyncPolicy{}},
+		Current:           current,
+		Desired:           desired,
+		ManagedRecords:    []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+		OwnedRecordFilter: endpoint.NewOwnedRecordFilter(suite.fooV1Cname.Labels[endpoint.OwnerLabelKey]),
+	}
+
+	changes := p.Calculate().Changes
+	validateEntries(suite.T(), changes.Create, expectedCreate)
+	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
+	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
+	validateEntries(suite.T(), changes.Delete, expectedDelete)
+}
+
+// TestCurrentWithConflictingDesired simulates where the desired records result in conflicting records types.
+// This could be the result of multiple sources generating conflicting records types. In this case there are
+// no changes planned since there is no conflict resolver for this situation.
+func (suite *PlanTestSuite) TestCurrentWithConflictingDesired() {
+	suite.fooA5.Labels[endpoint.OwnerLabelKey] = "nerf"
+	suite.fooAAAA.Labels[endpoint.OwnerLabelKey] = "nerf"
+	current := []*endpoint.Endpoint{suite.fooA5, suite.fooAAAA}
+	desired := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooA5, suite.fooAAAA}
+	expectedCreate := []*endpoint.Endpoint{}
+	expectedUpdateOld := []*endpoint.Endpoint{}
+	expectedUpdateNew := []*endpoint.Endpoint{}
+	expectedDelete := []*endpoint.Endpoint{}
+
+	p := &Plan{
+		Policies:          []Policy{&SyncPolicy{}},
+		Current:           current,
+		Desired:           desired,
+		ManagedRecords:    []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+		OwnedRecordFilter: endpoint.NewOwnedRecordFilter(suite.fooA5.Labels[endpoint.OwnerLabelKey]),
+	}
+
+	changes := p.Calculate().Changes
+	validateEntries(suite.T(), changes.Create, expectedCreate)
+	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
+	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
+	validateEntries(suite.T(), changes.Delete, expectedDelete)
+}
+
+// TestNoCurrentWithConflictingDesired simulates where the desired records result in conflicting records types.
+// This could be the result of multiple sources generating conflicting records types. In this case there are
+// no changes planned since there is no conflict resolver for this situation.
+func (suite *PlanTestSuite) TestNoCurrentWithConflictingDesired() {
+	current := []*endpoint.Endpoint{}
+	desired := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooA5, suite.fooAAAA}
+	expectedCreate := []*endpoint.Endpoint{}
+	expectedUpdateOld := []*endpoint.Endpoint{}
+	expectedUpdateNew := []*endpoint.Endpoint{}
 	expectedDelete := []*endpoint.Endpoint{}
 
 	p := &Plan{
 		Policies:       []Policy{&SyncPolicy{}},
 		Current:        current,
 		Desired:        desired,
-		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
 	changes := p.Calculate().Changes
@@ -652,10 +838,10 @@ func (suite *PlanTestSuite) TestDomainFiltersUpdate() {
 }
 
 func (suite *PlanTestSuite) TestAAAARecords() {
-
 	current := []*endpoint.Endpoint{}
 	desired := []*endpoint.Endpoint{suite.fooAAAA}
 	expectedCreate := []*endpoint.Endpoint{suite.fooAAAA}
+	expectNoChanges := []*endpoint.Endpoint{}
 
 	p := &Plan{
 		Policies:       []Policy{&SyncPolicy{}},
@@ -666,12 +852,16 @@ func (suite *PlanTestSuite) TestAAAARecords() {
 
 	changes := p.Calculate().Changes
 	validateEntries(suite.T(), changes.Create, expectedCreate)
+	validateEntries(suite.T(), changes.Delete, expectNoChanges)
+	validateEntries(suite.T(), changes.UpdateOld, expectNoChanges)
+	validateEntries(suite.T(), changes.UpdateNew, expectNoChanges)
 }
 
 func (suite *PlanTestSuite) TestDualStackRecords() {
 	current := []*endpoint.Endpoint{}
 	desired := []*endpoint.Endpoint{suite.dsA, suite.dsAAAA}
 	expectedCreate := []*endpoint.Endpoint{suite.dsA, suite.dsAAAA}
+	expectNoChanges := []*endpoint.Endpoint{}
 
 	p := &Plan{
 		Policies:       []Policy{&SyncPolicy{}},
@@ -682,6 +872,49 @@ func (suite *PlanTestSuite) TestDualStackRecords() {
 
 	changes := p.Calculate().Changes
 	validateEntries(suite.T(), changes.Create, expectedCreate)
+	validateEntries(suite.T(), changes.Delete, expectNoChanges)
+	validateEntries(suite.T(), changes.UpdateOld, expectNoChanges)
+	validateEntries(suite.T(), changes.UpdateNew, expectNoChanges)
+}
+
+func (suite *PlanTestSuite) TestDualStackRecordsDelete() {
+	current := []*endpoint.Endpoint{suite.dsA, suite.dsAAAA}
+	desired := []*endpoint.Endpoint{}
+	expectedDelete := []*endpoint.Endpoint{suite.dsA, suite.dsAAAA}
+	expectNoChanges := []*endpoint.Endpoint{}
+
+	p := &Plan{
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	changes := p.Calculate().Changes
+	validateEntries(suite.T(), changes.Delete, expectedDelete)
+	validateEntries(suite.T(), changes.Create, expectNoChanges)
+	validateEntries(suite.T(), changes.UpdateOld, expectNoChanges)
+	validateEntries(suite.T(), changes.UpdateNew, expectNoChanges)
+}
+
+func (suite *PlanTestSuite) TestDualStackToSingleStack() {
+	current := []*endpoint.Endpoint{suite.dsA, suite.dsAAAA}
+	desired := []*endpoint.Endpoint{suite.dsA}
+	expectedDelete := []*endpoint.Endpoint{suite.dsAAAA}
+	expectNoChanges := []*endpoint.Endpoint{}
+
+	p := &Plan{
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	changes := p.Calculate().Changes
+	validateEntries(suite.T(), changes.Delete, expectedDelete)
+	validateEntries(suite.T(), changes.Create, expectNoChanges)
+	validateEntries(suite.T(), changes.UpdateOld, expectNoChanges)
+	validateEntries(suite.T(), changes.UpdateNew, expectNoChanges)
 }
 
 func TestPlan(t *testing.T) {

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -928,6 +928,14 @@ func validateEntries(t *testing.T, entries, expected []*endpoint.Endpoint) {
 	}
 }
 
+func validateOwner(t *testing.T, entries []*endpoint.Endpoint, owner string) {
+	for _, entry := range entries {
+		if entry.Labels[endpoint.OwnerLabelKey] != owner {
+			t.Fatalf("expected owner label %q to match %q", entry.Labels[endpoint.OwnerLabelKey], owner)
+		}
+	}
+}
+
 func TestNormalizeDNSName(t *testing.T) {
 	records := []struct {
 		dnsName string

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -608,17 +608,17 @@ func (suite *PlanTestSuite) TestConflictingCurrentNoDesired() {
 }
 
 // TestCurrentWithConflictingDesired simulates where the desired records result in conflicting records types.
-// This could be the result of multiple sources generating conflicting records types. In this case there are
-// no changes planned since there is no conflict resolver for this situation.
+// This could be the result of multiple sources generating conflicting records types. In this case the conflict
+// resolver should prefer the CNAME record candidate and delete the other records.
 func (suite *PlanTestSuite) TestCurrentWithConflictingDesired() {
 	suite.fooA5.Labels[endpoint.OwnerLabelKey] = "nerf"
 	suite.fooAAAA.Labels[endpoint.OwnerLabelKey] = "nerf"
 	current := []*endpoint.Endpoint{suite.fooA5, suite.fooAAAA}
 	desired := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooA5, suite.fooAAAA}
-	expectedCreate := []*endpoint.Endpoint{}
+	expectedCreate := []*endpoint.Endpoint{suite.fooV1Cname}
 	expectedUpdateOld := []*endpoint.Endpoint{}
 	expectedUpdateNew := []*endpoint.Endpoint{}
-	expectedDelete := []*endpoint.Endpoint{}
+	expectedDelete := []*endpoint.Endpoint{suite.fooA5, suite.fooAAAA}
 
 	p := &Plan{
 		Policies:       []Policy{&SyncPolicy{}},
@@ -636,12 +636,12 @@ func (suite *PlanTestSuite) TestCurrentWithConflictingDesired() {
 }
 
 // TestNoCurrentWithConflictingDesired simulates where the desired records result in conflicting records types.
-// This could be the result of multiple sources generating conflicting records types. In this case there are
-// no changes planned since there is no conflict resolver for this situation.
+// This could be the result of multiple sources generating conflicting records types. In this case there the
+// conflict resolver should prefer the CNAME record and drop the other candidate record types.
 func (suite *PlanTestSuite) TestNoCurrentWithConflictingDesired() {
 	current := []*endpoint.Endpoint{}
 	desired := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooA5, suite.fooAAAA}
-	expectedCreate := []*endpoint.Endpoint{}
+	expectedCreate := []*endpoint.Endpoint{suite.fooV1Cname}
 	expectedUpdateOld := []*endpoint.Endpoint{}
 	expectedUpdateNew := []*endpoint.Endpoint{}
 	expectedDelete := []*endpoint.Endpoint{}

--- a/registry/noop.go
+++ b/registry/noop.go
@@ -40,8 +40,8 @@ func (im *NoopRegistry) GetDomainFilter() endpoint.DomainFilter {
 	return im.provider.GetDomainFilter()
 }
 
-func (im *NoopRegistry) GetOwnedRecordFilter() endpoint.EndpointFilterInterface {
-	return nil
+func (im *NoopRegistry) OwnerID() string {
+	return ""
 }
 
 // Records returns the current records from the dns provider

--- a/registry/noop.go
+++ b/registry/noop.go
@@ -40,6 +40,10 @@ func (im *NoopRegistry) GetDomainFilter() endpoint.DomainFilter {
 	return im.provider.GetDomainFilter()
 }
 
+func (im *NoopRegistry) GetOwnedRecordFilter() endpoint.EndpointFilterInterface {
+	return nil
+}
+
 // Records returns the current records from the dns provider
 func (im *NoopRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
 	return im.provider.Records(ctx)

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -19,8 +19,6 @@ package registry
 import (
 	"context"
 
-	log "github.com/sirupsen/logrus"
-
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 )
@@ -34,17 +32,6 @@ type Registry interface {
 	ApplyChanges(ctx context.Context, changes *plan.Changes) error
 	AdjustEndpoints(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint
 	GetDomainFilter() endpoint.DomainFilter
-}
-
-// TODO(ideahitme): consider moving this to Plan
-func filterOwnedRecords(ownerID string, eps []*endpoint.Endpoint) []*endpoint.Endpoint {
-	filtered := []*endpoint.Endpoint{}
-	for _, ep := range eps {
-		if endpointOwner, ok := ep.Labels[endpoint.OwnerLabelKey]; !ok || endpointOwner != ownerID {
-			log.Debugf(`Skipping endpoint %v because owner id does not match, found: "%s", required: "%s"`, ep, endpointOwner, ownerID)
-			continue
-		}
-		filtered = append(filtered, ep)
-	}
-	return filtered
+	// Evaluate if endpoint id owned by the registry and return true.
+	GetOwnedRecordFilter() endpoint.EndpointFilterInterface
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -32,6 +32,5 @@ type Registry interface {
 	ApplyChanges(ctx context.Context, changes *plan.Changes) error
 	AdjustEndpoints(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint
 	GetDomainFilter() endpoint.DomainFilter
-	// Evaluate if endpoint id owned by the registry and return true.
-	GetOwnedRecordFilter() endpoint.EndpointFilterInterface
+	OwnerID() string
 }

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -103,8 +103,8 @@ func (im *TXTRegistry) GetDomainFilter() endpoint.DomainFilter {
 	return im.provider.GetDomainFilter()
 }
 
-func (im *TXTRegistry) GetOwnedRecordFilter() endpoint.EndpointFilterInterface {
-	return endpoint.NewOwnedRecordFilter(im.ownerID)
+func (im *TXTRegistry) OwnerID() string {
+	return im.ownerID
 }
 
 // Records returns the current records from the registry excluding TXT Records
@@ -244,12 +244,11 @@ func (im *TXTRegistry) generateTXTRecord(r *endpoint.Endpoint) []*endpoint.Endpo
 // ApplyChanges updates dns provider with the changes
 // for each created/deleted record it will also take into account TXT records for creation/deletion
 func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
-	ownedRecordFilter := im.GetOwnedRecordFilter()
 	filteredChanges := &plan.Changes{
 		Create:    changes.Create,
-		UpdateNew: endpoint.ApplyEndpointFilter(ownedRecordFilter, changes.UpdateNew),
-		UpdateOld: endpoint.ApplyEndpointFilter(ownedRecordFilter, changes.UpdateOld),
-		Delete:    endpoint.ApplyEndpointFilter(ownedRecordFilter, changes.Delete),
+		UpdateNew: endpoint.FilterEndpointsByOwnerID(im.ownerID, changes.UpdateNew),
+		UpdateOld: endpoint.FilterEndpointsByOwnerID(im.ownerID, changes.UpdateOld),
+		Delete:    endpoint.FilterEndpointsByOwnerID(im.ownerID, changes.Delete),
 	}
 	for _, r := range filteredChanges.Create {
 		if r.Labels == nil {


### PR DESCRIPTION
When AAAA multi-target / dual stack support was
added via #2461 it broke ownership of domains across different clusters with different ingress records types.

For example if 2 clusters manage the same zone,
1 cluster uses A records and the other uses CNAME
records, when each record type is treated as a separate planning record, it will cause ownership to bounce back and forth and records to be constantly created and deleted.

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This change updates the planner to keep track of multiple
current records for a domain. This allows for A and AAAA
records to exist for a domain while allowing record type
changes.

The planner will ignore desired records for a domain that
represent conflicting record types allowed by RFC 1034 3.6.2.
For example if the desired records for a domain contains
a CNAME record plus any other record type no changes for
that domain will be planned.

The planner now contains an owned record filter provided
by the registry. This allows the planner to accurately plan
create updates when there are record type changes between
the current and desired endpoints. Without this filter the
planner could add create changes for domains not owned
by the controller.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2461

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
