### PR TITLE
chore: upgrade ExternalDNS to go 1.22.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.22.2'
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Install go version
       uses: actions/setup-go@v5
       with:
-        go-version: '^1.22'
+        go-version: '^1.22.2'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.22'
+          go-version: '^1.22.2'
 
       - run: |
           pip install -r docs/scripts/requirements.txt

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.22.2'
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/staging-image-tester.yaml
+++ b/.github/workflows/staging-image-tester.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.22.2'
       id: go
 
     - name: Check out code into the Go module directory

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'docker.io/library/golang:1.22-bookworm'
+  - name: 'docker.io/library/golang:1.22.2-bookworm'
     entrypoint: make
     env:
       - VERSION=$_GIT_TAG

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/external-dns
 
-go 1.22
+go 1.22.2
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3


### PR DESCRIPTION
### What does it do ?

Upgrade go lang from 1.22 to 1.22.2

### Motivation

It's fixing some CVEs and required by latest version of IBM sdk:

```shell
go: github.com/IBM/networking-go-sdk@v0.46.1 requires go >= 1.22.2; switching to go1.22.2
```

=> It will fix dependabot PR like [this one](https://github.com/kubernetes-sigs/external-dns/pull/4413).

### Checklist

- [x] Unit tests updated
- [x] End user documentation updated
