### PR TITLE
chore(chart): Allow to split management and workload

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Added
+
+- Allow to split management and workload. ([#4533](https://github.com/kubernetes-sigs/external-dns/pull/4533))[@sathieu](https://github.com/sathieu)
+
 ## [v1.14.5] - 2023-06-10
 
 ### Added

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -87,6 +87,109 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | `node`                 | ❌         |                        |
 | `pod`                  | ❌         |                        |
 
+## Global mode
+
+`global.mode` can be used to deploy external-dns controller in a management cluster and serviceAccount and RBAC in a workload cluster.
+
+Usage:
+
+- Create `values-workload-cluster1.yaml`:
+
+  ```yaml
+  # values-workload-cluster1.yaml
+  global:
+    mode: workload
+  ```
+
+- Create `values-mgmt-cluster1.yaml`:
+
+  ```yaml
+  # values-mgmt-cluster1.yaml
+  global:
+    mode: management
+
+  env:
+  - name: KUBERNETES_SERVICE_HOST
+    valueFrom:
+      configMapKeyRef:
+        name: kubernetes-service
+        key: KUBERNETES_SERVICE_HOST
+  - name: KUBERNETES_SERVICE_PORT
+    valueFrom:
+      configMapKeyRef:
+        name: kubernetes-service
+        key: KUBERNETES_SERVICE_PORT
+  - name: namespace
+    valueFrom:
+      configMapKeyRef:
+        name: kubernetes-service
+        key: namespace
+
+  extraVolumeMounts:
+  - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+    name: kube-api-access
+    readOnly: true
+  extraVolumes:
+  - name: kube-api-access
+    secret:
+      secretName: kube-api-access
+  ```
+
+- install on the workload cluster:
+
+```console
+$ export KUBECONFIG=cluster1.kubeconfig
+$ kubectl create namespace external-dns
+namespace/external-dns created
+$ helm upgrade --install external-dns external-dns/external-dns \
+  --namespace external-dns \
+  --values values-workload-cluster1.yaml
+NAME: external-dns
+LAST DEPLOYED: Wed May 28 15:46:42 2024
+NAMESPACE: external-dns
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+```
+
+- install on the management cluster:
+
+  ```console
+  $ export KUBECONFIG=mgmt.kubeconfig
+  $ kubectl create namespace external-dns-cluster1
+  namespace/external-dns-cluster1 created
+  $ helm upgrade --install external-dns-cluster1 external-dns/external-dns \
+    --namespace external-dns-cluster1 \
+    --values values-mgmt-cluster1.yaml
+  NAME: external-dns-cluster1
+  LAST DEPLOYED: Wed Sep 28 15:50:22 2022
+  NAMESPACE: external-dns-cluster1
+  STATUS: deployed
+  REVISION: 1
+  TEST SUITE: None
+  ```
+
+- Create `KUBECONFIG`:
+
+  ```console
+  $ export KUBECONFIG=cluster1.kubeconfig
+  $ ca_crt="$(kubectl get secret -n external-dns external-dns -ojsonpath={.data.'ca\.crt'} | base64 -d)"
+  $ token="$(kubectl get secret -n external-dns external-dns -ojsonpath={.data.token} | base64 -d)"
+  $ host_port="$(kubectl config view -ojson | jq .clusters[0].cluster.server -r | cut -d / -f3)"
+  $ KUBERNETES_SERVICE_HOST="$(echo "$host_port" | cut -d: -f1)"
+  $ KUBERNETES_SERVICE_PORT="$(echo "$host_port" | cut -d: -f2)"
+
+  $ export KUBECONFIG=cluster1.kubeconfig
+  $ kubectl create secret -n external-dns-cluster1 generic kube-api-access \
+      --from-literal="token=$token" \
+      --from-literal="ca.crt=$ca_crt" \
+      --from-literal="namespace=external-dns"
+  $ kubectl create configmap -n external-dns-cluster1 kubernetes-service \
+      --from-literal="KUBERNETES_SERVICE_HOST=$KUBERNETES_SERVICE_HOST" \
+      --from-literal="KUBERNETES_SERVICE_PORT=$KUBERNETES_SERVICE_PORT" \
+      --from-literal="namespace=external-dns"
+  ```
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/charts/external-dns/README.md.gotmpl
+++ b/charts/external-dns/README.md.gotmpl
@@ -82,6 +82,109 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | `node`                 | ❌         |                        |
 | `pod`                  | ❌         |                        |
 
+## Global mode
+
+`global.mode` can be used to deploy external-dns controller in a management cluster and serviceAccount and RBAC in a workload cluster.
+
+Usage:
+
+- Create `values-workload-cluster1.yaml`:
+
+  ```yaml
+  # values-workload-cluster1.yaml
+  global:
+    mode: workload
+  ```
+
+- Create `values-mgmt-cluster1.yaml`:
+
+  ```yaml
+  # values-mgmt-cluster1.yaml
+  global:
+    mode: management
+
+  env:
+  - name: KUBERNETES_SERVICE_HOST
+    valueFrom:
+      configMapKeyRef:
+        name: kubernetes-service
+        key: KUBERNETES_SERVICE_HOST
+  - name: KUBERNETES_SERVICE_PORT
+    valueFrom:
+      configMapKeyRef:
+        name: kubernetes-service
+        key: KUBERNETES_SERVICE_PORT
+  - name: namespace
+    valueFrom:
+      configMapKeyRef:
+        name: kubernetes-service
+        key: namespace
+
+  extraVolumeMounts:
+  - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+    name: kube-api-access
+    readOnly: true
+  extraVolumes:
+  - name: kube-api-access
+    secret:
+      secretName: kube-api-access
+  ```
+
+- install on the workload cluster:
+
+```console
+$ export KUBECONFIG=cluster1.kubeconfig
+$ kubectl create namespace external-dns
+namespace/external-dns created
+$ helm upgrade --install external-dns external-dns/external-dns \
+  --namespace external-dns \
+  --values values-workload-cluster1.yaml
+NAME: external-dns
+LAST DEPLOYED: Wed May 28 15:46:42 2024
+NAMESPACE: external-dns
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+```
+
+- install on the management cluster:
+
+  ```console
+  $ export KUBECONFIG=mgmt.kubeconfig
+  $ kubectl create namespace external-dns-cluster1
+  namespace/external-dns-cluster1 created
+  $ helm upgrade --install external-dns-cluster1 external-dns/external-dns \
+    --namespace external-dns-cluster1 \
+    --values values-mgmt-cluster1.yaml
+  NAME: external-dns-cluster1
+  LAST DEPLOYED: Wed Sep 28 15:50:22 2022
+  NAMESPACE: external-dns-cluster1
+  STATUS: deployed
+  REVISION: 1
+  TEST SUITE: None
+  ```
+
+- Create `KUBECONFIG`:
+
+  ```console
+  $ export KUBECONFIG=cluster1.kubeconfig
+  $ ca_crt="$(kubectl get secret -n external-dns external-dns -ojsonpath={.data.'ca\.crt'} | base64 -d)"
+  $ token="$(kubectl get secret -n external-dns external-dns -ojsonpath={.data.token} | base64 -d)"
+  $ host_port="$(kubectl config view -ojson | jq .clusters[0].cluster.server -r | cut -d / -f3)"
+  $ KUBERNETES_SERVICE_HOST="$(echo "$host_port" | cut -d: -f1)"
+  $ KUBERNETES_SERVICE_PORT="$(echo "$host_port" | cut -d: -f2)"
+
+  $ export KUBECONFIG=cluster1.kubeconfig
+  $ kubectl create secret -n external-dns-cluster1 generic kube-api-access \
+      --from-literal="token=$token" \
+      --from-literal="ca.crt=$ca_crt" \
+      --from-literal="namespace=external-dns"
+  $ kubectl create configmap -n external-dns-cluster1 kubernetes-service \
+      --from-literal="KUBERNETES_SERVICE_HOST=$KUBERNETES_SERVICE_HOST" \
+      --from-literal="KUBERNETES_SERVICE_PORT=$KUBERNETES_SERVICE_PORT" \
+      --from-literal="namespace=external-dns"
+  ```
+
 
 {{ template "chart.requirementsSection" . }}
 

--- a/charts/external-dns/templates/clusterrole.yaml
+++ b/charts/external-dns/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.global.mode "management" }}
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ .Values.namespaced | ternary "Role" "ClusterRole" }}
@@ -123,5 +124,6 @@ rules:
 {{- end }}
 {{- with .Values.rbac.additionalPermissions }}
   {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/external-dns/templates/clusterrolebinding.yaml
+++ b/charts/external-dns/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.global.mode "management" }}
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ .Values.namespaced | ternary "RoleBinding" "ClusterRoleBinding" }}
@@ -13,4 +14,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "external-dns.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.global.mode "workload" }}
 {{- $providerName := tpl (include "external-dns.providerName" .) $ }}
 apiVersion: apps/v1
 kind: Deployment
