### PR TITLE
feat(coredns): etcd authentication

### DIFF
--- a/docs/tutorials/coredns.md
+++ b/docs/tutorials/coredns.md
@@ -86,6 +86,7 @@ helm install --name my-coredns --values values.yaml stable/coredns
 ## Installing ExternalDNS
 ### Install external ExternalDNS
 ETCD_URLS is configured to etcd client service address.
+Optionnally, you can configure ETCD_USERNAME and ETCD_PASSWORD for authenticating to etcd.
 
 #### Manifest (for clusters without RBAC enabled)
 

--- a/provider/coredns/coredns.go
+++ b/provider/coredns/coredns.go
@@ -205,8 +205,10 @@ func getETCDConfig() (*etcdcv3.Config, error) {
 	}
 	etcdURLs := strings.Split(etcdURLsStr, ",")
 	firstURL := strings.ToLower(etcdURLs[0])
+	etcdUsername := os.Getenv("ETCD_USERNAME")
+	etcdPassword := os.Getenv("ETCD_PASSWORD")
 	if strings.HasPrefix(firstURL, "http://") {
-		return &etcdcv3.Config{Endpoints: etcdURLs}, nil
+		return &etcdcv3.Config{Endpoints: etcdURLs, Username: etcdUsername, Password: etcdPassword}, nil
 	} else if strings.HasPrefix(firstURL, "https://") {
 		caFile := os.Getenv("ETCD_CA_FILE")
 		certFile := os.Getenv("ETCD_CERT_FILE")
@@ -221,6 +223,8 @@ func getETCDConfig() (*etcdcv3.Config, error) {
 		return &etcdcv3.Config{
 			Endpoints: etcdURLs,
 			TLS:       tlsConfig,
+			Username:  etcdUsername,
+			Password:  etcdPassword,
 		}, nil
 	} else {
 		return nil, errors.New("etcd URLs must start with either http:// or https://")


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

Currently, the CoreDNS provider only work with no etcd authentication.
This PR adds etcd user/password authentication for CoreDNS provider by exposing `ETCD_USERNAME` and `ETCD_PASSWORD` environment variables.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2616

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
