### PR TITLE
fix(Azure DNS): external_dns_registry_errors_total metrics counter value

### DIFF
--- a/provider/azure/azure_privatedns_test.go
+++ b/provider/azure/azure_privatedns_test.go
@@ -18,6 +18,7 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	azcoreruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -350,6 +351,54 @@ func TestAzurePrivateDNSApplyChanges(t *testing.T) {
 		endpoint.NewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, endpoint.TTL(recordTTL), "10 other.com"),
 		endpoint.NewEndpointWithTTL("mail.example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
 	})
+}
+
+func TestAzurePrivateDNSApplyChangesRetrunError(t *testing.T) {
+	recordsClient := mockPrivateRecordSetsClient{}
+	zones := []*privatedns.PrivateZone{
+		createMockPrivateZone("example.com", "/privateDnsZones/example.com"),
+	}
+
+	zonesClient := newMockPrivateZonesClient(zones)
+
+	provider := newAzurePrivateDNSProvider(
+		endpoint.NewDomainFilter([]string{"foo.example.com"}),
+		endpoint.NewDomainFilter([]string{"example.com"}),
+		provider.NewZoneIDFilter([]string{""}),
+		false,
+		"group",
+		&zonesClient,
+		&recordsClient,
+	)
+
+	createRecords := []*endpoint.Endpoint{}
+
+	currentRecords := []*endpoint.Endpoint{
+		endpoint.NewEndpoint("old.foo.example.com", endpoint.RecordTypeA, "121.212.121.212"),
+		endpoint.NewEndpoint("oldcname.foo.example.com", endpoint.RecordTypeCNAME, "other.com"),
+		endpoint.NewEndpoint("old.nope.example.com", endpoint.RecordTypeA, "121.212.121.212"),
+	}
+	updatedRecords := []*endpoint.Endpoint{
+		endpoint.NewEndpointWithTTL("new.foo.example.com", endpoint.RecordTypeA, 3600, "111.222.111.222"),
+		endpoint.NewEndpointWithTTL("new.foo.example.com", endpoint.RecordTypeAAAA, 3600, "2001::111:222:111:222"),
+		endpoint.NewEndpointWithTTL("newcname.foo.example.com", endpoint.RecordTypeCNAME, 10, "other.com"),
+		endpoint.NewEndpoint("new.nope.example.com", endpoint.RecordTypeA, "222.111.222.111"),
+		endpoint.NewEndpoint("new.nope.example.com", endpoint.RecordTypeAAAA, "2001::222:111:222:111"),
+		endpoint.NewEndpointWithTTL("@.foo.example.com", endpoint.RecordTypeNAPTR, 10, "other.com"),
+	}
+
+	deleteRecords := []*endpoint.Endpoint{}
+
+	changes := &plan.Changes{
+		Create:    createRecords,
+		UpdateNew: updatedRecords,
+		UpdateOld: currentRecords,
+		Delete:    deleteRecords,
+	}
+
+	if err := provider.ApplyChanges(context.Background(), changes); err == nil {
+		t.Fatal(errors.New("ApplyChanges NotError"))
+	}
 }
 
 func TestAzurePrivateDNSApplyChangesDryRun(t *testing.T) {

--- a/provider/azure/azure_privatedns_test.go
+++ b/provider/azure/azure_privatedns_test.go
@@ -353,7 +353,7 @@ func TestAzurePrivateDNSApplyChanges(t *testing.T) {
 	})
 }
 
-func TestAzurePrivateDNSApplyChangesRetrunError(t *testing.T) {
+func TestAzurePrivateDNSApplyChangesReturnError(t *testing.T) {
 	recordsClient := mockPrivateRecordSetsClient{}
 	zones := []*privatedns.PrivateZone{
 		createMockPrivateZone("example.com", "/privateDnsZones/example.com"),

--- a/provider/azure/azure_test.go
+++ b/provider/azure/azure_test.go
@@ -359,7 +359,7 @@ func TestAzureApplyChanges(t *testing.T) {
 	})
 }
 
-func TestAzureApplyChangesRetrunError(t *testing.T) {
+func TestAzureApplyChangesReturnError(t *testing.T) {
 	recordsClient := mockRecordSetsClient{}
 	zonesClient := newMockZonesClient([]*dns.Zone{createMockZone("example.com", "/dnszones/example.com")})
 	provider := newAzureProvider(

--- a/provider/azure/azure_test.go
+++ b/provider/azure/azure_test.go
@@ -400,7 +400,7 @@ func TestAzureApplyChangesReturnError(t *testing.T) {
 	}
 
 	if err := provider.ApplyChanges(context.Background(), changes); err != nil {
-		t.Fatal(errors.New("ApplyChanges NotError"))
+		t.Fatal(errors.New("ApplyChanges Error"))
 	}
 }
 


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
The Azure provider should increment `external_dns_registry_errors_total` when changes cannot be submitted(found, updated, deleted, or created).

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4510 

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
