### PR TITLE
gateway-api: fix wildcard matching

### DIFF
--- a/source/gateway_grpcroute_test.go
+++ b/source/gateway_grpcroute_test.go
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 )
 
@@ -55,7 +54,7 @@ func TestGatewayGRPCRouteSourceEndpoints(t *testing.T) {
 			Name:      "internal",
 			Namespace: "default",
 		},
-		Spec: v1beta1.GatewaySpec{
+		Spec: v1.GatewaySpec{
 			Listeners: []v1.Listener{{
 				Protocol: v1.HTTPSProtocolType,
 			}},
@@ -74,10 +73,10 @@ func TestGatewayGRPCRouteSourceEndpoints(t *testing.T) {
 			},
 		},
 		Spec: v1alpha2.GRPCRouteSpec{
-			Hostnames: []v1alpha2.Hostname{"api-hostnames.foobar.internal"},
+			Hostnames: []v1.Hostname{"api-hostnames.foobar.internal"},
 		},
 		Status: v1alpha2.GRPCRouteStatus{
-			RouteStatus: v1a2RouteStatus(v1a2ParentRef("default", "internal")),
+			RouteStatus: gwRouteStatus(gwParentRef("default", "internal")),
 		},
 	}
 	_, err = gwClient.GatewayV1alpha2().GRPCRoutes(rt.Namespace).Create(ctx, rt, metav1.CreateOptions{})

--- a/source/gateway_tcproute_test.go
+++ b/source/gateway_tcproute_test.go
@@ -74,7 +74,7 @@ func TestGatewayTCPRouteSourceEndpoints(t *testing.T) {
 		},
 		Spec: v1alpha2.TCPRouteSpec{},
 		Status: v1alpha2.TCPRouteStatus{
-			RouteStatus: v1a2RouteStatus(v1a2ParentRef("default", "internal")),
+			RouteStatus: gwRouteStatus(gwParentRef("default", "internal")),
 		},
 	}
 	_, err = gwClient.GatewayV1alpha2().TCPRoutes(rt.Namespace).Create(ctx, rt, metav1.CreateOptions{})
@@ -92,32 +92,4 @@ func TestGatewayTCPRouteSourceEndpoints(t *testing.T) {
 		newTestEndpoint("api-annotation.foobar.internal", "A", ips...),
 		newTestEndpoint("api-template.foobar.internal", "A", ips...),
 	})
-}
-
-func v1a2ParentRef(namespace, name string) v1alpha2.ParentReference {
-	group := v1alpha2.Group("gateway.networking.k8s.io")
-	kind := v1alpha2.Kind("Gateway")
-	ref := v1alpha2.ParentReference{
-		Group:     &group,
-		Kind:      &kind,
-		Name:      v1alpha2.ObjectName(name),
-		Namespace: (*v1alpha2.Namespace)(&namespace),
-	}
-	return ref
-}
-
-func v1a2RouteStatus(refs ...v1alpha2.ParentReference) v1alpha2.RouteStatus {
-	var v v1alpha2.RouteStatus
-	for _, ref := range refs {
-		v.Parents = append(v.Parents, v1alpha2.RouteParentStatus{
-			ParentRef: ref,
-			Conditions: []metav1.Condition{
-				{
-					Type:   string(v1alpha2.RouteConditionAccepted),
-					Status: metav1.ConditionTrue,
-				},
-			},
-		})
-	}
-	return v
 }

