### PR TITLE
fix(aws): allow alias records to be created when using the alias annotation

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -669,7 +669,7 @@ func (p *AWSProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoi
 		if aliasString, ok := ep.GetProviderSpecificProperty(providerSpecificAlias); ok {
 			alias = aliasString == "true"
 			if alias {
-				if ep.RecordType != endpoint.RecordTypeA {
+				if ep.RecordType != endpoint.RecordTypeA && ep.RecordType != endpoint.RecordTypeCNAME {
 					ep.DeleteProviderSpecificProperty(providerSpecificAlias)
 				}
 			} else {

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -527,6 +527,7 @@ func TestAWSAdjustEndpoints(t *testing.T) {
 		endpoint.NewEndpoint("cname-test-elb.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com"),
 		endpoint.NewEndpoint("cname-test-elb-no-alias.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificAlias, "false"),
 		endpoint.NewEndpoint("cname-test-elb-no-eth.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false"), // eth = evaluate target health
+		endpoint.NewEndpoint("cname-test-elb-alias.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificAlias, "true").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true"),
 	}
 
 	records, err := provider.AdjustEndpoints(records)
@@ -539,6 +540,7 @@ func TestAWSAdjustEndpoints(t *testing.T) {
 		endpoint.NewEndpoint("cname-test-elb.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificAlias, "true").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true"),
 		endpoint.NewEndpoint("cname-test-elb-no-alias.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificAlias, "false"),
 		endpoint.NewEndpoint("cname-test-elb-no-eth.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificAlias, "true").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false"), // eth = evaluate target health
+		endpoint.NewEndpoint("cname-test-elb-alias.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificAlias, "true").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true"),
 	})
 }
 


### PR DESCRIPTION
**Description**

This PR attempts to fix https://github.com/kubernetes-sigs/external-dns/issues/4026 where creating AWS alias records fail on v0.14.0. My first time looking at external-dns source code. I think the failure only occurs when `external-dns.alpha.kubernetes.io/alias: 'true' ` 

The AdjustEndpoints method currently removes the alias property from records that aren't of type A. Although https://github.com/kubernetes-sigs/external-dns/pull/3910/files changes Alias records to be represented as A records, at the point the alias deletion occurs the endpoint is still a CNAME, and the alias property is deleted. A non-Alias record A is then attempted to be created and fails at the Route53 API with `error: InvalidChangeBatch: [Invalid Resource Record: 'FATAL problem: ARRDATAIllegalIPv4Address (Value is not a valid IPv4 address)` 

This PR fixes https://github.com/kubernetes-sigs/external-dns/issues/4026 by only removing the alias property where record is not an A record or not a CNAME, as the annotation makes sense to use with either.

Would appeciate any guidance on how to update the tests to ensure this change doesn't cause unneeded changes on the plan, or deletecreates.

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
