### PR TITLE
feat(DNSimple): User API tokens

### DIFF
--- a/docs/tutorials/dnsimple.md
+++ b/docs/tutorials/dnsimple.md
@@ -5,11 +5,15 @@ This tutorial describes how to setup ExternalDNS for usage with DNSimple.
 
 Make sure to use **>=0.4.6** version of ExternalDNS for this tutorial.
 
-## Created a DNSimple API Access Token
+## Create a DNSimple API Access Token
 
 A DNSimple API access token can be acquired by following the [provided documentation from DNSimple](https://support.dnsimple.com/articles/api-access-token/)
 
-The environment variable `DNSIMPLE_OAUTH` must be set to the API token generated for to run ExternalDNS with DNSimple.
+The environment variable `DNSIMPLE_OAUTH` must be set to the generated API token to run ExternalDNS with DNSimple.
+
+If the generated DNSimple API access token is a _User token_, as opposed to an _Account token_, the following environment variables must also be set:
+  - `DNSIMPLE_ACCOUNT_ID`: Set this to the account ID which the domains to be managed by ExternalDNS belong to (eg. `1001234`).
+  - `DNSIMPLE_ZONES`: Set this to a comma separated list of DNS zones to be managed by ExternalDNS (eg. `mydomain.com,example.com`).
 
 ## Deploy ExternalDNS
 
@@ -44,6 +48,10 @@ spec:
         env:
         - name: DNSIMPLE_OAUTH
           value: "YOUR_DNSIMPLE_API_KEY"
+        - name: DNSIMPLE_ACCOUNT_ID
+          value: "SET THIS IF USING A DNSIMPLE USER ACCESS TOKEN"
+        - name: DNSIMPLE_ZONES
+          value: "SET THIS IF USING A DNSIMPLE USER ACCESS TOKEN"
 ```
 
 ### Manifest (for clusters with RBAC enabled)
@@ -109,6 +117,10 @@ spec:
         env:
         - name: DNSIMPLE_OAUTH
           value: "YOUR_DNSIMPLE_API_KEY"
+        - name: DNSIMPLE_ACCOUNT_ID
+          value: "SET THIS IF USING A DNSIMPLE USER ACCESS TOKEN"
+        - name: DNSIMPLE_ZONES
+          value: "SET THIS IF USING A DNSIMPLE USER ACCESS TOKEN"
 ```
 
 

--- a/docs/tutorials/dnsimple.md
+++ b/docs/tutorials/dnsimple.md
@@ -11,7 +11,7 @@ A DNSimple API access token can be acquired by following the [provided documenta
 
 The environment variable `DNSIMPLE_OAUTH` must be set to the generated API token to run ExternalDNS with DNSimple.
 
-If the generated DNSimple API access token is a _User token_, as opposed to an _Account token_, the following environment variables must also be set:
+When the generated DNSimple API access token is a _User token_, as opposed to an _Account token_, the following environment variables must also be set:
   - `DNSIMPLE_ACCOUNT_ID`: Set this to the account ID which the domains to be managed by ExternalDNS belong to (eg. `1001234`).
   - `DNSIMPLE_ZONES`: Set this to a comma separated list of DNS zones to be managed by ExternalDNS (eg. `mydomain.com,example.com`).
 

--- a/provider/dnsimple/dnsimple.go
+++ b/provider/dnsimple/dnsimple.go
@@ -99,12 +99,6 @@ const (
 
 // NewDnsimpleProvider initializes a new Dnsimple based provider
 func NewDnsimpleProvider(domainFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, dryRun bool) (provider.Provider, error) {
-	return BuildDnsimpleProvider(domainFilter, zoneIDFilter, dryRun)
-}
-
-// Create a new Dnsimple based provider returning a *dnsimpleProvider. The *dnsimpleProvider return type is needed for testing purposes
-// therefore this method, and not NewDnsimpleProvider, must be the one used by dnsimple_test.go
-func BuildDnsimpleProvider(domainFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, dryRun bool) (*dnsimpleProvider, error) {
 	oauthToken := os.Getenv("DNSIMPLE_OAUTH")
 	if len(oauthToken) == 0 {
 		return nil, fmt.Errorf("no dnsimple oauth token provided")

--- a/provider/dnsimple/dnsimple.go
+++ b/provider/dnsimple/dnsimple.go
@@ -99,7 +99,7 @@ const (
 
 // NewDnsimpleProvider initializes a new Dnsimple based provider
 func NewDnsimpleProvider(domainFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, dryRun bool) (provider.Provider, error) {
-	return BuildDnsimpleProvider(domainFilter, zoneIDFilter, dryRun, false)
+	return BuildDnsimpleProvider(domainFilter, zoneIDFilter, dryRun)
 }
 
 // Create a new Dnsimple based provider returning a *dnsimpleProvider. The *dnsimpleProvider return type is needed for testing purposes

--- a/provider/dnsimple/dnsimple.go
+++ b/provider/dnsimple/dnsimple.go
@@ -151,7 +151,7 @@ func (p *dnsimpleProvider) GetAccountID(ctx context.Context) (accountID string, 
 	return int64ToString(whoamiResponse.Data.Account.ID), nil
 }
 
-func ZonesFromZoneString(zonestring string) (map[string]dnsimple.Zone) {
+func ZonesFromZoneString(zonestring string) map[string]dnsimple.Zone {
 	zones := make(map[string]dnsimple.Zone)
 	zoneNames := strings.Split(zonestring, ",")
 	for indexId, zoneName := range zoneNames {

--- a/provider/dnsimple/dnsimple.go
+++ b/provider/dnsimple/dnsimple.go
@@ -106,7 +106,6 @@ func NewDnsimpleProvider(domainFilter endpoint.DomainFilter, zoneIDFilter provid
 // therefore this method, and not NewDnsimpleProvider, must be the one used by dnsimple_test.go
 func BuildDnsimpleProvider(domainFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, dryRun bool) (*dnsimpleProvider, error) {
 	oauthToken := os.Getenv("DNSIMPLE_OAUTH")
-	dnsimpleAccountId := os.Getenv("DNSIMPLE_ACCOUNT_ID")
 	if len(oauthToken) == 0 {
 		return nil, fmt.Errorf("no dnsimple oauth token provided")
 	}
@@ -125,7 +124,7 @@ func BuildDnsimpleProvider(domainFilter endpoint.DomainFilter, zoneIDFilter prov
 		dryRun:       dryRun,
 	}
 
-	provider.accountID = dnsimpleAccountId
+	provider.accountID = os.Getenv("DNSIMPLE_ACCOUNT_ID")
 	if provider.accountID == "" {
 		whoamiResponse, err := provider.identity.Whoami(context.Background())
 		if err != nil {

--- a/provider/dnsimple/dnsimple.go
+++ b/provider/dnsimple/dnsimple.go
@@ -125,7 +125,7 @@ func BuildDnsimpleProvider(domainFilter endpoint.DomainFilter, zoneIDFilter prov
 	}
 
 	whoamiResponse := &dnsimple.WhoamiResponse{}
-	if skipWhoami == false {
+	if !skipWhoami {
 		var err error
 		whoamiResponse, err = provider.identity.Whoami(context.Background())
 		if err != nil {

--- a/provider/dnsimple/dnsimple_test.go
+++ b/provider/dnsimple/dnsimple_test.go
@@ -252,6 +252,16 @@ func TestNewDnsimpleProvider(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected to fail new provider on empty token")
 	}
+
+	os.Setenv("DNSIMPLE_OAUTH", "xxxxxxxxxxxxxxxxxxxxxxxxxx")
+	os.Setenv("DNSIMPLE_ACCOUNT_ID", "12345678")
+	builtProvider, err := BuildDnsimpleProvider(endpoint.NewDomainFilter([]string{"example.com"}), provider.NewZoneIDFilter([]string{""}), true, true)
+	if err != nil {
+		t.Errorf("Unexpected error thrown when testing BuildDnsimpleProvider with the DNSIMPLE_ACCOUNT_ID environment variable set")
+	}
+	assert.Equal(t, builtProvider.accountID, "12345678")
+	os.Unsetenv("DNSIMPLE_OAUTH")
+	os.Unsetenv("DNSIMPLE_ACCOUNT_ID")
 }
 
 func testDnsimpleGetRecordID(t *testing.T) {

--- a/provider/dnsimple/dnsimple_test.go
+++ b/provider/dnsimple/dnsimple_test.go
@@ -246,7 +246,9 @@ func TestNewDnsimpleProvider(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected to fail new provider on bad token")
 	}
+
 	os.Unsetenv("DNSIMPLE_OAUTH")
+	_, err = NewDnsimpleProvider(endpoint.NewDomainFilter([]string{"example.com"}), provider.NewZoneIDFilter([]string{""}), true)
 	if err == nil {
 		t.Errorf("Expected to fail new provider on empty token")
 	}

--- a/provider/dnsimple/dnsimple_test.go
+++ b/provider/dnsimple/dnsimple_test.go
@@ -227,6 +227,17 @@ func testDnsimpleSuitableZone(t *testing.T) {
 
 	zone := dnsimpleSuitableZone("example-beta.example.com", zones)
 	assert.Equal(t, zone.Name, "example.com")
+
+	os.Setenv("DNSIMPLE_ZONES", "environment-example.com,example.environment-example.com")
+	mockProvider.accountID = "3"
+	zones, err = mockProvider.Zones(ctx)
+	assert.Nil(t, err)
+
+	zone = dnsimpleSuitableZone("hello.example.environment-example.com", zones)
+	assert.Equal(t, zone.Name, "example.environment-example.com")
+
+	os.Unsetenv("DNSIMPLE_ZONES")
+	mockProvider.accountID = "1"
 }
 
 func TestNewDnsimpleProvider(t *testing.T) {

--- a/provider/dnsimple/dnsimple_test.go
+++ b/provider/dnsimple/dnsimple_test.go
@@ -255,11 +255,12 @@ func TestNewDnsimpleProvider(t *testing.T) {
 
 	os.Setenv("DNSIMPLE_OAUTH", "xxxxxxxxxxxxxxxxxxxxxxxxxx")
 	os.Setenv("DNSIMPLE_ACCOUNT_ID", "12345678")
-	builtProvider, err := BuildDnsimpleProvider(endpoint.NewDomainFilter([]string{"example.com"}), provider.NewZoneIDFilter([]string{""}), true)
+	providerTypedProvider, err := NewDnsimpleProvider(endpoint.NewDomainFilter([]string{"example.com"}), provider.NewZoneIDFilter([]string{""}), true)
+	dnsimpleTypedProvider := providerTypedProvider.(*dnsimpleProvider)
 	if err != nil {
-		t.Errorf("Unexpected error thrown when testing BuildDnsimpleProvider with the DNSIMPLE_ACCOUNT_ID environment variable set")
+		t.Errorf("Unexpected error thrown when testing NewDnsimpleProvider with the DNSIMPLE_ACCOUNT_ID environment variable set")
 	}
-	assert.Equal(t, builtProvider.accountID, "12345678")
+	assert.Equal(t, dnsimpleTypedProvider.accountID, "12345678")
 	os.Unsetenv("DNSIMPLE_OAUTH")
 	os.Unsetenv("DNSIMPLE_ACCOUNT_ID")
 }

--- a/provider/dnsimple/dnsimple_test.go
+++ b/provider/dnsimple/dnsimple_test.go
@@ -255,7 +255,7 @@ func TestNewDnsimpleProvider(t *testing.T) {
 
 	os.Setenv("DNSIMPLE_OAUTH", "xxxxxxxxxxxxxxxxxxxxxxxxxx")
 	os.Setenv("DNSIMPLE_ACCOUNT_ID", "12345678")
-	builtProvider, err := BuildDnsimpleProvider(endpoint.NewDomainFilter([]string{"example.com"}), provider.NewZoneIDFilter([]string{""}), true, true)
+	builtProvider, err := BuildDnsimpleProvider(endpoint.NewDomainFilter([]string{"example.com"}), provider.NewZoneIDFilter([]string{""}), true)
 	if err != nil {
 		t.Errorf("Unexpected error thrown when testing BuildDnsimpleProvider with the DNSIMPLE_ACCOUNT_ID environment variable set")
 	}


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
This _Pull Request_ introduces the following environment variables for overriding data retrieved from the DNSimple API. This is needed when using _User API_ DNSimple tokens (as opposed to _Account API_ DNSimple tokens) as this data cannot be accessed with a _User API_ token:

- `DNSIMPLE_ACCOUNT_ID`: The DNSimple account which owns the DNS records to be updated
- `DNSIMPLE_ZONES`: A comma separated list of DNS Zones in DNSimple which External-DNS will be allowed to manipulate

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4273

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
