### PR TITLE
Fix args for webhook deployment

### DIFF
--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -144,7 +144,7 @@ spec:
           {{- end }}
           {{- with .args }}
           args:
-            - {{ toYaml . | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
             - name: http-webhook


### PR DESCRIPTION
The upfront bullet point resulted in `- ""` and could brake the webhook container.