--- a/source/gateway_test.go
+++ b/source/gateway_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGatewayMatchingHost(t *testing.T) {
+	tests := []struct {
+		desc string
+		a, b string
+		host string
+		ok   bool
+	}{
+		{
+			desc: "ipv4-rejected",
+			a:    "1.2.3.4",
+			ok:   false,
+		},
+		{
+			desc: "ipv6-rejected",
+			a:    "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+			ok:   false,
+		},
+		{
+			desc: "empty-matches-empty",
+			ok:   true,
+		},
+		{
+			desc: "empty-matches-nonempty",
+			a:    "example.net",
+			host: "example.net",
+			ok:   true,
+		},
+		{
+			desc: "simple-match",
+			a:    "example.net",
+			b:    "example.net",
+			host: "example.net",
+			ok:   true,
+		},
+		{
+			desc: "wildcard-matches-longer",
+			a:    "*.example.net",
+			b:    "test.example.net",
+			host: "test.example.net",
+			ok:   true,
+		},
+		{
+			desc: "wildcard-matches-equal-length",
+			a:    "*.example.net",
+			b:    "a.example.net",
+			host: "a.example.net",
+			ok:   true,
+		},
+		{
+			desc: "wildcard-matches-multiple-subdomains",
+			a:    "*.example.net",
+			b:    "foo.bar.test.example.net",
+			host: "foo.bar.test.example.net",
+			ok:   true,
+		},
+		{
+			desc: "wildcard-doesnt-match-parent",
+			a:    "*.example.net",
+			b:    "example.net",
+			ok:   false,
+		},
+		{
+			desc: "wildcard-must-be-complete-label",
+			a:    "*example.net",
+			b:    "test.example.net",
+			ok:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			for i := 0; i < 2; i++ {
+				if host, ok := gwMatchingHost(tt.a, tt.b); host != tt.host || ok != tt.ok {
+					t.Errorf(
+						"gwMatchingHost(%q, %q); got: %q, %v; want: %q, %v",
+						tt.a, tt.b, host, ok, tt.host, tt.ok,
+					)
+				}
+				tt.a, tt.b = tt.b, tt.a
+			}
+		})
+
+	}
+}
+
+func TestIsDNS1123Domain(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   string
+		ok   bool
+	}{
+		{
+			desc: "empty",
+			ok:   false,
+		},
+		{
+			desc: "label-too-long",
+			in:   strings.Repeat("x", 64) + ".example.net",
+			ok:   false,
+		},
+		{
+			desc: "domain-too-long",
+			in:   strings.Repeat("testing.", 256/(len("testing."))) + "example.net",
+			ok:   false,
+		},
+		{
+			desc: "hostname",
+			in:   "example",
+			ok:   true,
+		},
+		{
+			desc: "domain",
+			in:   "example.net",
+			ok:   true,
+		},
+		{
+			desc: "subdomain",
+			in:   "test.example.net",
+			ok:   true,
+		},
+		{
+			desc: "dashes",
+			in:   "test-with-dash.example.net",
+			ok:   true,
+		},
+		{
+			desc: "dash-prefix",
+			in:   "-dash-prefix.example.net",
+			ok:   false,
+		},
+		{
+			desc: "dash-suffix",
+			in:   "dash-suffix-.example.net",
+			ok:   false,
+		},
+		{
+			desc: "underscore",
+			in:   "under_score.example.net",
+			ok:   false,
+		},
+		{
+			desc: "plus",
+			in:   "pl+us.example.net",
+			ok:   false,
+		},
+		{
+			desc: "brackets",
+			in:   "bra[k]ets.example.net",
+			ok:   false,
+		},
+		{
+			desc: "parens",
+			in:   "pa[re]ns.example.net",
+			ok:   false,
+		},
+		{
+			desc: "wild",
+			in:   "*.example.net",
+			ok:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if ok := isDNS1123Domain(tt.in); ok != tt.ok {
+				t.Errorf("isDNS1123Domain(%q); got: %v; want: %v", tt.in, ok, tt.ok)
+			}
+		})
+	}
+}

--- a/source/gateway_tlsroute_test.go
+++ b/source/gateway_tlsroute_test.go
@@ -73,10 +73,10 @@ func TestGatewayTLSRouteSourceEndpoints(t *testing.T) {
 			},
 		},
 		Spec: v1alpha2.TLSRouteSpec{
-			Hostnames: []v1alpha2.Hostname{"api-hostnames.foobar.internal"},
+			Hostnames: []v1.Hostname{"api-hostnames.foobar.internal"},
 		},
 		Status: v1alpha2.TLSRouteStatus{
-			RouteStatus: v1a2RouteStatus(v1a2ParentRef("default", "internal")),
+			RouteStatus: gwRouteStatus(gwParentRef("default", "internal")),
 		},
 	}
 	_, err = gwClient.GatewayV1alpha2().TLSRoutes(rt.Namespace).Create(ctx, rt, metav1.CreateOptions{})

--- a/source/gateway_udproute_test.go
+++ b/source/gateway_udproute_test.go
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 )
 
@@ -55,7 +54,7 @@ func TestGatewayUDPRouteSourceEndpoints(t *testing.T) {
 			Name:      "internal",
 			Namespace: "default",
 		},
-		Spec: v1beta1.GatewaySpec{
+		Spec: v1.GatewaySpec{
 			Listeners: []v1.Listener{{
 				Protocol: v1.UDPProtocolType,
 			}},
@@ -75,7 +74,7 @@ func TestGatewayUDPRouteSourceEndpoints(t *testing.T) {
 		},
 		Spec: v1alpha2.UDPRouteSpec{},
 		Status: v1alpha2.UDPRouteStatus{
-			RouteStatus: v1a2RouteStatus(v1a2ParentRef("default", "internal")),
+			RouteStatus: gwRouteStatus(gwParentRef("default", "internal")),
 		},
 	}
 	_, err = gwClient.GatewayV1alpha2().UDPRoutes(rt.Namespace).Create(ctx, rt, metav1.CreateOptions{})


### PR DESCRIPTION
**Description**

This tidies up some loose ends from the Gateway API upgrade from v0.7.1 to v1.0.0 and brings the wildcard matching into compliance with the spec. Originally, the spec was like TLS certificates where a wildcard would only match a single subdomain level. It changed in v0.5.0 to be a multi-level matcher.

https://github.com/kubernetes-sigs/gateway-api/pull/1173

**Checklist**

- [X] Unit tests updated