### PR TITLE
fix: possible nil ptr for invalid records like too long name

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -416,6 +416,9 @@ func (p *AWSProvider) records(ctx context.Context, zones map[string]*route53.Hos
 			}
 
 			for _, ep := range newEndpoints {
+				if ep == nil {
+					continue
+				}
 				if r.SetIdentifier != nil {
 					ep.SetIdentifier = aws.StringValue(r.SetIdentifier)
 					switch {

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -354,6 +354,12 @@ func TestAWSRecords(t *testing.T) {
 			ResourceRecords: []*route53.ResourceRecord{{Value: aws.String("8.8.8.8")}},
 		},
 		{
+			Name:            aws.String("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA.ext-dns-test-2.teapot.zalan.do."),
+			Type:            aws.String(route53.RRTypeA),
+			TTL:             aws.Int64(recordTTL),
+			ResourceRecords: []*route53.ResourceRecord{},
+		},
+		{
 			Name:            aws.String("*.wildcard-test.zone-2.ext-dns-test-2.teapot.zalan.do."),
 			Type:            aws.String(route53.RRTypeA),
 			TTL:             aws.Int64(recordTTL),


### PR DESCRIPTION
fix: possible nil ptr for invalid records like too long name

see also: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DomainNameFormat.html

closes https://github.com/kubernetes-sigs/external-dns/pull/4293

**Checklist**

- [x] Unit tests updated
