### PR TITLE
 fix(service): omit nil endpoints and prefer endpointsForHostname()

### DIFF
--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -264,6 +264,13 @@ func testEndpointsFromIngress(t *testing.T) {
 			expected:               []*endpoint.Endpoint{},
 			ignoreIngressRulesSpec: true,
 		},
+		{
+			title: "invalid hostname does not generate endpoints",
+			ingress: fakeIngress{
+				dnsnames:  []string{"this-is-an-exceedingly-long-label-that-external-dns-should-reject.example.org"},
+			},
+			expected: []*endpoint.Endpoint{},
+		},
 	} {
 		t.Run(ti.title, func(t *testing.T) {
 			realIngress := ti.ingress.Ingress()

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -1560,6 +1560,17 @@ func TestClusterIpServices(t *testing.T) {
 			expected:      []*endpoint.Endpoint{},
 			labelSelector: "app=web-external",
 		},
+		{
+			title:        "invalid hostname does not generate endpoints",
+			svcNamespace: "testing",
+			svcName:      "foo",
+			svcType:      v1.ServiceTypeClusterIP,
+			annotations: map[string]string{
+				hostnameAnnotationKey: "this-is-an-exceedingly-long-label-that-external-dns-should-reject.example.org.",
+			},
+			clusterIP: "1.2.3.4",
+			expected:  []*endpoint.Endpoint{},
+		},
 	} {
 		tc := tc
 		t.Run(tc.title, func(t *testing.T) {

--- a/source/source.go
+++ b/source/source.go
@@ -284,52 +284,41 @@ func endpointsForHostname(hostname string, targets endpoint.Targets, ttl endpoin
 	}
 
 	if len(aTargets) > 0 {
-		epA := &endpoint.Endpoint{
-			DNSName:          strings.TrimSuffix(hostname, "."),
-			Targets:          aTargets,
-			RecordTTL:        ttl,
-			RecordType:       endpoint.RecordTypeA,
-			Labels:           endpoint.NewLabels(),
-			ProviderSpecific: providerSpecific,
-			SetIdentifier:    setIdentifier,
+		epA := endpoint.NewEndpointWithTTL(hostname, endpoint.RecordTypeA, ttl, aTargets...)
+		if epA != nil {
+			epA.ProviderSpecific = providerSpecific
+			epA.SetIdentifier = setIdentifier
+			if resource != "" {
+				epA.Labels[endpoint.ResourceLabelKey] = resource
+			}
+			endpoints = append(endpoints, epA)
 		}
-		if resource != "" {
-			epA.Labels[endpoint.ResourceLabelKey] = resource
-		}
-		endpoints = append(endpoints, epA)
 	}
 
 	if len(aaaaTargets) > 0 {
-		epAAAA := &endpoint.Endpoint{
-			DNSName:          strings.TrimSuffix(hostname, "."),
-			Targets:          aaaaTargets,
-			RecordTTL:        ttl,
-			RecordType:       endpoint.RecordTypeAAAA,
-			Labels:           endpoint.NewLabels(),
-			ProviderSpecific: providerSpecific,
-			SetIdentifier:    setIdentifier,
+		epAAAA := endpoint.NewEndpointWithTTL(hostname, endpoint.RecordTypeAAAA, ttl, aaaaTargets...)
+		if epAAAA != nil {
+			epAAAA.ProviderSpecific = providerSpecific
+			epAAAA.SetIdentifier = setIdentifier
+			if resource != "" {
+				epAAAA.Labels[endpoint.ResourceLabelKey] = resource
+			}
+			endpoints = append(endpoints, epAAAA)
 		}
-		if resource != "" {
-			epAAAA.Labels[endpoint.ResourceLabelKey] = resource
-		}
-		endpoints = append(endpoints, epAAAA)
 	}
 
 	if len(cnameTargets) > 0 {
-		epCNAME := &endpoint.Endpoint{
-			DNSName:          strings.TrimSuffix(hostname, "."),
-			Targets:          cnameTargets,
-			RecordTTL:        ttl,
-			RecordType:       endpoint.RecordTypeCNAME,
-			Labels:           endpoint.NewLabels(),
-			ProviderSpecific: providerSpecific,
-			SetIdentifier:    setIdentifier,
+		epCNAME := endpoint.NewEndpointWithTTL(hostname, endpoint.RecordTypeCNAME, ttl, cnameTargets...)
+		if epCNAME != nil {
+			epCNAME.ProviderSpecific = providerSpecific
+			epCNAME.SetIdentifier = setIdentifier
+			if resource != "" {
+				epCNAME.Labels[endpoint.ResourceLabelKey] = resource
+			}
+			endpoints = append(endpoints, epCNAME)
 		}
-		if resource != "" {
-			epCNAME.Labels[endpoint.ResourceLabelKey] = resource
-		}
-		endpoints = append(endpoints, epCNAME)
 	}
+
 	return endpoints
 }
 


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

From Services, don't try to create records for invalid endpoints, e.g. when they contain a label that's too long (ref: #3017)

Add a test to make sure Ingresses behave as expected, too.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
<!-- Fixes #ISSUE -->

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
