### PR TITLE
webhook: Move httpapi into own package

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ import (
 	"sigs.k8s.io/external-dns/provider/vinyldns"
 	"sigs.k8s.io/external-dns/provider/vultr"
 	"sigs.k8s.io/external-dns/provider/webhook"
+	webhookapi "sigs.k8s.io/external-dns/provider/webhook/api"
 	"sigs.k8s.io/external-dns/registry"
 	"sigs.k8s.io/external-dns/source"
 )
@@ -413,7 +414,7 @@ func main() {
 	}
 
 	if cfg.WebhookServer {
-		webhook.StartHTTPApi(p, nil, cfg.WebhookProviderReadTimeout, cfg.WebhookProviderWriteTimeout, "127.0.0.1:8888")
+		webhookapi.StartHTTPApi(p, nil, cfg.WebhookProviderReadTimeout, cfg.WebhookProviderWriteTimeout, "127.0.0.1:8888")
 		os.Exit(0)
 	}
 

--- a/provider/webhook/api/httpapi.go
+++ b/provider/webhook/api/httpapi.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package webhook
+package api
 
 import (
 	"context"
@@ -30,6 +30,11 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	MediaTypeFormatAndVersion = "application/external.dns.webhook+json;version=1"
+	ContentTypeHeader         = "Content-Type"
+)
+
 type WebhookServer struct {
 	Provider provider.Provider
 }
@@ -43,7 +48,7 @@ func (p *WebhookServer) RecordsHandler(w http.ResponseWriter, req *http.Request)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		w.Header().Set(contentTypeHeader, mediaTypeFormatAndVersion)
+		w.Header().Set(ContentTypeHeader, MediaTypeFormatAndVersion)
 		w.WriteHeader(http.StatusOK)
 		if err := json.NewEncoder(w).Encode(records); err != nil {
 			log.Errorf("Failed to encode records: %v", err)
@@ -58,7 +63,7 @@ func (p *WebhookServer) RecordsHandler(w http.ResponseWriter, req *http.Request)
 		}
 		err := p.Provider.ApplyChanges(context.Background(), &changes)
 		if err != nil {
-			log.Errorf("Failed to Apply Changes: %v", err)
+			log.Errorf("Failed to apply changes: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -83,7 +88,7 @@ func (p *WebhookServer) AdjustEndpointsHandler(w http.ResponseWriter, req *http.
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	w.Header().Set(contentTypeHeader, mediaTypeFormatAndVersion)
+	w.Header().Set(ContentTypeHeader, MediaTypeFormatAndVersion)
 	pve, err := p.Provider.AdjustEndpoints(pve)
 	if err != nil {
 		log.Errorf("Failed to call adjust endpoints: %v", err)
@@ -97,7 +102,7 @@ func (p *WebhookServer) AdjustEndpointsHandler(w http.ResponseWriter, req *http.
 }
 
 func (p *WebhookServer) NegotiateHandler(w http.ResponseWriter, req *http.Request) {
-	w.Header().Set(contentTypeHeader, mediaTypeFormatAndVersion)
+	w.Header().Set(ContentTypeHeader, MediaTypeFormatAndVersion)
 	json.NewEncoder(w).Encode(p.Provider.GetDomainFilter())
 }
 

--- a/provider/webhook/api/httpapi_test.go
+++ b/provider/webhook/api/httpapi_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package webhook
+package api
 
 import (
 	"bytes"

--- a/provider/webhook/webhook_test.go
+++ b/provider/webhook/webhook_test.go
@@ -26,12 +26,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/external-dns/endpoint"
+	webhookapi "sigs.k8s.io/external-dns/provider/webhook/api"
 )
 
 func TestInvalidDomainFilter(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/" {
-			w.Header().Set(contentTypeHeader, mediaTypeFormatAndVersion)
+			w.Header().Set(webhookapi.ContentTypeHeader, webhookapi.MediaTypeFormatAndVersion)
 			w.WriteHeader(200)
 			return
 		}
@@ -50,7 +51,7 @@ func TestValidDomainfilter(t *testing.T) {
 	domainFilter := endpoint.NewDomainFilter([]string{"example.com"})
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/" {
-			w.Header().Set(contentTypeHeader, mediaTypeFormatAndVersion)
+			w.Header().Set(webhookapi.ContentTypeHeader, webhookapi.MediaTypeFormatAndVersion)
 			json.NewEncoder(w).Encode(domainFilter)
 			return
 		}
@@ -65,7 +66,7 @@ func TestValidDomainfilter(t *testing.T) {
 func TestRecords(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/" {
-			w.Header().Set(contentTypeHeader, mediaTypeFormatAndVersion)
+			w.Header().Set(webhookapi.ContentTypeHeader, webhookapi.MediaTypeFormatAndVersion)
 			w.Write([]byte(`{}`))
 			return
 		}
@@ -89,7 +90,7 @@ func TestRecords(t *testing.T) {
 func TestRecordsWithErrors(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/" {
-			w.Header().Set(contentTypeHeader, mediaTypeFormatAndVersion)
+			w.Header().Set(webhookapi.ContentTypeHeader, webhookapi.MediaTypeFormatAndVersion)
 			w.Write([]byte(`{}`))
 			return
 		}
@@ -108,7 +109,7 @@ func TestApplyChanges(t *testing.T) {
 	successfulApplyChanges := true
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/" {
-			w.Header().Set(contentTypeHeader, mediaTypeFormatAndVersion)
+			w.Header().Set(webhookapi.ContentTypeHeader, webhookapi.MediaTypeFormatAndVersion)
 			w.Write([]byte(`{}`))
 			return
 		}
@@ -135,7 +136,7 @@ func TestApplyChanges(t *testing.T) {
 func TestAdjustEndpoints(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/" {
-			w.Header().Set(contentTypeHeader, mediaTypeFormatAndVersion)
+			w.Header().Set(webhookapi.ContentTypeHeader, webhookapi.MediaTypeFormatAndVersion)
 			w.Write([]byte(`{}`))
 			return
 		}
@@ -188,7 +189,7 @@ func TestAdjustEndpoints(t *testing.T) {
 func TestAdjustendpointsWithError(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/" {
-			w.Header().Set(contentTypeHeader, mediaTypeFormatAndVersion)
+			w.Header().Set(webhookapi.ContentTypeHeader, webhookapi.MediaTypeFormatAndVersion)
 			w.Write([]byte(`{}`))
 			return
 		}


### PR DESCRIPTION
**Description**
This moves the webhook httpapi into its own package to improve reusability.

Main reason to do that is to avoid side effects from webhook.go which includes an init() func that will be called package-wide.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
