### PR TITLE
feat: add support for ingress backed istio gateways

### DIFF
--- a/docs/tutorials/istio.md
+++ b/docs/tutorials/istio.md
@@ -270,6 +270,34 @@ transfer-encoding: chunked
 
 **Note:** The `-H` flag in the original Istio tutorial is no longer necessary in the `curl` commands.
 
+### Optional Gateway Annotation
+
+To support setups where an Ingress resource is used provision an external LB you can add the following annotation to your Gateway
+
+**Note:** The Ingress namespace can be omitted if its in the same namespace as the gateway
+
+```bash
+$ cat <<EOF | kubectl apply -f -
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: httpbin-gateway
+  namespace: istio-system
+  annotations:
+    "external-dns.alpha.kubernetes.io/istio-ingress-backed-gateway": "$ingressNamespace/$ingressName"
+spec:
+  selector:
+    istio: ingressgateway # use Istio default gateway implementation
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+EOF
+```
+
 ### Debug ExternalDNS
 
 * Look for the deployment pod to see the status

--- a/docs/tutorials/istio.md
+++ b/docs/tutorials/istio.md
@@ -284,7 +284,7 @@ metadata:
   name: httpbin-gateway
   namespace: istio-system
   annotations:
-    "external-dns.alpha.kubernetes.io/istio-ingress-backed-gateway": "$ingressNamespace/$ingressName"
+    "external-dns.alpha.kubernetes.io/ingress": "$ingressNamespace/$ingressName"
 spec:
   selector:
     istio: ingressgateway # use Istio default gateway implementation

--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -263,7 +263,7 @@ func (sc *gatewaySource) targetsFromGateway(ctx context.Context, gateway *networ
 		return
 	}
 
-	ingressStr, found := gateway.Annotations[IstioIngressBackedGateway]
+	ingressStr, found := gateway.Annotations[IstioGatewayIngressSource]
 	if found && ingressStr != "" {
 		targets, err = sc.targetsFromIngress(ctx, ingressStr, gateway)
 		return

--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -166,7 +166,7 @@ func (sc *gatewaySource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, e
 			continue
 		}
 
-		gwEndpoints, err := sc.endpointsFromGateway(gwHostnames, gateway)
+		gwEndpoints, err := sc.endpointsFromGateway(ctx, gwHostnames, gateway)
 		if err != nil {
 			return nil, err
 		}
@@ -232,9 +232,40 @@ func (sc *gatewaySource) setResourceLabel(gateway *networkingv1alpha3.Gateway, e
 	}
 }
 
