### PR TITLE
fix(aws-provider): remove matchParent condition

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -300,7 +300,7 @@ func (p *AWSProvider) Zones(ctx context.Context) (map[string]*route53.HostedZone
 				continue
 			}
 
-			if !p.domainFilter.Match(aws.StringValue(zone.Name)) {
+			if !p.domainFilter.Match(aws.StringValue(zone.Name)) && !p.domainFilter.MatchParent(aws.StringValue(zone.Name)) {
 				continue
 			}
 

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -300,7 +300,8 @@ func (p *AWSProvider) Zones(ctx context.Context) (map[string]*route53.HostedZone
 				continue
 			}
 
-			if !p.domainFilter.Match(aws.StringValue(zone.Name)) && !p.domainFilter.MatchParent(aws.StringValue(zone.Name)) {
+			// if !p.domainFilter.Match(aws.StringValue(zone.Name)) && !p.domainFilter.MatchParent(aws.StringValue(zone.Name)) {
+			if !p.domainFilter.Match(aws.StringValue(zone.Name)) {
 				continue
 			}
 

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -290,19 +290,23 @@ func TestAWSZones(t *testing.T) {
 
 	noZones := map[string]*route53.HostedZone{}
 
+	defaultDomainFilters := endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."})
+
 	for _, ti := range []struct {
 		msg            string
 		zoneIDFilter   provider.ZoneIDFilter
 		zoneTypeFilter provider.ZoneTypeFilter
 		zoneTagFilter  provider.ZoneTagFilter
+		domainFilters  endpoint.DomainFilter
 		expectedZones  map[string]*route53.HostedZone
 	}{
-		{"no filter", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), provider.NewZoneTagFilter([]string{}), allZones},
-		{"public filter", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter("public"), provider.NewZoneTagFilter([]string{}), publicZones},
-		{"private filter", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter("private"), provider.NewZoneTagFilter([]string{}), privateZones},
-		{"unknown filter", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter("unknown"), provider.NewZoneTagFilter([]string{}), noZones},
-		{"zone id filter", provider.NewZoneIDFilter([]string{"/hostedzone/zone-3.ext-dns-test-2.teapot.zalan.do."}), provider.NewZoneTypeFilter(""), provider.NewZoneTagFilter([]string{}), privateZones},
-		{"tag filter", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), provider.NewZoneTagFilter([]string{"zone=3"}), privateZones},
+		{"no filter", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), provider.NewZoneTagFilter([]string{}), defaultDomainFilters, allZones},
+		{"public filter", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter("public"), provider.NewZoneTagFilter([]string{}), defaultDomainFilters, publicZones},
+		{"private filter", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter("private"), provider.NewZoneTagFilter([]string{}), defaultDomainFilters, privateZones},
+		{"unknown filter", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter("unknown"), provider.NewZoneTagFilter([]string{}), defaultDomainFilters, noZones},
+		{"zone id filter", provider.NewZoneIDFilter([]string{"/hostedzone/zone-3.ext-dns-test-2.teapot.zalan.do."}), provider.NewZoneTypeFilter(""), provider.NewZoneTagFilter([]string{}), defaultDomainFilters, privateZones},
+		{"tag filter", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), provider.NewZoneTagFilter([]string{"zone=3"}), defaultDomainFilters, privateZones},
+		{"domain filter zone-1", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), provider.NewZoneTagFilter([]string{}), endpoint.NewDomainFilter([]string{"zone-1.ext-dns-test-2.teapot.zalan.do"}), map[string]*route53.HostedZone{"/hostedzone/zone-1.ext-dns-test-2.teapot.zalan.do.": allZones["/hostedzone/zone-1.ext-dns-test-2.teapot.zalan.do."]}},
 	} {
 		provider, _ := newAWSProviderWithTagFilter(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), ti.zoneIDFilter, ti.zoneTypeFilter, ti.zoneTagFilter, defaultEvaluateTargetHealth, false, nil)
 


### PR DESCRIPTION
**Description**

    According to official external-dns source repository:
    PNDS provider is the only one which uses MatchParent functionality. The
    MatchParent functionality breaks domain and regex domain filters. It
    also makes PDNS provider behave differently than other providers while
    having the same configuration. MatchParent can be replaced by using
    multiple domain filters. After discussion with maintainers we concluded
    that MatchParent should be removed.

**Checklist**
- [x] Unit tests updated
