### PR TITLE
fix: re-add api-approved.kubernetes.io annotation

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -357,6 +357,7 @@ type DNSEndpointStatus struct {
 // +kubebuilder:resource:path=dnsendpoints
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:annotations="api-approved.kubernetes.io=https://github.com/kubernetes-sigs/external-dns/pull/2007"
 // +versionName=v1alpha1
 
 type DNSEndpoint struct {


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This re-adds the `api-approved.kubernetes.io` annotation that was removed with 4e6dd80301bccf8ccc7fb06db49d3ad4ef2191b1.

Fixes #4487.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
