### PR TITLE
use only tags with prefix v for version determination

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ BINARY        ?= external-dns
 SOURCES        = $(shell find . -name '*.go')
 IMAGE_STAGING  = gcr.io/k8s-staging-external-dns/$(BINARY)
 IMAGE         ?= us.gcr.io/k8s-artifacts-prod/external-dns/$(BINARY)
-VERSION       ?= $(shell git describe --tags --always --dirty)
+VERSION       ?= $(shell git describe --tags --always --dirty --match "v*")
 BUILD_FLAGS   ?= -v
 LDFLAGS       ?= -X sigs.k8s.io/external-dns/pkg/apis/externaldns.Version=$(VERSION) -w -s
 ARCHS          = amd64 arm64 arm/v7

--- a/scripts/releaser.sh
+++ b/scripts/releaser.sh
@@ -9,7 +9,7 @@ function generate_changelog {
   # current tag is a full release
   previous_tag=""
   while [[ -z $previous_tag || ( $previous_tag == *-* && $current_tag != *-* ) ]]; do
-    previous_tag="$(git describe --tags "$start_ref"^ --abbrev=0)"
+    previous_tag="$(git describe --tags "$start_ref"^ --abbrev=0 --match "v*")"
     start_ref="$previous_tag"
   done
 

--- a/scripts/run-trivy.sh
+++ b/scripts/run-trivy.sh
@@ -10,4 +10,4 @@ chmod +x trivy
 
 # run trivy
 cd - 
-/tmp/trivy image --exit-code 1 us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:$(git describe --tags --always --dirty)
+/tmp/trivy image --exit-code 1 us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:$(git describe --tags --always --dirty --match "v*")


### PR DESCRIPTION
**Description**

<img width="633" alt="grafik" src="https://github.com/kubernetes-sigs/external-dns/assets/6190136/eac1cf18-aae7-49f1-a4c5-a70e2ac6fc20">

`git describe` uses the wrong tag for the container images.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
