### PR TITLE
Gateway API: Revert Gateway and HTTPRoute objects from v1 to v1beta1

### DIFF
--- a/docs/tutorials/gateway-api.md
+++ b/docs/tutorials/gateway-api.md
@@ -5,10 +5,25 @@ It is meant to supplement the other provider-specific setup tutorials.
 
 ## Supported API Versions
 
-As the Gateway API is still in an experimental phase, ExternalDNS makes no backwards
-compatibilty guarantees regarding its support. However, it currently supports a mixture of
-v1alpha2, v1beta1, v1 APIs. Gateways and HTTPRoutes are supported using the v1 and v1beta1 API (which is converted to v1 when using the latest CRDs).
-GRPCRoutes, TLSRoutes, TCPRoutes, and UDPRoutes are supported using the v1alpha2 API.
+ExternalDNS currently supports a mixture of v1alpha2, v1beta1, v1 APIs.
+
+Gateway API has two release channels: Standard and Experimental.
+The Experimental channel includes v1alpha2, v1beta2, and v1 APIs.
+The Standard channel only includes v1beta2 and v1 APIs, not v1alpha2.
+
+TCPRoutes, TLSRoutes, and UDPRoutes only exist in v1alpha2 and continued support for
+these versions is NOT guaranteed. At some time in the future, Gateway API will graduate
+these Routes to v1. ExternalDNS will likely follow that upgrade and move to the v1 API,
+where they will be available in the Standard release channel. This will be a breaking
+change if your Experimental CRDs are not updated to include the new v1 API.
+
+Gateways and HTTPRoutes are available in v1alpha2, v1beta1, and v1 APIs.
+However, some notable environments are behind in upgrading their CRDs to include the v1 API.
+For compatibility reasons Gateways and HTTPRoutes use the v1beta1 API.
+
+GRPCRoutes are available in v1alpha2 and v1 APIs, not v1beta2.
+Therefore, GRPCRoutes use the v1 API which is available in both release channels.
+Unfortunately, this means they will not be available in environments with old CRDs.
 
 ## Hostnames
 

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -34,9 +34,10 @@ import (
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	cache "k8s.io/client-go/tools/cache"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gateway "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 	informers "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions"
-	informers_v1 "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/apis/v1"
+	informers_v1beta1 "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/apis/v1beta1"
 
 	"sigs.k8s.io/external-dns/endpoint"
 )
