### PR TITLE
feat(digitalocean): add mx and txt records support

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ The following tutorials are provided:
 * [NS1](docs/tutorials/ns1.md)
 * [NS Record Creation with CRD Source](docs/sources/ns-record.md)
 * [MX Record Creation with CRD Source](docs/sources/mx-record.md)
+* [TXT Record Creation with CRD Source](docs/sources/txt-record.md)
 * [OpenStack Designate](docs/tutorials/designate.md)
 * [Oracle Cloud Infrastructure (OCI) DNS](docs/tutorials/oracle.md)
 * [PowerDNS](docs/tutorials/pdns.md)

--- a/docs/sources/mx-record.md
+++ b/docs/sources/mx-record.md
@@ -1,12 +1,12 @@
 # MX record with CRD source
 
 You can create and manage MX records with the help of [CRD source](../contributing/crd-source.md)
-and `DNSEndpoint` CRD. Currently, this feature is only supported by `aws`, `azure`, and `google` providers.
+and `DNSEndpoint` CRD. Currently, this feature is only supported by `aws`, `azure`, `google` and `digital_ocean` providers.
 
 In order to start managing MX records you need to set the `--managed-record-types MX` flag.
 
 ```console
-external-dns --source crd --provider {aws|azure|google} --managed-record-types A --managed-record-types CNAME --managed-record-types MX
+external-dns --source crd --provider {aws|azure|google|digital_ocean} --managed-record-types A --managed-record-types CNAME --managed-record-types MX
 ```
 
 Targets within the CRD need to be specified according to the RFC 1034 (section 3.6.1). Below is an example of

--- a/docs/sources/mx-record.md
+++ b/docs/sources/mx-record.md
@@ -1,12 +1,12 @@
 # MX record with CRD source
 
 You can create and manage MX records with the help of [CRD source](../contributing/crd-source.md)
-and `DNSEndpoint` CRD. Currently, this feature is only supported by `aws`, `azure`, `google` and `digital_ocean` providers.
+and `DNSEndpoint` CRD. Currently, this feature is only supported by `aws`, `azure`, `google` and `digitalocean` providers.
 
 In order to start managing MX records you need to set the `--managed-record-types MX` flag.
 
 ```console
-external-dns --source crd --provider {aws|azure|google|digital_ocean} --managed-record-types A --managed-record-types CNAME --managed-record-types MX
+external-dns --source crd --provider {aws|azure|google|digitalocean} --managed-record-types A --managed-record-types CNAME --managed-record-types MX
 ```
 
 Targets within the CRD need to be specified according to the RFC 1034 (section 3.6.1). Below is an example of

--- a/docs/sources/txt-record.md
+++ b/docs/sources/txt-record.md
@@ -1,12 +1,12 @@
 # Creating TXT record with CRD source
 
 You can create and manage TXT records with the help of [CRD source](../contributing/crd-source.md)
-and `DNSEndpoint` CRD. Currently, this feature is only supported by `digital_ocean` providers.
+and `DNSEndpoint` CRD. Currently, this feature is only supported by `digitalocean` providers.
 
-In order to start managing MX records you need to set the `--managed-record-types TXT` flag.
+In order to start managing TXT records you need to set the `--managed-record-types TXT` flag.
 
 ```console
-external-dns --source crd --provider {digital_ocean} --managed-record-types A --managed-record-types CNAME --managed-record-types TXT
+external-dns --source crd --provider {digitalocean} --managed-record-types A --managed-record-types CNAME --managed-record-types TXT
 ```
 
 Targets within the CRD need to be specified according to the RFC 1035 (section 3.3.14). Below is an example of

--- a/docs/sources/txt-record.md
+++ b/docs/sources/txt-record.md
@@ -1,0 +1,30 @@
+# Creating TXT record with CRD source
+
+You can create and manage TXT records with the help of [CRD source](../contributing/crd-source.md)
+and `DNSEndpoint` CRD. Currently, this feature is only supported by `digital_ocean` providers.
+
+In order to start managing MX records you need to set the `--managed-record-types TXT` flag.
+
+```console
+external-dns --source crd --provider {digital_ocean} --managed-record-types A --managed-record-types CNAME --managed-record-types TXT
+```
+
+Targets within the CRD need to be specified according to the RFC 1035 (section 3.3.14). Below is an example of
+`example.com` DNS TXT two records creation.
+
+**NOTE** Current implementation do not support RFC 6763 (section 6).
+
+```yaml
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: examplemxrecord
+spec:
+  endpoints:
+    - dnsName: example.com
+      recordTTL: 180
+      recordType: TXT
+      targets:
+        - SOMETXT
+        - ANOTHERTXT
+```

