### PR TITLE
Support trailing point for SRV targets, specially for PowerDNS

### DIFF
--- a/provider/pdns/pdns.go
+++ b/provider/pdns/pdns.go
@@ -314,7 +314,7 @@ func (p *PDNSProvider) ConvertEndpointsToZones(eps []*endpoint.Endpoint, changet
 				records := []pgo.Record{}
 				RecordType_ := ep.RecordType
 				for _, t := range ep.Targets {
-					if ep.RecordType == "CNAME" || ep.RecordType == "ALIAS" {
+					if ep.RecordType == "CNAME" || ep.RecordType == "ALIAS" || ep.RecordType == "SRV" {
 						t = provider.EnsureTrailingDot(t)
 					}
 					records = append(records, pgo.Record{Content: t})

--- a/source/crd.go
+++ b/source/crd.go
@@ -190,7 +190,7 @@ func (cs *crdSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 
 			illegalTarget := false
 			for _, target := range ep.Targets {
-				if strings.HasSuffix(target, ".") {
+				if ep.RecordType != "SRV" && strings.HasSuffix(target, ".")  {
 					illegalTarget = true
 					break
 				}

--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -396,7 +396,7 @@ func testCRDSourceEndpoints(t *testing.T) {
 			endpoints: []*endpoint.Endpoint{
 				{
 					DNSName:    "_svc._tcp.example.org",
-					Targets:    endpoint.Targets{"0 0 80 abc.example.org", "0 0 80 def.example.org"},
+					Targets:    endpoint.Targets{"0 0 80 abc.example.org.", "0 0 80 def.example.org."},
 					RecordType: endpoint.RecordTypeSRV,
 					RecordTTL:  180,
 				},


### PR DESCRIPTION

**Description**

Accept SRV targets with trailing dot.



Fixes [#4267](https://github.com/kubernetes-sigs/external-dns/issues/4267)

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
