### PR TITLE
docs: add setup example with helm chart on some providers

### DIFF
--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -35,6 +35,35 @@ helm upgrade --install external-dns external-dns/external-dns --version 1.14.4
 Configuring the _ExternalDNS_ provider should be done via the `provider.name` value with provider specific configuration being set via the `provider.<name>.<key>` values, where supported, and the `extraArgs` value. For legacy support `provider` can be set to the name of the provider with all additional configuration being set via the `extraArgs` value.
 See [documentation](https://kubernetes-sigs.github.io/external-dns/#new-providers) for more info on available providers and tutorials.
 
+### Provider Example
+#### Setting Up ExternalDNS with CloudFlare
+To deploy ExternalDNS configured for the CloudFlare DNS provider, begin by creating a Kubernetes secret to securely store your CloudFlare API key. This key will enable ExternalDNS to authenticate with CloudFlare:
+```shell
+kubectl create secret generic cloudflare-api-key --from-literal=apiKey=YOUR_API_KEY
+```
+Ensure to replace YOUR_API_KEY with your actual CloudFlare API key.
+
+Next, create a values.yaml file to configure ExternalDNS to use CloudFlare as the DNS provider. This file should include the necessary environment variables:
+```shell
+provider: 
+  name: cloudflare
+env:
+  - name: CF_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: cloudflare-api-key
+        key: apiKey
+  - name: CF_API_EMAIL
+    value: "example@example.com"
+```
+Replace your-email@example.com with the email associated with your CloudFlare account.
+
+Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
+```shell
+helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
+```
+This command will configure ExternalDNS to manage DNS records using CloudFlare, based on resources present in your Kubernetes cluster.
+
 ### Providers with Specific Configuration Support
 
 | Provider               | Supported  |

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -41,6 +41,18 @@ See [documentation](https://kubernetes-sigs.github.io/external-dns/#new-provider
 |------------------------|------------|
 | `webhook`              | ✅         |
 
+### Other Providers
+
+For set up for a specific provider using the Helm chart, see the following links:
+- [AWS](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md#using-helm-with-oidc)
+- [akamai-edgedns](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/akamai-edgedns.md#using-helm)
+- [cloudflare](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/cloudflare.md#using-helm)
+- [digitalocean](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/digitalocean.md#using-helm)
+- [godaddy](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/godaddy.md#using-helm)
+- [ns1](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/ns1.md#using-helm)
+- [plural](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/plural.md#using-helm)
+- [vultr](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/vultr.md#using-helm)
+
 ## Namespaced Scoped Installation
 
 external-dns supports running on a namespaced only scope, too.

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -35,35 +35,6 @@ helm upgrade --install external-dns external-dns/external-dns --version 1.14.4
 Configuring the _ExternalDNS_ provider should be done via the `provider.name` value with provider specific configuration being set via the `provider.<name>.<key>` values, where supported, and the `extraArgs` value. For legacy support `provider` can be set to the name of the provider with all additional configuration being set via the `extraArgs` value.
 See [documentation](https://kubernetes-sigs.github.io/external-dns/#new-providers) for more info on available providers and tutorials.
 
-### Provider Example
-#### Setting Up ExternalDNS with CloudFlare
-To deploy ExternalDNS configured for the CloudFlare DNS provider, begin by creating a Kubernetes secret to securely store your CloudFlare API key. This key will enable ExternalDNS to authenticate with CloudFlare:
-```shell
-kubectl create secret generic cloudflare-api-key --from-literal=apiKey=YOUR_API_KEY
-```
-Ensure to replace YOUR_API_KEY with your actual CloudFlare API key.
-
-Next, create a values.yaml file to configure ExternalDNS to use CloudFlare as the DNS provider. This file should include the necessary environment variables:
-```shell
-provider: 
-  name: cloudflare
-env:
-  - name: CF_API_KEY
-    valueFrom:
-      secretKeyRef:
-        name: cloudflare-api-key
-        key: apiKey
-  - name: CF_API_EMAIL
-    value: "example@example.com"
-```
-Replace your-email@example.com with the email associated with your CloudFlare account.
-
-Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
-```shell
-helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
-```
-This command will configure ExternalDNS to manage DNS records using CloudFlare, based on resources present in your Kubernetes cluster.
-
 ### Providers with Specific Configuration Support
 
 | Provider               | Supported  |

--- a/charts/external-dns/README.md.gotmpl
+++ b/charts/external-dns/README.md.gotmpl
@@ -25,6 +25,16 @@ After you've installed the repo you can install the chart.
 helm upgrade --install {{ template "chart.name" . }} external-dns/{{ template "chart.name" . }} --version {{ template "chart.version" . }}
 ```
 
+For set up for a specific provider, see the following examples:
+- [AWS](https://github.com/omerap12/external-dns/blob/docs/helm-documentation/docs/tutorials/aws.md#using-helm-with-oidc)
+- [akamai-edgedns](https://github.com/omerap12/external-dns/blob/docs/helm-documentation/docs/tutorials/akamai-edgedns.md#using-helm)
+- [cloudflare](https://github.com/omerap12/external-dns/blob/docs/helm-documentation/docs/tutorials/cloudflare.md#using-helm)
+- [digitalocean](https://github.com/omerap12/external-dns/blob/docs/helm-documentation/docs/tutorials/digitalocean.md#using-helm)
+- [godaddy](https://github.com/omerap12/external-dns/blob/docs/helm-documentation/docs/tutorials/godaddy.md#using-helm)
+- [ns1](https://github.com/omerap12/external-dns/blob/docs/helm-documentation/docs/tutorials/ns1.md#using-helm)
+- [plural](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/plural.md#deploy-externaldns)
+- [vultr](https://github.com/omerap12/external-dns/blob/docs/helm-documentation/docs/tutorials/vultr.md#using-helm)
+
 ## Providers
 
 Configuring the _ExternalDNS_ provider should be done via the `provider.name` value with provider specific configuration being set via the `provider.<name>.<key>` values, where supported, and the `extraArgs` value. For legacy support `provider` can be set to the name of the provider with all additional configuration being set via the `extraArgs` value.

--- a/charts/external-dns/README.md.gotmpl
+++ b/charts/external-dns/README.md.gotmpl
@@ -25,7 +25,9 @@ After you've installed the repo you can install the chart.
 helm upgrade --install {{ template "chart.name" . }} external-dns/{{ template "chart.name" . }} --version {{ template "chart.version" . }}
 ```
 
-For set up for a specific provider, see the following examples:
+## Providers
+
+For set up for a specific provider using the Helm chart, see the following links:
 - [AWS](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md#using-helm-with-oidc)
 - [akamai-edgedns](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/akamai-edgedns.md#using-helm)
 - [cloudflare](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/cloudflare.md#using-helm)
@@ -34,8 +36,6 @@ For set up for a specific provider, see the following examples:
 - [ns1](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/ns1.md#using-helm)
 - [plural](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/plural.md#using-helm)
 - [vultr](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/vultr.md#using-helm)
-
-## Providers
 
 Configuring the _ExternalDNS_ provider should be done via the `provider.name` value with provider specific configuration being set via the `provider.<name>.<key>` values, where supported, and the `extraArgs` value. For legacy support `provider` can be set to the name of the provider with all additional configuration being set via the `extraArgs` value.
 See [documentation](https://kubernetes-sigs.github.io/external-dns/#new-providers) for more info on available providers and tutorials.

--- a/charts/external-dns/README.md.gotmpl
+++ b/charts/external-dns/README.md.gotmpl
@@ -26,14 +26,14 @@ helm upgrade --install {{ template "chart.name" . }} external-dns/{{ template "c
 ```
 
 For set up for a specific provider, see the following examples:
-- [AWS](https://github.com/omerap12/external-dns/blob/docs/helm-documentation/docs/tutorials/aws.md#using-helm-with-oidc)
-- [akamai-edgedns](https://github.com/omerap12/external-dns/blob/docs/helm-documentation/docs/tutorials/akamai-edgedns.md#using-helm)
-- [cloudflare](https://github.com/omerap12/external-dns/blob/docs/helm-documentation/docs/tutorials/cloudflare.md#using-helm)
-- [digitalocean](https://github.com/omerap12/external-dns/blob/docs/helm-documentation/docs/tutorials/digitalocean.md#using-helm)
-- [godaddy](https://github.com/omerap12/external-dns/blob/docs/helm-documentation/docs/tutorials/godaddy.md#using-helm)
-- [ns1](https://github.com/omerap12/external-dns/blob/docs/helm-documentation/docs/tutorials/ns1.md#using-helm)
-- [plural](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/plural.md#deploy-externaldns)
-- [vultr](https://github.com/omerap12/external-dns/blob/docs/helm-documentation/docs/tutorials/vultr.md#using-helm)
+- [AWS](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md#using-helm-with-oidc)
+- [akamai-edgedns](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/akamai-edgedns.md#using-helm)
+- [cloudflare](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/cloudflare.md#using-helm)
+- [digitalocean](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/digitalocean.md#using-helm)
+- [godaddy](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/godaddy.md#using-helm)
+- [ns1](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/ns1.md#using-helm)
+- [plural](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/plural.md#using-helm)
+- [vultr](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/vultr.md#using-helm)
 
 ## Providers
 

--- a/charts/external-dns/README.md.gotmpl
+++ b/charts/external-dns/README.md.gotmpl
@@ -27,6 +27,17 @@ helm upgrade --install {{ template "chart.name" . }} external-dns/{{ template "c
 
 ## Providers
 
+Configuring the _ExternalDNS_ provider should be done via the `provider.name` value with provider specific configuration being set via the `provider.<name>.<key>` values, where supported, and the `extraArgs` value. For legacy support `provider` can be set to the name of the provider with all additional configuration being set via the `extraArgs` value.
+See [documentation](https://kubernetes-sigs.github.io/external-dns/#new-providers) for more info on available providers and tutorials.
+
+### Providers with Specific Configuration Support
+
+| Provider               | Supported  |
+|------------------------|------------|
+| `webhook`              | ✅         |
+
+### Other Providers
+
 For set up for a specific provider using the Helm chart, see the following links:
 - [AWS](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md#using-helm-with-oidc)
 - [akamai-edgedns](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/akamai-edgedns.md#using-helm)
@@ -36,15 +47,6 @@ For set up for a specific provider using the Helm chart, see the following links
 - [ns1](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/ns1.md#using-helm)
 - [plural](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/plural.md#using-helm)
 - [vultr](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/vultr.md#using-helm)
-
-Configuring the _ExternalDNS_ provider should be done via the `provider.name` value with provider specific configuration being set via the `provider.<name>.<key>` values, where supported, and the `extraArgs` value. For legacy support `provider` can be set to the name of the provider with all additional configuration being set via the `extraArgs` value.
-See [documentation](https://kubernetes-sigs.github.io/external-dns/#new-providers) for more info on available providers and tutorials.
-
-### Providers with Specific Configuration Support
-
-| Provider               | Supported  |
-|------------------------|------------|
-| `webhook`              | ✅         |
 
 ## Namespaced Scoped Installation
 

--- a/docs/tutorials/akamai-edgedns.md
+++ b/docs/tutorials/akamai-edgedns.md
@@ -77,8 +77,8 @@ env:
 ```
 
 Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
-```shell
 
+```shell
 helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
 ```
 

--- a/docs/tutorials/akamai-edgedns.md
+++ b/docs/tutorials/akamai-edgedns.md
@@ -34,7 +34,48 @@ In addition to specifying auth credentials individually, an Akamai Edgegrid .edg
 
 An operational External-DNS deployment consists of an External-DNS container and service. The following sections demonstrate the ConfigMap objects that would make up an example functional external DNS kubernetes configuration utilizing NGINX as the service.
 
-Connect your `kubectl` client to the External-DNS cluster, and then apply one of the following manifest files:
+Connect your `kubectl` client to the External-DNS cluster.
+
+Begin by creating a Kubernetes secret to securely store your  Akamai Edge DNS Access Tokens. This key will enable ExternalDNS to authenticate with Akamai Edge DNS:
+```shell
+kubectl create secret generic external-dns --from-literal=EXTERNAL_DNS_AKAMAI_SERVICECONSUMERDOMAIN=YOUR_SERVICECONSUMERDOMAIN --from-literal=EXTERNAL_DNS_AKAMAI_CLIENT_TOKEN=YOUR_CLIENT_TOKEN --from-literal=EXTERNAL_DNS_AKAMAI_CLIENT_SECRET=YOUR_CLIENT_SECRET --from-literal=EXTERNAL_DNS_AKAMAI_ACCESS_TOKEN=YOUR_ACCESS_TOKEN
+```
+Ensure to replace YOUR_SERVICECONSUMERDOMAIN, EXTERNAL_DNS_AKAMAI_CLIENT_TOKEN, YOUR_CLIENT_SECRET and YOUR_ACCESS_TOKEN with your actual Akamai Edge DNS API keys.
+
+Then apply one of the following manifests file to deploy ExternalDNS.
+
+### Using Helm
+
+Create a values.yaml file to configure ExternalDNS to use Akamai Edge DNS as the DNS provider. This file should include the necessary environment variables:
+```shell
+provider:
+  name: akamai
+env:
+  - name: EXTERNAL_DNS_AKAMAI_SERVICECONSUMERDOMAIN
+    valueFrom:
+      secretKeyRef:
+        name: external-dns
+        key: EXTERNAL_DNS_AKAMAI_SERVICECONSUMERDOMAIN
+  - name: EXTERNAL_DNS_AKAMAI_CLIENT_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: external-dns
+        key: EXTERNAL_DNS_AKAMAI_CLIENT_TOKEN
+  - name: EXTERNAL_DNS_AKAMAI_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: external-dns
+        key: EXTERNAL_DNS_AKAMAI_CLIENT_SECRET
+  - name: EXTERNAL_DNS_AKAMAI_ACCESS_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: external-dns
+        key: EXTERNAL_DNS_AKAMAI_ACCESS_TOKEN
+```
+Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
+```shell
+helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
+```
 
 ### Manifest (for clusters without RBAC enabled)
 

--- a/docs/tutorials/akamai-edgedns.md
+++ b/docs/tutorials/akamai-edgedns.md
@@ -37,6 +37,7 @@ An operational External-DNS deployment consists of an External-DNS container and
 Connect your `kubectl` client to the External-DNS cluster.
 
 Begin by creating a Kubernetes secret to securely store your  Akamai Edge DNS Access Tokens. This key will enable ExternalDNS to authenticate with Akamai Edge DNS:
+
 ```shell
 kubectl create secret generic AKAMAI-DNS --from-literal=EXTERNAL_DNS_AKAMAI_SERVICECONSUMERDOMAIN=YOUR_SERVICECONSUMERDOMAIN --from-literal=EXTERNAL_DNS_AKAMAI_CLIENT_TOKEN=YOUR_CLIENT_TOKEN --from-literal=EXTERNAL_DNS_AKAMAI_CLIENT_SECRET=YOUR_CLIENT_SECRET --from-literal=EXTERNAL_DNS_AKAMAI_ACCESS_TOKEN=YOUR_ACCESS_TOKEN
 ```
@@ -48,6 +49,7 @@ Then apply one of the following manifests file to deploy ExternalDNS.
 ### Using Helm
 
 Create a values.yaml file to configure ExternalDNS to use Akamai Edge DNS as the DNS provider. This file should include the necessary environment variables:
+
 ```shell
 provider:
   name: akamai
@@ -73,8 +75,10 @@ env:
         name: AKAMAI-DNS
         key: EXTERNAL_DNS_AKAMAI_ACCESS_TOKEN
 ```
+
 Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
 ```shell
+
 helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
 ```
 

--- a/docs/tutorials/akamai-edgedns.md
+++ b/docs/tutorials/akamai-edgedns.md
@@ -38,8 +38,9 @@ Connect your `kubectl` client to the External-DNS cluster.
 
 Begin by creating a Kubernetes secret to securely store your  Akamai Edge DNS Access Tokens. This key will enable ExternalDNS to authenticate with Akamai Edge DNS:
 ```shell
-kubectl create secret generic external-dns --from-literal=EXTERNAL_DNS_AKAMAI_SERVICECONSUMERDOMAIN=YOUR_SERVICECONSUMERDOMAIN --from-literal=EXTERNAL_DNS_AKAMAI_CLIENT_TOKEN=YOUR_CLIENT_TOKEN --from-literal=EXTERNAL_DNS_AKAMAI_CLIENT_SECRET=YOUR_CLIENT_SECRET --from-literal=EXTERNAL_DNS_AKAMAI_ACCESS_TOKEN=YOUR_ACCESS_TOKEN
+kubectl create secret generic AKAMAI-DNS --from-literal=EXTERNAL_DNS_AKAMAI_SERVICECONSUMERDOMAIN=YOUR_SERVICECONSUMERDOMAIN --from-literal=EXTERNAL_DNS_AKAMAI_CLIENT_TOKEN=YOUR_CLIENT_TOKEN --from-literal=EXTERNAL_DNS_AKAMAI_CLIENT_SECRET=YOUR_CLIENT_SECRET --from-literal=EXTERNAL_DNS_AKAMAI_ACCESS_TOKEN=YOUR_ACCESS_TOKEN
 ```
+
 Ensure to replace YOUR_SERVICECONSUMERDOMAIN, EXTERNAL_DNS_AKAMAI_CLIENT_TOKEN, YOUR_CLIENT_SECRET and YOUR_ACCESS_TOKEN with your actual Akamai Edge DNS API keys.
 
 Then apply one of the following manifests file to deploy ExternalDNS.
@@ -54,22 +55,22 @@ env:
   - name: EXTERNAL_DNS_AKAMAI_SERVICECONSUMERDOMAIN
     valueFrom:
       secretKeyRef:
-        name: external-dns
+        name: AKAMAI-DNS
         key: EXTERNAL_DNS_AKAMAI_SERVICECONSUMERDOMAIN
   - name: EXTERNAL_DNS_AKAMAI_CLIENT_TOKEN
     valueFrom:
       secretKeyRef:
-        name: external-dns
+        name: AKAMAI-DNS
         key: EXTERNAL_DNS_AKAMAI_CLIENT_TOKEN
   - name: EXTERNAL_DNS_AKAMAI_CLIENT_SECRET
     valueFrom:
       secretKeyRef:
-        name: external-dns
+        name: AKAMAI-DNS
         key: EXTERNAL_DNS_AKAMAI_CLIENT_SECRET
   - name: EXTERNAL_DNS_AKAMAI_ACCESS_TOKEN
     valueFrom:
       secretKeyRef:
-        name: external-dns
+        name: AKAMAI-DNS
         key: EXTERNAL_DNS_AKAMAI_ACCESS_TOKEN
 ```
 Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
@@ -111,22 +112,22 @@ spec:
         - name: EXTERNAL_DNS_AKAMAI_SERVICECONSUMERDOMAIN
           valueFrom:
             secretKeyRef:
-              name: external-dns
+              name: AKAMAI-DNS
               key: EXTERNAL_DNS_AKAMAI_SERVICECONSUMERDOMAIN
         - name: EXTERNAL_DNS_AKAMAI_CLIENT_TOKEN
           valueFrom:
             secretKeyRef:
-              name: external-dns
+              name: AKAMAI-DNS
               key: EXTERNAL_DNS_AKAMAI_CLIENT_TOKEN
         - name: EXTERNAL_DNS_AKAMAI_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
-              name: external-dns
+              name: AKAMAI-DNS
               key: EXTERNAL_DNS_AKAMAI_CLIENT_SECRET
         - name: EXTERNAL_DNS_AKAMAI_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:
-              name: external-dns
+              name: AKAMAI-DNS
               key: EXTERNAL_DNS_AKAMAI_ACCESS_TOKEN
 ```
 
@@ -197,22 +198,22 @@ spec:
         - name: EXTERNAL_DNS_AKAMAI_SERVICECONSUMERDOMAIN
           valueFrom:
             secretKeyRef:
-              name: external-dns
+              name: AKAMAI-DNS
               key: EXTERNAL_DNS_AKAMAI_SERVICECONSUMERDOMAIN
         - name: EXTERNAL_DNS_AKAMAI_CLIENT_TOKEN
           valueFrom:
             secretKeyRef:
-              name: external-dns
+              name: AKAMAI-DNS
               key: EXTERNAL_DNS_AKAMAI_CLIENT_TOKEN
         - name: EXTERNAL_DNS_AKAMAI_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
-              name: external-dns
+              name: AKAMAI-DNS
               key: EXTERNAL_DNS_AKAMAI_CLIENT_SECRET
         - name: EXTERNAL_DNS_AKAMAI_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:
-              name: external-dns
+              name: AKAMAI-DNS
               key: EXTERNAL_DNS_AKAMAI_ACCESS_TOKEN
 ```
 

--- a/docs/tutorials/akamai-edgedns.md
+++ b/docs/tutorials/akamai-edgedns.md
@@ -82,6 +82,7 @@ Finally, install the ExternalDNS chart with Helm using the configuration specifi
 helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
 ```
 
+
 ### Manifest (for clusters without RBAC enabled)
 
 ```yaml

--- a/docs/tutorials/akamai-edgedns.md
+++ b/docs/tutorials/akamai-edgedns.md
@@ -79,7 +79,7 @@ env:
 Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
 
 ```shell
-helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
+helm upgrade --install external-dns external-dns/external-dns --values values.yaml
 ```
 
 

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -407,7 +407,7 @@ env:
 Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
 
 ```shell
-helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
+helm upgrade --install external-dns external-dns/external-dns --values values.yaml
 ```
 
 ### Manifest (for clusters without RBAC enabled)

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -395,6 +395,7 @@ kubectl get namespaces | grep -q $EXTERNALDNS_NS || \
 ## Using Helm (with OIDC)
 
 Create a values.yaml file to configure ExternalDNS:
+
 ```shell
 provider:
   name: aws
@@ -404,6 +405,7 @@ env:
 ```
 
 Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
+
 ```shell
 helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
 ```

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -392,6 +392,22 @@ kubectl get namespaces | grep -q $EXTERNALDNS_NS || \
   kubectl create namespace $EXTERNALDNS_NS
 ```
 
+## Using Helm (with OIDC)
+
+Create a values.yaml file to configure ExternalDNS:
+```shell
+provider:
+  name: aws
+env:
+  - name: AWS_DEFAULT_REGION
+    value: us-east-1 # change to region where EKS is installed
+```
+
+Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
+```shell
+helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
+```
+
 ### Manifest (for clusters without RBAC enabled)
 
 Save the following below as `externaldns-no-rbac.yaml`.

--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -37,9 +37,10 @@ Connect your `kubectl` client to the cluster you want to test ExternalDNS with.
 
 Begin by creating a Kubernetes secret to securely store your CloudFlare API key. This key will enable ExternalDNS to authenticate with CloudFlare:
 ```shell
-kubectl create secret generic cloudflare-api-key --from-literal=apiKey=YOUR_API_KEY
+kubectl create secret generic cloudflare-api-key --from-literal=API_KEY=YOUR_API_KEY ---from-literal=CF_API_EMAIL=YOUR_CLOUDFLARE_EMAIL
 ```
-Ensure to replace YOUR_API_KEY with your actual CloudFlare API key.
+Ensure to replace YOUR_API_KEY with your actual CloudFlare API key and YOUR_CLOUDFLARE_EMAIL with the email associated with your CloudFlare account.
+
 Then apply one of the following manifests file to deploy ExternalDNS.
 
 ### Using Helm
@@ -55,9 +56,11 @@ env:
         name: cloudflare-api-key
         key: apiKey
   - name: CF_API_EMAIL
-    value: "YOUR_CLOUDFLARE_EMAIL"
+    valueFrom:
+      secretKeyRef:
+        name: cloudflare-api-key
+        key: YOUR_CLOUDFLARE_EMAIL
 ```
-Replace YOUR_CLOUDFLARE_EMAIL with the email associated with your CloudFlare account.
 
 Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
 ```shell
@@ -94,12 +97,15 @@ spec:
         - --cloudflare-dns-records-per-page=5000 # (optional) configure how many DNS records to fetch per request
       env:
        - name: CF_API_KEY
-         valueFrom:
-          secretKeyRef:
-            name: cloudflare-api-key
-            key: apiKey
-        - name: CF_API_EMAIL
-          value: "YOUR_CLOUDFLARE_EMAIL"
+          valueFrom:
+            secretKeyRef:
+              name: cloudflare-api-key
+              key: API_KEY
+       - name: CF_API_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: cloudflare-api-key
+              key: YOUR_CLOUDFLARE_EMAIL
 ```
 
 ### Manifest (for clusters with RBAC enabled)
@@ -166,12 +172,15 @@ spec:
         - --cloudflare-dns-records-per-page=5000 # (optional) configure how many DNS records to fetch per request
         env:
        - name: CF_API_KEY
-         valueFrom:
+        valueFrom:
           secretKeyRef:
             name: cloudflare-api-key
             key: apiKey
-        - name: CF_API_EMAIL
-          value: "YOUR_CLOUDFLARE_EMAIL"
+       - name: CF_API_EMAIL
+         valueFrom:
+           secretKeyRef:
+             name: cloudflare-api-key
+             key: YOUR_CLOUDFLARE_EMAIL
 ```
 
 ## Deploying an Nginx Service

--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -68,7 +68,7 @@ env:
 Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
 
 ```shell
-helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
+helm upgrade --install external-dns external-dns/external-dns --values values.yaml
 ```
 
 ### Manifest (for clusters without RBAC enabled)

--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -34,7 +34,35 @@ Cloudflare API has a [global rate limit of 1,200 requests per five minutes](http
 ## Deploy ExternalDNS
 
 Connect your `kubectl` client to the cluster you want to test ExternalDNS with.
+
+Begin by creating a Kubernetes secret to securely store your CloudFlare API key. This key will enable ExternalDNS to authenticate with CloudFlare:
+```shell
+kubectl create secret generic cloudflare-api-key --from-literal=apiKey=YOUR_API_KEY
+```
+Ensure to replace YOUR_API_KEY with your actual CloudFlare API key.
 Then apply one of the following manifests file to deploy ExternalDNS.
+
+### Using Helm
+
+Create a values.yaml file to configure ExternalDNS to use CloudFlare as the DNS provider. This file should include the necessary environment variables:
+```shell
+provider: 
+  name: cloudflare
+env:
+  - name: CF_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: cloudflare-api-key
+        key: apiKey
+  - name: CF_API_EMAIL
+    value: "YOUR_CLOUDFLARE_EMAIL"
+```
+Replace YOUR_CLOUDFLARE_EMAIL with the email associated with your CloudFlare account.
+
+Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
+```shell
+helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
+```
 
 ### Manifest (for clusters without RBAC enabled)
 
@@ -64,9 +92,12 @@ spec:
         - --provider=cloudflare
         - --cloudflare-proxied # (optional) enable the proxy feature of Cloudflare (DDOS protection, CDN...)
         - --cloudflare-dns-records-per-page=5000 # (optional) configure how many DNS records to fetch per request
-        env:
-        - name: CF_API_KEY
-          value: "YOUR_CLOUDFLARE_API_KEY"
+      env:
+       - name: CF_API_KEY
+         valueFrom:
+          secretKeyRef:
+            name: cloudflare-api-key
+            key: apiKey
         - name: CF_API_EMAIL
           value: "YOUR_CLOUDFLARE_EMAIL"
 ```
@@ -134,8 +165,11 @@ spec:
         - --cloudflare-proxied # (optional) enable the proxy feature of Cloudflare (DDOS protection, CDN...)
         - --cloudflare-dns-records-per-page=5000 # (optional) configure how many DNS records to fetch per request
         env:
-        - name: CF_API_KEY
-          value: "YOUR_CLOUDFLARE_API_KEY"
+       - name: CF_API_KEY
+         valueFrom:
+          secretKeyRef:
+            name: cloudflare-api-key
+            key: apiKey
         - name: CF_API_EMAIL
           value: "YOUR_CLOUDFLARE_EMAIL"
 ```

--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -36,9 +36,11 @@ Cloudflare API has a [global rate limit of 1,200 requests per five minutes](http
 Connect your `kubectl` client to the cluster you want to test ExternalDNS with.
 
 Begin by creating a Kubernetes secret to securely store your CloudFlare API key. This key will enable ExternalDNS to authenticate with CloudFlare:
+
 ```shell
 kubectl create secret generic cloudflare-api-key --from-literal=API_KEY=YOUR_API_KEY ---from-literal=CF_API_EMAIL=YOUR_CLOUDFLARE_EMAIL
 ```
+
 Ensure to replace YOUR_API_KEY with your actual CloudFlare API key and YOUR_CLOUDFLARE_EMAIL with the email associated with your CloudFlare account.
 
 Then apply one of the following manifests file to deploy ExternalDNS.
@@ -46,6 +48,7 @@ Then apply one of the following manifests file to deploy ExternalDNS.
 ### Using Helm
 
 Create a values.yaml file to configure ExternalDNS to use CloudFlare as the DNS provider. This file should include the necessary environment variables:
+
 ```shell
 provider: 
   name: cloudflare
@@ -63,6 +66,7 @@ env:
 ```
 
 Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
+
 ```shell
 helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
 ```

--- a/docs/tutorials/digitalocean.md
+++ b/docs/tutorials/digitalocean.md
@@ -23,9 +23,11 @@ The environment variable `DO_TOKEN` will be needed to run ExternalDNS with Digit
 Connect your `kubectl` client to the cluster you want to test ExternalDNS with.
 
 Begin by creating a Kubernetes secret to securely store your DigitalOcean API key. This key will enable ExternalDNS to authenticate with DigitalOcean:
+
 ```shell
 kubectl create secret generic DO_TOKEN --from-literal=DO_TOKEN=YOUR_DIGITALOCEAN_API_KEY
 ```
+
 Ensure to replace YOUR_DIGITALOCEAN_API_KEY with your actual DigitalOcean API key.
 
 Then apply one of the following manifests file to deploy ExternalDNS.
@@ -33,6 +35,7 @@ Then apply one of the following manifests file to deploy ExternalDNS.
 ## Using Helm
 
 Create a values.yaml file to configure ExternalDNS to use DigitalOcean as the DNS provider. This file should include the necessary environment variables:
+
 ```shell
 provider: 
   name: digitalocean
@@ -45,6 +48,7 @@ env:
 ```
 
 ### Manifest (for clusters without RBAC enabled)
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment

--- a/docs/tutorials/digitalocean.md
+++ b/docs/tutorials/digitalocean.md
@@ -21,7 +21,28 @@ The environment variable `DO_TOKEN` will be needed to run ExternalDNS with Digit
 ## Deploy ExternalDNS
 
 Connect your `kubectl` client to the cluster you want to test ExternalDNS with.
+
+Begin by creating a Kubernetes secret to securely store your DigitalOcean API key. This key will enable ExternalDNS to authenticate with DigitalOcean:
+```shell
+kubectl create secret generic DO_TOKEN --from-literal=DO_TOKEN=YOUR_DIGITALOCEAN_API_KEY
+```
+Ensure to replace YOUR_DIGITALOCEAN_API_KEY with your actual DigitalOcean API key.
+
 Then apply one of the following manifests file to deploy ExternalDNS.
+
+## Using Helm
+
+Create a values.yaml file to configure ExternalDNS to use DigitalOcean as the DNS provider. This file should include the necessary environment variables:
+```shell
+provider: 
+  name: digitalocean
+env:
+  - name: DO_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: DO_TOKEN
+        key: DO_TOKEN
+```
 
 ### Manifest (for clusters without RBAC enabled)
 ```yaml
@@ -50,7 +71,10 @@ spec:
         - --provider=digitalocean
         env:
         - name: DO_TOKEN
-          value: "YOUR_DIGITALOCEAN_API_KEY"
+          valueFrom:
+            secretKeyRef:
+              name: DO_TOKEN
+              key: DO_TOKEN
 ```
 
 ### Manifest (for clusters with RBAC enabled)
@@ -114,7 +138,10 @@ spec:
         - --provider=digitalocean
         env:
         - name: DO_TOKEN
-          value: "YOUR_DIGITALOCEAN_API_KEY"
+          valueFrom:
+            secretKeyRef:
+              name: DO_TOKEN
+              key: DO_TOKEN
 ```
 
 

--- a/docs/tutorials/godaddy.md
+++ b/docs/tutorials/godaddy.md
@@ -27,6 +27,7 @@ Connect your `kubectl` client to the cluster with which you want to test Externa
 ## Using Helm
 
 Create a values.yaml file to configure ExternalDNS to use NS1 as the DNS provider. This file should include the necessary environment variables:
+
 ```shell
 provider: 
   name: godaddy 
@@ -38,6 +39,7 @@ extraArgs:
 Ensure to replace YOUR_API_KEY and YOUR_API_SECRET with your actual godaddy API key and godaddy API secret.
 
 Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
+
 ```shell
 helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
 ```

--- a/docs/tutorials/godaddy.md
+++ b/docs/tutorials/godaddy.md
@@ -41,7 +41,7 @@ Ensure to replace YOUR_API_KEY and YOUR_API_SECRET with your actual godaddy API 
 Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
 
 ```shell
-helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
+helm upgrade --install external-dns external-dns/external-dns --values values.yaml
 ```
 
 ### Manifest (for clusters without RBAC enabled)

--- a/docs/tutorials/godaddy.md
+++ b/docs/tutorials/godaddy.md
@@ -24,6 +24,24 @@ Using the [GoDaddy documentation](https://developer.godaddy.com/getstarted) you 
 
 Connect your `kubectl` client to the cluster with which you want to test ExternalDNS, and then apply one of the following manifest files for deployment:
 
+## Using Helm
+
+Create a values.yaml file to configure ExternalDNS to use NS1 as the DNS provider. This file should include the necessary environment variables:
+```shell
+provider: 
+  name: godaddy 
+extraArgs:
+  - --godaddy-api-key=YOUR_API_KEY
+  - --godaddy-api-secret=YOUR_API_SECRET
+```
+
+Ensure to replace YOUR_API_KEY and YOUR_API_SECRET with your actual godaddy API key and godaddy API secret.
+
+Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
+```shell
+helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
+```
+
 ### Manifest (for clusters without RBAC enabled)
 
 ```yaml

--- a/docs/tutorials/ns1.md
+++ b/docs/tutorials/ns1.md
@@ -69,7 +69,7 @@ env:
 Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
 
 ```shell
-helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
+helm upgrade --install external-dns external-dns/external-dns --values values.yaml
 ```
 
 ### Manifest (for clusters without RBAC enabled)

--- a/docs/tutorials/ns1.md
+++ b/docs/tutorials/ns1.md
@@ -42,6 +42,7 @@ var `NS1_APIKEY` will be needed to run ExternalDNS with NS1.
 Connect your `kubectl` client to the cluster with which you want to test ExternalDNS, and then apply one of the following manifest files for deployment:
 
 Begin by creating a Kubernetes secret to securely store your NS1 API key. This key will enable ExternalDNS to authenticate with NS1:
+
 ```shell
 kubectl create secret generic NS1_APIKEY --from-literal=NS1_API_KEY=YOUR_NS1_API_KEY
 ```
@@ -53,6 +54,7 @@ Then apply one of the following manifests file to deploy ExternalDNS.
 ## Using Helm
 
 Create a values.yaml file to configure ExternalDNS to use NS1 as the DNS provider. This file should include the necessary environment variables:
+
 ```shell
 provider: 
   name: ns1
@@ -65,6 +67,7 @@ env:
 ```
 
 Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
+
 ```shell
 helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
 ```

--- a/docs/tutorials/ns1.md
+++ b/docs/tutorials/ns1.md
@@ -52,7 +52,7 @@ Then apply one of the following manifests file to deploy ExternalDNS.
 
 ## Using Helm
 
-Create a values.yaml file to configure ExternalDNS to use CloudFlare as the DNS provider. This file should include the necessary environment variables:
+Create a values.yaml file to configure ExternalDNS to use NS1 as the DNS provider. This file should include the necessary environment variables:
 ```shell
 provider: 
   name: ns1

--- a/docs/tutorials/ns1.md
+++ b/docs/tutorials/ns1.md
@@ -41,7 +41,7 @@ var `NS1_APIKEY` will be needed to run ExternalDNS with NS1.
 
 Connect your `kubectl` client to the cluster with which you want to test ExternalDNS, and then apply one of the following manifest files for deployment:
 
-Begin by creating a Kubernetes secret to securely store your CloudFlare API key. This key will enable ExternalDNS to authenticate with CloudFlare:
+Begin by creating a Kubernetes secret to securely store your NS1 API key. This key will enable ExternalDNS to authenticate with NS1:
 ```shell
 kubectl create secret generic NS1_APIKEY --from-literal=NS1_API_KEY=YOUR_NS1_API_KEY
 ```

--- a/docs/tutorials/ns1.md
+++ b/docs/tutorials/ns1.md
@@ -41,6 +41,34 @@ var `NS1_APIKEY` will be needed to run ExternalDNS with NS1.
 
 Connect your `kubectl` client to the cluster with which you want to test ExternalDNS, and then apply one of the following manifest files for deployment:
 
+Begin by creating a Kubernetes secret to securely store your CloudFlare API key. This key will enable ExternalDNS to authenticate with CloudFlare:
+```shell
+kubectl create secret generic NS1_APIKEY --from-literal=NS1_API_KEY=YOUR_NS1_API_KEY
+```
+
+Ensure to replace YOUR_NS1_API_KEY with your actual NS1 API key.
+
+Then apply one of the following manifests file to deploy ExternalDNS.
+
+## Using Helm
+
+Create a values.yaml file to configure ExternalDNS to use CloudFlare as the DNS provider. This file should include the necessary environment variables:
+```shell
+provider: 
+  name: ns1
+env:
+  - name: NS1_APIKEY
+    valueFrom:
+      secretKeyRef:
+        name: NS1_APIKEY
+        key: NS1_API_KEY
+```
+
+Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
+```shell
+helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
+```
+
 ### Manifest (for clusters without RBAC enabled)
 
 ```yaml
@@ -67,8 +95,11 @@ spec:
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
         - --provider=ns1
         env:
-        - name: NS1_APIKEY
-          value: "YOUR_NS1_API_KEY"
+       - name: NS1_APIKEY
+          valueFrom:
+            secretKeyRef:
+              name: NS1_APIKEY
+              key: NS1_API_KEY
 ```
 
 ### Manifest (for clusters with RBAC enabled)
@@ -131,8 +162,11 @@ spec:
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
         - --provider=ns1
         env:
-        - name: NS1_APIKEY
-          value: "YOUR_NS1_API_KEY"
+       - name: NS1_APIKEY
+          valueFrom:
+            secretKeyRef:
+              name: NS1_APIKEY
+              key: NS1_API_KEY
 ```
 
 ## Deploying an Nginx Service

--- a/docs/tutorials/plural.md
+++ b/docs/tutorials/plural.md
@@ -18,6 +18,7 @@ Then apply one of the following manifests file to deploy ExternalDNS.
 ## Using Helm
 
 Create a values.yaml file to configure ExternalDNS to use plural DNS as the DNS provider. This file should include the necessary environment variables:
+
 ```shell
 provider:
   name: plural
@@ -35,6 +36,7 @@ env:
 ```
 
 Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
+
 ```shell
 helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
 ```

--- a/docs/tutorials/plural.md
+++ b/docs/tutorials/plural.md
@@ -15,6 +15,30 @@ To create the secret you can run `kubectl create secret generic plural-env --fro
 Connect your `kubectl` client to the cluster you want to test ExternalDNS with.
 Then apply one of the following manifests file to deploy ExternalDNS.
 
+## Using Helm
+
+Create a values.yaml file to configure ExternalDNS to use plural DNS as the DNS provider. This file should include the necessary environment variables:
+```shell
+provider:
+  name: plural
+extraArgs:
+  - --plural-cluster=example-plural-cluster
+  - --plural-provider=aws # gcp, azure, equinix and kind are also possible
+env:
+  - name: PLURAL_ACCESS_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: PLURAL_ACCESS_TOKEN
+        key: plural-env
+  - name: PLURAL_ENDPOINT
+    value: https://app.plural.sh 
+```
+
+Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
+```shell
+helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
+```
+
 ### Manifest (for clusters without RBAC enabled)
 
 ```yaml

--- a/docs/tutorials/plural.md
+++ b/docs/tutorials/plural.md
@@ -38,7 +38,7 @@ env:
 Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
 
 ```shell
-helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
+helm upgrade --install external-dns external-dns/external-dns --values values.yaml
 ```
 
 ### Manifest (for clusters without RBAC enabled)

--- a/docs/tutorials/vultr.md
+++ b/docs/tutorials/vultr.md
@@ -20,7 +20,35 @@ The environment variable `VULTR_API_KEY` will be needed to run ExternalDNS with 
 ## Deploy ExternalDNS
 
 Connect your `kubectl` client to the cluster you want to test ExternalDNS with.
+
+Begin by creating a Kubernetes secret to securely store your  Akamai Edge DNS Access Tokens. This key will enable ExternalDNS to authenticate with Akamai Edge DNS:
+```shell
+kubectl create secret generic VULTR_API_KEY --from-literal=VULTR_API_KEY=YOUR_VULTR_API_KEY
+```
+
+Ensure to replace YOUR_VULTR_API_KEY, with your actual Vultr API key.
+
+
 Then apply one of the following manifests file to deploy ExternalDNS.
+
+### Using Helm
+
+reate a values.yaml file to configure ExternalDNS to use Akamai Edge DNS as the DNS provider. This file should include the necessary environment variables:
+```shell
+provider:
+  name: akamai
+env:
+  - name: VULTR_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: VULTR_API_KEY
+        key: VULTR_API_KEY
+```
+
+Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
+```shell
+helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
+```
 
 ### Manifest (for clusters without RBAC enabled)
 
@@ -49,7 +77,10 @@ spec:
         - --provider=vultr
         env:
         - name: VULTR_API_KEY
-          value: "YOU_VULTR_API_KEY"
+          valueFrom:
+            secretKeyRef:
+              name: VULTR_API_KEY
+              key: VULTR_API_KEY
 ```
 
 ### Manifest (for clusters with RBAC enabled)
@@ -113,7 +144,10 @@ spec:
         - --provider=vultr
         env:
         - name: VULTR_API_KEY
-          value: "YOU_VULTR_API_KEY"
+          valueFrom:
+            secretKeyRef:
+              name: VULTR_API_KEY
+              key: VULTR_API_KEY
 ```
 
 ## Deploying a Nginx Service

--- a/docs/tutorials/vultr.md
+++ b/docs/tutorials/vultr.md
@@ -50,7 +50,7 @@ env:
 Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
 
 ```shell
-helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
+helm upgrade --install external-dns external-dns/external-dns --values values.yaml
 ```
 
 ### Manifest (for clusters without RBAC enabled)

--- a/docs/tutorials/vultr.md
+++ b/docs/tutorials/vultr.md
@@ -22,6 +22,7 @@ The environment variable `VULTR_API_KEY` will be needed to run ExternalDNS with 
 Connect your `kubectl` client to the cluster you want to test ExternalDNS with.
 
 Begin by creating a Kubernetes secret to securely store your  Akamai Edge DNS Access Tokens. This key will enable ExternalDNS to authenticate with Akamai Edge DNS:
+
 ```shell
 kubectl create secret generic VULTR_API_KEY --from-literal=VULTR_API_KEY=YOUR_VULTR_API_KEY
 ```
@@ -34,6 +35,7 @@ Then apply one of the following manifests file to deploy ExternalDNS.
 ### Using Helm
 
 reate a values.yaml file to configure ExternalDNS to use Akamai Edge DNS as the DNS provider. This file should include the necessary environment variables:
+
 ```shell
 provider:
   name: akamai
@@ -46,6 +48,7 @@ env:
 ```
 
 Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
+
 ```shell
 helm upgrade --install external-dns external-dns/external-dns --version 1.14.4 --values values.yaml
 ```


### PR DESCRIPTION
**Description**
Updates the Helm chart documentation for ExternalDNS to include a detailed example of how to configure ExternalDNS with the CloudFlare provider. 
<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4396 

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
