### PR TITLE
docs: add reference to adguard webhook provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ See PR #3063 for all the discussions about it.
 
 Known providers using webhooks:
 * https://github.com/ionos-cloud/external-dns-ionos-plugin
+* https://github.com/muhlba91/external-dns-provider-adguard
 
 ## Status of providers
 


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

Adds the reference to https://github.com/muhlba91/external-dns-provider-adguard to support [AdguardHome](https://github.com/AdguardTeam/AdGuardHome).

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
