### PR TITLE
Add support for MX and SRV records in pdns provider

### DIFF
--- a/docs/tutorials/pdns.md
+++ b/docs/tutorials/pdns.md
@@ -172,3 +172,102 @@ Once the API shows the record correctly, you can double check your record using:
 ```bash
 $ dig @${PDNS_FQDN} echo.example.com.
 ```
+
+## Using CRD source to manage DNS records in PowerDNS
+
+[CRD source](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/contributing/crd-source.md) provides a generic mechanism and declarative way to manage DNS records in PowerDNS using external-dns.
+
+```bash
+external-dns --source=crd --provider=pdns \
+  --pdns-server={{ pdns-api-url }} \
+  --pdns-api-key={{ pdns-api-key }} \
+  --domain-filter=example.com \
+  --managed-record-types=A \
+  --managed-record-types=CNAME \
+  --managed-record-types=TXT \
+  --managed-record-types=MX \
+  --managed-record-types=SRV
+```
+
+Not all the record types are enabled by default so we can enable the required record types using `--managed-record-types`.
+
+* Example for record type `A`
+
+```yaml
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: examplearecord
+spec:
+  endpoints:
+  - dnsName: example.com
+    recordTTL: 60
+    recordType: A
+    targets:
+    - 10.0.0.1
+```
+
+* Example for record type `CNAME`
+
+```yaml
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: examplecnamerecord
+spec:
+  endpoints:
+  - dnsName: test-a.example.com
+    recordTTL: 300
+    recordType: CNAME
+    targets:
+    - example.com
+```
+
+* Example for record type `TXT`
+
+```yaml
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: exampletxtrecord
+spec:
+  endpoints:
+  - dnsName: example.com
+    recordTTL: 3600
+    recordType: TXT
+    targets:
+      - '"v=spf1 include:spf.protection.example.com include:example.org -all"'
+      - '"apple-domain-verification=XXXXXXXXXXXXX"'
+```
+
+* Example for record type `MX`
+
+```yaml
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: examplemxrecord
+spec:
+  endpoints:
+  - dnsName: example.com
+    recordTTL: 3600
+    recordType: MX
+    targets:
+      - "10 mailhost1.example.com"
+```
+
+* Example for record type `SRV`
+
+```yaml
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: examplesrvrecord
+spec:
+  endpoints:
+  - dnsName: _service._tls.example.com
+    recordTTL: 180
+    recordType: SRV
+    targets:
+      - "100 1 443 service.example.com"
+```

--- a/provider/pdns/pdns.go
+++ b/provider/pdns/pdns.go
@@ -314,7 +314,7 @@ func (p *PDNSProvider) ConvertEndpointsToZones(eps []*endpoint.Endpoint, changet
 				records := []pgo.Record{}
 				RecordType_ := ep.RecordType
 				for _, t := range ep.Targets {
-					if ep.RecordType == "CNAME" || ep.RecordType == "ALIAS" {
+					if ep.RecordType == "CNAME" || ep.RecordType == "ALIAS" || ep.RecordType == "MX" || ep.RecordType == "SRV" {
 						t = provider.EnsureTrailingDot(t)
 					}
 					records = append(records, pgo.Record{Content: t})


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR enables MX and SRV record support for PowerDNS provider in ExternalDNS. Especially for PowerDNS API, it requires explicit trailing dot for records having FQDN such as CNAME, MX, SRV, etc.. For CNAME record, its already covered here https://github.com/kubernetes-sigs/external-dns/blob/master/provider/pdns/pdns.go#L317-L318 so I added trailing dot for MX and SRV records now.

**Errors Fixed**

Error from PDNS API for SRV record creation
```
level=debug msg="PDNS API response:
level=fatal msg="Failed to do run once: Status: 422 Unprocessable Entity, Body: {\"error\": \"Record _service._tls.example.com./SRV '100 1 443 service.example.com': Not in expected format (parsed as '100 1 443 service.example.com.')\"}"
```
Error from PDNS API for MX record creation
```
level=fatal msg="Failed to do run once: Status: 422 Unprocessable Entity, Body: {\"error\": \"Record test.example.com./MX '10 mailhost1.example.com': Not in expected format (parsed as '10 mailhost1.example.com.')\"}
```

The above errors is fixed by this PR.

Fixes #3930 #4267 

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
