### PR TITLE
fix(cloudflare): trimSpace on token read from file

### DIFF
--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -175,7 +175,7 @@ func NewCloudFlareProvider(domainFilter endpoint.DomainFilter, zoneIDFilter prov
 			if err != nil {
 				return nil, fmt.Errorf("failed to read CF_API_TOKEN from file: %w", err)
 			}
-			token = string(tokenBytes)
+			token = strings.TrimSpace(string(tokenBytes))
 		}
 		config, err = cloudflare.NewWithAPIToken(token)
 	} else {


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
This change cleans the Cloudflare API Token that was read from file. This is useful if the file contains spaces or newlines.
<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
<!-- Fixes #ISSUE -->

**Checklist**

(both aspects not needed)

- [x] Unit tests updated
- [x] End user documentation updated
