### PR TITLE
feat: add soft errors to pdns provider

### DIFF
--- a/provider/pdns/pdns.go
+++ b/provider/pdns/pdns.go
@@ -392,7 +392,7 @@ func (p *PDNSProvider) mutateRecords(endpoints []*endpoint.Endpoint, changetype 
 	for _, zone := range zonelist {
 		jso, err := json.Marshal(zone)
 		if err != nil {
-			return provider.NewSoftError(fmt.Errorf("JSON Marshal for zone struct failed: %v", err))
+			log.Errorf("JSON Marshal for zone struct failed!")
 		} else {
 			log.Debugf("Struct for PatchZone:\n%s", string(jso))
 		}


### PR DESCRIPTION
Add soft errors to pdns provider where it is possible to retry or recover.

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Leverages #4166 by adding soft errors to the pdns provider

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
