### PR TITLE
feat: provider generic annotations

### DIFF
--- a/internal/testutils/mock_source.go
+++ b/internal/testutils/mock_source.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"time"
 
+	"sigs.k8s.io/external-dns/pkg/apis"
+
 	"github.com/stretchr/testify/mock"
 
 	"sigs.k8s.io/external-dns/endpoint"
@@ -57,4 +59,11 @@ func (m *MockSource) AddEventHandler(ctx context.Context, handler func()) {
 			}
 		}
 	}()
+}
+
+func (b *MockSource) SetProviderSpecificConfig(_ apis.ProviderSpecificConfig) {
+}
+
+func (b *MockSource) GetProviderSpecificAnnotations(_ map[string]string) (endpoint.ProviderSpecific, string) {
+	return nil, ""
 }

--- a/main.go
+++ b/main.go
@@ -431,6 +431,12 @@ func main() {
 		os.Exit(0)
 	}
 
+	ps, err := p.GetProviderSpecific(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	endpointsSource.SetProviderSpecificConfig(ps)
+
 	var r registry.Registry
 	switch cfg.Registry {
 	case "dynamodb":

--- a/pkg/apis/types.go
+++ b/pkg/apis/types.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apis
+
+type ProviderSpecificConfig struct {
+	Translation       map[string]string `json:"translation"`
+	PrefixTranslation map[string]string `json:"prefixTranslation"`
+}

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"time"
 
+	"sigs.k8s.io/external-dns/pkg/apis"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/route53"
@@ -291,6 +293,14 @@ func NewAWSProvider(awsConfig AWSConfig, client Route53API) (*AWSProvider, error
 	}
 
 	return provider, nil
+}
+
+func (p *AWSProvider) GetProviderSpecific(_ context.Context) (apis.ProviderSpecificConfig, error) {
+	return apis.ProviderSpecificConfig{
+		PrefixTranslation: map[string]string{
+			"external-dns.alpha.kubernetes.io/aws-": "aws/",
+		},
+	}, nil
 }
 
 // Zones returns the list of hosted zones.

--- a/provider/dyn/soap/services.go
+++ b/provider/dyn/soap/services.go
@@ -5,8 +5,9 @@ package dynsoap
 import (
 	"context"
 	"encoding/xml"
-	"github.com/hooklift/gowsdl/soap"
 	"time"
+
+	"github.com/hooklift/gowsdl/soap"
 )
 
 // against "unused imports"

--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -242,7 +242,7 @@ func TestGoogleZonesVisibilityFilterPrivatePeering(t *testing.T) {
 
 	zones, err := provider.Zones(context.Background())
 	require.NoError(t, err)
-	
+
 	validateZones(t, zones, map[string]*dns.ManagedZone{
 		"svc-local": {Name: "svc-local", DnsName: "svc.local.", Id: 1005, Visibility: "private"},
 	})
@@ -694,7 +694,6 @@ func newGoogleProviderZoneOverlap(t *testing.T, domainFilter endpoint.DomainFilt
 		Visibility: "private",
 	})
 
-
 	createZone(t, provider, &dns.ManagedZone{
 		Name:       "svc-local",
 		DnsName:    "svc.local.",
@@ -703,13 +702,13 @@ func newGoogleProviderZoneOverlap(t *testing.T, domainFilter endpoint.DomainFilt
 	})
 
 	createZone(t, provider, &dns.ManagedZone{
-		Name:       "svc-local-peer",
-		DnsName:    "svc.local.",
-		Id:         10006,
-		Visibility: "private",
+		Name:          "svc-local-peer",
+		DnsName:       "svc.local.",
+		Id:            10006,
+		Visibility:    "private",
 		PeeringConfig: &dns.ManagedZonePeeringConfig{TargetNetwork: nil},
 	})
-	
+
 	provider.dryRun = dryRun
 
 	return provider

--- a/provider/ibmcloud/ibmcloud.go
+++ b/provider/ibmcloud/ibmcloud.go
@@ -24,6 +24,8 @@ import (
 	"strconv"
 	"strings"
 
+	"sigs.k8s.io/external-dns/pkg/apis"
+
 	"github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/crn"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/networking-go-sdk/dnsrecordsv1"
@@ -301,7 +303,7 @@ func (c *ibmcloudConfig) Validate(authenticator core.Authenticator, domainFilter
 // NewIBMCloudProvider creates a new IBMCloud provider.
 //
 // Returns the provider or an error if a provider could not be created.
-func NewIBMCloudProvider(configFile string, domainFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, source source.Source, proxiedByDefault bool, dryRun bool) (*IBMCloudProvider, error) {
+func NewIBMCloudProvider(configFile string, domainFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, source source.Source, proxiedByDefault bool, dryRun bool) (provider.Provider, error) {
 	cfg, err := getConfig(configFile)
 	if err != nil {
 		return nil, err
@@ -333,6 +335,14 @@ func NewIBMCloudProvider(configFile string, domainFilter endpoint.DomainFilter, 
 		DryRun:           dryRun,
 	}
 	return provider, nil
+}
+
+func (p *IBMCloudProvider) GetProviderSpecific(_ context.Context) (apis.ProviderSpecificConfig, error) {
+	return apis.ProviderSpecificConfig{
+		PrefixTranslation: map[string]string{
+			"external-dns.alpha.kubernetes.io/ibmcloud-": "ibmcloud/",
+		},
+	}, nil
 }
 
 // Records gets the current records.

--- a/provider/oci/cache_test.go
+++ b/provider/oci/cache_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package oci
 
 import (
-	"github.com/oracle/oci-go-sdk/v65/dns"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/oracle/oci-go-sdk/v65/dns"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestZoneCache(t *testing.T) {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -22,6 +22,8 @@ import (
 	"net"
 	"strings"
 
+	"sigs.k8s.io/external-dns/pkg/apis"
+
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 )
@@ -49,6 +51,7 @@ type Provider interface {
 	// Endpoints. It is permitted to modify the supplied endpoints.
 	AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error)
 	GetDomainFilter() endpoint.DomainFilter
+	GetProviderSpecific(ctx context.Context) (apis.ProviderSpecificConfig, error)
 }
 
 type BaseProvider struct{}
@@ -59,6 +62,10 @@ func (b BaseProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoi
 
 func (b BaseProvider) GetDomainFilter() endpoint.DomainFilter {
 	return endpoint.DomainFilter{}
+}
+
+func (b BaseProvider) GetProviderSpecific(_ context.Context) (apis.ProviderSpecificConfig, error) {
+	return apis.ProviderSpecificConfig{}, nil
 }
 
 type contextKey struct {

--- a/provider/scaleway/scaleway.go
+++ b/provider/scaleway/scaleway.go
@@ -23,6 +23,8 @@ import (
 	"strconv"
 	"strings"
 
+	"sigs.k8s.io/external-dns/pkg/apis"
+
 	domain "github.com/scaleway/scaleway-sdk-go/api/domain/v2beta1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	log "github.com/sirupsen/logrus"
@@ -101,6 +103,14 @@ func NewScalewayProvider(ctx context.Context, domainFilter endpoint.DomainFilter
 		domainAPI:    domainAPI,
 		dryRun:       dryRun,
 		domainFilter: domainFilter,
+	}, nil
+}
+
+func (p *ScalewayProvider) GetProviderSpecific(_ context.Context) (apis.ProviderSpecificConfig, error) {
+	return apis.ProviderSpecificConfig{
+		PrefixTranslation: map[string]string{
+			"external-dns.alpha.kubernetes.io/scw-": "scw/",
+		},
 	}, nil
 }
 

--- a/provider/webhook/api/httpapi_test.go
+++ b/provider/webhook/api/httpapi_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"sigs.k8s.io/external-dns/pkg/apis"
+
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
@@ -37,6 +39,11 @@ var records []*endpoint.Endpoint
 type FakeWebhookProvider struct {
 	err          error
 	domainFilter endpoint.DomainFilter
+}
+
+func (p FakeWebhookProvider) GetProviderSpecific(ctx context.Context) (apis.ProviderSpecificConfig, error) {
+	//TODO implement me
+	panic("implement me")
 }
 
 func (p FakeWebhookProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {

--- a/source/ambassador_host.go
+++ b/source/ambassador_host.go
@@ -54,6 +54,7 @@ var ambHostGVR = schemeGroupVersion.WithResource("hosts")
 // The IngressRoute implementation uses the spec.virtualHost.fqdn value for the hostname.
 // Use targetAnnotationKey to explicitly set Endpoint.
 type ambassadorHostSource struct {
+	BaseSource
 	dynamicKubeClient      dynamic.Interface
 	kubeClient             kubernetes.Interface
 	namespace              string
@@ -164,12 +165,12 @@ func (sc *ambassadorHostSource) Endpoints(ctx context.Context) ([]*endpoint.Endp
 }
 
 // endpointsFromHost extracts the endpoints from a Host object
-func (sc *ambassadorHostSource) endpointsFromHost(ctx context.Context, host *ambassador.Host, targets endpoint.Targets) ([]*endpoint.Endpoint, error) {
+func (sc *ambassadorHostSource) endpointsFromHost(_ context.Context, host *ambassador.Host, targets endpoint.Targets) ([]*endpoint.Endpoint, error) {
 	var endpoints []*endpoint.Endpoint
 	annotations := host.Annotations
 
 	resource := fmt.Sprintf("host/%s/%s", host.Namespace, host.Name)
-	providerSpecific, setIdentifier := getProviderSpecificAnnotations(annotations)
+	providerSpecific, setIdentifier := sc.GetProviderSpecificAnnotations(annotations)
 	ttl := getTTLFromAnnotations(annotations, resource)
 
 	if host.Spec != nil {

--- a/source/ambassador_host_test.go
+++ b/source/ambassador_host_test.go
@@ -18,6 +18,7 @@ package source
 
 import (
 	"fmt"
+	"sigs.k8s.io/external-dns/pkg/apis"
 	"testing"
 
 	ambassador "github.com/datawire/ambassador/pkg/api/getambassador.io/v2"
@@ -234,8 +235,8 @@ func TestAmbassadorHostSource(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "basic-host",
 					Annotations: map[string]string{
-						ambHostAnnotation:    hostAnnotation,
-						CloudflareProxiedKey: "true",
+						ambHostAnnotation: hostAnnotation,
+						"external-dns.alpha.kubernetes.io/cloudflare-proxied": "true",
 					},
 				},
 				Spec: &ambassador.HostSpec{
@@ -313,6 +314,9 @@ func TestAmbassadorHostSource(t *testing.T) {
 			assert.NoError(t, err)
 
 			source, err := NewAmbassadorHostSource(context.TODO(), fakeDynamicClient, fakeKubernetesClient, namespace)
+			source.SetProviderSpecificConfig(apis.ProviderSpecificConfig{Translation: map[string]string{
+				"external-dns.alpha.kubernetes.io/cloudflare-proxied": "external-dns.alpha.kubernetes.io/cloudflare-proxied",
+			}})
 			assert.NoError(t, err)
 			assert.NotNil(t, source)
 

--- a/source/cloudfoundry.go
+++ b/source/cloudfoundry.go
@@ -26,6 +26,7 @@ import (
 )
 
 type cloudfoundrySource struct {
+	BaseSource
 	client *cfclient.Client
 }
 

--- a/source/connector.go
+++ b/source/connector.go
@@ -34,6 +34,7 @@ const (
 // connectorSource is an implementation of Source that provides endpoints by connecting
 // to a remote tcp server. The encoding/decoding is done using encoder/gob package.
 type connectorSource struct {
+	BaseSource
 	remoteServer string
 }
 

--- a/source/contour_httpproxy.go
+++ b/source/contour_httpproxy.go
@@ -40,6 +40,7 @@ import (
 // The HTTPProxy implementation uses the spec.virtualHost.fqdn value for the hostname.
 // Use targetAnnotationKey to explicitly set Endpoint.
 type httpProxySource struct {
+	BaseSource
 	dynamicKubeClient        dynamic.Interface
 	namespace                string
 	annotationFilter         string
@@ -199,7 +200,7 @@ func (sc *httpProxySource) endpointsFromTemplate(httpProxy *projectcontour.HTTPP
 		}
 	}
 
-	providerSpecific, setIdentifier := getProviderSpecificAnnotations(httpProxy.Annotations)
+	providerSpecific, setIdentifier := sc.GetProviderSpecificAnnotations(httpProxy.Annotations)
 
 	var endpoints []*endpoint.Endpoint
 	for _, hostname := range hostnames {
@@ -258,7 +259,7 @@ func (sc *httpProxySource) endpointsFromHTTPProxy(httpProxy *projectcontour.HTTP
 		}
 	}
 
-	providerSpecific, setIdentifier := getProviderSpecificAnnotations(httpProxy.Annotations)
+	providerSpecific, setIdentifier := sc.GetProviderSpecificAnnotations(httpProxy.Annotations)
 
 	var endpoints []*endpoint.Endpoint
 

--- a/source/contour_httpproxy_test.go
+++ b/source/contour_httpproxy_test.go
@@ -1145,7 +1145,7 @@ func (ir fakeHTTPProxy) HTTPProxy() *projectcontour.HTTPProxy {
 		},
 		Spec: spec,
 		Status: projectcontour.HTTPProxyStatus{
-			LoadBalancer:  lb,
+			LoadBalancer: lb,
 		},
 	}
 

--- a/source/crd.go
+++ b/source/crd.go
@@ -42,6 +42,7 @@ import (
 // crdSource is an implementation of Source that provides endpoints by listing
 // specified CRD and fetching Endpoints embedded in Spec.
 type crdSource struct {
+	BaseSource
 	crdClient        rest.Interface
 	namespace        string
 	crdResource      string

--- a/source/dedupsource.go
+++ b/source/dedupsource.go
@@ -26,6 +26,7 @@ import (
 
 // dedupSource is a Source that removes duplicate endpoints from its wrapped source.
 type dedupSource struct {
+	BaseSource
 	source Source
 }
 

--- a/source/empty.go
+++ b/source/empty.go
@@ -23,7 +23,9 @@ import (
 )
 
 // emptySource is a Source that returns no endpoints.
-type emptySource struct{}
+type emptySource struct {
+	BaseSource
+}
 
 func (e *emptySource) AddEventHandler(ctx context.Context, handler func()) {
 }

--- a/source/f5_virtualserver.go
+++ b/source/f5_virtualserver.go
@@ -48,6 +48,7 @@ var f5VirtualServerGVR = schema.GroupVersionResource{
 
 // virtualServerSource is an implementation of Source for F5 VirtualServer objects.
 type f5VirtualServerSource struct {
+	BaseSource
 	dynamicKubeClient     dynamic.Interface
 	virtualServerInformer informers.GenericInformer
 	kubeClient            kubernetes.Interface

--- a/source/fake.go
+++ b/source/fake.go
@@ -32,6 +32,7 @@ import (
 // fakeSource is an implementation of Source that provides dummy endpoints for
 // testing/dry-running of dns providers without needing an attached Kubernetes cluster.
 type fakeSource struct {
+	BaseSource
 	dnsName string
 }
 

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -81,6 +81,7 @@ func newGatewayInformerFactory(client gateway.Interface, namespace string, label
 }
 
 type gatewayRouteSource struct {
+	BaseSource
 	gwNamespace string
 	gwLabels    labels.Selector
 	gwInformer  informers_v1.GatewayInformer
@@ -230,7 +231,7 @@ func (src *gatewayRouteSource) Endpoints(ctx context.Context) ([]*endpoint.Endpo
 
 		// Create endpoints from hostnames and targets.
 		resource := fmt.Sprintf("%s/%s/%s", kind, meta.Namespace, meta.Name)
-		providerSpecific, setIdentifier := getProviderSpecificAnnotations(annots)
+		providerSpecific, setIdentifier := src.GetProviderSpecificAnnotations(annots)
 		ttl := getTTLFromAnnotations(annots, resource)
 		for host, targets := range hostTargets {
 			endpoints = append(endpoints, endpointsForHostname(host, targets, ttl, providerSpecific, setIdentifier, resource)...)

--- a/source/gloo_proxy.go
+++ b/source/gloo_proxy.go
@@ -95,6 +95,7 @@ type proxyVirtualHostMetadataSourceResourceRef struct {
 }
 
 type glooSource struct {
+	BaseSource
 	dynamicKubeClient dynamic.Interface
 	kubeClient        kubernetes.Interface
 	glooNamespaces    []string
@@ -104,9 +105,9 @@ type glooSource struct {
 func NewGlooSource(dynamicKubeClient dynamic.Interface, kubeClient kubernetes.Interface,
 	glooNamespaces []string) (Source, error) {
 	return &glooSource{
-		dynamicKubeClient,
-		kubeClient,
-		glooNamespaces,
+		dynamicKubeClient: dynamicKubeClient,
+		kubeClient:        kubeClient,
+		glooNamespaces:    glooNamespaces,
 	}, nil
 }
 
@@ -166,7 +167,7 @@ func (gs *glooSource) generateEndpointsFromProxy(ctx context.Context, proxy *pro
 				return nil, err
 			}
 			ttl := getTTLFromAnnotations(annotations, resource)
-			providerSpecific, setIdentifier := getProviderSpecificAnnotations(annotations)
+			providerSpecific, setIdentifier := gs.GetProviderSpecificAnnotations(annotations)
 			for _, domain := range virtualHost.Domains {
 				endpoints = append(endpoints, endpointsForHostname(strings.TrimSuffix(domain, "."), targets, ttl, providerSpecific, setIdentifier, "")...)
 			}

--- a/source/gloo_proxy_test.go
+++ b/source/gloo_proxy_test.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"sigs.k8s.io/external-dns/pkg/apis"
+
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -402,6 +404,9 @@ func TestGlooSource(t *testing.T) {
 		})
 
 	source, err := NewGlooSource(fakeDynamicClient, fakeKubernetesClient, []string{defaultGlooNamespace})
+	source.SetProviderSpecificConfig(apis.ProviderSpecificConfig{PrefixTranslation: map[string]string{
+		"external-dns.alpha.kubernetes.io/aws-": "aws/",
+	}})
 	assert.NoError(t, err)
 	assert.NotNil(t, source)
 

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	"sigs.k8s.io/external-dns/pkg/apis"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -274,7 +276,7 @@ func testEndpointsFromIngress(t *testing.T) {
 	} {
 		t.Run(ti.title, func(t *testing.T) {
 			realIngress := ti.ingress.Ingress()
-			validateEndpoints(t, endpointsFromIngress(realIngress, ti.ignoreHostnameAnnotation, ti.ignoreIngressTLSSpec, ti.ignoreIngressRulesSpec), ti.expected)
+			validateEndpoints(t, endpointsFromIngress(realIngress, ti.ignoreHostnameAnnotation, ti.ignoreIngressTLSSpec, ti.ignoreIngressRulesSpec, apis.ProviderSpecificConfig{}), ti.expected)
 		})
 	}
 }
@@ -373,7 +375,7 @@ func testEndpointsFromIngressHostnameSourceAnnotation(t *testing.T) {
 	} {
 		t.Run(ti.title, func(t *testing.T) {
 			realIngress := ti.ingress.Ingress()
-			validateEndpoints(t, endpointsFromIngress(realIngress, false, false, false), ti.expected)
+			validateEndpoints(t, endpointsFromIngress(realIngress, false, false, false, apis.ProviderSpecificConfig{}), ti.expected)
 		})
 	}
 }

--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -46,6 +46,7 @@ const IstioGatewayIngressSource = "external-dns.alpha.kubernetes.io/ingress"
 // The gateway implementation uses the spec.servers.hosts values for the hostnames.
 // Use targetAnnotationKey to explicitly set Endpoint.
 type gatewaySource struct {
+	BaseSource
 	kubeClient               kubernetes.Interface
 	istioClient              istioclient.Interface
 	namespace                string
@@ -324,7 +325,7 @@ func (sc *gatewaySource) endpointsFromGateway(ctx context.Context, hostnames []s
 		}
 	}
 
-	providerSpecific, setIdentifier := getProviderSpecificAnnotations(annotations)
+	providerSpecific, setIdentifier := sc.GetProviderSpecificAnnotations(annotations)
 
 	for _, host := range hostnames {
 		endpoints = append(endpoints, endpointsForHostname(host, targets, ttl, providerSpecific, setIdentifier, resource)...)

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -46,6 +46,7 @@ const IstioMeshGateway = "mesh"
 // The implementation uses the spec.hosts values for the hostnames.
 // Use targetAnnotationKey to explicitly set Endpoint.
 type virtualServiceSource struct {
+	BaseSource
 	kubeClient               kubernetes.Interface
 	istioClient              istioclient.Interface
 	namespace                string
@@ -226,7 +227,7 @@ func (sc *virtualServiceSource) endpointsFromTemplate(ctx context.Context, virtu
 
 	ttl := getTTLFromAnnotations(virtualService.Annotations, resource)
 
-	providerSpecific, setIdentifier := getProviderSpecificAnnotations(virtualService.Annotations)
+	providerSpecific, setIdentifier := sc.GetProviderSpecificAnnotations(virtualService.Annotations)
 
 	var endpoints []*endpoint.Endpoint
 	for _, hostname := range hostnames {
@@ -317,7 +318,7 @@ func (sc *virtualServiceSource) endpointsFromVirtualService(ctx context.Context,
 
 	targetsFromAnnotation := getTargetsFromTargetAnnotation(virtualservice.Annotations)
 
-	providerSpecific, setIdentifier := getProviderSpecificAnnotations(virtualservice.Annotations)
+	providerSpecific, setIdentifier := sc.GetProviderSpecificAnnotations(virtualservice.Annotations)
 
 	for _, host := range virtualservice.Spec.Hosts {
 		if host == "" || host == "*" {

--- a/source/kong_tcpingress.go
+++ b/source/kong_tcpingress.go
@@ -47,6 +47,7 @@ var kongGroupdVersionResource = schema.GroupVersionResource{
 
 // kongTCPIngressSource is an implementation of Source for Kong TCPIngress objects.
 type kongTCPIngressSource struct {
+	BaseSource
 	annotationFilter         string
 	ignoreHostnameAnnotation bool
 	dynamicKubeClient        dynamic.Interface
@@ -210,7 +211,7 @@ func (sc *kongTCPIngressSource) endpointsFromTCPIngress(tcpIngress *TCPIngress, 
 
 	ttl := getTTLFromAnnotations(tcpIngress.Annotations, resource)
 
-	providerSpecific, setIdentifier := getProviderSpecificAnnotations(tcpIngress.Annotations)
+	providerSpecific, setIdentifier := sc.GetProviderSpecificAnnotations(tcpIngress.Annotations)
 
 	if !sc.ignoreHostnameAnnotation {
 		hostnameList := getHostnamesFromAnnotations(tcpIngress.Annotations)

--- a/source/multisource.go
+++ b/source/multisource.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/apis"
 )
 
 // multiSource is a Source that merges the endpoints of its nested Sources.
@@ -51,6 +52,16 @@ func (ms *multiSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, err
 	}
 
 	return result, nil
+}
+
+func (ms *multiSource) SetProviderSpecificConfig(cfg apis.ProviderSpecificConfig) {
+	for i := range ms.children {
+		ms.children[i].SetProviderSpecificConfig(cfg)
+	}
+}
+
+func (ms *multiSource) GetProviderSpecificAnnotations(_ map[string]string) (endpoint.ProviderSpecific, string) {
+	return nil, ""
 }
 
 func (ms *multiSource) AddEventHandler(ctx context.Context, handler func()) {

--- a/source/node.go
+++ b/source/node.go
@@ -34,6 +34,7 @@ import (
 )
 
 type nodeSource struct {
+	BaseSource
 	client           kubernetes.Interface
 	annotationFilter string
 	fqdnTemplate     *template.Template

--- a/source/openshift_route.go
+++ b/source/openshift_route.go
@@ -42,6 +42,7 @@ import (
 // The targetAnnotationKey can be used to explicitly set an alternative
 // endpoint, if desired.
 type ocpRouteSource struct {
+	BaseSource
 	client                   versioned.Interface
 	namespace                string
 	annotationFilter         string
@@ -184,7 +185,7 @@ func (ors *ocpRouteSource) endpointsFromTemplate(ocpRoute *routev1.Route) ([]*en
 		targets = targetsFromRoute
 	}
 
-	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ocpRoute.Annotations)
+	providerSpecific, setIdentifier := ors.GetProviderSpecificAnnotations(ocpRoute.Annotations)
 
 	var endpoints []*endpoint.Endpoint
 	for _, hostname := range hostnames {
@@ -238,7 +239,7 @@ func (ors *ocpRouteSource) endpointsFromOcpRoute(ocpRoute *routev1.Route, ignore
 		targets = targetsFromRoute
 	}
 
-	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ocpRoute.Annotations)
+	providerSpecific, setIdentifier := ors.GetProviderSpecificAnnotations(ocpRoute.Annotations)
 
 	if host != "" {
 		endpoints = append(endpoints, endpointsForHostname(host, targets, ttl, providerSpecific, setIdentifier, resource)...)

--- a/source/pod.go
+++ b/source/pod.go
@@ -31,6 +31,7 @@ import (
 )
 
 type podSource struct {
+	BaseSource
 	client        kubernetes.Interface
 	namespace     string
 	podInformer   coreinformers.PodInformer

--- a/source/service.go
+++ b/source/service.go
@@ -42,6 +42,7 @@ import (
 // matched services' entrypoints it will return a corresponding
 // Endpoint object.
 type serviceSource struct {
+	BaseSource
 	client           kubernetes.Interface
 	namespace        string
 	annotationFilter string
@@ -377,7 +378,7 @@ func (sc *serviceSource) endpointsFromTemplate(svc *v1.Service) ([]*endpoint.End
 		return nil, err
 	}
 
-	providerSpecific, setIdentifier := getProviderSpecificAnnotations(svc.Annotations)
+	providerSpecific, setIdentifier := sc.GetProviderSpecificAnnotations(svc.Annotations)
 
 	var endpoints []*endpoint.Endpoint
 	for _, hostname := range hostnames {
@@ -392,7 +393,7 @@ func (sc *serviceSource) endpoints(svc *v1.Service) []*endpoint.Endpoint {
 	var endpoints []*endpoint.Endpoint
 	// Skip endpoints if we do not want entries from annotations
 	if !sc.ignoreHostnameAnnotation {
-		providerSpecific, setIdentifier := getProviderSpecificAnnotations(svc.Annotations)
+		providerSpecific, setIdentifier := sc.GetProviderSpecificAnnotations(svc.Annotations)
 		var hostnameList []string
 		var internalHostnameList []string
 

--- a/source/shared_test.go
+++ b/source/shared_test.go
@@ -93,7 +93,7 @@ func validateEndpoint(t *testing.T, endpoint, expected *endpoint.Endpoint) {
 
 	if (len(expected.ProviderSpecific) != 0 || len(endpoint.ProviderSpecific) != 0) &&
 		!reflect.DeepEqual(endpoint.ProviderSpecific, expected.ProviderSpecific) {
-		t.Errorf("ProviderSpecific expected %s, got %s", expected.ProviderSpecific, endpoint.ProviderSpecific)
+		t.Errorf("ProviderSpecific expected %v, got %v", expected.ProviderSpecific, endpoint.ProviderSpecific)
 	}
 
 	if endpoint.SetIdentifier != expected.SetIdentifier {

--- a/source/skipper_routegroup.go
+++ b/source/skipper_routegroup.go
@@ -47,6 +47,7 @@ const (
 )
 
 type routeGroupSource struct {
+	BaseSource
 	cli                      routeGroupListClient
 	apiServer                string
 	namespace                string
@@ -312,7 +313,7 @@ func (sc *routeGroupSource) endpointsFromTemplate(rg *routeGroup) ([]*endpoint.E
 		targets = targetsFromRouteGroupStatus(rg.Status)
 	}
 
-	providerSpecific, setIdentifier := getProviderSpecificAnnotations(rg.Metadata.Annotations)
+	providerSpecific, setIdentifier := sc.GetProviderSpecificAnnotations(rg.Metadata.Annotations)
 
 	var endpoints []*endpoint.Endpoint
 	// splits the FQDN template and removes the trailing periods
@@ -354,7 +355,7 @@ func (sc *routeGroupSource) endpointsFromRouteGroup(rg *routeGroup) []*endpoint.
 		}
 	}
 
-	providerSpecific, setIdentifier := getProviderSpecificAnnotations(rg.Metadata.Annotations)
+	providerSpecific, setIdentifier := sc.GetProviderSpecificAnnotations(rg.Metadata.Annotations)
 
 	for _, src := range rg.Spec.Hosts {
 		if src == "" {

--- a/source/targetfiltersource.go
+++ b/source/targetfiltersource.go
@@ -26,6 +26,7 @@ import (
 
 // targetFilterSource is a Source that removes endpoints matching the target filter from its wrapped source.
 type targetFilterSource struct {
+	BaseSource
 	source       Source
 	targetFilter endpoint.TargetFilterInterface
 }

--- a/source/targetfiltersource_test.go
+++ b/source/targetfiltersource_test.go
@@ -43,6 +43,7 @@ func (m *mockTargetNetFilter) Match(target string) bool {
 
 // echoSource is a Source that returns the endpoints passed in on creation.
 type echoSource struct {
+	BaseSource
 	endpoints []*endpoint.Endpoint
 }
 

--- a/source/traefik_proxy.go
+++ b/source/traefik_proxy.go
@@ -79,6 +79,7 @@ var (
 )
 
 type traefikSource struct {
+	BaseSource
 	annotationFilter           string
 	ignoreHostnameAnnotation   bool
 	dynamicKubeClient          dynamic.Interface
@@ -670,7 +671,7 @@ func (ts *traefikSource) endpointsFromIngressRoute(ingressRoute *IngressRoute, t
 
 	ttl := getTTLFromAnnotations(ingressRoute.Annotations, resource)
 
-	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ingressRoute.Annotations)
+	providerSpecific, setIdentifier := ts.GetProviderSpecificAnnotations(ingressRoute.Annotations)
 
 	if !ts.ignoreHostnameAnnotation {
 		hostnameList := getHostnamesFromAnnotations(ingressRoute.Annotations)
@@ -706,7 +707,7 @@ func (ts *traefikSource) endpointsFromIngressRouteTCP(ingressRoute *IngressRoute
 
 	ttl := getTTLFromAnnotations(ingressRoute.Annotations, resource)
 
-	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ingressRoute.Annotations)
+	providerSpecific, setIdentifier := ts.GetProviderSpecificAnnotations(ingressRoute.Annotations)
 
 	if !ts.ignoreHostnameAnnotation {
 		hostnameList := getHostnamesFromAnnotations(ingressRoute.Annotations)
@@ -743,7 +744,7 @@ func (ts *traefikSource) endpointsFromIngressRouteUDP(ingressRoute *IngressRoute
 
 	ttl := getTTLFromAnnotations(ingressRoute.Annotations, resource)
 
-	providerSpecific, setIdentifier := getProviderSpecificAnnotations(ingressRoute.Annotations)
+	providerSpecific, setIdentifier := ts.GetProviderSpecificAnnotations(ingressRoute.Annotations)
 
 	if !ts.ignoreHostnameAnnotation {
 		hostnameList := getHostnamesFromAnnotations(ingressRoute.Annotations)

--- a/source/traefik_proxy_test.go
+++ b/source/traefik_proxy_test.go
@@ -19,8 +19,9 @@ package source
 import (
 	"context"
 	"encoding/json"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
**Description**
With the new webhook functionality, it is possible to add provider specific annotations for webhook provider at moment.

This solves it in a generic way without changing anything.

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
