### PR TITLE
webhook: Fix metric name and add request gauges

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -194,6 +194,18 @@ Here is the full list of available metrics provided by ExternalDNS:
 | external_dns_source_a_records                            | Number of A records in source                                      | Gauge   |
 
 
+If you're using the webhook provider, the following additional metrics will be provided:
+
+| Name                                                         | Description                                            | Type    |
+| ------------------------------------------------------------ | ------------------------------------------------------ | ------- |
+| external_dns_webhook_provider_records_errors_total           | Number of errors with the /records method              | Gauge   |
+| external_dns_webhook_provider_records_requests_total         | Number of requests made to the /records method         | Gauge   |
+| external_dns_webhook_provider_applychanges_errors_total      | Number of errors with the /applychanges method         | Gauge   |
+| external_dns_webhook_provider_applychanges_requests_total    | Number of requests made to the /applychanges method    | Gauge   |
+| external_dns_webhook_provider_adjustendpoints_errors_total   | Number of errors with the /adjustendpoints method      | Gauge   |
+| external_dns_webhook_provider_adjustendpoints_requests_total | Number of requests made to the /adjustendpoints method | Gauge   |
+
+
 ### How can I run ExternalDNS under a specific GCP Service Account, e.g. to access DNS records in other projects?
 
 Have a look at https://github.com/linki/mate/blob/v0.6.2/examples/google/README.md#permissions


### PR DESCRIPTION
**Description**

This adds requests metrics and renames the metric names to fit best practices.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
