### PR TITLE
feat(WebhookProvider): Let WebhookProvider return `SoftError` on response status codes >= 500

### DIFF
--- a/provider/webhook/webhook.go
+++ b/provider/webhook/webhook.go
@@ -26,6 +26,7 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
 	webhookapi "sigs.k8s.io/external-dns/provider/webhook/api"
 
 	backoff "github.com/cenkalti/backoff/v4"
@@ -180,7 +181,11 @@ func (p WebhookProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, err
 	if resp.StatusCode != http.StatusOK {
 		recordsErrorsGauge.Inc()
 		log.Debugf("Failed to get records with code %d", resp.StatusCode)
-		return nil, fmt.Errorf("failed to get records with code %d", resp.StatusCode)
+		err := fmt.Errorf("failed to get records with code %d", resp.StatusCode)
+		if resp.StatusCode >= http.StatusInternalServerError {
+			return nil, provider.NewSoftError(err)
+		}
+		return nil, err
 	}
 
 	endpoints := []*endpoint.Endpoint{}
@@ -224,7 +229,11 @@ func (p WebhookProvider) ApplyChanges(ctx context.Context, changes *plan.Changes
 	if resp.StatusCode != http.StatusNoContent {
 		applyChangesErrorsGauge.Inc()
 		log.Debugf("Failed to apply changes with code %d", resp.StatusCode)
-		return fmt.Errorf("failed to apply changes with code %d", resp.StatusCode)
+		err := fmt.Errorf("failed to apply changes with code %d", resp.StatusCode)
+		if resp.StatusCode >= http.StatusInternalServerError {
+			return provider.NewSoftError(err)
+		}
+		return err
 	}
 	return nil
 }
@@ -270,7 +279,11 @@ func (p WebhookProvider) AdjustEndpoints(e []*endpoint.Endpoint) ([]*endpoint.En
 	if resp.StatusCode != http.StatusOK {
 		adjustEndpointsErrorsGauge.Inc()
 		log.Debugf("Failed to AdjustEndpoints with code %d", resp.StatusCode)
-		return nil, fmt.Errorf("failed to AdjustEndpoints with code %d", resp.StatusCode)
+		err := fmt.Errorf("failed to AdjustEndpoints with code  %d", resp.StatusCode)
+		if resp.StatusCode >= http.StatusInternalServerError {
+			return nil, provider.NewSoftError(err)
+		}
+		return nil, err
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&endpoints); err != nil {

--- a/provider/webhook/webhook_test.go
+++ b/provider/webhook/webhook_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/provider"
 	webhookapi "sigs.k8s.io/external-dns/provider/webhook/api"
 )
 
@@ -99,10 +100,11 @@ func TestRecordsWithErrors(t *testing.T) {
 	}))
 	defer svr.Close()
 
-	provider, err := NewWebhookProvider(svr.URL)
+	p, err := NewWebhookProvider(svr.URL)
 	require.NoError(t, err)
-	_, err = provider.Records(context.Background())
+	_, err = p.Records(context.Background())
 	require.NotNil(t, err)
+	require.ErrorIs(t, err, provider.SoftError)
 }
 
 func TestApplyChanges(t *testing.T) {
@@ -122,15 +124,16 @@ func TestApplyChanges(t *testing.T) {
 	}))
 	defer svr.Close()
 
-	provider, err := NewWebhookProvider(svr.URL)
+	p, err := NewWebhookProvider(svr.URL)
 	require.NoError(t, err)
-	err = provider.ApplyChanges(context.TODO(), nil)
+	err = p.ApplyChanges(context.TODO(), nil)
 	require.NoError(t, err)
 
 	successfulApplyChanges = false
 
-	err = provider.ApplyChanges(context.TODO(), nil)
+	err = p.ApplyChanges(context.TODO(), nil)
 	require.NotNil(t, err)
+	require.ErrorIs(t, err, provider.SoftError)
 }
 
 func TestAdjustEndpoints(t *testing.T) {
@@ -198,7 +201,7 @@ func TestAdjustendpointsWithError(t *testing.T) {
 	}))
 	defer svr.Close()
 
-	provider, err := NewWebhookProvider(svr.URL)
+	p, err := NewWebhookProvider(svr.URL)
 	require.NoError(t, err)
 	endpoints := []*endpoint.Endpoint{
 		{
@@ -210,6 +213,7 @@ func TestAdjustendpointsWithError(t *testing.T) {
 			},
 		},
 	}
-	_, err = provider.AdjustEndpoints(endpoints)
+	_, err = p.AdjustEndpoints(endpoints)
 	require.Error(t, err)
+	require.ErrorIs(t, err, provider.SoftError)
 }


### PR DESCRIPTION
**Description**

#4166 introduced the `SoftError` as a way for providers to signal that an error is transient and should not lead to the controller bailing out of execution, to somewhat mitigate the changes made in #3009.

For some in-tree providers (AWS, Azure, and Oracle Cloud Infrastructure), `SoftError` support has already been implemented. This PR lets the `WebhookProvider` return `SoftError`s for any HTTP Response with a status code >= 500  returned by webhook providers, in order to implement this for out-of-tree providers as well.

As 5xx status codes indicate a temporary problem on the provider side, it seems fitting to me that any response with such a code should be handled as a `SoftError`. This is in line with the definition of the `SoftError`, which "is meant for error propagation from providers to tell that this is a transient error." It is also in line with the [webhook provider tutorial](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/webhook-provider.md), which states that 

> only 5xx responses will be retried and only 20x will be considered as successful. All status codes different from those will be considered a failure on ExternalDNS's side.

This is my first PR here, happy about any feedback regarding the overall contribution process as well 😊 

**Checklist**

- [X] Unit tests updated
- [ ] End user documentation updated
  - I wasn't sure if any user documentation needed updates, please advise if and where I should add something.
