### PR TITLE
Webhook provider: Use correct error gauge in `AdjustEndpoints()` func

### DIFF
--- a/provider/webhook/webhook.go
+++ b/provider/webhook/webhook.go
@@ -274,7 +274,7 @@ func (p WebhookProvider) AdjustEndpoints(e []*endpoint.Endpoint) ([]*endpoint.En
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&endpoints); err != nil {
-		recordsErrorsGauge.Inc()
+		adjustEndpointsErrorsGauge.Inc()
 		log.Debugf("Failed to decode response body: %s", err.Error())
 		return nil, err
 	}


### PR DESCRIPTION
**Description**

As requested in #4319, I extracted this fix from the change set there.

The wrong endpoint gauge is used in the webhook provider once in the `AdjustEndpoints()` function. Seems to come from a copy-paste mistake, and messes up the metrics a little.

Opening this PR now for completeness, however depending on which PR gets merged first, the other one needs to be rebased, I guess.

**Checklist**

- ~~Unit tests updated~~ not needed
- ~~End user documentation updated~~ not needed
