### PR TITLE
feat: add support for host aliases for f5 virtual server resource

### DIFF
--- a/source/f5_virtualserver.go
+++ b/source/f5_virtualserver.go
@@ -160,6 +160,7 @@ func (vs *f5VirtualServerSource) endpointsFromVirtualServers(virtualServers []*f
 		}
 
 		endpoints = append(endpoints, endpointsForHostname(virtualServer.Spec.Host, targets, ttl, nil, "", resource)...)
+		endpoints = append(endpoints, endpointsForHostAliases(virtualServer.Spec.HostAliases, targets, ttl, nil, "", resource)...)
 	}
 
 	return endpoints, nil


### PR DESCRIPTION
**Description**
Use the F5 Virtual server hostilities property to create DNS records as well.

Fixes #4543

**Checklist**
- [ ] Unit tests updated
- [ ] End user documentation updated
