### PR TITLE
fix(aws): check endpoint for nil before using in aws provider

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -435,10 +435,12 @@ func (p *AWSProvider) records(ctx context.Context, zones map[string]*profiledZon
 				}
 
 				ep := endpoint.NewEndpointWithTTL(wildcardUnescape(aws.StringValue(r.Name)), aws.StringValue(r.Type), ttl, targets...)
-				if aws.StringValue(r.Type) == endpoint.RecordTypeCNAME {
-					ep = ep.WithProviderSpecific(providerSpecificAlias, "false")
+				if ep != nil {
+					if aws.StringValue(r.Type) == endpoint.RecordTypeCNAME {
+						ep = ep.WithProviderSpecific(providerSpecificAlias, "false")
+					}
+					newEndpoints = append(newEndpoints, ep)
 				}
-				newEndpoints = append(newEndpoints, ep)
 			}
 
 			if r.AliasTarget != nil {
@@ -446,11 +448,13 @@ func (p *AWSProvider) records(ctx context.Context, zones map[string]*profiledZon
 				if ttl == 0 {
 					ttl = recordTTL
 				}
-				ep := endpoint.
-					NewEndpointWithTTL(wildcardUnescape(aws.StringValue(r.Name)), endpoint.RecordTypeA, ttl, aws.StringValue(r.AliasTarget.DNSName)).
-					WithProviderSpecific(providerSpecificEvaluateTargetHealth, fmt.Sprintf("%t", aws.BoolValue(r.AliasTarget.EvaluateTargetHealth))).
-					WithProviderSpecific(providerSpecificAlias, "true")
-				newEndpoints = append(newEndpoints, ep)
+				ep := endpoint.NewEndpointWithTTL(wildcardUnescape(aws.StringValue(r.Name)), endpoint.RecordTypeA, ttl, aws.StringValue(r.AliasTarget.DNSName))
+				if ep != nil {
+					ep = ep.
+						WithProviderSpecific(providerSpecificEvaluateTargetHealth, fmt.Sprintf("%t", aws.BoolValue(r.AliasTarget.EvaluateTargetHealth))).
+						WithProviderSpecific(providerSpecificAlias, "true")
+					newEndpoints = append(newEndpoints, ep)
+				}
 			}
 
 			for _, ep := range newEndpoints {

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -492,6 +492,13 @@ func TestAWSRecords(t *testing.T) {
 			TTL:             aws.Int64(recordTTL),
 			ResourceRecords: []*route53.ResourceRecord{{Value: aws.String("10 mailhost1.example.com")}, {Value: aws.String("20 mailhost2.example.com")}},
 		},
+		{
+			// This domain has 63 characters but one of them is `~` which encodes to a longer string than allowed
+			Name:            aws.String("long-domain-with-irregular-characters\\176longer-than-63-characters.zone-1.ext-dns-test-2.teapot.zalan.do."),
+			Type:            aws.String(route53.RRTypeCname),
+			TTL:             aws.Int64(recordTTL),
+			ResourceRecords: []*route53.ResourceRecord{{Value: aws.String("long-domain.example.com")}},
+		},
 	})
 
 	records, err := provider.Records(context.Background())


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

Check endpoints for nil to ensure they are valid before use in AWS provider

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes https://github.com/kubernetes-sigs/external-dns/issues/4176

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
