### PR TITLE
Ignore unknown provider specific properties

### DIFF
--- a/endpoint/provider_specific_property_filter.go
+++ b/endpoint/provider_specific_property_filter.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint
+
+import (
+	"strings"
+)
+
+type ProviderSpecificPropertyFilter struct {
+	// Names of the provider specific properties to match
+	Names []string
+	// Prefixes of the provider specific properties to match
+	Prefixes []string
+}
+
+// Match checks whether a ProviderSpecificProperty.Name can be found in the
+// ProviderSpecificPropertyFilter.
+func (pf ProviderSpecificPropertyFilter) Match(name string) bool {
+	for _, pfName := range pf.Names {
+		if pfName == name {
+			return true
+		}
+	}
+	for _, prefix := range pf.Prefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// Filter removes all ProviderSpecificProperty's that don't match from every endpoint.
+func (pf ProviderSpecificPropertyFilter) Filter(endpoints []*Endpoint) {
+	for _, ep := range endpoints {
+		for _, providerSpecific := range ep.ProviderSpecific {
+			if !pf.Match(providerSpecific.Name) {
+				ep.DeleteProviderSpecificProperty(providerSpecific.Name)
+			}
+		}
+	}
+}

--- a/endpoint/provider_specific_property_filter.go
+++ b/endpoint/provider_specific_property_filter.go
@@ -18,6 +18,8 @@ package endpoint
 
 import (
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type ProviderSpecificPropertyFilter struct {
@@ -48,6 +50,10 @@ func (pf ProviderSpecificPropertyFilter) Filter(endpoints []*Endpoint) {
 	for _, ep := range endpoints {
 		for _, providerSpecific := range ep.ProviderSpecific {
 			if !pf.Match(providerSpecific.Name) {
+				log.WithFields(log.Fields{
+					"dnsName": ep.DNSName,
+					"targets": ep.Targets,
+				}).Debugf("Provider specific property ignored by provider: %s", providerSpecific.Name)
 				ep.DeleteProviderSpecificProperty(providerSpecific.Name)
 			}
 		}

--- a/endpoint/provider_specific_property_filter_test.go
+++ b/endpoint/provider_specific_property_filter_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type providerSpecificPropertyFilterTest struct {
+	names             []string
+	prefixes          []string
+	endpoints         []*Endpoint
+	expectedEndpoints []*Endpoint
+}
+
+var providerSpecificPropertyFilterTests = []providerSpecificPropertyFilterTest{
+	// 0. No Names or Prefixes
+	{
+		[]string{},
+		[]string{},
+		[]*Endpoint{
+			{
+				DNSName: "a.example.com",
+				ProviderSpecific: []ProviderSpecificProperty{
+					{Name: "prefix1/name1"},
+					{Name: "name1"},
+				},
+			},
+			{
+				DNSName: "b.example.com",
+				ProviderSpecific: []ProviderSpecificProperty{
+					{Name: "prefix2/name1"},
+					{Name: "name2"},
+				},
+			},
+		},
+		[]*Endpoint{
+			{
+				DNSName:          "a.example.com",
+				ProviderSpecific: []ProviderSpecificProperty{},
+			},
+			{
+				DNSName:          "b.example.com",
+				ProviderSpecific: []ProviderSpecificProperty{},
+			},
+		},
+	},
+	// 1. Only Names
+	{
+		[]string{"name1", "name2"},
+		[]string{},
+		[]*Endpoint{
+			{
+				DNSName: "a.example.com",
+				ProviderSpecific: []ProviderSpecificProperty{
+					{Name: "name1"},
+					{Name: "name2"},
+					{Name: "name3"},
+					{Name: "prefix1/name1"},
+				},
+			},
+		},
+		[]*Endpoint{
+			{
+				DNSName: "a.example.com",
+				ProviderSpecific: []ProviderSpecificProperty{
+					{Name: "name1"},
+					{Name: "name2"},
+				},
+			},
+		},
+	},
+	// 2. Only Prefixes
+	{
+		[]string{},
+		[]string{"prefix1/", "prefix2"},
+		[]*Endpoint{
+			{
+				DNSName: "a.example.com",
+				ProviderSpecific: []ProviderSpecificProperty{
+					{Name: "prefix1/foo"},
+					{Name: "prefix1-bar"},
+					{Name: "prefix2"},
+					{Name: "prefix3"},
+				},
+			},
+		},
+		[]*Endpoint{
+			{
+				DNSName: "a.example.com",
+				ProviderSpecific: []ProviderSpecificProperty{
+					{Name: "prefix1/foo"},
+					{Name: "prefix2"},
+				},
+			},
+		},
+	},
+	// 3. No Endpoints
+	{
+		[]string{"name1"},
+		[]string{"prefix1/"},
+		[]*Endpoint{},
+		[]*Endpoint{},
+	},
+	// 4. Both Names and Prefixes
+	{
+		[]string{"name1"},
+		[]string{"prefix1/"},
+		[]*Endpoint{
+			{
+				DNSName: "a.example.com",
+				ProviderSpecific: []ProviderSpecificProperty{
+					{Name: "prefix1/property"},
+					{Name: "prefix2/property"},
+					{Name: "name10"},
+				},
+			},
+			{
+				DNSName: "b.example.com",
+				ProviderSpecific: []ProviderSpecificProperty{
+					{Name: "prefix1/property"},
+					{Name: "name1"},
+					{Name: "name2"},
+				},
+			},
+		},
+		[]*Endpoint{
+			{
+				DNSName: "a.example.com",
+				ProviderSpecific: []ProviderSpecificProperty{
+					{Name: "prefix1/property"},
+				},
+			},
+			{
+				DNSName: "b.example.com",
+				ProviderSpecific: []ProviderSpecificProperty{
+					{Name: "prefix1/property"},
+					{Name: "name1"},
+				},
+			},
+		},
+	},
+}
+
+func TestPropertyFilter(t *testing.T) {
+	for i, tt := range providerSpecificPropertyFilterTests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			propertyFilter := ProviderSpecificPropertyFilter{
+				Names:    tt.names,
+				Prefixes: tt.prefixes,
+			}
+
+			propertyFilter.Filter(tt.endpoints)
+
+			assert.Equal(t, tt.endpoints, tt.expectedEndpoints)
+		})
+	}
+}

--- a/endpoint/provider_specific_property_filter_test.go
+++ b/endpoint/provider_specific_property_filter_test.go
@@ -169,7 +169,7 @@ func TestPropertyFilter(t *testing.T) {
 
 			propertyFilter.Filter(tt.endpoints)
 
-			assert.Equal(t, tt.endpoints, tt.expectedEndpoints)
+			assert.Equal(t, tt.expectedEndpoints, tt.endpoints)
 		})
 	}
 }

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -789,6 +789,13 @@ func (p *AWSProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoi
 		} else {
 			ep.DeleteProviderSpecificProperty(providerSpecificEvaluateTargetHealth)
 		}
