### PR TITLE
Revert #3588 "IPv6 internal node IPs are usable externally"

### DIFF
--- a/docs/tutorials/nodes.md
+++ b/docs/tutorials/nodes.md
@@ -3,9 +3,8 @@
 This tutorial describes how to configure ExternalDNS to use the cluster nodes as source.
 Using nodes (`--source=node`) as source is possible to synchronize a DNS zone with the nodes of a cluster.
 
-The node source adds an `A` record per each node `externalIP` (if not found, any IPv4 `internalIP` is used instead).
-It also adds an `AAAA` record per each node IPv6 `internalIP`.
-The TTL of the records can be set with the `external-dns.alpha.kubernetes.io/ttl` node annotation.
+The node source adds `A` and `AAAA` record per each node `externalIP` (if not found, node's `internalIP`s are used).
+The TTL record can be set with the `external-dns.alpha.kubernetes.io/ttl` node annotation.
 
 ## Manifest (for cluster without RBAC enabled)
 

--- a/source/compatibility.go
+++ b/source/compatibility.go
@@ -158,8 +158,7 @@ func legacyEndpointsFromDNSControllerNodePortService(svc *v1.Service, sc *servic
 			}
 			for _, address := range node.Status.Addresses {
 				recordType := suitableType(address.Address)
-				// IPv6 addresses are labeled as NodeInternalIP despite being usable externally as well.
-				if isExternal && (address.Type == v1.NodeExternalIP || (address.Type == v1.NodeInternalIP && recordType == endpoint.RecordTypeAAAA)) {
+				if isExternal && address.Type == v1.NodeExternalIP {
 					endpoints = append(endpoints, endpoint.NewEndpoint(hostname, recordType, address.Address))
 				}
 				if isInternal && address.Type == v1.NodeInternalIP {

--- a/source/node.go
+++ b/source/node.go
@@ -169,18 +169,13 @@ func (ns *nodeSource) nodeAddresses(node *v1.Node) ([]string, error) {
 		v1.NodeExternalIP: {},
 		v1.NodeInternalIP: {},
 	}
-	var ipv6Addresses []string
 
 	for _, addr := range node.Status.Addresses {
 		addresses[addr.Type] = append(addresses[addr.Type], addr.Address)
-		// IPv6 addresses are labeled as NodeInternalIP despite being usable externally as well.
-		if addr.Type == v1.NodeInternalIP && suitableType(addr.Address) == endpoint.RecordTypeAAAA {
-			ipv6Addresses = append(ipv6Addresses, addr.Address)
-		}
 	}
 
 	if len(addresses[v1.NodeExternalIP]) > 0 {
-		return append(addresses[v1.NodeExternalIP], ipv6Addresses...), nil
+		return addresses[v1.NodeExternalIP], nil
 	}
 
 	if len(addresses[v1.NodeInternalIP]) > 0 {

--- a/source/node_test.go
+++ b/source/node_test.go
@@ -159,7 +159,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 			title:         "node with fqdn template returns two endpoints with dual-stack IP addresses and expanded hostname",
 			fqdnTemplate:  "{{.Name}}.example.org",
 			nodeName:      "node1",
-			nodeAddresses: []v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}, {Type: v1.NodeInternalIP, Address: "2001:DB8::8"}},
+			nodeAddresses: []v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}, {Type: v1.NodeExternalIP, Address: "2001:DB8::8"}},
 			expected: []*endpoint.Endpoint{
 				{RecordType: "A", DNSName: "node1.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
 				{RecordType: "AAAA", DNSName: "node1.example.org", Targets: endpoint.Targets{"2001:DB8::8"}},
@@ -176,7 +176,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 		{
 			title:         "node with both external, internal, and IPv6 IP returns endpoints with external IPs",
 			nodeName:      "node1",
-			nodeAddresses: []v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}, {Type: v1.NodeInternalIP, Address: "2.3.4.5"}, {Type: v1.NodeInternalIP, Address: "2001:DB8::8"}},
+			nodeAddresses: []v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}, {Type: v1.NodeInternalIP, Address: "2.3.4.5"}, {Type: v1.NodeExternalIP, Address: "2001:DB8::8"}},
 			expected: []*endpoint.Endpoint{
 				{RecordType: "A", DNSName: "node1", Targets: endpoint.Targets{"1.2.3.4"}},
 				{RecordType: "AAAA", DNSName: "node1", Targets: endpoint.Targets{"2001:DB8::8"}},

--- a/source/pod.go
+++ b/source/pod.go
@@ -110,10 +110,8 @@ func (ps *podSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 				if len(targets) == 0 {
 					node, _ := ps.nodeInformer.Lister().Get(pod.Spec.NodeName)
 					for _, address := range node.Status.Addresses {
-						recordType := suitableType(address.Address)
-						// IPv6 addresses are labeled as NodeInternalIP despite being usable externally as well.
-						if address.Type == corev1.NodeExternalIP || (address.Type == corev1.NodeInternalIP && recordType == endpoint.RecordTypeAAAA) {
-							addToEndpointMap(endpointMap, domain, recordType, address.Address)
+						if address.Type == corev1.NodeExternalIP {
+							addToEndpointMap(endpointMap, domain, suitableType(address.Address), address.Address)
 						}
 					}
 				} else {
@@ -137,10 +135,8 @@ func (ps *podSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 				for _, domain := range domainList {
 					node, _ := ps.nodeInformer.Lister().Get(pod.Spec.NodeName)
 					for _, address := range node.Status.Addresses {
-						recordType := suitableType(address.Address)
-						// IPv6 addresses are labeled as NodeInternalIP despite being usable externally as well.
-						if address.Type == corev1.NodeExternalIP || (address.Type == corev1.NodeInternalIP && recordType == endpoint.RecordTypeAAAA) {
-							addToEndpointMap(endpointMap, domain, recordType, address.Address)
+						if address.Type == corev1.NodeExternalIP {
+							addToEndpointMap(endpointMap, domain, suitableType(address.Address), address.Address)
 						}
 					}
 				}

--- a/source/pod_test.go
+++ b/source/pod_test.go
@@ -185,8 +185,8 @@ func TestPodSource(t *testing.T) {
 			"",
 			"",
 			[]*endpoint.Endpoint{
-				{DNSName: "a.foo.example.org", Targets: endpoint.Targets{"2001:DB8::1", "2001:DB8::2"}, RecordType: endpoint.RecordTypeAAAA},
-				{DNSName: "internal.a.foo.example.org", Targets: endpoint.Targets{"2001:DB8::1", "2001:DB8::2"}, RecordType: endpoint.RecordTypeAAAA},
+				{DNSName: "a.foo.example.org", Targets: endpoint.Targets{"2001:DB8::1", "2001:DB8::2", "2001:DB8::2"}, RecordType: endpoint.RecordTypeAAAA},
+				{DNSName: "internal.a.foo.example.org", Targets: endpoint.Targets{"2001:DB8::1", "2001:DB8::2", "2001:DB8::3", "2001:DB8::4"}, RecordType: endpoint.RecordTypeAAAA},
 			},
 			false,
 			[]*corev1.Node{
@@ -196,7 +196,7 @@ func TestPodSource(t *testing.T) {
 					},
 					Status: corev1.NodeStatus{
 						Addresses: []corev1.NodeAddress{
-							{Type: corev1.NodeInternalIP, Address: "2001:DB8::1"},
+							{Type: corev1.NodeExternalIP, Address: "2001:DB8::1"},
 						},
 					},
 				},
@@ -206,7 +206,18 @@ func TestPodSource(t *testing.T) {
 					},
 					Status: corev1.NodeStatus{
 						Addresses: []corev1.NodeAddress{
-							{Type: corev1.NodeInternalIP, Address: "2001:DB8::2"},
+							{Type: corev1.NodeExternalIP, Address: "2001:DB8::2"},
+							{Type: corev1.NodeInternalIP, Address: "2001:DB8::3"},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-node3",
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{Type: corev1.NodeInternalIP, Address: "2001:DB8::4"},
 						},
 					},
 				},
@@ -244,6 +255,40 @@ func TestPodSource(t *testing.T) {
 					},
 					Status: corev1.PodStatus{
 						PodIP: "2001:DB8::2",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-pod3",
+						Namespace: "kube-system",
+						Annotations: map[string]string{
+							internalHostnameAnnotationKey: "internal.a.foo.example.org",
+							hostnameAnnotationKey:         "a.foo.example.org",
+						},
+					},
+					Spec: corev1.PodSpec{
+						HostNetwork: true,
+						NodeName:    "my-node2",
+					},
+					Status: corev1.PodStatus{
+						PodIP: "2001:DB8::3",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-pod4",
+						Namespace: "kube-system",
+						Annotations: map[string]string{
+							internalHostnameAnnotationKey: "internal.a.foo.example.org",
+							hostnameAnnotationKey:         "a.foo.example.org",
+						},
+					},
+					Spec: corev1.PodSpec{
+						HostNetwork: true,
+						NodeName:    "my-node3",
+					},
+					Status: corev1.PodStatus{
+						PodIP: "2001:DB8::4",
 					},
 				},
 			},
@@ -253,8 +298,8 @@ func TestPodSource(t *testing.T) {
 			"",
 			"kops-dns-controller",
 			[]*endpoint.Endpoint{
-				{DNSName: "a.foo.example.org", Targets: endpoint.Targets{"2001:DB8::1", "2001:DB8::2"}, RecordType: endpoint.RecordTypeAAAA},
-				{DNSName: "internal.a.foo.example.org", Targets: endpoint.Targets{"2001:DB8::1", "2001:DB8::2"}, RecordType: endpoint.RecordTypeAAAA},
+				{DNSName: "a.foo.example.org", Targets: endpoint.Targets{"2001:DB8::1", "2001:DB8::2", "2001:DB8::2"}, RecordType: endpoint.RecordTypeAAAA},
+				{DNSName: "internal.a.foo.example.org", Targets: endpoint.Targets{"2001:DB8::1", "2001:DB8::2", "2001:DB8::3", "2001:DB8::4"}, RecordType: endpoint.RecordTypeAAAA},
 			},
 			false,
 			[]*corev1.Node{
@@ -264,7 +309,7 @@ func TestPodSource(t *testing.T) {
 					},
 					Status: corev1.NodeStatus{
 						Addresses: []corev1.NodeAddress{
-							{Type: corev1.NodeInternalIP, Address: "2001:DB8::1"},
+							{Type: corev1.NodeExternalIP, Address: "2001:DB8::1"},
 						},
 					},
 				},
@@ -274,7 +319,18 @@ func TestPodSource(t *testing.T) {
 					},
 					Status: corev1.NodeStatus{
 						Addresses: []corev1.NodeAddress{
-							{Type: corev1.NodeInternalIP, Address: "2001:DB8::2"},
+							{Type: corev1.NodeExternalIP, Address: "2001:DB8::2"},
+							{Type: corev1.NodeInternalIP, Address: "2001:DB8::3"},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-node3",
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{Type: corev1.NodeInternalIP, Address: "2001:DB8::4"},
 						},
 					},
 				},
@@ -312,6 +368,40 @@ func TestPodSource(t *testing.T) {
 					},
 					Status: corev1.PodStatus{
 						PodIP: "2001:DB8::2",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-pod3",
+						Namespace: "kube-system",
+						Annotations: map[string]string{
+							kopsDNSControllerInternalHostnameAnnotationKey: "internal.a.foo.example.org",
+							kopsDNSControllerHostnameAnnotationKey:         "a.foo.example.org",
+						},
+					},
+					Spec: corev1.PodSpec{
+						HostNetwork: true,
+						NodeName:    "my-node2",
+					},
+					Status: corev1.PodStatus{
+						PodIP: "2001:DB8::3",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-pod4",
+						Namespace: "kube-system",
+						Annotations: map[string]string{
+							kopsDNSControllerInternalHostnameAnnotationKey: "internal.a.foo.example.org",
+							kopsDNSControllerHostnameAnnotationKey:         "a.foo.example.org",
+						},
+					},
+					Spec: corev1.PodSpec{
+						HostNetwork: true,
+						NodeName:    "my-node3",
+					},
+					Status: corev1.PodStatus{
+						PodIP: "2001:DB8::4",
 					},
 				},
 			},
@@ -406,7 +496,7 @@ func TestPodSource(t *testing.T) {
 					Status: corev1.NodeStatus{
 						Addresses: []corev1.NodeAddress{
 							{Type: corev1.NodeExternalIP, Address: "54.10.11.1"},
-							{Type: corev1.NodeInternalIP, Address: "2001:DB8::1"},
+							{Type: corev1.NodeExternalIP, Address: "2001:DB8::1"},
 							{Type: corev1.NodeInternalIP, Address: "10.0.1.1"},
 						},
 					},

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -1690,7 +1690,7 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeExternalIP, Address: "54.10.11.1"},
 						{Type: v1.NodeInternalIP, Address: "10.0.1.1"},
-						{Type: v1.NodeInternalIP, Address: "2001:DB8::1"},
+						{Type: v1.NodeExternalIP, Address: "2001:DB8::1"},
 					},
 				},
 			}, {
@@ -1701,7 +1701,8 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeExternalIP, Address: "54.10.11.2"},
 						{Type: v1.NodeInternalIP, Address: "10.0.1.2"},
