### PR TITLE
Update to Go 1.22.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22.2'
+        go-version: '1.22.4'
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Install go version
       uses: actions/setup-go@v5
       with:
-        go-version: '^1.22.2'
+        go-version: '^1.22.4'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.22.2'
+          go-version: '^1.22.4'
 
       - run: |
           pip install -r docs/scripts/requirements.txt

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22.2'
+        go-version: '1.22.4'
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/staging-image-tester.yaml
+++ b/.github/workflows/staging-image-tester.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22.2'
+        go-version: '1.22.4'
       id: go
 
     - name: Check out code into the Go module directory

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'docker.io/library/golang:1.22.2-bookworm'
+  - name: 'docker.io/library/golang:1.22.4-bookworm'
     entrypoint: make
     env:
       - VERSION=$_GIT_TAG

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/external-dns
 
-go 1.22.2
+go 1.22.4
 
 require (
 	cloud.google.com/go/compute/metadata v0.3.0


### PR DESCRIPTION
**Description**

This PR upgrades the project to Go 1.22.4. This is needed to be able to update one of the dependencies (IBM provider) that requires go 1.22.3 at the minimum.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