+
+		// Remove non-AWS provider specific properties
+		for _, providerSpecific := range ep.ProviderSpecific {
+			if providerSpecific.Name != providerSpecificAlias && providerSpecific.Name[0:4] != "aws/" {
+				ep.DeleteProviderSpecificProperty(providerSpecific.Name)
+			}
+		}
 	}
 	return endpoints, nil
 }

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -568,6 +568,7 @@ func TestAWSAdjustEndpoints(t *testing.T) {
 		endpoint.NewEndpoint("cname-test-elb-no-alias.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificAlias, "false"),
 		endpoint.NewEndpoint("cname-test-elb-no-eth.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false"), // eth = evaluate target health
 		endpoint.NewEndpoint("cname-test-elb-alias.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificAlias, "true").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true"),
+		endpoint.NewEndpoint("a-test-other-provider-specific.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8").WithProviderSpecific(providerSpecificAlias, "true").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true").WithProviderSpecific("external-dns.alpha.kubernetes.io/cloudflare-proxied", "false"),
 	}
 
 	records, err := provider.AdjustEndpoints(records)
@@ -581,6 +582,7 @@ func TestAWSAdjustEndpoints(t *testing.T) {
 		endpoint.NewEndpoint("cname-test-elb-no-alias.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificAlias, "false"),
 		endpoint.NewEndpoint("cname-test-elb-no-eth.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificAlias, "true").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false"), // eth = evaluate target health
 		endpoint.NewEndpoint("cname-test-elb-alias.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificAlias, "true").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true"),
+		endpoint.NewEndpoint("a-test-other-provider-specific.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8").WithProviderSpecific(providerSpecificAlias, "true").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true"),
 	})
 }
 

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -1972,6 +1972,9 @@ func newAWSProviderWithTagFilter(t *testing.T, domainFilter endpoint.DomainFilte
 		dryRun:                false,
 		zonesCache:            &zonesListCache{duration: 1 * time.Minute},
 		failedChangesQueue:    make(map[string]Route53Changes),
+		BaseProvider: provider.BaseProvider{
+			ProviderSpecificPropertyFilter: awsProviderSpecificPropertyFilter,
+		},
 	}
 
 	createAWSZone(t, provider, &route53types.HostedZone{

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -43,7 +43,12 @@ const (
 	cloudFlareUpdate = "UPDATE"
 	// defaultCloudFlareRecordTTL 1 = automatic
 	defaultCloudFlareRecordTTL = 1
+	providerSpecificProxied    = "external-dns.alpha.kubernetes.io/cloudflare-proxied"
 )
+
+var cloudflareProviderSpecificPropertyFilter = endpoint.ProviderSpecificPropertyFilter{
+	Names: []string{providerSpecificProxied},
+}
 
 // We have to use pointers to bools now, as the upstream cloudflare-go library requires them
 // see: https://github.com/cloudflare/cloudflare-go/pull/595
@@ -210,6 +215,9 @@ func NewCloudFlareProvider(domainFilter endpoint.DomainFilter, zoneIDFilter prov
 		DryRun:            dryRun,
 		DNSRecordsPerPage: dnsRecordsPerPage,
 		RegionKey:         regionKey,
+		BaseProvider: provider.BaseProvider{
+			ProviderSpecificPropertyFilter: cloudflareProviderSpecificPropertyFilter,
+		},
 	}
 	return provider, nil
 }
@@ -416,6 +424,11 @@ func (p *CloudFlareProvider) submitChanges(ctx context.Context, changes []*cloud
 
 // AdjustEndpoints modifies the endpoints as needed by the specific provider
 func (p *CloudFlareProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
+	endpoints, err := p.BaseProvider.AdjustEndpoints(endpoints)
+	if err != nil {
+		return endpoints, err
+	}
+
 	adjustedEndpoints := []*endpoint.Endpoint{}
 	for _, e := range endpoints {
 		proxied := shouldBeProxied(e, p.proxiedByDefault)

--- a/provider/ibmcloud/ibmcloud_test.go
+++ b/provider/ibmcloud/ibmcloud_test.go
@@ -178,6 +178,9 @@ func newTestIBMCloudProvider(private bool) *IBMCloudProvider {
 		DryRun:       false,
 		instanceID:   "test123",
 		privateZone:  private,
+		BaseProvider: provider.BaseProvider{
+			ProviderSpecificPropertyFilter: ibmProviderSpecificPropertyFilter,
+		},
 	}
 }
 
@@ -355,6 +358,10 @@ func TestAdjustEndpoints(t *testing.T) {
 					Name:  "ibmcloud-proxied",
 					Value: "1",
 				},
+				{
+					Name:  "extra-property",
+					Value: "true",
+				},
 			},
 		},
 	}
