### PR TITLE
service source uses externalIPs in ExternalName type if available

### DIFF
--- a/docs/sources/service.md
+++ b/docs/sources/service.md
@@ -106,5 +106,6 @@ as one of the values.
 
 ### ExternalName
 
-Creates a target with the value of the Service's `externalName` field.
+1. If the Service has one or more `spec.externalIPs`, uses the values in that field.
+2. Otherwise, creates a target with the value of the Service's `externalName` field.
 

--- a/source/service.go
+++ b/source/service.go
@@ -555,6 +555,9 @@ func extractServiceIps(svc *v1.Service) endpoint.Targets {
 }
 
 func extractServiceExternalName(svc *v1.Service) endpoint.Targets {
+	if len(svc.Spec.ExternalIPs) > 0 {
+		return svc.Spec.ExternalIPs
+	}
 	return endpoint.Targets{svc.Spec.ExternalName}
 }
 

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -3545,6 +3545,7 @@ func TestExternalServices(t *testing.T) {
 		labels                   map[string]string
 		annotations              map[string]string
 		externalName             string
+		externalIPs              []string
 		expected                 []*endpoint.Endpoint
 		expectError              bool
 	}{
@@ -3562,6 +3563,7 @@ func TestExternalServices(t *testing.T) {
 				hostnameAnnotationKey: "service.example.org",
 			},
 			"111.111.111.111",
+			[]string{},
 			[]*endpoint.Endpoint{
 				{DNSName: "service.example.org", Targets: endpoint.Targets{"111.111.111.111"}, RecordType: endpoint.RecordTypeA},
 			},
@@ -3581,6 +3583,7 @@ func TestExternalServices(t *testing.T) {
 				hostnameAnnotationKey: "service.example.org",
 			},
 			"2001:db8::111",
+			[]string{},
 			[]*endpoint.Endpoint{
 				{DNSName: "service.example.org", Targets: endpoint.Targets{"2001:db8::111"}, RecordType: endpoint.RecordTypeAAAA},
 			},
@@ -3600,8 +3603,29 @@ func TestExternalServices(t *testing.T) {
 				hostnameAnnotationKey: "service.example.org",
 			},
 			"remote.example.com",
+			[]string{},
 			[]*endpoint.Endpoint{
 				{DNSName: "service.example.org", Targets: endpoint.Targets{"remote.example.com"}, RecordType: endpoint.RecordTypeCNAME},
+			},
+			false,
+		},
+		{
+			"annotated ExternalName service with externalIPs returns a single endpoint with multiple targets",
+			"",
+			"testing",
+			"foo",
+			v1.ServiceTypeExternalName,
+			"",
+			"",
+			false,
+			map[string]string{"component": "foo"},
+			map[string]string{
+				hostnameAnnotationKey: "service.example.org",
+			},
+			"service.example.org",
+			[]string{"10.2.3.4", "11.2.3.4"},
+			[]*endpoint.Endpoint{
+				{DNSName: "service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"10.2.3.4", "11.2.3.4"}},
 			},
 			false,
 		},
@@ -3617,6 +3641,7 @@ func TestExternalServices(t *testing.T) {
 				Spec: v1.ServiceSpec{
 					Type:         tc.svcType,
 					ExternalName: tc.externalName,
+					ExternalIPs:  tc.externalIPs,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:   tc.svcNamespace,


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
If externalIPs are available in ExternalName type services, then external-dns uses those IPs instead of externalName field.
Useful for developing additional operators..
**Checklist**

- [X] Unit tests updated
- [X] End user documentation updated
