### PR TITLE
fix(httpProxy): drop status==valid filter

### DIFF
--- a/source/contour_httpproxy.go
+++ b/source/contour_httpproxy.go
@@ -140,9 +140,6 @@ func (sc *httpProxySource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint,
 			log.Debugf("Skipping HTTPProxy %s/%s because controller value does not match, found: %s, required: %s",
 				hp.Namespace, hp.Name, controller, controllerAnnotationValue)
 			continue
-		} else if hp.Status.CurrentStatus != "valid" {
-			log.Debugf("Skipping HTTPProxy %s/%s because it is not valid", hp.Namespace, hp.Name)
-			continue
 		}
 
 		hpEndpoints, err := sc.endpointsFromHTTPProxy(hp)
@@ -244,11 +241,6 @@ func (sc *httpProxySource) filterByAnnotations(httpProxies []*projectcontour.HTT
 
 // endpointsFromHTTPProxyConfig extracts the endpoints from a Contour HTTPProxy object
 func (sc *httpProxySource) endpointsFromHTTPProxy(httpProxy *projectcontour.HTTPProxy) ([]*endpoint.Endpoint, error) {
-	if httpProxy.Status.CurrentStatus != "valid" {
-		log.Warn(errors.Errorf("cannot generate endpoints for HTTPProxy with status %s", httpProxy.Status.CurrentStatus))
-		return nil, nil
-	}
-
 	resource := fmt.Sprintf("HTTPProxy/%s/%s", httpProxy.Namespace, httpProxy.Name)
 
 	ttl := getTTLFromAnnotations(httpProxy.Annotations, resource)

--- a/source/contour_httpproxy_test.go
+++ b/source/contour_httpproxy_test.go
@@ -270,14 +270,6 @@ func testEndpointsFromHTTPProxy(t *testing.T) {
 			expected:  []*endpoint.Endpoint{},
 		},
 		{
-			title: "one rule.host invalid httpproxy",
-			httpProxy: fakeHTTPProxy{
-				host:    "foo.bar",
-				invalid: true,
-			},
-			expected: []*endpoint.Endpoint{},
-		},
-		{
 			title:     "no targets",
 			httpProxy: fakeHTTPProxy{},
 			expected:  []*endpoint.Endpoint{},
@@ -1114,19 +1106,11 @@ type fakeHTTPProxy struct {
 	annotations map[string]string
 
 	host         string
-	invalid      bool
 	delegate     bool
 	loadBalancer fakeLoadBalancerService
 }
 
 func (ir fakeHTTPProxy) HTTPProxy() *projectcontour.HTTPProxy {
-	var status string
-	if ir.invalid {
-		status = "invalid"
-	} else {
-		status = "valid"
-	}
-
 	var spec projectcontour.HTTPProxySpec
 	if ir.delegate {
 		spec = projectcontour.HTTPProxySpec{}
@@ -1161,7 +1145,6 @@ func (ir fakeHTTPProxy) HTTPProxy() *projectcontour.HTTPProxy {
 		},
 		Spec: spec,
 		Status: projectcontour.HTTPProxyStatus{
-			CurrentStatus: status,
 			LoadBalancer:  lb,
 		},
 	}


### PR DESCRIPTION
**Description**
According to the contour design docs: [conflict](https://github.com/projectcontour/contour/blob/main/design/httpproxy-conflict.md), [status](https://github.com/projectcontour/contour/blob/main/design/httpproxy-status-conditions.md)
The status field can be invalid in many different situations, even not directly related to the httpProxy definition.
Also, most of them are not fatal and contour will try to serve traffic by other rules, even if one of the routing paths is broken.

As an example we currently working on defining an API gateway based on HTTPProxy, and a situation can happen when the service underlines gateway, can be deleted or renamed accidentally (that situation will lead to downtime because of external-dns filter out "invalid" definitions and drop our DNS record - this is the main issue here). 

There is an example of an invalid state, where the contour can send traffic by other routes, but external-dns will delete the record because of only "valid" filtering.
```
status:
  conditions:
    - errors:
        - message: >-
            Spec.Routes unresolved service reference: service
            "app-ns/ab-tests1" not found
  currentStatus: invalid
  description: At least one error present, see Errors for details
  loadBalancer:
    ingress:
      - hostname: lpfk.example.com
```

In the parse function `endpointsFromHTTPProxy` we only read three fields:

1. `metadata.annotations`
2. `spec.virtualhost.fqdn` (which we check for emptiness and it can't be empty in normal circumstances)
3. `status.loadBalancer.ingress` - controlled by contour and validated/defined by contour pkg. 

```
kubectl -n app-ns apply --force -f ./broken.httpProxy.yaml
The HTTPProxy "broken-proxy" is invalid: spec.virtualhost.fqdn: Required value
````

I suggest dropping valid/invalid filtering completely, another ingress (istio, gloo & etc) resources just don't have that field and if ingress itself exists - a record must be created. That is expected behavior.
Behavior where we check the internal state of objects, like senseless but syntax valid objects, missing services, tls - is not external-dns part of the job.

Thanks!

**Checklist**
- [x] Unit tests updated
- [x] End user documentation updated - not applicable
