### PR TITLE
Add an option to not bail on errors

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -196,6 +196,8 @@ type Controller struct {
 	ExcludeRecordTypes []string
 	// MinEventSyncInterval is used as window for batching events
 	MinEventSyncInterval time.Duration
+	// BailOnError treat RunOnce Errors as fatal
+	BailOnError bool
 }
 
 // RunOnce runs a single iteration of a reconciliation loop.
@@ -331,7 +333,11 @@ func (c *Controller) Run(ctx context.Context) {
 	for {
 		if c.ShouldRunOnce(time.Now()) {
 			if err := c.RunOnce(ctx); err != nil {
-				log.Fatal(err)
+				if c.BailOnError {
+					log.Fatal(err)
+				} else {
+					log.Error(err)
+				}
 			}
 		}
 		select {

--- a/main.go
+++ b/main.go
@@ -456,6 +456,7 @@ func main() {
 		ManagedRecordTypes:   cfg.ManagedDNSRecordTypes,
 		ExcludeRecordTypes:   cfg.ExcludeDNSRecordTypes,
 		MinEventSyncInterval: cfg.MinEventSyncInterval,
+		BailOnError:          cfg.BailOnError,
 	}
 
 	if cfg.Once {

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -157,6 +157,7 @@ type Config struct {
 	MinEventSyncInterval               time.Duration
 	Once                               bool
 	DryRun                             bool
+	BailOnError                        bool
 	UpdateEvents                       bool
 	LogFormat                          string
 	MetricsAddress                     string
@@ -319,6 +320,7 @@ var defaultConfig = &Config{
 	Interval:                    time.Minute,
 	Once:                        false,
 	DryRun:                      false,
+	BailOnError:                 true,
 	UpdateEvents:                false,
 	LogFormat:                   "text",
 	MetricsAddress:              ":7979",
@@ -615,6 +617,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("min-event-sync-interval", "The minimum interval between two consecutive synchronizations triggered from kubernetes events in duration format (default: 5s)").Default(defaultConfig.MinEventSyncInterval.String()).DurationVar(&cfg.MinEventSyncInterval)
 	app.Flag("once", "When enabled, exits the synchronization loop after the first iteration (default: disabled)").BoolVar(&cfg.Once)
 	app.Flag("dry-run", "When enabled, prints DNS record changes rather than actually performing them (default: disabled)").BoolVar(&cfg.DryRun)
+	app.Flag("bail-on-error", "When enabled, errors will be treated as fatal and cause external-dns to exit (default: true)").BoolVar(&cfg.BailOnError)
 	app.Flag("events", "When enabled, in addition to running every interval, the reconciliation loop will get triggered when supported sources change (default: disabled)").BoolVar(&cfg.UpdateEvents)
 
 	// Miscellaneous flags


### PR DESCRIPTION
**Description**
https://github.com/kubernetes-sigs/external-dns/pull/3009 causes external-dns to exit on any errors returned up the stack even though some providers return "soft" errors which do not need to be treated as fatal as they most likely will work on the next controller sync.  This change adds a new bail-on-error flag that allows the user to decide how these errors should be treated.  The current behavior keeps the current default of exiting on an error however this can be changed to by adding --no-bail-on-error flag.

Fixes #4067

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