@@ -37,14 +38,18 @@ spec:
         {{- end }}
       {{- end }}
     spec:
-    {{- if not (quote .Values.automountServiceAccountToken | empty) }}
-      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
-    {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if ne .Values.global.mode "management" }}
+        {{- if not (quote .Values.automountServiceAccountToken | empty) }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+        {{- end }}
       serviceAccountName: {{ include "external-dns.serviceAccountName" . }}
+      {{- else }}
+      automountServiceAccountToken: false
+      {{- end }}
       {{- with .Values.shareProcessNamespace }}
       shareProcessNamespace: {{ . }}
       {{- end }}
@@ -206,3 +211,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/external-dns/templates/secret.yaml
+++ b/charts/external-dns/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.global.mode "workload" }}
 {{- if .Values.secretConfiguration.enabled }}
 apiVersion: v1
 kind: Secret
@@ -9,5 +10,6 @@ metadata:
 data:
 {{- range $key, $value := .Values.secretConfiguration.data }}
   {{ $key }}: {{ tpl $value $ | b64enc | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/external-dns/templates/service.yaml
+++ b/charts/external-dns/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.global.mode "workload" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -25,3 +26,4 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
+{{- end }}

--- a/charts/external-dns/templates/serviceaccount.yaml
+++ b/charts/external-dns/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.global.mode "management" }}
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -14,4 +15,5 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end }}

