### PR TITLE
fix(traefik): Nil pointer exception if legacy traefik is disabled

### DIFF
--- a/source/traefik_proxy.go
+++ b/source/traefik_proxy.go
@@ -759,14 +759,26 @@ func (ts *traefikSource) AddEventHandler(ctx context.Context, handler func()) {
 	// Right now there is no way to remove event handler from informer, see:
 	// https://github.com/kubernetes/kubernetes/issues/79610
 	log.Debug("Adding event handler for IngressRoute")
-	ts.ingressRouteInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
-	ts.oldIngressRouteInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
+	if ts.ingressRouteInformer != nil {
+		ts.ingressRouteInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
+	}
+	if ts.oldIngressRouteInformer != nil {
+		ts.oldIngressRouteInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
+	}
 	log.Debug("Adding event handler for IngressRouteTCP")
-	ts.ingressRouteTcpInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
-	ts.oldIngressRouteTcpInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
+	if ts.ingressRouteTcpInformer != nil {
+		ts.ingressRouteTcpInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
+	}
+	if ts.oldIngressRouteTcpInformer != nil {
+		ts.oldIngressRouteTcpInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
+	}
 	log.Debug("Adding event handler for IngressRouteUDP")
-	ts.ingressRouteUdpInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
-	ts.oldIngressRouteUdpInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
+	if ts.ingressRouteUdpInformer != nil {
+		ts.ingressRouteUdpInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
+	}
+	if ts.oldIngressRouteUdpInformer != nil {
+		ts.oldIngressRouteUdpInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
+	}
 }
 
 // newTraefikUnstructuredConverter returns a new unstructuredConverter initialized


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Fixed a nil pointer exception if using traefik v3.

The legacy CRDs are no longer shipped.
Starting external-dns with legacy enabled -> timeout
Starting external-dns with legacy disabled -> Nil pointer exception. Fixed by this PR.