-						{Type: v1.NodeInternalIP, Address: "2001:DB8::2"},
+						{Type: v1.NodeExternalIP, Address: "2001:DB8::2"},
+						{Type: v1.NodeInternalIP, Address: "2001:DB8::3"},
 					},
 				},
 			}},
@@ -1724,7 +1725,7 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeExternalIP, Address: "54.10.11.1"},
 						{Type: v1.NodeInternalIP, Address: "10.0.1.1"},
-						{Type: v1.NodeInternalIP, Address: "2001:DB8::1"},
+						{Type: v1.NodeExternalIP, Address: "2001:DB8::1"},
 					},
 				},
 			}, {
@@ -1735,7 +1736,8 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeExternalIP, Address: "54.10.11.2"},
 						{Type: v1.NodeInternalIP, Address: "10.0.1.2"},
-						{Type: v1.NodeInternalIP, Address: "2001:DB8::2"},
+						{Type: v1.NodeExternalIP, Address: "2001:DB8::2"},
+						{Type: v1.NodeInternalIP, Address: "2001:DB8::3"},
 					},
 				},
 			}},
@@ -1761,7 +1763,7 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeExternalIP, Address: "54.10.11.1"},
 						{Type: v1.NodeInternalIP, Address: "10.0.1.1"},
-						{Type: v1.NodeInternalIP, Address: "2001:DB8::1"},
+						{Type: v1.NodeExternalIP, Address: "2001:DB8::1"},
 					},
 				},
 			}, {
@@ -1772,7 +1774,8 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeExternalIP, Address: "54.10.11.2"},
 						{Type: v1.NodeInternalIP, Address: "10.0.1.2"},
