### PR TITLE
feat: additional template functions

### DIFF
--- a/docs/advanced/fqdn-templating.md
+++ b/docs/advanced/fqdn-templating.md
@@ -68,10 +68,9 @@ The template uses the following data from the source object (e.g., a `Service` o
 | Function     | Description                                                                              |
 |:-------------|:-----------------------------------------------------------------------------------------|
 | `trimPrefix`  | Function from the `strings` package. Returns `string` without the provided leading prefix. |
-| `replace`     | Function that performs a simple replacement of all `old` string with `new` in the source string.  | 
+| `replace`     | Function that performs a simple replacement of all `old` string with `new` in the source string. |
 | `isIPv4`      | Function that checks if a string is a valid IPv4 address. |
 | `isIPv6`      | Function that checks if a string is a valid IPv6 address (including IPv4-mapped IPv6). |
-
 
 ---
 

--- a/docs/advanced/fqdn-templating.md
+++ b/docs/advanced/fqdn-templating.md
@@ -68,6 +68,10 @@ The template uses the following data from the source object (e.g., a `Service` o
 | Function     | Description                                                                              |
 |:-------------|:-----------------------------------------------------------------------------------------|
 | `trimPrefix`  | Function from the `strings` package. Returns `string` without the provided leading prefix. |
+| `replace`     | Function that performs a simple replacement of all `old` string with `new` in the source string.  | 
+| `isIPv4`      | Function that checks if a string is a valid IPv4 address. |
+| `isIPv6`      | Function that checks if a string is a valid IPv6 address (including IPv4-mapped IPv6). |
+
 
 ---
 
@@ -304,3 +308,12 @@ args:
 ```
 
 By setting the hostname annotation in the ingress resource, ExternalDNS constructs the FQDN accordingly. This approach allows for dynamic DNS entries without hardcoding hostnames.
+
+### Using a Node's Addresses for FQDNs
+
+```yml
+args:
+  - --fqdn-template="{{range .Status.Addresses}}{{if and (eq .Type \"ExternalIP\") (isIPv4 .Address)}}{{.Address | replace \".\" \"-\"}}{{break}}{{end}}{{end}}.example.com
+```
+
+This is a complex template that iternates through a list of a Node's Addresses and creates a FQDN with public IPv4 addresses.

--- a/source/fqdn/fqdn.go
+++ b/source/fqdn/fqdn.go
@@ -30,7 +30,7 @@ func ParseTemplate(fqdnTemplate string) (tmpl *template.Template, err error) {
 		"trimPrefix": strings.TrimPrefix,
 		"replace":    replace,
 		"isIPv6":     isIPv6String,
-		"isIPvv":     isIPv4String,
+		"isIPv4":     isIPv4String,
 	}
 	return template.New("endpoint").Funcs(funcs).Parse(fqdnTemplate)
 }

--- a/source/fqdn/fqdn.go
+++ b/source/fqdn/fqdn.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fqdn
 
 import (
+	"net/netip"
 	"strings"
 	"text/template"
 )
@@ -27,6 +28,34 @@ func ParseTemplate(fqdnTemplate string) (tmpl *template.Template, err error) {
 	}
 	funcs := template.FuncMap{
 		"trimPrefix": strings.TrimPrefix,
+		"replace":    replace,
+		"isIPv6":     isIPv6String,
+		"isIPvv":     isIPv4String,
 	}
 	return template.New("endpoint").Funcs(funcs).Parse(fqdnTemplate)
+}
+
+// replace all instances of old with new in src string.
+// adheres to syntax from https://masterminds.github.io/sprig/strings.html.
+func replace(old, new, src string) string {
+	return strings.Replace(src, old, new, -1)
+}
+
+// isIPv6String reports whether the target string is an IPv6 address,
+// including IPv4-mapped IPv6 addresses.
+func isIPv6String(target string) bool {
+	netIP, err := netip.ParseAddr(target)
+	if err != nil {
+		return false
+	}
+	return netIP.Is6()
+}
+
+// isIPv4String reports whether the target string is an IPv4 address.
+func isIPv4String(target string) bool {
+	netIP, err := netip.ParseAddr(target)
+	if err != nil {
+		return false
+	}
+	return netIP.Is4()
 }

--- a/source/fqdn/fqdn.go
+++ b/source/fqdn/fqdn.go
@@ -35,10 +35,12 @@ func ParseTemplate(fqdnTemplate string) (tmpl *template.Template, err error) {
 	return template.New("endpoint").Funcs(funcs).Parse(fqdnTemplate)
 }
 
-// replace all instances of old with new in src string.
+// replace all instances of oldValue with newValue in target string.
 // adheres to syntax from https://masterminds.github.io/sprig/strings.html.
-func replace(old, new, src string) string {
-	return strings.Replace(src, old, new, -1)
+//
+//lint:ignore QF1004 Using strings.Replace due to argument order requirements
+func replace(oldValue, newValue, target string) string {
+	return strings.Replace(target, oldValue, newValue, -1)
 }
 
 // isIPv6String reports whether the target string is an IPv6 address,

--- a/source/fqdn/fqdn.go
+++ b/source/fqdn/fqdn.go
@@ -38,8 +38,7 @@ func ParseTemplate(fqdnTemplate string) (tmpl *template.Template, err error) {
 // replace all instances of oldValue with newValue in target string.
 // adheres to syntax from https://masterminds.github.io/sprig/strings.html.
 func replace(oldValue, newValue, target string) string {
-	//lint:ignore QF1004 Using strings.Replace due to argument order requirements
-	return strings.Replace(target, oldValue, newValue, -1)
+	return strings.ReplaceAll(target, oldValue, newValue)
 }
 
 // isIPv6String reports whether the target string is an IPv6 address,

--- a/source/fqdn/fqdn.go
+++ b/source/fqdn/fqdn.go
@@ -37,9 +37,8 @@ func ParseTemplate(fqdnTemplate string) (tmpl *template.Template, err error) {
 
 // replace all instances of oldValue with newValue in target string.
 // adheres to syntax from https://masterminds.github.io/sprig/strings.html.
-//
-//lint:ignore QF1004 Using strings.Replace due to argument order requirements
 func replace(oldValue, newValue, target string) string {
+	//lint:ignore QF1004 Using strings.Replace due to argument order requirements
 	return strings.Replace(target, oldValue, newValue, -1)
 }
 

--- a/source/fqdn/fqdn_test.go
+++ b/source/fqdn/fqdn_test.go
@@ -60,6 +60,31 @@ func TestParseTemplate(t *testing.T) {
 			expectError:      false,
 			annotationFilter: "kubernetes.io/ingress.class=nginx",
 		},
+		{
+			name:         "replace template function",
+			expectError:  false,
+			fqdnTemplate: "{{\"hello.world\" | replace \".\" \"-\"}}.ext-dns.test.com",
+		},
+		{
+			name:         "isIPv4 template function with valid IPv4",
+			expectError:  false,
+			fqdnTemplate: "{{if isIPv4 \"192.168.1.1\"}}valid{{else}}invalid{{end}}.ext-dns.test.com",
+		},
+		{
+			name:         "isIPv4 template function with invalid IPv4",
+			expectError:  false,
+			fqdnTemplate: "{{if isIPv4 \"not.an.ip.addr\"}}valid{{else}}invalid{{end}}.ext-dns.test.com",
+		},
+		{
+			name:         "isIPv6 template function with valid IPv6",
+			expectError:  false,
+			fqdnTemplate: "{{if isIPv6 \"2001:db8::1\"}}valid{{else}}invalid{{end}}.ext-dns.test.com",
+		},
+		{
+			name:         "isIPv6 template function with invalid IPv6",
+			expectError:  false,
+			fqdnTemplate: "{{if isIPv6 \"not:ipv6:addr\"}}valid{{else}}invalid{{end}}.ext-dns.test.com",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := ParseTemplate(tt.fqdnTemplate)

--- a/source/fqdn/fqdn_test.go
+++ b/source/fqdn/fqdn_test.go
@@ -96,3 +96,130 @@ func TestParseTemplate(t *testing.T) {
 		})
 	}
 }
+
+func TestReplace(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		oldValue string
+		newValue string
+		target   string
+		expected string
+	}{
+		{
+			name:     "simple replacement",
+			oldValue: "old",
+			newValue: "new",
+			target:   "old-value",
+			expected: "new-value",
+		},
+		{
+			name:     "multiple replacements",
+			oldValue: ".",
+			newValue: "-",
+			target:   "hello.world.com",
+			expected: "hello-world-com",
+		},
+		{
+			name:     "no replacement needed",
+			oldValue: "x",
+			newValue: "y",
+			target:   "hello-world",
+			expected: "hello-world",
+		},
+		{
+			name:     "empty strings",
+			oldValue: "",
+			newValue: "",
+			target:   "test",
+			expected: "test",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := replace(tt.oldValue, tt.newValue, tt.target)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsIPv6String(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "valid IPv6",
+			input:    "2001:db8::1",
+			expected: true,
+		},
+		{
+			name:     "valid IPv6 with multiple segments",
+			input:    "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+			expected: true,
+		},
+		{
+			name:     "valid IPv4-mapped IPv6",
+			input:    "::ffff:192.168.1.1",
+			expected: true,
+		},
+		{
+			name:     "invalid IPv6",
+			input:    "not:ipv6:addr",
+			expected: false,
+		},
+		{
+			name:     "IPv4 address",
+			input:    "192.168.1.1",
+			expected: false,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isIPv6String(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsIPv4String(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "valid IPv4",
+			input:    "192.168.1.1",
+			expected: true,
+		},
+		{
+			name:     "invalid IPv4",
+			input:    "256.256.256.256",
+			expected: false,
+		},
+		{
+			name:     "IPv6 address",
+			input:    "2001:db8::1",
+			expected: false,
+		},
+		{
+			name:     "invalid format",
+			input:    "not.an.ip",
+			expected: false,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isIPv4String(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/source/node_test.go
+++ b/source/node_test.go
@@ -67,6 +67,11 @@ func testNodeSourceNewNodeSource(t *testing.T) {
 			fqdnTemplate: "{{.Name}}-{{.Namespace}}.ext-dns.test.com",
 		},
 		{
+			title:        "complex template",
+			expectError:  false,
+			fqdnTemplate: "{{range .Status.Addresses}}{{if and (eq .Type \"ExternalIP\") (isIPv4 .Address)}}{{.Address | replace \".\" \"-\"}}{{break}}{{end}}{{end}}.ext-dns.test.com",
+		},
+		{
 			title:            "non-empty annotation filter label",
 			expectError:      false,
 			annotationFilter: "kubernetes.io/ingress.class=nginx",


### PR DESCRIPTION
**Description**

Adds a few useful text/template functions:

- replace: replace all substrings in a target string
- isIPv6: exposes an existing function that returns a bool to let you know if a string is an IPv6 address
- isIPv4: a new function that returns a bool to let you know if a string is an IPv4 address

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
N/A

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
