### PR TITLE
Add etcd basic auth support for CoreDNS provider

### DIFF
--- a/docs/tutorials/coredns.md
+++ b/docs/tutorials/coredns.md
@@ -87,7 +87,7 @@ helm install --name my-coredns --values values.yaml stable/coredns
 ### Install external ExternalDNS
 ETCD_URLS is configured to etcd client service address.
 
-If the etcd client being used has basic auth enabled, for example when using the [bitnami/etcd](https://artifacthub.io/packages/helm/bitnami/etcd) chart, the `ETCD_USERNAME` and `ETCD_PASSWORD` environment variables can be used to provide the credentials. 
+`ETCD_USERNAME` and `ETCD_PASSWORD` environment variables can be used to provide the credentials when etcd client has basic auth enabled. 
 
 #### Manifest (for clusters without RBAC enabled)
 

--- a/docs/tutorials/coredns.md
+++ b/docs/tutorials/coredns.md
@@ -87,6 +87,8 @@ helm install --name my-coredns --values values.yaml stable/coredns
 ### Install external ExternalDNS
 ETCD_URLS is configured to etcd client service address.
 
+If the etcd client being used has basic auth enabled, for example when using the [bitnami/etcd](https://artifacthub.io/packages/helm/bitnami/etcd) chart, the `ETCD_USERNAME` and `ETCD_PASSWORD` environment variables can be used to provide the credentials. 
+
 #### Manifest (for clusters without RBAC enabled)
 
 ```yaml

--- a/provider/coredns/coredns.go
+++ b/provider/coredns/coredns.go
@@ -205,8 +205,14 @@ func getETCDConfig() (*etcdcv3.Config, error) {
 	}
 	etcdURLs := strings.Split(etcdURLsStr, ",")
 	firstURL := strings.ToLower(etcdURLs[0])
+	etcdUsername := os.Getenv("ETCD_USERNAME")
+	etcdPassword := os.Getenv("ETCD_PASSWORD")
 	if strings.HasPrefix(firstURL, "http://") {
-		return &etcdcv3.Config{Endpoints: etcdURLs}, nil
+		return &etcdcv3.Config{
+			Endpoints: etcdURLs,
+			Username:  etcdUsername,
+			Password:  etcdPassword,
+		}, nil
 	} else if strings.HasPrefix(firstURL, "https://") {
 		caFile := os.Getenv("ETCD_CA_FILE")
 		certFile := os.Getenv("ETCD_CERT_FILE")
@@ -221,6 +227,8 @@ func getETCDConfig() (*etcdcv3.Config, error) {
 		return &etcdcv3.Config{
 			Endpoints: etcdURLs,
 			TLS:       tlsConfig,
+			Username:  etcdUsername,
+			Password:  etcdPassword,
 		}, nil
 	} else {
 		return nil, errors.New("etcd URLs must start with either http:// or https://")


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Add support for passing basic auth credentials to the CoreDNS provider for connecting with etcd. 

Introduces the new environment variables 
- `ETCD_USERNAME`
- `ETCD_PASSWORD`

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2616

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
