### PR TITLE
fix: add clarification to endpoint unit tests

### DIFF
--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -153,7 +153,7 @@ func TestIsLess(t *testing.T) {
 	}
 }
 
-func TestFilterEndpointsByOwnerID(t *testing.T) {
+func TestFilterEndpointsByOwnerIDWithRecordTypeA(t *testing.T) {
 	foo1 := &Endpoint{
 		DNSName:    "foo.com",
 		RecordType: RecordTypeA,
@@ -162,8 +162,8 @@ func TestFilterEndpointsByOwnerID(t *testing.T) {
 		},
 	}
 	foo2 := &Endpoint{
-		DNSName:    "foo.com",
-		RecordType: RecordTypeCNAME,
+		DNSName:    "foo2.com",
+		RecordType: RecordTypeA,
 		Labels: Labels{
 			OwnerLabelKey: "foo",
 		},
@@ -171,6 +171,62 @@ func TestFilterEndpointsByOwnerID(t *testing.T) {
 	bar := &Endpoint{
 		DNSName:    "foo.com",
 		RecordType: RecordTypeA,
+		Labels: Labels{
+			OwnerLabelKey: "bar",
+		},
+	}
+	type args struct {
+		ownerID string
+		eps     []*Endpoint
+	}
+	tests := []struct {
+		name string
+		args args
+		want []*Endpoint
+	}{
+		{
+			name: "filter values",
+			args: args{
+				ownerID: "foo",
+				eps: []*Endpoint{
+					foo1,
+					foo2,
+					bar,
+				},
+			},
+			want: []*Endpoint{
+				foo1,
+				foo2,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FilterEndpointsByOwnerID(tt.args.ownerID, tt.args.eps); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ApplyEndpointFilter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterEndpointsByOwnerIDWithRecordTypeCNAME(t *testing.T) {
+	foo1 := &Endpoint{
+		DNSName:    "foo.com",
+		RecordType: RecordTypeCNAME,
+		Labels: Labels{
+			OwnerLabelKey: "foo",
+		},
+	}
+	foo2 := &Endpoint{
+		DNSName:    "foo2.com",
+		RecordType: RecordTypeCNAME,
+		Labels: Labels{
+			OwnerLabelKey: "foo",
+		},
+	}
+	bar := &Endpoint{
+		DNSName:    "foo.com",
+		RecordType: RecordTypeCNAME,
 		Labels: Labels{
 			OwnerLabelKey: "bar",
 		},


### PR DESCRIPTION
**Description**

Based on the conversation during #4296 this is an addition to clarify that A records cannot live with CNAME records with the same hostnames. Since the function that was developed is not expected to validate the type of records, this unit test was splitted into 2 different Record types to avoid any type of possible confusion in the future.

Fixes #4339

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