-func (sc *gatewaySource) targetsFromGateway(gateway *networkingv1alpha3.Gateway) (targets endpoint.Targets, err error) {
+func (sc *gatewaySource) targetsFromIngress(ctx context.Context, ingressStr string, gateway *networkingv1alpha3.Gateway) (targets endpoint.Targets, err error) {
+	namespace, name, err := parseIngress(ingressStr)
+	if err != nil {
+		log.Debugf("Failed parsing ingressStr %s of Gateway %s/%s", ingressStr, gateway.Namespace, gateway.Name)
+		return nil, err
+	}
+	if namespace == "" {
+		namespace = gateway.Namespace
+	}
+
+	ingress, err := sc.kubeClient.NetworkingV1().Ingresses(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	for _, lb := range ingress.Status.LoadBalancer.Ingress {
+		if lb.IP != "" {
+			targets = append(targets, lb.IP)
+		} else if lb.Hostname != "" {
+			targets = append(targets, lb.Hostname)
+		}
+	}
+	return
+}
+
+func (sc *gatewaySource) targetsFromGateway(ctx context.Context, gateway *networkingv1alpha3.Gateway) (targets endpoint.Targets, err error) {
 	targets = getTargetsFromTargetAnnotation(gateway.Annotations)
 	if len(targets) > 0 {
+		return
+	}
+
+	ingressStr, found := gateway.Annotations[IstioIngressBackedGateway]
+	if found && ingressStr != "" {
+		targets, err = sc.targetsFromIngress(ctx, ingressStr, gateway)
 		return
 	}
 
@@ -262,7 +293,7 @@ func (sc *gatewaySource) targetsFromGateway(gateway *networkingv1alpha3.Gateway)
 }
 
 // endpointsFromGatewayConfig extracts the endpoints from an Istio Gateway Config object
-func (sc *gatewaySource) endpointsFromGateway(hostnames []string, gateway *networkingv1alpha3.Gateway) ([]*endpoint.Endpoint, error) {
+func (sc *gatewaySource) endpointsFromGateway(ctx context.Context, hostnames []string, gateway *networkingv1alpha3.Gateway) ([]*endpoint.Endpoint, error) {
 	var endpoints []*endpoint.Endpoint
 
 	annotations := gateway.Annotations
@@ -274,7 +305,7 @@ func (sc *gatewaySource) endpointsFromGateway(hostnames []string, gateway *netwo
 	targets := getTargetsFromTargetAnnotation(annotations)
 
 	if len(targets) == 0 {
-		targets, err = sc.targetsFromGateway(gateway)
+		targets, err = sc.targetsFromGateway(ctx, gateway)
 		if err != nil {
 			return nil, err
 		}

--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -243,7 +243,7 @@ func parseIngress(ingress string) (namespace, name string, err error) {
 	} else if len(parts) == 1 {
 		name = parts[0]
 	} else {
-		err = fmt.Errorf("invalid ingress name (name or namespace/name) found '%v'", ingress)
+		err = fmt.Errorf("invalid ingress name (name or namespace/name) found %q", ingress)
 	}
 
 	return
@@ -252,8 +252,7 @@ func parseIngress(ingress string) (namespace, name string, err error) {
 func (sc *gatewaySource) targetsFromIngress(ctx context.Context, ingressStr string, gateway *networkingv1alpha3.Gateway) (targets endpoint.Targets, err error) {
 	namespace, name, err := parseIngress(ingressStr)
 	if err != nil {
-		log.Debugf("Failed parsing ingressStr %s of Gateway %s/%s", ingressStr, gateway.Namespace, gateway.Name)
-		return nil, err
+		return nil, fmt.Errorf("failed to parse Ingress annotation on Gateway (%s/%s): %w", gateway.Namespace, gateway.Name, err)
 	}
 	if namespace == "" {
 		namespace = gateway.Namespace
@@ -280,8 +279,8 @@ func (sc *gatewaySource) targetsFromGateway(ctx context.Context, gateway *networ
 		return
 	}
 
-	ingressStr, found := gateway.Annotations[IstioGatewayIngressSource]
-	if found && ingressStr != "" {
+	ingressStr, ok := gateway.Annotations[IstioGatewayIngressSource]
+	if ok && ingressStr != "" {
 		targets, err = sc.targetsFromIngress(ctx, ingressStr, gateway)
 		return
 	}

--- a/source/istio_gateway_test.go
+++ b/source/istio_gateway_test.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"testing"
 
-	networkv1 "k8s.io/api/networking/v1"
-
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,6 +28,7 @@ import (
 	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
 	v1 "k8s.io/api/core/v1"
+	networkv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 

--- a/source/istio_gateway_test.go
+++ b/source/istio_gateway_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	networkv1 "k8s.io/api/networking/v1"
+
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,6 +43,7 @@ type GatewaySuite struct {
 	suite.Suite
 	source     Source
 	lbServices []*v1.Service
+	ingresses  []*networkv1.Ingress
 }
 
 func (suite *GatewaySuite) SetupTest() {
@@ -65,6 +68,26 @@ func (suite *GatewaySuite) SetupTest() {
 
 	for _, service := range suite.lbServices {
 		_, err = fakeKubernetesClient.CoreV1().Services(service.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
+		suite.NoError(err, "should succeed")
+	}
+
+	suite.ingresses = []*networkv1.Ingress{
+		(fakeIngress{
+			ips:       []string{"2.2.2.2"},
+			hostnames: []string{"v2"},
+			namespace: "istio-system",
+			name:      "istio-ingress",
+		}).Ingress(),
+		(fakeIngress{
+			ips:       []string{"3.3.3.3"},
+			hostnames: []string{"v62"},
+			namespace: "istio-system",
+			name:      "istio-ingress2",
+		}).Ingress(),
+	}
+
+	for _, ingress := range suite.ingresses {
+		_, err = fakeKubernetesClient.NetworkingV1().Ingresses(ingress.Namespace).Create(context.Background(), ingress, metav1.CreateOptions{})
 		suite.NoError(err, "should succeed")
 	}
 
@@ -167,6 +190,7 @@ func testEndpointsFromGatewayConfig(t *testing.T) {
 	for _, ti := range []struct {
 		title      string
 		lbServices []fakeIngressGatewayService
+		ingresses  []fakeIngress
 		config     fakeGatewayConfig
 		expected   []*endpoint.Endpoint
 	}{
@@ -231,6 +255,30 @@ func testEndpointsFromGatewayConfig(t *testing.T) {
 			},
 		},
 		{
+			title: "one rule.host one ingress.IP",
+			ingresses: []fakeIngress{
+				{
+					name: "ingress1",
+					ips:  []string{"8.8.8.8"},
+				},
+			},
+			config: fakeGatewayConfig{
+				annotations: map[string]string{
+					IstioGatewayIngressSource: "ingress1",
+				},
+				dnsnames: [][]string{
+					{"foo.bar"},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
+				},
+			},
+		},
+		{
 			title: "one rule.host two lb.IP and two lb.Hostname",
 			lbServices: []fakeIngressGatewayService{
 				{
@@ -239,6 +287,36 @@ func testEndpointsFromGatewayConfig(t *testing.T) {
 				},
 			},
 			config: fakeGatewayConfig{
+				dnsnames: [][]string{
+					{"foo.bar"},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8", "127.0.0.1"},
+				},
+				{
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"elb.com", "alb.com"},
+				},
+			},
+		},
+		{
+			title: "one rule.host two ingress.IP and two ingress.Hostname",
+			ingresses: []fakeIngress{
+				{
+					name:      "ingress1",
+					ips:       []string{"8.8.8.8", "127.0.0.1"},
+					hostnames: []string{"elb.com", "alb.com"},
+				},
+			},
+			config: fakeGatewayConfig{
+				annotations: map[string]string{
+					IstioGatewayIngressSource: "ingress1",
+				},
 				dnsnames: [][]string{
 					{"foo.bar"},
 				},
@@ -285,6 +363,25 @@ func testEndpointsFromGatewayConfig(t *testing.T) {
 			expected: []*endpoint.Endpoint{},
 		},
 		{
+			title: "one empty rule.host with gateway ingress annotation",
+			ingresses: []fakeIngress{
+				{
+					name:      "ingress1",
+					ips:       []string{"8.8.8.8", "127.0.0.1"},
+					hostnames: []string{"elb.com", "alb.com"},
+				},
+			},
+			config: fakeGatewayConfig{
+				annotations: map[string]string{
+					IstioGatewayIngressSource: "ingress1",
+				},
+				dnsnames: [][]string{
+					{""},
+				},
+			},
+			expected: []*endpoint.Endpoint{},
+		},
+		{
 			title:      "no targets",
 			lbServices: []fakeIngressGatewayService{{}},
 			config: fakeGatewayConfig{
@@ -321,17 +418,47 @@ func testEndpointsFromGatewayConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			title: "one gateway, ingress in seperate namespace",
+			ingresses: []fakeIngress{
+				{
+					hostnames: []string{"lb.com"},
+					namespace: "istio-other2",
+					name:      "ingress1",
+				},
+				{
+					hostnames: []string{"lb2.com"},
+					namespace: "istio-other",
+					name:      "ingress2",
+				},
+			},
+			config: fakeGatewayConfig{
+				annotations: map[string]string{
+					IstioGatewayIngressSource: "istio-other2/ingress1",
+				},
+				dnsnames: [][]string{
+					{"foo.bar"}, // Kubernetes requires removal of trailing dot
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
+				},
+			},
+		},
 	} {
 		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
 			t.Parallel()
 
 			gatewayCfg := ti.config.Config()
-			if source, err := newTestGatewaySource(ti.lbServices); err != nil {
+			if source, err := newTestGatewaySource(ti.lbServices, ti.ingresses); err != nil {
 				require.NoError(t, err)
 			} else if hostnames, err := source.hostNamesFromGateway(gatewayCfg); err != nil {
 				require.NoError(t, err)
-			} else if endpoints, err := source.endpointsFromGateway(hostnames, gatewayCfg); err != nil {
+			} else if endpoints, err := source.endpointsFromGateway(context.Background(), hostnames, gatewayCfg); err != nil {
 				require.NoError(t, err)
 			} else {
 				validateEndpoints(t, endpoints, ti.expected)
@@ -348,6 +475,7 @@ func testGatewayEndpoints(t *testing.T) {
 		targetNamespace          string
 		annotationFilter         string
 		lbServices               []fakeIngressGatewayService
+		ingresses                []fakeIngress
 		configItems              []fakeGatewayConfig
 		expected                 []*endpoint.Endpoint
 		expectError              bool
@@ -462,6 +590,40 @@ func testGatewayEndpoints(t *testing.T) {
 					name:      "fake1",
 					namespace: "testing1",
 					dnsnames:  [][]string{{"example.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
+				},
+				{
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
+				},
+			},
+		},
+		{
+			title:           "one simple gateways on different namespace and a target namespace, one ingress service",
+			targetNamespace: "testing1",
+			ingresses: []fakeIngress{
+				{
+					name:      "ingress1",
+					ips:       []string{"8.8.8.8"},
+					hostnames: []string{"lb.com"},
+					namespace: "testing2",
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: "testing1",
+					dnsnames:  [][]string{{"example.org"}},
+					annotations: map[string]string{
+						IstioGatewayIngressSource: "testing2/ingress1",
+					},
 				},
 			},
 			expected: []*endpoint.Endpoint{
@@ -808,7 +970,8 @@ func testGatewayEndpoints(t *testing.T) {
 					name:      "fake3",
 					namespace: "",
 					annotations: map[string]string{
-						targetAnnotationKey: "1.2.3.4",
+						IstioGatewayIngressSource: "not-real/ingress1",
+						targetAnnotationKey:       "1.2.3.4",
 					},
 					dnsnames: [][]string{{"example3.org"}},
 				},
@@ -913,6 +1076,45 @@ func testGatewayEndpoints(t *testing.T) {
 					annotations: map[string]string{
 						hostnameAnnotationKey: "dns-through-hostname.com",
 						targetAnnotationKey:   "gateway-target.com",
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					Targets:    endpoint.Targets{"gateway-target.com"},
+					RecordType: endpoint.RecordTypeCNAME,
+				},
+				{
+					DNSName:    "dns-through-hostname.com",
+					Targets:    endpoint.Targets{"gateway-target.com"},
+					RecordType: endpoint.RecordTypeCNAME,
+				},
+			},
+		},
+		{
+			title:           "gateway rules with hostname, target and ingress annotation",
+			targetNamespace: "",
+			lbServices: []fakeIngressGatewayService{
+				{
+					ips: []string{},
+				},
+			},
+			ingresses: []fakeIngress{
+				{
+					name: "ingress1",
+					ips:  []string{},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: "",
+					annotations: map[string]string{
+						IstioGatewayIngressSource: "ingress1",
+						hostnameAnnotationKey:     "dns-through-hostname.com",
+						targetAnnotationKey:       "gateway-target.com",
 					},
 					dnsnames: [][]string{{"example.org"}},
 				},
@@ -1065,6 +1267,35 @@ func testGatewayEndpoints(t *testing.T) {
 			fqdnTemplate: "{{.Name}}.ext-dns.test.com",
 		},
 		{
+			title:           "Gateway with empty ingress annotation",
+			targetNamespace: "",
+			lbServices: []fakeIngressGatewayService{
+				{
+					ips:       []string{},
+					hostnames: []string{},
+				},
+			},
+			ingresses: []fakeIngress{
+				{
+					name:      "ingress1",
+					ips:       []string{},
+					hostnames: []string{},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: "",
+					annotations: map[string]string{
+						IstioGatewayIngressSource: "",
+					},
+					dnsnames: [][]string{},
+				},
+			},
+			expected:     []*endpoint.Endpoint{},
+			fqdnTemplate: "{{.Name}}.ext-dns.test.com",
+		},
+		{
 			title:           "ignore hostname annotations",
 			targetNamespace: "",
 			lbServices: []fakeIngressGatewayService{
@@ -1176,6 +1407,28 @@ func testGatewayEndpoints(t *testing.T) {
 				},
 			},
 		},
+		{
+			title:           "gateways with ingress annotation; ingress not found",
+			targetNamespace: "",
+			ingresses: []fakeIngress{
+				{
+					name: "ingress1",
+					ips:  []string{"8.8.8.8"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: "",
+					annotations: map[string]string{
+						IstioGatewayIngressSource: "ingress2",
+					},
+					dnsnames: [][]string{{"new.org"}},
+				},
+			},
+			expected:    []*endpoint.Endpoint{},
+			expectError: true,
+		},
 	} {
 		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
@@ -1186,6 +1439,12 @@ func testGatewayEndpoints(t *testing.T) {
 			for _, lb := range ti.lbServices {
 				service := lb.Service()
 				_, err := fakeKubernetesClient.CoreV1().Services(service.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+
+			for _, ing := range ti.ingresses {
+				ingress := ing.Ingress()
+				_, err := fakeKubernetesClient.NetworkingV1().Ingresses(ingress.Namespace).Create(context.Background(), ingress, metav1.CreateOptions{})
 				require.NoError(t, err)
 			}
 
@@ -1221,13 +1480,20 @@ func testGatewayEndpoints(t *testing.T) {
 }
 
 // gateway specific helper functions
-func newTestGatewaySource(loadBalancerList []fakeIngressGatewayService) (*gatewaySource, error) {
+func newTestGatewaySource(loadBalancerList []fakeIngressGatewayService, ingressList []fakeIngress) (*gatewaySource, error) {
 	fakeKubernetesClient := fake.NewSimpleClientset()
 	fakeIstioClient := istiofake.NewSimpleClientset()
 
 	for _, lb := range loadBalancerList {
 		service := lb.Service()
 		_, err := fakeKubernetesClient.CoreV1().Services(service.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
+		if err != nil {
+			return nil, err
+		}
+	}
+	for _, ing := range ingressList {
+		ingress := ing.Ingress()
+		_, err := fakeKubernetesClient.NetworkingV1().Ingresses(ingress.Namespace).Create(context.Background(), ingress, metav1.CreateOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -42,10 +42,6 @@ import (
 // IstioMeshGateway is the built in gateway for all sidecars
 const IstioMeshGateway = "mesh"
 
-// IstioGatewayIngressSource is the annotation used to determine if the gateway is implemented by an Ingress object
-// instead of a standard LoadBalancer service type
-const IstioGatewayIngressSource = "external-dns.alpha.kubernetes.io/ingress"
-
 // virtualServiceSource is an implementation of Source for Istio VirtualService objects.
 // The implementation uses the spec.hosts values for the hostnames.
 // Use targetAnnotationKey to explicitly set Endpoint.
@@ -430,19 +426,6 @@ func parseGateway(gateway string) (namespace, name string, err error) {
 		name = parts[0]
 	} else {
 		err = fmt.Errorf("invalid gateway name (name or namespace/name) found '%v'", gateway)
-	}
-
-	return
-}
-
-func parseIngress(ingress string) (namespace, name string, err error) {
-	parts := strings.Split(ingress, "/")
-	if len(parts) == 2 {
-		namespace, name = parts[0], parts[1]
-	} else if len(parts) == 1 {
-		name = parts[0]
-	} else {
-		err = fmt.Errorf("invalid ingress name (name or namespace/name) found '%v'", ingress)
 	}
 
 	return

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -434,8 +434,7 @@ func parseGateway(gateway string) (namespace, name string, err error) {
 func (sc *virtualServiceSource) targetsFromIngress(ctx context.Context, ingressStr string, gateway *networkingv1alpha3.Gateway) (targets endpoint.Targets, err error) {
 	namespace, name, err := parseIngress(ingressStr)
 	if err != nil {
-		log.Debugf("Failed parsing ingressStr %s of Gateway %s/%s", ingressStr, gateway.Namespace, gateway.Name)
-		return nil, err
+		return nil, fmt.Errorf("failed to parse Ingress annotation on Gateway (%s/%s): %w", gateway.Namespace, gateway.Name, err)
 	}
 	if namespace == "" {
 		namespace = gateway.Namespace
@@ -462,8 +461,8 @@ func (sc *virtualServiceSource) targetsFromGateway(ctx context.Context, gateway 
 		return
 	}
 
-	ingressStr, found := gateway.Annotations[IstioGatewayIngressSource]
-	if found && ingressStr != "" {
+	ingressStr, ok := gateway.Annotations[IstioGatewayIngressSource]
+	if ok && ingressStr != "" {
 		targets, err = sc.targetsFromIngress(ctx, ingressStr, gateway)
 		return
 	}

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -44,7 +44,7 @@ const IstioMeshGateway = "mesh"
 
 // IstioIngressBackedGateway is used to determine if the gateway is implemented by an Ingress object
 // instead of a standard LoadBalancer service type
-const IstioIngressBackedGateway = "external-dns.alpha.kubernetes.io/istio-ingress-backed-gateway"
+const IstioIngressBackedGateway = "external-dns.alpha.kubernetes.io/ingress"
 
 // virtualServiceSource is an implementation of Source for Istio VirtualService objects.
 // The implementation uses the spec.hosts values for the hostnames.

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -42,9 +42,9 @@ import (
 // IstioMeshGateway is the built in gateway for all sidecars
 const IstioMeshGateway = "mesh"
 
-// IstioIngressBackedGateway is used to determine if the gateway is implemented by an Ingress object
+// IstioGatewayIngressSource is the annotation used to determine if the gateway is implemented by an Ingress object
 // instead of a standard LoadBalancer service type
-const IstioIngressBackedGateway = "external-dns.alpha.kubernetes.io/ingress"
+const IstioGatewayIngressSource = "external-dns.alpha.kubernetes.io/ingress"
 
 // virtualServiceSource is an implementation of Source for Istio VirtualService objects.
 // The implementation uses the spec.hosts values for the hostnames.
@@ -479,7 +479,7 @@ func (sc *virtualServiceSource) targetsFromGateway(ctx context.Context, gateway 
 		return
 	}
 
-	ingressStr, found := gateway.Annotations[IstioIngressBackedGateway]
+	ingressStr, found := gateway.Annotations[IstioGatewayIngressSource]
 	if found && ingressStr != "" {
 		targets, err = sc.targetsFromIngress(ctx, ingressStr, gateway)
 		return


### PR DESCRIPTION
**Description**

This adds support for a new annotation on an Istio Gateway to allow getting a target from an ingress object in place of a LoadBalancer service type. 

This is particularly useful for GCP's Anthos Service Mesh as they [guide](https://cloud.google.com/architecture/exposing-service-mesh-apps-through-gke-ingress/deployment) users to setup their gateways using a ClusterIP service type with an Ingress routing all traffic to the Gateway.

I don't see other annotation implementations for Source's and I'm looking for some guidance here on where this annotation should live (or if some other signal should be used in place of the annotation)


Fixes #2911

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
