### PR TITLE
Include labelSelector for affinity and topologySpreadConstraints

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ability to configure `imagePullSecrets` via helm `global` value ([#4667](https://github.com/kubernetes-sigs/external-dns/pull/4667)) _@jkroepke_
 - Added options to configure `labelFilter` and `managedRecordTypes` via dedicated helm values ([#4849](https://github.com/kubernetes-sigs/external-dns/pull/4849)) _@abaguas_
 
+### Fixed
+
+- Fixed automatic addition of pod selector labels to `affinity` and `topologySpreadConstraints` if not defined. _@pvickery-ParamountCommerce_
+
 ## [v1.15.0] - 2023-09-10
 
 ### Changed

--- a/charts/external-dns/ci/ci-values.yaml
+++ b/charts/external-dns/ci/ci-values.yaml
@@ -2,3 +2,35 @@ labelFilter: foo=bar
 managedRecordTypes: []
 provider:
   name: inmemory
+affinity:
+  podAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: "kubernetes.io/hostname"
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - test
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: "kubernetes.io/hostname"
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: "kubernetes.io/hostname"
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: "kubernetes.io/hostname"
+        labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+                - test
+
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: "topology.kubernetes.io/zone"
+    whenUnsatisfiable: "ScheduleAnyway"

--- a/charts/external-dns/templates/_helpers.tpl
+++ b/charts/external-dns/templates/_helpers.tpl
@@ -93,3 +93,12 @@ The image to use for optional webhook sidecar
 {{- printf "%s:%s" .repository .tag }}
 {{- end }}
 {{- end }}
+
+{{/*
+The pod affinity default label Selector
+*/}}
+{{- define "external-dns.labelSelector" -}}
+labelSelector:
+  matchLabels:
+    {{ include "external-dns.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $defaultSelector := (include "external-dns.labelSelector" $ ) | fromYaml -}}
 {{- $providerName := tpl (include "external-dns.providerName" .) $ }}
 apiVersion: apps/v1
 kind: Deployment
@@ -203,11 +204,67 @@ spec:
       {{- end }}
       {{- with .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+      {{- with .podAffinity }}
+        podAffinity:
+          {{- with .preferredDuringSchedulingIgnoredDuringExecution }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+          {{- range . }}
+            - podAffinityTerm:
+              {{- if dig "podAffinityTerm" "labelSelector" nil . }}
+                {{- toYaml .podAffinityTerm | nindent 16 }}
+              {{- else }}
+                {{- (merge $defaultSelector .podAffinityTerm) | toYaml | nindent 16 }}
+              {{- end }}
+              weight: {{ .weight  }}
+          {{- end }}
+          {{- end }}
+          {{- with .requiredDuringSchedulingIgnoredDuringExecution }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+          {{- range . }}
+            {{- if dig "labelSelector" nil . }}
+              - {{ toYaml . | indent 16 | trim }}
+            {{- else }}
+              - {{ (merge $defaultSelector .) | toYaml | indent 16 | trim }}
+            {{- end }}
+          {{- end }}
+          {{- end }}
+      {{- end }}
+      {{- with .podAntiAffinity }}
+        podAntiAffinity:
+          {{- with .preferredDuringSchedulingIgnoredDuringExecution }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+          {{- range . }}
+            - podAffinityTerm:
+              {{- if dig "podAffinityTerm" "labelSelector" nil . }}
+                {{- toYaml .podAffinityTerm | nindent 16 }}
+              {{- else }}
+                {{- (merge $defaultSelector .podAffinityTerm) | toYaml | nindent 16 }}
+              {{- end }}
+              weight: {{ .weight  }}
+          {{- end }}
+          {{- end }}
+          {{- with .requiredDuringSchedulingIgnoredDuringExecution }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+          {{- range . }}
+            {{- if dig "labelSelector" nil . }}
+              - {{ toYaml . | indent 16 | trim }}
+            {{- else }}
+              - {{ (merge $defaultSelector .) | toYaml | indent 16 | trim }}
+            {{- end }}
+          {{- end }}
+          {{- end }}
+      {{- end }}
       {{- end }}
       {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
+        {{- range . }}
+        - {{ toYaml . | nindent 10 | trim }}
+          {{- if not (hasKey . "labelSelector") }}
+          labelSelector:
+            matchLabels:
+              {{- include "external-dns.selectorLabels" $ | nindent 12 }}
+          {{- end }}
+        {{- end }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

The labelSelector is used to track the pods that are used for the topologySpreadConstraints calculation. matchLabelKeys is used to only use the pods in the current version of the deployments replicaset.

I believe the following message isn't true before this PR.
https://github.com/kubernetes-sigs/external-dns/blob/1ceaf798ae830b9ba9d76dfbb9ee11d6273d3637/charts/external-dns/values.yaml#L155-L156

More details about matchLabelKeys can be found here:
- https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
- https://kubernetes.io/blog/2023/04/17/fine-grained-pod-topology-spread-features-beta/#kep-3243-respect-pod-topology-spread-after-rolling-upgrades
- https://pauldally.medium.com/the-most-common-reason-your-topologyspreadconstraint-isnt-working-fb9ce25297cd




<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->


**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
