### PR TITLE
feat: add support for aws dualstack nlbs

### DIFF
--- a/docs/tutorials/aws-load-balancer-controller.md
+++ b/docs/tutorials/aws-load-balancer-controller.md
@@ -181,7 +181,7 @@ an AAAA record of the same name, that each are aliases for the same ALB.
 
 AWS supports both IPv4 and "dualstack" (both IPv4 and IPv6) interfaces for NLBs.
 The AWS Load Balancer Controller uses the `service.beta.kubernetes.io/aws-load-balancer-ip-address-type`
-[annotation][5] (which defaults to `ipv4`) to determine this. If this annotation is
+[annotation][5] (which defaults to `ipv4`) to determine this. When this annotation is
 set to `dualstack` then ExternalDNS will create two alias records (one A record
 and one AAAA record) for each hostname associated with the service object of type loadbalancer.
 

--- a/docs/tutorials/aws-load-balancer-controller.md
+++ b/docs/tutorials/aws-load-balancer-controller.md
@@ -182,7 +182,7 @@ an AAAA record of the same name, that each are aliases for the same ALB.
 AWS supports both IPv4 and "dualstack" (both IPv4 and IPv6) interfaces for NLBs.
 The AWS Load Balancer Controller uses the `service.beta.kubernetes.io/aws-load-balancer-ip-address-type`
 [annotation][5] (which defaults to `ipv4`) to determine this. When this annotation is
-set to `dualstack` then ExternalDNS will create two alias records (one A record
+set to `dualstack`, ExternalDNS create two alias records (one A record
 and one AAAA record) for each hostname associated with the service object of type loadbalancer.
 
 [5]: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.7/guide/service/annotations/#ip-address-type

--- a/docs/tutorials/aws-load-balancer-controller.md
+++ b/docs/tutorials/aws-load-balancer-controller.md
@@ -177,7 +177,6 @@ The above Ingress object will result in the creation of an ALB with a dualstack
 interface. ExternalDNS will create both an A `echoserver.example.org` record and
 an AAAA record of the same name, that each are aliases for the same ALB.
 
-
 ## Dualstack NLBs
 
 AWS supports both IPv4 and "dualstack" (both IPv4 and IPv6) interfaces for NLBs.

--- a/docs/tutorials/aws-load-balancer-controller.md
+++ b/docs/tutorials/aws-load-balancer-controller.md
@@ -176,3 +176,38 @@ spec:
 The above Ingress object will result in the creation of an ALB with a dualstack
 interface. ExternalDNS will create both an A `echoserver.example.org` record and
 an AAAA record of the same name, that each are aliases for the same ALB.
+
+
+## Dualstack NLBs
+
+AWS supports both IPv4 and "dualstack" (both IPv4 and IPv6) interfaces for NLBs.
+The AWS Load Balancer Controller uses the `service.beta.kubernetes.io/aws-load-balancer-ip-address-type`
+[annotation][5] (which defaults to `ipv4`) to determine this. If this annotation is
+set to `dualstack` then ExternalDNS will create two alias records (one A record
+and one AAAA record) for each hostname associated with the service object of type loadbalancer.
+
+[5]: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.7/guide/service/annotations/#ip-address-type
+
+Example:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: echoserver
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: external
+    service.beta.kubernetes.io/aws-load-balancer-ip-address-type: dualstack
+spec:
+  selector:
+    app: echoserver
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+  type: LoadBalancer
+```
+
+The above Service object will result in the creation of a NLB with a dualstack
+interface. ExternalDNS will create both an A `echoserver.example.org` record and
+an AAAA record of the same name, that each are aliases for the same NLB.

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -244,6 +244,31 @@ func testServiceSourceEndpoints(t *testing.T) {
 			},
 		},
 		{
+			title:        "annotated dualstack services return an endpoint with dualstack label",
+			svcNamespace: "testing",
+			svcName:      "foo",
+			svcType:      v1.ServiceTypeLoadBalancer,
+			labels:       map[string]string{},
+			annotations: map[string]string{
+				hostnameAnnotationKey:     "foo.example.org.",
+				nlbDualstackAnnotationKey: nlbDualstackAnnotationValue,
+			},
+			externalIPs:        []string{},
+			lbs:                []string{"https://www.example.com"},
+			serviceTypesFilter: []string{},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "foo.example.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"https://www.example.com"},
+					Labels: endpoint.Labels{
+						"resource":  "service/testing/foo",
+						"dualstack": "true",
+					},
+				},
+			},
+		},
+		{
 			title:                    "hostname annotation on services is ignored",
 			svcNamespace:             "testing",
 			svcName:                  "foo",


### PR DESCRIPTION
**Description**

The controller creates AAAA recs for AWS dualstack ALBs correctly but doesn't support dualstack NLBs. This PR adds support for AAAA recs for dualstack NLBs.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes [#4509](https://github.com/kubernetes-sigs/external-dns/issues/4509)

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
