### PR TITLE
feat!: update GRPCRoute client from v1alpha2 to stable v1

### DIFF
--- a/source/gateway_grpcroute.go
+++ b/source/gateway_grpcroute.go
@@ -20,19 +20,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	informers "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions"
-	informers_v1a2 "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/apis/v1alpha2"
+	informers_v1 "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/apis/v1"
 )
 
 // NewGatewayGRPCRouteSource creates a new Gateway GRPCRoute source with the given config.
 func NewGatewayGRPCRouteSource(clients ClientGenerator, config *Config) (Source, error) {
 	return newGatewayRouteSource(clients, config, "GRPCRoute", func(factory informers.SharedInformerFactory) gatewayRouteInformer {
-		return &gatewayGRPCRouteInformer{factory.Gateway().V1alpha2().GRPCRoutes()}
+		return &gatewayGRPCRouteInformer{factory.Gateway().V1().GRPCRoutes()}
 	})
 }
 
-type gatewayGRPCRoute struct{ route v1alpha2.GRPCRoute } // NOTE: Must update TypeMeta in List when changing the APIVersion.
+type gatewayGRPCRoute struct{ route v1.GRPCRoute } // NOTE: Must update TypeMeta in List when changing the APIVersion.
 
 func (rt *gatewayGRPCRoute) Object() kubeObject           { return &rt.route }
 func (rt *gatewayGRPCRoute) Metadata() *metav1.ObjectMeta { return &rt.route.ObjectMeta }
@@ -41,7 +40,7 @@ func (rt *gatewayGRPCRoute) Protocol() v1.ProtocolType    { return v1.HTTPSProto
 func (rt *gatewayGRPCRoute) RouteStatus() v1.RouteStatus  { return rt.route.Status.RouteStatus }
 
 type gatewayGRPCRouteInformer struct {
-	informers_v1a2.GRPCRouteInformer
+	informers_v1.GRPCRouteInformer
 }
 
 func (inf gatewayGRPCRouteInformer) List(namespace string, selector labels.Selector) ([]gatewayRoute, error) {
@@ -55,7 +54,7 @@ func (inf gatewayGRPCRouteInformer) List(namespace string, selector labels.Selec
 		// We make a shallow copy since we're only interested in setting the TypeMeta.
 		clone := *rt
 		clone.TypeMeta = metav1.TypeMeta{
-			APIVersion: v1alpha2.GroupVersion.String(),
+			APIVersion: v1.GroupVersion.String(),
 			Kind:       "GRPCRoute",
 		}
 		routes[i] = &gatewayGRPCRoute{clone}

--- a/source/gateway_grpcroute_test.go
+++ b/source/gateway_grpcroute_test.go
@@ -26,7 +26,6 @@ import (
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/external-dns/endpoint"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 )
 
@@ -64,7 +63,7 @@ func TestGatewayGRPCRouteSourceEndpoints(t *testing.T) {
 	_, err = gwClient.GatewayV1().Gateways(gw.Namespace).Create(ctx, gw, metav1.CreateOptions{})
 	require.NoError(t, err, "failed to create Gateway")
 
-	rt := &v1alpha2.GRPCRoute{
+	rt := &v1.GRPCRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "api",
 			Namespace: "default",
@@ -79,7 +78,7 @@ func TestGatewayGRPCRouteSourceEndpoints(t *testing.T) {
 			RouteStatus: gwRouteStatus(gwParentRef("default", "internal")),
 		},
 	}
-	_, err = gwClient.GatewayV1alpha2().GRPCRoutes(rt.Namespace).Create(ctx, rt, metav1.CreateOptions{})
+	_, err = gwClient.GatewayV1().GRPCRoutes(rt.Namespace).Create(ctx, rt, metav1.CreateOptions{})
 	require.NoError(t, err, "failed to create GRPCRoute")
 
 	src, err := NewGatewayGRPCRouteSource(clients, &Config{


### PR DESCRIPTION
**Description**

Updates GRPCRoute client to use v1 stable (as GRPCRoute has graduated to stable)

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated


**Notes**
We have dog-fooded this change and it works as expected. 