--- a/charts/external-dns/templates/servicemonitor.yaml
+++ b/charts/external-dns/templates/servicemonitor.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.global.mode "workload" }}
 {{- if .Values.serviceMonitor.enabled -}}
 {{- $providerName := include "external-dns.providerName" . }}
 apiVersion: monitoring.coreos.com/v1
@@ -83,4 +84,5 @@ spec:
   targetLabels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/external-dns/templates/token-secret.yaml
+++ b/charts/external-dns/templates/token-secret.yaml
@@ -1,0 +1,12 @@
+{{- if eq .Values.global.mode "workload" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "external-dns.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "external-dns.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/service-account.name: {{ include "external-dns.serviceAccountName" . }}
+type: kubernetes.io/service-account-token
+{{- end }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -2,6 +2,10 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+  # -- One of full, management, workload. See [README](https://github.com/kubernetes-sigs/external-dns/blob/master/charts/external-dns/README.md#global-mode)
+  mode: full
+
 image:
   # -- Image repository for the `external-dns` container.
   repository: registry.k8s.io/external-dns/external-dns


### PR DESCRIPTION
**Description**

~~On top of https://github.com/kubernetes-sigs/external-dns/pull/4524.~~

Below is from `README`:

## Global mode

`global.mode` can be used to deploy external-dns controller in a management cluster and serviceAccount and RBAC in a workload cluster.

Usage:

- Create `values-workload-cluster1.yaml`:

  ```yaml
  # values-workload-cluster1.yaml
  global:
    mode: workload
  ```

- Create `values-mgmt-cluster1.yaml`:

  ```yaml
  # values-mgmt-cluster1.yaml
  global:
    mode: management

  envFrom:
  - configMapRef:
      name: kubernetes-service

  extraVolumeMounts:
  - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
    name: kube-api-access
    readOnly: true
  extraVolumes:
  - name: kube-api-access
    secret:
      secretName: kube-api-access
  ```

- install on the workload cluster:

```console
$ export KUBECONFIG=cluster1.kubeconfig
$ kubectl create namespace external-dns
namespace/external-dns created
$ helm upgrade --install external-dns external-dns/external-dns \
  --namespace external-dns \
  --values values-workload-cluster1.yaml
NAME: external-dns
LAST DEPLOYED: Wed May 28 15:46:42 2024
NAMESPACE: external-dns
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

- install on the management cluster:

  ```console
  $ export KUBECONFIG=mgmt.kubeconfig
  $ kubectl create namespace external-dns-cluster1
  namespace/external-dns-cluster1 created
  $ helm upgrade --install external-dns-cluster1 external-dns/external-dns \
    --namespace external-dns-cluster1 \
    --values values-mgmt-cluster1.yaml
  NAME: external-dns-cluster1
  LAST DEPLOYED: Wed Sep 28 15:50:22 2022
  NAMESPACE: external-dns-cluster1
  STATUS: deployed
  REVISION: 1
  TEST SUITE: None
  ```

- Create `KUBECONFIG`:

  ```console
  $ export KUBECONFIG=cluster1.kubeconfig
  $ ca_crt="$(kubectl get secret -n external-dns external-dns -ojsonpath={.data.'ca\.crt'} | base64 -d)"
  $ token="$(kubectl get secret -n external-dns external-dns -ojsonpath={.data.token} | base64 -d)"
  $ host_port="$(kubectl config view -ojson | jq .clusters[0].cluster.server -r | cut -d / -f3)"
  $ KUBERNETES_SERVICE_HOST="$(echo "$host_port" | cut -d: -f1)"
  $ KUBERNETES_SERVICE_PORT="$(echo "$host_port" | cut -d: -f2)"

  $ export KUBECONFIG=cluster1.kubeconfig
  $ kubectl create secret -n external-dns-cluster1 generic kube-api-access \
      --from-literal="token=$token" \
      --from-literal="ca.crt=$ca_crt" \
      --from-literal="namespace=external-dns"
  $ kubectl create configmap -n external-dns-cluster1 kubernetes-service \
      --from-literal="KUBERNETES_SERVICE_HOST=$KUBERNETES_SERVICE_HOST" \
      --from-literal="KUBERNETES_SERVICE_PORT=$KUBERNETES_SERVICE_PORT" \
      --from-literal="namespace=external-dns"
  ```


**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
