### PR TITLE
Support of target annotations in gateway source

### DIFF
--- a/docs/annotations/annotations.md
+++ b/docs/annotations/annotations.md
@@ -12,7 +12,7 @@ The following table documents which sources support which annotations:
 | CloudFoundry |            |          |                   |         |     |                     |
 | CRD          |            |          |                   |         |     |                     |
 | F5           |            |          |                   |         | Yes |                     |
-| Gateway      | Yes        | Yes[^1]  |                   |         | Yes | Yes                 |
+| Gateway      | Yes        | Yes[^1]  |                   | Yes     | Yes | Yes                 |
 | Gloo         |            |          |                   |         | Yes | Yes                 |
 | Ingress      | Yes        | Yes[^1]  |                   | Yes     | Yes | Yes                 |
 | Istio        | Yes        | Yes[^1]  |                   | Yes     | Yes | Yes                 |

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -357,10 +357,10 @@ func (c *gatewayRouteResolver) resolve(rt gatewayRoute) (map[string]endpoint.Tar
 				targets := getTargetsFromTargetAnnotation(annots)
 				if len(targets) == 0 {
 					for _, addr := range gw.gateway.Status.Addresses {
-						hostTargets[host] = append(hostTargets[host], addr.Value)
+						targets = append(targets, addr.Value)
 					}
 				}
-				hostTargets[host] = targets
+				hostTargets[host] = append(hostTargets[host], targets...)
 				match = true
 			}
 		}

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -352,9 +352,15 @@ func (c *gatewayRouteResolver) resolve(rt gatewayRoute) (map[string]endpoint.Tar
 				if !ok {
 					continue
 				}
-				for _, addr := range gw.gateway.Status.Addresses {
-					hostTargets[host] = append(hostTargets[host], addr.Value)
+				annots := meta.GetAnnotations()
+
+				targets := getTargetsFromTargetAnnotation(annots)
+				if len(targets) == 0 {
+					for _, addr := range gw.gateway.Status.Addresses {
+						hostTargets[host] = append(hostTargets[host], addr.Value)
+					}
 				}
+				hostTargets[host] = targets
 				match = true
 			}
 		}

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -25,10 +25,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kubefake "k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
-
-	"sigs.k8s.io/external-dns/endpoint"
 )
 
 func mustGetLabelSelector(s string) labels.Selector {


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Supports `external-dns.alpha.kubernetes.io/target` annotation on Gateway Routes, so that the DNS record targets are configurable at Route level.

Expecting this to provide more flexibility on configuring DNS for different kinds of Gateway API implementations - please refer to #3749 for details on the issue.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #3749 

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