error message without:
```
time="2024-05-25T09:06:10Z" level=info msg="config: {APIServerURL: KubeConfig: RequestTimeout:30s DefaultTargets:] GlooNamespaces:[gloo-system] SkipperRouteGroupVersion:zalando.org/v1 Sources:[service ingress traefik-proxy] Namespace: AnnotationFilter: LabelFilter: IngressClassNames:] FQDNTemplate: CombineFQDNAndAnnotation:false IgnoreHostnameAnnotation:false IgnoreIngressTLSSpec:false IgnoreIngressRulesSpec:false GatewayNamespace: GatewayLabelFilter: Compatibility: PublishInternal:false PublishHostIP:false AlwaysPublishNotReadyAddresses:false ConnectorSourceServer:localhost:8080 Provider:designate GoogleProject: GoogleBatchChangeSize:1000 GoogleBatchChangeInterval:1s GoogleZoneVisibility: DomainFilter:[demo.budd.ee] ExcludeDomains:] RegexDomainFilter: RegexDomainExclusion: ZoneNameFilter:] ZoneIDFilter:] TargetNetFilter:] ExcludeTargetNets:] AlibabaCloudConfigFile:/etc/kubernetes/alibaba-cloud.json AlibabaCloudZoneType: AWSZoneType: AWSZoneTagFilter:] AWSAssumeRole: AWSAssumeRoleExternalID: AWSBatchChangeSize:1000 AWSBatchChangeSizeBytes:32000 AWSBatchChangeSizeValues:1000 AWSBatchChangeInterval:1s AWSEvaluateTargetHealth:true AWSAPIRetries:3 AWSPreferCNAME:false AWSZoneCacheDuration:0s AWSSDServiceCleanup:false AWSZoneMatchParent:false AWSDynamoDBRegion: AWSDynamoDBTable:external-dns AzureConfigFile:/etc/kubernetes/azure.json AzureResourceGroup: AzureSubscriptionID: AzureUserAssignedIdentityClientID: BluecatDNSConfiguration: BluecatConfigFile:/etc/kubernetes/bluecat.json BluecatDNSView: BluecatGatewayHost: BluecatRootZone: BluecatDNSServerName: BluecatDNSDeployType:no-deploy BluecatSkipTLSVerify:false CloudflareProxied:false CloudflareDNSRecordsPerPage:100 CoreDNSPrefix:/skydns/ RcodezeroTXTEncrypt:false AkamaiServiceConsumerDomain: AkamaiClientToken: AkamaiClientSecret: AkamaiAccessToken: AkamaiEdgercPath: AkamaiEdgercSection: InfobloxGridHost: InfobloxWapiPort:443 InfobloxWapiUsername:admin InfobloxWapiPassword: InfobloxWapiVersion:2.3.1 InfobloxSSLVerify:true InfobloxView: InfobloxMaxResults:0 InfobloxFQDNRegEx: InfobloxNameRegEx: InfobloxCreatePTR:false InfobloxCacheDuration:0 DynCustomerName: DynUsername: DynPassword: DynMinTTLSeconds:0 OCIConfigFile:/etc/kubernetes/oci.yaml OCICompartmentOCID: OCIAuthInstancePrincipal:false OCIZoneScope:GLOBAL OCIZoneCacheDuration:0s InMemoryZones:] OVHEndpoint:ovh-eu OVHApiRateLimit:20 PDNSServer:http://localhost:8081 PDNSAPIKey: PDNSSkipTLSVerify:false TLSCA: TLSClientCert: TLSClientCertKey: Policy:sync Registry:txt TXTOwnerID:demo TXTPrefix:%{record_type}-- TXTSuffix: TXTEncryptEnabled:false TXTEncryptAESKey: Interval:5m0s MinEventSyncInterval:5s Once:false DryRun:false UpdateEvents:true LogFormat:text MetricsAddress::7979 LogLevel:info TXTCacheInterval:0s TXTWildcardReplacement: ExoscaleEndpoint: ExoscaleAPIKey: ExoscaleAPISecret: ExoscaleAPIEnvironment:api ExoscaleAPIZone:ch-gva-2 CRDSourceAPIVersion:externaldns.k8s.io/v1alpha1 CRDSourceKind:DNSEndpoint ServiceTypeFilter:] CFAPIEndpoint: CFUsername: CFPassword: ResolveServiceLoadBalancerHostname:false RFC2136Host: RFC2136Port:0 RFC2136Zone:] RFC2136Insecure:false RFC2136GSSTSIG:false RFC2136KerberosRealm: RFC2136KerberosUsername: RFC2136KerberosPassword: RFC2136TSIGKeyName: RFC2136TSIGSecret: RFC2136TSIGSecretAlg: RFC2136TAXFR:false RFC2136MinTTL:0s RFC2136BatchChangeSize:50 RFC2136UseTLS:false RFC2136SkipTLSVerify:false NS1Endpoint: NS1IgnoreSSL:false NS1MinTTLSeconds:0 TransIPAccountName: TransIPPrivateKeyFile: DigitalOceanAPIPageSize:50 ManagedDNSRecordTypes:[A AAAA CNAME] ExcludeDNSRecordTypes:] GoDaddyAPIKey: GoDaddySecretKey: GoDaddyTTL:0 GoDaddyOTE:false OCPRouterName: IBMCloudProxied:false IBMCloudConfigFile:/etc/kubernetes/ibmcloud.json TencentCloudConfigFile:/etc/kubernetes/tencent-cloud.json TencentCloudZoneType: PiholeServer: PiholePassword: PiholeTLSInsecureSkipVerify:false PluralCluster: PluralProvider: WebhookProviderURL:http://localhost:8888 WebhookProviderReadTimeout:5s WebhookProviderWriteTimeout:10s WebhookServer:false TraefikDisableLegacy:true TraefikDisableNew:false}"
time="2024-05-25T09:06:10Z" level=info msg="Instantiating new Kubernetes client"
time="2024-05-25T09:06:10Z" level=info msg="Using inCluster-config based on serviceaccount-token"
time="2024-05-25T09:06:10Z" level=info msg="Created Kubernetes client https://10.96.0.1:443"
time="2024-05-25T09:06:10Z" level=info msg="Using inCluster-config based on serviceaccount-token"
time="2024-05-25T09:06:10Z" level=info msg="Created Dynamic Kubernetes client https://10.96.0.1:443"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1b7a1b1]

goroutine 1 [running]:
sigs.k8s.io/external-dns/source.(*traefikSource).AddEventHandler(0xc000df58c0, {0x0?, 0xc00219eea0?}, 0x410385?)
    sigs.k8s.io/external-dns/source/traefik_proxy.go:763 +0x91
sigs.k8s.io/external-dns/source.(*multiSource).AddEventHandler(0x7f8c3531e108?, {0x4180868, 0xc0000d2d20}, 0xc0011a34e0?)
    sigs.k8s.io/external-dns/source/multisource.go:58 +0x44
sigs.k8s.io/external-dns/source.(*dedupSource).AddEventHandler(0x410705?, {0x4180868?, 0xc0000d2d20?}, 0xc001680701?)
    sigs.k8s.io/external-dns/source/dedupsource.go:63 +0x25
sigs.k8s.io/external-dns/source.(*targetFilterSource).AddEventHandler(0x31909e0?, {0x4180868?, 0xc0000d2d20?}, 0x4?)
    sigs.k8s.io/external-dns/source/targetfiltersource.go:72 +0x25
main.main()
    sigs.k8s.io/external-dns/main.go:485 +0x4c17
Stream closed EOF for external-dns/external-dns-7cb9848848-5j8qn (external-dns)

```


**Checklist**

- [x] Unit tests updated (not needed)
- [x] End user documentation updated (not needed)

**Note for reviewers**

Instead of the nil check, I would like to split the traefik source into legacy and new to prepare removal of legacy.
I will prepare a separate PR.
