### PR TITLE
doc: Add netcup webhook provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Known providers using webhooks:
 | Adguard Home Provider | https://github.com/muhlba91/external-dns-provider-adguard | 
 | STACKIT | https://github.com/stackitcloud/external-dns-stackit-webhook | 
 | GleSYS | https://github.com/glesys/external-dns-glesys | 
+| Netcup | https://github.com/mrueg/external-dns-netcup-webhook |
 
 ## Status of providers
 


### PR DESCRIPTION

**Description**

Adds a link to a [netcup webhook provider](https://github.com/mrueg/external-dns-netcup-webhook) 
**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
