### PR TITLE
fix: include cloudflare error in metrics and logs

### DIFF
--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -321,7 +321,6 @@ func (p *CloudFlareProvider) submitChanges(ctx context.Context, changes []*cloud
 
 		var failedChange bool
 		for _, change := range changes {
-
 			logFields := log.Fields{
 				"record": change.ResourceRecord.Name,
 				"type":   change.ResourceRecord.Type,
@@ -369,7 +368,6 @@ func (p *CloudFlareProvider) submitChanges(ctx context.Context, changes []*cloud
 					log.WithFields(logFields).Errorf("failed to create record: %v", err)
 				}
 			}
-
 		}
 
 		if failedChange {


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Collect zone errors when submitting changes in the Cloudflare provider so that they are included in Prometheus metrics. I copied the approach used in the AWS provider.

I opted *not* to capture "failed to find previous record" errors as they aren't exactly registry errors.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4081

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated