### PR TITLE
Fix(ipv6):  support ipv6 shortener and expander equal

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -75,7 +75,17 @@ func (t Targets) Len() int {
 }
 
 func (t Targets) Less(i, j int) bool {
-	return t[i] < t[j]
+	ipi, err := netip.ParseAddr(t[i])
+	if err != nil {
+		return t[i] < t[j]
+	}
+
+	ipj, err := netip.ParseAddr(t[j])
+	if err != nil {
+		return t[i] < t[j]
+	}
+
+	return ipi.String() < ipj.String()
 }
 
 func (t Targets) Swap(i, j int) {
@@ -92,6 +102,26 @@ func (t Targets) Same(o Targets) bool {
 
 	for i, e := range t {
 		if !strings.EqualFold(e, o[i]) {
+			ipA, err := netip.ParseAddr(e)
+			if err != nil {
+				log.WithFields(log.Fields{
+					"targets":           t,
+					"comparisonTargets": o,
+				}).Debugf("Couldn't parse %s as an IP address: %v", e, err)
+			}
+
+			ipB, err := netip.ParseAddr(o[i])
+			if err != nil {
+				log.WithFields(log.Fields{
+					"targets":           t,
+					"comparisonTargets": o,
+				}).Debugf("Couldn't parse %s as an IP address: %v", e, err)
+			}
+
+			// IPv6 Address Shortener == IPv6 Address Expander
+			if ipA.IsValid() && ipB.IsValid() {
+				return ipA.String() == ipB.String()
+			}
 			return false
 		}
 	}

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -102,6 +102,7 @@ func (t Targets) Same(o Targets) bool {
 
 	for i, e := range t {
 		if !strings.EqualFold(e, o[i]) {
+			// IPv6 can be shortened, so it should be parsed for equality checking
 			ipA, err := netip.ParseAddr(e)
 			if err != nil {
 				log.WithFields(log.Fields{

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -41,12 +41,40 @@ func TestTargetsSame(t *testing.T) {
 		{""},
 		{"1.2.3.4"},
 		{"8.8.8.8", "8.8.4.4"},
+		{"dd:dd::01", "::1", "::0001"},
 		{"example.org", "EXAMPLE.ORG"},
 	}
 
 	for _, d := range tests {
 		if d.Same(d) != true {
 			t.Errorf("%#v should equal %#v", d, d)
+		}
+	}
+}
+
+func TestSameSuccess(t *testing.T) {
+	tests := []struct {
+		a Targets
+		b Targets
+	}{
+		{
+			[]string{"::1"},
+			[]string{"::0001"},
+		},
+		{
+			[]string{"::1", "dd:dd::01"},
+			[]string{"dd:00dd::0001", "::0001"},
+		},
+
+		{
+			[]string{"::1", "dd:dd::01"},
+			[]string{"00dd:dd::0001", "::0001"},
+		},
+	}
+
+	for _, d := range tests {
+		if d.a.Same(d.b) == false {
+			t.Errorf("%#v should equal %#v", d.a, d.b)
 		}
 	}
 }

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -70,6 +70,10 @@ func TestSameSuccess(t *testing.T) {
 			[]string{"::1", "dd:dd::01"},
 			[]string{"00dd:dd::0001", "::0001"},
 		},
+		{
+			[]string{"::1", "1.1.1.1", "2600.com", "3.3.3.3"},
+			[]string{"2600.com", "::0001", "3.3.3.3", "1.1.1.1"},
+		},
 	}
 
 	for _, d := range tests {
@@ -96,6 +100,10 @@ func TestSameFailures(t *testing.T) {
 		}, {
 			[]string{"1.2.3.4", "4.3.2.1"},
 			[]string{"8.8.8.8", "8.8.4.4"},
+		},
+		{
+			[]string{"::1", "2600.com", "3.3.3.3"},
+			[]string{"2600.com", "3.3.3.3", "1.1.1.1"},
 		},
 	}
 


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4326 

Support Short and Long IPv6 addresses to be recognized as the same.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
