### PR TITLE
fix #4483: re-add approval annotation to CRD

### DIFF
--- a/docs/contributing/crd-source/crd-manifest.yaml
+++ b/docs/contributing/crd-source/crd-manifest.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+    api-approved.kubernetes.io: "https://github.com/kubernetes-sigs/external-dns/pull/2007"
   name: dnsendpoints.externaldns.k8s.io
 spec:
   group: externaldns.k8s.io


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
The approval annotation for the DNSEndpoint CRD was removed and is impacting charts referring to this (see: https://github.com/bitnami/charts/issues/25967#issuecomment-2118911165)
<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4483 

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
