### PR TITLE
Fix Gateway API TLS TCP Route

### DIFF
--- a/source/gateway.go
+++ b/source/gateway.go
@@ -476,12 +476,17 @@ func uniqueTargets(targets endpoint.Targets) endpoint.Targets {
 
 // gwProtocolMatches returns whether a and b are the same protocol,
 // where HTTP and HTTPS are considered the same.
+// and TLS and TCP are considered the same.
 func gwProtocolMatches(a, b v1.ProtocolType) bool {
 	if a == v1.HTTPSProtocolType {
 		a = v1.HTTPProtocolType
 	}
 	if b == v1.HTTPSProtocolType {
 		b = v1.HTTPProtocolType
+	}
+	// if Listener is TLS and Route is TCP, then we'll treat the Listener as TCP.
+	if a == v1.TCPProtocolType && b == v1.TLSProtocolType {
+		b = v1.TCPProtocolType
 	}
 	return a == b
 }

--- a/source/gateway_test.go
+++ b/source/gateway_test.go
@@ -19,6 +19,8 @@ package source
 import (
 	"strings"
 	"testing"
+
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 func TestGatewayMatchingHost(t *testing.T) {
@@ -99,6 +101,60 @@ func TestGatewayMatchingHost(t *testing.T) {
 					)
 				}
 				tt.a, tt.b = tt.b, tt.a
+			}
+		})
+
+	}
+}
+
+func TestGatewayMatchingProtocol(t *testing.T) {
+	tests := []struct {
+		route, lis string
+		desc       string
+		ok         bool
+	}{
+		{
+			desc:  "protocol-matches-lis-https-route-http",
+			route: "HTTP",
+			lis:   "HTTPS",
+			ok:    true,
+		},
+		{
+			desc:  "protocol-match-invalid-list-https-route-tcp",
+			route: "TCP",
+			lis:   "HTTPS",
+			ok:    false,
+		},
+		{
+			desc:  "protocol-match-valid-lis-tls-route-tls",
+			route: "TLS",
+			lis:   "TLS",
+			ok:    true,
+		},
+		{
+			desc:  "protocol-match-valid-lis-TLS-route-TCP",
+			route: "TCP",
+			lis:   "TLS",
+			ok:    true,
+		},
+		{
+			desc:  "protocol-match-valid-lis-TLS-route-TCP",
+			route: "TLS",
+			lis:   "TCP",
+			ok:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			for i := 0; i < 2; i++ {
+				if ok := gwProtocolMatches(v1.ProtocolType(tt.route), v1.ProtocolType(tt.lis)); ok != tt.ok {
+					t.Errorf(
+						"gwProtocolMatches(%q, %q); got: %v; want: %v",
+						tt.route, tt.lis, ok, tt.ok,
+					)
+				}
+				//tt.a, tt.b = tt.b, tt.a
 			}
 		})
 


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
Resolves an issue with the TLS/TCP route matching. 
<!-- Please provide a summary of the change here. -->
Add test to check for matches against valid configurations from Gateway API spec
Add custom check for TLS -> TCP Route

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4011

**Checklist**

- [x ] Unit tests updated
- [ ] End user documentation updated
