### PR TITLE
fix: add debug log for gateway not having status

### DIFF
--- a/source/gateway.go
+++ b/source/gateway.go
@@ -289,6 +289,10 @@ func (c *gatewayRouteResolver) resolve(rt gatewayRoute) (map[string]endpoint.Tar
 	hostTargets := make(map[string]endpoint.Targets)
 
 	meta := rt.Metadata()
+	if len(rt.RouteStatus().Parents) == 0 {
+		log.Debugf("No gateway accepted a parentRef in %s %s/%s", c.src.rtKind, meta.Namespace, meta.Name)
+		return hostTargets, nil
+	}
 	for _, rps := range rt.RouteStatus().Parents {
 		// Confirm the Parent is the standard Gateway kind.
 		ref := rps.ParentRef


### PR DESCRIPTION
**Description**

Add a debug log when `status.Parents` is empty in Gateway API implementation.

Fixes #4439

Does not need documentation of test update. Tests never test for debug messages anyway.

