### PR TITLE
docs(gke): detail how to configure workload identity

### DIFF
--- a/docs/tutorials/gke.md
+++ b/docs/tutorials/gke.md
@@ -14,7 +14,7 @@ This solution will only work when both CloudDNS and GKE are provisioned in the s
 
 ### Configure Project Environment
 
-Setup your environment to work with Google Cloud Platform. Fill in your variables as needed, e.g. target project.
+Set up your environment to work with Google Cloud Platform. Fill in your variables as needed, e.g. target project.
 
 ```bash
 # set variables to the appropriate desired values
@@ -206,46 +206,99 @@ kubectl create secret generic "external-dns" --namespace ${EXTERNALDNS_NS:-"defa
 ```
 
 After this, follow the steps in [Deploy ExternalDNS](#deploy-externaldns).  Make sure to set the `--google-project` flag to match Cloud DNS project name. Make sure to uncomment out the section that mounts the secret to the ExternalDNS pods.
+
 ### Workload Identity
 
-[Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) allows workloads in your GKE cluster to impersonate GSA (Google Service Accounts) using KSA (Kubernetes Service Accounts) configured during deployemnt.  These are the steps to use this feature with ExternalDNS.
+[Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) allows workloads in your GKE cluster to [authenticate directly to GCP](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity#credential-flow) using Kubernetes Service Accounts
 
-#### Create GSA for use with Workload Identity
+You have an option to chose from using the gcloud CLI or using Terraform.
 
-```bash
-DNS_SA_NAME="external-dns-sa"
-DNS_SA_EMAIL="$DNS_SA_NAME@${GKE_PROJECT_ID}.iam.gserviceaccount.com"
+=== "gcloud CLI"
 
-gcloud iam service-accounts create $DNS_SA_NAME --display-name $DNS_SA_NAME
-gcloud projects add-iam-policy-binding $DNS_PROJECT_ID \
-   --member serviceAccount:$DNS_SA_EMAIL --role "roles/dns.admin"
-```
+    The below instructions assume you are using the default Kubernetes Service account name of `external-dns` in the namespace `external-dns`
 
-#### Link KSA to GSA
+    Grant the Kubernetes service account DNS `roles/dns.admin` at project level
+    
+    ```shell
+    gcloud projects add-iam-policy-binding projects/DNS_PROJECT_ID \
+        --role=roles/dns.admin \
+        --member=principal://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/PROJECT_ID.svc.id.goog/subject/ns/external-dns/sa/external-dns \
+        --condition=None
+    ```
+    
+    Replace the following:
+    
+    * `DNS_PROJECT_ID` : Project ID of your DNS project. If DNS is in the same project as your GKE cluster, use your GKE project.
+    * `PROJECT_ID`: your Google Cloud project ID of your GKE Cluster
+    * `PROJECT_NUMBER`: your numerical Google Cloud project number of your GKE cluster
 
-Add an IAM policy binding bewtween the workload identity GSA and ExternalDNS GSA.  This will link the ExternalDNS KSA to ExternalDNS GSA.
+    If you wish to change the namespace, replace 
 
-```bash
-gcloud iam service-accounts add-iam-policy-binding $DNS_SA_EMAIL \
-  --role "roles/iam.workloadIdentityUser" \
-  --member "serviceAccount:$GKE_PROJECT_ID.svc.id.goog[${EXTERNALDNS_NS:-"default"}/external-dns]"
-```
+    * `ns/external-dns` with `ns/<your namespace`  
+    * `sa/external-dns` with `sa/<your ksa>`
+
+
+
+=== "Terraform"
+
+    The below instructions assume you are using the default Kubernetes Service account name of `external-dns` in the namespace `external-dns`
+
+    Create a file called `main.tf` and place in it the below. _Note: If you're an experienced terraform user feel free to split these out in to different files_ 
+
+    ```hcl
+    variable "gke-project" {
+      type        = string
+      description = "Name of the project that the GKE cluster exists in"
+      default     = "GKE-PROJECT"
+    }
+    
+    variable "ksa_name" {
+      type        = string
+      description = "Name of the Kubernetes service account that will be accessing the DNS Zones"
+      default     = "external-dns"
+    }
+    
+    variable "kns_name" {
+      type        = string
+      description = "Name of the Kubernetes Namespace"
+      default     = "external-dns"
+    }
+    
+    data "google_project" "project" {
+      project_id = var.gke-project
+    }
+    
+    locals {
+      member = "principal://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${var.gke-project}.svc.id.goog/subject/ns/${var.kns_name}/sa/${var.ksa_name}"
+    }
+    
+    resource "google_project_iam_member" "external_dns" {
+      member  = local.member
+      project = "DNS-PROJECT"
+      role    = "roles/dns.admin"
+    }
+    ```
+    
+    Replace the following
+    
+    * `GKE-PROJECT` : Project that contains your GKE cluster
+    * `DNS-PROJECT` : Project that holds your DNS zones
+    
+    You can also change the below if you plan to use a different service account name and namespace
+    
+    * `variable "ksa_name"` : Name of the Kubernetes service account external-dns will use
+    * `variable "kns_name"` : Name of the Kubernetes Name Space that will have external-dns installed to
+
+
 
 #### Deploy External DNS
 
 Deploy ExternalDNS with the following steps below, documented under [Deploy ExternalDNS](#deploy-externaldns).  Set the `--google-project` flag to the Cloud DNS project name.
 
-#### Link KSA to GSA in Kubernetes
-
-Add the proper workload identity annotation to the ExternalDNS KSA.
-
-```bash
-kubectl annotate serviceaccount "external-dns" \
-  --namespace ${EXTERNALDNS_NS:-"default"} \
-  "iam.gke.io/gcp-service-account=$DNS_SA_EMAIL"
-```
-
 #### Update ExternalDNS pods
+
+!!! note "Only required if not enabled on all nodes"
+    If you have GKE Workload Identity enabled on all nodes in your cluster, the below step is not necessary 
 
 Update the Pod spec to schedule the workloads on nodes that use Workload Identity and to use the annotated Kubernetes service account.
 


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Updating the GKE workload identity page as per #4362, as the way it works has changed in the past 2 weeks

I have also made the decision to move the workload identity section higher up in the documentation and below is my logic

* Google _strongly_ recommend users do not use the default service account, or node service accounts
* Google has[ published a flow chart on this](https://cloud.google.com/docs/authentication#auth-decision-tree) where they recommend they (users) use Workload identity



<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4362 

**Checklist**

- [ ] Unit tests updated (No _code_ (eg: go) was changed in this PR)
- [x] End user documentation updated

---

Commits signed, and I should have an existing CLA with the CNCF
