### PR TITLE
chore(chart): Released chart for v0.14.1

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,8 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
-- Added support for dnsConfig. ([#4265](https://github.com/kubernetes-sigs/external-dns/pull/4265)) [@davhdavh](https://github.com/davhdavh)
-- Added support for DNSEndpoint CRD ([#4322](https://github.com/kubernetes-sigs/external-dns/pull/4322)) [@onedr0p](https://github.com/onedr0p)
+## [v1.14.4] - 2023-04-03
+
+### Added
+
+- Added support for setting `dnsConfig`. ([#4265](https://github.com/kubernetes-sigs/external-dns/pull/4265)) _@davhdavh_
+- Added support for `DNSEndpoint` CRD. ([#4322](https://github.com/kubernetes-sigs/external-dns/pull/4322)) _@onedr0p_
+
+### Changed
+
+- Updated _ExternalDNS_ OCI image version to [v0.14.1](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.14.1). ([#4357](https://github.com/kubernetes-sigs/external-dns/pull/4357)) _@stevehipwell_
 
 ## [v1.14.3] - 2023-01-26
 
@@ -157,3 +165,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fix RBAC for `istio-virtualservice` source when `istio-gateway` isn't also added. ([#2564](https://github.com/kubernetes-sigs/external-dns/pull/2564)) [@mcwarman](https://github.com/mcwarman)
+
+<!--
+RELEASE LINKS
+-->
+[UNRELEASED]: https://github.com/kubernetes-sigs/external-dns/tree/master/charts/external-dns
+[v1.14.4]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.14.4
+[v1.14.3]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.14.3
+[v1.14.2]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.14.2
+[v1.14.1]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.14.1
+[v1.14.0]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.14.0
+[v1.13.1]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.13.1
+[v1.13.0]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.13.0
+[v1.12.2]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.12.2
+[v1.12.1]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.12.1
+[v1.12.0]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.12.0
+[v1.11.0]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.11.0
+[v1.10.1]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.10.1
+[v1.10.0]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.10.0
+[v1.9.0]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.9.0
+[v1.8.0]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.8.0

--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: external-dns
 description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 type: application
-version: 1.14.3
-appVersion: 0.14.0
+version: 1.14.4
+appVersion: 0.14.1
 keywords:
   - kubernetes
   - externaldns
@@ -20,9 +20,7 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "Fixed args for webhook deployment."
-    - kind: fixed
-      description: "Fixed support for `gateway-grpcroute`, `gateway-tlsroute`, `gateway-tcproute` & `gateway-udproute`."
-    - kind: fixed
-      description: "Fixed incorrect implementation for setting the `automountServiceAccountToken`."
+    - kind: added
+      description: "Added support for dnsConfig."
+    - kind: changed
+      description: "Updated _ExternalDNS_ OCI image version to [v0.14.1](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.14.1)."

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -1,6 +1,6 @@
 # external-dns
 
-![Version: 1.14.3](https://img.shields.io/badge/Version-1.14.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.14.0](https://img.shields.io/badge/AppVersion-0.14.0-informational?style=flat-square)
+![Version: 1.14.4](https://img.shields.io/badge/Version-1.14.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.14.1](https://img.shields.io/badge/AppVersion-0.14.1-informational?style=flat-square)
 
 ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 
@@ -27,7 +27,7 @@ helm repo add external-dns https://kubernetes-sigs.github.io/external-dns/
 After you've installed the repo you can install the chart.
 
 ```shell
-helm upgrade --install external-dns external-dns/external-dns --version 1.14.3
+helm upgrade --install external-dns external-dns/external-dns --version 1.14.4
 ```
 
 ## Providers


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR updates the Helm chart to use ExternalDNS [0.14.1](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.14.1).

This release also includes the following changes.

- #4265
- #4322

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4333

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
