### PR TITLE
Add --webhook-server flag for running as a webhook server

### DIFF
--- a/docs/tutorials/webhook-provider.md
+++ b/docs/tutorials/webhook-provider.md
@@ -34,11 +34,16 @@ To simplify the discovery of providers, we will accept pull requests that will a
 
 ## Run the AWS provider with the webhook provider.
 
-To test the Webhook provider and provide a reference implementation, we added the functionality to run the AWS provider as a webhook. To run the AWS provider as a webhook, you need the following flags:
+To test the Webhook provider and provide a reference implementation, we added the functionality to run ExternalDNS as a webhook. To run the AWS provider as a webhook, you need the following flags:
 
 ```yaml
-- --provider=webhook
-- --run-aws-provider-as-webhook
+- --webhook-server
+- --provider=aws
+- --source=ingress
 ```
 
-What will happen behind the scenes is that the AWS provider will be be started as an HTTP server exposed only on localhost and the webhook provider will be configured to talk to it. This is the same setup that we recommend for other providers and a good way to test the Webhook provider.
+The value of the `--source` flag is ignored in this mode.
+
+This will start the AWS provider as an HTTP server exposed only on localhost.
+In a separate process/container, run ExternalDNS with `--provider=webhook`.
+This is the same setup that we recommend for other providers and a good way to test the Webhook provider.

--- a/docs/tutorials/webhook-provider.md
+++ b/docs/tutorials/webhook-provider.md
@@ -32,7 +32,7 @@ The server needs to respond to those requests by reading the `Accept` header and
 
 To simplify the discovery of providers, we will accept pull requests that will add links to providers in the [README](../../README.md) file. This list will only serve the purpose of simplifying finding providers and will not constitute an official endorsement of any of the externally implemented providers unless otherwise stated.
 
-## Run the AWS provider with the webhook provider.
+## Run an ExternalDNS in-tree provider as a webhook.
 
 To test the Webhook provider and provide a reference implementation, we added the functionality to run ExternalDNS as a webhook. To run the AWS provider as a webhook, you need the following flags:
 

--- a/main.go
+++ b/main.go
@@ -432,6 +432,11 @@ func main() {
 		log.Fatal(err)
 	}
 
+	if cfg.WebhookServer {
+		webhook.StartHTTPApi(p, nil, cfg.WebhookProviderReadTimeout, cfg.WebhookProviderWriteTimeout, "127.0.0.1:8888")
+		os.Exit(0)
+	}
+
 	var r registry.Registry
 	switch cfg.Registry {
 	case "dynamodb":

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -213,6 +213,7 @@ type Config struct {
 	RunAWSProviderAsWebhook            bool
 	WebhookProviderReadTimeout         time.Duration
 	WebhookProviderWriteTimeout        time.Duration
+	WebhookServer                      bool
 }
 
 var defaultConfig = &Config{
@@ -364,6 +365,7 @@ var defaultConfig = &Config{
 	WebhookProviderURL:          "http://localhost:8888",
 	WebhookProviderReadTimeout:  5 * time.Second,
 	WebhookProviderWriteTimeout: 10 * time.Second,
+	WebhookServer:               false,
 }
 
 // NewConfig returns new Config object
@@ -614,6 +616,8 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("run-aws-provider-as-webhook", "[EXPERIMENTAL] When enabled, the AWS provider will be run as a webhook (default: false). To be used together with 'webhook' as provider.").BoolVar(&cfg.RunAWSProviderAsWebhook)
 	app.Flag("webhook-provider-read-timeout", "[EXPERIMENTAL] The read timeout for the webhook provider in duration format (default: 5s)").Default(defaultConfig.WebhookProviderReadTimeout.String()).DurationVar(&cfg.WebhookProviderReadTimeout)
 	app.Flag("webhook-provider-write-timeout", "[EXPERIMENTAL] The write timeout for the webhook provider in duration format (default: 10s)").Default(defaultConfig.WebhookProviderWriteTimeout.String()).DurationVar(&cfg.WebhookProviderWriteTimeout)
+
+	app.Flag("webhook-server", "[EXPERIMENTAL] When enabled, runs as a webhook server instead of a controller. (default: false).").BoolVar(&cfg.WebhookServer)
 
 	_, err := app.Parse(args)
 	if err != nil {


### PR DESCRIPTION

**Description**

Adds a `--webhook-server` flag for running an arbitrary provider as a webhook. This will be helpful in testing
Helm chart support for webhooks and the webhook provider itself.

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
