### PR TITLE
feat: initial OpenAPI spec for webhook provider

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,3 +33,13 @@ jobs:
       run: |
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
         make lint
+
+    - name: Install Vacuum
+      # See: https://quobix.com/vacuum/installing/
+      run: |
+        curl -fsSL https://quobix.com/scripts/install_vacuum.sh | sh > /dev/null
+      shell: bash
+    - name: Run Vacuum
+      run: |
+        vacuum lint -d api/webhook.yaml
+      shell: bash

--- a/api/webhook.yaml
+++ b/api/webhook.yaml
@@ -1,0 +1,149 @@
+---
+openapi: "3.0.0"
+info:
+  version: 0.14.0
+  title: External DNS Webhook Server
+  description: >-
+    Implements the external DNS webhook endpoints.
+  contact:
+    url: https://github.com/kubernetes-sigs/external-dns
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+paths:
+  /:
+    get:
+      summary: >-
+        Initialisation and negotiates headers and returns domain
+        filter.
+      description: |
+        Initialisation and negotiates headers and returns domain
+        filter.
+      operationId: negotiate
+      responses:
+        '200':
+          description: Positive response
+          content:
+            application/external.dns.webhook+json;version=1:
+              schema:
+                $ref: '#/components/schemas/filters'
+        '500':
+          description: Failure
+
+  /records:
+    get:
+      summary: Returns the current records.
+      description: |
+        Get the current records from the provider and return them.
+      operationId: getRecords
+      responses:
+        '200':
+          description: Positive response
+          content:
+            application/external.dns.webhook+json;version=1:
+              schema:
+                $ref: '#/components/schemas/endpoints'
+        '500':
+          description: Failure
+
+    post:
+      summary: Applies the changes.
+      description: |
+        Set the records in the provider based on those supplied here.
+      operationId: setRecords
+      requestBody:
+        required: true
+        content:
+          application/external.dns.webhook+json;version=1:
+            schema:
+              $ref: '#/components/schemas/changes'
+      responses:
+        '204':
+          description: Positive response
+        '500':
+          description: Failure
+
+  /adjustendpoints:
+    post:
+      summary: Executes the AdjustEndpoints method.
+      description: |
+        Adjusts the records in the provider based on those supplied here.
+      operationId: adjustRecords
+      requestBody:
+        required: true
+        content:
+          application/external.dns.webhook+json;version=1:
+            schema:
+              $ref: '#/components/schemas/endpoints'
+      responses:
+        '200':
+          description: Positive response
+          content:
+            application/external.dns.webhook+json;version=1:
+              schema:
+                $ref: '#/components/schemas/endpoints'
+        '500':
+          description: Failure
+
+components:
+  schemas:
+    filters:
+      type: object
+      properties:
+        filters:
+          type: array
+          items:
+            type: string
+
+    endpoints:
+      type: array
+      items:
+        $ref: '#/components/schemas/endpoint'
+
+    endpoint:
+      type: object
+      properties:
+        dnsName:
+          type: string
+        targets:
+          $ref: '#/components/schemas/targets'
+        recordType:
+          type: string
+        setIdentifier:
+          type: string
+        recordTTL:
+          type: integer
+          format: int64
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+        providerSpecific:
+          type: array
+          items:
+            $ref: '#/components/schemas/providerSpecificProperty'
+
+    targets:
+      type: array
+      items:
+        type: string
+
+    providerSpecificProperty:
+      type: object
+      properties:
+        name:
+          type: string
+        value:
+          type: string
+
+    changes:
+      type: object
+      properties:
+        create:
+          $ref: '#/components/schemas/endpoints'
+        updateOld:
+          $ref: '#/components/schemas/endpoints'
+        updateNew:
+          $ref: '#/components/schemas/endpoints'
+        delete:
+          $ref: '#/components/schemas/endpoints'

--- a/api/webhook.yaml
+++ b/api/webhook.yaml
@@ -98,9 +98,7 @@ paths:
       tags: [update]
       requestBody:
         description: |
-          This is the list of records to be adjusted.
-
-          TODO: Explain how this should be applied.
+          This is the list of changes to be applied.
         required: true
         content:
           application/external.dns.webhook+json;version=1:
@@ -135,14 +133,14 @@ components:
 
     endpoints:
       description: |
-        TODO: explain the endpoints array.
+        This is a list of DNS records.
       type: array
       items:
         $ref: '#/components/schemas/endpoint'
 
     endpoint:
       description: |
-        TODO: explain the endpoint object.
+        This is a DNS record.
       type: object
       properties:
         dnsName:
@@ -171,7 +169,8 @@ components:
 
     targets:
       description: |
-        TODO: explain the targets array.
+        This is the list of targets that this DNS record points to.
+        So for an A record it will be a list of IP addresses.
       type: array
       items:
         type: string
@@ -195,7 +194,11 @@ components:
 
     changes:
       description: |
-        TODO: explain the changes object.
+        This is the list of changes that need to be applied.  There are
+        four lists of endpoints.  The `create` and `delete` lists are lists
+        of records to create and delete respectively.  The `updateOld` and
+        `updateNew` lists are paired.  For each entry there's the old version
+        of the record and a new version of the record.
       type: object
       properties:
         create:

--- a/api/webhook.yaml
+++ b/api/webhook.yaml
@@ -10,6 +10,16 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
+tags:
+  - name: initialization
+    description: Endpoints for initial negotiation.
+  - name: listing
+    description: Endpoints to get listings of DNS records.
+  - name: update
+    description: Endpoints to update DNS records.
+servers:
+  - url: http://localhost:10721
+    description: Server url for a k8s deployment.
 paths:
   /:
     get:
@@ -20,38 +30,52 @@ paths:
         Initialisation and negotiates headers and returns domain
         filter.
       operationId: negotiate