--- a/provider/digitalocean/digital_ocean.go
+++ b/provider/digitalocean/digital_ocean.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/digitalocean/godo"
@@ -158,13 +159,15 @@ func (p *DigitalOceanProvider) Records(ctx context.Context) ([]*endpoint.Endpoin
 	endpoints := []*endpoint.Endpoint{}
 	for _, zone := range zones {
 		records, err := p.fetchRecords(ctx, zone.Name)
+
 		if err != nil {
 			return nil, err
 		}
 
 		for _, r := range records {
-			if provider.SupportedRecordType(r.Type) {
+			if p.SupportedRecordType(r.Type) {
 				name := r.Name + "." + zone.Name
+				data := r.Data
 
 				// root name is identified by @ and should be
 				// translated to zone name for the endpoint entry.
@@ -172,7 +175,11 @@ func (p *DigitalOceanProvider) Records(ctx context.Context) ([]*endpoint.Endpoin
 					name = zone.Name
 				}
 
-				ep := endpoint.NewEndpointWithTTL(name, r.Type, endpoint.TTL(r.TTL), r.Data)
+				if r.Type == endpoint.RecordTypeMX {
+					data = fmt.Sprintf("%d %s", r.Priority, r.Data)
+				}
+
+				ep := endpoint.NewEndpointWithTTL(name, r.Type, endpoint.TTL(r.TTL), data)
 
 				endpoints = append(endpoints, ep)
 			}
@@ -283,16 +290,26 @@ func makeDomainEditRequest(domain, name, recordType, data string, ttl int) *godo
 
 	// For some reason the DO API requires the '.' at the end of "data" in case of CNAME request.
 	// Example: {"type":"CNAME","name":"hello","data":"www.example.com."}
-	if recordType == endpoint.RecordTypeCNAME && !strings.HasSuffix(data, ".") {
+	if (recordType == endpoint.RecordTypeCNAME || recordType == endpoint.RecordTypeMX) && !strings.HasSuffix(data, ".") {
 		data += "."
 	}
 
-	return &godo.DomainRecordEditRequest{
+	request := &godo.DomainRecordEditRequest{
 		Name: adjustedName,
 		Type: recordType,
 		Data: data,
 		TTL:  ttl,
 	}
+
+	if recordType == endpoint.RecordTypeMX {
+		priority, domain, err := parseMxTarget(data)
+		if err == nil {
+			request.Priority = int(priority)
+			request.Data = provider.EnsureTrailingDot(domain)
+		}
+	}
+
+	return request
 }
 
 // submitChanges applies an instance of `digitalOceanChanges` to the DigitalOcean API.
@@ -303,13 +320,19 @@ func (p *DigitalOceanProvider) submitChanges(ctx context.Context, changes *digit
 	}
 
 	for _, c := range changes.Creates {
-		log.WithFields(log.Fields{
+		logFields := log.Fields{
 			"domain":     c.Domain,
 			"dnsName":    c.Options.Name,
 			"recordType": c.Options.Type,
 			"data":       c.Options.Data,
 			"ttl":        c.Options.TTL,
-		}).Debug("Creating domain record")
+		}
+
+		if c.Options.Type == endpoint.RecordTypeMX {
+			logFields["priotity"] = c.Options.Priority
+		}
+
+		log.WithFields(logFields).Debug("Creating domain record")
 
 		if p.DryRun {
 			continue
@@ -322,13 +345,17 @@ func (p *DigitalOceanProvider) submitChanges(ctx context.Context, changes *digit
 	}
 
 	for _, u := range changes.Updates {
-		log.WithFields(log.Fields{
+		logFields := log.Fields{
 			"domain":     u.Domain,
 			"dnsName":    u.Options.Name,
 			"recordType": u.Options.Type,
 			"data":       u.Options.Data,
 			"ttl":        u.Options.TTL,
-		}).Debug("Updating domain record")
+		}
+		if u.Options.Type == endpoint.RecordTypeMX {
+			logFields["priotity"] = u.Options.Priority
+		}
+		log.WithFields(logFields).Debug("Updating domain record")
 
 		if p.DryRun {
 			continue
@@ -589,6 +616,16 @@ func processDeleteActions(
 	return nil
 }
 
+// SupportedRecordType returns true if the record type is supported by the provider
+func (p *DigitalOceanProvider) SupportedRecordType(recordType string) bool {
+	switch recordType {
+	case "MX", "TXT":
+		return true
+	default:
+		return provider.SupportedRecordType(recordType)
+	}
+}
+
 // ApplyChanges applies the given set of generic changes to the provider.
 func (p *DigitalOceanProvider) ApplyChanges(ctx context.Context, planChanges *plan.Changes) error {
 	// TODO: This should only retrieve zones affected by the given `planChanges`.
@@ -616,4 +653,19 @@ func (p *DigitalOceanProvider) ApplyChanges(ctx context.Context, planChanges *pl
 	}
 
 	return p.submitChanges(ctx, &changes)
+}
+
+func parseMxTarget(mxTarget string) (priority int64, exchange string, err error) {
+	targetParts := strings.SplitN(mxTarget, " ", 2)
+	if len(targetParts) != 2 {
+		return priority, exchange, fmt.Errorf("mx target needs to be of form '10 example.com'")
+	}
+
+	priorityRaw, exchange := targetParts[0], targetParts[1]
+	priority, err = strconv.ParseInt(priorityRaw, 10, 32)
+	if err != nil {
+		return priority, exchange, fmt.Errorf("invalid priority specified")
+	}
+
+	return priority, exchange, nil
 }

--- a/provider/digitalocean/digital_ocean.go
+++ b/provider/digitalocean/digital_ocean.go
@@ -306,6 +306,13 @@ func makeDomainEditRequest(domain, name, recordType, data string, ttl int) *godo
 		if err == nil {
 			request.Priority = int(priority)
 			request.Data = provider.EnsureTrailingDot(domain)
+		} else {
+			log.WithFields(log.Fields{
+				"domain":     domain,
+				"dnsName":    name,
+				"recordType": recordType,
+				"data":       data,
+			}).Warn("Unable to parse MX target")
 		}
 	}
 
@@ -329,7 +336,7 @@ func (p *DigitalOceanProvider) submitChanges(ctx context.Context, changes *digit
 		}
 
 		if c.Options.Type == endpoint.RecordTypeMX {
-			logFields["priotity"] = c.Options.Priority
+			logFields["priority"] = c.Options.Priority
 		}
 
 		log.WithFields(logFields).Debug("Creating domain record")
@@ -353,7 +360,7 @@ func (p *DigitalOceanProvider) submitChanges(ctx context.Context, changes *digit
 			"ttl":        u.Options.TTL,
 		}
 		if u.Options.Type == endpoint.RecordTypeMX {
-			logFields["priotity"] = u.Options.Priority
+			logFields["priority"] = u.Options.Priority
 		}
 		log.WithFields(logFields).Debug("Updating domain record")
 
@@ -619,7 +626,7 @@ func processDeleteActions(
 // SupportedRecordType returns true if the record type is supported by the provider
 func (p *DigitalOceanProvider) SupportedRecordType(recordType string) bool {
 	switch recordType {
-	case "MX", "TXT":
+	case "MX":
 		return true
 	default:
 		return provider.SupportedRecordType(recordType)

--- a/provider/digitalocean/digital_ocean_test.go
+++ b/provider/digitalocean/digital_ocean_test.go
@@ -100,6 +100,9 @@ func (m *mockDigitalOceanClient) Records(ctx context.Context, domain string, opt
 					{ID: 1, Name: "foo.ext-dns-test", Type: "CNAME"},
 					{ID: 2, Name: "bar.ext-dns-test", Type: "CNAME"},
 					{ID: 3, Name: "@", Type: endpoint.RecordTypeCNAME},
+					{ID: 4, Name: "@", Type: endpoint.RecordTypeMX, Priority: 10, Data: "mx1.foo.com."},
+					{ID: 5, Name: "@", Type: endpoint.RecordTypeMX, Priority: 10, Data: "mx2.foo.com."},
+					{ID: 6, Name: "@", Type: endpoint.RecordTypeTXT, Data: "SOME-TXT-TEXT"},
 				}, &godo.Response{
 					Links: &godo.Links{
 						Pages: &godo.Pages{
@@ -344,6 +347,28 @@ func TestDigitalOceanMakeDomainEditRequest(t *testing.T) {
 		Data: "bar.example.com.",
 		TTL:  customTTL,
 	}, r4)
+
+	// Ensure that MX records have `.` appended.
+	r5 := makeDomainEditRequest("example.com", "foo.example.com", endpoint.RecordTypeMX,
+		"10 mx.example.com", digitalOceanRecordTTL)
+	assert.Equal(t, &godo.DomainRecordEditRequest{
+		Type:     endpoint.RecordTypeMX,
+		Name:     "foo",
+		Data:     "mx.example.com.",
+		Priority: 10,
+		TTL:      digitalOceanRecordTTL,
+	}, r5)
+
+	// Ensure that MX records do not have an extra `.` appended if they already have a `.`
+	r6 := makeDomainEditRequest("example.com", "foo.example.com", endpoint.RecordTypeMX,
+		"10 mx.example.com.", digitalOceanRecordTTL)
+	assert.Equal(t, &godo.DomainRecordEditRequest{
+		Type:     endpoint.RecordTypeMX,
+		Name:     "foo",
+		Data:     "mx.example.com.",
+		Priority: 10,
+		TTL:      digitalOceanRecordTTL,
+	}, r6)
 }
 
 func TestDigitalOceanApplyChanges(t *testing.T) {
@@ -375,6 +400,8 @@ func TestDigitalOceanProcessCreateActions(t *testing.T) {
 		"example.com": {
 			endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "foo.example.com"),
+			endpoint.NewEndpoint("example.com", endpoint.RecordTypeMX, "10 mx.example.com"),
+			endpoint.NewEndpoint("example.com", endpoint.RecordTypeTXT, "SOME-TXT-TEXT"),
 		},
 	}
 
@@ -382,7 +409,7 @@ func TestDigitalOceanProcessCreateActions(t *testing.T) {
 	err := processCreateActions(recordsByDomain, createsByDomain, &changes)
 	require.NoError(t, err)
 
-	assert.Equal(t, 2, len(changes.Creates))
+	assert.Equal(t, 4, len(changes.Creates))
 	assert.Equal(t, 0, len(changes.Updates))
 	assert.Equal(t, 0, len(changes.Deletes))
 
@@ -402,6 +429,25 @@ func TestDigitalOceanProcessCreateActions(t *testing.T) {
 				Name: "@",
 				Type: endpoint.RecordTypeCNAME,
 				Data: "foo.example.com.",
+				TTL:  digitalOceanRecordTTL,
+			},
+		},
+		{
+			Domain: "example.com",
+			Options: &godo.DomainRecordEditRequest{
+				Name:     "@",
+				Type:     endpoint.RecordTypeMX,
+				Priority: 10,
+				Data:     "mx.example.com.",
+				TTL:      digitalOceanRecordTTL,
+			},
+		},
+		{
+			Domain: "example.com",
+			Options: &godo.DomainRecordEditRequest{
+				Name: "@",
+				Type: endpoint.RecordTypeTXT,
+				Data: "SOME-TXT-TEXT",
 				TTL:  digitalOceanRecordTTL,
 			},
 		},
@@ -436,6 +482,29 @@ func TestDigitalOceanProcessUpdateActions(t *testing.T) {
 				Data: "foo.example.com.",
 				TTL:  digitalOceanRecordTTL,
 			},
+			{
+				ID:       4,
+				Name:     "@",
+				Type:     endpoint.RecordTypeMX,
+				Data:     "mx1.example.com.",
+				Priority: 10,
+				TTL:      digitalOceanRecordTTL,
+			},
+			{
+				ID:       5,
+				Name:     "@",
+				Type:     endpoint.RecordTypeMX,
+				Data:     "mx2.example.com.",
+				Priority: 10,
+				TTL:      digitalOceanRecordTTL,
+			},
+			{
+				ID:   6,
+				Name: "@",
+				Type: endpoint.RecordTypeTXT,
+				Data: "SOME_TXTX_TEXT",
+				TTL:  digitalOceanRecordTTL,
+			},
 		},
 	}
 
@@ -443,6 +512,8 @@ func TestDigitalOceanProcessUpdateActions(t *testing.T) {
 		"example.com": {
 			endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "10.11.12.13"),
 			endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "bar.example.com"),
+			endpoint.NewEndpoint("example.com", endpoint.RecordTypeMX, "10 mx3.example.com"),
+			endpoint.NewEndpoint("example.com", endpoint.RecordTypeTXT, "ANOTHER-TXT"),
 		},
 	}
 
@@ -450,9 +521,9 @@ func TestDigitalOceanProcessUpdateActions(t *testing.T) {
 	err := processUpdateActions(recordsByDomain, updatesByDomain, &changes)
 	require.NoError(t, err)
 
-	assert.Equal(t, 2, len(changes.Creates))
+	assert.Equal(t, 4, len(changes.Creates))
 	assert.Equal(t, 0, len(changes.Updates))
-	assert.Equal(t, 3, len(changes.Deletes))
+	assert.Equal(t, 6, len(changes.Deletes))
 
 	expectedCreates := []*digitalOceanChangeCreate{
 		{
@@ -470,6 +541,25 @@ func TestDigitalOceanProcessUpdateActions(t *testing.T) {
 				Name: "@",
 				Type: endpoint.RecordTypeCNAME,
 				Data: "bar.example.com.",
+				TTL:  digitalOceanRecordTTL,
+			},
+		},
+		{
+			Domain: "example.com",
+			Options: &godo.DomainRecordEditRequest{
+				Name:     "@",
+				Type:     endpoint.RecordTypeMX,
+				Data:     "mx3.example.com.",
+				Priority: 10,
+				TTL:      digitalOceanRecordTTL,
+			},
+		},
+		{
+			Domain: "example.com",
+			Options: &godo.DomainRecordEditRequest{
+				Name: "@",
+				Type: endpoint.RecordTypeTXT,
+				Data: "ANOTHER-TXT",
 				TTL:  digitalOceanRecordTTL,
 			},
 		},
@@ -491,6 +581,18 @@ func TestDigitalOceanProcessUpdateActions(t *testing.T) {
 		{
 			Domain:   "example.com",
 			RecordID: 3,
+		},
+		{
+			Domain:   "example.com",
+			RecordID: 4,
+		},
+		{
+			Domain:   "example.com",
+			RecordID: 5,
+		},
+		{
+			Domain:   "example.com",
+			RecordID: 6,
 		},
 	}
 
@@ -597,6 +699,26 @@ func TestDigitalOceanGetMatchingDomainRecords(t *testing.T) {
 			Type: endpoint.RecordTypeA,
 			Data: "9.10.11.12",
 		},
+		{
+			ID:       5,
+			Name:     "@",
+			Type:     endpoint.RecordTypeMX,
+			Priority: 10,
+			Data:     "mx1.foo.com.",
+		},
+		{
+			ID:       6,
+			Name:     "@",
+			Type:     endpoint.RecordTypeMX,
+			Priority: 10,
+			Data:     "mx2.foo.com.",
+		},
+		{
+			ID:   7,
+			Name: "@",
+			Type: endpoint.RecordTypeTXT,
+			Data: "MYTXT",
+		},
 	}
 
 	ep1 := endpoint.NewEndpoint("foo.com", endpoint.RecordTypeCNAME)
@@ -627,6 +749,17 @@ func TestDigitalOceanGetMatchingDomainRecords(t *testing.T) {
 	r2 := getMatchingDomainRecords(records, "example.com", ep4)
 	assert.Equal(t, 1, len(r2))
 	assert.Equal(t, "9.10.11.12", r2[0].Data)
+
+	ep5 := endpoint.NewEndpoint("example.com", endpoint.RecordTypeMX)
+	r3 := getMatchingDomainRecords(records, "example.com", ep5)
+	assert.Equal(t, 2, len(r3))
+	assert.Equal(t, "mx1.foo.com.", r3[0].Data)
+	assert.Equal(t, "mx2.foo.com.", r3[1].Data)
+
+	ep6 := endpoint.NewEndpoint("example.com", endpoint.RecordTypeTXT)
+	r4 := getMatchingDomainRecords(records, "example.com", ep6)
+	assert.Equal(t, 1, len(r4))
+	assert.Equal(t, "MYTXT", r4[0].Data)
 }
 
 func validateDigitalOceanZones(t *testing.T, zones []godo.Domain, expected []godo.Domain) {
@@ -663,7 +796,7 @@ func TestDigitalOceanAllRecords(t *testing.T) {
 	if err != nil {
 		t.Errorf("should not fail, %s", err)
 	}
-	require.Equal(t, 5, len(records))
+	require.Equal(t, 7, len(records))
 
 	provider.Client = &mockDigitalOceanRecordsFail{}
 	_, err = provider.Records(ctx)
@@ -678,11 +811,13 @@ func TestDigitalOceanMergeRecordsByNameType(t *testing.T) {
 		endpoint.NewEndpoint("bar.example.com", "A", "1.2.3.4"),
 		endpoint.NewEndpoint("foo.example.com", "A", "5.6.7.8"),
 		endpoint.NewEndpoint("foo.example.com", "CNAME", "somewhere.out.there.com"),
+		endpoint.NewEndpoint("bar.example.com", "MX", "10 bar.mx1.com"),
+		endpoint.NewEndpoint("bar.example.com", "MX", "10 bar.mx2.com"),
 	}
 
 	merged := mergeEndpointsByNameType(xs)
 
-	assert.Equal(t, 3, len(merged))
+	assert.Equal(t, 4, len(merged))
 	sort.SliceStable(merged, func(i, j int) bool {
 		if merged[i].DNSName != merged[j].DNSName {
 			return merged[i].DNSName < merged[j].DNSName
@@ -693,14 +828,17 @@ func TestDigitalOceanMergeRecordsByNameType(t *testing.T) {
 	assert.Equal(t, "A", merged[0].RecordType)
 	assert.Equal(t, 1, len(merged[0].Targets))
 	assert.Equal(t, "1.2.3.4", merged[0].Targets[0])
-
-	assert.Equal(t, "foo.example.com", merged[1].DNSName)
-	assert.Equal(t, "A", merged[1].RecordType)
+	assert.Equal(t, "MX", merged[1].RecordType)
 	assert.Equal(t, 2, len(merged[1].Targets))
-	assert.ElementsMatch(t, []string{"1.2.3.4", "5.6.7.8"}, merged[1].Targets)
+	assert.ElementsMatch(t, []string{"10 bar.mx1.com", "10 bar.mx2.com"}, merged[1].Targets)
 
 	assert.Equal(t, "foo.example.com", merged[2].DNSName)
-	assert.Equal(t, "CNAME", merged[2].RecordType)
-	assert.Equal(t, 1, len(merged[2].Targets))
-	assert.Equal(t, "somewhere.out.there.com", merged[2].Targets[0])
+	assert.Equal(t, "A", merged[2].RecordType)
+	assert.Equal(t, 2, len(merged[2].Targets))
+	assert.ElementsMatch(t, []string{"1.2.3.4", "5.6.7.8"}, merged[2].Targets)
+
+	assert.Equal(t, "foo.example.com", merged[3].DNSName)
+	assert.Equal(t, "CNAME", merged[3].RecordType)
+	assert.Equal(t, 1, len(merged[3].Targets))
+	assert.Equal(t, "somewhere.out.there.com", merged[3].Targets[0])
 }

--- a/provider/digitalocean/digital_ocean_test.go
+++ b/provider/digitalocean/digital_ocean_test.go
@@ -813,11 +813,13 @@ func TestDigitalOceanMergeRecordsByNameType(t *testing.T) {
 		endpoint.NewEndpoint("foo.example.com", "CNAME", "somewhere.out.there.com"),
 		endpoint.NewEndpoint("bar.example.com", "MX", "10 bar.mx1.com"),
 		endpoint.NewEndpoint("bar.example.com", "MX", "10 bar.mx2.com"),
+		endpoint.NewEndpoint("foo.example.com", "TXT", "txtone"),
+		endpoint.NewEndpoint("foo.example.com", "TXT", "txttwo"),
 	}
 
 	merged := mergeEndpointsByNameType(xs)
 
-	assert.Equal(t, 4, len(merged))
+	assert.Equal(t, 5, len(merged))
 	sort.SliceStable(merged, func(i, j int) bool {
 		if merged[i].DNSName != merged[j].DNSName {
 			return merged[i].DNSName < merged[j].DNSName
@@ -841,4 +843,9 @@ func TestDigitalOceanMergeRecordsByNameType(t *testing.T) {
 	assert.Equal(t, "CNAME", merged[3].RecordType)
 	assert.Equal(t, 1, len(merged[3].Targets))
 	assert.Equal(t, "somewhere.out.there.com", merged[3].Targets[0])
+
+	assert.Equal(t, "foo.example.com", merged[4].DNSName)
+	assert.Equal(t, "TXT", merged[4].RecordType)
+	assert.Equal(t, 2, len(merged[4].Targets))
+	assert.ElementsMatch(t, []string{"txtone", "txttwo"}, merged[4].Targets)
 }


### PR DESCRIPTION
**Description**

Add support for MX and TXT records creation for DigitalOcean provider via CRD Source.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
