### PR TITLE
fix(istio): support for ExternalIPs in Istio resources

### DIFF
--- a/docs/tutorials/istio.md
+++ b/docs/tutorials/istio.md
@@ -246,6 +246,11 @@ spec:
 EOF
 ```
 
+To get the targets to the extracted DNS names, external-dns is able to gather information from the kubernetes service of the Istio Ingress Gateway.
+Please take a look at the [source service documentation](../sources/service.md) for more information on this.
+
+It is also possible to set the targets manually by using the `external-dns.alpha.kubernetes.io/target` annotation on the Istio Ingress Gateway resource or the Istio VirtualService.
+
 #### Access the sample service using `curl`
 ```bash
 $ curl -I http://httpbin.example.com/status/200

--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -289,6 +289,11 @@ func (sc *gatewaySource) targetsFromGateway(ctx context.Context, gateway *networ
 			continue
 		}
 
+		if len(service.Spec.ExternalIPs) > 0 {
+			targets = append(targets, service.Spec.ExternalIPs...)
+			continue
+		}
+
 		for _, lb := range service.Status.LoadBalancer.Ingress {
 			if lb.IP != "" {
 				targets = append(targets, lb.IP)

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -470,6 +470,11 @@ func (sc *virtualServiceSource) targetsFromGateway(ctx context.Context, gateway 
 			continue
 		}
 
+		if len(service.Spec.ExternalIPs) > 0 {
+			targets = append(targets, service.Spec.ExternalIPs...)
+			continue
+		}
+
 		for _, lb := range service.Status.LoadBalancer.Ingress {
 			if lb.IP != "" {
 				targets = append(targets, lb.IP)


### PR DESCRIPTION
**Description**

✨ Add support for ExternalIPs in Istio Gateway and VirtualService 
ℹ️ This commit extends Istio Gateway and VirtualService resources to support ExternalIPs. 
The changes include:
- Checking if service has ExternalIPs defined
- If yes, adding them to the list of targets
- If not, continuing with the existing process

👌 Now you can have your Istio resources use `externalIPs` too! 🎉

Not to be `ip`-percritical, but don't we all love an `ip`grade! 🎈

Fixes #1718 
Fixes https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3490

Reason being is that aws load balancer controller does not support creating ALBs on service type resources and if provisioned using e.g. terraform, will also *not* add any status fields to the service.
To still be able to point to targets from the service, externalIPs is required and functional using the ingress provider.
This is however not the case for the Istio implementations, here externalIPs does not pose any effect - this PR shall fix this and align the source providers from Istio with other source providers external-dns provides.

Sample diagram of infrastructure:
<img width="836" alt="want-ALB-NLB" src="https://github.com/kubernetes-sigs/external-dns/assets/40307978/3cff6a5f-fc4b-4997-8195-3ecfa7e08a11">

Here the NLBs are to provide static pre-allocated IPs to the ALBs.
Which is the suggested solution by AWS for getting static IPs for ALBs. ($$$)

Target accumulation stops after extracting externalIPs, if there are any.
This is because status loadbalancers should be ignored as they might not be the loadbalancer of first contact and externalIPs should mark the external availability endpoint if set.

Plus, it seems like `service.go` has chosen the same approach in `extractLoadBalancerTargets`.

Note: This problem should also be fixable by using the targetAnnotationKey at the Istio-Gateway resource.

I have additionally tested this PR in an EKS Cluster for both Istio sources.


**Checklist**

- [X] Unit tests updated
- [x] End user documentation updated

End user documentation already includes an `spec.externalIPs` statement, which comes only true after this PR for Istio sources.

> 2. Otherwise, if the Service has one or more `spec.externalIPs`, uses the values in that field.
