### PR TITLE
Add documentation about etcd HTTPS for CoreDNS provider

### DIFF
--- a/docs/tutorials/coredns.md
+++ b/docs/tutorials/coredns.md
@@ -86,7 +86,7 @@ helm install --name my-coredns --values values.yaml stable/coredns
 ## Installing ExternalDNS
 ### Install external ExternalDNS
 ETCD_URLS is configured to etcd client service address.
-Optionnally, you can configure ETCD_USERNAME and ETCD_PASSWORD for authenticating to etcd.
+Optionally, you can configure ETCD_USERNAME and ETCD_PASSWORD for authenticating to etcd. It is also possible to connect to the etcd cluster via HTTPS using the following environment variables: ETCD_CA_FILE, ETCD_CERT_FILE, ETCD_KEY_FILE, ETCD_TLS_SERVER_NAME, ETCD_TLS_INSECURE.
 
 #### Manifest (for clusters without RBAC enabled)
 


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
As reported in #4537, HTTPS is supported for connections to the ETCD cluster, but it is not documented.

<!-- Please provide a summary of the change here. -->
I have added a small sentence in order to let others know that it is already there, and what variables to use to configure it.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4537 

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
