### PR TITLE
Add org.opencontainers.image.source label to container image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ build/$(BINARY): $(SOURCES)
 build.push/multiarch: ko
 	KO_DOCKER_REPO=${IMAGE} \
     VERSION=${VERSION} \
-    ko build --tags ${VERSION} --platform=${IMG_PLATFORM} --bare --sbom ${IMG_SBOM} --push=${IMG_PUSH} .
+    ko build --tags ${VERSION} --image-label org.opencontainers.image.source="https://github.com/kubernetes-sigs/external-dns" --platform=${IMG_PLATFORM} --bare --sbom ${IMG_SBOM} --push=${IMG_PUSH} .
 
 build.image/multiarch:
 	$(MAKE) IMG_PUSH=false build.push/multiarch

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,10 @@ build/$(BINARY): $(SOURCES)
 build.push/multiarch: ko
 	KO_DOCKER_REPO=${IMAGE} \
     VERSION=${VERSION} \
-    ko build --tags ${VERSION} --image-label org.opencontainers.image.source="https://github.com/kubernetes-sigs/external-dns" --platform=${IMG_PLATFORM} --bare --sbom ${IMG_SBOM} --push=${IMG_PUSH} .
+    ko build --tags ${VERSION} --bare --sbom ${IMG_SBOM} \
+      --image-label org.opencontainers.image.source="https://github.com/kubernetes-sigs/external-dns" \
+      --image-label org.opencontainers.image.revision=$(shell git rev-parse HEAD) \
+      --platform=${IMG_PLATFORM}  --push=${IMG_PUSH} .
 
 build.image/multiarch:
 	$(MAKE) IMG_PUSH=false build.push/multiarch


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Add the label `org.opencontainers.image.source="https://github.com/kubernetes-sigs/external-dns"` to the container image. 
This helps for example Renovate to add Release Notes to PRs that update the container image.
https://docs.renovatebot.com/modules/datasource/docker/

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE (No issue created)

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