-						{Type: v1.NodeInternalIP, Address: "2001:DB8::2"},
+						{Type: v1.NodeExternalIP, Address: "2001:DB8::2"},
+						{Type: v1.NodeInternalIP, Address: "2001:DB8::3"},
 					},
 				},
 			}},
@@ -1835,7 +1838,7 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeExternalIP, Address: "54.10.11.1"},
 						{Type: v1.NodeInternalIP, Address: "10.0.1.1"},
-						{Type: v1.NodeInternalIP, Address: "2001:DB8::1"},
+						{Type: v1.NodeExternalIP, Address: "2001:DB8::1"},
 					},
 				},
 			}, {
@@ -1846,7 +1849,8 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeExternalIP, Address: "54.10.11.2"},
 						{Type: v1.NodeInternalIP, Address: "10.0.1.2"},
-						{Type: v1.NodeInternalIP, Address: "2001:DB8::2"},
+						{Type: v1.NodeExternalIP, Address: "2001:DB8::2"},
+						{Type: v1.NodeInternalIP, Address: "2001:DB8::3"},
 					},
 				},
 			}},
@@ -1879,7 +1883,7 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeExternalIP, Address: "54.10.11.1"},
 						{Type: v1.NodeInternalIP, Address: "10.0.1.1"},
-						{Type: v1.NodeInternalIP, Address: "2001:DB8::1"},
+						{Type: v1.NodeExternalIP, Address: "2001:DB8::1"},
 					},
 				},
 			}, {
@@ -1890,7 +1894,8 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeExternalIP, Address: "54.10.11.2"},
 						{Type: v1.NodeInternalIP, Address: "10.0.1.2"},
