### PR TITLE
feature(chart): Add extraObjects field to support additional manifest…

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Added
+
+- Added support for `extraObjects` argument ([#4569](https://github.com/kubernetes-sigs/external-dns/pull/4569)) _@cloudziu_
+
 ## [v1.14.5] - 2023-06-10
 
 ### Added

--- a/charts/external-dns/templates/_helpers.tpl
+++ b/charts/external-dns/templates/_helpers.tpl
@@ -93,3 +93,14 @@ The image to use for optional webhook sidecar
 {{- printf "%s:%s" .repository .tag }}
 {{- end }}
 {{- end }}
+
+{{/*
+Renders a complete tree, even values that contains template.
+*/}}
+{{- define "external-dns.render" -}}
+{{- if typeIs "string" .value }}
+{{- tpl .value .context }}
+{{ else }}
+{{- tpl (.value | toYaml) .context }}
+{{- end }}
+{{- end -}}

--- a/charts/external-dns/templates/extramanifests.yaml
+++ b/charts/external-dns/templates/extramanifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{ include "external-dns.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -283,6 +283,9 @@ provider:
 # -- Extra arguments to provide to _ExternalDNS_.
 extraArgs: []
 
+# -- Extra manifests to include in the chart.
+extraObjects: []
+
 secretConfiguration:
   # -- If `true`, create a `Secret` to store sensitive provider configuration (**DEPRECATED**).
   enabled: false


### PR DESCRIPTION
Hello! 
First of all, thank you for your hard work on this project.
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
I would like to propose a feature, that will allow adding custom manifest files into the Helm Chart. I took the idea of the implementation from a [different helm chart repository](https://github.com/external-secrets/external-secrets/blob/main/deploy/charts/external-secrets/templates/extra-manifests.yaml).

An example use case is to include the `External-DNS` secret file as an ExternalSecret Object. 

I've tested it locally with `helm template`, `helm install` and `helm uninstall`. Additional manifest were added to the chart and also removed when the chard was uninstalled.
- added `charts/external-dns/templates/extramanifests.yaml`
- updated `charts/external-dns/templates/_helpers.tpl` with `external-dns.render`
- updated `charts/external-dns/values.yaml` with an example `extraObjects: []` field

**Example**
```yaml
# values.yaml
extraVolumes:
  - name: azure-config-file
    secret:
      secretName: azure-config-file

extraVolumeMounts:
  - name: azure-config-file
    mountPath: /etc/kubernetes
    readOnly: true

extraObjects:
  - apiVersion: external-secrets.io/v1beta1
    kind: ExternalSecret
    metadata:
      name: azure-config-file
      namespace: '{{ .Release.Namespace }}'
    spec:
      refreshInterval: 1h
      secretStoreRef:
        kind: ClusterSecretStore
        name: storeName
      target:
        name: azure-config-file
        creationPolicy: Owner
      data:
      - secretKey: azure.json
        remoteRef:
          key: secret/external-dns-config
```

Helm template output (truncated):
```
---
# Source: external-dns/templates/extramanifests.yaml
apiVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
  name: azure-config-file
  namespace: 'external-dns'
spec:
  data:
  - remoteRef:
      key: secret/external-dns-config
    secretKey: azure.json
  refreshInterval: 1h
  secretStoreRef:
    kind: ClusterSecretStore
    name: storeName
  target:
    creationPolicy: Owner
    name: azure-config-file
```

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
