### PR TITLE
fix(chart): allow secret to not be mounted

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Avoid to mount configuration secret if not needed () [@capuche2412](https://github.com/capuche2412)
 - Avoid unnecessary pod restart on each helm chart version. ([#4103](https://github.com/kubernetes-sigs/external-dns/pull/4103)) [@jkroepke](https://github.com/jkroepke)
 
 ## [v1.13.1] - 2023-09-07

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -115,9 +115,9 @@ spec:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
-          {{- if or .Values.secretConfiguration.enabled .Values.extraVolumeMounts }}
+          {{- if or (and .Values.secretConfiguration.enabled .Values.secretConfiguration.mountPath) .Values.extraVolumeMounts }}
           volumeMounts:
-            {{- if .Values.secretConfiguration.enabled }}
+            {{- if and .Values.secretConfiguration.enabled .Values.secretConfiguration.mountPath }}
             - name: secrets
               mountPath: {{ tpl .Values.secretConfiguration.mountPath $ }}
             {{- with .Values.secretConfiguration.subPath }}
@@ -132,9 +132,9 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- if or .Values.secretConfiguration.enabled .Values.extraVolumes }}
+      {{- if or (and .Values.secretConfiguration.enabled .Values.secretConfiguration.mountPath) .Values.extraVolumes }}
       volumes:
-        {{- if .Values.secretConfiguration.enabled }}
+        {{- if and .Values.secretConfiguration.enabled .Values.secretConfiguration.mountPath }}
         - name: secrets
           secret:
             secretName: {{ include "external-dns.fullname" . }}


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Hello !

In our use case, we want to use the secret only as an environment variable. Hence, it is not necessary to mount it. This PR aims to fix this by just not mounting the secret when the path is not provided. To give a precise example, if we precise an API_TOKEN in env we do not want to mount it as well.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes https://github.com/kubernetes-sigs/external-dns/issues/4142

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