-						{Type: v1.NodeInternalIP, Address: "2001:DB8::2"},
+						{Type: v1.NodeExternalIP, Address: "2001:DB8::2"},
+						{Type: v1.NodeInternalIP, Address: "2001:DB8::3"},
 					},
 				},
 			}},
@@ -2016,7 +2021,7 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 			expected: []*endpoint.Endpoint{
 				{DNSName: "_foo._tcp.foo.example.org", Targets: endpoint.Targets{"0 50 30192 foo.example.org"}, RecordType: endpoint.RecordTypeSRV},
 				{DNSName: "foo.example.org", Targets: endpoint.Targets{"10.0.1.1", "10.0.1.2"}, RecordType: endpoint.RecordTypeA},
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"2001:DB8::1", "2001:DB8::2"}, RecordType: endpoint.RecordTypeAAAA},
+				{DNSName: "foo.example.org", Targets: endpoint.Targets{"2001:DB8::3"}, RecordType: endpoint.RecordTypeAAAA},
 			},
 			nodes: []*v1.Node{{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2026,7 +2031,7 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeExternalIP, Address: "54.10.11.1"},
 						{Type: v1.NodeInternalIP, Address: "10.0.1.1"},
-						{Type: v1.NodeInternalIP, Address: "2001:DB8::1"},
+						{Type: v1.NodeExternalIP, Address: "2001:DB8::1"},
 					},
 				},
 			}, {
@@ -2037,7 +2042,8 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeExternalIP, Address: "54.10.11.2"},
 						{Type: v1.NodeInternalIP, Address: "10.0.1.2"},
