### PR TITLE
fix(azure): sovereign cloud support

### DIFF
--- a/provider/azure/azure.go
+++ b/provider/azure/azure.go
@@ -24,6 +24,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	azcoreruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	dns "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
@@ -74,11 +76,20 @@ func NewAzureProvider(configFile string, domainFilter endpoint.DomainFilter, zon
 	if err != nil {
 		return nil, fmt.Errorf("failed to get credentials: %w", err)
 	}
-	zonesClient, err := dns.NewZonesClient(cfg.SubscriptionID, cred, nil)
+	cloudCfg, err := getCloudConfiguration(cfg.Cloud)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cloud configuration: %w", err)
+	}
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud: cloudCfg,
+		},
+	}
+	zonesClient, err := dns.NewZonesClient(cfg.SubscriptionID, cred, opts)
 	if err != nil {
 		return nil, err
 	}
-	recordSetsClient, err := dns.NewRecordSetsClient(cfg.SubscriptionID, cred, nil)
+	recordSetsClient, err := dns.NewRecordSetsClient(cfg.SubscriptionID, cred, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/azure/azure.go
+++ b/provider/azure/azure.go
@@ -24,8 +24,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	azcoreruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	dns "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
@@ -72,24 +70,16 @@ func NewAzureProvider(configFile string, domainFilter endpoint.DomainFilter, zon
 	if err != nil {
 		return nil, fmt.Errorf("failed to read Azure config file '%s': %v", configFile, err)
 	}
-	cred, err := getCredentials(*cfg)
+	cred, clientOpts, err := getCredentials(*cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get credentials: %w", err)
 	}
-	cloudCfg, err := getCloudConfiguration(cfg.Cloud)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get cloud configuration: %w", err)
-	}
-	opts := &arm.ClientOptions{
-		ClientOptions: azcore.ClientOptions{
-			Cloud: cloudCfg,
-		},
-	}
-	zonesClient, err := dns.NewZonesClient(cfg.SubscriptionID, cred, opts)
+
+	zonesClient, err := dns.NewZonesClient(cfg.SubscriptionID, cred, clientOpts)
 	if err != nil {
 		return nil, err
 	}
-	recordSetsClient, err := dns.NewRecordSetsClient(cfg.SubscriptionID, cred, opts)
+	recordSetsClient, err := dns.NewRecordSetsClient(cfg.SubscriptionID, cred, clientOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/azure/azure_private_dns.go
+++ b/provider/azure/azure_private_dns.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	azcoreruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	privatedns "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
@@ -68,11 +70,20 @@ func NewAzurePrivateDNSProvider(configFile string, domainFilter endpoint.DomainF
 	if err != nil {
 		return nil, fmt.Errorf("failed to get credentials: %w", err)
 	}
-	zonesClient, err := privatedns.NewPrivateZonesClient(cfg.SubscriptionID, cred, nil)
+	cloudCfg, err := getCloudConfiguration(cfg.Cloud)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cloud configuration: %w", err)
+	}
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud: cloudCfg,
+		},
+	}
+	zonesClient, err := privatedns.NewPrivateZonesClient(cfg.SubscriptionID, cred, opts)
 	if err != nil {
 		return nil, err
 	}
-	recordSetsClient, err := privatedns.NewRecordSetsClient(cfg.SubscriptionID, cred, nil)
+	recordSetsClient, err := privatedns.NewRecordSetsClient(cfg.SubscriptionID, cred, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/azure/azure_private_dns.go
+++ b/provider/azure/azure_private_dns.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	azcoreruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	privatedns "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
@@ -66,24 +64,16 @@ func NewAzurePrivateDNSProvider(configFile string, domainFilter endpoint.DomainF
 	if err != nil {
 		return nil, fmt.Errorf("failed to read Azure config file '%s': %v", configFile, err)
 	}
-	cred, err := getCredentials(*cfg)
+	cred, clientOpts, err := getCredentials(*cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get credentials: %w", err)
 	}
-	cloudCfg, err := getCloudConfiguration(cfg.Cloud)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get cloud configuration: %w", err)
-	}
-	opts := &arm.ClientOptions{
-		ClientOptions: azcore.ClientOptions{
-			Cloud: cloudCfg,
-		},
-	}
-	zonesClient, err := privatedns.NewPrivateZonesClient(cfg.SubscriptionID, cred, opts)
+
+	zonesClient, err := privatedns.NewPrivateZonesClient(cfg.SubscriptionID, cred, clientOpts)
 	if err != nil {
 		return nil, err
 	}
-	recordSetsClient, err := privatedns.NewRecordSetsClient(cfg.SubscriptionID, cred, opts)
+	recordSetsClient, err := privatedns.NewRecordSetsClient(cfg.SubscriptionID, cred, clientOpts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Description**

The old implementation allowed use of alternative Azure Clouds (Azure China, Azure Gov etc.)
With the changes to the new SDK, the other clouds were partially implemented : the authentication to the other clouds was working but the calls to the management endpoints to create/delete records was only targeting public Azure Cloud.
This PR aims to fix this bug.
To test it, an access to an sovereign cloud is required. The requestor who filled the issue has access to one and validated the fix.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #3927

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
