### PR TITLE
Make --ignore-hostname-annotation flag more consistent

### DIFF
--- a/docs/annotations/annotations.md
+++ b/docs/annotations/annotations.md
@@ -16,13 +16,13 @@ The following table documents which sources support which annotations:
 | Gloo         |            |          |                   | Yes     | Yes[^5] | Yes[^5]             |
 | Ingress      | Yes        | Yes[^1]  |                   | Yes     | Yes     | Yes                 |
 | Istio        | Yes        | Yes[^1]  |                   | Yes     | Yes     | Yes                 |
-| Kong         |            | Yes      |                   | Yes     | Yes     | Yes                 |
+| Kong         |            | Yes[^1]  |                   | Yes     | Yes     | Yes                 |
 | Node         | Yes        |          |                   | Yes     | Yes     |                     |
 | OpenShift    | Yes        | Yes[^1]  |                   | Yes     | Yes     | Yes                 |
 | Pod          |            | Yes      | Yes               | Yes     |         |                     |
 | Service      | Yes        | Yes[^1]  | Yes[^1][^2]       | Yes[^3] | Yes     | Yes                 |
 | Skipper      | Yes        | Yes[^1]  |                   | Yes     | Yes     | Yes                 |
-| Traefik      |            | Yes      |                   | Yes     | Yes     | Yes                 |
+| Traefik      |            | Yes[^1]  |                   | Yes     | Yes     | Yes                 |
 
 [^1]: Unless the `--ignore-hostname-annotation` flag is specified.
 [^2]: Only behaves differently than `hostname` for `Service`s of type `ClusterIP` or `LoadBalancer`.

--- a/source/store.go
+++ b/source/store.go
@@ -300,7 +300,7 @@ func BuildWithConfig(ctx context.Context, source string, p ClientGenerator, cfg 
 		if err != nil {
 			return nil, err
 		}
-		return NewTraefikSource(ctx, dynamicClient, kubernetesClient, cfg.Namespace, cfg.AnnotationFilter)
+		return NewTraefikSource(ctx, dynamicClient, kubernetesClient, cfg.Namespace, cfg.AnnotationFilter, cfg.IgnoreHostnameAnnotation)
 	case "openshift-route":
 		ocpClient, err := p.OpenShiftClient()
 		if err != nil {
@@ -341,7 +341,7 @@ func BuildWithConfig(ctx context.Context, source string, p ClientGenerator, cfg 
 		if err != nil {
 			return nil, err
 		}
-		return NewKongTCPIngressSource(ctx, dynamicClient, kubernetesClient, cfg.Namespace, cfg.AnnotationFilter)
+		return NewKongTCPIngressSource(ctx, dynamicClient, kubernetesClient, cfg.Namespace, cfg.AnnotationFilter, cfg.IgnoreHostnameAnnotation)
 	case "f5-virtualserver":
 		kubernetesClient, err := p.KubeClient()
 		if err != nil {


### PR DESCRIPTION

**Description**

Makes the `--ignore-hostname-annotation` flag more consistent by making it affect the Kong and Traefik sources as well.

The Pod source then becomes the only source that isn't affected by the flag. This is because the Pod source has  no other source of hostnames.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
