### PR TITLE
Add AWS API gateway endpoint zoneId mappings

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -126,7 +126,7 @@ var canonicalHostedZones = map[string]string{
 	"elb.af-south-1.amazonaws.com":        "Z203XCE67M25HM",
 	// Global Accelerator
 	"awsglobalaccelerator.com": "Z2BJ6XQ5FK7U4H",
-	// Cloudfront
+	// Cloudfront and AWS API Gateway edge-optimized endpoints
 	"cloudfront.net": "Z2FDTNDATAQYW2",
 	// VPC Endpoint (PrivateLink)
 	"eu-west-2.vpce.amazonaws.com":      "Z7K1066E3PUKB",
@@ -158,6 +158,32 @@ var canonicalHostedZones = map[string]string{
 	"us-gov-west-1.vpce.amazonaws.com":  "Z12529ZODG2B6H",
 	"us-west-1.vpce.amazonaws.com":      "Z12I86A8N7VCZO",
 	"us-west-2.vpce.amazonaws.com":      "Z1YSA3EXCYUU9Z",
+	// AWS API Gateway (Regional endpoints)
+	// See: https://docs.aws.amazon.com/general/latest/gr/apigateway.html
+	"execute-api.us-east-2.amazonaws.com":      "ZOJJZC49E0EPZ",
+	"execute-api.us-east-1.amazonaws.com":      "Z1UJRXOUMOOFQ8",
+	"execute-api.us-west-1.amazonaws.com":      "Z2MUQ32089INYE",
+	"execute-api.us-west-2.amazonaws.com":      "Z2OJLYMUO9EFXC",
+	"execute-api.af-south-1.amazonaws.com":     "Z2DHW2332DAMTN",
+	"execute-api.ap-east-1.amazonaws.com":      "Z3FD1VL90ND7K5",
+	"execute-api.ap-south-1.amazonaws.com":     "Z3VO1THU9YC4UR",
+	"execute-api.ap-northeast-2.amazonaws.com": "Z20JF4UZKIW1U8",
+	"execute-api.ap-southeast-1.amazonaws.com": "ZL327KTPIQFUL",
+	"execute-api.ap-southeast-2.amazonaws.com": "Z2RPCDW04V8134",
+	"execute-api.ap-northeast-1.amazonaws.com": "Z1YSHQZHG15GKL",
+	"execute-api.ca-central-1.amazonaws.com":   "Z19DQILCV0OWEC",
+	"execute-api.eu-central-1.amazonaws.com":   "Z1U9ULNL0V5AJ3",
+	"execute-api.eu-west-1.amazonaws.com":      "ZLY8HYME6SFDD",
+	"execute-api.eu-west-2.amazonaws.com":      "ZJ5UAJN8Y3Z2Q",
+	"execute-api.eu-south-1.amazonaws.com":     "Z3BT4WSQ9TDYZV",
+	"execute-api.eu-west-3.amazonaws.com":      "Z3KY65QIEKYHQQ",
+	"execute-api.eu-south-2.amazonaws.com":     "Z02499852UI5HEQ5JVWX3",
+	"execute-api.eu-north-1.amazonaws.com":     "Z3UWIKFBOOGXPP",
+	"execute-api.me-south-1.amazonaws.com":     "Z20ZBPC0SS8806",
+	"execute-api.me-central-1.amazonaws.com":   "Z08780021BKYYY8U0YHTV",
+	"execute-api.sa-east-1.amazonaws.com":      "ZCMLWB8V5SYIT",
+	"execute-api.us-gov-east-1.amazonaws.com":  "Z3SE9ATJYCRCZJ",
+	"execute-api.us-gov-west-1.amazonaws.com":  "Z1K6XKP9SAGWDV",
 }
 
 // Route53API is the subset of the AWS Route53 API that we actually use.  Add methods as required. Signatures must match exactly.


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
- Adds mappings for API gateway regional endpoints to Route 53 Hosted Zone IDs.
- API gateway edge-optimized endpoints are served using CloudFront which has an existing mapping. ([Ref](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-basic-concept.html#apigateway-definition-edge-optimized-api-endpoint))

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #3609 

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
