### PR TITLE
Gandi provider: refactor tests to be more readable, robusts, and extensible; and minor fixes

### DIFF
--- a/provider/gandi/gandi.go
+++ b/provider/gandi/gandi.go
@@ -129,7 +129,10 @@ func (p *GandiProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, erro
 						"zone":   zone,
 					}).Debug("Returning endpoint record")
 
-					endpoints = append(endpoints, endpoint.NewEndpoint(name, r.RrsetType, v))
+					endpoints = append(
+						endpoints,
+						endpoint.NewEndpointWithTTL(name, r.RrsetType, endpoint.TTL(r.RrsetTTL), v),
+					)
 				}
 			}
 		}

--- a/provider/gandi/gandi.go
+++ b/provider/gandi/gandi.go
@@ -166,15 +166,28 @@ func (p *GandiProvider) submitChanges(ctx context.Context, changes []*GandiChang
 
 	for _, changes := range zoneChanges {
 		for _, change := range changes {
-			// Prepare record name
-			recordName := strings.TrimSuffix(change.Record.RrsetName, "."+change.ZoneName)
-			if recordName == change.ZoneName {
-				recordName = "@"
-			}
 			if change.Record.RrsetType == endpoint.RecordTypeCNAME && !strings.HasSuffix(change.Record.RrsetValues[0], ".") {
 				change.Record.RrsetValues[0] += "."
 			}
-			change.Record.RrsetName = recordName
+
+			// Prepare record name
+			if change.Record.RrsetName == change.ZoneName {
+				log.WithFields(log.Fields{
+					"record": change.Record.RrsetName,
+					"type":   change.Record.RrsetType,
+					"value":  change.Record.RrsetValues[0],
+					"ttl":    change.Record.RrsetTTL,
+					"action": change.Action,
+					"zone":   change.ZoneName,
+				}).Debugf("Converting record name: %s to apex domain (@)", change.Record.RrsetName)
+
+				change.Record.RrsetName = "@"
+			} else {
+				change.Record.RrsetName = strings.TrimSuffix(
+					change.Record.RrsetName,
+					"."+change.ZoneName,
+				)
+			}
 
 			log.WithFields(log.Fields{
 				"record": change.Record.RrsetName,


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This refactors the gandi provider tests to make them more robust, easier to extend, and hopefully more readable

This also includes two minor fixes : 
 - the conversion of an endpoint DNSName to `@` for apex domains is not robust (as pointed out [here](https://github.com/kubernetes-sigs/external-dns/pull/3855#discussion_r1291912657) - a test case was added to cover this)
 - the TTL field is not filled when fetching endpoints (discovered when rewriting the tests)

This relates to #3855 - I am trying to make changes to the Gandi provider more reliable and reduce noise on improvement/feature PRs

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated (_no change in functionality, doc was not touched_)
