### PR TITLE
fix(ambassador): don't resolve LB hostname

### DIFF
--- a/source/ambassador_host.go
+++ b/source/ambassador_host.go
@@ -196,7 +196,7 @@ func (sc *ambassadorHostSource) targetsFromAmbassadorLoadBalancer(ctx context.Co
 		return nil, err
 	}
 
-	var targets = extractLoadBalancerTargets(svc, true)
+	var targets = extractLoadBalancerTargets(svc, false)
 
 	return targets, nil
 }


### PR DESCRIPTION
**Description**

Following PR https://github.com/kubernetes-sigs/external-dns/pull/3734, external-dns is now able to use Ambassador service external IPs when creating DNS records.

However, it is configured to resolve LB hostnames by default, which was not the case before.
Purpose of this PR is to restore the previous behavior - and create CNAME to LB hostname instead.