### PR TITLE
fix(pdns): provider implicitly changes CNAME to ALIAS

### DIFF
--- a/provider/pdns/pdns.go
+++ b/provider/pdns/pdns.go
@@ -316,12 +316,14 @@ func (p *PDNSProvider) ConvertEndpointsToZones(eps []*endpoint.Endpoint, changet
 				for _, t := range ep.Targets {
 					if ep.RecordType == "CNAME" || ep.RecordType == "ALIAS" {
 						t = provider.EnsureTrailingDot(t)
-						if t != zone.Name && !strings.HasSuffix(t, "."+zone.Name) {
-							RecordType_ = "ALIAS"
-						}
 					}
 					records = append(records, pgo.Record{Content: t})
 				}
+
+				if dnsname == zone.Name && ep.RecordType == "CNAME" {
+					RecordType_ = "ALIAS"
+				}
+
 				rrset := pgo.RrSet{
 					Name:       dnsname,
 					Type_:      RecordType_,

--- a/provider/pdns/pdns.go
+++ b/provider/pdns/pdns.go
@@ -321,6 +321,7 @@ func (p *PDNSProvider) ConvertEndpointsToZones(eps []*endpoint.Endpoint, changet
 				}
 
 				if dnsname == zone.Name && ep.RecordType == "CNAME" {
+					log.Debugf("Converting APEX record %s from CNAME to ALIAS", dnsname)
 					RecordType_ = "ALIAS"
 				}
 


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/external-dns/issues/3970

The PR https://github.com/kubernetes-sigs/external-dns/pull/3338 introduces a broken behavior, where a CNAME is converted to an ALIAS if the **target** doesn't match its zone, which doesn't make sense in terms of DNS. The scenario that @epollia describes, is about the limitation of DNS, that limits the use of CNAMEs to subdomains only. Only A and AAAA are allowed for the apex (simply speaking). For this reason, pdns supports the custom ALIAS record type, which resolves the target on the server instead of the client. 

This change ensures the auto-conversion of CNAME to ALIAS on the domain apex, and removes the superflous target dependant conversion.

**Checklist**

- [x] Unit tests updated