### PR TITLE
Refactor getTTLFromAnnotations() to not return error

### DIFF
--- a/source/ambassador_host.go
+++ b/source/ambassador_host.go
@@ -173,10 +173,7 @@ func (sc *ambassadorHostSource) endpointsFromHost(ctx context.Context, host *amb
 	resource := fmt.Sprintf("host/%s/%s", host.Namespace, host.Name)
 
 	annotations := host.Annotations
-	ttl, err := getTTLFromAnnotations(annotations)
-	if err != nil {
-		return nil, err
-	}
+	ttl := getTTLFromAnnotations(annotations)
 
 	if host.Spec != nil {
 		hostname := host.Spec.Hostname

--- a/source/ambassador_host.go
+++ b/source/ambassador_host.go
@@ -173,7 +173,7 @@ func (sc *ambassadorHostSource) endpointsFromHost(ctx context.Context, host *amb
 	resource := fmt.Sprintf("host/%s/%s", host.Namespace, host.Name)
 
 	annotations := host.Annotations
-	ttl := getTTLFromAnnotations(annotations)
+	ttl := getTTLFromAnnotations(annotations, resource)
 
 	if host.Spec != nil {
 		hostname := host.Spec.Hostname

--- a/source/contour_httpproxy.go
+++ b/source/contour_httpproxy.go
@@ -186,10 +186,7 @@ func (sc *httpProxySource) endpointsFromTemplate(httpProxy *projectcontour.HTTPP
 		return nil, err
 	}
 
-	ttl, err := getTTLFromAnnotations(httpProxy.Annotations)
-	if err != nil {
-		log.Warn(err)
-	}
+	ttl := getTTLFromAnnotations(httpProxy.Annotations)
 
 	targets := getTargetsFromTargetAnnotation(httpProxy.Annotations)
 	if len(targets) == 0 {
@@ -252,10 +249,7 @@ func (sc *httpProxySource) endpointsFromHTTPProxy(httpProxy *projectcontour.HTTP
 		return nil, nil
 	}
 
-	ttl, err := getTTLFromAnnotations(httpProxy.Annotations)
-	if err != nil {
-		log.Warn(err)
-	}
+	ttl := getTTLFromAnnotations(httpProxy.Annotations)
 
 	targets := getTargetsFromTargetAnnotation(httpProxy.Annotations)
 

--- a/source/contour_httpproxy.go
+++ b/source/contour_httpproxy.go
@@ -186,7 +186,9 @@ func (sc *httpProxySource) endpointsFromTemplate(httpProxy *projectcontour.HTTPP
 		return nil, err
 	}
 
-	ttl := getTTLFromAnnotations(httpProxy.Annotations)
+	resource := fmt.Sprintf("HTTPProxy/%s/%s", httpProxy.Namespace, httpProxy.Name)
+
+	ttl := getTTLFromAnnotations(httpProxy.Annotations, resource)
 
 	targets := getTargetsFromTargetAnnotation(httpProxy.Annotations)
 	if len(targets) == 0 {
@@ -201,8 +203,6 @@ func (sc *httpProxySource) endpointsFromTemplate(httpProxy *projectcontour.HTTPP
 	}
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(httpProxy.Annotations)
-
-	resource := fmt.Sprintf("HTTPProxy/%s/%s", httpProxy.Namespace, httpProxy.Name)
 
 	var endpoints []*endpoint.Endpoint
 	for _, hostname := range hostnames {
@@ -249,7 +249,9 @@ func (sc *httpProxySource) endpointsFromHTTPProxy(httpProxy *projectcontour.HTTP
 		return nil, nil
 	}
 
-	ttl := getTTLFromAnnotations(httpProxy.Annotations)
+	resource := fmt.Sprintf("HTTPProxy/%s/%s", httpProxy.Namespace, httpProxy.Name)
+
+	ttl := getTTLFromAnnotations(httpProxy.Annotations, resource)
 
 	targets := getTargetsFromTargetAnnotation(httpProxy.Annotations)
 
@@ -265,8 +267,6 @@ func (sc *httpProxySource) endpointsFromHTTPProxy(httpProxy *projectcontour.HTTP
 	}
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(httpProxy.Annotations)
-
-	resource := fmt.Sprintf("HTTPProxy/%s/%s", httpProxy.Namespace, httpProxy.Name)
 
 	var endpoints []*endpoint.Endpoint
 

--- a/source/f5_virtualserver.go
+++ b/source/f5_virtualserver.go
@@ -147,7 +147,9 @@ func (vs *f5VirtualServerSource) endpointsFromVirtualServers(virtualServers []*f
 	var endpoints []*endpoint.Endpoint
 
 	for _, virtualServer := range virtualServers {
-		ttl := getTTLFromAnnotations(virtualServer.Annotations)
+		resource := fmt.Sprintf("f5-virtualserver/%s/%s", virtualServer.Namespace, virtualServer.Name)
+
+		ttl := getTTLFromAnnotations(virtualServer.Annotations, resource)
 
 		targets := getTargetsFromTargetAnnotation(virtualServer.Annotations)
 		if len(targets) == 0 && virtualServer.Spec.VirtualServerAddress != "" {
@@ -157,7 +159,6 @@ func (vs *f5VirtualServerSource) endpointsFromVirtualServers(virtualServers []*f
 			targets = append(targets, virtualServer.Status.VSAddress)
 		}
 
-		resource := fmt.Sprintf("f5-virtualserver/%s/%s", virtualServer.Namespace, virtualServer.Name)
 		endpoints = append(endpoints, endpointsForHostname(virtualServer.Spec.Host, targets, ttl, nil, "", resource)...)
 	}
 

--- a/source/f5_virtualserver.go
+++ b/source/f5_virtualserver.go
@@ -147,10 +147,7 @@ func (vs *f5VirtualServerSource) endpointsFromVirtualServers(virtualServers []*f
 	var endpoints []*endpoint.Endpoint
 
 	for _, virtualServer := range virtualServers {
-		ttl, err := getTTLFromAnnotations(virtualServer.Annotations)
-		if err != nil {
-			return nil, err
-		}
+		ttl := getTTLFromAnnotations(virtualServer.Annotations)
 
 		targets := getTargetsFromTargetAnnotation(virtualServer.Annotations)
 		if len(targets) == 0 && virtualServer.Spec.VirtualServerAddress != "" {

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -230,10 +230,7 @@ func (src *gatewayRouteSource) Endpoints(ctx context.Context) ([]*endpoint.Endpo
 		// Create endpoints from hostnames and targets.
 		resource := fmt.Sprintf("%s/%s/%s", kind, meta.Namespace, meta.Name)
 		providerSpecific, setIdentifier := getProviderSpecificAnnotations(annots)
-		ttl, err := getTTLFromAnnotations(annots)
-		if err != nil {
-			log.Warn(err)
-		}
+		ttl := getTTLFromAnnotations(annots)
 		for host, targets := range hostTargets {
 			endpoints = append(endpoints, endpointsForHostname(host, targets, ttl, providerSpecific, setIdentifier, resource)...)
 		}

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -230,7 +230,7 @@ func (src *gatewayRouteSource) Endpoints(ctx context.Context) ([]*endpoint.Endpo
 		// Create endpoints from hostnames and targets.
 		resource := fmt.Sprintf("%s/%s/%s", kind, meta.Namespace, meta.Name)
 		providerSpecific, setIdentifier := getProviderSpecificAnnotations(annots)
-		ttl := getTTLFromAnnotations(annots)
+		ttl := getTTLFromAnnotations(annots, resource)
 		for host, targets := range hostTargets {
 			endpoints = append(endpoints, endpointsForHostname(host, targets, ttl, providerSpecific, setIdentifier, resource)...)
 		}

--- a/source/gloo_proxy.go
+++ b/source/gloo_proxy.go
@@ -161,10 +161,7 @@ func (gs *glooSource) generateEndpointsFromProxy(ctx context.Context, proxy *pro
 			if err != nil {
 				return nil, err
 			}
-			ttl, err := getTTLFromAnnotations(annotations)
-			if err != nil {
-				return nil, err
-			}
+			ttl := getTTLFromAnnotations(annotations)
 			providerSpecific, setIdentifier := getProviderSpecificAnnotations(annotations)
 			for _, domain := range virtualHost.Domains {
 				endpoints = append(endpoints, endpointsForHostname(strings.TrimSuffix(domain, "."), targets, ttl, providerSpecific, setIdentifier, "")...)

--- a/source/ingress.go
+++ b/source/ingress.go
@@ -188,10 +188,7 @@ func (sc *ingressSource) endpointsFromTemplate(ing *networkv1.Ingress) ([]*endpo
 		return nil, err
 	}
 
-	ttl, err := getTTLFromAnnotations(ing.Annotations)
-	if err != nil {
-		log.Warn(err)
-	}
+	ttl := getTTLFromAnnotations(ing.Annotations)
 
 	targets := getTargetsFromTargetAnnotation(ing.Annotations)
 	if len(targets) == 0 {
@@ -289,10 +286,7 @@ func (sc *ingressSource) setDualstackLabel(ingress *networkv1.Ingress, endpoints
 
 // endpointsFromIngress extracts the endpoints from ingress object
 func endpointsFromIngress(ing *networkv1.Ingress, ignoreHostnameAnnotation bool, ignoreIngressTLSSpec bool, ignoreIngressRulesSpec bool) []*endpoint.Endpoint {
-	ttl, err := getTTLFromAnnotations(ing.Annotations)
-	if err != nil {
-		log.Warn(err)
-	}
+	ttl := getTTLFromAnnotations(ing.Annotations)
 
 	targets := getTargetsFromTargetAnnotation(ing.Annotations)
 

--- a/source/ingress.go
+++ b/source/ingress.go
@@ -188,7 +188,9 @@ func (sc *ingressSource) endpointsFromTemplate(ing *networkv1.Ingress) ([]*endpo
 		return nil, err
 	}
 
-	ttl := getTTLFromAnnotations(ing.Annotations)
+	resource := fmt.Sprintf("ingress/%s/%s", ing.Namespace, ing.Name)
+
+	ttl := getTTLFromAnnotations(ing.Annotations, resource)
 
 	targets := getTargetsFromTargetAnnotation(ing.Annotations)
 	if len(targets) == 0 {
@@ -196,8 +198,6 @@ func (sc *ingressSource) endpointsFromTemplate(ing *networkv1.Ingress) ([]*endpo
 	}
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ing.Annotations)
-
-	resource := fmt.Sprintf("ingress/%s/%s", ing.Namespace, ing.Name)
 
 	var endpoints []*endpoint.Endpoint
 	for _, hostname := range hostnames {
@@ -286,7 +286,9 @@ func (sc *ingressSource) setDualstackLabel(ingress *networkv1.Ingress, endpoints
 
 // endpointsFromIngress extracts the endpoints from ingress object
 func endpointsFromIngress(ing *networkv1.Ingress, ignoreHostnameAnnotation bool, ignoreIngressTLSSpec bool, ignoreIngressRulesSpec bool) []*endpoint.Endpoint {
-	ttl := getTTLFromAnnotations(ing.Annotations)
+	resource := fmt.Sprintf("ingress/%s/%s", ing.Namespace, ing.Name)
+
+	ttl := getTTLFromAnnotations(ing.Annotations, resource)
 
 	targets := getTargetsFromTargetAnnotation(ing.Annotations)
 
@@ -295,8 +297,6 @@ func endpointsFromIngress(ing *networkv1.Ingress, ignoreHostnameAnnotation bool,
 	}
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ing.Annotations)
-
-	resource := fmt.Sprintf("ingress/%s/%s", ing.Namespace, ing.Name)
 
 	// Gather endpoints defined on hosts sections of the ingress
 	var definedHostsEndpoints []*endpoint.Endpoint

--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -304,15 +304,12 @@ func (sc *gatewaySource) targetsFromGateway(ctx context.Context, gateway *networ
 // endpointsFromGatewayConfig extracts the endpoints from an Istio Gateway Config object
 func (sc *gatewaySource) endpointsFromGateway(ctx context.Context, hostnames []string, gateway *networkingv1alpha3.Gateway) ([]*endpoint.Endpoint, error) {
 	var endpoints []*endpoint.Endpoint
+	var err error
 
 	annotations := gateway.Annotations
-	ttl, err := getTTLFromAnnotations(annotations)
-	if err != nil {
-		log.Warn(err)
-	}
+	ttl := getTTLFromAnnotations(annotations)
 
 	targets := getTargetsFromTargetAnnotation(annotations)
-
 	if len(targets) == 0 {
 		targets, err = sc.targetsFromGateway(ctx, gateway)
 		if err != nil {

--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -306,8 +306,10 @@ func (sc *gatewaySource) endpointsFromGateway(ctx context.Context, hostnames []s
 	var endpoints []*endpoint.Endpoint
 	var err error
 
+	resource := fmt.Sprintf("gateway/%s/%s", gateway.Namespace, gateway.Name)
+
 	annotations := gateway.Annotations
-	ttl := getTTLFromAnnotations(annotations)
+	ttl := getTTLFromAnnotations(annotations, resource)
 
 	targets := getTargetsFromTargetAnnotation(annotations)
 	if len(targets) == 0 {
@@ -318,8 +320,6 @@ func (sc *gatewaySource) endpointsFromGateway(ctx context.Context, hostnames []s
 	}
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(annotations)
-
-	resource := fmt.Sprintf("gateway/%s/%s", gateway.Namespace, gateway.Name)
 
 	for _, host := range hostnames {
 		endpoints = append(endpoints, endpointsForHostname(host, targets, ttl, providerSpecific, setIdentifier, resource)...)

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -222,11 +222,11 @@ func (sc *virtualServiceSource) endpointsFromTemplate(ctx context.Context, virtu
 		return nil, err
 	}
 
-	ttl := getTTLFromAnnotations(virtualService.Annotations)
+	resource := fmt.Sprintf("virtualservice/%s/%s", virtualService.Namespace, virtualService.Name)
+
+	ttl := getTTLFromAnnotations(virtualService.Annotations, resource)
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(virtualService.Annotations)
-
-	resource := fmt.Sprintf("virtualservice/%s/%s", virtualService.Namespace, virtualService.Name)
 
 	var endpoints []*endpoint.Endpoint
 	for _, hostname := range hostnames {
@@ -311,13 +311,13 @@ func (sc *virtualServiceSource) endpointsFromVirtualService(ctx context.Context,
 	var endpoints []*endpoint.Endpoint
 	var err error
 
-	ttl := getTTLFromAnnotations(virtualservice.Annotations)
+	resource := fmt.Sprintf("virtualservice/%s/%s", virtualservice.Namespace, virtualservice.Name)
+
+	ttl := getTTLFromAnnotations(virtualservice.Annotations, resource)
 
 	targetsFromAnnotation := getTargetsFromTargetAnnotation(virtualservice.Annotations)
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(virtualservice.Annotations)
-
-	resource := fmt.Sprintf("virtualservice/%s/%s", virtualservice.Namespace, virtualservice.Name)
 
 	for _, host := range virtualservice.Spec.Hosts {
 		if host == "" || host == "*" {

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -222,10 +222,7 @@ func (sc *virtualServiceSource) endpointsFromTemplate(ctx context.Context, virtu
 		return nil, err
 	}
 
-	ttl, err := getTTLFromAnnotations(virtualService.Annotations)
-	if err != nil {
-		log.Warn(err)
-	}
+	ttl := getTTLFromAnnotations(virtualService.Annotations)
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(virtualService.Annotations)
 
@@ -312,11 +309,9 @@ func (sc *virtualServiceSource) targetsFromVirtualService(ctx context.Context, v
 // endpointsFromVirtualService extracts the endpoints from an Istio VirtualService Config object
 func (sc *virtualServiceSource) endpointsFromVirtualService(ctx context.Context, virtualservice *networkingv1alpha3.VirtualService) ([]*endpoint.Endpoint, error) {
 	var endpoints []*endpoint.Endpoint
+	var err error
 
-	ttl, err := getTTLFromAnnotations(virtualservice.Annotations)
-	if err != nil {
-		log.Warn(err)
-	}
+	ttl := getTTLFromAnnotations(virtualservice.Annotations)
 
 	targetsFromAnnotation := getTargetsFromTargetAnnotation(virtualservice.Annotations)
 

--- a/source/kong_tcpingress.go
+++ b/source/kong_tcpingress.go
@@ -204,10 +204,7 @@ func (sc *kongTCPIngressSource) setDualstackLabel(tcpIngress *TCPIngress, endpoi
 func (sc *kongTCPIngressSource) endpointsFromTCPIngress(tcpIngress *TCPIngress, targets endpoint.Targets) ([]*endpoint.Endpoint, error) {
 	var endpoints []*endpoint.Endpoint
 
-	ttl, err := getTTLFromAnnotations(tcpIngress.Annotations)
-	if err != nil {
-		return nil, err
-	}
+	ttl := getTTLFromAnnotations(tcpIngress.Annotations)
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(tcpIngress.Annotations)
 

--- a/source/kong_tcpingress.go
+++ b/source/kong_tcpingress.go
@@ -204,11 +204,11 @@ func (sc *kongTCPIngressSource) setDualstackLabel(tcpIngress *TCPIngress, endpoi
 func (sc *kongTCPIngressSource) endpointsFromTCPIngress(tcpIngress *TCPIngress, targets endpoint.Targets) ([]*endpoint.Endpoint, error) {
 	var endpoints []*endpoint.Endpoint
 
-	ttl := getTTLFromAnnotations(tcpIngress.Annotations)
+	resource := fmt.Sprintf("tcpingress/%s/%s", tcpIngress.Namespace, tcpIngress.Name)
+
+	ttl := getTTLFromAnnotations(tcpIngress.Annotations, resource)
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(tcpIngress.Annotations)
-
-	resource := fmt.Sprintf("tcpingress/%s/%s", tcpIngress.Namespace, tcpIngress.Name)
 
 	hostnameList := getHostnamesFromAnnotations(tcpIngress.Annotations)
 	for _, hostname := range hostnameList {

--- a/source/node.go
+++ b/source/node.go
@@ -104,7 +104,7 @@ func (ns *nodeSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, erro
 
 		log.Debugf("creating endpoint for node %s", node.Name)
 
-		ttl := getTTLFromAnnotations(node.Annotations)
+		ttl := getTTLFromAnnotations(node.Annotations, fmt.Sprintf("node/%s", node.Name))
 
 		// create new endpoint with the information we already have
 		ep := &endpoint.Endpoint{

--- a/source/node.go
+++ b/source/node.go
@@ -104,10 +104,7 @@ func (ns *nodeSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, erro
 
 		log.Debugf("creating endpoint for node %s", node.Name)
 
-		ttl, err := getTTLFromAnnotations(node.Annotations)
-		if err != nil {
-			log.Warn(err)
-		}
+		ttl := getTTLFromAnnotations(node.Annotations)
 
 		// create new endpoint with the information we already have
 		ep := &endpoint.Endpoint{

--- a/source/openshift_route.go
+++ b/source/openshift_route.go
@@ -174,10 +174,7 @@ func (ors *ocpRouteSource) endpointsFromTemplate(ocpRoute *routev1.Route) ([]*en
 		return nil, err
 	}
 
-	ttl, err := getTTLFromAnnotations(ocpRoute.Annotations)
-	if err != nil {
-		log.Warn(err)
-	}
+	ttl := getTTLFromAnnotations(ocpRoute.Annotations)
 
 	targets := getTargetsFromTargetAnnotation(ocpRoute.Annotations)
 	if len(targets) == 0 {
@@ -230,10 +227,7 @@ func (ors *ocpRouteSource) filterByAnnotations(ocpRoutes []*routev1.Route) ([]*r
 func (ors *ocpRouteSource) endpointsFromOcpRoute(ocpRoute *routev1.Route, ignoreHostnameAnnotation bool) []*endpoint.Endpoint {
 	var endpoints []*endpoint.Endpoint
 
-	ttl, err := getTTLFromAnnotations(ocpRoute.Annotations)
-	if err != nil {
-		log.Warn(err)
-	}
+	ttl := getTTLFromAnnotations(ocpRoute.Annotations)
 
 	targets := getTargetsFromTargetAnnotation(ocpRoute.Annotations)
 	targetsFromRoute, host := ors.getTargetsFromRouteStatus(ocpRoute.Status)

--- a/source/openshift_route.go
+++ b/source/openshift_route.go
@@ -174,7 +174,9 @@ func (ors *ocpRouteSource) endpointsFromTemplate(ocpRoute *routev1.Route) ([]*en
 		return nil, err
 	}
 
-	ttl := getTTLFromAnnotations(ocpRoute.Annotations)
+	resource := fmt.Sprintf("route/%s/%s", ocpRoute.Namespace, ocpRoute.Name)
+
+	ttl := getTTLFromAnnotations(ocpRoute.Annotations, resource)
 
 	targets := getTargetsFromTargetAnnotation(ocpRoute.Annotations)
 	if len(targets) == 0 {
@@ -183,8 +185,6 @@ func (ors *ocpRouteSource) endpointsFromTemplate(ocpRoute *routev1.Route) ([]*en
 	}
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ocpRoute.Annotations)
-
-	resource := fmt.Sprintf("route/%s/%s", ocpRoute.Namespace, ocpRoute.Name)
 
 	var endpoints []*endpoint.Endpoint
 	for _, hostname := range hostnames {
@@ -227,7 +227,9 @@ func (ors *ocpRouteSource) filterByAnnotations(ocpRoutes []*routev1.Route) ([]*r
 func (ors *ocpRouteSource) endpointsFromOcpRoute(ocpRoute *routev1.Route, ignoreHostnameAnnotation bool) []*endpoint.Endpoint {
 	var endpoints []*endpoint.Endpoint
 
-	ttl := getTTLFromAnnotations(ocpRoute.Annotations)
+	resource := fmt.Sprintf("route/%s/%s", ocpRoute.Namespace, ocpRoute.Name)
+
+	ttl := getTTLFromAnnotations(ocpRoute.Annotations, resource)
 
 	targets := getTargetsFromTargetAnnotation(ocpRoute.Annotations)
 	targetsFromRoute, host := ors.getTargetsFromRouteStatus(ocpRoute.Status)
@@ -237,8 +239,6 @@ func (ors *ocpRouteSource) endpointsFromOcpRoute(ocpRoute *routev1.Route, ignore
 	}
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ocpRoute.Annotations)
-
-	resource := fmt.Sprintf("route/%s/%s", ocpRoute.Namespace, ocpRoute.Name)
 
 	if host != "" {
 		endpoints = append(endpoints, endpointsForHostname(host, targets, ttl, providerSpecific, setIdentifier, resource)...)

--- a/source/service.go
+++ b/source/service.go
@@ -460,10 +460,7 @@ func (sc *serviceSource) setResourceLabel(service *v1.Service, endpoints []*endp
 
 func (sc *serviceSource) generateEndpoints(svc *v1.Service, hostname string, providerSpecific endpoint.ProviderSpecific, setIdentifier string, useClusterIP bool) []*endpoint.Endpoint {
 	hostname = strings.TrimSuffix(hostname, ".")
-	ttl, err := getTTLFromAnnotations(svc.Annotations)
-	if err != nil {
-		log.Warn(err)
-	}
+	ttl := getTTLFromAnnotations(svc.Annotations)
 
 	epA := &endpoint.Endpoint{
 		RecordTTL:  ttl,
@@ -510,6 +507,7 @@ func (sc *serviceSource) generateEndpoints(svc *v1.Service, hostname string, pro
 			}
 		case v1.ServiceTypeNodePort:
 			// add the nodeTargets and extract an SRV endpoint
+			var err error
 			targets, err = sc.extractNodePortTargets(svc)
 			if err != nil {
 				log.Errorf("Unable to extract targets from service %s/%s error: %v", svc.Namespace, svc.Name, err)

--- a/source/service.go
+++ b/source/service.go
@@ -460,7 +460,7 @@ func (sc *serviceSource) setResourceLabel(service *v1.Service, endpoints []*endp
 
 func (sc *serviceSource) generateEndpoints(svc *v1.Service, hostname string, providerSpecific endpoint.ProviderSpecific, setIdentifier string, useClusterIP bool) []*endpoint.Endpoint {
 	hostname = strings.TrimSuffix(hostname, ".")
-	ttl := getTTLFromAnnotations(svc.Annotations)
+	ttl := getTTLFromAnnotations(svc.Annotations, fmt.Sprintf("service/%s/%s", svc.Namespace, svc.Name))
 
 	epA := &endpoint.Endpoint{
 		RecordTTL:  ttl,

--- a/source/skipper_routegroup.go
+++ b/source/skipper_routegroup.go
@@ -300,8 +300,10 @@ func (sc *routeGroupSource) endpointsFromTemplate(rg *routeGroup) ([]*endpoint.E
 
 	hostnames := buf.String()
 
+	resource := fmt.Sprintf("routegroup/%s/%s", rg.Metadata.Namespace, rg.Metadata.Name)
+
 	// error handled in endpointsFromRouteGroup(), otherwise duplicate log
-	ttl := getTTLFromAnnotations(rg.Metadata.Annotations)
+	ttl := getTTLFromAnnotations(rg.Metadata.Annotations, resource)
 
 	targets := getTargetsFromTargetAnnotation(rg.Metadata.Annotations)
 
@@ -310,8 +312,6 @@ func (sc *routeGroupSource) endpointsFromTemplate(rg *routeGroup) ([]*endpoint.E
 	}
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(rg.Metadata.Annotations)
-
-	resource := fmt.Sprintf("routegroup/%s/%s", rg.Metadata.Namespace, rg.Metadata.Name)
 
 	var endpoints []*endpoint.Endpoint
 	// splits the FQDN template and removes the trailing periods
@@ -336,7 +336,10 @@ func (sc *routeGroupSource) setRouteGroupDualstackLabel(rg *routeGroup, eps []*e
 // annotation logic ported from source/ingress.go without Spec.TLS part, because it'S not supported in RouteGroup
 func (sc *routeGroupSource) endpointsFromRouteGroup(rg *routeGroup) []*endpoint.Endpoint {
 	endpoints := []*endpoint.Endpoint{}
-	ttl := getTTLFromAnnotations(rg.Metadata.Annotations)
+
+	resource := fmt.Sprintf("routegroup/%s/%s", rg.Metadata.Namespace, rg.Metadata.Name)
+
+	ttl := getTTLFromAnnotations(rg.Metadata.Annotations, resource)
 
 	targets := getTargetsFromTargetAnnotation(rg.Metadata.Annotations)
 	if len(targets) == 0 {
@@ -351,8 +354,6 @@ func (sc *routeGroupSource) endpointsFromRouteGroup(rg *routeGroup) []*endpoint.
 	}
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(rg.Metadata.Annotations)
-
-	resource := fmt.Sprintf("routegroup/%s/%s", rg.Metadata.Namespace, rg.Metadata.Name)
 
 	for _, src := range rg.Spec.Hosts {
 		if src == "" {

--- a/source/skipper_routegroup.go
+++ b/source/skipper_routegroup.go
@@ -301,7 +301,7 @@ func (sc *routeGroupSource) endpointsFromTemplate(rg *routeGroup) ([]*endpoint.E
 	hostnames := buf.String()
 
 	// error handled in endpointsFromRouteGroup(), otherwise duplicate log
-	ttl, _ := getTTLFromAnnotations(rg.Metadata.Annotations)
+	ttl := getTTLFromAnnotations(rg.Metadata.Annotations)
 
 	targets := getTargetsFromTargetAnnotation(rg.Metadata.Annotations)
 
@@ -336,10 +336,7 @@ func (sc *routeGroupSource) setRouteGroupDualstackLabel(rg *routeGroup, eps []*e
 // annotation logic ported from source/ingress.go without Spec.TLS part, because it'S not supported in RouteGroup
 func (sc *routeGroupSource) endpointsFromRouteGroup(rg *routeGroup) []*endpoint.Endpoint {
 	endpoints := []*endpoint.Endpoint{}
-	ttl, err := getTTLFromAnnotations(rg.Metadata.Annotations)
-	if err != nil {
-		log.Warnf("Failed to get TTL from annotation: %v", err)
-	}
+	ttl := getTTLFromAnnotations(rg.Metadata.Annotations)
 
 	targets := getTargetsFromTargetAnnotation(rg.Metadata.Annotations)
 	if len(targets) == 0 {

--- a/source/source_test.go
+++ b/source/source_test.go
@@ -82,9 +82,8 @@ func TestGetTTLFromAnnotations(t *testing.T) {
 		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
-			ttl, err := getTTLFromAnnotations(tc.annotations)
+			ttl := getTTLFromAnnotations(tc.annotations)
 			assert.Equal(t, tc.expectedTTL, ttl)
-			assert.Equal(t, tc.expectedErr, err)
 		})
 	}
 }

--- a/source/source_test.go
+++ b/source/source_test.go
@@ -30,59 +30,50 @@ func TestGetTTLFromAnnotations(t *testing.T) {
 		title       string
 		annotations map[string]string
 		expectedTTL endpoint.TTL
-		expectedErr error
 	}{
 		{
 			title:       "TTL annotation not present",
 			annotations: map[string]string{"foo": "bar"},
 			expectedTTL: endpoint.TTL(0),
-			expectedErr: nil,
 		},
 		{
 			title:       "TTL annotation value is not a number",
 			annotations: map[string]string{ttlAnnotationKey: "foo"},
 			expectedTTL: endpoint.TTL(0),
-			expectedErr: fmt.Errorf("\"foo\" is not a valid TTL value"),
 		},
 		{
 			title:       "TTL annotation value is empty",
 			annotations: map[string]string{ttlAnnotationKey: ""},
 			expectedTTL: endpoint.TTL(0),
-			expectedErr: fmt.Errorf("\"\" is not a valid TTL value"),
 		},
 		{
 			title:       "TTL annotation value is negative number",
 			annotations: map[string]string{ttlAnnotationKey: "-1"},
 			expectedTTL: endpoint.TTL(0),
-			expectedErr: fmt.Errorf("TTL value must be between [%d, %d]", ttlMinimum, ttlMaximum),
 		},
 		{
 			title:       "TTL annotation value is too high",
 			annotations: map[string]string{ttlAnnotationKey: fmt.Sprintf("%d", 1<<32)},
 			expectedTTL: endpoint.TTL(0),
-			expectedErr: fmt.Errorf("TTL value must be between [%d, %d]", ttlMinimum, ttlMaximum),
 		},
 		{
 			title:       "TTL annotation value is set correctly using integer",
 			annotations: map[string]string{ttlAnnotationKey: "60"},
 			expectedTTL: endpoint.TTL(60),
-			expectedErr: nil,
 		},
 		{
 			title:       "TTL annotation value is set correctly using duration (whole)",
 			annotations: map[string]string{ttlAnnotationKey: "10m"},
 			expectedTTL: endpoint.TTL(600),
-			expectedErr: nil,
 		},
 		{
 			title:       "TTL annotation value is set correctly using duration (fractional)",
 			annotations: map[string]string{ttlAnnotationKey: "20.5s"},
 			expectedTTL: endpoint.TTL(20),
-			expectedErr: nil,
 		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
-			ttl := getTTLFromAnnotations(tc.annotations)
+			ttl := getTTLFromAnnotations(tc.annotations, "resource/test")
 			assert.Equal(t, tc.expectedTTL, ttl)
 		})
 	}

--- a/source/traefik_proxy.go
+++ b/source/traefik_proxy.go
@@ -647,11 +647,11 @@ func (ts *traefikSource) setDualstackLabelIngressRouteUDP(ingressRoute *IngressR
 func (ts *traefikSource) endpointsFromIngressRoute(ingressRoute *IngressRoute, targets endpoint.Targets) ([]*endpoint.Endpoint, error) {
 	var endpoints []*endpoint.Endpoint
 
-	ttl := getTTLFromAnnotations(ingressRoute.Annotations)
+	resource := fmt.Sprintf("ingressroute/%s/%s", ingressRoute.Namespace, ingressRoute.Name)
+
+	ttl := getTTLFromAnnotations(ingressRoute.Annotations, resource)
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ingressRoute.Annotations)
-
-	resource := fmt.Sprintf("ingressroute/%s/%s", ingressRoute.Namespace, ingressRoute.Name)
 
 	hostnameList := getHostnamesFromAnnotations(ingressRoute.Annotations)
 	for _, hostname := range hostnameList {
@@ -681,11 +681,11 @@ func (ts *traefikSource) endpointsFromIngressRoute(ingressRoute *IngressRoute, t
 func (ts *traefikSource) endpointsFromIngressRouteTCP(ingressRoute *IngressRouteTCP, targets endpoint.Targets) ([]*endpoint.Endpoint, error) {
 	var endpoints []*endpoint.Endpoint
 
-	ttl := getTTLFromAnnotations(ingressRoute.Annotations)
+	resource := fmt.Sprintf("ingressroutetcp/%s/%s", ingressRoute.Namespace, ingressRoute.Name)
+
+	ttl := getTTLFromAnnotations(ingressRoute.Annotations, resource)
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ingressRoute.Annotations)
-
-	resource := fmt.Sprintf("ingressroutetcp/%s/%s", ingressRoute.Namespace, ingressRoute.Name)
 
 	hostnameList := getHostnamesFromAnnotations(ingressRoute.Annotations)
 	for _, hostname := range hostnameList {
@@ -716,11 +716,11 @@ func (ts *traefikSource) endpointsFromIngressRouteTCP(ingressRoute *IngressRoute
 func (ts *traefikSource) endpointsFromIngressRouteUDP(ingressRoute *IngressRouteUDP, targets endpoint.Targets) ([]*endpoint.Endpoint, error) {
 	var endpoints []*endpoint.Endpoint
 
-	ttl := getTTLFromAnnotations(ingressRoute.Annotations)
+	resource := fmt.Sprintf("ingressrouteudp/%s/%s", ingressRoute.Namespace, ingressRoute.Name)
+
+	ttl := getTTLFromAnnotations(ingressRoute.Annotations, resource)
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ingressRoute.Annotations)
-
-	resource := fmt.Sprintf("ingressrouteudp/%s/%s", ingressRoute.Namespace, ingressRoute.Name)
 
 	hostnameList := getHostnamesFromAnnotations(ingressRoute.Annotations)
 	for _, hostname := range hostnameList {

--- a/source/traefik_proxy.go
+++ b/source/traefik_proxy.go
@@ -647,10 +647,7 @@ func (ts *traefikSource) setDualstackLabelIngressRouteUDP(ingressRoute *IngressR
 func (ts *traefikSource) endpointsFromIngressRoute(ingressRoute *IngressRoute, targets endpoint.Targets) ([]*endpoint.Endpoint, error) {
 	var endpoints []*endpoint.Endpoint
 
-	ttl, err := getTTLFromAnnotations(ingressRoute.Annotations)
-	if err != nil {
-		return nil, err
-	}
+	ttl := getTTLFromAnnotations(ingressRoute.Annotations)
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ingressRoute.Annotations)
 
@@ -684,10 +681,7 @@ func (ts *traefikSource) endpointsFromIngressRoute(ingressRoute *IngressRoute, t
 func (ts *traefikSource) endpointsFromIngressRouteTCP(ingressRoute *IngressRouteTCP, targets endpoint.Targets) ([]*endpoint.Endpoint, error) {
 	var endpoints []*endpoint.Endpoint
 
-	ttl, err := getTTLFromAnnotations(ingressRoute.Annotations)
-	if err != nil {
-		return nil, err
-	}
+	ttl := getTTLFromAnnotations(ingressRoute.Annotations)
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ingressRoute.Annotations)
 
@@ -722,10 +716,7 @@ func (ts *traefikSource) endpointsFromIngressRouteTCP(ingressRoute *IngressRoute
 func (ts *traefikSource) endpointsFromIngressRouteUDP(ingressRoute *IngressRouteUDP, targets endpoint.Targets) ([]*endpoint.Endpoint, error) {
 	var endpoints []*endpoint.Endpoint
 
-	ttl, err := getTTLFromAnnotations(ingressRoute.Annotations)
-	if err != nil {
-		return nil, err
-	}
+	ttl := getTTLFromAnnotations(ingressRoute.Annotations)
 
 	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ingressRoute.Annotations)
 


### PR DESCRIPTION

**Description**

Refactors getTTLFromAnnotations() to not return an error. The only correct thing to do is to log the parsing failure and continue with a default TTL.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
