### PR TITLE
[PI-2536] fix: use svc annotation to create aaaa records

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,8 @@ test:
 BINARY        ?= external-dns
 SOURCES        = $(shell find . -name '*.go')
 IMAGE_STAGING  = gcr.io/k8s-staging-external-dns/$(BINARY)
-IMAGE         ?= us.gcr.io/k8s-artifacts-prod/external-dns/$(BINARY)
-VERSION       ?= $(shell git describe --tags --always --dirty)
+IMAGE         ?= 165463520094.dkr.ecr.ap-northeast-1.amazonaws.com/ops-spaas/external-dns
+VERSION       ?= v0.13.5-patch01
 BUILD_FLAGS   ?= -v
 LDFLAGS       ?= -X sigs.k8s.io/external-dns/pkg/apis/externaldns.Version=$(VERSION) -w -s
 ARCHS          = amd64 arm64 arm/v7
@@ -163,7 +163,7 @@ build.docker: build.setup build.$(ARCH)
 		--tag $${image} .
 
 build.mini:
-	docker build --rm --tag "$(IMAGE):$(VERSION)-mini" --build-arg VERSION="$(VERSION)" -f Dockerfile.mini .
+	docker build --rm --tag "$(IMAGE):$(VERSION)" --build-arg VERSION="$(VERSION)" -f Dockerfile.mini .
 
 clean:
 	@rm -rf build

--- a/source/service.go
+++ b/source/service.go
@@ -201,6 +201,7 @@ func (sc *serviceSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, e
 
 		log.Debugf("Endpoints generated from service: %s/%s: %v", svc.Namespace, svc.Name, svcEndpoints)
 		sc.setResourceLabel(svc, svcEndpoints)
+		sc.setDualstackLabel(svc, svcEndpoints)
 		endpoints = append(endpoints, svcEndpoints...)
 	}
 
@@ -455,6 +456,16 @@ func (sc *serviceSource) filterByServiceType(services []*v1.Service) []*v1.Servi
 func (sc *serviceSource) setResourceLabel(service *v1.Service, endpoints []*endpoint.Endpoint) {
 	for _, ep := range endpoints {
 		ep.Labels[endpoint.ResourceLabelKey] = fmt.Sprintf("service/%s/%s", service.Namespace, service.Name)
+	}
+}
+
+func (sc *serviceSource) setDualstackLabel(service *v1.Service, endpoints []*endpoint.Endpoint) {
+	val, ok := service.Annotations[ALBDualstackAnnotationKey]
+	if ok && val == ALBDualstackAnnotationValue {
+		log.Debugf("Adding dualstack label to service %s/%s.", service.Namespace, service.Name)
+		for _, ep := range endpoints {
+			ep.Labels[endpoint.DualstackLabelKey] = "true"
+		}
 	}
 }
 


### PR DESCRIPTION
https://gocro-dev.atlassian.net/browse/PI-2536

This PR shows interim changes needed to support aaaa recs for services and to fix the duplicate txt record issue in v0.13.5.

This is NOT a permanent solution and we should fall back to upstream once fixes are merged and released in upstream, probably by v0.13.7 or v0.14.1. (Check the status of PRs linked in the ticket)