### PR TITLE
handle apex domain through gandi ALIAS

### DIFF
--- a/provider/gandi/gandi_test.go
+++ b/provider/gandi/gandi_test.go
@@ -200,6 +200,13 @@ func TestGandiProvider_RecordsReturnsCorrectEndpoints(t *testing.T) {
 				RrsetHref:   exampleDotComUri + "/records/test/A",
 				RrsetValues: []string{"192.168.0.2"},
 			},
+			{
+				RrsetType:   RecordTypeALIAS,
+				RrsetTTL:    600,
+				RrsetName:   "@",
+				RrsetHref:   exampleDotComUri + "/records/test/ALIAS",
+				RrsetValues: []string{"lb-2.example.com"},
+			},
 		},
 	}
 
@@ -230,6 +237,12 @@ func TestGandiProvider_RecordsReturnsCorrectEndpoints(t *testing.T) {
 			RecordType: endpoint.RecordTypeA,
 			DNSName:    "test.example.com",
 			Targets:    endpoint.Targets{"192.168.0.2"},
+			RecordTTL:  600,
+		},
+		{
+			RecordType: endpoint.RecordTypeCNAME,
+			DNSName:    "example.com",
+			Targets:    endpoint.Targets{"lb-2.example.com"},
 			RecordTTL:  600,
 		},
 	}
@@ -304,6 +317,12 @@ func TestGandiProvider_ApplyChangesMakesExpectedAPICalls(t *testing.T) {
 			RecordType: "A",
 			RecordTTL:  666,
 		},
+		{
+			DNSName:    "example.com",
+			Targets:    endpoint.Targets{"lb.example.net"},
+			RecordType: "CNAME",
+			RecordTTL:  666,
+		},
 	}
 	changes.UpdateNew = []*endpoint.Endpoint{
 		{
@@ -343,6 +362,16 @@ func TestGandiProvider_ApplyChangesMakesExpectedAPICalls(t *testing.T) {
 				RrsetType:   endpoint.RecordTypeA,
 				RrsetName:   "test2",
 				RrsetValues: []string{"192.168.0.1"},
+				RrsetTTL:    666,
+			},
+		},
+		{
+			Name: "CreateDomainRecord",
+			FQDN: "example.com",
+			Record: livedns.DomainRecord{
+				RrsetType:   RecordTypeALIAS,
+				RrsetName:   "@",
+				RrsetValues: []string{"lb.example.net."},
 				RrsetTTL:    666,
 			},
 		},


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR allow gandi provider to redirect apex domain to an FQDN. 

From my understanding, CNAME record only can be used for subdomains and external-dns force CNAME if record value is an FQDN. To fill this gap some DNS provider introduce a new record type ALIAS. ALIAS record is a type of DNS record that points your domain name to a hostname instead of an IP address. The ALIAS record is similar to a CNAME record, which is used to point subdomains to a hostname. This allow us to register a record an apex domain `@` with a FQDN.

So back on this PR, the fix convert an CNAME to an ALIAS, if the `record.RrsetName == "@" and record.RrsetType == "CNAME"`. And env var (`GANDI_PREFER_ALIAS`) has been added to keep old things working as expected.

[What Are ALIAS Records?](https://docs.gandi.net/en/domain_names/faq/record_types/alias_record.html)

This fix has been tested in our preproduction environment and work as expected.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
