### PR TITLE
[TXT Registry] Make the nonce stable when generating delete records

### DIFF
--- a/registry/txt.go
+++ b/registry/txt.go
@@ -220,7 +220,7 @@ func (im *TXTRegistry) generateTXTRecord(r *endpoint.Endpoint) []*endpoint.Endpo
 
 	endpoints := make([]*endpoint.Endpoint, 0)
 
-	if !im.mapper.recordTypeInAffix() && r.RecordType != endpoint.RecordTypeAAAA {
+	if !im.txtEncryptEnabled && !im.mapper.recordTypeInAffix() && r.RecordType != endpoint.RecordTypeAAAA {
 		// old TXT record format
 		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true, im.txtEncryptEnabled, im.txtEncryptAESKey))
 		if txt != nil {


### PR DESCRIPTION
This PR addresses the issue of the current behavior being incompatible with Route53 when using TXT registry with encryption enabled. AWS requires the `Delete` change request to be called with the exact same record set that is currently present in Route53. However, this is not happening due to the following reasons:

1. The [generateTXTRecord](https://github.com/kubernetes-sigs/external-dns/blob/bd8658e89a1fe3e255621103091717b20f8312b8/registry/txt.go#L196) function generates both old and new format TXT records, each encrypted with a new random nonce.
2. The [Records()](https://github.com/kubernetes-sigs/external-dns/blob/bd8658e89a1fe3e255621103091717b20f8312b8/registry/txt.go#L146C22-L146C22) function stores only one of these records in the `labelsMap` when iterating through the TXT labels.
3. The call to [generateTXTRecord](https://github.com/kubernetes-sigs/external-dns/blob/bd8658e89a1fe3e255621103091717b20f8312b8/registry/txt.go#L175C26-L175C26) within `Records()` results in the [deletion of the nonce](https://github.com/kubernetes-sigs/external-dns/blob/bd8658e89a1fe3e255621103091717b20f8312b8/registry/txt.go#L207) from the labels.
4. The final call to `generateTXTRecord` within [ApplyChanges](https://github.com/kubernetes-sigs/external-dns/blob/bd8658e89a1fe3e255621103091717b20f8312b8/registry/txt.go#L253) regenerates the nonce again, leading to an entirely different target.

To resolve this issue, this PR disables the generation of old-style TXT records and old to new migrations when encryption is enabled. It also ensures that the `txtEncryptionNonce` does not get removed from labels, instead it is ignored when serializing. 

Nonce generation has been moved outside of the `EncryptText` and the nonce get's added to the record's labels. This is required in order to ensure that the nonce exists on the record when it gets added to the cache.

Fixes: #3668
Supersedes: #3808

**Checklist**

- [x] Unit tests updated