### PR TITLE
[helm chart] Only create ServiceMonitor if CRD/api resource is available

### DIFF
--- a/charts/external-dns/templates/servicemonitor.yaml
+++ b/charts/external-dns/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.enabled -}}
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled }}
 {{- $providerName := include "external-dns.providerName" . }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor


### PR DESCRIPTION
**Description**
It is best practice to make sure a given api resource is defined in the cluster before trying to create it.
Example: https://github.com/fluent/helm-charts/blob/154127f95f40ea53f7955826a937340cf2b48dad/charts/fluent-bit/templates/servicemonitor.yaml#L1C1-L1C106
