### PR TITLE
[WIP] docs: remove tenantId from external-dns-azure secret

### DIFF
--- a/docs/tutorials/azure.md
+++ b/docs/tutorials/azure.md
@@ -405,7 +405,6 @@ type: Opaque
 data:
   azure.json: |
     {
-      "tenantId": "<TENANT_ID>",
       "subscriptionId": "<SUBSCRIPTION_ID>",
       "resourceGroup": "<AZURE_DNS_ZONE_RESOURCE_GROUP>",
       "useWorkloadIdentityExtension": true


### PR DESCRIPTION
**Description**

Removing `tenantId` in the Secret that is to be created for deploying `external-dns` with [Helm in Azure with Managed Identities using Workload Identity](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/azure.md#helm)

With `tenantId` present in the Secret the `external-dns` pods run into CrashLoopBackOff with following error:
```
time="2024-04-25T06:34:37Z" level=fatal msg="WorkloadIdentityCredential: unable to resolve an endpoint: http call(https://login.microsoftonline.com/XXXXX-REDACTED-XXXXXX/v2.0/.well-known/openid-configuration)(GET) error: reply status code was 400:\n{\"error\":\"invalid_tenant\",\"error_description\":\"AADSTS90002: Tenant 'XXXXX-REDACTED-XXXXXX' not found. Check to make sure you have the correct tenant ID and are signing into the correct cloud. Check with your subscription administrator, this may happen if there are no active subscriptions for the tenant. Trace ID: 56aa0372-738d-43ae-896d-d4fa9eb92101 Correlation ID: 45d49251-1a76-4be5-ac80-e6829e8c4bed Timestamp: 2024-04-25 06:34:37Z\",\"error_codes\":[90002],\"timestamp\":\"2024-04-25 06:34:37Z\",\"trace_id\":\"56aa0372-738d-43ae-896d-d4fa9eb92101\",\"correlation_id\":\"45d49251-1a76-4be5-ac80-e6829e8c4bed\",\"error_uri\":\"https://login.microsoftonline.com/error?code=90002\"}"
```  
Error Details: https://login.microsoftonline.com/error?code=90002


The above error is also seen when you try to login using `azcli` from a pod with same service account and namespace using federated credentials:

```
~ # az login --federated-token "$(cat ${AZ_TOKEN})" --service-principal -u XXXX-MANAGEDIDENTITY-XXXX  -t XXXXX-REDACTED-XXXXXX
Failed to resolve tenant 'XXXXX-REDACTED-XXXXXX'.

Error detail: {"error":"invalid_tenant","error_description":"AADSTS90002: Tenant 'XXXXX-REDACTED-XXXXXX' not found. Check to make sure you have the correct tenant ID and are signing into the correct cloud. Check with your subscription administrator, this may happen if there are no active subscriptions for the tenant. Trace ID: 6ac60ea5-e0f8-4267-9f66-a02110b53300 Correlation ID: 0a1d6bf7-168c-4840-946d-4b116b9c28e1 Timestamp: 2024-04-25 09:47:44Z","error_codes":[90002],"timestamp":"2024-04-25 09:47:44Z","trace_id":"6ac60ea5-e0f8-4267-9f66-a02110b53300","correlation_id":"0a1d6bf7-168c-4840-946d-4b116b9c28e1","error_uri":"https://login.microsoftonline.com/error?code=90002"}
```

We were able to fix this after removing `tenantId` field from the Secret `external-dns-azure`, as it was not seen in the `kubectl` patch commands that create the same Secret [using kubectl as alternative method](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/azure.md#create-a-configuration-file-for-the-managed-identity), in the same document

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
