### PR TITLE
Webhook provider helm chart fixes

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `provider.webhook.resources` behavior to correctly leverage resource limits ([#4560](https://github.com/kubernetes-sigs/external-dns/pull/4560))
+- Fixed `provider.webhook.imagePullPolicy` behavior to correctly leverage pull policy ([#4643](https://github.com/kubernetes-sigs/external-dns/pull/4643)) _@kimsondrup_
+- Add correct webhook metric port to `Service` and `ServiceMonitor` ([#4643](https://github.com/kubernetes-sigs/external-dns/pull/4643)) _@kimsondrup_
 
 ## [v1.14.5] - 2023-06-10
 

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -134,6 +134,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | provider.webhook.readinessProbe | object | See _values.yaml_ | [Readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `webhook` container. |
 | provider.webhook.resources | object | `{}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the `webhook` container. |
 | provider.webhook.securityContext | object | See _values.yaml_ | [Pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) for the `webhook` container. |
+| provider.webhook.service.metricsPort | int | `8080` | Webhook metrics port for the service. |
 | provider.webhook.serviceMonitor | object | See _values.yaml_ | Optional [Service Monitor](https://prometheus-operator.dev/docs/operator/design/#servicemonitor) configuration for the `webhook` container. |
 | rbac.additionalPermissions | list | `[]` | Additional rules to add to the `ClusterRole`. |
 | rbac.create | bool | `true` | If `true`, create a `ClusterRole` & `ClusterRoleBinding` with access to the Kubernetes API. |

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -147,7 +147,7 @@ spec:
         {{- with .Values.provider.webhook }}
         - name: webhook
           image: {{ include "external-dns.webhookImage" . }}
-          imagePullPolicy: {{ $.Values.image.pullPolicy }}
+          imagePullPolicy: {{ .image.pullPolicy }}
           {{- with .env }}
           env:
             {{- toYaml . | nindent 12 }}

--- a/charts/external-dns/templates/service.yaml
+++ b/charts/external-dns/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- $providerName := include "external-dns.providerName" . }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -25,3 +26,11 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
+    {{- if eq $providerName "webhook" }}
+    {{- with .Values.provider.webhook.service }}
+    - name: http-wh-metrics
+      port: {{ .metricsPort }}
+      targetPort: http-wh-metrics
+      protocol: TCP
+    {{- end }}
+    {{- end }}

--- a/charts/external-dns/templates/servicemonitor.yaml
+++ b/charts/external-dns/templates/servicemonitor.yaml
@@ -51,7 +51,7 @@ spec:
       {{- end }}
     {{- if eq $providerName "webhook" }}
     {{- with .Values.provider.webhook.serviceMonitor }}
-    - port: webhook-metrics
+    - port: http-wh-metrics
       path: /metrics
       {{- with .interval }}
       interval: {{ . }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -269,6 +269,9 @@ provider:
       timeoutSeconds: 5
       failureThreshold: 6
       successThreshold: 1
+    service:
+      # -- Webhook metrics port for the service.
+      metricsPort: 8080
     # -- Optional [Service Monitor](https://prometheus-operator.dev/docs/operator/design/#servicemonitor) configuration for the `webhook` container.
     # @default -- See _values.yaml_
     serviceMonitor:


### PR DESCRIPTION
Description

Fix mismatching values in the chart relating to the webhook provider

- ~~Add webhook resources values to deployment~~ #4560
- Add webhook metrics port to service
- Correct webhook metric port in servicemonitor
- Use correct imagePullPolicy value for webhook container

~~This PR also contains #4681, if #4681 is rejected then this PR need to be rebased~~