### PR TITLE
feat(helm-template): add traefik-proxy-v3 source for traefik-helm-chart v28

### DIFF
--- a/charts/external-dns/templates/clusterrole.yaml
+++ b/charts/external-dns/templates/clusterrole.yaml
@@ -103,6 +103,11 @@ rules:
     resources: ["ingressroutes", "ingressroutetcps", "ingressrouteudps"]
     verbs: ["get","watch","list"]
 {{- end }}
+{{- if has "traefik-proxy-v3" .Values.sources }}
+  - apiGroups: ["traefik.io"]
+    resources: ["ingressroutes", "ingressroutetcps", "ingressrouteudps"]
+    verbs: ["get","watch","list"]
+{{- end }}
 {{- if has "openshift-route" .Values.sources }}
   - apiGroups: ["route.openshift.io"]
     resources: ["routes"]

--- a/docs/tutorials/traefik-proxy.md
+++ b/docs/tutorials/traefik-proxy.md
@@ -3,7 +3,9 @@
 This tutorial describes how to configure ExternalDNS to use the Traefik Proxy source.
 It is meant to supplement the other provider-specific setup tutorials.
 
-## Manifest (for clusters without RBAC enabled)
+# Using Manifest 
+
+## Without RBAC enabled
 
 ```yaml
 apiVersion: apps/v1
@@ -30,9 +32,11 @@ spec:
         - --provider=aws
         - --registry=txt
         - --txt-owner-id=my-identifier
+        # use this flag when using Traefik helm chart >= v28
+        - --traefik-disable-legacy 
 ```
 
-## Manifest (for clusters with RBAC enabled)
+## With RBAC enabled
 
 ```yaml
 apiVersion: v1
@@ -51,7 +55,7 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["list","watch"]
-- apiGroups: ["traefik.containo.us","traefik.io"]
+- apiGroups: ["traefik.io"]
   resources: ["ingressroutes", "ingressroutetcps", "ingressrouteudps"]
   verbs: ["get","watch","list"]
 ---
@@ -93,10 +97,27 @@ spec:
         - --provider=aws
         - --registry=txt
         - --txt-owner-id=my-identifier
+        # use this flag when using Traefik helm chart >= v28
+        - --traefik-disable-legacy 
 ```
 
-## Deploying a Traefik IngressRoute
-Create a IngressRoute file called 'traefik-ingress.yaml' with the following contents:
+# Using Helm chart
+
+## With RBAC enabled
+
+```yaml
+rbac:
+  create: true
+sources:
+  - traefik-proxy-v3
+extraArgs:
+  - traefik-disable-legacy 
+```
+
+# Deploying a Traefik IngressRoute
+
+Create an IngressRoute file called 'traefik-ingress.yaml' with the following contents:
+
 ```yaml
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
@@ -118,7 +139,7 @@ spec:
           port: port
 ```
 
-Note the annotation on the IngressRoute (`external-dns.alpha.kubernetes.io/target`); use the same hostname as the traefik DNS.
+Note the annotation on the IngressRoute (`external-dns.alpha.kubernetes.io/target`); use the same hostname as the Traefik DNS.
 
 ExternalDNS uses this annotation to determine what services should be registered with DNS.
 
@@ -128,7 +149,7 @@ Create the IngressRoute:
 $ kubectl create -f traefik-ingress.yaml
 ```
 
-Depending where you run your IngressRoute it can take a little while for ExternalDNS synchronize the DNS record.
+Depending on where you run your IngressRoute it can take a little while for ExternalDNS to synchronize the DNS record.
 
 ## Cleanup
 
@@ -145,6 +166,31 @@ $ kubectl delete -f externaldns.yaml
 | --- | --- |
 | --traefik-disable-legacy | Disable listeners on Resources under traefik.containo.us |
 | --traefik-disable-new | Disable listeners on Resources under traefik.io |
+
+Example:
+
+1. Manifest
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  ...
+  template:
+    ...
+    spec:
+      ...
+      args:
+        ...
+        - --traefik-disable-legacy
+```
+
+2. Helm chart
+```yaml
+sources:
+  - traefik-proxy-v3
+extraArgs:
+  - traefik-disable-legacy 
+```
 
 ### Disabling Resource Listeners
 

--- a/pkg/apis/externaldns/types_test.go
+++ b/pkg/apis/externaldns/types_test.go
@@ -131,6 +131,8 @@ var (
 		WebhookProviderURL:          "http://localhost:8888",
 		WebhookProviderReadTimeout:  5 * time.Second,
 		WebhookProviderWriteTimeout: 10 * time.Second,
+		TraefikDisableLegacy:        false,
+		TraefikDisableNew:           false,
 	}
 
 	overriddenConfig = &Config{
@@ -243,6 +245,8 @@ var (
 		WebhookProviderURL:          "http://localhost:8888",
 		WebhookProviderReadTimeout:  5 * time.Second,
 		WebhookProviderWriteTimeout: 10 * time.Second,
+		TraefikDisableLegacy:        true,
+		TraefikDisableNew:           true,
 	}
 )
 
@@ -385,6 +389,8 @@ func TestParseFlags(t *testing.T) {
 				"--ibmcloud-config-file=ibmcloud.json",
 				"--tencent-cloud-config-file=tencent-cloud.json",
 				"--tencent-cloud-zone-type=private",
+				"--traefik-disable-legacy",
+				"--traefik-disable-new",
 			},
 			envVars:  map[string]string{},
 			expected: overriddenConfig,
@@ -500,6 +506,8 @@ func TestParseFlags(t *testing.T) {
 				"EXTERNAL_DNS_IBMCLOUD_CONFIG_FILE":            "ibmcloud.json",
 				"EXTERNAL_DNS_TENCENT_CLOUD_CONFIG_FILE":       "tencent-cloud.json",
 				"EXTERNAL_DNS_TENCENT_CLOUD_ZONE_TYPE":         "private",
+				"EXTERNAL_DNS_TRAEFIK_DISABLE_LEGACY":          "1",
+				"EXTERNAL_DNS_TRAEFIK_DISABLE_NEW":             "1",
 			},
 			expected: overriddenConfig,
 		},


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Traefik Helm Chart v28 - Traefik service v3.0 deprecated the old "traefik.containo.us" api group, so it's better to have another built-in option for traefik-proxy.

It's refered in Traefik helm chart: [/external-dns/charts/external-dns /CHANGELOG.md](https://github.com/traefik/traefik-helm-chart/blob/master/traefik/Changelog.md#2800-rc1----)

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
