### PR TITLE
Potential fix for nonce usage issue on update record when encryption is enabled

### DIFF
--- a/endpoint/crypto.go
+++ b/endpoint/crypto.go
@@ -94,6 +94,25 @@ func DecryptText(text string, aesKey []byte) (decryptResult string, encryptNonce
 	return string(plaindata), base64.StdEncoding.EncodeToString(nonce), nil
 }
 
+// GenerateNonce generates and returns a nonce
+func GenerateNonce(aesKey []byte) (string, error) {
+	block, err := aes.NewCipher(aesKey)
+	if err != nil {
+		return "", err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(nonce), nil
+}
+
 // decompressData gzip compressed data
 func decompressData(data []byte) (resData []byte, err error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))

--- a/endpoint/labels.go
+++ b/endpoint/labels.go
@@ -151,6 +151,22 @@ func (l Labels) Serialize(withQuotes bool, txtEncryptEnabled bool, aesKey []byte
 	if withQuotes {
 		text = fmt.Sprintf("\"%s\"", text)
 	}
+
+	// Adding back the nonce to labelMap as UPDATE of ownership records require it.
+	l[txtEncryptionNonce] = string(encryptionNonce)
+
 	log.Debugf("Serialized text after encryption is %#v.", text)
 	return text
+}
+
+// AddNonce generates and adds a nonce to the label map.
+func (l Labels) AddNonce(encryptionEnabled bool, aesKey []byte) {
+	if encryptionEnabled && len(aesKey) != 0 {
+		nonce, err := GenerateNonce(aesKey)
+		if err != nil {
+			log.Fatalf("Failed to generate nonce using the encryption key %#v. Got error %#v.", aesKey, err)
+			return
+		}
+		l[txtEncryptionNonce] = nonce
+	}
 }

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -245,6 +245,8 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 			r.Labels = make(map[string]string)
 		}
 		r.Labels[endpoint.OwnerLabelKey] = im.ownerID
+		// The nonce should be the same for both ownership records, hence generating it in advance.
+		r.Labels.AddNonce(im.txtEncryptEnabled, im.txtEncryptAESKey)
 
 		filteredChanges.Create = append(filteredChanges.Create, im.generateTXTRecord(r)...)
 
@@ -277,6 +279,8 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 
 	// make sure TXT records are consistently updated as well
 	for _, r := range filteredChanges.UpdateNew {
+		// The nonce should be the same for both ownership records, hence generating it in advance.
+		r.Labels.AddNonce(im.txtEncryptEnabled, im.txtEncryptAESKey)
 		filteredChanges.UpdateNew = append(filteredChanges.UpdateNew, im.generateTXTRecord(r)...)
 		// add new version of record to cache
 		if im.cacheInterval > 0 {


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
- First part of the fix adds the deleted nonce back to labels associated with the ownership record in [Serialize()](https://github.com/kubernetes-sigs/external-dns/blob/master/endpoint/labels.go#L131) method.
- Since the ownership records are always generated from base A/CNAME record, second part of the fix updates the record encryption method such that, same nonce will be used for encrypting both old and new ownership records associated with an A/CNAME record. Since contents generated for both old and new ownership record are the same, the cipher text after encryption will also be the same as same nonce value is used. This fixes the UPDATE record failures, however has an impact on the entropy, but will help avoiding major changes to the ownership record book keeping code.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #3953 

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
