### PR TITLE
fix(registry): only migrate from old to new records

### DIFF
--- a/registry/txt.go
+++ b/registry/txt.go
@@ -191,8 +191,11 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 			if plan.IsManagedRecord(ep.RecordType, im.managedRecordTypes, im.excludeRecordTypes) {
 				// Get desired TXT records and detect the missing ones
 				desiredTXTs := im.generateTXTRecord(ep)
-				for _, desiredTXT := range desiredTXTs {
-					if _, exists := txtRecordsMap[desiredTXT.DNSName]; !exists {
+				// Exactly two records are old- and new- style, respectively
+				if len(desiredTXTs) == 2 {
+					newTXT := desiredTXTs[1]
+					if _, exists := txtRecordsMap[newTXT.DNSName]; !exists {
+						// New-style record doesn't exist, handle forward migration
 						ep.WithProviderSpecific(providerSpecificForceUpdate, "true")
 					}
 				}


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

TXT registry should only migrate forward (add new-style records if they aren't present)

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4358

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
