### PR TITLE
fix: dynamodb registry when statements over 25

### DIFF
--- a/registry/dynamodb.go
+++ b/registry/dynamodb.go
@@ -477,6 +477,7 @@ func (im *DynamoDBRegistry) appendDelete(statements []*dynamodb.BatchStatementRe
 func (im *DynamoDBRegistry) executeStatements(ctx context.Context, statements []*dynamodb.BatchStatementRequest, handleErr func(request *dynamodb.BatchStatementRequest, response *dynamodb.BatchStatementResponse) error) error {
 	for len(statements) > 0 {
 		var chunk []*dynamodb.BatchStatementRequest
+                // DynamoDB allows a maximum batch size of 25 items.
 		if len(statements) > 25 {
 			chunk = statements[:25]
 			statements = statements[25:]

--- a/registry/dynamodb.go
+++ b/registry/dynamodb.go
@@ -478,7 +478,7 @@ func (im *DynamoDBRegistry) executeStatements(ctx context.Context, statements []
 	for len(statements) > 0 {
 		var chunk []*dynamodb.BatchStatementRequest
 		if len(statements) > 25 {
-			chunk = chunk[:25]
+			chunk = statements[:25]
 			statements = statements[25:]
 		} else {
 			chunk = statements

--- a/registry/dynamodb.go
+++ b/registry/dynamodb.go
@@ -68,6 +68,9 @@ type DynamoDBRegistry struct {
 
 const dynamodbAttributeMigrate = "dynamodb/needs-migration"
 
+// DynamoDB allows a maximum batch size of 25 items.
+var dynamodbMaxBatchSize uint8 = 25
+
 // NewDynamoDBRegistry returns a new DynamoDBRegistry object.
 func NewDynamoDBRegistry(provider provider.Provider, ownerID string, dynamodbAPI DynamoDBAPI, table string, txtPrefix, txtSuffix, txtWildcardReplacement string, managedRecordTypes, excludeRecordTypes []string, txtEncryptAESKey []byte, cacheInterval time.Duration) (*DynamoDBRegistry, error) {
 	if ownerID == "" {
@@ -477,10 +480,9 @@ func (im *DynamoDBRegistry) appendDelete(statements []*dynamodb.BatchStatementRe
 func (im *DynamoDBRegistry) executeStatements(ctx context.Context, statements []*dynamodb.BatchStatementRequest, handleErr func(request *dynamodb.BatchStatementRequest, response *dynamodb.BatchStatementResponse) error) error {
 	for len(statements) > 0 {
 		var chunk []*dynamodb.BatchStatementRequest
-                // DynamoDB allows a maximum batch size of 25 items.
-		if len(statements) > 25 {
-			chunk = statements[:25]
-			statements = statements[25:]
+		if len(statements) > int(dynamodbMaxBatchSize) {
+			chunk = statements[:dynamodbMaxBatchSize]
+			statements = statements[dynamodbMaxBatchSize:]
 		} else {
 			chunk = statements
 			statements = nil

--- a/registry/dynamodb_test.go
+++ b/registry/dynamodb_test.go
@@ -295,6 +295,603 @@ func TestDynamoDBRegistryApplyChanges(t *testing.T) {
 			},
 		},
 		{
+			name: "create many",
+			changes: plan.Changes{
+				Create: []*endpoint.Endpoint{
+					{
+						DNSName:       "new1.test-zone.example.org",
+						Targets:       endpoint.Targets{"new1.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new1-ingress",
+						},
+					},
+					{
+						DNSName:       "new2.test-zone.example.org",
+						Targets:       endpoint.Targets{"new2.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new2-ingress",
+						},
+					},
+					{
+						DNSName:       "new3.test-zone.example.org",
+						Targets:       endpoint.Targets{"new3.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new3-ingress",
+						},
+					},
+					{
+						DNSName:       "new4.test-zone.example.org",
+						Targets:       endpoint.Targets{"new4.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new4-ingress",
+						},
+					},
+					{
+						DNSName:       "new5.test-zone.example.org",
+						Targets:       endpoint.Targets{"new5.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new5-ingress",
+						},
+					},
+					{
+						DNSName:       "new6.test-zone.example.org",
+						Targets:       endpoint.Targets{"new6.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new6-ingress",
+						},
+					},
+					{
+						DNSName:       "new7.test-zone.example.org",
+						Targets:       endpoint.Targets{"new7.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new7-ingress",
+						},
+					},
+					{
+						DNSName:       "new8.test-zone.example.org",
+						Targets:       endpoint.Targets{"new8.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new8-ingress",
+						},
+					},
+					{
+						DNSName:       "new9.test-zone.example.org",
+						Targets:       endpoint.Targets{"new9.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new9-ingress",
+						},
+					},
+					{
+						DNSName:       "new10.test-zone.example.org",
+						Targets:       endpoint.Targets{"new10.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new10-ingress",
+						},
+					},
+					{
+						DNSName:       "new11.test-zone.example.org",
+						Targets:       endpoint.Targets{"new11.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new11-ingress",
+						},
+					},
+					{
+						DNSName:       "new12.test-zone.example.org",
+						Targets:       endpoint.Targets{"new12.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new12-ingress",
+						},
+					},
+					{
+						DNSName:       "new13.test-zone.example.org",
+						Targets:       endpoint.Targets{"new13.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new13-ingress",
+						},
+					},
+					{
+						DNSName:       "new14.test-zone.example.org",
+						Targets:       endpoint.Targets{"new14.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new14-ingress",
+						},
+					},
+					{
+						DNSName:       "new15.test-zone.example.org",
+						Targets:       endpoint.Targets{"new15.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new15-ingress",
+						},
+					},
+					{
+						DNSName:       "new16.test-zone.example.org",
+						Targets:       endpoint.Targets{"new16.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new16-ingress",
+						},
+					},
+					{
+						DNSName:       "new17.test-zone.example.org",
+						Targets:       endpoint.Targets{"new17.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new17-ingress",
+						},
+					},
+					{
+						DNSName:       "new18.test-zone.example.org",
+						Targets:       endpoint.Targets{"new18.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new18-ingress",
+						},
+					},
+					{
+						DNSName:       "new19.test-zone.example.org",
+						Targets:       endpoint.Targets{"new19.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new19-ingress",
+						},
+					},
+					{
+						DNSName:       "new20.test-zone.example.org",
+						Targets:       endpoint.Targets{"new20.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new20-ingress",
+						},
+					},
+					{
+						DNSName:       "new21.test-zone.example.org",
+						Targets:       endpoint.Targets{"new21.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new21-ingress",
+						},
+					},
+					{
+						DNSName:       "new22.test-zone.example.org",
+						Targets:       endpoint.Targets{"new22.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new22-ingress",
+						},
+					},
+					{
+						DNSName:       "new23.test-zone.example.org",
+						Targets:       endpoint.Targets{"new23.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new23-ingress",
+						},
+					},
+					{
+						DNSName:       "new24.test-zone.example.org",
+						Targets:       endpoint.Targets{"new24.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new24-ingress",
+						},
+					},
+					{
+						DNSName:       "new25.test-zone.example.org",
+						Targets:       endpoint.Targets{"new25.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new25-ingress",
+						},
+					},
+					{
+						DNSName:       "new26.test-zone.example.org",
+						Targets:       endpoint.Targets{"new26.loadbalancer.com"},
+						RecordType:    endpoint.RecordTypeCNAME,
+						SetIdentifier: "set-new",
+						Labels: map[string]string{
+							endpoint.ResourceLabelKey: "ingress/default/new26-ingress",
+						},
+					},
+				},
+			},
+			stubConfig: DynamoDBStubConfig{
+				ExpectInsert: map[string]map[string]string{
+					"new1.test-zone.example.org#CNAME#set-new":  {endpoint.ResourceLabelKey: "ingress/default/new1-ingress"},
+					"new2.test-zone.example.org#CNAME#set-new":  {endpoint.ResourceLabelKey: "ingress/default/new2-ingress"},
+					"new3.test-zone.example.org#CNAME#set-new":  {endpoint.ResourceLabelKey: "ingress/default/new3-ingress"},
+					"new4.test-zone.example.org#CNAME#set-new":  {endpoint.ResourceLabelKey: "ingress/default/new4-ingress"},
+					"new5.test-zone.example.org#CNAME#set-new":  {endpoint.ResourceLabelKey: "ingress/default/new5-ingress"},
+					"new6.test-zone.example.org#CNAME#set-new":  {endpoint.ResourceLabelKey: "ingress/default/new6-ingress"},
+					"new7.test-zone.example.org#CNAME#set-new":  {endpoint.ResourceLabelKey: "ingress/default/new7-ingress"},
+					"new8.test-zone.example.org#CNAME#set-new":  {endpoint.ResourceLabelKey: "ingress/default/new8-ingress"},
+					"new9.test-zone.example.org#CNAME#set-new":  {endpoint.ResourceLabelKey: "ingress/default/new9-ingress"},
+					"new10.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new10-ingress"},
+					"new11.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new11-ingress"},
+					"new12.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new12-ingress"},
+					"new13.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new13-ingress"},
+					"new14.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new14-ingress"},
+					"new15.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new15-ingress"},
+					"new16.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new16-ingress"},
+					"new17.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new17-ingress"},
+					"new18.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new18-ingress"},
+					"new19.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new19-ingress"},
+					"new20.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new20-ingress"},
+					"new21.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new21-ingress"},
+					"new22.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new22-ingress"},
+					"new23.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new23-ingress"},
+					"new24.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new24-ingress"},
+					"new25.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new25-ingress"},
+					"new26.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new26-ingress"},
+				},
+				ExpectDelete: sets.New("quux.test-zone.example.org#A#set-2"),
+			},
+			expectedRecords: []*endpoint.Endpoint{
+				{
+					DNSName:    "foo.test-zone.example.org",
+					Targets:    endpoint.Targets{"foo.loadbalancer.com"},
+					RecordType: endpoint.RecordTypeCNAME,
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey: "",
+					},
+				},
+				{
+					DNSName:    "bar.test-zone.example.org",
+					Targets:    endpoint.Targets{"my-domain.com"},
+					RecordType: endpoint.RecordTypeCNAME,
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/my-ingress",
+					},
+				},
+				{
+					DNSName:       "baz.test-zone.example.org",
+					Targets:       endpoint.Targets{"1.1.1.1"},
+					RecordType:    endpoint.RecordTypeA,
+					SetIdentifier: "set-1",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/my-ingress",
+					},
+				},
+				{
+					DNSName:       "baz.test-zone.example.org",
+					Targets:       endpoint.Targets{"2.2.2.2"},
+					RecordType:    endpoint.RecordTypeA,
+					SetIdentifier: "set-2",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/other-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new1.test-zone.example.org",
+					Targets:       endpoint.Targets{"new1.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new1-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new2.test-zone.example.org",
+					Targets:       endpoint.Targets{"new2.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new2-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new3.test-zone.example.org",
+					Targets:       endpoint.Targets{"new3.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new3-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new4.test-zone.example.org",
+					Targets:       endpoint.Targets{"new4.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new4-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new5.test-zone.example.org",
+					Targets:       endpoint.Targets{"new5.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new5-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new6.test-zone.example.org",
+					Targets:       endpoint.Targets{"new6.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new6-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new7.test-zone.example.org",
+					Targets:       endpoint.Targets{"new7.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new7-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new8.test-zone.example.org",
+					Targets:       endpoint.Targets{"new8.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new8-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new9.test-zone.example.org",
+					Targets:       endpoint.Targets{"new9.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new9-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new10.test-zone.example.org",
+					Targets:       endpoint.Targets{"new10.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new10-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new11.test-zone.example.org",
+					Targets:       endpoint.Targets{"new11.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new11-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new12.test-zone.example.org",
+					Targets:       endpoint.Targets{"new12.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new12-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new13.test-zone.example.org",
+					Targets:       endpoint.Targets{"new13.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new13-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new14.test-zone.example.org",
+					Targets:       endpoint.Targets{"new14.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new14-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new15.test-zone.example.org",
+					Targets:       endpoint.Targets{"new15.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new15-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new16.test-zone.example.org",
+					Targets:       endpoint.Targets{"new16.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new16-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new17.test-zone.example.org",
+					Targets:       endpoint.Targets{"new17.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new17-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new18.test-zone.example.org",
+					Targets:       endpoint.Targets{"new18.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new18-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new19.test-zone.example.org",
+					Targets:       endpoint.Targets{"new19.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new19-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new20.test-zone.example.org",
+					Targets:       endpoint.Targets{"new20.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new20-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new21.test-zone.example.org",
+					Targets:       endpoint.Targets{"new21.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new21-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new22.test-zone.example.org",
+					Targets:       endpoint.Targets{"new22.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new22-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new23.test-zone.example.org",
+					Targets:       endpoint.Targets{"new23.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new23-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new24.test-zone.example.org",
+					Targets:       endpoint.Targets{"new24.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new24-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new25.test-zone.example.org",
+					Targets:       endpoint.Targets{"new25.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new25-ingress",
+					},
+				},
+
+				{
+					DNSName:       "new26.test-zone.example.org",
+					Targets:       endpoint.Targets{"new26.loadbalancer.com"},
+					RecordType:    endpoint.RecordTypeCNAME,
+					SetIdentifier: "set-new",
+					Labels: map[string]string{
+						endpoint.OwnerLabelKey:    "test-owner",
+						endpoint.ResourceLabelKey: "ingress/default/new26-ingress",
+					},
+				},
+			},
+		},
+		{
 			name: "create orphaned",
 			changes: plan.Changes{
 				Create: []*endpoint.Endpoint{

--- a/registry/dynamodb_test.go
+++ b/registry/dynamodb_test.go
@@ -217,6 +217,7 @@ func TestDynamoDBRegistryRecords(t *testing.T) {
 func TestDynamoDBRegistryApplyChanges(t *testing.T) {
 	for _, tc := range []struct {
 		name            string
+		maxBatchSize    uint8
 		stubConfig      DynamoDBStubConfig
 		addRecords      []*endpoint.Endpoint
 		changes         plan.Changes
@@ -295,7 +296,8 @@ func TestDynamoDBRegistryApplyChanges(t *testing.T) {
 			},
 		},
 		{
-			name: "create more entries than DynamoDB batch size limit (25)",
+			name:         "create more entries than DynamoDB batch size limit",
+			maxBatchSize: 2,
 			changes: plan.Changes{
 				Create: []*endpoint.Endpoint{
 					{
@@ -325,243 +327,13 @@ func TestDynamoDBRegistryApplyChanges(t *testing.T) {
 							endpoint.ResourceLabelKey: "ingress/default/new3-ingress",
 						},
 					},
-					{
-						DNSName:       "new4.test-zone.example.org",
-						Targets:       endpoint.Targets{"new4.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new4-ingress",
-						},
-					},
-					{
-						DNSName:       "new5.test-zone.example.org",
-						Targets:       endpoint.Targets{"new5.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new5-ingress",
-						},
-					},
-					{
-						DNSName:       "new6.test-zone.example.org",
-						Targets:       endpoint.Targets{"new6.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new6-ingress",
-						},
-					},
-					{
-						DNSName:       "new7.test-zone.example.org",
-						Targets:       endpoint.Targets{"new7.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new7-ingress",
-						},
-					},
-					{
-						DNSName:       "new8.test-zone.example.org",
-						Targets:       endpoint.Targets{"new8.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new8-ingress",
-						},
-					},
-					{
-						DNSName:       "new9.test-zone.example.org",
-						Targets:       endpoint.Targets{"new9.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new9-ingress",
-						},
-					},
-					{
-						DNSName:       "new10.test-zone.example.org",
-						Targets:       endpoint.Targets{"new10.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new10-ingress",
-						},
-					},
-					{
-						DNSName:       "new11.test-zone.example.org",
-						Targets:       endpoint.Targets{"new11.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new11-ingress",
-						},
-					},
-					{
-						DNSName:       "new12.test-zone.example.org",
-						Targets:       endpoint.Targets{"new12.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new12-ingress",
-						},
-					},
-					{
-						DNSName:       "new13.test-zone.example.org",
-						Targets:       endpoint.Targets{"new13.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new13-ingress",
-						},
-					},
-					{
-						DNSName:       "new14.test-zone.example.org",
-						Targets:       endpoint.Targets{"new14.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new14-ingress",
-						},
-					},
-					{
-						DNSName:       "new15.test-zone.example.org",
-						Targets:       endpoint.Targets{"new15.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new15-ingress",
-						},
-					},
-					{
-						DNSName:       "new16.test-zone.example.org",
-						Targets:       endpoint.Targets{"new16.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new16-ingress",
-						},
-					},
-					{
-						DNSName:       "new17.test-zone.example.org",
-						Targets:       endpoint.Targets{"new17.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new17-ingress",
-						},
-					},
-					{
-						DNSName:       "new18.test-zone.example.org",
-						Targets:       endpoint.Targets{"new18.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new18-ingress",
-						},
-					},
-					{
-						DNSName:       "new19.test-zone.example.org",
-						Targets:       endpoint.Targets{"new19.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new19-ingress",
-						},
-					},
-					{
-						DNSName:       "new20.test-zone.example.org",
-						Targets:       endpoint.Targets{"new20.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new20-ingress",
-						},
-					},
-					{
-						DNSName:       "new21.test-zone.example.org",
-						Targets:       endpoint.Targets{"new21.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new21-ingress",
-						},
-					},
-					{
-						DNSName:       "new22.test-zone.example.org",
-						Targets:       endpoint.Targets{"new22.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new22-ingress",
-						},
-					},
-					{
-						DNSName:       "new23.test-zone.example.org",
-						Targets:       endpoint.Targets{"new23.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new23-ingress",
-						},
-					},
-					{
-						DNSName:       "new24.test-zone.example.org",
-						Targets:       endpoint.Targets{"new24.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new24-ingress",
-						},
-					},
-					{
-						DNSName:       "new25.test-zone.example.org",
-						Targets:       endpoint.Targets{"new25.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new25-ingress",
-						},
-					},
-					{
-						DNSName:       "new26.test-zone.example.org",
-						Targets:       endpoint.Targets{"new26.loadbalancer.com"},
-						RecordType:    endpoint.RecordTypeCNAME,
-						SetIdentifier: "set-new",
-						Labels: map[string]string{
-							endpoint.ResourceLabelKey: "ingress/default/new26-ingress",
-						},
-					},
 				},
 			},
 			stubConfig: DynamoDBStubConfig{
 				ExpectInsert: map[string]map[string]string{
-					"new1.test-zone.example.org#CNAME#set-new":  {endpoint.ResourceLabelKey: "ingress/default/new1-ingress"},
-					"new2.test-zone.example.org#CNAME#set-new":  {endpoint.ResourceLabelKey: "ingress/default/new2-ingress"},
-					"new3.test-zone.example.org#CNAME#set-new":  {endpoint.ResourceLabelKey: "ingress/default/new3-ingress"},
-					"new4.test-zone.example.org#CNAME#set-new":  {endpoint.ResourceLabelKey: "ingress/default/new4-ingress"},
-					"new5.test-zone.example.org#CNAME#set-new":  {endpoint.ResourceLabelKey: "ingress/default/new5-ingress"},
-					"new6.test-zone.example.org#CNAME#set-new":  {endpoint.ResourceLabelKey: "ingress/default/new6-ingress"},
-					"new7.test-zone.example.org#CNAME#set-new":  {endpoint.ResourceLabelKey: "ingress/default/new7-ingress"},
-					"new8.test-zone.example.org#CNAME#set-new":  {endpoint.ResourceLabelKey: "ingress/default/new8-ingress"},
-					"new9.test-zone.example.org#CNAME#set-new":  {endpoint.ResourceLabelKey: "ingress/default/new9-ingress"},
-					"new10.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new10-ingress"},
-					"new11.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new11-ingress"},
-					"new12.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new12-ingress"},
-					"new13.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new13-ingress"},
-					"new14.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new14-ingress"},
-					"new15.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new15-ingress"},
-					"new16.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new16-ingress"},
-					"new17.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new17-ingress"},
-					"new18.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new18-ingress"},
-					"new19.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new19-ingress"},
-					"new20.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new20-ingress"},
-					"new21.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new21-ingress"},
-					"new22.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new22-ingress"},
-					"new23.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new23-ingress"},
-					"new24.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new24-ingress"},
-					"new25.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new25-ingress"},
-					"new26.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new26-ingress"},
+					"new1.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new1-ingress"},
+					"new2.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new2-ingress"},
+					"new3.test-zone.example.org#CNAME#set-new": {endpoint.ResourceLabelKey: "ingress/default/new3-ingress"},
 				},
 				ExpectDelete: sets.New("quux.test-zone.example.org#A#set-2"),
 			},
@@ -603,7 +375,6 @@ func TestDynamoDBRegistryApplyChanges(t *testing.T) {
 						endpoint.ResourceLabelKey: "ingress/default/other-ingress",
 					},
 				},
-
 				{
 					DNSName:       "new1.test-zone.example.org",
 					Targets:       endpoint.Targets{"new1.loadbalancer.com"},
@@ -614,7 +385,6 @@ func TestDynamoDBRegistryApplyChanges(t *testing.T) {
 						endpoint.ResourceLabelKey: "ingress/default/new1-ingress",
 					},
 				},
-
 				{
 					DNSName:       "new2.test-zone.example.org",
 					Targets:       endpoint.Targets{"new2.loadbalancer.com"},
@@ -625,7 +395,6 @@ func TestDynamoDBRegistryApplyChanges(t *testing.T) {
 						endpoint.ResourceLabelKey: "ingress/default/new2-ingress",
 					},
 				},
-
 				{
 					DNSName:       "new3.test-zone.example.org",
 					Targets:       endpoint.Targets{"new3.loadbalancer.com"},
@@ -634,259 +403,6 @@ func TestDynamoDBRegistryApplyChanges(t *testing.T) {
 					Labels: map[string]string{
 						endpoint.OwnerLabelKey:    "test-owner",
 						endpoint.ResourceLabelKey: "ingress/default/new3-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new4.test-zone.example.org",
-					Targets:       endpoint.Targets{"new4.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new4-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new5.test-zone.example.org",
-					Targets:       endpoint.Targets{"new5.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new5-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new6.test-zone.example.org",
-					Targets:       endpoint.Targets{"new6.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new6-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new7.test-zone.example.org",
-					Targets:       endpoint.Targets{"new7.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new7-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new8.test-zone.example.org",
-					Targets:       endpoint.Targets{"new8.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new8-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new9.test-zone.example.org",
-					Targets:       endpoint.Targets{"new9.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new9-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new10.test-zone.example.org",
-					Targets:       endpoint.Targets{"new10.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new10-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new11.test-zone.example.org",
-					Targets:       endpoint.Targets{"new11.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new11-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new12.test-zone.example.org",
-					Targets:       endpoint.Targets{"new12.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new12-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new13.test-zone.example.org",
-					Targets:       endpoint.Targets{"new13.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new13-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new14.test-zone.example.org",
-					Targets:       endpoint.Targets{"new14.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new14-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new15.test-zone.example.org",
-					Targets:       endpoint.Targets{"new15.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new15-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new16.test-zone.example.org",
-					Targets:       endpoint.Targets{"new16.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new16-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new17.test-zone.example.org",
-					Targets:       endpoint.Targets{"new17.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new17-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new18.test-zone.example.org",
-					Targets:       endpoint.Targets{"new18.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new18-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new19.test-zone.example.org",
-					Targets:       endpoint.Targets{"new19.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new19-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new20.test-zone.example.org",
-					Targets:       endpoint.Targets{"new20.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new20-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new21.test-zone.example.org",
-					Targets:       endpoint.Targets{"new21.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new21-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new22.test-zone.example.org",
-					Targets:       endpoint.Targets{"new22.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new22-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new23.test-zone.example.org",
-					Targets:       endpoint.Targets{"new23.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new23-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new24.test-zone.example.org",
-					Targets:       endpoint.Targets{"new24.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new24-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new25.test-zone.example.org",
-					Targets:       endpoint.Targets{"new25.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new25-ingress",
-					},
-				},
-
-				{
-					DNSName:       "new26.test-zone.example.org",
-					Targets:       endpoint.Targets{"new26.loadbalancer.com"},
-					RecordType:    endpoint.RecordTypeCNAME,
-					SetIdentifier: "set-new",
-					Labels: map[string]string{
-						endpoint.OwnerLabelKey:    "test-owner",
-						endpoint.ResourceLabelKey: "ingress/default/new26-ingress",
 					},
 				},
 			},
@@ -1508,6 +1024,11 @@ func TestDynamoDBRegistryApplyChanges(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			originalMaxBatchSize := dynamodbMaxBatchSize
+			if tc.maxBatchSize > 0 {
+				dynamodbMaxBatchSize = 2
+			}
+
 			api, p := newDynamoDBAPIStub(t, &tc.stubConfig)
 			if len(tc.addRecords) > 0 {
 				_ = p.(*wrappedProvider).Provider.ApplyChanges(context.Background(), &plan.Changes{
@@ -1542,6 +1063,8 @@ func TestDynamoDBRegistryApplyChanges(t *testing.T) {
 			if tc.expectedError == "" {
 				assert.Empty(t, r.orphanedLabels)
 			}
+
+			dynamodbMaxBatchSize = originalMaxBatchSize
 		})
 	}
 }

--- a/registry/dynamodb_test.go
+++ b/registry/dynamodb_test.go
@@ -295,7 +295,7 @@ func TestDynamoDBRegistryApplyChanges(t *testing.T) {
 			},
 		},
 		{
-			name: "create many",
+			name: "create more entries than DynamoDB batch size limit (25)",
 			changes: plan.Changes{
 				Create: []*endpoint.Endpoint{
 					{

--- a/registry/dynamodb_test.go
+++ b/registry/dynamodb_test.go
@@ -1026,7 +1026,7 @@ func TestDynamoDBRegistryApplyChanges(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			originalMaxBatchSize := dynamodbMaxBatchSize
 			if tc.maxBatchSize > 0 {
-				dynamodbMaxBatchSize = 2
+				dynamodbMaxBatchSize = tc.maxBatchSize
 			}
 
 			api, p := newDynamoDBAPIStub(t, &tc.stubConfig)


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
In the DynamoDB Registry, fix the `chunk` variable when the number of statements is over 25.

The test is a bit verbose, but I figured that keeping the logic of a loop out the test case was better than a shorter test. 

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #3921

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
