### PR TITLE
ci: remove `confusing-naming` property

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,6 @@ linters-settings:
   misspell:
     locale: US
   revive:
-    confusing-naming: false
     ignore-generated-header: true
     rules:
       - name: confusing-naming


### PR DESCRIPTION
The property `confusing-naming` is not valid here

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->


**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
