### PR TITLE
Support GoDaddy domains with PENDING_DNS_ACTIVE status

### DIFF
--- a/provider/godaddy/client.go
+++ b/provider/godaddy/client.go
@@ -338,7 +338,7 @@ func (c *Client) UnmarshalResponse(response *http.Response, resType interface{})
 func (c *Client) validate() error {
 	var response interface{}
 
-	if err := c.Get("/v1/domains?statuses=ACTIVE", response); err != nil {
+	if err := c.Get(domainsURI, response); err != nil {
 		return err
 	}
 

--- a/provider/godaddy/godaddy.go
+++ b/provider/godaddy/godaddy.go
@@ -44,7 +44,7 @@ var actionNames = []string{
 	"delete",
 }
 
-var domainsURI = "/v1/domains?statuses=ACTIVE,PENDING_DNS_ACTIVE"
+const domainsURI = "/v1/domains?statuses=ACTIVE,PENDING_DNS_ACTIVE"
 
 // ErrRecordToMutateNotFound when ApplyChange has to update/delete and didn't found the record in the existing zone (Change with no record ID)
 var ErrRecordToMutateNotFound = errors.New("record to mutate not found in current zone")

--- a/provider/godaddy/godaddy.go
+++ b/provider/godaddy/godaddy.go
@@ -44,6 +44,8 @@ var actionNames = []string{
 	"delete",
 }
 
+var domainsURI = "/v1/domains?statuses=ACTIVE,PENDING_DNS_ACTIVE"
+
 // ErrRecordToMutateNotFound when ApplyChange has to update/delete and didn't found the record in the existing zone (Change with no record ID)
 var ErrRecordToMutateNotFound = errors.New("record to mutate not found in current zone")
 
@@ -154,7 +156,7 @@ func (p *GDProvider) zones() ([]string, error) {
 	zones := []gdZone{}
 	filteredZones := []string{}
 
-	if err := p.client.Get("/v1/domains?statuses=ACTIVE", &zones); err != nil {
+	if err := p.client.Get(domainsURI, &zones); err != nil {
 		return nil, err
 	}
 

--- a/provider/godaddy/godaddy_test.go
+++ b/provider/godaddy/godaddy_test.go
@@ -95,7 +95,7 @@ func TestGoDaddyZones(t *testing.T) {
 	}
 
 	// Basic zones
-	client.On("Get", "/v1/domains?statuses=ACTIVE").Return([]gdZone{
+	client.On("Get", domainsURI).Return([]gdZone{
 		{
 			Domain: "example.com",
 		},
@@ -113,7 +113,7 @@ func TestGoDaddyZones(t *testing.T) {
 	client.AssertExpectations(t)
 
 	// Error on getting zones
-	client.On("Get", "/v1/domains?statuses=ACTIVE").Return(nil, ErrAPIDown).Once()
+	client.On("Get", domainsURI).Return(nil, ErrAPIDown).Once()
 	domains, err = provider.zones()
 	assert.Error(err)
 	assert.Nil(domains)
@@ -128,7 +128,7 @@ func TestGoDaddyZoneRecords(t *testing.T) {
 	}
 
 	// Basic zones records
-	client.On("Get", "/v1/domains?statuses=ACTIVE").Return([]gdZone{
+	client.On("Get", domainsURI).Return([]gdZone{
 		{
 			Domain: zoneNameExampleNet,
 		},
@@ -180,7 +180,7 @@ func TestGoDaddyZoneRecords(t *testing.T) {
 	client.AssertExpectations(t)
 
 	// Error on getting zones list
-	client.On("Get", "/v1/domains?statuses=ACTIVE").Return(nil, ErrAPIDown).Once()
+	client.On("Get", domainsURI).Return(nil, ErrAPIDown).Once()
 	zones, records, err = provider.zonesRecords(context.TODO(), false)
 	assert.Error(err)
 	assert.Nil(zones)
@@ -188,7 +188,7 @@ func TestGoDaddyZoneRecords(t *testing.T) {
 	client.AssertExpectations(t)
 
 	// Error on getting zone records
-	client.On("Get", "/v1/domains?statuses=ACTIVE").Return([]gdZone{
+	client.On("Get", domainsURI).Return([]gdZone{
 		{
 			Domain: zoneNameExampleNet,
 		},
@@ -204,7 +204,7 @@ func TestGoDaddyZoneRecords(t *testing.T) {
 	client.AssertExpectations(t)
 
 	// Error on getting zone record detail
-	client.On("Get", "/v1/domains?statuses=ACTIVE").Return([]gdZone{
+	client.On("Get", domainsURI).Return([]gdZone{
 		{
 			Domain: zoneNameExampleNet,
 		},
@@ -227,7 +227,7 @@ func TestGoDaddyRecords(t *testing.T) {
 	}
 
 	// Basic zones records
-	client.On("Get", "/v1/domains?statuses=ACTIVE").Return([]gdZone{
+	client.On("Get", domainsURI).Return([]gdZone{
 		{
 			Domain: zoneNameExampleOrg,
 		},
@@ -308,7 +308,7 @@ func TestGoDaddyRecords(t *testing.T) {
 	client.AssertExpectations(t)
 
 	// Error getting zone
-	client.On("Get", "/v1/domains?statuses=ACTIVE").Return(nil, ErrAPIDown).Once()
+	client.On("Get", domainsURI).Return(nil, ErrAPIDown).Once()
 	endpoints, err = provider.Records(context.TODO())
 	assert.Error(err)
 	assert.Nil(endpoints)
@@ -345,7 +345,7 @@ func TestGoDaddyChange(t *testing.T) {
 	}
 
 	// Fetch domains
-	client.On("Get", "/v1/domains?statuses=ACTIVE").Return([]gdZone{
+	client.On("Get", domainsURI).Return([]gdZone{
 		{
 			Domain: zoneNameExampleNet,
 		},
@@ -416,7 +416,7 @@ func TestGoDaddyErrorResponse(t *testing.T) {
 	}
 
 	// Fetch domains
-	client.On("Get", "/v1/domains?statuses=ACTIVE").Return([]gdZone{
+	client.On("Get", domainsURI).Return([]gdZone{
 		{
 			Domain: zoneNameExampleNet,
 		},


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

The problem in issue #3888 is that GoDaddy marks domains that aren't registered by GoDaddy itself with the status "PENDING_DNS_ACTIVE" instead of "ACTIVE". External-DNS filters these domains and only selects domains with the status "ACTIVE", using the statuses request parameter. To solve this issue, I'm including results with both statuses.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
