### PR TITLE
Update Scaleway provider to support config files

### DIFF
--- a/docs/tutorials/scaleway.md
+++ b/docs/tutorials/scaleway.md
@@ -19,7 +19,16 @@ In this example we will use `example.com` as an example.
 To use ExternalDNS with Scaleway DNS, you need to create an API token (composed of the Access Key and the Secret Key).
 You can either use existing ones or you can create a new token, as explained in [How to generate an API token](https://www.scaleway.com/en/docs/generate-an-api-token/) or directly by going to the [credentials page](https://console.scaleway.com/account/organization/credentials).
 
+Scaleway provider supports configuring credentials using profiles or supplying it directly with environment variables.
 
+### Configuration using a config file
+You can supply the credentials through a config file:
+1. Create the config file. Check out [Scaleway docs](https://github.com/scaleway/scaleway-sdk-go/blob/master/scw/README.md#scaleway-config) for instructions
+2. Mount it as a Secret into the Pod
+3. Configure environment variable `SCW_PROFILE` to match the profile name in the config file
+4. Configure environment variable `SCW_CONFIG_PATH` to match the location of the mounted config file
+
+### Configuration using environment variables
 Two environment variables are needed to run ExternalDNS with Scaleway DNS:
 - `SCW_ACCESS_KEY` which is the Access Key.
 - `SCW_SECRET_KEY` which is the Secret Key.
@@ -61,6 +70,20 @@ spec:
           value: "<your access key>"
         - name: SCW_SECRET_KEY
           value: "<your secret key>"
+        ### Set if configuring using a config file. Make sure to create the Secret first.
+        # - name: SCW_PROFILE
+        #   value: "<profile name>"
+        # - name: SCW_CONFIG_PATH
+        #   value: /etc/scw/config.yaml
+    #     volumeMounts:
+    #     - name: scw-config
+    #       mountPath: /etc/scw/config.yaml
+    #       readOnly: true
+    # volumes:
+    # - name: scw-config
+    #   secret:
+    #     secretName: scw-config
+    ###
 ```
 
 ### Manifest (for clusters with RBAC enabled)
@@ -127,6 +150,20 @@ spec:
           value: "<your access key>"
         - name: SCW_SECRET_KEY
           value: "<your secret key>"
+        ### Set if configuring using a config file. Make sure to create the Secret first.
+        # - name: SCW_PROFILE
+        #   value: "<profile name>"
+        # - name: SCW_CONFIG_PATH
+        #   value: /etc/scw/config.yaml
+    #     volumeMounts:
+    #     - name: scw-config
+    #       mountPath: /etc/scw/config.yaml
+    #       readOnly: true
+    # volumes:
+    # - name: scw-config
+    #   secret:
+    #     secretName: scw-config
+    ###
 ```
 
 

--- a/provider/scaleway/scaleway.go
+++ b/provider/scaleway/scaleway.go
@@ -65,7 +65,9 @@ func NewScalewayProvider(ctx context.Context, domainFilter endpoint.DomainFilter
 			defaultPageSize = 1000
 		}
 	}
+	p, _ := scw.MustLoadConfig().GetActiveProfile()
 	scwClient, err := scw.NewClient(
+		scw.WithProfile(p),
 		scw.WithEnv(),
 		scw.WithUserAgent("ExternalDNS/"+externaldns.Version),
 		scw.WithDefaultPageSize(uint32(defaultPageSize)),

--- a/provider/scaleway/scaleway_test.go
+++ b/provider/scaleway/scaleway_test.go
@@ -111,9 +111,26 @@ func (m *mockScalewayDomain) UpdateDNSZoneRecords(req *domain.UpdateDNSZoneRecor
 }
 
 func TestScalewayProvider_NewScalewayProvider(t *testing.T) {
+	profile := `profiles:
+  foo:
+    access_key: SCWXXXXXXXXXXXXXXXXX
+    secret_key: 11111111-1111-1111-1111-111111111111
+`
+	tmpDir := t.TempDir()
+	err := os.WriteFile(tmpDir+"/config.yaml", []byte(profile), 0600)
+	if err != nil {
+		t.Errorf("failed : %s", err)
+	}
+	_ = os.Setenv(scw.ScwActiveProfileEnv, "foo")
+	_ = os.Setenv(scw.ScwConfigPathEnv, tmpDir+"/config.yaml")
+	_, err = NewScalewayProvider(context.TODO(), endpoint.NewDomainFilter([]string{"example.com"}), true)
+	if err != nil {
+		t.Errorf("failed : %s", err)
+	}
+
 	_ = os.Setenv(scw.ScwAccessKeyEnv, "SCWXXXXXXXXXXXXXXXXX")
 	_ = os.Setenv(scw.ScwSecretKeyEnv, "11111111-1111-1111-1111-111111111111")
-	_, err := NewScalewayProvider(context.TODO(), endpoint.NewDomainFilter([]string{"example.com"}), true)
+	_, err = NewScalewayProvider(context.TODO(), endpoint.NewDomainFilter([]string{"example.com"}), true)
 	if err != nil {
 		t.Errorf("failed : %s", err)
 	}


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Update Scaleway provider to support supplying the credentials through config files. A config file can be read from a Secret mounted as a Volume inside the Pod.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
