### PR TITLE
Webhook provider helm chart fixes

### DIFF
--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -147,7 +147,7 @@ spec:
         {{- with .Values.provider.webhook }}
         - name: webhook
           image: {{ include "external-dns.webhookImage" . }}
-          imagePullPolicy: {{ $.Values.image.pullPolicy }}
+          imagePullPolicy: {{ .image.pullPolicy }}
           {{- with .env }}
           env:
             {{- toYaml . | nindent 12 }}
@@ -175,6 +175,10 @@ spec:
           {{- end }}
           {{- with .securityContext }}
           securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- end }}

--- a/charts/external-dns/templates/servicemonitor.yaml
+++ b/charts/external-dns/templates/servicemonitor.yaml
@@ -51,7 +51,7 @@ spec:
       {{- end }}
     {{- if eq $providerName "webhook" }}
     {{- with .Values.provider.webhook.serviceMonitor }}
-    - port: webhook-metrics
+    - port: http-wh-metrics
       path: /metrics
       {{- with .interval }}
       interval: {{ . }}


### PR DESCRIPTION
**Description**

Fix mismatching values in the chart relating to the webhook provider 
- Add webhook resources values to deployment
- Correct webhook containers metric port in servicemonitor
- Use correct imagePullPolicy value for webhook container
