### PR TITLE
Add provider cache

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -186,7 +186,7 @@ type Controller struct {
 	// The interval between individual synchronizations
 	Interval time.Duration
 	// The DomainFilter defines which DNS records to keep or exclude
-	DomainFilter endpoint.DomainFilter
+	DomainFilter endpoint.DomainFilterInterface
 	// The nextRunAt used for throttling and batching reconciliation
 	nextRunAt time.Time
 	// The runAtMutex is for atomic updating of nextRunAt and lastRunAt
@@ -245,7 +245,7 @@ func (c *Controller) RunOnce(ctx context.Context) error {
 		Policies:       []plan.Policy{c.Policy},
 		Current:        records,
 		Desired:        endpoints,
-		DomainFilter:   endpoint.MatchAllDomainFilters{&c.DomainFilter, &registryFilter},
+		DomainFilter:   endpoint.MatchAllDomainFilters{c.DomainFilter, registryFilter},
 		ManagedRecords: c.ManagedRecordTypes,
 		ExcludeRecords: c.ExcludeRecordTypes,
 		OwnerID:        c.Registry.OwnerID(),

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -57,7 +57,7 @@ type errorMockProvider struct {
 	mockProvider
 }
 
-func (p *filteredMockProvider) GetDomainFilter() endpoint.DomainFilter {
+func (p *filteredMockProvider) GetDomainFilter() endpoint.DomainFilterInterface {
 	return p.domainFilter
 }
 

--- a/docs/rate-limits.md
+++ b/docs/rate-limits.md
@@ -1,0 +1,76 @@
+DNS provider API rate limits considerations
+===========================================
+
+## Introduction
+
+By design, external-dns refreshes all the records of a zone using API calls.
+This refresh may happen peridically and upon any changed object if the flag `--events` is enabled.
+
+Depending on the size of the zone and the infrastructure deployment, this may lead to having external-dns
+hitting the DNS provider's rate-limits more easily.
+
+In particular, it has been found that, with 200k records in an AWS Route53 zone, each refresh triggers around
+70 API calls to retrieve all the records, making it more likely to hit the AWS Route53 API rate limits.
+
+To prevent this problem from happening, external-dns has implemented a cache to reduce the pressure on the DNS
+provider APIs.
+
+This cache is optional and systematically invalidated when DNS records have been changed in the cluster
+(new or deleted domains or changed target).
+
+## Trade-offs
+
+The major trade-off of this setting relies in the ability to recover from a deleted record on the DNS provider side.
+As the DNS records are cached in memory, external-dns will not be made aware of the missing records and will hence
+take a longer time to restore the deleted or modified record on the provider side.
+
+This option is enabled using the `--provider-cache-time=15m` command line argument, and disabled when `--provider-cache-time=0m`
+
+## Monitoring
+
+You can evaluate the behaviour of the cache thanks to the built-in metrics
+
+* `external_dns_provider_cache_records_calls`
+   The number of calls to the provider cache Records list.
+   The label `from_cache=true` indicates that the records were retrieved from memory and the DNS provider was not reached
+   The label `from_cache=false` indicates that the cache was not used and the records were retrieved from the provider
+* `external_dns_provider_cache_apply_changes_calls`
+   The number of calls to the provider cache ApplyChanges.
+   Each ApplyChange systematically invalidates the cache and makes subsequent Records list to be retrieved from the provider without cache.
+
+## Related options
+
+This global option is available for all providers and can be used in pair with other global
+or provider-specific options to fine-tune the behaviour of external-dns
+to match the specific needs of your deployments, with the goal to reduce the number of API calls to your DNS provider.
+
+* Google
+  `--google-batch-change-interval=1s` When using the Google provider, set the interval between batch changes. ($EXTERNAL_DNS_GOOGLE_BATCH_CHANGE_INTERVAL)
+  `--google-batch-change-size=1000` When using the Google provider, set the maximum number of changes that will be applied in each batch.
+* AWS
+  `--aws-batch-change-interval=1s` When using the AWS provider, set the interval between batch changes.
+  `--aws-batch-change-size=1000` When using the AWS provider, set the maximum number of changes that will be applied in each batch.
+  `--aws-batch-change-size-bytes=32000` When using the AWS provider, set the maximum byte size that will be applied in each batch.
+  `--aws-batch-change-size-values=1000` When using the AWS provider, set the maximum total record values that will be applied in each batch.
+  `--aws-zones-cache-duration=0s` When using the AWS provider, set the zones list cache TTL (0s to disable).
+  `--[no-]aws-zone-match-parent` Expand limit possible target by sub-domains
+* Cloudflare
+  `--cloudflare-dns-records-per-page=100` When using the Cloudflare provider, specify how many DNS records listed per page, max possible 5,000 (default: 100)
+* OVH
+  `--ovh-api-rate-limit=20` When using the OVH provider, specify the API request rate limit, X operations by seconds (default: 20)
+
+* Global
+  `--registry=txt` The registry implementation to use to keep track of DNS record ownership (default: txt, options: txt, noop, dynamodb, aws-sd)
+  `--txt-cache-interval=0s` The interval between cache synchronizations in duration format (default: disabled)
+  `--interval=1m0s` The interval between two consecutive synchronizations in duration format (default: 1m)
+  `--min-event-sync-interval=5s` The minimum interval between two consecutive synchronizations triggered from kubernetes events in duration format (default: 5s)
+  `--[no-]events` When enabled, in addition to running every interval, the reconciliation loop will get triggered when supported sources change (default: disabled)
+
+A general recommendation is to enable `--events` and keep `--min-event-sync-interval` relatively low to have a better responsiveness when records are
+created or updated inside the cluster.
+This should represent an acceptable propagation time between the creation of your k8s resources and the time they become registered in your DNS server.
+
+On a general manner, the higher the `--provider-cache-time`, the lower the impact on the rate limits, but also, the slower the recovery in case of a deletion.
+The `--provider-cache-time` value should hence be set to an acceptable time to automatically recover restore deleted records.
+
+✍️ Note that caching is done within the external-dns controller memory. You can invalidate the cache at any point in time by restarting it (for example doing a rolling update).

--- a/docs/rate-limits.md
+++ b/docs/rate-limits.md
@@ -6,10 +6,10 @@ DNS provider API rate limits considerations
 By design, external-dns refreshes all the records of a zone using API calls.
 This refresh may happen peridically and upon any changed object if the flag `--events` is enabled.
 
-Depending on the size of the zone and the infrastructure deployment, this may lead to having external-dns
+Depending on the size of the zone and the infrastructure deployment, this may lead to external-dns
 hitting the DNS provider's rate-limits more easily.
 
-In particular, it has been found that, with 200k records in an AWS Route53 zone, each refresh triggers around
+In particular, it has been found that with 200k records in an AWS Route53 zone, each refresh triggers around
 70 API calls to retrieve all the records, making it more likely to hit the AWS Route53 API rate limits.
 
 To prevent this problem from happening, external-dns has implemented a cache to reduce the pressure on the DNS
@@ -24,19 +24,19 @@ The major trade-off of this setting relies in the ability to recover from a dele
 As the DNS records are cached in memory, external-dns will not be made aware of the missing records and will hence
 take a longer time to restore the deleted or modified record on the provider side.
 
-This option is enabled using the `--provider-cache-time=15m` command line argument, and disabled when `--provider-cache-time=0m`
+This option is enabled using the `--provider-cache-time=15m` command line argument, and turned off when `--provider-cache-time=0m`
 
 ## Monitoring
 
 You can evaluate the behaviour of the cache thanks to the built-in metrics
 
 * `external_dns_provider_cache_records_calls`
-   The number of calls to the provider cache Records list.
-   The label `from_cache=true` indicates that the records were retrieved from memory and the DNS provider was not reached
-   The label `from_cache=false` indicates that the cache was not used and the records were retrieved from the provider
+   * The number of calls to the provider cache Records list.
+   * The label `from_cache=true` indicates that the records were retrieved from memory and the DNS provider was not reached
+   * The label `from_cache=false` indicates that the cache was not used and the records were retrieved from the provider
 * `external_dns_provider_cache_apply_changes_calls`
-   The number of calls to the provider cache ApplyChanges.
-   Each ApplyChange systematically invalidates the cache and makes subsequent Records list to be retrieved from the provider without cache.
+   * The number of calls to the provider cache ApplyChanges.
+   * Each ApplyChange systematically invalidates the cache and makes subsequent Records list to be retrieved from the provider without cache.
 
 ## Related options
 
@@ -45,26 +45,26 @@ or provider-specific options to fine-tune the behaviour of external-dns
 to match the specific needs of your deployments, with the goal to reduce the number of API calls to your DNS provider.
 
 * Google
-  `--google-batch-change-interval=1s` When using the Google provider, set the interval between batch changes. ($EXTERNAL_DNS_GOOGLE_BATCH_CHANGE_INTERVAL)
-  `--google-batch-change-size=1000` When using the Google provider, set the maximum number of changes that will be applied in each batch.
+  * `--google-batch-change-interval=1s` When using the Google provider, set the interval between batch changes. ($EXTERNAL_DNS_GOOGLE_BATCH_CHANGE_INTERVAL)
+  * `--google-batch-change-size=1000` When using the Google provider, set the maximum number of changes that will be applied in each batch.
 * AWS
-  `--aws-batch-change-interval=1s` When using the AWS provider, set the interval between batch changes.
-  `--aws-batch-change-size=1000` When using the AWS provider, set the maximum number of changes that will be applied in each batch.
-  `--aws-batch-change-size-bytes=32000` When using the AWS provider, set the maximum byte size that will be applied in each batch.
-  `--aws-batch-change-size-values=1000` When using the AWS provider, set the maximum total record values that will be applied in each batch.
-  `--aws-zones-cache-duration=0s` When using the AWS provider, set the zones list cache TTL (0s to disable).
-  `--[no-]aws-zone-match-parent` Expand limit possible target by sub-domains
+  * `--aws-batch-change-interval=1s` When using the AWS provider, set the interval between batch changes.
+  * `--aws-batch-change-size=1000` When using the AWS provider, set the maximum number of changes that will be applied in each batch.
+  * `--aws-batch-change-size-bytes=32000` When using the AWS provider, set the maximum byte size that will be applied in each batch.
+  * `--aws-batch-change-size-values=1000` When using the AWS provider, set the maximum total record values that will be applied in each batch.
+  * `--aws-zones-cache-duration=0s` When using the AWS provider, set the zones list cache TTL (0s to disable).
+  * `--[no-]aws-zone-match-parent` Expand limit possible target by sub-domains
 * Cloudflare
-  `--cloudflare-dns-records-per-page=100` When using the Cloudflare provider, specify how many DNS records listed per page, max possible 5,000 (default: 100)
+  * `--cloudflare-dns-records-per-page=100` When using the Cloudflare provider, specify how many DNS records listed per page, max possible 5,000 (default: 100)
 * OVH
-  `--ovh-api-rate-limit=20` When using the OVH provider, specify the API request rate limit, X operations by seconds (default: 20)
+  * `--ovh-api-rate-limit=20` When using the OVH provider, specify the API request rate limit, X operations by seconds (default: 20)
 
 * Global
-  `--registry=txt` The registry implementation to use to keep track of DNS record ownership (default: txt, options: txt, noop, dynamodb, aws-sd)
-  `--txt-cache-interval=0s` The interval between cache synchronizations in duration format (default: disabled)
-  `--interval=1m0s` The interval between two consecutive synchronizations in duration format (default: 1m)
-  `--min-event-sync-interval=5s` The minimum interval between two consecutive synchronizations triggered from kubernetes events in duration format (default: 5s)
-  `--[no-]events` When enabled, in addition to running every interval, the reconciliation loop will get triggered when supported sources change (default: disabled)
+  * `--registry=txt` The registry implementation to use to keep track of DNS record ownership (default: txt, options: txt, noop, dynamodb, aws-sd)
+  * `--txt-cache-interval=0s` The interval between cache synchronizations in duration format (default: disabled)
+  * `--interval=1m0s` The interval between two consecutive synchronizations in duration format (default: 1m)
+  * `--min-event-sync-interval=5s` The minimum interval between two consecutive synchronizations triggered from kubernetes events in duration format (default: 5s)
+  * `--[no-]events` When enabled, in addition to running every interval, the reconciliation loop will get triggered when supported sources change (default: disabled)
 
 A general recommendation is to enable `--events` and keep `--min-event-sync-interval` relatively low to have a better responsiveness when records are
 created or updated inside the cluster.

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -912,6 +912,8 @@ Route53 has a [5 API requests per second per account hard quota](https://docs.aw
 Running several fast polling ExternalDNS instances in a given account can easily hit that limit. Some ways to reduce the request rate include:
 * Reduce the polling loop's synchronization interval at the possible cost of slower change propagation (but see `--events` below to reduce the impact).
   * `--interval=5m` (default `1m`)
+* Cache the results of the zone at the possible cost of slower propagation when the zone gets modified from other sources
+  * `--provider-cache-time=15m` (default `0m`)
 * Trigger the polling loop on changes to K8s objects, rather than only at `interval` and ensure a minimum of time between events, to have responsive updates with long poll intervals
   * `--events`
   * `--min-event-sync-interval=5m` (default `5s`)

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -912,7 +912,7 @@ Route53 has a [5 API requests per second per account hard quota](https://docs.aw
 Running several fast polling ExternalDNS instances in a given account can easily hit that limit. Some ways to reduce the request rate include:
 * Reduce the polling loop's synchronization interval at the possible cost of slower change propagation (but see `--events` below to reduce the impact).
   * `--interval=5m` (default `1m`)
-* Enable a Cache to store the zone records list. It comes with a cost: slower propagation when the zone gets modified from other sources.
+* Enable a Cache to store the zone records list. It comes with a cost: slower propagation when the zone gets modified from other sources such as the AWS console, terraform, cloudformation or anything similar.
   * `--provider-cache-time=15m` (default `0m`)
 * Trigger the polling loop on changes to K8s objects, rather than only at `interval` and ensure a minimum of time between events, to have responsive updates with long poll intervals
   * `--events`

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -912,7 +912,7 @@ Route53 has a [5 API requests per second per account hard quota](https://docs.aw
 Running several fast polling ExternalDNS instances in a given account can easily hit that limit. Some ways to reduce the request rate include:
 * Reduce the polling loop's synchronization interval at the possible cost of slower change propagation (but see `--events` below to reduce the impact).
   * `--interval=5m` (default `1m`)
-* Cache the results of the zone at the possible cost of slower propagation when the zone gets modified from other sources
+* Enable a Cache to store the zone records list. It comes with a cost: slower propagation when the zone gets modified from other sources.
   * `--provider-cache-time=15m` (default `0m`)
 * Trigger the polling loop on changes to K8s objects, rather than only at `interval` and ensure a minimum of time between events, to have responsive updates with long poll intervals
   * `--events`

--- a/endpoint/domain_filter.go
+++ b/endpoint/domain_filter.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 )
 
-type MatchAllDomainFilters []*DomainFilter
+type MatchAllDomainFilters []DomainFilterInterface
 
 func (f MatchAllDomainFilters) Match(domain string) bool {
 	for _, filter := range f {
@@ -39,6 +39,10 @@ func (f MatchAllDomainFilters) Match(domain string) bool {
 	return true
 }
 
+type DomainFilterInterface interface {
+	Match(domain string) bool
+}
+
 // DomainFilter holds a lists of valid domain names
 type DomainFilter struct {
 	// Filters define what domains to match
@@ -50,6 +54,8 @@ type DomainFilter struct {
 	// regexExclusion defines a regular expression to exclude the domains matched
 	regexExclusion *regexp.Regexp
 }
+
+var _ DomainFilterInterface = &DomainFilter{}
 
 // domainFilterSerde is a helper type for serializing and deserializing DomainFilter.
 type domainFilterSerde struct {

--- a/main.go
+++ b/main.go
@@ -402,10 +402,10 @@ func main() {
 	}
 
 	if cfg.ProviderCacheTime > 0 {
-		p = &provider.CachedProvider{
-			Provider:     p,
-			RefreshDelay: cfg.ProviderCacheTime,
-		}
+		p = provider.NewCachedProvider(
+			p,
+			cfg.ProviderCacheTime,
+		)
 	}
 
 	var r registry.Registry

--- a/main.go
+++ b/main.go
@@ -401,6 +401,13 @@ func main() {
 		os.Exit(0)
 	}
 
+	if cfg.ProviderCacheTime > 0 {
+		p = &provider.CachedProvider{
+			Provider:     p,
+			RefreshDelay: cfg.ProviderCacheTime,
+		}
+	}
+
 	var r registry.Registry
 	switch cfg.Registry {
 	case "dynamodb":

--- a/main.go
+++ b/main.go
@@ -421,7 +421,7 @@ func main() {
 	case "txt":
 		r, err = registry.NewTXTRegistry(p, cfg.TXTPrefix, cfg.TXTSuffix, cfg.TXTOwnerID, cfg.TXTCacheInterval, cfg.TXTWildcardReplacement, cfg.ManagedDNSRecordTypes, cfg.ExcludeDNSRecordTypes, cfg.TXTEncryptEnabled, []byte(cfg.TXTEncryptAESKey))
 	case "aws-sd":
-		r, err = registry.NewAWSSDRegistry(p.(*awssd.AWSSDProvider), cfg.TXTOwnerID)
+		r, err = registry.NewAWSSDRegistry(p, cfg.TXTOwnerID)
 	default:
 		log.Fatalf("unknown registry: %s", cfg.Registry)
 	}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
       - Initial Design: docs/initial-design.md
       - TTL: docs/ttl.md
       - MultiTarget: docs/proposal/multi-target.md
+      - ProviderCache: docs/rate-limits.md
   - Contributing:
       - Kubernetes Contributions: CONTRIBUTING.md
       - Release: docs/release.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,7 @@ nav:
       - Initial Design: docs/initial-design.md
       - TTL: docs/ttl.md
       - MultiTarget: docs/proposal/multi-target.md
-      - ProviderCache: docs/rate-limits.md
+      - Rate Limits: docs/rate-limits.md
   - Contributing:
       - Kubernetes Contributions: CONTRIBUTING.md
       - Release: docs/release.md

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -67,6 +67,7 @@ type Config struct {
 	AlwaysPublishNotReadyAddresses     bool
 	ConnectorSourceServer              string
 	Provider                           string
+	ProviderCacheTime                  int
 	GoogleProject                      string
 	GoogleBatchChangeSize              int
 	GoogleBatchChangeInterval          time.Duration
@@ -239,6 +240,7 @@ var defaultConfig = &Config{
 	PublishHostIP:               false,
 	ConnectorSourceServer:       "localhost:8080",
 	Provider:                    "",
+	ProviderCacheTime:           0,
 	GoogleProject:               "",
 	GoogleBatchChangeSize:       1000,
 	GoogleBatchChangeInterval:   time.Second,
@@ -456,6 +458,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	// Flags related to providers
 	providers := []string{"akamai", "alibabacloud", "aws", "aws-sd", "azure", "azure-dns", "azure-private-dns", "bluecat", "civo", "cloudflare", "coredns", "designate", "digitalocean", "dnsimple", "dyn", "exoscale", "gandi", "godaddy", "google", "ibmcloud", "inmemory", "linode", "ns1", "oci", "ovh", "pdns", "pihole", "plural", "rcodezero", "rdns", "rfc2136", "safedns", "scaleway", "skydns", "tencentcloud", "transip", "ultradns", "vinyldns", "vultr", "webhook"}
 	app.Flag("provider", "The DNS provider where the DNS records will be created (required, options: "+strings.Join(providers, ", ")+")").Required().PlaceHolder("provider").EnumVar(&cfg.Provider, providers...)
+	app.Flag("provider-cache-time", "The time to cache the DNS provider record list requests.").Default(defaultConfig.ProviderCacheTime.String()).DurationVar(&cfg.ProviderCacheTime)
 	app.Flag("domain-filter", "Limit possible target zones by a domain suffix; specify multiple times for multiple domains (optional)").Default("").StringsVar(&cfg.DomainFilter)
 	app.Flag("exclude-domains", "Exclude subdomains (optional)").Default("").StringsVar(&cfg.ExcludeDomains)
 	app.Flag("regex-domain-filter", "Limit possible domains and target zones by a Regex filter; Overrides domain-filter (optional)").Default(defaultConfig.RegexDomainFilter.String()).RegexpVar(&cfg.RegexDomainFilter)

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -67,7 +67,7 @@ type Config struct {
 	AlwaysPublishNotReadyAddresses     bool
 	ConnectorSourceServer              string
 	Provider                           string
-	ProviderCacheTime                  int
+	ProviderCacheTime                  time.Duration
 	GoogleProject                      string
 	GoogleBatchChangeSize              int
 	GoogleBatchChangeInterval          time.Duration

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -567,7 +567,7 @@ func (p *AWSProvider) createUpdateChanges(newEndpoints, oldEndpoints []*endpoint
 }
 
 // GetDomainFilter generates a filter to exclude any domain that is not controlled by the provider
-func (p *AWSProvider) GetDomainFilter() endpoint.DomainFilter {
+func (p *AWSProvider) GetDomainFilter() endpoint.DomainFilterInterface {
 	zones, err := p.Zones(context.Background())
 	if err != nil {
 		log.Errorf("failed to list zones: %v", err)

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -319,10 +319,10 @@ func TestAWSZones(t *testing.T) {
 func TestAWSRecordsFilter(t *testing.T) {
 	provider, _ := newAWSProvider(t, endpoint.DomainFilter{}, provider.ZoneIDFilter{}, provider.ZoneTypeFilter{}, false, false, nil)
 	domainFilter := provider.GetDomainFilter()
-	assert.NotNil(t, domainFilter)
+	require.NotNil(t, domainFilter)
 	require.IsType(t, endpoint.DomainFilter{}, domainFilter)
 	count := 0
-	filters := domainFilter.Filters
+	filters := domainFilter.(endpoint.DomainFilter).Filters
 	for _, tld := range []string{
 		"zone-4.ext-dns-test-3.teapot.zalan.do",
 		".zone-4.ext-dns-test-3.teapot.zalan.do",

--- a/provider/cached_provider.go
+++ b/provider/cached_provider.go
@@ -72,6 +72,7 @@ func (c *CachedProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, err
 }
 func (c *CachedProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
 	if !changes.HasChanges() {
+		log.Info("Records cache provider: no changes to be applied")
 		return nil
 	}
 	c.Reset()

--- a/provider/cached_provider.go
+++ b/provider/cached_provider.go
@@ -1,0 +1,73 @@
+package provider
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+)
+
+var (
+	cachedRecordsCallsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "external_dns",
+			Subsystem: "provider",
+			Name:      "cache_records_calls",
+			Help:      "Number of calls to the provider cache Records list.",
+		},
+		[]string{
+			"from_cache",
+		},
+	)
+	cachedApplyChangesCallsTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "external_dns",
+			Subsystem: "provider",
+			Name:      "cache_apply_changes_calls",
+			Help:      "Number of calls to the provider cache ApplyChanges.",
+		},
+	)
+)
+
+type CachedProvider struct {
+	Provider
+	RefreshDelay time.Duration
+	err          error
+	lastRead     time.Time
+	cache        []*endpoint.Endpoint
+}
+
+func (c *CachedProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	if c.needRefresh() {
+		c.cache, c.err = c.Provider.Records(ctx)
+		c.lastRead = time.Now()
+		cachedRecordsCallsTotal.WithLabelValues("false").Inc()
+	} else {
+		cachedRecordsCallsTotal.WithLabelValues("true").Inc()
+	}
+	return c.cache, c.err
+}
+func (c *CachedProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
+	c.Reset()
+	cachedApplyChangesCallsTotal.Inc()
+	return c.Provider.ApplyChanges(ctx, changes)
+}
+
+func (c *CachedProvider) Reset() {
+	c.err = nil
+	c.cache = nil
+	c.lastRead = time.Time{}
+}
+
+func (c *CachedProvider) needRefresh() bool {
+	if c.cache == nil || c.err != nil {
+		return true
+	}
+	return time.Now().After(c.lastRead.Add(c.RefreshDelay))
+}
+
+func init() {
+	prometheus.MustRegister(cachedRecordsCallsTotal)
+}

--- a/provider/cached_provider.go
+++ b/provider/cached_provider.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
+
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 )

--- a/provider/cached_provider.go
+++ b/provider/cached_provider.go
@@ -59,7 +59,7 @@ type CachedProvider struct {
 }
 
 func NewCachedProvider(provider Provider, refreshDelay time.Duration) *CachedProvider {
-	registerMetrics.Do(func() {
+	registerCacheProviderMetrics.Do(func() {
 		prometheus.MustRegister(cachedRecordsCallsTotal)
 	})
 	return &CachedProvider{

--- a/provider/cached_provider.go
+++ b/provider/cached_provider.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package provider
 
 import (

--- a/provider/cached_provider_test.go
+++ b/provider/cached_provider_test.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package provider
 
 import (

--- a/provider/cached_provider_test.go
+++ b/provider/cached_provider_test.go
@@ -1,0 +1,164 @@
+package provider
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+)
+
+type testProviderFunc struct {
+	records             func(ctx context.Context) ([]*endpoint.Endpoint, error)
+	applyChanges        func(ctx context.Context, changes *plan.Changes) error
+	propertyValuesEqual func(name string, previous string, current string) bool
+	adjustEndpoints     func(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint
+	getDomainFilter     func() endpoint.DomainFilterInterface
+}
+
+func (p *testProviderFunc) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	return p.records(ctx)
+}
+
+func (p *testProviderFunc) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
+	return p.applyChanges(ctx, changes)
+}
+
+func (p *testProviderFunc) PropertyValuesEqual(name string, previous string, current string) bool {
+	return p.propertyValuesEqual(name, previous, current)
+}
+
+func (p *testProviderFunc) AdjustEndpoints(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint {
+	return p.adjustEndpoints(endpoints)
+}
+
+func (p *testProviderFunc) GetDomainFilter() endpoint.DomainFilterInterface {
+	return p.getDomainFilter()
+}
+
+func recordsNotCalled(t *testing.T) func(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	return func(ctx context.Context) ([]*endpoint.Endpoint, error) {
+		t.Errorf("unexpected call to Records")
+		return nil, nil
+	}
+}
+
+func applyChangesNotCalled(t *testing.T) func(ctx context.Context, changes *plan.Changes) error {
+	return func(ctx context.Context, changes *plan.Changes) error {
+		t.Errorf("unexpected call to ApplyChanges")
+		return nil
+	}
+}
+
+func propertyValuesEqualNotCalled(t *testing.T) func(name string, previous string, current string) bool {
+	return func(name string, previous string, current string) bool {
+		t.Errorf("unexpected call to PropertyValuesEqual")
+		return false
+	}
+}
+
+func adjustEndpointsNotCalled(t *testing.T) func(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint {
+	return func(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint {
+		t.Errorf("unexpected call to AdjustEndpoints")
+		return endpoints
+	}
+}
+
+func newTestProviderFunc(t *testing.T) *testProviderFunc {
+	return &testProviderFunc{
+		records:             recordsNotCalled(t),
+		applyChanges:        applyChangesNotCalled(t),
+		propertyValuesEqual: propertyValuesEqualNotCalled(t),
+		adjustEndpoints:     adjustEndpointsNotCalled(t),
+	}
+}
+
+func TestCachedProviderCallsProviderOnFirstCall(t *testing.T) {
+	testProvider := newTestProviderFunc(t)
+	testProvider.records = func(ctx context.Context) ([]*endpoint.Endpoint, error) {
+		return []*endpoint.Endpoint{{DNSName: "domain.fqdn"}}, nil
+	}
+	provider := CachedProvider{
+		Provider: testProvider,
+	}
+	endpoints, err := provider.Records(context.Background())
+	assert.NoError(t, err)
+	require.NotNil(t, endpoints)
+	require.Len(t, endpoints, 1)
+	require.NotNil(t, endpoints[0])
+	assert.Equal(t, "domain.fqdn", endpoints[0].DNSName)
+}
+
+func TestCachedProviderUsesCacheWhileValid(t *testing.T) {
+	testProvider := newTestProviderFunc(t)
+	testProvider.records = func(ctx context.Context) ([]*endpoint.Endpoint, error) {
+		return []*endpoint.Endpoint{{DNSName: "domain.fqdn"}}, nil
+	}
+	provider := CachedProvider{
+		RefreshDelay: 30 * time.Second,
+		Provider:     testProvider,
+	}
+	_, err := provider.Records(context.Background())
+	require.NoError(t, err)
+
+	t.Run("With consecutive calls within the caching time frame", func(t *testing.T) {
+		testProvider.records = recordsNotCalled(t)
+		endpoints, err := provider.Records(context.Background())
+		assert.NoError(t, err)
+		require.NotNil(t, endpoints)
+		require.Len(t, endpoints, 1)
+		require.NotNil(t, endpoints[0])
+		assert.Equal(t, "domain.fqdn", endpoints[0].DNSName)
+	})
+
+	t.Run("When the caching time frame is exceeded", func(t *testing.T) {
+		testProvider.records = func(ctx context.Context) ([]*endpoint.Endpoint, error) {
+			return []*endpoint.Endpoint{{DNSName: "new.domain.fqdn"}}, nil
+		}
+		provider.lastRead = time.Now().Add(-20 * time.Minute)
+		endpoints, err := provider.Records(context.Background())
+		assert.NoError(t, err)
+		require.NotNil(t, endpoints)
+		require.Len(t, endpoints, 1)
+		require.NotNil(t, endpoints[0])
+		assert.Equal(t, "new.domain.fqdn", endpoints[0].DNSName)
+	})
+}
+
+func TestCachedProviderForcesCacheRefreshOnUpdate(t *testing.T) {
+	testProvider := newTestProviderFunc(t)
+	testProvider.records = func(ctx context.Context) ([]*endpoint.Endpoint, error) {
+		return []*endpoint.Endpoint{{DNSName: "domain.fqdn"}}, nil
+	}
+	provider := CachedProvider{
+		RefreshDelay: 30 * time.Second,
+		Provider:     testProvider,
+	}
+	_, err := provider.Records(context.Background())
+	require.NoError(t, err)
+
+	t.Run("When the caching time frame is exceeded", func(t *testing.T) {
+		testProvider.records = recordsNotCalled(t)
+		testProvider.applyChanges = func(ctx context.Context, changes *plan.Changes) error {
+			return nil
+		}
+		err := provider.ApplyChanges(context.Background(), &plan.Changes{})
+		assert.NoError(t, err)
+		t.Run("Next call to Records is not cached", func(t *testing.T) {
+			testProvider.applyChanges = applyChangesNotCalled(t)
+			testProvider.records = func(ctx context.Context) ([]*endpoint.Endpoint, error) {
+				return []*endpoint.Endpoint{{DNSName: "new.domain.fqdn"}}, nil
+			}
+			endpoints, err := provider.Records(context.Background())
+
+			assert.NoError(t, err)
+			require.NotNil(t, endpoints)
+			require.Len(t, endpoints, 1)
+			require.NotNil(t, endpoints[0])
+			assert.Equal(t, "new.domain.fqdn", endpoints[0].DNSName)
+		})
+	})
+}

--- a/provider/cached_provider_test.go
+++ b/provider/cached_provider_test.go
@@ -17,6 +17,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -30,7 +31,7 @@ type testProviderFunc struct {
 	records             func(ctx context.Context) ([]*endpoint.Endpoint, error)
 	applyChanges        func(ctx context.Context, changes *plan.Changes) error
 	propertyValuesEqual func(name string, previous string, current string) bool
-	adjustEndpoints     func(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint
+	adjustEndpoints     func(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error)
 	getDomainFilter     func() endpoint.DomainFilterInterface
 }
 
@@ -46,7 +47,7 @@ func (p *testProviderFunc) PropertyValuesEqual(name string, previous string, cur
 	return p.propertyValuesEqual(name, previous, current)
 }
 
-func (p *testProviderFunc) AdjustEndpoints(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint {
+func (p *testProviderFunc) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
 	return p.adjustEndpoints(endpoints)
 }
 
@@ -75,10 +76,10 @@ func propertyValuesEqualNotCalled(t *testing.T) func(name string, previous strin
 	}
 }
 
-func adjustEndpointsNotCalled(t *testing.T) func(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint {
-	return func(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint {
+func adjustEndpointsNotCalled(t *testing.T) func(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
+	return func(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
 		t.Errorf("unexpected call to AdjustEndpoints")
-		return endpoints
+		return endpoints, errors.New("unexpected call to AdjustEndpoints")
 	}
 }
 

--- a/provider/inmemory/inmemory.go
+++ b/provider/inmemory/inmemory.go
@@ -46,7 +46,7 @@ var (
 // initialized as dns provider with no records
 type InMemoryProvider struct {
 	provider.BaseProvider
-	domain         endpoint.DomainFilter
+	domain         endpoint.DomainFilterInterface
 	client         *inMemoryClient
 	filter         *filter
 	OnApplyChanges func(ctx context.Context, changes *plan.Changes)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -48,7 +48,7 @@ type Provider interface {
 	// unnecessary (potentially failing) changes. It may also modify other fields, add, or remove
 	// Endpoints. It is permitted to modify the supplied endpoints.
 	AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error)
-	GetDomainFilter() endpoint.DomainFilter
+	GetDomainFilter() endpoint.DomainFilterInterface
 }
 
 type BaseProvider struct{}
@@ -57,7 +57,7 @@ func (b BaseProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoi
 	return endpoints, nil
 }
 
-func (b BaseProvider) GetDomainFilter() endpoint.DomainFilter {
+func (b BaseProvider) GetDomainFilter() endpoint.DomainFilterInterface {
 	return endpoint.DomainFilter{}
 }
 

--- a/provider/webhook/api/httpapi_test.go
+++ b/provider/webhook/api/httpapi_test.go
@@ -62,7 +62,7 @@ func (p FakeWebhookProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]
 	return endpoints, nil
 }
 
-func (p FakeWebhookProvider) GetDomainFilter() endpoint.DomainFilter {
+func (p FakeWebhookProvider) GetDomainFilter() endpoint.DomainFilterInterface {
 	return p.domainFilter
 }
 

--- a/provider/webhook/webhook.go
+++ b/provider/webhook/webhook.go
@@ -296,7 +296,7 @@ func (p WebhookProvider) AdjustEndpoints(e []*endpoint.Endpoint) ([]*endpoint.En
 }
 
 // GetDomainFilter make calls to get the serialized version of the domain filter
-func (p WebhookProvider) GetDomainFilter() endpoint.DomainFilter {
+func (p WebhookProvider) GetDomainFilter() endpoint.DomainFilterInterface {
 	return p.DomainFilter
 }
 

--- a/registry/aws_sd_registry.go
+++ b/registry/aws_sd_registry.go
@@ -42,7 +42,7 @@ func NewAWSSDRegistry(provider provider.Provider, ownerID string) (*AWSSDRegistr
 	}, nil
 }
 
-func (sdr *AWSSDRegistry) GetDomainFilter() endpoint.DomainFilter {
+func (sdr *AWSSDRegistry) GetDomainFilter() endpoint.DomainFilterInterface {
 	return sdr.provider.GetDomainFilter()
 }
 

--- a/registry/dynamodb.go
+++ b/registry/dynamodb.go
@@ -105,7 +105,7 @@ func NewDynamoDBRegistry(provider provider.Provider, ownerID string, dynamodbAPI
 	}, nil
 }
 
-func (im *DynamoDBRegistry) GetDomainFilter() endpoint.DomainFilter {
+func (im *DynamoDBRegistry) GetDomainFilter() endpoint.DomainFilterInterface {
 	return im.provider.GetDomainFilter()
 }
 

--- a/registry/noop.go
+++ b/registry/noop.go
@@ -36,7 +36,7 @@ func NewNoopRegistry(provider provider.Provider) (*NoopRegistry, error) {
 	}, nil
 }
 
-func (im *NoopRegistry) GetDomainFilter() endpoint.DomainFilter {
+func (im *NoopRegistry) GetDomainFilter() endpoint.DomainFilterInterface {
 	return im.provider.GetDomainFilter()
 }
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -31,6 +31,6 @@ type Registry interface {
 	Records(ctx context.Context) ([]*endpoint.Endpoint, error)
 	ApplyChanges(ctx context.Context, changes *plan.Changes) error
 	AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error)
-	GetDomainFilter() endpoint.DomainFilter
+	GetDomainFilter() endpoint.DomainFilterInterface
 	OwnerID() string
 }

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -95,7 +95,7 @@ func getSupportedTypes() []string {
 	return []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME, endpoint.RecordTypeNS}
 }
 
-func (im *TXTRegistry) GetDomainFilter() endpoint.DomainFilter {
+func (im *TXTRegistry) GetDomainFilter() endpoint.DomainFilterInterface {
 	return im.provider.GetDomainFilter()
 }
 


### PR DESCRIPTION
**Description**

In the current implementation, DNS providers are called to list all records on every loop. This is expensive in terms of number of requests to the provider and may result in being rate limited, as reported in 1293 and 3397.

In our case, we have approximately 20,000 records in our AWS Hosted Zone. The ListResourceRecordSets API call allows a maximum of 300 items per call. That requires 67 API calls per external-dns deployment during every sync period

With this, we introduce an optional generic caching mechanism at the provider level, that re-uses the latest known list of records for a given time.

This prevents from expensive Provider calls to list all records for each object modification that does not change the actual record (annotations, statuses, ingress routing, ...)

This introduces 2 trade-offs:

1. Any changes or corruption directly on the provider side will be longer to detect and to resolve, up to the cache time

2. Any conflicting records in the DNS provider (such as a different external-dns instance) injected during the cache validity will cause the first iteration of the next reconcile loop to fail, and hence add a delay until the next retry

**Checklist**

- [X] Unit tests updated
- [X] End user documentation updated

reopen #3402