@@ -83,7 +84,7 @@ func newGatewayInformerFactory(client gateway.Interface, namespace string, label
 type gatewayRouteSource struct {
 	gwNamespace string
 	gwLabels    labels.Selector
-	gwInformer  informers_v1.GatewayInformer
+	gwInformer  informers_v1beta1.GatewayInformer
 
 	rtKind        string
 	rtNamespace   string
@@ -124,8 +125,8 @@ func newGatewayRouteSource(clients ClientGenerator, config *Config, kind string,
 	}
 
 	informerFactory := newGatewayInformerFactory(client, config.GatewayNamespace, gwLabels)
-	gwInformer := informerFactory.Gateway().V1().Gateways() // TODO: Gateway informer should be shared across gateway sources.
-	gwInformer.Informer()                                   // Register with factory before starting.
+	gwInformer := informerFactory.Gateway().V1beta1().Gateways() // TODO: Gateway informer should be shared across gateway sources.
+	gwInformer.Informer()                                        // Register with factory before starting.
 
 	rtInformerFactory := informerFactory
 	if config.Namespace != config.GatewayNamespace || !selectorsEqual(rtLabels, gwLabels) {
@@ -251,11 +252,11 @@ type gatewayRouteResolver struct {
 }
 
 type gatewayListeners struct {
-	gateway   *v1.Gateway
+	gateway   *v1beta1.Gateway
 	listeners map[v1.SectionName][]v1.Listener
 }
 
-func newGatewayRouteResolver(src *gatewayRouteSource, gateways []*v1.Gateway, namespaces []*corev1.Namespace) *gatewayRouteResolver {
+func newGatewayRouteResolver(src *gatewayRouteSource, gateways []*v1beta1.Gateway, namespaces []*corev1.Namespace) *gatewayRouteResolver {
 	// Create Gateway Listener lookup table.
 	gws := make(map[types.NamespacedName]gatewayListeners, len(gateways))
 	for _, gw := range gateways {
@@ -395,7 +396,7 @@ func (c *gatewayRouteResolver) hosts(rt gatewayRoute) ([]string, error) {
 	return hostnames, nil
 }
 
-func (c *gatewayRouteResolver) routeIsAllowed(gw *v1.Gateway, lis *v1.Listener, rt gatewayRoute) bool {
+func (c *gatewayRouteResolver) routeIsAllowed(gw *v1beta1.Gateway, lis *v1.Listener, rt gatewayRoute) bool {
 	meta := rt.Metadata()
 	allow := lis.AllowedRoutes
 

--- a/source/gateway_grpcroute_test.go
+++ b/source/gateway_grpcroute_test.go
@@ -26,6 +26,7 @@ import (
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/external-dns/endpoint"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 )
 
@@ -48,7 +49,7 @@ func TestGatewayGRPCRouteSourceEndpoints(t *testing.T) {
 	require.NoError(t, err, "failed to create Namespace")
 
 	ips := []string{"10.64.0.1", "10.64.0.2"}
-	gw := &v1.Gateway{
+	gw := &v1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "internal",
 			Namespace: "default",
@@ -60,7 +61,7 @@ func TestGatewayGRPCRouteSourceEndpoints(t *testing.T) {
 		},
 		Status: gatewayStatus(ips...),
 	}
-	_, err = gwClient.GatewayV1().Gateways(gw.Namespace).Create(ctx, gw, metav1.CreateOptions{})
+	_, err = gwClient.GatewayV1beta1().Gateways(gw.Namespace).Create(ctx, gw, metav1.CreateOptions{})
 	require.NoError(t, err, "failed to create Gateway")
 
 	rt := &v1.GRPCRoute{

--- a/source/gateway_httproute.go
+++ b/source/gateway_httproute.go
@@ -20,14 +20,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	informers "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions"
-	informers_v1 "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/apis/v1"
+	informers_v1beta1 "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/apis/v1beta1"
 )
 
 // NewGatewayHTTPRouteSource creates a new Gateway HTTPRoute source with the given config.
 func NewGatewayHTTPRouteSource(clients ClientGenerator, config *Config) (Source, error) {
 	return newGatewayRouteSource(clients, config, "HTTPRoute", func(factory informers.SharedInformerFactory) gatewayRouteInformer {
-		return &gatewayHTTPRouteInformer{factory.Gateway().V1().HTTPRoutes()}
+		return &gatewayHTTPRouteInformer{factory.Gateway().V1beta1().HTTPRoutes()}
 	})
 }
 
@@ -40,7 +41,7 @@ func (rt *gatewayHTTPRoute) Protocol() v1.ProtocolType    { return v1.HTTPProtoc
 func (rt *gatewayHTTPRoute) RouteStatus() v1.RouteStatus  { return rt.route.Status.RouteStatus }
 
 type gatewayHTTPRouteInformer struct {
-	informers_v1.HTTPRouteInformer
+	informers_v1beta1.HTTPRouteInformer
 }
 
 func (inf gatewayHTTPRouteInformer) List(namespace string, selector labels.Selector) ([]gatewayRoute, error) {
@@ -54,10 +55,10 @@ func (inf gatewayHTTPRouteInformer) List(namespace string, selector labels.Selec
 		// We make a shallow copy since we're only interested in setting the TypeMeta.
 		clone := *rt
 		clone.TypeMeta = metav1.TypeMeta{
-			APIVersion: v1.GroupVersion.String(),
+			APIVersion: v1beta1.GroupVersion.String(),
 			Kind:       "HTTPRoute",
 		}
-		routes[i] = &gatewayHTTPRoute{clone}
+		routes[i] = &gatewayHTTPRoute{v1.HTTPRoute(clone)}
 	}
 	return routes, nil
 }

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -27,6 +27,7 @@ import (
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/external-dns/endpoint"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 )
 
@@ -135,7 +136,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 		title      string
 		config     Config
 		namespaces []*corev1.Namespace
-		gateways   []*v1.Gateway
+		gateways   []*v1beta1.Gateway
 		routes     []*v1.HTTPRoute
 		endpoints  []*endpoint.Endpoint
 	}{
@@ -145,7 +146,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				GatewayNamespace: "gateway-namespace",
 			},
 			namespaces: namespaces("gateway-namespace", "not-gateway-namespace", "route-namespace"),
-			gateways: []*v1.Gateway{
+			gateways: []*v1beta1.Gateway{
 				{
 					ObjectMeta: objectMeta("gateway-namespace", "test"),
 					Spec: v1.GatewaySpec{
@@ -184,7 +185,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				Namespace: "route-namespace",
 			},
 			namespaces: namespaces("gateway-namespace", "route-namespace", "not-route-namespace"),
-			gateways: []*v1.Gateway{{
+			gateways: []*v1beta1.Gateway{{
 				ObjectMeta: objectMeta("gateway-namespace", "test"),
 				Spec: v1.GatewaySpec{
 					Listeners: []v1.Listener{{
@@ -220,7 +221,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				GatewayLabelFilter: "foo=bar",
 			},
 			namespaces: namespaces("default"),
-			gateways: []*v1.Gateway{
+			gateways: []*v1beta1.Gateway{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "labels-match",
@@ -264,7 +265,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				LabelFilter: mustGetLabelSelector("foo=bar"),
 			},
 			namespaces: namespaces("default"),
-			gateways: []*v1.Gateway{{
+			gateways: []*v1beta1.Gateway{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.GatewaySpec{
 					Listeners: []v1.Listener{{Protocol: v1.HTTPProtocolType}},
@@ -305,7 +306,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				AnnotationFilter: "foo=bar",
 			},
 			namespaces: namespaces("default"),
-			gateways: []*v1.Gateway{{
+			gateways: []*v1beta1.Gateway{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.GatewaySpec{
 					Listeners: []v1.Listener{{Protocol: v1.HTTPProtocolType}},
@@ -344,7 +345,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			title:      "SkipControllerAnnotation",
 			config:     Config{},
 			namespaces: namespaces("default"),
-			gateways: []*v1.Gateway{{
+			gateways: []*v1beta1.Gateway{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.GatewaySpec{
 					Listeners: []v1.Listener{{Protocol: v1.HTTPProtocolType}},
@@ -370,7 +371,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			title:      "MultipleGateways",
 			config:     Config{},
 			namespaces: namespaces("default"),
-			gateways: []*v1.Gateway{
+			gateways: []*v1beta1.Gateway{
 				{
 					ObjectMeta: objectMeta("default", "one"),
 					Spec: v1.GatewaySpec{
@@ -404,7 +405,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			title:      "MultipleListeners",
 			config:     Config{},
 			namespaces: namespaces("default"),
-			gateways: []*v1.Gateway{{
+			gateways: []*v1beta1.Gateway{{
 				ObjectMeta: objectMeta("default", "one"),
 				Spec: v1.GatewaySpec{
 					Listeners: []v1.Listener{
@@ -440,7 +441,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			title:      "SectionNameMatch",
 			config:     Config{},
 			namespaces: namespaces("default"),
-			gateways: []*v1.Gateway{{
+			gateways: []*v1beta1.Gateway{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.GatewaySpec{
 					Listeners: []v1.Listener{
@@ -476,7 +477,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			title:      "PortNumberMatch",
 			config:     Config{},
 			namespaces: namespaces("default"),
-			gateways: []*v1.Gateway{{
+			gateways: []*v1beta1.Gateway{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.GatewaySpec{
 					Listeners: []v1.Listener{
@@ -520,7 +521,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			title:      "WildcardInGateway",
 			config:     Config{},
 			namespaces: namespaces("default"),
-			gateways: []*v1.Gateway{{
+			gateways: []*v1beta1.Gateway{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.GatewaySpec{
 					Listeners: []v1.Listener{{
@@ -547,7 +548,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			title:      "WildcardInRoute",
 			config:     Config{},
 			namespaces: namespaces("default"),
-			gateways: []*v1.Gateway{{
+			gateways: []*v1beta1.Gateway{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.GatewaySpec{
 					Listeners: []v1.Listener{{
@@ -574,7 +575,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			title:      "WildcardInRouteAndGateway",
 			config:     Config{},
 			namespaces: namespaces("default"),
-			gateways: []*v1.Gateway{{
+			gateways: []*v1beta1.Gateway{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.GatewaySpec{
 					Listeners: []v1.Listener{{
@@ -601,7 +602,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			title:      "NoRouteHostname",
 			config:     Config{},
 			namespaces: namespaces("default"),
-			gateways: []*v1.Gateway{{
+			gateways: []*v1beta1.Gateway{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.GatewaySpec{
 					Listeners: []v1.Listener{{
@@ -640,7 +641,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			title:      "NoHostnames",
 			config:     Config{},
 			namespaces: namespaces("default"),
-			gateways: []*v1.Gateway{{
+			gateways: []*v1beta1.Gateway{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.GatewaySpec{
 					Listeners: []v1.Listener{{Protocol: v1.HTTPProtocolType}},
@@ -660,7 +661,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			title:      "HostnameAnnotation",
 			config:     Config{},
 			namespaces: namespaces("default"),
-			gateways: []*v1.Gateway{{
+			gateways: []*v1beta1.Gateway{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.GatewaySpec{
 					Listeners: []v1.Listener{{Protocol: v1.HTTPProtocolType}},
@@ -707,7 +708,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				IgnoreHostnameAnnotation: true,
 			},
 			namespaces: namespaces("default"),
-			gateways: []*v1.Gateway{{
+			gateways: []*v1beta1.Gateway{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.GatewaySpec{
 					Listeners: []v1.Listener{{Protocol: v1.HTTPProtocolType}},
@@ -737,7 +738,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				FQDNTemplate: "{{.Name}}.zero.internal, {{.Name}}.one.internal. ,  {{.Name}}.two.internal  ",
 			},
 			namespaces: namespaces("default"),
-			gateways: []*v1.Gateway{{
+			gateways: []*v1beta1.Gateway{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.GatewaySpec{
 					Listeners: []v1.Listener{{Protocol: v1.HTTPProtocolType}},
@@ -774,7 +775,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				CombineFQDNAndAnnotation: true,
 			},
 			namespaces: namespaces("default"),
-			gateways: []*v1.Gateway{{
+			gateways: []*v1beta1.Gateway{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.GatewaySpec{
 					Listeners: []v1.Listener{{Protocol: v1.HTTPProtocolType}},
@@ -797,7 +798,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			title:      "TTL",
 			config:     Config{},
 			namespaces: namespaces("default"),
-			gateways: []*v1.Gateway{{
+			gateways: []*v1beta1.Gateway{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.GatewaySpec{
 					Listeners: []v1.Listener{{Protocol: v1.HTTPProtocolType}},
@@ -837,7 +838,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			title:      "ProviderAnnotations",
 			config:     Config{},
 			namespaces: namespaces("default"),
-			gateways: []*v1.Gateway{{
+			gateways: []*v1beta1.Gateway{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.GatewaySpec{
 					Listeners: []v1.Listener{{Protocol: v1.HTTPProtocolType}},
@@ -868,7 +869,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			title:      "DifferentHostnameDifferentGateway",
 			config:     Config{},
 			namespaces: namespaces("default"),
-			gateways: []*v1.Gateway{
+			gateways: []*v1beta1.Gateway{
 				{
 					ObjectMeta: objectMeta("default", "one"),
 					Spec: v1.GatewaySpec{
@@ -909,7 +910,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			title:      "AllowedRoutesSameNamespace",
 			config:     Config{},
 			namespaces: namespaces("same-namespace", "other-namespace"),
-			gateways: []*v1.Gateway{{
+			gateways: []*v1beta1.Gateway{{
 				ObjectMeta: objectMeta("same-namespace", "test"),
 				Spec: v1.GatewaySpec{
 					Listeners: []v1.Listener{{
@@ -965,7 +966,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 					},
 				},
 			},
-			gateways: []*v1.Gateway{{
+			gateways: []*v1beta1.Gateway{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.GatewaySpec{
 					Listeners: []v1.Listener{{
@@ -1006,7 +1007,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			title:      "MissingNamespace",
 			config:     Config{},
 			namespaces: nil,
-			gateways: []*v1.Gateway{{
+			gateways: []*v1beta1.Gateway{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.GatewaySpec{
 					Listeners: []v1.Listener{{
@@ -1039,7 +1040,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				GatewayNamespace: "gateway-namespace",
 			},
 			namespaces: namespaces("gateway-namespace", "route-namespace"),
-			gateways: []*v1.Gateway{
+			gateways: []*v1beta1.Gateway{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "overriden-gateway",
@@ -1076,7 +1077,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				GatewayNamespace: "gateway-namespace",
 			},
 			namespaces: namespaces("gateway-namespace", "route-namespace"),
-			gateways: []*v1.Gateway{
+			gateways: []*v1beta1.Gateway{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "overriden-gateway",
@@ -1127,7 +1128,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			ctx := context.Background()
 			gwClient := gatewayfake.NewSimpleClientset()
 			for _, gw := range tt.gateways {
-				_, err := gwClient.GatewayV1().Gateways(gw.Namespace).Create(ctx, gw, metav1.CreateOptions{})
+				_, err := gwClient.GatewayV1beta1().Gateways(gw.Namespace).Create(ctx, gw, metav1.CreateOptions{})
 				require.NoError(t, err, "failed to create Gateway")
 
 			}

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -137,7 +137,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 		config     Config
 		namespaces []*corev1.Namespace
 		gateways   []*v1beta1.Gateway
-		routes     []*v1.HTTPRoute
+		routes     []*v1beta1.HTTPRoute
 		endpoints  []*endpoint.Endpoint
 	}{
 		{
@@ -165,7 +165,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 					Status: gatewayStatus("2.3.4.5"),
 				},
 			},
-			routes: []*v1.HTTPRoute{{
+			routes: []*v1beta1.HTTPRoute{{
 				ObjectMeta: objectMeta("route-namespace", "test"),
 				Spec: v1.HTTPRouteSpec{
 					Hostnames: hostnames("test.example.internal"),
@@ -195,7 +195,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 				Status: gatewayStatus("1.2.3.4"),
 			}},
-			routes: []*v1.HTTPRoute{
+			routes: []*v1beta1.HTTPRoute{
 				{
 					ObjectMeta: objectMeta("route-namespace", "test"),
 					Spec: v1.HTTPRouteSpec{
@@ -245,7 +245,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 					Status: gatewayStatus("2.3.4.5"),
 				},
 			},
-			routes: []*v1.HTTPRoute{{
+			routes: []*v1beta1.HTTPRoute{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.HTTPRouteSpec{
 					Hostnames: hostnames("test.example.internal"),
@@ -272,7 +272,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 				Status: gatewayStatus("1.2.3.4"),
 			}},
-			routes: []*v1.HTTPRoute{
+			routes: []*v1beta1.HTTPRoute{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "labels-match",
@@ -313,7 +313,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 				Status: gatewayStatus("1.2.3.4"),
 			}},
-			routes: []*v1.HTTPRoute{
+			routes: []*v1beta1.HTTPRoute{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "annotations-match",
@@ -352,7 +352,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 				Status: gatewayStatus("1.2.3.4"),
 			}},
-			routes: []*v1.HTTPRoute{{
+			routes: []*v1beta1.HTTPRoute{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "api",
 					Namespace: "default",
@@ -387,7 +387,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 					Status: gatewayStatus("2.3.4.5"),
 				},
 			},
-			routes: []*v1.HTTPRoute{{
+			routes: []*v1beta1.HTTPRoute{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.HTTPRouteSpec{
 					Hostnames: hostnames("test.example.internal"),
@@ -423,7 +423,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 				Status: gatewayStatus("1.2.3.4"),
 			}},
-			routes: []*v1.HTTPRoute{{
+			routes: []*v1beta1.HTTPRoute{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.HTTPRouteSpec{
 					Hostnames: hostnames("*.example.internal"),
@@ -459,7 +459,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 				Status: gatewayStatus("1.2.3.4"),
 			}},
-			routes: []*v1.HTTPRoute{{
+			routes: []*v1beta1.HTTPRoute{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.HTTPRouteSpec{
 					Hostnames: hostnames("*.example.internal"),
@@ -503,7 +503,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 				Status: gatewayStatus("1.2.3.4"),
 			}},
-			routes: []*v1.HTTPRoute{{
+			routes: []*v1beta1.HTTPRoute{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.HTTPRouteSpec{
 					Hostnames: hostnames("*.example.internal"),
@@ -531,7 +531,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 				Status: gatewayStatus("1.2.3.4"),
 			}},
-			routes: []*v1.HTTPRoute{{
+			routes: []*v1beta1.HTTPRoute{{
 				ObjectMeta: objectMeta("default", "no-hostname"),
 				Spec: v1.HTTPRouteSpec{
 					Hostnames: []v1.Hostname{
@@ -558,7 +558,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 				Status: gatewayStatus("1.2.3.4"),
 			}},
-			routes: []*v1.HTTPRoute{{
+			routes: []*v1beta1.HTTPRoute{{
 				ObjectMeta: objectMeta("default", "no-hostname"),
 				Spec: v1.HTTPRouteSpec{
 					Hostnames: []v1.Hostname{
@@ -585,7 +585,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 				Status: gatewayStatus("1.2.3.4"),
 			}},
-			routes: []*v1.HTTPRoute{{
+			routes: []*v1beta1.HTTPRoute{{
 				ObjectMeta: objectMeta("default", "no-hostname"),
 				Spec: v1.HTTPRouteSpec{
 					Hostnames: []v1.Hostname{
@@ -612,7 +612,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 				Status: gatewayStatus("1.2.3.4"),
 			}},
-			routes: []*v1.HTTPRoute{{
+			routes: []*v1beta1.HTTPRoute{{
 				ObjectMeta: objectMeta("default", "no-hostname"),
 				Spec: v1.HTTPRouteSpec{
 					Hostnames: nil,
@@ -628,7 +628,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			config:     Config{},
 			namespaces: namespaces("default"),
 			gateways:   nil,
-			routes: []*v1.HTTPRoute{{
+			routes: []*v1beta1.HTTPRoute{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.HTTPRouteSpec{
 					Hostnames: hostnames("example.internal"),
@@ -648,7 +648,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 				Status: gatewayStatus("1.2.3.4"),
 			}},
-			routes: []*v1.HTTPRoute{{
+			routes: []*v1beta1.HTTPRoute{{
 				ObjectMeta: objectMeta("default", "no-hostname"),
 				Spec: v1.HTTPRouteSpec{
 					Hostnames: nil,
@@ -668,7 +668,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 				Status: gatewayStatus("1.2.3.4"),
 			}},
-			routes: []*v1.HTTPRoute{
+			routes: []*v1beta1.HTTPRoute{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "without-hostame",
@@ -715,7 +715,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 				Status: gatewayStatus("1.2.3.4"),
 			}},
-			routes: []*v1.HTTPRoute{{
+			routes: []*v1beta1.HTTPRoute{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "with-hostame",
 					Namespace: "default",
@@ -745,7 +745,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 				Status: gatewayStatus("1.2.3.4"),
 			}},
-			routes: []*v1.HTTPRoute{
+			routes: []*v1beta1.HTTPRoute{
 				{
 					ObjectMeta: objectMeta("default", "fqdn-with-hostnames"),
 					Spec: v1.HTTPRouteSpec{
@@ -782,7 +782,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 				Status: gatewayStatus("1.2.3.4"),
 			}},
-			routes: []*v1.HTTPRoute{{
+			routes: []*v1beta1.HTTPRoute{{
 				ObjectMeta: objectMeta("default", "fqdn-with-hostnames"),
 				Spec: v1.HTTPRouteSpec{
 					Hostnames: hostnames("fqdn-with-hostnames.internal"),
@@ -805,7 +805,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 				Status: gatewayStatus("1.2.3.4"),
 			}},
-			routes: []*v1.HTTPRoute{
+			routes: []*v1beta1.HTTPRoute{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "valid-ttl",
@@ -845,7 +845,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 				Status: gatewayStatus("1.2.3.4"),
 			}},
-			routes: []*v1.HTTPRoute{{
+			routes: []*v1beta1.HTTPRoute{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "provider-annotations",
 					Namespace: "default",
@@ -891,7 +891,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 					Status: gatewayStatus("2.3.4.5"),
 				},
 			},
-			routes: []*v1.HTTPRoute{{
+			routes: []*v1beta1.HTTPRoute{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.HTTPRouteSpec{
 					Hostnames: hostnames("test.one.internal", "test.two.internal"),
@@ -924,7 +924,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 				Status: gatewayStatus("1.2.3.4"),
 			}},
-			routes: []*v1.HTTPRoute{
+			routes: []*v1beta1.HTTPRoute{
 				{
 					ObjectMeta: objectMeta("same-namespace", "test"),
 					Spec: v1.HTTPRouteSpec{
@@ -983,7 +983,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 				Status: gatewayStatus("1.2.3.4"),
 			}},
-			routes: []*v1.HTTPRoute{
+			routes: []*v1beta1.HTTPRoute{
 				{
 					ObjectMeta: objectMeta("foo", "test"),
 					Spec: v1.HTTPRouteSpec{
@@ -1025,7 +1025,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 				Status: gatewayStatus("1.2.3.4"),
 			}},
-			routes: []*v1.HTTPRoute{{
+			routes: []*v1beta1.HTTPRoute{{
 				ObjectMeta: objectMeta("default", "test"),
 				Spec: v1.HTTPRouteSpec{
 					Hostnames: hostnames("example.internal"),
@@ -1058,7 +1058,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 					Status: gatewayStatus("1.2.3.4"),
 				},
 			},
-			routes: []*v1.HTTPRoute{{
+			routes: []*v1beta1.HTTPRoute{{
 				ObjectMeta: objectMeta("route-namespace", "test"),
 				Spec: v1.HTTPRouteSpec{
 					Hostnames: hostnames("test.example.internal"),
@@ -1105,7 +1105,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 					Status: gatewayStatus("2.3.4.5"),
 				},
 			},
-			routes: []*v1.HTTPRoute{{
+			routes: []*v1beta1.HTTPRoute{{
 				ObjectMeta: objectMeta("route-namespace", "test"),
 				Spec: v1.HTTPRouteSpec{
 					Hostnames: hostnames("test.example.internal"),
@@ -1133,7 +1133,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 
 			}
 			for _, rt := range tt.routes {
-				_, err := gwClient.GatewayV1().HTTPRoutes(rt.Namespace).Create(ctx, rt, metav1.CreateOptions{})
+				_, err := gwClient.GatewayV1beta1().HTTPRoutes(rt.Namespace).Create(ctx, rt, metav1.CreateOptions{})
 				require.NoError(t, err, "failed to create HTTPRoute")
 			}
 			kubeClient := kubefake.NewSimpleClientset()

--- a/source/gateway_tcproute_test.go
+++ b/source/gateway_tcproute_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 )
 
@@ -49,7 +50,7 @@ func TestGatewayTCPRouteSourceEndpoints(t *testing.T) {
 	require.NoError(t, err, "failed to create Namespace")
 
 	ips := []string{"10.64.0.1", "10.64.0.2"}
-	gw := &v1.Gateway{
+	gw := &v1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "internal",
 			Namespace: "default",
@@ -61,7 +62,7 @@ func TestGatewayTCPRouteSourceEndpoints(t *testing.T) {
 		},
 		Status: gatewayStatus(ips...),
 	}
-	_, err = gwClient.GatewayV1().Gateways(gw.Namespace).Create(ctx, gw, metav1.CreateOptions{})
+	_, err = gwClient.GatewayV1beta1().Gateways(gw.Namespace).Create(ctx, gw, metav1.CreateOptions{})
 	require.NoError(t, err, "failed to create Gateway")
 
 	rt := &v1alpha2.TCPRoute{

--- a/source/gateway_tlsroute_test.go
+++ b/source/gateway_tlsroute_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 )
 
@@ -49,7 +50,7 @@ func TestGatewayTLSRouteSourceEndpoints(t *testing.T) {
 	require.NoError(t, err, "failed to create Namespace")
 
 	ips := []string{"10.64.0.1", "10.64.0.2"}
-	gw := &v1.Gateway{
+	gw := &v1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "internal",
 			Namespace: "default",
@@ -61,7 +62,7 @@ func TestGatewayTLSRouteSourceEndpoints(t *testing.T) {
 		},
 		Status: gatewayStatus(ips...),
 	}
-	_, err = gwClient.GatewayV1().Gateways(gw.Namespace).Create(ctx, gw, metav1.CreateOptions{})
+	_, err = gwClient.GatewayV1beta1().Gateways(gw.Namespace).Create(ctx, gw, metav1.CreateOptions{})
 	require.NoError(t, err, "failed to create Gateway")
 
 	rt := &v1alpha2.TLSRoute{

--- a/source/gateway_udproute_test.go
+++ b/source/gateway_udproute_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 )
 
@@ -49,7 +50,7 @@ func TestGatewayUDPRouteSourceEndpoints(t *testing.T) {
 	require.NoError(t, err, "failed to create Namespace")
 
 	ips := []string{"10.64.0.1", "10.64.0.2"}
-	gw := &v1.Gateway{
+	gw := &v1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "internal",
 			Namespace: "default",
@@ -61,7 +62,7 @@ func TestGatewayUDPRouteSourceEndpoints(t *testing.T) {
 		},
 		Status: gatewayStatus(ips...),
 	}
-	_, err = gwClient.GatewayV1().Gateways(gw.Namespace).Create(ctx, gw, metav1.CreateOptions{})
+	_, err = gwClient.GatewayV1beta1().Gateways(gw.Namespace).Create(ctx, gw, metav1.CreateOptions{})
 	require.NoError(t, err, "failed to create Gateway")
 
 	rt := &v1alpha2.UDPRoute{


### PR DESCRIPTION
**Description**

This reverts Kubernetes API interactions for Gateway and HTTPRoute objects from APIVersion v1 to v1beta1.

Fixes #4366

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
