### PR TITLE
fix(aws): Add support for eks pod identities to NewSession()

### DIFF
--- a/provider/aws/session.go
+++ b/provider/aws/session.go
@@ -18,13 +18,10 @@ package aws
 
 import (
 	"fmt"
-	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/linki/instrumented_http"
 	"github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
@@ -38,19 +35,7 @@ type AWSSessionConfig struct {
 }
 
 func NewSession(awsConfig AWSSessionConfig) (*session.Session, error) {
-	config := aws.NewConfig().WithMaxRetries(awsConfig.APIRetries)
-
-	config.WithHTTPClient(
-		instrumented_http.NewClient(config.HTTPClient, &instrumented_http.Callbacks{
-			PathProcessor: func(path string) string {
-				parts := strings.Split(path, "/")
-				return parts[len(parts)-1]
-			},
-		}),
-	)
-
 	session, err := session.NewSessionWithOptions(session.Options{
-		Config:            *config,
 		SharedConfigState: session.SharedConfigEnable,
 	})
 	if err != nil {


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Removed the config var from the NewSession function, the ideia is to discuss and evaluate a better option to implement this solution, I am not a golang developer but I am interested in contributing with my time if someone is available to guide me.

I don't understand the actual need of the Config being passed to the session.NewSessionWithOptions() function. There for I don't know the extend of the impact of this PR, I have tested and it works with Eks Pod Identities, I will be testing with IRSA and update here.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4353 

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
