### PR TITLE
Use ServiceIP for ClusterIP Services with internal-hostname annotation

### DIFF
--- a/docs/annotations/annotations.md
+++ b/docs/annotations/annotations.md
@@ -25,7 +25,7 @@ The following table documents which sources support which annotations:
 | Traefik      |            | Yes      |                   | Yes     | Yes | Yes                 |
 
 [^1]: Unless the `--ignore-hostname-annotation` flag is specified.
-[^2]: Only behaves differently than `hostname` for `Service`s of type `LoadBalancer`.
+[^2]: Only behaves differently than `hostname` for `Service`s of type `ClusterIP` or `LoadBalancer`.
 [^3]: Also supported on `Pods` referenced from a headless `Service`'s `Endpoints`.
 [^4]: The annotation should be on the `Gateway`
 

--- a/docs/sources/service.md
+++ b/docs/sources/service.md
@@ -75,7 +75,8 @@ or the `--publish-host-ip` flag was specified, uses the Pod's `status.hostIP` fi
 
 ### ClusterIP (not headless)
 
-1. If the `--publish-internal-services` flag is specified, uses the `spec.ServiceIP`.
+1. If the hostname came from an `external-dns.alpha.kubernetes.io/internal-hostname` annotation
+or the `--publish-internal-services` flag was specified, uses the `spec.ServiceIP`.
 
 2. Otherwise, does not create any targets.
 

--- a/source/service.go
+++ b/source/service.go
@@ -505,7 +505,7 @@ func (sc *serviceSource) generateEndpoints(svc *v1.Service, hostname string, pro
 		case v1.ServiceTypeClusterIP:
 			if svc.Spec.ClusterIP == v1.ClusterIPNone {
 				endpoints = append(endpoints, sc.extractHeadlessEndpoints(svc, hostname, ttl)...)
-			} else if sc.publishInternal {
+			} else if useClusterIP || sc.publishInternal {
 				targets = extractServiceIps(svc)
 			}
 		case v1.ServiceTypeNodePort:


### PR DESCRIPTION

**Description**

If a domain name comes from a `external-dns.alpha.kubernetes.io/internal-hostname` annotation on a non-headless ClusterIP Service, publish the Service's ClusterIP.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
