### PR TITLE
chore: update maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,18 +7,18 @@
 
 approvers:
   - johngmyers
+  - mloiseleur
   - raffo
-  - njuettner
   - szuecs
 
 reviewers:
   - johngmyers
-  - njuettner
+  - mloiseleur
   - raffo
   - szuecs
-  - mloiseleur
 
 emeritus_approvers:
   - hjacobs
   - linki
+  - njuettner
   - seanmalloy


### PR DESCRIPTION
# Description

Update maintainers

1. Move @njuettner to emeritus_approvers. Recent review activity has been extremely low.
2. Move @mloiseleur to approvers.

**Checklist**

- [x] Reviewers for more than 3 month
- [x] Reviewed [more than 134 PRs](https://github.com/kubernetes-sigs/external-dns/pulls?q=is%3Apr+assignee%3Amloiseleur+)
- [x] With no objections from other subproject owners

Linked PRs:
- https://github.com/kubernetes/k8s.io/pull/6541
- https://github.com/kubernetes/test-infra/pull/32191