@@ -364,8 +371,12 @@ func TestAdjustEndpoints(t *testing.T) {
 
 	assert.Equal(t, endpoint.TTL(0), ep[0].RecordTTL)
 	assert.Equal(t, "test.example.com", ep[0].DNSName)
-	proxied, _ := ep[0].GetProviderSpecificProperty("ibmcloud-proxied")
+	proxied, found := ep[0].GetProviderSpecificProperty("ibmcloud-proxied")
+	assert.True(t, found)
 	assert.Equal(t, "true", proxied)
+	extra, found := ep[0].GetProviderSpecificProperty("extra-property")
+	assert.False(t, found)
+	assert.Equal(t, "", extra)
 }
 
 func TestPrivateZone_withFilterID(t *testing.T) {

--- a/provider/plural/plural.go
+++ b/provider/plural/plural.go
@@ -83,10 +83,6 @@ func (p *PluralProvider) Records(_ context.Context) (endpoints []*endpoint.Endpo
 	return
 }
 
-func (p *PluralProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
-	return endpoints, nil
-}
-
 func (p *PluralProvider) ApplyChanges(_ context.Context, diffs *plan.Changes) error {
 	var changes []*RecordChange
 	for _, endpoint := range diffs.Create {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -51,9 +51,14 @@ type Provider interface {
 	GetDomainFilter() endpoint.DomainFilterInterface
 }
 
-type BaseProvider struct{}
+type BaseProvider struct {
+	ProviderSpecificPropertyFilter endpoint.ProviderSpecificPropertyFilter
+}
 
 func (b BaseProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
+	// Filter out ProviderSpecificProperties not recognized by this Provider
+	b.ProviderSpecificPropertyFilter.Filter(endpoints)
+
 	return endpoints, nil
 }
 

--- a/provider/scaleway/scaleway.go
+++ b/provider/scaleway/scaleway.go
@@ -39,6 +39,10 @@ const (
 	scalewayPriorityKey     string = "scw/priority"
 )
 
+var scalewayProviderSpecificPropertyFilter = endpoint.ProviderSpecificPropertyFilter{
+	Prefixes: []string{"scw/"},
+}
+
 // ScalewayProvider implements the DNS provider for Scaleway DNS
 type ScalewayProvider struct {
 	provider.BaseProvider
@@ -101,11 +105,19 @@ func NewScalewayProvider(ctx context.Context, domainFilter endpoint.DomainFilter
 		domainAPI:    domainAPI,
 		dryRun:       dryRun,
 		domainFilter: domainFilter,
+		BaseProvider: provider.BaseProvider{
+			ProviderSpecificPropertyFilter: scalewayProviderSpecificPropertyFilter,
+		},
 	}, nil
 }
 
 // AdjustEndpoints is used to normalize the endoints
 func (p *ScalewayProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
+	endpoints, err := p.BaseProvider.AdjustEndpoints(endpoints)
+	if err != nil {
+		return endpoints, err
+	}
+
 	eps := make([]*endpoint.Endpoint, len(endpoints))
 	for i := range endpoints {
 		eps[i] = endpoints[i]

--- a/provider/webhook/webhook.go
+++ b/provider/webhook/webhook.go
@@ -40,6 +40,9 @@ const (
 )
 
 var (
+	webhookProviderSpecificPropertyFilter = endpoint.ProviderSpecificPropertyFilter{
+		Prefixes: []string{"webhook/"},
+	}
 	recordsErrorsGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "external_dns",
@@ -242,6 +245,9 @@ func (p WebhookProvider) ApplyChanges(ctx context.Context, changes *plan.Changes
 // based on a provider specific requirement.
 // This method returns an empty slice in case there is a technical error on the provider's side so that no endpoints will be considered.
 func (p WebhookProvider) AdjustEndpoints(e []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
+	// Filter out ProviderSpecificProperties not recognized by this Provider
+	webhookProviderSpecificPropertyFilter.Filter(e)
+
 	adjustEndpointsRequestsGauge.Inc()
 	endpoints := []*endpoint.Endpoint{}
 	u, err := url.JoinPath(p.remoteServerURL.String(), "adjustendpoints")

--- a/provider/webhook/webhook_test.go
+++ b/provider/webhook/webhook_test.go
@@ -176,6 +176,16 @@ func TestAdjustEndpoints(t *testing.T) {
 			Targets: endpoint.Targets{
 				"",
 			},
+			ProviderSpecific: endpoint.ProviderSpecific{
+				{
+					Name:  "webhook/property",
+					Value: "value",
+				},
+				{
+					Name:  "extra/property",
+					Value: "value",
+				},
+			},
 		},
 	}
 	adjustedEndpoints, err := provider.AdjustEndpoints(endpoints)
@@ -186,6 +196,12 @@ func TestAdjustEndpoints(t *testing.T) {
 		RecordType: "A",
 		Targets: endpoint.Targets{
 			"",
+		},
+		ProviderSpecific: endpoint.ProviderSpecific{
+			{
+				Name:  "webhook/property",
+				Value: "value",
+			},
 		},
 	}}, adjustedEndpoints)
 }


### PR DESCRIPTION
**Description**

Currently if an endpoint contains a provider specific property for a provider other than the currently configured provider, the current provider will still consider it in the desired state. This will cause the endpoint to be marked as needing an update because when the provider loads the actual state it will never have that specific property set (ie. the desired and actual state never match). This causes unnecessary updates to be made on every sync.

This PR updates the providers to only consider its own specific properties (ie. ignore properties for other providers).

**Checklist**

- [X] Unit tests updated
- [ ] End user documentation updated
