### PR TITLE
fix(chart): Fix webhook install failure

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+## [v1.14.1] - 2024-01-11
+
+### Fixed
+
+- Fixed webhook install failure: `"http-webhook-metrics": must be no more than 15 characters`. ([#4173](https://github.com/kubernetes-sigs/external-dns/pull/4173)) [@gabe565](https://github.com/gabe565)
+
 ## [v1.14.0] - 2024-01-10
 
 ### Added

--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: external-dns
 description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 type: application
-version: 1.14.0
+version: 1.14.1
 appVersion: 0.14.0
 keywords:
   - kubernetes
@@ -20,17 +20,5 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "Added the option to explicitly enable or disable service account token automounting. ([#3983](https://github.com/kubernetes-sigs/external-dns/"
-    - kind: added
-      description: "Added the option to configure revisionHistoryLimit on the K8s Deployment resource. ([#4008](https://github.com/kubernetes-sigs/external-dns/pull/4008)) [@arnisoph](https://github.com/arnisoph)"
-    - kind: added
-      description: "Added support for webhook providers, as a sidecar. ([#4032](https://github.com/kubernetes-sigs/external-dns/pull/4032) [@mloiseleur](https://github.com/mloiseleur)"
-    - kind: added
-      description: "Added the option to configure ipFamilyPolicy and ipFamilies of external-dns Service.  ([#4153](https://github.com/kubernetes-sigs/external-dns/pull/4153)) [@dongjiang1989](https://github.com/dongjiang1989)"
-    - kind: changed
-      description: "Avoid unnecessary pod restart on each helm chart version. ([#4103](https://github.com/kubernetes-sigs/external-dns/pull/4103)) [@jkroepke](https://github.com/jkroepke)"
-    - kind: changed
-      description: "Updated _ExternalDNS_ OCI image version to [v0.14.0](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.14.0). ([#4073](https://github.com/kubernetes-sigs/external-dns/pull/4073)) [@appkins](https://github.com/appkins)"
-    - kind: deprecated
-      description: "The `secretConfiguration` value has been deprecated in favour of creating secrets external to the Helm chart and configuring their use via the `extraVolumes` & `extraVolumeMounts` values. ([#4161](https://github.com/kubernetes-sigs/external-dns/pull/4161)) [@stevehipwell](https://github.com/stevehipwell)"
+    - kind: fixed
+      description: "Fixed webhook install failure: `http-webhook-metrics: must be no more than 15 characters`. ([#4173](https://github.com/kubernetes-sigs/external-dns/pull/4173)) [@gabe565](https://github.com/gabe565)"

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -1,6 +1,6 @@
 # external-dns
 
-![Version: 1.14.0](https://img.shields.io/badge/Version-1.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.14.0](https://img.shields.io/badge/AppVersion-0.14.0-informational?style=flat-square)
+![Version: 1.14.1](https://img.shields.io/badge/Version-1.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.14.0](https://img.shields.io/badge/AppVersion-0.14.0-informational?style=flat-square)
 
 ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 
@@ -27,7 +27,7 @@ helm repo add external-dns https://kubernetes-sigs.github.io/external-dns/
 After you've installed the repo you can install the chart.
 
 ```shell
-helm upgrade --install external-dns external-dns/external-dns --version 1.14.0
+helm upgrade --install external-dns external-dns/external-dns --version 1.14.1
 ```
 
 ## Providers

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -150,7 +150,7 @@ spec:
             - name: http-webhook
               protocol: TCP
               containerPort: 8888
-            - name: http-webhook-metrics
+            - name: http-wh-metrics
               protocol: TCP
               containerPort: 8080
           livenessProbe:


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
v1.14.0 added the ability to deploy a webhook container, but it fails to install due to a character limit. Relevant install log:
```
Helm upgrade failed for release adguard-home/adguard-home-external-dns with chart external-dns@1.14.0: cannot patch "adguard-home-external-dns" with kind Deployment: Deployment.apps "adguard-home-external-dns" is invalid: spec.template.spec.containers[1].ports[1].name: Invalid value: "http-webhook-metrics": must be no more than 15 characters
```

This PR renames `http-webhook-metrics` to `webhook-metrics` to fix this error.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4174 

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
