### PR TITLE
fix(linode): don't try to create existing records

### DIFF
--- a/provider/linode/linode.go
+++ b/provider/linode/linode.go
@@ -315,7 +315,8 @@ func (p *LinodeProvider) ApplyChanges(ctx context.Context, changes *plan.Changes
 					"zoneName":   zone.Domain,
 					"dnsName":    ep.DNSName,
 					"recordType": ep.RecordType,
-				}).Warn("Records found which should not exist")
+				}).Warn("Records found which should not exist. Not touching it.")
+				continue
 			}
 
 			recordType, err := convertRecordType(ep.RecordType)

--- a/provider/linode/linode_test.go
+++ b/provider/linode/linode_test.go
@@ -366,6 +366,11 @@ func TestLinodeApplyChanges(t *testing.T) {
 			DNSName:    "bar.io",
 			RecordType: "A",
 			Targets:    []string{"targetBar"},
+		}, {
+			// This record should be skipped as it already exists
+			DNSName:    "foo.com",
+			RecordType: "TXT",
+			Targets:    []string{"txt"},
 		}},
 		Delete: []*endpoint.Endpoint{{
 			DNSName:    "api.baz.com",


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
A bug in the Linode provider can result in an unbounded explosion of TXT records being created. For example, if external-dns attempts to create a CNAME in a zone that has a conflicting A record, it will fail but will still create 2 new TXT records every single time.

Instead, we can just skip creating records that already exist since they should only ever be in the list of updates.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #3045

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
