### PR TITLE
Bump the timeout for golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ golangci-lint:
 
 # Run the golangci-lint tool
 go-lint: golangci-lint
-	golangci-lint run --timeout=15m ./...
+	golangci-lint run --timeout=30m ./...
 
 .PHONY: licensecheck
 


### PR DESCRIPTION

**Description**

golangci-lint has been timing out frequently when run in Prow. Increase the timeout to fix this.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
