### PR TITLE
[TXT Registry] Fix `Records()` case handling

### DIFF
--- a/registry/txt.go
+++ b/registry/txt.go
@@ -346,9 +346,9 @@ func (pr affixNameMapper) dropAffixExtractType(name string) (baseName, recordTyp
 
 	if pr.recordTypeInAffix() {
 		for _, t := range getSupportedTypes() {
-			t = strings.ToLower(t)
-			iPrefix := strings.ReplaceAll(prefix, recordTemplate, t)
-			iSuffix := strings.ReplaceAll(suffix, recordTemplate, t)
+			tLower := strings.ToLower(t)
+			iPrefix := strings.ReplaceAll(prefix, recordTemplate, tLower)
+			iSuffix := strings.ReplaceAll(suffix, recordTemplate, tLower)
 
 			if pr.isPrefix() && strings.HasPrefix(name, iPrefix) {
 				return strings.TrimPrefix(name, iPrefix), t

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -89,6 +89,7 @@ func testTXTRegistryRecords(t *testing.T) {
 	t.Run("With suffix", testTXTRegistryRecordsSuffixed)
 	t.Run("No prefix", testTXTRegistryRecordsNoPrefix)
 	t.Run("With templated prefix", testTXTRegistryRecordsPrefixedTemplated)
+	t.Run("With templated suffix", testTXTRegistryRecordsSuffixedTemplated)
 }
 
 func testTXTRegistryRecordsPrefixed(t *testing.T) {
@@ -473,6 +474,38 @@ func testTXTRegistryRecordsPrefixedTemplated(t *testing.T) {
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
 
 	r, _ = NewTXTRegistry(p, "TxT-%{record_type}.", "", "owner", time.Hour, "wc", []string{}, false, nil)
+	records, _ = r.Records(ctx)
+
+	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
+}
+
+func testTXTRegistryRecordsSuffixedTemplated(t *testing.T) {
+	ctx := context.Background()
+	p := inmemory.NewInMemoryProvider()
+	p.CreateZone(testZone)
+	p.ApplyChanges(ctx, &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			newEndpointWithOwner("bar.test-zone.example.org", "8.8.8.8", endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("bartxtcname.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+		},
+	})
+	expectedRecords := []*endpoint.Endpoint{
+		{
+			DNSName:    "bar.test-zone.example.org",
+			Targets:    endpoint.Targets{"8.8.8.8"},
+			RecordType: endpoint.RecordTypeCNAME,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
+	}
+
+	r, _ := NewTXTRegistry(p, "", "txt%{record_type}", "owner", time.Hour, "wc", []string{}, false, nil)
+	records, _ := r.Records(ctx)
+
+	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
+
+	r, _ = NewTXTRegistry(p, "", "TxT%{record_type}", "owner", time.Hour, "wc", []string{}, false, nil)
 	records, _ = r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))


### PR DESCRIPTION
There's an issue in `Records()` function in `TXT Registry`. When using templated affix, `recordType` will be passed in lowercase in:
 https://github.com/kubernetes-sigs/external-dns/blob/6a53959385267e313675fd0024d91662ca4b69cf/registry/txt.go#L140-L144

This will then fail to match against the computed key with uppercase recordType in:
https://github.com/kubernetes-sigs/external-dns/blob/6a53959385267e313675fd0024d91662ca4b69cf/registry/txt.go#L159-L175

Surprisingly it wasn't caught by any of the existing tests. I've added few cases should capture that in the future.

**Checklist**

- [x] Unit tests updated
