### PR TITLE
WIP Support provider-specific annotations on DNSEndpoint CRD

### DIFF
--- a/docs/annotations/annotations.md
+++ b/docs/annotations/annotations.md
@@ -10,7 +10,7 @@ The following table documents which sources support which annotations:
 | Connector    |            |          |                   |         |     |                     |
 | Contour      | Yes        | Yes[^1]  |                   | Yes     | Yes | Yes                 |
 | CloudFoundry |            |          |                   |         |     |                     |
-| CRD          |            |          |                   |         |     |                     |
+| CRD          |            |          |                   |         |     | Yes[^4]             |
 | F5           |            |          |                   |         | Yes |                     |
 | Gateway      | Yes        | Yes[^1]  |                   |         | Yes | Yes                 |
 | Gloo         |            |          |                   |         | Yes | Yes                 |
@@ -27,6 +27,7 @@ The following table documents which sources support which annotations:
 [^1]: Unless the `--ignore-hostname-annotation` flag is specified.
 [^2]: Only behaves differently than `hostname` for `Service`s of type `LoadBalancer`.
 [^3]: Also supported on `Pods` referenced from a headless `Service`'s `Endpoints`.
+[^4]: The set identifier comes from `setIdentifier` field of the spec, not the annotation.
 
 ## external-dns.alpha.kubernetes.io/access
 

--- a/docs/contributing/crd-source.md
+++ b/docs/contributing/crd-source.md
@@ -34,8 +34,7 @@ type Endpoint struct {
 	// +optional
 	Labels Labels `json:"labels,omitempty"`
 	// ProviderSpecific stores provider specific config
-	// +optional
-	ProviderSpecific ProviderSpecific `json:"providerSpecific,omitempty"`
+	ProviderSpecific ProviderSpecific `json:"-"`
 }
 
 type DNSEndpointSpec struct {

--- a/docs/contributing/crd-source/crd-manifest.yaml
+++ b/docs/contributing/crd-source/crd-manifest.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
-    api-approved.kubernetes.io: "https://github.com/kubernetes-sigs/external-dns/pull/2007"
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: dnsendpoints.externaldns.k8s.io
 spec:
@@ -22,10 +20,14 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -34,7 +36,8 @@ spec:
             properties:
               endpoints:
                 items:
-                  description: Endpoint is a high-level way of a connection between a service and an IP
+                  description: Endpoint is a high-level way of a connection between
+                    a service and an IP
                   properties:
                     dnsName:
                       description: The hostname of the DNS record
@@ -44,26 +47,18 @@ spec:
                         type: string
                       description: Labels stores labels defined for the Endpoint
                       type: object
-                    providerSpecific:
-                      description: ProviderSpecific stores provider specific config
-                      items:
-                        description: ProviderSpecificProperty holds the name and value of a configuration which is specific to individual DNS providers
-                        properties:
-                          name:
-                            type: string
-                          value:
-                            type: string
-                        type: object
-                      type: array
                     recordTTL:
                       description: TTL for the record
                       format: int64
                       type: integer
                     recordType:
-                      description: RecordType type of record, e.g. CNAME, A, SRV, TXT etc
+                      description: RecordType type of record, e.g. CNAME, A, AAAA,
+                        SRV, TXT etc
                       type: string
                     setIdentifier:
-                      description: Identifier to distinguish multiple records with the same name and type (e.g. Route53 records with routing policies other than 'simple')
+                      description: Identifier to distinguish multiple records with
+                        the same name and type (e.g. Route53 records with routing
+                        policies other than 'simple')
                       type: string
                     targets:
                       description: The targets the DNS record points to
@@ -86,9 +81,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -185,8 +185,7 @@ type Endpoint struct {
 	// +optional
 	Labels Labels `json:"labels,omitempty"`
 	// ProviderSpecific stores provider specific config
-	// +optional
-	ProviderSpecific ProviderSpecific `json:"providerSpecific,omitempty"`
+	ProviderSpecific ProviderSpecific `json:"-"`
 }
 
 // NewEndpoint initialization method to be used to create an endpoint

--- a/source/crd.go
+++ b/source/crd.go
@@ -182,6 +182,9 @@ func (cs *crdSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 	for _, dnsEndpoint := range result.Items {
 		// Make sure that all endpoints have targets for A or CNAME type
 		crdEndpoints := []*endpoint.Endpoint{}
+
+		providerSpecific, _ := getProviderSpecificAnnotations(dnsEndpoint.Annotations)
+
 		for _, ep := range dnsEndpoint.Spec.Endpoints {
 			if (ep.RecordType == "CNAME" || ep.RecordType == "A" || ep.RecordType == "AAAA") && len(ep.Targets) < 1 {
 				log.Warnf("Endpoint %s with DNSName %s has an empty list of targets", dnsEndpoint.ObjectMeta.Name, ep.DNSName)
@@ -203,6 +206,8 @@ func (cs *crdSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 			if ep.Labels == nil {
 				ep.Labels = endpoint.NewLabels()
 			}
+
+			ep.ProviderSpecific = providerSpecific
 
 			crdEndpoints = append(crdEndpoints, ep)
 		}

--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -383,6 +383,32 @@ func testCRDSourceEndpoints(t *testing.T) {
 			expectEndpoints: true,
 			expectError:     false,
 		},
+		{
+			title:                "crd with provider-specific annotation",
+			registeredAPIVersion: "test.k8s.io/v1alpha1",
+			apiVersion:           "test.k8s.io/v1alpha1",
+			registeredKind:       "DNSEndpoint",
+			kind:                 "DNSEndpoint",
+			namespace:            "foo",
+			registeredNamespace:  "foo",
+			annotations:          map[string]string{"external-dns.alpha.kubernetes.io/alias": "true"},
+			endpoints: []*endpoint.Endpoint{
+				{
+					DNSName:    "abc.example.org",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+					RecordTTL:  180,
+					ProviderSpecific: endpoint.ProviderSpecific{
+						{
+							Name:  "alias",
+							Value: "true",
+						},
+					},
+				},
+			},
+			expectEndpoints: true,
+			expectError:     false,
+		},
 	} {
 		ti := ti
 		t.Run(ti.title, func(t *testing.T) {


### PR DESCRIPTION

**Description**

For DNSEndpoint CRDs, consumes provider-specific properties from the standard annotations instead
of from the CRD's spec.

This is because the spec had a different key namespace than the annotations. Consistency in the key namespace is more important than consuming from the CRD's spec.

The set identifier is still consumed from the CRD's spec, not the annotation.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