-						{Type: v1.NodeInternalIP, Address: "2001:DB8::2"},
+						{Type: v1.NodeExternalIP, Address: "2001:DB8::2"},
+						{Type: v1.NodeInternalIP, Address: "2001:DB8::3"},
 					},
 				},
 			}},
@@ -2066,7 +2072,7 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeExternalIP, Address: "54.10.11.1"},
 						{Type: v1.NodeInternalIP, Address: "10.0.1.1"},
-						{Type: v1.NodeInternalIP, Address: "2001:DB8::1"},
+						{Type: v1.NodeExternalIP, Address: "2001:DB8::1"},
 					},
 				},
 			}, {
@@ -2077,7 +2083,8 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeExternalIP, Address: "54.10.11.2"},
 						{Type: v1.NodeInternalIP, Address: "10.0.1.2"},
-						{Type: v1.NodeInternalIP, Address: "2001:DB8::2"},
+						{Type: v1.NodeExternalIP, Address: "2001:DB8::2"},
+						{Type: v1.NodeInternalIP, Address: "2001:DB8::3"},
 					},
 				},
 			}},
@@ -2095,9 +2102,9 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{DNSName: "internal.foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"10.0.1.1"}},
-				{DNSName: "internal.foo.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:DB8::1"}},
+				{DNSName: "internal.foo.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:DB8::20"}},
 				{DNSName: "internal.bar.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"10.0.1.1"}},
-				{DNSName: "internal.bar.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:DB8::1"}},
+				{DNSName: "internal.bar.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:DB8::20"}},
 			},
 			nodes: []*v1.Node{{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2110,7 +2117,8 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeExternalIP, Address: "54.10.11.1"},
 						{Type: v1.NodeInternalIP, Address: "10.0.1.1"},
-						{Type: v1.NodeInternalIP, Address: "2001:DB8::1"},
+						{Type: v1.NodeExternalIP, Address: "2001:DB8::1"},
+						{Type: v1.NodeInternalIP, Address: "2001:DB8::20"},
 					},
 				},
 			}, {
@@ -2124,7 +2132,8 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeExternalIP, Address: "54.10.11.2"},
 						{Type: v1.NodeInternalIP, Address: "10.0.1.2"},
-						{Type: v1.NodeInternalIP, Address: "2001:DB8::2"},
+						{Type: v1.NodeExternalIP, Address: "2001:DB8::2"},
+						{Type: v1.NodeInternalIP, Address: "2001:DB8::3"},
 					},
 				},
 			}},
