### PR TITLE
chart: Allow to optout CRD installation

### DIFF
--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -94,6 +94,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | affinity | object | `{}` | Affinity settings for `Pod` [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels. |
 | automountServiceAccountToken | bool | `nil` | Set this to `false` to [opt out of API credential automounting](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting) for the `Pod`. |
 | commonLabels | object | `{}` | Labels to add to all chart resources. |
+| deployCrd | bool | `true` | Deploy dnsenpoint CRD |
 | deploymentAnnotations | object | `{}` | Annotations to add to the `Deployment`. |
 | deploymentStrategy | object | `{"type":"Recreate"}` | [Deployment Strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy). |
 | dnsConfig | object | `nil` | [DNS config](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config) for the pod, if not set the default will be used. |

--- a/charts/external-dns/templates/crd-template.yaml
+++ b/charts/external-dns/templates/crd-template.yaml
@@ -1,0 +1,3 @@
+{{- if .Values.deployCrd }}
+{{- .Files.Get "crds/dnsendpoint.yaml" }}
+{{- end }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# -- Deploy dnsendpoint CRD
+deployCrd: true
+
 image:
   # -- Image repository for the `external-dns` container.
   repository: registry.k8s.io/external-dns/external-dns


### PR DESCRIPTION
DNS Endpoint crd might be already part of a different chart. Allow to skip installation of CRD

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
