### PR TITLE
Add support for adguard home

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ ExternalDNS allows you to keep selected zones (via `--domain-filter`) synchroniz
 * [TencentCloud DNSPod](https://cloud.tencent.com/product/cns)
 * [Plural](https://www.plural.sh/)
 * [Pi-hole](https://pi-hole.net/)
+* [Adguard Home](https://github.com/AdguardTeam/AdGuardHome)
 
 ExternalDNS is, by default, aware of the records it is managing, therefore it can safely manage non-empty hosted zones. We strongly encourage you to set `--txt-owner-id` to a unique value that doesn't change for the lifetime of your cluster. You might also want to run ExternalDNS in a dry run mode (`--dry-run` flag) to see the changes to be submitted to your DNS Provider API.
 
@@ -123,6 +124,7 @@ The following table clarifies the current status of the providers according to t
 | TencentCloud | Alpha | @Hyzhou |
 | Plural | Alpha | @michaeljguarino |
 | Pi-hole | Alpha | @tinyzimmer |
+| Adguard Home | Alpha | |
 
 ## Kubernetes version compatibility
 

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ import (
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns/validation"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
+	"sigs.k8s.io/external-dns/provider/adguard"
 	"sigs.k8s.io/external-dns/provider/akamai"
 	"sigs.k8s.io/external-dns/provider/alibabacloud"
 	"sigs.k8s.io/external-dns/provider/aws"
@@ -405,6 +406,12 @@ func main() {
 		p, err = tencentcloud.NewTencentCloudProvider(domainFilter, zoneIDFilter, cfg.TencentCloudConfigFile, cfg.TencentCloudZoneType, cfg.DryRun)
 	case "webhook":
 		p, err = webhook.NewWebhookProvider(cfg.WebhookProviderURL)
+	case "adguard":
+		p, err = adguard.NewProvider(adguard.Config{
+			Username: cfg.AdguardHomeUser,
+			Password: cfg.AdguardHomePassword,
+			Server:   cfg.AdguardHomeServer,
+		})
 	default:
 		log.Fatalf("unknown dns provider: %s", cfg.Provider)
 	}

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -213,6 +213,9 @@ type Config struct {
 	WebhookProviderReadTimeout         time.Duration
 	WebhookProviderWriteTimeout        time.Duration
 	WebhookServer                      bool
+	AdguardHomeServer                  string
+	AdguardHomeUser                    string
+	AdguardHomePassword                string `secure:"yes"`
 }
 
 var defaultConfig = &Config{
@@ -454,7 +457,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("exclude-target-net", "Exclude target nets (optional)").StringsVar(&cfg.ExcludeTargetNets)
 
 	// Flags related to providers
-	providers := []string{"akamai", "alibabacloud", "aws", "aws-sd", "azure", "azure-dns", "azure-private-dns", "bluecat", "civo", "cloudflare", "coredns", "designate", "digitalocean", "dnsimple", "dyn", "exoscale", "gandi", "godaddy", "google", "ibmcloud", "infoblox", "inmemory", "linode", "ns1", "oci", "ovh", "pdns", "pihole", "plural", "rcodezero", "rdns", "rfc2136", "safedns", "scaleway", "skydns", "tencentcloud", "transip", "ultradns", "vinyldns", "vultr", "webhook"}
+	providers := []string{"akamai", "alibabacloud", "aws", "aws-sd", "azure", "azure-dns", "azure-private-dns", "bluecat", "civo", "cloudflare", "coredns", "designate", "digitalocean", "dnsimple", "dyn", "exoscale", "gandi", "godaddy", "google", "ibmcloud", "infoblox", "inmemory", "linode", "ns1", "oci", "ovh", "pdns", "pihole", "plural", "rcodezero", "rdns", "rfc2136", "safedns", "scaleway", "skydns", "tencentcloud", "transip", "ultradns", "vinyldns", "vultr", "webhook", "adguard"}
 	app.Flag("provider", "The DNS provider where the DNS records will be created (required, options: "+strings.Join(providers, ", ")+")").Required().PlaceHolder("provider").EnumVar(&cfg.Provider, providers...)
 	app.Flag("domain-filter", "Limit possible target zones by a domain suffix; specify multiple times for multiple domains (optional)").Default("").StringsVar(&cfg.DomainFilter)
 	app.Flag("exclude-domains", "Exclude subdomains (optional)").Default("").StringsVar(&cfg.ExcludeDomains)

--- a/provider/adguard/adguard.go
+++ b/provider/adguard/adguard.go
@@ -1,0 +1,287 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adguard
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
+)
+
+const (
+	ListRewrites  = "/control/rewrite/list"
+	DeleteRewrite = "/control/rewrite/delete"
+	CreateRwrite  = "/control/rewrite/add"
+	UpdateRewrite = "/control/rewrite/update"
+)
+
+var (
+	ErrInvalidConfig = errors.New("invalid config")
+)
+
+// RewriteEntry represents the RewriteEntry in Adguard's API
+type RewriteEntry struct {
+	// Domain is the domain Adguard will rewrite
+	Domain string `json:"domain"`
+	// Answer is the A, AAA, or CNAME Adguard will rewrite to
+	Answer string `json:"answer"`
+}
+
+type UpdateRewriteEntry struct {
+	Target RewriteEntry `json:"target"`
+	Update RewriteEntry `json:"update"`
+}
+
+type httpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+func defaultHttpClient() httpClient {
+	return &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return errors.New("redirect attmempted")
+		},
+	}
+}
+
+// Provider is the provider implementation for AdGuard Home
+//
+// AdGuard Home API documentation is located at https://github.com/AdguardTeam/AdGuardHome/tree/master/openapi
+type Provider struct {
+	provider.BaseProvider
+	config Config
+
+	client httpClient
+}
+
+// Explicitly ensure interface is implemented
+var _ provider.Provider = &Provider{}
+
+// NewProvider creates a provder for AdGuard Home
+func NewProvider(config Config) (*Provider, error) {
+	if err := config.validate(); err != nil {
+		return nil, errors.Join(ErrInvalidConfig, err)
+	}
+	return &Provider{
+		config: config,
+		client: defaultHttpClient(),
+	}, nil
+}
+
+func (ap Provider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	resp, err := ap.makeRequest(ctx, http.MethodGet, ListRewrites, nil)
+	if err != nil {
+		return nil, fmt.Errorf("adguard records: %w", err)
+	}
+
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("bad response: %v", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	var records []RewriteEntry
+	if err := json.Unmarshal(body, &records); err != nil {
+		return nil, fmt.Errorf("unmarshal body: %w", err)
+	}
+
+	return recordsToEndpoints(records), nil
+}
+
+func (ap Provider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
+	if changes == nil || !changes.HasChanges() {
+		return nil
+	}
+
+	if err := ap.createEndpoints(ctx, changes.Create); err != nil {
+		return fmt.Errorf("adguard create: %w", err)
+	}
+
+	if err := ap.deleteEndpoints(ctx, changes.Delete); err != nil {
+		return fmt.Errorf("adguard delete: %w", err)
+	}
+
+	if err := ap.updateEndpoints(ctx, changes.UpdateOld, changes.UpdateNew); err != nil {
+		return fmt.Errorf("adguard update: %w", err)
+	}
+
+	return nil
+}
+
+func (ap Provider) createEndpoints(ctx context.Context, endpoints []*endpoint.Endpoint) error {
+	for _, endpoint := range endpoints {
+		if err := ap.createEndpoint(ctx, endpoint); err != nil {
+			return fmt.Errorf("create %s: %w", endpoint.DNSName, err)
+		}
+	}
+
+	return nil
+}
+
+func (ap Provider) createEndpoint(ctx context.Context, endpoint *endpoint.Endpoint) error {
+	resp, err := ap.postRequest(ctx, endpoint, CreateRwrite)
+	if err != nil {
+		return err
+	}
+
+	return validateResponse(resp)
+}
+
+func (ap Provider) deleteEndpoints(ctx context.Context, endpoints []*endpoint.Endpoint) error {
+	for _, endpoint := range endpoints {
+		if err := ap.deleteEndpoint(ctx, endpoint); err != nil {
+			return fmt.Errorf("delete %s: %w", endpoint.DNSName, err)
+		}
+	}
+	return nil
+}
+
+func (ap Provider) deleteEndpoint(ctx context.Context, endpoint *endpoint.Endpoint) error {
+	resp, err := ap.postRequest(ctx, endpoint, DeleteRewrite)
+	if err != nil {
+		return err
+	}
+
+	return validateResponse(resp)
+}
+
+func (ap Provider) updateEndpoints(ctx context.Context, oldEndpoints, newEndpoints []*endpoint.Endpoint) error {
+	oldMapping := map[string]*endpoint.Endpoint{}
+	for _, old := range oldEndpoints {
+		oldMapping[old.DNSName] = old
+	}
+
+	for _, endpoint := range newEndpoints {
+		if err := ap.updateEndpoint(ctx, oldMapping[endpoint.DNSName], endpoint); err != nil {
+			return fmt.Errorf("update %s: %w", endpoint.DNSName, err)
+		}
+	}
+
+	return nil
+}
+
+func (ap Provider) updateEndpoint(ctx context.Context, old, new *endpoint.Endpoint) error {
+	updateData := UpdateRewriteEntry{
+		Target: RewriteEntry{
+			Domain: old.DNSName,
+			Answer: old.Targets.String(),
+		},
+		Update: RewriteEntry{
+			Domain: new.DNSName,
+			Answer: new.Targets.String(),
+		},
+	}
+	json, err := json.Marshal(updateData)
+	if err != nil {
+		return err
+	}
+
+	resp, err := ap.makeRequest(ctx, http.MethodPut, UpdateRewrite, bytes.NewBuffer(json))
+	if err != nil {
+		return err
+	}
+
+	return validateResponse(resp)
+}
+
+func (ap Provider) postRequest(ctx context.Context, endpoint *endpoint.Endpoint, reqPath string) (*http.Response, error) {
+	entryBytes, err := getRewriteEntryJson(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := ap.makeRequest(ctx, http.MethodPost, reqPath, bytes.NewBuffer(entryBytes))
+	if err != nil {
+		return nil, fmt.Errorf("make request: %w", err)
+	}
+
+	return resp, nil
+}
+
+func (ap Provider) makeRequest(ctx context.Context, method string, reqPath string, data io.Reader) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, ap.config.Server+reqPath, data)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	req.SetBasicAuth(ap.config.Username, ap.config.Password)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ap.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("do request: %w", err)
+	}
+
+	return resp, err
+}
+
+func validateResponse(resp *http.Response) error {
+	if resp != nil {
+		defer func() { resp.Body.Close() }()
+		io.ReadAll(resp.Body)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("bad response: %v", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func getRewriteEntryJson(endpoint *endpoint.Endpoint) ([]byte, error) {
+	entry := RewriteEntry{
+		Domain: endpoint.DNSName,
+		Answer: endpoint.Targets.String(),
+	}
+
+	entryBytes, err := json.Marshal(entry)
+	if err != nil {
+		return nil, fmt.Errorf("json marshal: %w", err)
+	}
+	return entryBytes, nil
+}
+
+func recordsToEndpoints(records []RewriteEntry) []*endpoint.Endpoint {
+	endpoints := make([]*endpoint.Endpoint, len(records))
+	for i, record := range records {
+		if isAnswerCNAME(record.Answer) {
+			endpoints[i] = endpoint.NewEndpoint(record.Domain, endpoint.RecordTypeCNAME, record.Answer)
+		} else {
+			endpoints[i] = endpoint.NewEndpoint(record.Domain, endpoint.RecordTypeA, record.Answer)
+		}
+	}
+
+	return endpoints
+}
+
+func isAnswerCNAME(answer string) bool {
+	ip := net.ParseIP(answer)
+	return ip == nil
+}

--- a/provider/adguard/adguard_test.go
+++ b/provider/adguard/adguard_test.go
@@ -1,0 +1,412 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adguard
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
+)
+
+// mockClient mocks the http client and response
+//
+// maintains a map of records based on operations
+type mockClient struct {
+	resp *http.Response
+	err  error
+
+	t *testing.T
+
+	// records are potentially modified when Do is called
+	records map[string]RewriteEntry
+}
+
+func (mc mockClient) Do(req *http.Request) (*http.Response, error) {
+	mc.t.Helper()
+	defer func() {
+		if req != nil && req.Body != nil {
+			req.Body.Close()
+		}
+	}()
+
+	if mc.resp != nil || mc.err != nil {
+		return mc.resp, mc.err
+	}
+
+	switch req.URL.Path {
+	case ListRewrites:
+		entries := make([]RewriteEntry, 0, len(mc.records))
+		for _, entry := range mc.records {
+			entries = append(entries, entry)
+		}
+		jsonBytes, err := json.Marshal(entries)
+		if err != nil {
+			mc.t.Errorf("failed to marshal json: %v", err)
+		}
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewBuffer(jsonBytes)),
+		}
+		return resp, nil
+	case DeleteRewrite:
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			resp := &http.Response{
+				StatusCode: 400,
+				Body:       io.NopCloser(strings.NewReader("bad request")),
+			}
+			return resp, err
+		}
+		entry := &RewriteEntry{}
+		if err := json.Unmarshal(body, entry); err != nil {
+			resp := &http.Response{
+				StatusCode: 400,
+				Body:       io.NopCloser(strings.NewReader("bad request")),
+			}
+			return resp, err
+		}
+		delete(mc.records, entry.Domain)
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("OK"))}, nil
+	case CreateRwrite:
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			resp := &http.Response{
+				StatusCode: 400,
+				Body:       io.NopCloser(strings.NewReader("bad request")),
+			}
+			return resp, err
+		}
+		entry := &RewriteEntry{}
+		if err := json.Unmarshal(body, entry); err != nil {
+			resp := &http.Response{
+				StatusCode: 400,
+				Body:       io.NopCloser(strings.NewReader("bad request")),
+			}
+			return resp, err
+		}
+		mc.records[entry.Domain] = *entry
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("OK"))}, nil
+	case UpdateRewrite:
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			resp := &http.Response{
+				StatusCode: 400,
+				Body:       io.NopCloser(strings.NewReader("bad request")),
+			}
+			return resp, err
+		}
+		entry := &UpdateRewriteEntry{}
+		if err := json.Unmarshal(body, entry); err != nil {
+			resp := &http.Response{
+				StatusCode: 400,
+				Body:       io.NopCloser(strings.NewReader("bad request")),
+			}
+			return resp, err
+		}
+		existing, ok := mc.records[entry.Target.Domain]
+		if !ok || existing.Answer != entry.Target.Answer || entry.Update.Domain != entry.Target.Domain {
+			resp := &http.Response{
+				StatusCode: 400,
+				Body:       io.NopCloser(strings.NewReader("bad request - existing not found")),
+			}
+			return resp, nil
+		}
+		mc.records[entry.Update.Domain] = entry.Update
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("OK"))}, nil
+	default:
+		mc.t.Errorf("Received invalid path: %s", req.URL.Path)
+		return nil, nil
+	}
+}
+
+func TestNewAdguardProvider(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  Config
+		want    *Provider
+		wantErr error
+	}{
+		{
+			name: "Invalid Username",
+			config: Config{
+				Password: "superDuperSecret",
+				Server:   "https://where.you.run.adguard.fqdn",
+			},
+			wantErr: ErrInvalidUsername,
+		},
+		{
+			name: "Invalid Password",
+			config: Config{
+				Username: "greatestUsernameEver",
+				Server:   "https://where.you.run.adguard.fqdn",
+			},
+			wantErr: ErrInvalidPassword,
+		},
+		{
+			name: "Invalid Endpoint",
+			config: Config{
+				Username: "greatestUsernameEver",
+				Password: "superDuperSecret",
+			},
+			wantErr: ErrInvalidEndpoint,
+		},
+		{
+			name:    "Multiple Issues",
+			config:  Config{},
+			wantErr: ErrInvalidConfig,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewProvider(tt.config)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("NewAdguardProvider() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewAdguardProvider() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProvider_Records(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  Config
+		client  httpClient
+		want    []*endpoint.Endpoint
+		wantErr error
+	}{
+		{
+			name:   "Happy Path - has rewrites",
+			config: Config{},
+			client: mockClient{
+				t: t,
+				records: map[string]RewriteEntry{
+					"foo.bar.baz":      {Domain: "foo.bar.baz", Answer: "10.11.12.13"},
+					"stuff.and.things": {Domain: "stuff.and.things", Answer: "foo.bar.baz"},
+				},
+			},
+			want: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo.bar.baz", endpoint.RecordTypeA, "10.11.12.13"),
+				endpoint.NewEndpoint("stuff.and.things", endpoint.RecordTypeCNAME, "foo.bar.baz"),
+			},
+		},
+		{
+			name:   "Happy Path - no rewrites",
+			config: Config{},
+			client: mockClient{
+				t:       t,
+				records: map[string]RewriteEntry{},
+			},
+			want: []*endpoint.Endpoint{},
+		},
+		{
+			name:   "Throws an error",
+			config: Config{},
+			client: mockClient{
+				t:       t,
+				records: map[string]RewriteEntry{},
+				err:     assert.AnError,
+			},
+			want:    []*endpoint.Endpoint{},
+			wantErr: assert.AnError,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			ap := Provider{
+				config: tt.config,
+				client: tt.client,
+			}
+
+			got, err := ap.Records(ctx)
+			assert.ErrorIs(t, err, tt.wantErr)
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}
+
+func Test_recordsToEndpoints(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		records []RewriteEntry
+		want    []*endpoint.Endpoint
+	}{
+		{
+			name: "Mixed CNAME and IP answer",
+			records: []RewriteEntry{
+				{
+					Domain: "best.domain.ever",
+					Answer: "10.11.12.13",
+				},
+				{
+					Domain: "worst.domain.ever",
+					Answer: "best.domain.ever",
+				},
+			},
+			want: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("best.domain.ever", endpoint.RecordTypeA, "10.11.12.13"),
+				endpoint.NewEndpoint("worst.domain.ever", endpoint.RecordTypeCNAME, "best.domain.ever"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := recordsToEndpoints(tt.records); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("recordsToEndpoints() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProvider_ApplyChanges(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		config Config
+		client *mockClient
+	}
+	tests := []struct {
+		name        string
+		fields      fields
+		changes     *plan.Changes
+		wantErr     error
+		wantRecords map[string]RewriteEntry
+	}{
+		{
+			name: "Delete happy path",
+			fields: fields{
+				config: Config{
+					Username: "userHere",
+					Password: "superSecret",
+					Server:   "https://where.adguard.is.hosted",
+				},
+				client: &mockClient{
+					t: t,
+					records: map[string]RewriteEntry{
+						"some.cname.record": {Domain: "some.cname.record", Answer: "some.other.record"},
+						"some.a.record":     {Domain: "some.a.record", Answer: "10.0.0.10"},
+						"existing.entry":    {Domain: "existing.entry", Answer: "1.2.3.4"},
+					},
+				},
+			},
+			changes: &plan.Changes{
+				Delete: []*endpoint.Endpoint{
+					endpoint.NewEndpoint("some.cname.record", endpoint.RecordTypeCNAME, "some.other.record"),
+					endpoint.NewEndpoint("some.a.record", endpoint.RecordTypeA, "10.0.0.10"),
+				},
+			},
+			wantRecords: map[string]RewriteEntry{
+				"existing.entry": {Domain: "existing.entry", Answer: "1.2.3.4"},
+			},
+		},
+		{
+			name: "Create happy path",
+			fields: fields{
+				config: Config{
+					Username: "userHere",
+					Password: "superSecret",
+					Server:   "https://where.adguard.is.hosted",
+				},
+				client: &mockClient{
+					t: t,
+					records: map[string]RewriteEntry{
+						"existing.entry": {Domain: "existing.entry", Answer: "1.2.3.4"},
+					},
+				},
+			},
+			changes: &plan.Changes{
+				Create: []*endpoint.Endpoint{
+					endpoint.NewEndpoint("create.domain.here", endpoint.RecordTypeA, "10.10.10.10"),
+				},
+			},
+			wantRecords: map[string]RewriteEntry{
+				"create.domain.here": {Domain: "create.domain.here", Answer: "10.10.10.10"},
+				"existing.entry":     {Domain: "existing.entry", Answer: "1.2.3.4"},
+			},
+		},
+		{
+			name: "Update happy path",
+			fields: fields{
+				config: Config{
+					Username: "userHere",
+					Password: "superSecret",
+					Server:   "https://where.adguard.is.hosted",
+				},
+				client: &mockClient{
+					t: t,
+					records: map[string]RewriteEntry{
+						"update.domain.here": {Domain: "update.domain.here", Answer: "10.0.0.1"},
+					},
+				},
+			},
+			changes: &plan.Changes{
+				UpdateNew: []*endpoint.Endpoint{
+					endpoint.NewEndpoint("update.domain.here", endpoint.RecordTypeA, "10.10.10.10"),
+				},
+				UpdateOld: []*endpoint.Endpoint{
+					endpoint.NewEndpoint("update.domain.here", endpoint.RecordTypeA, "10.0.0.1"),
+				},
+			},
+			wantRecords: map[string]RewriteEntry{
+				"update.domain.here": {Domain: "update.domain.here", Answer: "10.10.10.10"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			ap := Provider{
+				BaseProvider: provider.BaseProvider{},
+				config:       tt.fields.config,
+				client:       tt.fields.client,
+			}
+			assert.ErrorIs(t, ap.ApplyChanges(ctx, tt.changes), tt.wantErr)
+			assert.Equal(t, tt.wantRecords, tt.fields.client.records)
+		})
+	}
+}

--- a/provider/adguard/config.go
+++ b/provider/adguard/config.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adguard
+
+import (
+	"errors"
+
+	"sigs.k8s.io/external-dns/endpoint"
+)
+
+var (
+	ErrInvalidUsername = errors.New("invalid username")
+	ErrInvalidPassword = errors.New("invalid password")
+	ErrInvalidEndpoint = errors.New("invalid endpoint")
+)
+
+type Config struct {
+	// Username is the username used to authenticate with Adguard Home.
+	// Required.
+	Username string
+	// Password is the plain text password used to authenticate.
+	// Required.
+	Password string
+	// Server where Adguard Home can be reached.
+	// Required
+	Server       string
+	DomainFilter endpoint.DomainFilter
+}
+
+func (ac Config) validate() error {
+	if ac.Username == "" {
+		return ErrInvalidUsername
+	}
+	if ac.Password == "" {
+		return ErrInvalidPassword
+	}
+	if ac.Server == "" {
+		return ErrInvalidEndpoint
+	}
+
+	return nil
+}


### PR DESCRIPTION


<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
I would like to use external dns with adguard home. #3243 appears to have been closed due to no activity.

I've taken a stab at implementation here. I've been unable to build and push the image to my private repository, so this has limited testing testing. I've included tests and verified that CRUD operations work against my deployment of adguard home.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #3243 

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
