### PR TITLE
Allow using envFrom to load environment variables

### DIFF
--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -84,6 +84,10 @@ spec:
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args:
             - --log-level={{ .Values.logLevel }}
             - --log-format={{ .Values.logFormat }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -113,6 +113,9 @@ securityContext:
 # -- [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `external-dns` container.
 env: []
 
+# -- [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `external-dns` container.
+envFrom: []
+
 # -- [Liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `external-dns` container.
 # @default -- See _values.yaml_
 livenessProbe:


### PR DESCRIPTION
**Description**

This change is in support of loading environment variables from secrets. The Gandi provider requires the use of an environment variable that needs to be presented securely and this facilitates that.

Fixes #4670

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
