### PR TITLE
helm: Avoid unnecessary pod restart on each helm chart version

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the option to explicitly enable or disable service account token automounting. ([#3983](https://github.com/kubernetes-sigs/external-dns/pull/3983)) [@gilles-gosuin](https://github.com/gilles-gosuin)
 - Added the option to configure revisionHistoryLimit on the K8s Deployment resource. ([#4008](https://github.com/kubernetes-sigs/external-dns/pull/4008)) [@arnisoph](https://github.com/arnisoph)
 
+### Changed
+
+- Avoid unnecessary pod restart on each helm chart version. ([#4103](https://github.com/kubernetes-sigs/external-dns/pull/4103)) [@jkroepke](https://github.com/jkroepke)
+
 ## [v1.13.1] - 2023-09-07
 
 ### Added

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       {{- if or .Values.secretConfiguration.enabled .Values.podAnnotations }}
       annotations:
         {{- if .Values.secretConfiguration.enabled }}
-        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/secret: {{ tpl (toYaml .Values.secretConfiguration.data) . | sha256sum }}
         {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR changes the the input of the config checksum which triggers the reload.

On master branch, the whole configmap/secret checksum is included as checksum input. The configmap contains labels which includes the helm chart version. Each new helm chart version forces a pod restart which is not always necessary. 

By define a finer input for the pod annotation checksum, unnecessary pod restarts can be avoided. 

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
