### PR TITLE
fix args for helm webhook deployment

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Fixed ValidationError when webhook container `args` values are provided. ([#4196](https://github.com/kubernetes-sigs/external-dns/pull/4196)) [@ArtificialQualia](https://github.com/ArtificialQualia)
+
 ## [v1.14.1] - 2024-01-11
 
 ### Fixed

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -144,7 +144,7 @@ spec:
           {{- end }}
           {{- with .args }}
           args:
-            - {{ toYaml . | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
             - name: http-webhook


### PR DESCRIPTION

**Description**

<!-- Please provide a summary of the change here. -->
This fixes what appears to be a typo in the helm release which is preventing the ability to provide `args` to the webhook container.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4195

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
