### PR TITLE
feat: resolve dns targets in ingress based records to create A/AAAA instead of CNAME

### DIFF
--- a/docs/sources/ingress.md
+++ b/docs/sources/ingress.md
@@ -46,3 +46,6 @@ the values from that.
 
 2. Otherwise, iterates over the Ingress's `status.loadBalancer.ingress`, 
 adding each non-empty `ip` and `hostname`. 
+
+In the case that `--resolve-ingress-target-hostname` set, it will resolve hostnames in the status to create 
+A/AAAA records instead of CNAME.

--- a/main.go
+++ b/main.go
@@ -156,6 +156,7 @@ func main() {
 		OCPRouterName:                  cfg.OCPRouterName,
 		UpdateEvents:                   cfg.UpdateEvents,
 		ResolveLoadBalancerHostname:    cfg.ResolveServiceLoadBalancerHostname,
+		ResolveIngressTargetHostname:   cfg.ResolveIngressTargetHostname,
 		TraefikDisableLegacy:           cfg.TraefikDisableLegacy,
 		TraefikDisableNew:              cfg.TraefikDisableNew,
 	}

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -178,6 +178,7 @@ type Config struct {
 	CFUsername                         string
 	CFPassword                         string
 	ResolveServiceLoadBalancerHostname bool
+	ResolveIngressTargetHostname       bool
 	RFC2136Host                        string
 	RFC2136Port                        int
 	RFC2136Zone                        []string
@@ -431,6 +432,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("kubeconfig", "Retrieve target cluster configuration from a Kubernetes configuration file (default: auto-detect)").Default(defaultConfig.KubeConfig).StringVar(&cfg.KubeConfig)
 	app.Flag("request-timeout", "Request timeout when calling Kubernetes APIs. 0s means no timeout").Default(defaultConfig.RequestTimeout.String()).DurationVar(&cfg.RequestTimeout)
 	app.Flag("resolve-service-load-balancer-hostname", "Resolve the hostname of LoadBalancer-type Service object to IP addresses in order to create DNS A/AAAA records instead of CNAMEs").BoolVar(&cfg.ResolveServiceLoadBalancerHostname)
+	app.Flag("resolve-ingress-target-hostname", "Resolve the hostname of Ingress target to IP addresses in order to create DNS A/AAAA records instead of CNAMEs").BoolVar(&cfg.ResolveIngressTargetHostname)
 
 	// Flags related to cloud foundry
 	app.Flag("cf-api-endpoint", "The fully-qualified domain name of the cloud foundry instance you are targeting").Default(defaultConfig.CFAPIEndpoint).StringVar(&cfg.CFAPIEndpoint)

--- a/source/store.go
+++ b/source/store.go
@@ -74,6 +74,7 @@ type Config struct {
 	OCPRouterName                  string
 	UpdateEvents                   bool
 	ResolveLoadBalancerHostname    bool
+	ResolveIngressTargetHostname   bool
 	TraefikDisableLegacy           bool
 	TraefikDisableNew              bool
 }
@@ -224,7 +225,7 @@ func BuildWithConfig(ctx context.Context, source string, p ClientGenerator, cfg 
 		if err != nil {
 			return nil, err
 		}
-		return NewIngressSource(ctx, client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.IgnoreHostnameAnnotation, cfg.IgnoreIngressTLSSpec, cfg.IgnoreIngressRulesSpec, cfg.LabelFilter, cfg.IngressClassNames)
+		return NewIngressSource(ctx, client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.IgnoreHostnameAnnotation, cfg.IgnoreIngressTLSSpec, cfg.IgnoreIngressRulesSpec, cfg.LabelFilter, cfg.IngressClassNames, cfg.ResolveLoadBalancerHostname)
 	case "pod":
 		client, err := p.KubeClient()
 		if err != nil {


### PR DESCRIPTION
**Description**

Similar feature to the one added in https://github.com/kubernetes-sigs/external-dns/pull/3554 but for ingress based records.
Turned off by default, if the flag is set it will resolve the target dns record, and create A/AAAA instead of CNAME.

**Checklist**

- [X] Unit tests updated
- [X] End user documentation updated
