### PR TITLE
feat: added support per dns cf proxy

### DIFF
--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -222,3 +222,10 @@ $ kubectl delete -f externaldns.yaml
 ## Setting cloudflare-proxied on a per-ingress basis
 
 Using the `external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"` annotation on your ingress, you can specify if the proxy feature of Cloudflare should be enabled for that record. This setting will override the global `--cloudflare-proxied` setting.
+
+Alternatively, you can specify individual hostnames for which you want to enable the proxy feature. This is useful when you need to proxy only specific DNS records. To do this, set the annotation to the desired hostname(s):
+```yaml
+external-dns.alpha.kubernetes.io/cloudflare-proxied: bar.com
+```
+
+will enable the proxy feature for the `bar.com` record.

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -247,6 +247,9 @@ func (e *Endpoint) GetProviderSpecificProperty(key string) (string, bool) {
 
 // SetProviderSpecificProperty sets the value of a ProviderSpecificProperty.
 func (e *Endpoint) SetProviderSpecificProperty(key string, value string) {
+	// Make a copy of the ProviderSpecific slice to avoid modifying the original slice as it's reused across multiple endpoints.
+	// cause of the split here for example: https://github.com/kubernetes-sigs/external-dns/blob/master/source/service.go#L399
+	e.ProviderSpecific = e.ProviderSpecific.DeepCopy()
 	for i, providerSpecific := range e.ProviderSpecific {
 		if providerSpecific.Name == key {
 			e.ProviderSpecific[i] = ProviderSpecificProperty{

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -473,6 +473,14 @@ func shouldBeProxied(endpoint *endpoint.Endpoint, proxiedByDefault bool) bool {
 
 	for _, v := range endpoint.ProviderSpecific {
 		if v.Name == source.CloudflareProxiedKey {
+			proxyValues := strings.Split(v.Value, ",")
+
+			for _, value := range proxyValues {
+				if value == endpoint.DNSName {
+					return true
+				}
+			}
+
 			b, err := strconv.ParseBool(v.Value)
 			if err != nil {
 				log.Errorf("Failed to parse annotation [%s]: %v", source.CloudflareProxiedKey, err)

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -612,12 +612,15 @@ func TestCloudflareSetProxiedByDomain(t *testing.T) {
 	var proxied *bool = proxyEnabled
 	var notProxied *bool = proxyDisabled
 	testCases := []struct {
-		recordType string
-		domain     string
-		proxiable  *bool
+		recordType             string
+		domain                 string
+		proxiable              *bool
+		cloudFlareProxiedValue string
 	}{
-		{"A", "bar.com", proxied},
-		{"A", "api.bar.com", notProxied},
+		{"A", "bar.com", proxied, "bar.com"},
+		{"A", "api.bar.com", notProxied, "bar.com"},
+		{"A", "api.bar.com", proxied, "bar.com,api.bar.com"},
+		{"A", "test.bar.com", notProxied, "bar.com,api.bar.com"},
 	}
 
 	for _, testCase := range testCases {
@@ -629,7 +632,7 @@ func TestCloudflareSetProxiedByDomain(t *testing.T) {
 				ProviderSpecific: endpoint.ProviderSpecific{
 					endpoint.ProviderSpecificProperty{
 						Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
-						Value: "bar.com",
+						Value: testCase.cloudFlareProxiedValue,
 					},
 				},
 			},


### PR DESCRIPTION
**Description**

We have a use case where we want to have 1 domain proxied through cloudflare and another one not proxied via cloudflare but using the same `service` 

So in this PR we are adding the possibility to pass a domain list in the `external-dns.alpha.kubernetes.io/cloudflare-proxied` 

So it's still possible to pass 
`external-dns.alpha.kubernetes.io/cloudflare-proxied: true/false`

but also
`external-dns.alpha.kubernetes.io/cloudflare-proxied: example.com,bar.com`

The setup we are going todo is like this:
```
external-dns.alpha.kubernetes.io/hostname: example.com,api.example.com
external-dns.alpha.kubernetes.io/cloudflare-proxied: example.com
```

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
