### PR TITLE
Fix PowerDNS regex domain filter

### DIFF
--- a/docs/tutorials/pdns.md
+++ b/docs/tutorials/pdns.md
@@ -63,6 +63,9 @@ eg. ```--domain-filter=.example.org``` will allow *only* zones that end in `.exa
 
 The filter can also match parent zones. For example `--domain-filter=a.example.com` will allow for zone `example.com`. If you want to match parent zones, you cannot pre-pend your filter with a ".", eg. `--domain-filter=.example.com` will not attempt to match parent zones.
 
+### Regex Domain Filter (`--regex-domain-filter`)
+`--regex-domain-filter` limits possible domains and target zone with a regex. It overrides domain filters and can be specified only once.
+
 ## RBAC
 
 If your cluster is RBAC enabled, you also need to setup the following, before you can run external-dns:
@@ -169,4 +172,3 @@ Once the API shows the record correctly, you can double check your record using:
 ```bash
 $ dig @${PDNS_FQDN} echo.example.com.
 ```
-

--- a/endpoint/domain_filter.go
+++ b/endpoint/domain_filter.go
@@ -90,10 +90,15 @@ func NewRegexDomainFilter(regexDomainFilter *regexp.Regexp, regexDomainExclusion
 	return DomainFilter{regex: regexDomainFilter, regexExclusion: regexDomainExclusion}
 }
 
+// IsRegexFilterConfigured checks if regex filter is set
+func (df *DomainFilter) IsRegexFilterConfigured() bool {
+	return df.regex != nil && df.regex.String() != ""
+}
+
 // Match checks whether a domain can be found in the DomainFilter.
 // RegexFilter takes precedence over Filters
 func (df DomainFilter) Match(domain string) bool {
-	if df.regex != nil && df.regex.String() != "" || df.regexExclusion != nil && df.regexExclusion.String() != "" {
+	if df.IsRegexFilterConfigured() || df.regexExclusion != nil && df.regexExclusion.String() != "" {
 		return matchRegex(df.regex, df.regexExclusion, domain)
 	}
 
@@ -164,7 +169,7 @@ func (df DomainFilter) MatchParent(domain string) bool {
 
 // IsConfigured returns true if any inclusion or exclusion rules have been specified.
 func (df DomainFilter) IsConfigured() bool {
-	if df.regex != nil && df.regex.String() != "" {
+	if df.IsRegexFilterConfigured() {
 		return true
 	} else if df.regexExclusion != nil && df.regexExclusion.String() != "" {
 		return true

--- a/provider/pdns/pdns.go
+++ b/provider/pdns/pdns.go
@@ -166,7 +166,8 @@ func (c *PDNSAPIClient) ListZones() (zones []pgo.Zone, resp *http.Response, err 
 func (c *PDNSAPIClient) PartitionZones(zones []pgo.Zone) (filteredZones []pgo.Zone, residualZones []pgo.Zone) {
 	if c.domainFilter.IsConfigured() {
 		for _, zone := range zones {
-			if c.domainFilter.Match(zone.Name) || c.domainFilter.MatchParent(zone.Name) {
+			isMatch := c.domainFilter.Match(zone.Name)
+			if isMatch || (!c.domainFilter.IsRegexFilterConfigured() && c.domainFilter.MatchParent(zone.Name)) {
 				filteredZones = append(filteredZones, zone)
 			} else {
 				residualZones = append(residualZones, zone)

--- a/provider/pdns/pdns_test.go
+++ b/provider/pdns/pdns_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -513,6 +514,8 @@ var (
 		Filters: []string{},
 	}
 
+	RegexDomainFilter = endpoint.NewRegexDomainFilter(regexp.MustCompile("example.com"), nil)
+
 	DomainFilterEmptyClient = &PDNSAPIClient{
 		dryRun:       false,
 		authCtx:      context.WithValue(context.Background(), pgo.ContextAPIKey, pgo.APIKey{Key: "TEST-API-KEY"}),
@@ -546,6 +549,13 @@ var (
 		authCtx:      context.WithValue(context.Background(), pgo.ContextAPIKey, pgo.APIKey{Key: "TEST-API-KEY"}),
 		client:       pgo.NewAPIClient(pgo.NewConfiguration()),
 		domainFilter: DomainFilterChildListMultiple,
+	}
+
+	RegexDomainFilterClient = &PDNSAPIClient{
+		dryRun:       false,
+		authCtx:      context.WithValue(context.Background(), pgo.ContextAPIKey, pgo.APIKey{Key: "TEST-API-KEY"}),
+		client:       pgo.NewAPIClient(pgo.NewConfiguration()),
+		domainFilter: RegexDomainFilter,
 	}
 )
 
@@ -1058,6 +1068,10 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSClientPartitionZones() {
 	filteredZones, residualZones = DomainFilterChildMultipleClient.PartitionZones(zoneList)
 	assert.Equal(suite.T(), partitionResultFilteredMultipleFilter, filteredZones)
 	assert.Equal(suite.T(), partitionResultResidualMultipleFilter, residualZones)
+
+	filteredZones, residualZones = RegexDomainFilterClient.PartitionZones(zoneList)
+	assert.Equal(suite.T(), partitionResultFilteredSingleFilter, filteredZones)
+	assert.Equal(suite.T(), partitionResultResidualSingleFilter, residualZones)
 }
 
 func TestNewPDNSProviderTestSuite(t *testing.T) {


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
Regex domain filter stopped working because `MatchParent` method was invoked during zone partitioning. The failure occured because `MatchParent` included wrong zones (zones not matcing the regex) in the filtered list. Subsequently listing of those zones failed because the pdns client did not have api token with permissions to list them. 

To fix this issue I disabled `MatchParent` functionality when matching domain using regex domain filter because `MatchParent` is a specific "extension" of domain filter.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #3816 

**Checklist**

- [x] Unit tests updated
- [x] End user documentation update
