### PR TITLE
Add envFrom field to deployment.yaml for external-dns Helm chart

### DIFF
--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -87,6 +87,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | dnsPolicy | string | `nil` | [DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) for the pod, if not set the default will be used. |
 | domainFilters | list | `[]` |  |
 | env | list | `[]` | [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `external-dns` container. |
+| envFrom | list | `[]` | [Environment variables from ConfigMap or Secret](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `external-dns` container. |
 | excludeDomains | list | `[]` |  |
 | extraArgs | list | `[]` | Extra arguments to provide to _ExternalDNS_. |
 | extraVolumeMounts | list | `[]` | Extra [volume mounts](https://kubernetes.io/docs/concepts/storage/volumes/) for the `external-dns` container. |

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -81,6 +81,10 @@ spec:
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args:
             - --log-level={{ .Values.logLevel }}
             - --log-format={{ .Values.logFormat }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -110,6 +110,9 @@ securityContext:
 # -- [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `external-dns` container.
 env: []
 
+# -- [Environment variables from ConfigMap or Secret](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `external-dns` container.
+envFrom: []
+
 # -- [Liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `external-dns` container.
 # @default -- See _values.yaml_
 livenessProbe:


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

Proposed change adds an `envFrom:` field to `charts/external-dns/templates/deployment.yaml` in order to be able to use environment variables referenced from a `Secret` or `ConfigMap`.  This allows more secure configuration options for providers like `pi-hole` (https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/pihole.md#externaldns-manifest), where the provider expects a `Secret` to exist. In this way, it can be referenced in the chart versus patching the `deployment` or insecurely passing a secret via `args` field in `values.yaml`.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
No issue exists for this.

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
