### PR TITLE
Tagget parameter TXTEncryptAESKey as secure

### DIFF
--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -150,7 +150,7 @@ type Config struct {
 	TXTPrefix                          string
 	TXTSuffix                          string
 	TXTEncryptEnabled                  bool
-	TXTEncryptAESKey                   string
+	TXTEncryptAESKey                   string `secure:"yes"`
 	Interval                           time.Duration
 	MinEventSyncInterval               time.Duration
 	Once                               bool


### PR DESCRIPTION
**Description**

Tagget parameter TXTEncryptAESKey as "secure" to avoid it being logged upon application startup.

Fixes #3790

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
