### PR TITLE
Fix AWS Cloud Map docs: annotation key/value pairs must be strings

### DIFF
--- a/docs/tutorials/aws-sd.md
+++ b/docs/tutorials/aws-sd.md
@@ -221,7 +221,7 @@ metadata:
   name: nginx
   annotations:
     external-dns.alpha.kubernetes.io/hostname: nginx.external-dns-test.my-org.com
-    external-dns.alpha.kubernetes.io/ttl: 60
+    external-dns.alpha.kubernetes.io/ttl: "60"
 spec:
     ...
 ```


### PR DESCRIPTION
**Description**
As-is, following the docs results in the following error:

```
json: cannot unmarshal number into Go struct field ObjectMeta.metadata.annotations of type string
```

Related to #4640 while going through the AWS Cloud Map API docs to validate the migration to aws-sdk-go-v2

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
