### PR TITLE
Add G-Core provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ ExternalDNS allows you to keep selected zones (via `--domain-filter`) synchroniz
 * [RcodeZero](https://www.rcodezero.at/)
 * [DigitalOcean](https://www.digitalocean.com/products/networking)
 * [DNSimple](https://dnsimple.com/)
+* [G-Core Labs](https://gcore.com/dns/)
 * [Infoblox](https://www.infoblox.com/products/dns/)
 * [Dyn](https://dyn.com/dns/)
 * [OpenStack Designate](https://docs.openstack.org/designate/latest/)
@@ -142,6 +143,7 @@ The following table clarifies the current status of the providers according to t
 | TencentCloud | Alpha | @Hyzhou |
 | Plural | Alpha | @michaeljguarino |
 | Pi-hole | Alpha | @tinyzimmer |
+| G-Core Labs | Alpha | |
 
 ## Kubernetes version compatibility
 
@@ -183,6 +185,7 @@ The following tutorials are provided:
 * [Dyn](docs/tutorials/dyn.md)
 * [Exoscale](docs/tutorials/exoscale.md)
 * [ExternalName Services](docs/tutorials/externalname.md)
+* [G-Core](docs/tutorials/gcore.md)
 * Google Kubernetes Engine
 	* [Using Google's Default Ingress Controller](docs/tutorials/gke.md)
 	* [Using the Nginx Ingress Controller](docs/tutorials/nginx-ingress.md)

--- a/docs/tutorials/gcore.md
+++ b/docs/tutorials/gcore.md
@@ -1,0 +1,195 @@
+# Setting up ExternalDNS for Services on G-Core Labs
+
+This tutorial describes how to setup ExternalDNS for use within a
+Kubernetes cluster using G-Core Labs DNS.
+
+Make sure to use **>=0.10** version of ExternalDNS for this tutorial.
+
+## Creating a zone with G-Core Labs DNS
+
+If you are new to G-Core Labs, we recommend you first read the following
+instructions for creating a zone.
+
+[Creating a zone using the G-Core Labs web console](https://dns.gcorelabs.com/zones)
+
+[Creating a zone using the G-Core Labs API](https://dnsapi.gcorelabs.com/docs#operation/CreateZone)
+
+## Creating G-Core Labs API key
+
+You first need to create a permanent API token.
+
+Using the [G-Core Labs documentation](https://gcorelabs.com/support/articles/360018625617/) you will have your `permanent API token`
+
+## Deploy ExternalDNS
+
+Connect your `kubectl` client to the cluster with which you want to test ExternalDNS, and then apply one of the following manifest files for deployment:
+
+### Manifest (for clusters without RBAC enabled)
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      containers:
+      - name: external-dns
+        image: k8s.gcr.io/external-dns/external-dns:v0.10.0
+        args:
+         - --source=service # ingress is also possible
+         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
+         - --provider=gcore
+        env:
+         - name: GCORE_PERMANENT_API_TOKEN
+           value: "YOUR_GCORE_PERMANENT_API_TOKEN"
+```
+
+### Manifest (for clusters with RBAC enabled)
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get","watch","list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get","watch","list"]
+- apiGroups: ["extensions","networking.k8s.io"]
+  resources: ["ingresses"]
+  verbs: ["get","watch","list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["list","watch"]
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["get","watch","list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+  namespace: default
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      serviceAccountName: external-dns
+      containers:
+      - name: external-dns
+        image: k8s.gcr.io/external-dns/external-dns:v0.7.7
+        args:
+          - --source=service # ingress is also possible
+          - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
+          - --provider=gcore
+        env:
+          - name: GCORE_PERMANENT_API_TOKEN
+            value: "YOUR_GCORE_PERMANENT_API_TOKEN"
+```
+
+## Deploying an Nginx Service
+
+Create a service file called 'nginx.yaml' with the following contents:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: example.com
+    external-dns.alpha.kubernetes.io/ttl: "120" #optional
+spec:
+  selector:
+    app: nginx
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+```
+
+**A note about annotations**
+
+Verify that the annotation on the service uses the same hostname as the G-Core Labs DNS zone created above. The annotation may also be a subdomain of the DNS zone (e.g. 'www.example.com').
+
+The TTL annotation can be used to configure the TTL on DNS records managed by ExternalDNS and is optional. If this annotation is not set, the TTL on records managed by ExternalDNS will default to 10.
+
+ExternalDNS uses the hostname annotation to determine which services should be registered with DNS. Removing the hostname annotation will cause ExternalDNS to remove the corresponding DNS records.
+
+### Create the deployment and service
+
+```
+$ kubectl create -f nginx.yaml
+```
+
+Depending on where you run your service, it may take some time for your cloud provider to create an external IP for the service. Once an external IP is assigned, ExternalDNS detects the new service IP address and synchronizes the G-Core Labs DNS records.
+
+## Verifying G-Core Labs DNS records
+
+Use the G-Core Labs web console or API to verify that the A record for your domain shows the external IP address of the services.
+
+## Cleanup
+
+Once you successfully configure and verify record management via ExternalDNS, you can delete the tutorial's example:
+
+```
+$ kubectl delete -f nginx.yaml
+$ kubectl delete -f externaldns.yaml
+```

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.2.0
 	github.com/F5Networks/k8s-bigip-ctlr/v2 v2.15.0
+	github.com/G-Core/gcore-dns-sdk-go v0.2.6
 	github.com/IBM-Cloud/ibm-cloud-cli-sdk v1.2.0
 	github.com/IBM/go-sdk-core/v5 v5.15.0
 	github.com/IBM/networking-go-sdk v0.44.0

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/F5Networks/k8s-bigip-ctlr/v2 v2.15.0 h1:zfJpJaYlAuhiM0hYWP67OEfYgWwFTC85B9Kvw4Z0TFA=
 github.com/F5Networks/k8s-bigip-ctlr/v2 v2.15.0/go.mod h1:FldIDBO8Hwd+RZGT8JGRGSWrzuS28OsXye5jhhZhTmg=
+github.com/G-Core/gcore-dns-sdk-go v0.2.6 h1:R82ANd7BnhIe2mV/12Ebdx9QYVl2++E4kfDIu97JEOk=
+github.com/G-Core/gcore-dns-sdk-go v0.2.6/go.mod h1:KliUjfPonDvXyAGNiuO+MYVG/7lmWHZ+4Hi0sPxgOjg=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v1.2.0 h1:+rQDqsHMRgh/3VkorvVVDAoRA6TxoSEOVO72O13wNks=
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v1.2.0/go.mod h1:tNq2mqCFCMbQfSy33uzMKPeDsMNwuqnLbazrnOjRtIs=

--- a/main.go
+++ b/main.go
@@ -388,6 +388,8 @@ func main() {
 		p, err = godaddy.NewGoDaddyProvider(ctx, domainFilter, cfg.GoDaddyTTL, cfg.GoDaddyAPIKey, cfg.GoDaddySecretKey, cfg.GoDaddyOTE, cfg.DryRun)
 	case "gandi":
 		p, err = gandi.NewGandiProvider(ctx, domainFilter, cfg.DryRun)
+	case gcore.ProviderName:
+		p, err = gcore.NewProvider(domainFilter, cfg.DryRun)
 	case "pihole":
 		p, err = pihole.NewPiholeProvider(
 			pihole.PiholeConfig{

--- a/provider/gcore/gcore.go
+++ b/provider/gcore/gcore.go
@@ -1,0 +1,365 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gcore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	gdns "github.com/G-Core/gcore-dns-sdk-go"
+	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
+)
+
+const (
+	ProviderName = "gcore"
+	envAPIToken  = "GCORE_PERMANENT_API_TOKEN"
+	logDryRun    = "[DryRun] "
+	maxTimeout   = 60 * time.Second
+)
+
+type dnsManager interface {
+	AddZoneRRSet(ctx context.Context,
+		zone, recordName, recordType string,
+		values []gdns.ResourceRecord, ttl int, opts ...gdns.AddZoneOpt) error
+	ZonesWithRecords(ctx context.Context, filters ...func(zone *gdns.ZonesFilter)) ([]gdns.Zone, error)
+	Zones(ctx context.Context, filters ...func(zone *gdns.ZonesFilter)) ([]gdns.Zone, error)
+	DeleteRRSetRecord(ctx context.Context, zone, name, recordType string, contents ...string) error
+}
+
+type dnsProvider struct {
+	domainFilter endpoint.DomainFilter
+	client       dnsManager
+	dryRun       bool
+}
+
+func NewProvider(domainFilter endpoint.DomainFilter, dryRun bool) (provider.Provider, error) {
+	log.Infof("%s: starting init provider: filters=%+v , dryRun=%v",
+		ProviderName, domainFilter.Filters, dryRun)
+	defer log.Infof("%s: finishing init provider", ProviderName)
+	apiToken := os.Getenv(envAPIToken)
+	if apiToken == "" {
+		return nil, EnvError("empty " + envAPIToken)
+	}
+	p := &dnsProvider{
+		domainFilter: domainFilter,
+		client:       gdns.NewClient(gdns.PermanentAPIKeyAuth(apiToken)),
+		dryRun:       dryRun,
+	}
+
+	return p, nil
+}
+
+func (p *dnsProvider) Records(rootCtx context.Context) ([]*endpoint.Endpoint, error) {
+	log.Infof("%s: starting get records", ProviderName)
+	filters := make([]func(*gdns.ZonesFilter), 0, 1)
+	if len(p.domainFilter.Filters) > 0 {
+		filters = append(filters, func(filter *gdns.ZonesFilter) {
+			filter.Names = p.domainFilter.Filters
+		})
+	}
+	ctx, cancel := p.ctxWithMyTimeout(rootCtx)
+	defer cancel()
+	zs, err := p.client.ZonesWithRecords(ctx, filters...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: records: %w", ProviderName, err)
+	}
+	result := make([]*endpoint.Endpoint, 0)
+	for _, z := range zs {
+		for _, r := range z.Records {
+			if !provider.SupportedRecordType(r.Type) {
+				continue
+			}
+			result = append(result,
+				endpoint.NewEndpointWithTTL(r.Name, r.Type, endpoint.TTL(r.TTL), r.ShortAnswers...))
+		}
+	}
+	defer log.Debugf("%s: finishing get records: %d", ProviderName, len(result))
+	return result, nil
+}
+
+func (p *dnsProvider) ApplyChanges(rootCtx context.Context, changes *plan.Changes) error {
+	if !changes.HasChanges() {
+		return nil
+	}
+	log.Infof("%s: starting apply changes createLen=%d, deleteLen=%d, updateOldLen=%d, updateNewLen=%d",
+		ProviderName, len(changes.Create), len(changes.Delete), len(changes.UpdateOld), len(changes.UpdateNew))
+	ctx, cancel := p.ctxWithMyTimeout(rootCtx)
+	defer cancel()
+	gr1, _ := errgroup.WithContext(ctx)
+	gr2, _ := errgroup.WithContext(ctx)
+	extractZone := p.zoneFromDNSNameGetter()
+	appliedChanges := struct {
+		created uint
+		deleted uint
+		updated uint
+	}{}
+	// prepare zone to add changes by removing outdated records
+	for _, d := range changes.UpdateNew {
+		d := d
+		zone := extractZone(d.DNSName)
+		if zone == "" {
+			continue
+		}
+		recordValues := make([]string, 0)
+		errMsg := make([]string, 0)
+		// find content diff to delete
+		for _, content := range unexistingTargets(d, changes.UpdateOld, false) {
+			appliedChanges.updated++
+			msg := fmt.Sprintf("update old %s %s %s",
+				d.DNSName, d.RecordType, content)
+			if p.dryRun {
+				log.Info(logDryRun + msg)
+				continue
+			}
+			log.Debug(msg)
+			recordValues = append(recordValues, content)
+			errMsg = append(errMsg, msg)
+		}
+		if len(recordValues) == 0 {
+			continue
+		}
+		gr2.Go(func() error {
+			return errSafeWrap(strings.Join(errMsg, "; "),
+				p.client.DeleteRRSetRecord(ctx, zone, d.DNSName, d.RecordType, recordValues...))
+		})
+	}
+	// remove deleted records
+	for _, d := range changes.Delete {
+		d := d
+		zone := extractZone(d.DNSName)
+		if zone == "" {
+			continue
+		}
+		recordValues := make([]string, 0)
+		errMsg := make([]string, 0)
+		for _, content := range d.Targets {
+			appliedChanges.deleted++
+			msg := fmt.Sprintf("delete %s %s %s",
+				d.DNSName, d.RecordType, content)
+			if p.dryRun {
+				log.Info(logDryRun + msg)
+				continue
+			}
+			log.Debug(msg)
+			recordValues = append(recordValues, content)
+			errMsg = append(errMsg, msg)
+		}
+		gr1.Go(func() error {
+			return errSafeWrap(strings.Join(errMsg, "; "),
+				p.client.DeleteRRSetRecord(ctx, zone, d.DNSName, d.RecordType, recordValues...))
+		})
+	}
+	// add created records
+	for _, c := range changes.Create {
+		c := c
+		zone := extractZone(c.DNSName)
+		if zone == "" {
+			continue
+		}
+		recordValues := make([]gdns.ResourceRecord, 0)
+		errMsg := make([]string, 0)
+		for _, content := range c.Targets {
+			appliedChanges.created++
+			msg := fmt.Sprintf("create %s %s %s", c.DNSName, c.RecordType, content)
+			if p.dryRun {
+				log.Info(logDryRun + msg)
+				continue
+			}
+			log.Debug(msg)
+			recordValues = append(recordValues,
+				*(&gdns.ResourceRecord{}).SetContent(c.RecordType, content))
+			errMsg = append(errMsg, msg)
+		}
+		gr1.Go(func() error {
+			return errSafeWrap(strings.Join(errMsg, "; "),
+				p.client.AddZoneRRSet(ctx, zone, c.DNSName, c.RecordType, recordValues, int(c.RecordTTL)))
+		})
+	}
+	// wait preparing before send updates to records
+	err := gr2.Wait()
+	if err != nil {
+		return fmt.Errorf("%s: apply changes: %w", ProviderName, err)
+	}
+	// add changes
+	for _, c := range changes.UpdateNew {
+		c := c
+		zone := extractZone(c.DNSName)
+		if zone == "" {
+			continue
+		}
+		recordValues := make([]gdns.ResourceRecord, 0)
+		errMsg := make([]string, 0)
+		// find content diff to add
+		for _, content := range unexistingTargets(c, changes.UpdateOld, true) {
+			appliedChanges.updated++
+			msg := fmt.Sprintf("update new %s %s %s", c.DNSName, c.RecordType, content)
+			if p.dryRun {
+				log.Info(logDryRun + msg)
+				continue
+			}
+			log.Debug(msg)
+			recordValues = append(recordValues,
+				*(&gdns.ResourceRecord{}).SetContent(c.RecordType, content))
+			errMsg = append(errMsg, msg)
+		}
+		if len(recordValues) == 0 {
+			continue
+		}
+		gr1.Go(func() error {
+			return errSafeWrap(strings.Join(errMsg, "; "),
+				p.client.AddZoneRRSet(ctx, zone, c.DNSName, c.RecordType, recordValues, int(c.RecordTTL)))
+		})
+	}
+	err = gr1.Wait()
+	if err != nil {
+		return fmt.Errorf("%s: apply changes: %w", ProviderName, err)
+	}
+	log.Infof("%s: finishing apply changes created=%d, deleted=%d, updated=%d",
+		ProviderName, appliedChanges.created, appliedChanges.deleted, appliedChanges.updated)
+	return nil
+}
+
+func (p *dnsProvider) GetDomainFilter() endpoint.DomainFilter {
+	log.Debugf("%s: starting get domain filters", ProviderName)
+	zs, err := p.client.Zones(context.Background())
+	if err != nil {
+		log.Errorf("%s: get domain filters: %v", ProviderName, err)
+		return endpoint.DomainFilter{}
+	}
+	domains := make([]string, 0)
+	for _, z := range zs {
+		domains = append(domains, z.Name, "."+z.Name)
+	}
+	defer log.Debugf("%s: finishing get domain filters with %+v", ProviderName, domains)
+	return endpoint.NewDomainFilter(domains)
+}
+
+func (p *dnsProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
+	return endpoints, nil
+}
+
+func (p *dnsProvider) PropertyValuesEqual(_ string, previous string, current string) bool {
+	return previous == current
+}
+
+func (p *dnsProvider) zoneFromDNSNameGetter() func(name string) (zone string) {
+	existingZones := p.GetDomainFilter()
+	search := make(map[string]string)
+	for _, zone := range existingZones.Filters {
+		search[zone] = strings.Trim(zone, ".")
+	}
+	return func(name string) (zone string) {
+		for _, possibleZone := range extractAllZones(name) {
+			if result, ok := search[possibleZone]; ok {
+				return result
+			}
+		}
+		return ""
+	}
+}
+
+func (p *dnsProvider) ctxWithMyTimeout(rootCtx context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(context.Background(), maxTimeout)
+	go func() {
+		select {
+		case <-rootCtx.Done():
+			ctxErr := rootCtx.Err()
+			if ctxErr != nil && strings.Contains(ctxErr.Error(), "deadline exceeded") {
+				return
+			}
+			log.Warningf("%s: ctx done: %v", ProviderName, ctxErr)
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	return ctx, cancel
+}
+
+func extractAllZones(dnsName string) []string {
+	parts := strings.Split(strings.Trim(dnsName, "."), ".")
+	if len(parts) < 2 {
+		return nil
+	}
+
+	var zones []string
+	for i := 0; i < len(parts)-1; i++ {
+		zones = append(zones, strings.Join(parts[i:], "."))
+	}
+
+	return zones
+}
+
+func errSafeWrap(msg string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", msg, err)
+}
+
+func unexistingTargets(existing *endpoint.Endpoint,
+	toCompare []*endpoint.Endpoint, diffFromExisting bool) endpoint.Targets {
+	for _, compare := range toCompare {
+		if compare.RecordType != existing.RecordType || compare.DNSName != existing.DNSName {
+			continue
+		}
+		result := endpoint.Targets{}
+		if diffFromExisting {
+			for _, fromTar := range existing.Targets {
+				exist := false
+				for _, curTar := range compare.Targets {
+					if curTar == fromTar {
+						exist = true
+						break
+					}
+				}
+				if exist {
+					continue
+				}
+				result = append(result, fromTar)
+			}
+		} else {
+			for _, fromTar := range compare.Targets {
+				exist := false
+				for _, curTar := range existing.Targets {
+					if curTar == fromTar {
+						exist = true
+						break
+					}
+				}
+				if exist {
+					continue
+				}
+				result = append(result, fromTar)
+			}
+		}
+		return result
+	}
+	return nil
+}
+
+// EnvError description
+type EnvError string
+
+func (e EnvError) Error() string {
+	return fmt.Sprintf("invalid evirement var: %s", string(e))
+}

--- a/provider/gcore/gcore_test.go
+++ b/provider/gcore/gcore_test.go
@@ -1,0 +1,550 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gcore
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	gdns "github.com/G-Core/gcore-dns-sdk-go"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+)
+
+type dnsManagerMock struct {
+	addZoneRRSet      func(ctx context.Context, zone, recordName, recordType string, values []gdns.ResourceRecord, ttl int) error
+	zonesWithRecords  func(ctx context.Context, filters ...func(zone *gdns.ZonesFilter)) ([]gdns.Zone, error)
+	zones             func(ctx context.Context, filters ...func(zone *gdns.ZonesFilter)) ([]gdns.Zone, error)
+	deleteRRSetRecord func(ctx context.Context, zone, name, recordType string, contents ...string) error
+}
+
+func (d dnsManagerMock) AddZoneRRSet(ctx context.Context,
+	zone, recordName, recordType string,
+	values []gdns.ResourceRecord, ttl int, _ ...gdns.AddZoneOpt) error {
+	return d.addZoneRRSet(ctx, zone, recordName, recordType, values, ttl)
+}
+func (d dnsManagerMock) ZonesWithRecords(ctx context.Context, filters ...func(zone *gdns.ZonesFilter)) ([]gdns.Zone, error) {
+	return d.zonesWithRecords(ctx, filters...)
+}
+func (d dnsManagerMock) Zones(ctx context.Context, filters ...func(zone *gdns.ZonesFilter)) ([]gdns.Zone, error) {
+	return d.zones(ctx, filters...)
+}
+func (d dnsManagerMock) DeleteRRSetRecord(ctx context.Context, zone, name, recordType string, contents ...string) error {
+	return d.deleteRRSetRecord(ctx, zone, name, recordType, contents...)
+}
+
+func Test_dnsProvider_Records(t *testing.T) {
+	type fields struct {
+		domainFilter endpoint.DomainFilter
+		client       dnsManager
+		dryRun       bool
+	}
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []endpoint.Endpoint
+		wantErr bool
+	}{
+		{
+			name: "no_filter",
+			fields: fields{
+				domainFilter: endpoint.DomainFilter{},
+				client: dnsManagerMock{
+					zonesWithRecords: func(ctx context.Context,
+						filters ...func(zone *gdns.ZonesFilter)) ([]gdns.Zone, error) {
+						return []gdns.Zone{
+							{
+								Name: "example.com",
+								Records: []gdns.ZoneRecord{
+									{
+										Name:         "test.example.com",
+										Type:         "A",
+										TTL:          10,
+										ShortAnswers: []string{"1.1.1.1"},
+									},
+								},
+							},
+						}, nil
+					},
+				},
+				dryRun: false,
+			},
+			args: args{
+				ctx: context.Background(),
+			},
+			want: []endpoint.Endpoint{
+				*endpoint.NewEndpointWithTTL(
+					"test.example.com", "A", endpoint.TTL(10), []string{"1.1.1.1"}...),
+			},
+			wantErr: false,
+		},
+		{
+			name: "filtered",
+			fields: fields{
+				domainFilter: endpoint.DomainFilter{Filters: []string{"example.com"}},
+				client: dnsManagerMock{
+					zonesWithRecords: func(ctx context.Context,
+						filters ...func(zone *gdns.ZonesFilter)) ([]gdns.Zone, error) {
+						zoneFilter := &gdns.ZonesFilter{}
+						for _, op := range filters {
+							op(zoneFilter)
+						}
+						val := []gdns.Zone{
+							{
+								Name: "example.com",
+								Records: []gdns.ZoneRecord{
+									{
+										Name:         "test.example.com",
+										Type:         "A",
+										TTL:          10,
+										ShortAnswers: []string{"1.1.1.1"},
+									},
+								},
+							},
+						}
+						res := make([]gdns.Zone, 0)
+						for _, v := range val {
+							for _, name := range zoneFilter.Names {
+								if name == v.Name {
+									res = append(res, v)
+								}
+							}
+						}
+						return res, nil
+					},
+				},
+				dryRun: false,
+			},
+			args: args{
+				ctx: context.Background(),
+			},
+			want: []endpoint.Endpoint{
+				*endpoint.NewEndpointWithTTL(
+					"test.example.com", "A", endpoint.TTL(10), []string{"1.1.1.1"}...),
+			},
+			wantErr: false,
+		},
+		{
+			name: "error",
+			fields: fields{
+				domainFilter: endpoint.DomainFilter{Filters: []string{"example.com"}},
+				client: dnsManagerMock{
+					zonesWithRecords: func(ctx context.Context,
+						filters ...func(zone *gdns.ZonesFilter)) ([]gdns.Zone, error) {
+						return nil, fmt.Errorf("test")
+					},
+				},
+				dryRun: false,
+			},
+			args: args{
+				ctx: context.Background(),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &dnsProvider{
+				domainFilter: tt.fields.domainFilter,
+				client:       tt.fields.client,
+				dryRun:       tt.fields.dryRun,
+			}
+			got, err := p.Records(tt.args.ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Records() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			toCompare := make([]endpoint.Endpoint, len(got))
+			for i, e := range got {
+				toCompare[i] = *e
+			}
+			if !reflect.DeepEqual(toCompare, tt.want) {
+				t.Errorf("Records() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_dnsProvider_GetDomainFilter(t *testing.T) {
+	type fields struct {
+		domainFilter endpoint.DomainFilter
+		client       dnsManager
+		dryRun       bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   endpoint.DomainFilter
+	}{
+		{
+			name: "not_empty",
+			fields: fields{
+				domainFilter: endpoint.DomainFilter{},
+				client: dnsManagerMock{
+					zones: func(ctx context.Context,
+						filters ...func(zone *gdns.ZonesFilter)) ([]gdns.Zone, error) {
+						return []gdns.Zone{{Name: "example.com"}}, nil
+					},
+				},
+				dryRun: false,
+			},
+			want: endpoint.NewDomainFilter([]string{"example.com", ".example.com"}),
+		},
+		{
+			name: "empty",
+			fields: fields{
+				domainFilter: endpoint.DomainFilter{},
+				client: dnsManagerMock{
+					zones: func(ctx context.Context,
+						filters ...func(zone *gdns.ZonesFilter)) ([]gdns.Zone, error) {
+						return []gdns.Zone{}, nil
+					},
+				},
+				dryRun: false,
+			},
+			want: endpoint.NewDomainFilter([]string{}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &dnsProvider{
+				domainFilter: tt.fields.domainFilter,
+				client:       tt.fields.client,
+				dryRun:       tt.fields.dryRun,
+			}
+			if got := p.GetDomainFilter(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetDomainFilter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_dnsProvider_ApplyChanges(t *testing.T) {
+	type fields struct {
+		domainFilter endpoint.DomainFilter
+		client       dnsManager
+		dryRun       bool
+	}
+	type args struct {
+		ctx     context.Context
+		changes *plan.Changes
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "delete exist in filter",
+			fields: fields{
+				domainFilter: endpoint.DomainFilter{},
+				client: dnsManagerMock{
+					zones: func(ctx context.Context,
+						filters ...func(zone *gdns.ZonesFilter)) ([]gdns.Zone, error) {
+						return []gdns.Zone{{Name: "test.com"}}, nil
+					},
+					deleteRRSetRecord: func(ctx context.Context, zone, name, recordType string, contents ...string) error {
+						if zone == "test.com" && name == "my.test.com" && recordType == "A" && contents[0] == "1.1.1.1" {
+							return nil
+						}
+						return fmt.Errorf("deleteRRSetRecord wrong params")
+					},
+				},
+				dryRun: false,
+			},
+			args: args{
+				ctx: context.Background(),
+				changes: &plan.Changes{
+					Delete: []*endpoint.Endpoint{
+						endpoint.NewEndpointWithTTL("my.test.com", "A", 10, "1.1.1.1"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "delete exist in filter with left dot",
+			fields: fields{
+				domainFilter: endpoint.DomainFilter{},
+				client: dnsManagerMock{
+					zones: func(ctx context.Context,
+						filters ...func(zone *gdns.ZonesFilter)) ([]gdns.Zone, error) {
+						return []gdns.Zone{{Name: "test.com"}}, nil
+					},
+					deleteRRSetRecord: func(ctx context.Context, zone, name, recordType string, contents ...string) error {
+						if zone == "test.com" && name == ".my.test.com" && recordType == "A" && contents[0] == "1.1.1.1" {
+							return nil
+						}
+						return fmt.Errorf("deleteRRSetRecord wrong params")
+					},
+				},
+				dryRun: false,
+			},
+			args: args{
+				ctx: context.Background(),
+				changes: &plan.Changes{
+					Delete: []*endpoint.Endpoint{
+						endpoint.NewEndpointWithTTL(".my.test.com", "A", 10, "1.1.1.1"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "delete not exist in filter",
+			fields: fields{
+				domainFilter: endpoint.DomainFilter{},
+				client: dnsManagerMock{
+					zones: func(ctx context.Context,
+						filters ...func(zone *gdns.ZonesFilter)) ([]gdns.Zone, error) {
+						return []gdns.Zone{{Name: "test.com"}}, nil
+					},
+				},
+				dryRun: false,
+			},
+			args: args{
+				ctx: context.Background(),
+				changes: &plan.Changes{
+					Delete: []*endpoint.Endpoint{
+						endpoint.NewEndpointWithTTL("my.t.com", "A", 10, "1.1.1.1"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "delete error",
+			fields: fields{
+				domainFilter: endpoint.DomainFilter{},
+				client: dnsManagerMock{
+					zones: func(ctx context.Context,
+						filters ...func(zone *gdns.ZonesFilter)) ([]gdns.Zone, error) {
+						return []gdns.Zone{{Name: "test.com"}}, nil
+					},
+					deleteRRSetRecord: func(ctx context.Context, zone, name, recordType string, contents ...string) error {
+						if zone == "test.com" && name == "my.test.com" && recordType == "A" && contents[0] == "1.1.1.1" {
+							return nil
+						}
+						return fmt.Errorf("deleteRRSetRecord wrong params")
+					},
+				},
+				dryRun: false,
+			},
+			args: args{
+				ctx: context.Background(),
+				changes: &plan.Changes{
+					Delete: []*endpoint.Endpoint{
+						endpoint.NewEndpointWithTTL("my1.test.com", "A", 10, "1.1.1.1"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "create ok",
+			fields: fields{
+				domainFilter: endpoint.DomainFilter{},
+				client: dnsManagerMock{
+					zones: func(ctx context.Context,
+						filters ...func(zone *gdns.ZonesFilter)) ([]gdns.Zone, error) {
+						return []gdns.Zone{{Name: "test.com"}}, nil
+					},
+					addZoneRRSet: func(ctx context.Context, zone, recordName, recordType string, values []gdns.ResourceRecord, ttl int) error {
+						if zone == "test.com" &&
+							ttl == 10 &&
+							recordName == "my.test.com" &&
+							recordType == "A" &&
+							values[0].Content[0] == "1.1.1.1" {
+							return nil
+						}
+						return fmt.Errorf("addZoneRRSet wrong params")
+					},
+				},
+				dryRun: false,
+			},
+			args: args{
+				ctx: context.Background(),
+				changes: &plan.Changes{
+					Create: []*endpoint.Endpoint{
+						endpoint.NewEndpointWithTTL("my.test.com", "A", 10, "1.1.1.1"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "update ok",
+			fields: fields{
+				domainFilter: endpoint.DomainFilter{},
+				client: dnsManagerMock{
+					zones: func(ctx context.Context,
+						filters ...func(zone *gdns.ZonesFilter)) ([]gdns.Zone, error) {
+						return []gdns.Zone{{Name: "test.com"}}, nil
+					},
+					deleteRRSetRecord: func(ctx context.Context, zone, name, recordType string, contents ...string) error {
+						if zone == "test.com" && name == "my.test.com" && recordType == "A" && contents[0] == "1.1.1.1" {
+							return nil
+						}
+						return fmt.Errorf("deleteRRSetRecord wrong params: %s %s %s %+v",
+							zone, name, recordType, contents)
+					},
+					addZoneRRSet: func(ctx context.Context, zone, recordName, recordType string, values []gdns.ResourceRecord, ttl int) error {
+						if zone == "test.com" &&
+							ttl == 10 &&
+							recordName == "my.test.com" &&
+							recordType == "A" &&
+							values[0].Content[0] == "1.2.3.4" {
+							return nil
+						}
+						return fmt.Errorf("addZoneRRSet wrong params")
+					},
+				},
+				dryRun: false,
+			},
+			args: args{
+				ctx: context.Background(),
+				changes: &plan.Changes{
+					UpdateOld: []*endpoint.Endpoint{
+						endpoint.NewEndpointWithTTL("my.test.com", "A", 10, "1.1.1.1"),
+						endpoint.NewEndpointWithTTL("my1.test.com", "A", 10, "1.1.1.2"),
+					},
+					UpdateNew: []*endpoint.Endpoint{
+						endpoint.NewEndpointWithTTL("my.test.com", "A", 10, "1.2.3.4"),
+						endpoint.NewEndpointWithTTL("my1.test.com", "A", 10, "1.1.1.2"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &dnsProvider{
+				domainFilter: tt.fields.domainFilter,
+				client:       tt.fields.client,
+				dryRun:       tt.fields.dryRun,
+			}
+			if err := p.ApplyChanges(tt.args.ctx, tt.args.changes); (err != nil) != tt.wantErr {
+				t.Errorf("ApplyChanges() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_extractAllZones(t *testing.T) {
+	type args struct {
+		dnsName string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "3th level",
+			args: args{
+				dnsName: "my.test.com",
+			},
+			want: []string{"my.test.com", "test.com"},
+		},
+		{
+			name: "with dots",
+			args: args{
+				dnsName: ".my.test.com.",
+			},
+			want: []string{"my.test.com", "test.com"},
+		},
+		{
+			name: "2d level",
+			args: args{
+				dnsName: "test.com",
+			},
+			want: []string{"test.com"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractAllZones(tt.args.dnsName); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("extractAllZones() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNonExistingTargets(t *testing.T) {
+	type args struct {
+		existing         *endpoint.Endpoint
+		toCompare        []*endpoint.Endpoint
+		diffFromExisting bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want endpoint.Targets
+	}{
+		{
+			name: "not from existing",
+			args: args{
+				existing: endpoint.NewEndpointWithTTL(
+					"my.test.com", "A", 10, "1.1.1.1", "1.2.2.2"),
+				toCompare: []*endpoint.Endpoint{
+					endpoint.NewEndpointWithTTL(
+						"my.test.com", "A", 10, "1.1.1.1", "1.2.3.4"),
+					endpoint.NewEndpointWithTTL(
+						"my.test.com", "AAAA", 10, "1.1.1.1", "1.3.3.4"),
+					endpoint.NewEndpointWithTTL(
+						"no.test.com", "A", 10, "1.1.1.1", "1.3.3.4"),
+				},
+				diffFromExisting: false,
+			},
+			want: endpoint.Targets{"1.2.3.4"},
+		},
+		{
+			name: "from existing",
+			args: args{
+				existing: endpoint.NewEndpointWithTTL(
+					"my.test.com", "A", 10, "1.1.1.1", "1.2.2.2"),
+				toCompare: []*endpoint.Endpoint{
+					endpoint.NewEndpointWithTTL(
+						"my.test.com", "A", 10, "1.1.1.1", "1.2.3.4"),
+					endpoint.NewEndpointWithTTL(
+						"my.test.com", "AAAA", 10, "1.1.1.1", "1.3.3.4"),
+					endpoint.NewEndpointWithTTL(
+						"no.test.com", "A", 10, "1.1.1.1", "1.3.3.4"),
+				},
+				diffFromExisting: true,
+			},
+			want: endpoint.Targets{"1.2.2.2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := unexistingTargets(tt.args.existing, tt.args.toCompare, tt.args.diffFromExisting); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("unexistingTargets() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description**

add g-core provider

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated

taken from old commits of https://github.com/kubernetes-sigs/external-dns/pull/2203 just minor modification to match current signature of G-Core's SDK

100% coverage
![image](https://github.com/kubernetes-sigs/external-dns/assets/1061610/06dc58a5-c825-4a01-8133-79a9b1c2524b)