+      tags: [initialization]
       responses:
         '200':
-          description: Positive response
+          description: |
+            The list of domains this DNS provider serves.
           content:
             application/external.dns.webhook+json;version=1:
               schema:
                 $ref: '#/components/schemas/filters'
+              example:
+                filters:
+                  - example.com
         '500':
-          description: Failure
+          description: |
+            Failed to provide the list of domains we serve.
 
   /records:
     get:
       summary: Returns the current records.
       description: |
-        Get the current records from the provider and return them.
+        Get the current records from the DNS provider and return them.
       operationId: getRecords
+      tags: [listing]
       responses:
         '200':
-          description: Positive response
+          description: |
+            Provided the list of DNS records successfully.
           content:
             application/external.dns.webhook+json;version=1:
               schema:
                 $ref: '#/components/schemas/endpoints'
         '500':
-          description: Failure
+          description: |
+            Failed to provide the list of DNS records.
 
     post:
       summary: Applies the changes.
       description: |
-        Set the records in the provider based on those supplied here.
+        Set the records in the DNS provider based on those supplied here.
       operationId: setRecords
+      tags: [update]
       requestBody:
+        description: |
+          This is the list of changes that are required.
+
+          TODO: Explain how this should be applied.
         required: true
         content:
           application/external.dns.webhook+json;version=1:
@@ -59,9 +83,11 @@ paths:
               $ref: '#/components/schemas/changes'
       responses:
         '204':
-          description: Positive response
+          description: |
+            Changes were accepted.
         '500':
-          description: Failure
+          description: |
+            Changes were not accepted.
 
   /adjustendpoints:
     post:
@@ -69,7 +95,12 @@ paths:
       description: |
         Adjusts the records in the provider based on those supplied here.
       operationId: adjustRecords
+      tags: [update]
       requestBody:
+        description: |
+          This is the list of records to be adjusted.
+
+          TODO: Explain how this should be applied.
         required: true
         content:
           application/external.dns.webhook+json;version=1:
@@ -77,17 +108,21 @@ paths:
               $ref: '#/components/schemas/endpoints'
       responses:
         '200':
-          description: Positive response
+          description: |
+            Adjustments were accepted.
           content:
             application/external.dns.webhook+json;version=1:
               schema:
                 $ref: '#/components/schemas/endpoints'
         '500':
-          description: Failure
+          description: |
+            Adjustments were not accepted.
 
 components:
   schemas:
     filters:
+      description: |
+        TODO: explain the filters object.
       type: object
       properties:
         filters:
@@ -96,11 +131,15 @@ components:
             type: string
 
     endpoints:
+      description: |
+        TODO: explain the endpoints array.
       type: array
       items:
         $ref: '#/components/schemas/endpoint'
 
     endpoint:
+      description: |
+        TODO: explain the endpoint object.
       type: object
       properties:
         dnsName:
@@ -122,21 +161,38 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/providerSpecificProperty'
+      example:
+        dnsName: foo.example.com
+        recordType: A
+        recordTTL: 60
 
     targets:
+      description: |
+        TODO: explain the targets array.
       type: array
       items:
         type: string
+      example:
+        - 1.2.3.4
+        - 1.2.3.5
 
     providerSpecificProperty:
+      description: |
+        TODO: explain the provider object.  What might this be used for?
+        Examples?
       type: object
       properties:
         name:
           type: string
         value:
           type: string
+      example:
+        name: foo
+        value: bar
 
     changes:
+      description: |
+        TODO: explain the changes object.
       type: object
       properties:
         create:

--- a/api/webhook.yaml
+++ b/api/webhook.yaml
@@ -18,7 +18,7 @@ tags:
   - name: update
     description: Endpoints to update DNS records.
 servers:
-  - url: http://localhost:10721
+  - url: http://localhost:8888
     description: Server url for a k8s deployment.
 paths:
   /:
@@ -129,6 +129,9 @@ components:
           type: array
           items:
             type: string
+      example:
+        filters:
+          - foo.example.com
 
     endpoints:
       description: |

--- a/api/webhook.yaml
+++ b/api/webhook.yaml
@@ -73,9 +73,11 @@ paths:
       tags: [update]
       requestBody:
         description: |
-          This is the list of changes that are required.
-
-          TODO: Explain how this should be applied.
+          This is the list of changes that need to be applied.  There are
+          four lists of endpoints.  The `create` and `delete` lists are lists
+          of records to create and delete respectively.  The `updateOld` and
+          `updateNew` lists are paired.  For each entry there's the old version
+          of the record and a new version of the record.
         required: true
         content:
           application/external.dns.webhook+json;version=1:
@@ -194,11 +196,12 @@ components:
 
     changes:
       description: |
-        This is the list of changes that need to be applied.  There are
-        four lists of endpoints.  The `create` and `delete` lists are lists
-        of records to create and delete respectively.  The `updateOld` and
-        `updateNew` lists are paired.  For each entry there's the old version
-        of the record and a new version of the record.
+        This is the list of changes send by `external-dns` that need to
+        be applied.  There are four lists of endpoints.  The `create`
+        and `delete` lists are lists of records to create and delete
+        respectively.  The `updateOld` and `updateNew` lists are paired.
+        For each entry there's the old version of the record and a new
+        version of the record.
       type: object
       properties:
         create:


### PR DESCRIPTION
This provides the initial OpenAPI doc describing the webhook API as described in the code.  Really need far better descriptions for each endpoint and for each element in the schemas.

The goal is to make it far easier to implement providers.  I'm using a similar document [here](https://gitlab.com/lyda/external-dns-openwrt)

Relates to #4138

Not a goal for this PR, but possibly for a future one is to generate the webhook client with [oapi-codegen](https://github.com/deepmap/oapi-codegen).