### PR TITLE
Add exclude domains value in Chart

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+## Added
+
+- Added support for setting `excludeDomains` argument.  ([#4380](https://github.com/kubernetes-sigs/external-dns/pull/4380))[@bford-evs](https://github.com/bford-evs)
+
 ## [v1.14.4] - 2023-04-03
 
 ### Added

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -87,6 +87,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | dnsPolicy | string | `nil` | [DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) for the pod, if not set the default will be used. |
 | domainFilters | list | `[]` |  |
 | env | list | `[]` | [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `external-dns` container. |
+| excludeDomains | list | `[]` |  |
 | extraArgs | list | `[]` | Extra arguments to provide to _ExternalDNS_. |
 | extraVolumeMounts | list | `[]` | Extra [volume mounts](https://kubernetes.io/docs/concepts/storage/volumes/) for the `external-dns` container. |
 | extraVolumes | list | `[]` | Extra [volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the `Pod`. |

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -108,6 +108,9 @@ spec:
             {{- range .Values.domainFilters }}
             - --domain-filter={{ . }}
             {{- end }}
+            {{- range .Values.excludeDomains }}
+            - --exclude-domains={{ . }}
+            {{- end }}
             - --provider={{ $providerName }}
           {{- range .Values.extraArgs }}
             - {{ tpl . $ }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -219,6 +219,9 @@ txtSuffix:
 ## - Limit possible target zones by domain suffixes.
 domainFilters: []
 
+## -- Intentionally exclude domains from being managed.
+excludeDomains: []
+
 provider:
   # -- _ExternalDNS_ provider name; for the available providers and how to configure them see [README](https://github.com/kubernetes-sigs/external-dns/blob/master/charts/external-dns/README.md#providers).
   name: aws


### PR DESCRIPTION
**Description**

This Pull Request adds the excludeDomains argument into the template to enable the ability to easily exclude domains without passing additional extra arguments and a more readable list consistent with the domain filtering list that can be set in the values for the chart. 

**Checklist**

- [x] End user documentation updated
