### PR TITLE
chore(ci): fix storage use, go version and lint job

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,5 +31,4 @@ jobs:
 
     - name: Lint
       run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.53.3
         make lint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,4 +31,5 @@ jobs:
 
     - name: Lint
       run: |
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.53.3
         make lint

--- a/.github/workflows/staging-image-tester.yml
+++ b/.github/workflows/staging-image-tester.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
-        go-version: 1.19
+        go-version: '1.20'
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/staging-image-tester.yml
+++ b/.github/workflows/staging-image-tester.yml
@@ -44,9 +44,3 @@ jobs:
 
     - name: Clean
       run: make clean
-
-    - name: Test build on armv7
-      run: make build.image-arm/v7
-
-    - name: Clean
-      run: make clean

--- a/.github/workflows/staging-image-tester.yml
+++ b/.github/workflows/staging-image-tester.yml
@@ -33,5 +33,20 @@ jobs:
       run: |
         go get -v -t -d ./...
 
-    - name: Test
-      run: make build.image/multiarch
+    - name: Test build on amd64
+      run: make build.image-amd64
+
+    - name: Clean
+      run: make clean
+
+    - name: Test build on arm64
+      run: make build.image-arm64
+
+    - name: Clean
+      run: make clean
+
+    - name: Test build on armv7
+      run: make build.image-arm/v7
+
+    - name: Clean
+      run: make clean

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ endif
 .PHONY: go-lint
 
 golangci-lint:
-	@test -s $(go env GOPATH)/bin/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.53.3
+	@command -v golangci-lint > /dev/null || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.53.3
 
 # Run the golangci-lint tool
 go-lint: golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,7 @@ build.mini:
 
 clean:
 	@rm -rf build
+	@go clean -cache
 
  # Builds and push container images to the staging bucket.
 .PHONY: release.staging

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,11 @@ endif
 
 .PHONY: go-lint
 
+golangci-lint:
+	@test -s $(go env GOPATH)/bin/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.53.3
+
 # Run the golangci-lint tool
-go-lint:
+go-lint: golangci-lint
 	golangci-lint run --timeout=15m ./...
 
 .PHONY: licensecheck


### PR DESCRIPTION
**Description**

There are currently multiple issues in the CI system:
1. Go version used for `build All Images` is still go 1.19, it was missed in #3673
2. `pull-external-dns-lint` is launched on each PR and cannot succeed
3. `Build all images` is taking too much space on disk and fails on many PRs

This PR fixes this. 
