### PR TITLE
always use tcp for rfc2136

### DIFF
--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -37,9 +37,6 @@ import (
 )
 
 const (
-	// maximum size of a UDP transport message in DNS protocol
-	udpMaxMsgSize = 512
-
 	// maximum time DNS client can be off from server for an update to succeed
 	clockSkew = 300
 )
@@ -408,9 +405,7 @@ func (r rfc2136Provider) SendMessage(msg *dns.Msg) error {
 		}
 	}
 
-	if msg.Len() > udpMaxMsgSize {
-		c.Net = "tcp"
-	}
+	c.Net = "tcp"
 
 	resp, _, err := c.Exchange(msg, r.nameserver)
 	if err != nil {


### PR DESCRIPTION
**Description**

This PR removes the existing logic to use UDP or TCP for sending RFC2136 update queries, instead always using TCP.

The motivation behind this is to fix #3836. The DNS library used defers appending the TSIG signature until final serialization is complete (I used it as a reference implementation before, so am quite familiar). This results in the length check not using the proper packet length, but the pre-TSIG-length for determining TCP or UDP. Sending a UDP packet > 512 bytes for DNS is invalid (even if the network supports it), resulting in DNS servers discarding the packet as corrupt.

Rationale for completely removing UDP support here, is that the preceding AXFR uses TCP anyway (required by DNS protocol), and any performance gain from using UDP instead of TCP here is minuscule compared to the default one minute between sync times in external-dns.

Fixes #3836, #3204

I tested this fix in my cluster and confirmed the issue is fixed.
