### PR TITLE
use `port.Name` to populate srv records

### DIFF
--- a/source/service.go
+++ b/source/service.go
@@ -724,13 +724,19 @@ func (sc *serviceSource) extractNodePortEndpoints(svc *v1.Service, hostname stri
 			// see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
 			serviceName := svc.ObjectMeta.Name
 
+			// figure out the port name
+			portName := strings.ToLower(string(port.Name))
+			if portName == "" {
+				portName = serviceName
+			}
+
 			// figure out the protocol
 			protocol := strings.ToLower(string(port.Protocol))
 			if protocol == "" {
 				protocol = "tcp"
 			}
 
-			recordName := fmt.Sprintf("_%s._%s.%s", serviceName, protocol, hostname)
+			recordName := fmt.Sprintf("_%s._%s.%s", portName, protocol, hostname)
 
 			var ep *endpoint.Endpoint
 			if ttl.IsConfigured() {


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
It is in the best intention of the user to name their services with a self-explanatory identifier and not with the canonical protocol specification.

Let's image we use the [bitnami mongodb-sharded chart](https://github.com/bitnami/charts/tree/main/bitnami/mongodb-sharded) to create a database that we'll expose using srv records. The chart will create a service along the lines of:
```yaml
apiVersion: v1
kind: Service
metadata:
  name: orders-db
  annotations:
    external-dns.alpha.kubernetes.io/hostname: orders.acme.com
spec:
    type: NodePort
    ports:
    - name: mongodb
      port: 27017
      targetPort: mongodb
    - name: metrics
      port: 9216
      targetPort: metrics
```

Not only the mongodb client will expect the following srv to connect `_mongodb._tcp.orders.acme.com` when the actual dns record that will be created is `_orders-db._tcp.orders.acme.com` but also this srv record will have 2 values:

```
_orders-db._tcp.orders.acme.com 300 IN SRV 0 50 30225 orders.acme.com
_orders-db._tcp.orders.acme.com 300 IN SRV 0 50 31971 orders.acme.com
```

It will be much better to get the fqdn using the port's name to construct the following 2 records:

```
_mongodb._tcp.orders.acme.com. 300 IN SRV 0 50 31971 orders.acme.com.
_metrics._tcp.orders.acme.com. 300 IN SRV 0 50 30225 orders.acme.com.
```

<br class="Apple-interchange-newline">


<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4000

*NOTE: As this is my first pr here and I don't have that much experience with go. i'll wait for a reply before changing the unit tests and run the whole suite*

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
