### PR TITLE
fix(helm): make use of resource values for webhook

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Fixed `provider.webhook.resources` behavior to correctly leverage resource limits ([#4560](https://github.com/kubernetes-sigs/external-dns/pull/4560))
+
 ## [v1.14.5] - 2023-06-10
 
 ### Added
@@ -58,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Restore template support in `.Values.provider` and `.Values.provider.name` 
+- Restore template support in `.Values.provider` and `.Values.provider.name`
 
 ## [v1.14.1] - 2024-01-11
 

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -173,6 +173,10 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
+          {{- with .resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

The resource limits set by the user when leveraging the webhook sidecar should be respected and implemented when they are passed via helm values. This change alters the deployment template to use those limits if they are set in the values. I believe this was intended to work when it was first implemented but never had the supporting logic added to the deployment template.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
I didn't see and issue for this (surprisingly).

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