@@ -2141,9 +2150,9 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				{DNSName: "internal.foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"10.0.1.1", "10.0.1.2"}},
-				{DNSName: "internal.foo.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:DB8::1", "2001:DB8::2"}},
+				{DNSName: "internal.foo.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:DB8::3"}},
 				{DNSName: "internal.bar.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"10.0.1.1", "10.0.1.2"}},
-				{DNSName: "internal.bar.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:DB8::1", "2001:DB8::2"}},
+				{DNSName: "internal.bar.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:DB8::3"}},
 			},
 			nodes: []*v1.Node{{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2156,7 +2165,7 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeExternalIP, Address: "54.10.11.1"},
 						{Type: v1.NodeInternalIP, Address: "10.0.1.1"},
-						{Type: v1.NodeInternalIP, Address: "2001:DB8::1"},
+						{Type: v1.NodeExternalIP, Address: "2001:DB8::1"},
 					},
 				},
 			}, {
@@ -2170,7 +2179,8 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeExternalIP, Address: "54.10.11.2"},
 						{Type: v1.NodeInternalIP, Address: "10.0.1.2"},
-						{Type: v1.NodeInternalIP, Address: "2001:DB8::2"},
+						{Type: v1.NodeExternalIP, Address: "2001:DB8::2"},
+						{Type: v1.NodeInternalIP, Address: "2001:DB8::3"},
 					},
 				},
 			}},
@@ -2202,7 +2212,7 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeExternalIP, Address: "54.10.11.1"},
 						{Type: v1.NodeInternalIP, Address: "10.0.1.1"},
-						{Type: v1.NodeInternalIP, Address: "2001:DB8::1"},
+						{Type: v1.NodeExternalIP, Address: "2001:DB8::1"},
 					},
 				},
 			}, {
@@ -2216,7 +2226,8 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeExternalIP, Address: "54.10.11.2"},
 						{Type: v1.NodeInternalIP, Address: "10.0.1.2"},
-						{Type: v1.NodeInternalIP, Address: "2001:DB8::2"},
+						{Type: v1.NodeExternalIP, Address: "2001:DB8::2"},
+						{Type: v1.NodeInternalIP, Address: "2001:DB8::3"},
 					},
 				},
 			}},
@@ -2245,7 +2256,7 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeExternalIP, Address: "54.10.11.1"},
 						{Type: v1.NodeInternalIP, Address: "10.0.1.1"},
-						{Type: v1.NodeInternalIP, Address: "2001:DB8::1"},
+						{Type: v1.NodeExternalIP, Address: "2001:DB8::1"},
 					},
 				},
 			}, {
@@ -2259,7 +2270,8 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeExternalIP, Address: "54.10.11.2"},
 						{Type: v1.NodeInternalIP, Address: "10.0.1.2"},
-						{Type: v1.NodeInternalIP, Address: "2001:DB8::2"},
+						{Type: v1.NodeExternalIP, Address: "2001:DB8::2"},
+						{Type: v1.NodeInternalIP, Address: "2001:DB8::3"},
 					},
 				},
 			}},
@@ -2848,7 +2860,7 @@ func TestHeadlessServices(t *testing.T) {
 					Status: v1.NodeStatus{
 						Addresses: []v1.NodeAddress{
 							{
-								Type:    v1.NodeInternalIP,
+								Type:    v1.NodeExternalIP,
 								Address: "2001:db8::4",
 							},
 						},
@@ -2895,7 +2907,7 @@ func TestHeadlessServices(t *testing.T) {
 								Address: "1.2.3.4",
 							},
 							{
-								Type:    v1.NodeInternalIP,
+								Type:    v1.NodeExternalIP,
 								Address: "2001:db8::4",
 							},
 						},


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
This reverts commit 683663e9c21f0ed9a2cff073f555baec6752dadc from #3588.
As stated in #4566, the behavior of IPv4 and IPv6 addresses should not differ the way it currently does.
This PR makes external-dns respect the difference between a Kubernetes `internal` and `external` Node-IP (again).

The tests are updated so that they check with both Internal and External IP where it makes sense to do so.

**Reasoning**

The fact that IPv6 addresses _could_ be reached from the global networks is not a good enough reason to remove the possibility to not create IPv6 DNS records.
If you want to have external-dns create `AAAA` records for your "private" IPv6 addresses, you should mark them as `ExternalIP`, not have external-dns create them no matter what.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4566

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated

**Additional Notes**

The next release after this PR should include a "Important Changes" section mentioning this change. Even though [v0.13.5](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.13.5) did not have this for #3588. IMO it should have had it too.
