### PR TITLE
Encryption of TXT records not working as per documentation

### DIFF
--- a/endpoint/crypto.go
+++ b/endpoint/crypto.go
@@ -42,7 +42,12 @@ func GenerateNonce() ([]byte, error) {
 
 // EncryptText gzip input data and encrypts it using the supplied AES key
 func EncryptText(text string, aesKey []byte, nonceEncoded []byte) (string, error) {
-	block, err := aes.NewCipher(aesKey)
+	decodedaesKey, err := base64.URLEncoding.DecodeString(string(aesKey))
+	if err != nil {
+		fmt.Println("Error decoding base64:", err)
+		return "", err
+	}
+	block, err := aes.NewCipher(decodedaesKey)
 	if err != nil {
 		return "", err
 	}

--- a/endpoint/crypto.go
+++ b/endpoint/crypto.go
@@ -37,7 +37,7 @@ func GenerateNonce() ([]byte, error) {
 	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
 		return nil, err
 	}
-	return []byte(base64.StdEncoding.EncodeToString(nonce)), nil
+	return []byte(base64.URLEncoding.EncodeToString(nonce)), nil
 }
 
 // EncryptText gzip input data and encrypts it using the supplied AES key

--- a/endpoint/crypto.go
+++ b/endpoint/crypto.go
@@ -44,7 +44,7 @@ func GenerateNonce() ([]byte, error) {
 func EncryptText(text string, aesKey []byte, nonceEncoded []byte) (string, error) {
 	decodedaesKey, err := base64.URLEncoding.DecodeString(string(aesKey))
 	if err != nil {
-		fmt.Println("Error decoding base64 when encrypt text:", err)
+		fmt.Println("Error decoding base64:", err)
 		return "", err
 	}
 	block, err := aes.NewCipher(decodedaesKey)

--- a/endpoint/crypto.go
+++ b/endpoint/crypto.go
@@ -37,12 +37,12 @@ func GenerateNonce() ([]byte, error) {
 	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
 		return nil, err
 	}
-	return []byte(base64.URLEncoding.EncodeToString(nonce)), nil
+	return []byte(base64.StdEncoding.EncodeToString(nonce)), nil
 }
 
 // EncryptText gzip input data and encrypts it using the supplied AES key
 func EncryptText(text string, aesKey []byte, nonceEncoded []byte) (string, error) {
-	decodedaesKey, err := base64.URLEncoding.DecodeString(string(aesKey))
+	decodedaesKey, err := base64.StdEncoding.DecodeString(string(aesKey))
 	if err != nil {
 		fmt.Println("Error decoding base64:", err)
 		return "", err
@@ -58,7 +58,7 @@ func EncryptText(text string, aesKey []byte, nonceEncoded []byte) (string, error
 	}
 
 	nonce := make([]byte, standardGcmNonceSize)
-	if _, err = base64.URLEncoding.Decode(nonce, nonceEncoded); err != nil {
+	if _, err = base64.StdEncoding.Decode(nonce, nonceEncoded); err != nil {
 		return "", err
 	}
 
@@ -68,7 +68,7 @@ func EncryptText(text string, aesKey []byte, nonceEncoded []byte) (string, error
 	}
 
 	cipherData := gcm.Seal(nonce, nonce, data, nil)
-	return base64.URLEncoding.EncodeToString(cipherData), nil
+	return base64.StdEncoding.EncodeToString(cipherData), nil
 }
 
 // DecryptText decrypt gziped data using a supplied AES encryption key ang ungzip it
@@ -88,7 +88,7 @@ func DecryptText(text string, aesKey []byte) (decryptResult string, encryptNonce
 		return "", "", err
 	}
 	nonceSize := gcm.NonceSize()
-	data, err := base64.URLEncoding.DecodeString(text)
+	data, err := base64.StdEncoding.DecodeString(text)
 	if err != nil {
 		return "", "", err
 	}
@@ -106,7 +106,7 @@ func DecryptText(text string, aesKey []byte) (decryptResult string, encryptNonce
 		return "", "", err
 	}
 
-	return string(plaindata), base64.URLEncoding.EncodeToString(nonce), nil
+	return string(plaindata), base64.StdEncoding.EncodeToString(nonce), nil
 }
 
 // decompressData gzip compressed data

--- a/endpoint/crypto.go
+++ b/endpoint/crypto.go
@@ -42,9 +42,9 @@ func GenerateNonce() ([]byte, error) {
 
 // EncryptText gzip input data and encrypts it using the supplied AES key
 func EncryptText(text string, aesKey []byte, nonceEncoded []byte) (string, error) {
-	decodedaesKey, err := base64.StdEncoding.DecodeString(string(aesKey))
+	decodedaesKey, err := base64.URLEncoding.DecodeString(string(aesKey))
 	if err != nil {
-		fmt.Println("Error decoding base64:", err)
+		fmt.Println("Error decoding base64 when encrypt text:", err)
 		return "", err
 	}
 	block, err := aes.NewCipher(decodedaesKey)
@@ -58,7 +58,7 @@ func EncryptText(text string, aesKey []byte, nonceEncoded []byte) (string, error
 	}
 
 	nonce := make([]byte, standardGcmNonceSize)
-	if _, err = base64.StdEncoding.Decode(nonce, nonceEncoded); err != nil {
+	if _, err = base64.URLEncoding.Decode(nonce, nonceEncoded); err != nil {
 		return "", err
 	}
 
@@ -68,7 +68,7 @@ func EncryptText(text string, aesKey []byte, nonceEncoded []byte) (string, error
 	}
 
 	cipherData := gcm.Seal(nonce, nonce, data, nil)
-	return base64.StdEncoding.EncodeToString(cipherData), nil
+	return base64.URLEncoding.EncodeToString(cipherData), nil
 }
 
 // DecryptText decrypt gziped data using a supplied AES encryption key ang ungzip it
@@ -76,7 +76,7 @@ func EncryptText(text string, aesKey []byte, nonceEncoded []byte) (string, error
 func DecryptText(text string, aesKey []byte) (decryptResult string, encryptNonce string, err error) {
 	decodedaesKey, err := base64.URLEncoding.DecodeString(string(aesKey))
 	if err != nil {
-		fmt.Println("Error decoding base64:", err)
+		fmt.Println("Error decoding base64 when decrypt text:", err)
 		return "", "", err
 	}
 	block, err := aes.NewCipher(decodedaesKey)
@@ -88,7 +88,7 @@ func DecryptText(text string, aesKey []byte) (decryptResult string, encryptNonce
 		return "", "", err
 	}
 	nonceSize := gcm.NonceSize()
-	data, err := base64.StdEncoding.DecodeString(text)
+	data, err := base64.URLEncoding.DecodeString(text)
 	if err != nil {
 		return "", "", err
 	}
@@ -106,7 +106,7 @@ func DecryptText(text string, aesKey []byte) (decryptResult string, encryptNonce
 		return "", "", err
 	}
 
-	return string(plaindata), base64.StdEncoding.EncodeToString(nonce), nil
+	return string(plaindata), base64.URLEncoding.EncodeToString(nonce), nil
 }
 
 // decompressData gzip compressed data

--- a/endpoint/crypto_test.go
+++ b/endpoint/crypto_test.go
@@ -24,8 +24,11 @@ import (
 
 func TestEncrypt(t *testing.T) {
 	// Verify that text encryption and decryption works
-	aesKey := []byte("1WGwUWyQ-vnVIZNpAT8k3i2Vjm4_2xacplj_8FzF7K8=")
-	plaintext := "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
+	//aesKey := []byte("1WGwUWyQ-vnVIZNpAT8k3i2Vjm4_2xacplj_8FzF7K8=")
+	aesKey := []byte("UHopdKnIiiLPQWo3DXVpU5crYdM7pV1nkzD0TJLqJ4M=")
+	//plaintext := "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
+	plaintext := "heritage=external-dns,external-dns/owner=foo-owner,external-dns/resource=foo-resource"
+
 	encryptedtext, err := EncryptText(plaintext, aesKey, nil)
 	require.NoError(t, err)
 	decryptedtext, _, err := DecryptText(encryptedtext, aesKey)

--- a/endpoint/crypto_test.go
+++ b/endpoint/crypto_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestEncrypt(t *testing.T) {
 	// Verify that text encryption and decryption works
-	aesKey := []byte("s%zF`.*'5`9.AhI2!B,.~hmbs^.*TL?;")
+	aesKey := []byte("1WGwUWyQ-vnVIZNpAT8k3i2Vjm4_2xacplj_8FzF7K8=")
 	plaintext := "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
 	encryptedtext, err := EncryptText(plaintext, aesKey, nil)
 	require.NoError(t, err)
@@ -49,7 +49,7 @@ func TestEncrypt(t *testing.T) {
 	}
 
 	// Verify that a known encrypted text is decrypted to what is expected
-	encryptedtext = "0Mfzf6wsN8llrfX0ucDZ6nlc2+QiQfKKedjPPLu5atb2I35L9nUZeJcCnuLVW7CVW3K0h94vSuBLdXnMrj8Vcm0M09shxaoF48IcCpD03XtQbKXqk2hPbsW6+JybvplHIQGr16/PcjUSObGmR9yjf38+qEltApkKvrPjsyw43BX4eE10rL0Bln33UJD7/w+zazRDPFlAcbGtkt0ETKHnvyB3/aCddLipvrhjCXj2ZY/ktRF6h716kJRgXU10dCIQHFYU45MIdxI+k10HK3yZqhI2V0Gp2xjrFV/LRQ7/OS9SFee4asPWUYxbCEsnOzp8qc0dCPFSo1dtADzWnUZnsAcbnjtudT4milfLJc5CxDk1v3ykqQ/ajejwHjWQ7b8U6AsTErbezfdcqrb5IzkLgHb5TosnfrdDmNc9GcKfpsrCHbVY8KgNwMVdtwavLv7d9WM6sooUlZ3t0sABGkzagXQmPRvwLnkSOlie5XrnzWo8/8/4UByLga29CaXO"
+	encryptedtext = "AAAAAAAAAAAAAAAAvH4TwB_FqFti68hCmBuj2i5bhrNgwh01-YXi9-VpW2TIpSA0PIjJBDpRcYRxmOo0Ra_KzJ1L8CxX1LxAwp7KKmI13OEO2e-lu9GX4jJlWwSBEkkw3q-vb3mY12r9n58oILbyot_A53vqSVU-chsLqsnF0n0-Ktqt4XAkpnoPVE0YI7fE9cGuMmK0GdwEwZLR_4gsw5jAz5nFqRez3BnKjzq3gwf-n2YoCCKYBeZduVEkhFnR3CUGF7UU30_sV_y6RZJfFTgKLElEAQ_85qe2KL5i9k4g9RUXUwjY019UmhvpOWH-skHDZQ9umbPhL2TB0v9JB48vts9aGCPd81OSBwP1I5Kzb3iKYRJBNVVz5OI1RR79IDt4vw7H4Z0NzvJB5lymr3tO8nVn-gmvF4V_2gIRzk9tcx7B77vrHchJ7xXx4OIUFThR6mFoK1bTzfoaaQsD-EoK6gSOmsvigAf6jG5NXakH6q4PmjhLuMAMoDqG"
 	decryptedtext, _, err = DecryptText(encryptedtext, aesKey)
 	require.NoError(t, err)
 	if decryptedtext != plaintext {

--- a/endpoint/crypto_test.go
+++ b/endpoint/crypto_test.go
@@ -35,13 +35,13 @@ func TestEncrypt(t *testing.T) {
 	}
 
 	// Verify that decrypt returns an error and empty data if wrong AES encryption key is used
-	decryptedtext, _, err = DecryptText(encryptedtext, []byte("s'J!jD`].LC?g&Oa11AgTub,j48ts/96"))
+	decryptedtext, _, err = DecryptText(encryptedtext, []byte("ihjatU7dkGyKQvGD6OjXRRZ1qnEDyUzqeLkwcjcyfFY="))
 	require.Error(t, err)
 	if decryptedtext != "" {
 		t.Error("Data decryption failed, empty string should be as result")
 	}
 
-	// Verify that decrypt returns an error and empty data if unencrypted input is is supplied
+	// Verify that decrypt returns an error and empty data if unencrypted input is supplied
 	decryptedtext, _, err = DecryptText(plaintext, aesKey)
 	require.Error(t, err)
 	if decryptedtext != "" {

--- a/endpoint/crypto_test.go
+++ b/endpoint/crypto_test.go
@@ -24,11 +24,8 @@ import (
 
 func TestEncrypt(t *testing.T) {
 	// Verify that text encryption and decryption works
-	//aesKey := []byte("1WGwUWyQ-vnVIZNpAT8k3i2Vjm4_2xacplj_8FzF7K8=")
-	aesKey := []byte("UHopdKnIiiLPQWo3DXVpU5crYdM7pV1nkzD0TJLqJ4M=")
-	//plaintext := "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
-	plaintext := "heritage=external-dns,external-dns/owner=foo-owner,external-dns/resource=foo-resource"
-
+	aesKey := []byte("1WGwUWyQ-vnVIZNpAT8k3i2Vjm4_2xacplj_8FzF7K8=")
+	plaintext := "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
 	encryptedtext, err := EncryptText(plaintext, aesKey, nil)
 	require.NoError(t, err)
 	decryptedtext, _, err := DecryptText(encryptedtext, aesKey)

--- a/endpoint/labels_test.go
+++ b/endpoint/labels_test.go
@@ -44,10 +44,10 @@ func (suite *LabelsSuite) SetupTest() {
 		"owner":    "foo-owner",
 		"resource": "foo-resource",
 	}
-	suite.aesKey = []byte(")K_Fy|?Z.64#UuHm`}[d!GC%WJM_fs{_")
+	suite.aesKey = []byte("UHopdKnIiiLPQWo3DXVpU5crYdM7pV1nkzD0TJLqJ4M=")
 	suite.fooAsText = "heritage=external-dns,external-dns/owner=foo-owner,external-dns/resource=foo-resource"
 	suite.fooAsTextWithQuotes = fmt.Sprintf(`"%s"`, suite.fooAsText)
-	suite.fooAsTextEncrypted = `+lvP8q9KHJ6BS6O81i2Q6DLNdf2JSKy8j/gbZKviTZlGYj7q+yDoYMgkQ1hPn6urtGllM5bfFMcaaHto52otQtiOYrX8990J3kQqg4s47m3bH3Ejl8RSxSSuWJM3HJtPghQzYg0/LSOsdQ0=`
+	suite.fooAsTextEncrypted = `AAAAAAAAAAAAAAAAGcAGgNYa7U2O1rc_MESQ6w_p2KxI1X6mXnnU8g8ls2v19nR9Nqt-wWd8ZyqtvU8Y8OIKlzg8ax1SAlL0KWX-gN6jIi8OdK9vG1a_2KgKZqhEaxcYgvvgPaKALDuAdtY=`
 	suite.fooAsTextWithQuotesEncrypted = fmt.Sprintf(`"%s"`, suite.fooAsTextEncrypted)
 	suite.barTextAsMap = map[string]string{
 		"owner":    "bar-owner",

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -71,7 +71,7 @@ func NewTXTRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID st
 	if len(txtEncryptAESKey) == 0 {
 		txtEncryptAESKey = nil
 	} else if len(txtEncryptAESKeyDecoded) != 32 {
-		return nil, errors.New("the decoded AES Encryption key must have a length of 32 bytes")
+		return nil, errors.New("the AES Encryption key must have a length of 32 bytes")
 	}
 	if txtEncryptEnabled && txtEncryptAESKey == nil {
 		return nil, errors.New("the AES Encryption key must be set when TXT record encryption is enabled")

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -64,7 +64,6 @@ func NewTXTRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID st
 	if ownerID == "" {
 		return nil, errors.New("owner id cannot be empty")
 	}
-	//txtEncryptAESKeyDecoded := txtEncryptAESKey
 	txtEncryptAESKeyDecoded, err := base64.URLEncoding.DecodeString(string(txtEncryptAESKey))
 	if err != nil {
 		return nil, errors.New("error decoding base64 AES Encryption Key")

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -64,7 +64,7 @@ func NewTXTRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID st
 	if ownerID == "" {
 		return nil, errors.New("owner id cannot be empty")
 	}
-	txtEncryptAESKeyDecoded, err := base64.StdEncoding.DecodeString(string(txtEncryptAESKey))
+	txtEncryptAESKeyDecoded, err := base64.URLEncoding.DecodeString(string(txtEncryptAESKey))
 	if err != nil {
 		return nil, errors.New("error decoding base64 AES Encryption Key")
 	}

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -61,7 +61,6 @@ type TXTRegistry struct {
 
 // NewTXTRegistry returns new TXTRegistry object
 func NewTXTRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID string, cacheInterval time.Duration, txtWildcardReplacement string, managedRecordTypes, excludeRecordTypes []string, txtEncryptEnabled bool, txtEncryptAESKey []byte) (*TXTRegistry, error) {
-	log.Infof("What")
 	if ownerID == "" {
 		return nil, errors.New("owner id cannot be empty")
 	}

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -18,6 +18,7 @@ package registry
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"strings"
 	"time"
@@ -60,13 +61,19 @@ type TXTRegistry struct {
 
 // NewTXTRegistry returns new TXTRegistry object
 func NewTXTRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID string, cacheInterval time.Duration, txtWildcardReplacement string, managedRecordTypes, excludeRecordTypes []string, txtEncryptEnabled bool, txtEncryptAESKey []byte) (*TXTRegistry, error) {
+	log.Infof("What")
 	if ownerID == "" {
 		return nil, errors.New("owner id cannot be empty")
 	}
+	//txtEncryptAESKeyDecoded := txtEncryptAESKey
+	txtEncryptAESKeyDecoded, err := base64.URLEncoding.DecodeString(string(txtEncryptAESKey))
+	if err != nil {
+		return nil, errors.New("error decoding base64 AES Encryption Key")
+	}
 	if len(txtEncryptAESKey) == 0 {
 		txtEncryptAESKey = nil
-	} else if len(txtEncryptAESKey) != 32 {
-		return nil, errors.New("the AES Encryption key must have a length of 32 bytes")
+	} else if len(txtEncryptAESKeyDecoded) != 32 {
+		return nil, errors.New("the decoded AES Encryption key must have a length of 32 bytes")
 	}
 	if txtEncryptEnabled && txtEncryptAESKey == nil {
 		return nil, errors.New("the AES Encryption key must be set when TXT record encryption is enabled")

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -64,7 +64,7 @@ func NewTXTRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID st
 	if ownerID == "" {
 		return nil, errors.New("owner id cannot be empty")
 	}
-	txtEncryptAESKeyDecoded, err := base64.URLEncoding.DecodeString(string(txtEncryptAESKey))
+	txtEncryptAESKeyDecoded, err := base64.StdEncoding.DecodeString(string(txtEncryptAESKey))
 	if err != nil {
 		return nil, errors.New("error decoding base64 AES Encryption Key")
 	}

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -82,7 +82,6 @@ func NewTXTRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID st
 	}
 
 	mapper := newaffixNameMapper(txtPrefix, txtSuffix, txtWildcardReplacement)
-
 	return &TXTRegistry{
 		provider:            provider,
 		ownerID:             ownerID,

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -1540,7 +1540,7 @@ func TestTXTRegistryApplyChangesEncrypt(t *testing.T) {
 		},
 	})
 
-	r, _ := NewTXTRegistry(p, "txt.", "", "owner", time.Hour, "", []string{}, []string{}, true, []byte("12345678901234567890123456789012"))
+	r, _ := NewTXTRegistry(p, "txt.", "", "owner", time.Hour, "", []string{}, []string{}, true, []byte("zXQDtIgJvPMWpySWeOZJQ8K18V1J4KikQRkZq_JldL0="))
 	records, _ := r.Records(ctx)
 	changes := &plan.Changes{
 		Delete: records,

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -67,7 +67,7 @@ func testTXTRegistryNew(t *testing.T) {
 	assert.Equal(t, "owner", r.ownerID)
 	assert.Equal(t, p, r.provider)
 
-	aesKey := []byte(";k&l)nUC/33:{?d{3)54+,AD?]SX%yh^")
+	aesKey := []byte("FNj6zBS2AJ34FoHu6gHHAD0it3gzFC1dvPKbDrx1X5Q=")
 	_, err = NewTXTRegistry(p, "", "", "owner", time.Hour, "", []string{}, []string{}, false, nil)
 	require.NoError(t, err)
 

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -1536,11 +1536,12 @@ func TestTXTRegistryApplyChangesEncrypt(t *testing.T) {
 	p.ApplyChanges(ctx, &plan.Changes{
 		Create: []*endpoint.Endpoint{
 			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwnerAndOwnedRecord("txt.cname-foobar.test-zone.example.org", "\"h8UQ6jelUFUsEIn7SbFktc2MYXPx/q8lySqI4VwfVtVaIbb2nkHWV/88KKbuLtu7fJNzMir8ELVeVnRSY01KdiIuj7ledqZe5ailEjQaU5Z6uEKd5pgs6sH8\"", endpoint.RecordTypeTXT, "", "foobar.test-zone.example.org"),
+			// plainText target: "heritage=external-dns,external-dns/owner=owner"
+			newEndpointWithOwnerAndOwnedRecord("txt.cname-foobar.test-zone.example.org", "\"AAAAAAAAAAAAAAAAvH4TwB_FqFti606aBF-Uom5QTJt33lPbZOpu7DynLDJ1QXXJ0Ob5OqJ31Giun8HsMuVID_tzBQa_eY2NhR-31y-bxNwa00JcPA56rWc3\"", endpoint.RecordTypeTXT, "", "foobar.test-zone.example.org"),
 		},
 	})
 
-	r, _ := NewTXTRegistry(p, "txt.", "", "owner", time.Hour, "", []string{}, []string{}, true, []byte("zXQDtIgJvPMWpySWeOZJQ8K18V1J4KikQRkZq_JldL0="))
+	r, _ := NewTXTRegistry(p, "txt.", "", "owner", time.Hour, "", []string{}, []string{}, true, []byte("1WGwUWyQ-vnVIZNpAT8k3i2Vjm4_2xacplj_8FzF7K8="))
 	records, _ := r.Records(ctx)
 	changes := &plan.Changes{
 		Delete: records,
@@ -1550,7 +1551,7 @@ func TestTXTRegistryApplyChangesEncrypt(t *testing.T) {
 	expected := &plan.Changes{
 		Delete: []*endpoint.Endpoint{
 			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
-			newEndpointWithOwnerAndOwnedRecord("txt.cname-foobar.test-zone.example.org", "\"h8UQ6jelUFUsEIn7SbFktc2MYXPx/q8lySqI4VwfVtVaIbb2nkHWV/88KKbuLtu7fJNzMir8ELVeVnRSY01KdiIuj7ledqZe5ailEjQaU5Z6uEKd5pgs6sH8\"", endpoint.RecordTypeTXT, "", "foobar.test-zone.example.org"),
+			newEndpointWithOwnerAndOwnedRecord("txt.cname-foobar.test-zone.example.org", "\"AAAAAAAAAAAAAAAAvH4TwB_FqFti606aBF-Uom5QTJt33lPbZOpu7DynLDJ1QXXJ0Ob5OqJ31Giun8HsMuVID_tzBQa_eY2NhR-31y-bxNwa00JcPA56rWc3\"", endpoint.RecordTypeTXT, "", "foobar.test-zone.example.org"),
 		},
 	}
 


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
Fix the issue that Encryption of TXT records does take base64 encryption key.
<!-- Please provide a summary of the change here. -->
1. Use `base64.URLEncoding` instead of `base64.StdEncoding`: Since TXT records are often used in DNS settings, which can be included in URLs, it makes sense to use URL-safe characters to avoid potential issues with special characters that have different meanings in URLs. Also per document https://github.com/kubernetes-sigs/external-dns/blob/master/docs/registry/txt.md#encryption the key we generated is URL safe. 
2. Update function `EncryptText` and `DecryptText` to take encode aes key as input however decode before encrypt and decrypt. Matching doc description.
3. update unit test.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #3992 

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
