### PR TITLE
Make routegroup client IPv6 compatible

### DIFF
--- a/source/skipper_routegroup.go
+++ b/source/skipper_routegroup.go
@@ -210,7 +210,8 @@ func NewRouteGroupSource(timeout time.Duration, token, tokenPath, apiServerURL, 
 	apiServer := u.String()
 	// strip port if well known port, because of TLS certificate match
 	if u.Scheme == "https" && u.Port() == "443" {
-		apiServer = "https://" + u.Hostname()
+		// correctly handle IPv6 addresses by keeping surrounding `[]`.
+		apiServer = "https://" + strings.TrimSuffix(u.Host, ":443")
 	}
 
 	sc := &routeGroupSource{


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

On IPv6 based clusters the `InClusterConfig` (from client-go) will correctly produce a valid URL for an IPv6 IP address [with the required `[]` surrounding the IPv6 address](https://github.com/kubernetes/client-go/blob/84a6fe7e4032ae1b8bc03b5208e771c5f7103549/rest/config.go#L536).
However, in the routegroup client the host is parsed via `url.Parse` and the `url.Hostname()` method returns the IPv6 Address _without_ the `[]` leading to the following error:

```
Get \"https://fd6d:ef2a:acf6::1/apis/zalando.org/v1/routegroups\": dial tcp: lookup fd6d:ef2a:acf6:: no such host"
```

To work around this, we use `u.Host` and trim away the already known port `:443`.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
