### PR TITLE
fix logline mentioning plugin api

### DIFF
--- a/provider/webhook/webhook.go
+++ b/provider/webhook/webhook.go
@@ -123,7 +123,7 @@ func NewWebhookProvider(u string) (*WebhookProvider, error) {
 	err = backoff.Retry(func() error {
 		resp, err = client.Do(req)
 		if err != nil {
-			log.Debugf("Failed to connect to plugin api: %v", err)
+			log.Debugf("Failed to connect to webhook: %v", err)
 			return err
 		}
 		// we currently only use 200 as success, but considering okay all 2XX for future usage
@@ -134,7 +134,7 @@ func NewWebhookProvider(u string) (*WebhookProvider, error) {
 	}, backoff.WithMaxRetries(backoff.NewExponentialBackOff(), maxRetries))
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to plugin api: %v", err)
+		return nil, fmt.Errorf("failed to connect to webhook: %v", err)
 	}
 
 	contentType := resp.Header.Get(webhookapi.ContentTypeHeader)


### PR DESCRIPTION
**Description**

This PR changes a logline that was merged at the time in which we implemented the webhook functionality. This was originally called "plugin" and it looks like a logline mentioning the old name is still in the codebase. This PR renames that to webhook.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
