### PR TITLE
Do not risk exposing unauthenticated webhook port on container

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `provider.webhook.resources` behavior to correctly leverage resource limits ([#4560](https://github.com/kubernetes-sigs/external-dns/pull/4560))
 - Fixed `provider.webhook.imagePullPolicy` behavior to correctly leverage pull policy ([#4643](https://github.com/kubernetes-sigs/external-dns/pull/4643)) _@kimsondrup_
 - Add correct webhook metric port to `Service` and `ServiceMonitor` ([#4643](https://github.com/kubernetes-sigs/external-dns/pull/4643)) _@kimsondrup_
+- No longer require the unauthenticated webhook provider port to be exposed for health probes ([#4691](https://github.com/kubernetes-sigs/external-dns/pull/4691)) _@kimsondrup_ _@hatrx_
 
 ## [v1.14.5] - 2023-06-10
 

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -134,7 +134,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | provider.webhook.readinessProbe | object | See _values.yaml_ | [Readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `webhook` container. |
 | provider.webhook.resources | object | `{}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the `webhook` container. |
 | provider.webhook.securityContext | object | See _values.yaml_ | [Pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) for the `webhook` container. |
-| provider.webhook.service.metricsPort | int | `8080` | Webhook metrics port for the service. |
+| provider.webhook.service.port | int | `8080` | Webhook exposed HTTP port for the service. |
 | provider.webhook.serviceMonitor | object | See _values.yaml_ | Optional [Service Monitor](https://prometheus-operator.dev/docs/operator/design/#servicemonitor) configuration for the `webhook` container. |
 | rbac.additionalPermissions | list | `[]` | Additional rules to add to the `ClusterRole`. |
 | rbac.create | bool | `true` | If `true`, create a `ClusterRole` & `ClusterRoleBinding` with access to the Kubernetes API. |

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -159,9 +159,6 @@ spec:
           ports:
             - name: http-webhook
               protocol: TCP
-              containerPort: 8888
-            - name: http-wh-metrics
-              protocol: TCP
               containerPort: 8080
           livenessProbe:
             {{- toYaml .livenessProbe | nindent 12 }}

--- a/charts/external-dns/templates/service.yaml
+++ b/charts/external-dns/templates/service.yaml
@@ -28,9 +28,9 @@ spec:
       protocol: TCP
     {{- if eq $providerName "webhook" }}
     {{- with .Values.provider.webhook.service }}
-    - name: http-wh-metrics
-      port: {{ .metricsPort }}
-      targetPort: http-wh-metrics
+    - name: http-webhook
+      port: {{ .port }}
+      targetPort: http-webhook
       protocol: TCP
     {{- end }}
     {{- end }}

--- a/charts/external-dns/templates/servicemonitor.yaml
+++ b/charts/external-dns/templates/servicemonitor.yaml
@@ -51,7 +51,7 @@ spec:
       {{- end }}
     {{- if eq $providerName "webhook" }}
     {{- with .Values.provider.webhook.serviceMonitor }}
-    - port: http-wh-metrics
+    - port: http-webhook
       path: /metrics
       {{- with .interval }}
       interval: {{ . }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -270,8 +270,8 @@ provider:
       failureThreshold: 6
       successThreshold: 1
     service:
-      # -- Webhook metrics port for the service.
-      metricsPort: 8080
+      # -- Webhook exposed HTTP port for the service.
+      port: 8080
     # -- Optional [Service Monitor](https://prometheus-operator.dev/docs/operator/design/#servicemonitor) configuration for the `webhook` container.
     # @default -- See _values.yaml_
     serviceMonitor:

--- a/docs/tutorials/webhook-provider.md
+++ b/docs/tutorials/webhook-provider.md
@@ -16,24 +16,32 @@ Providers implementing the HTTP API have to keep in sync with changes to the JSO
 
 The following table represents the methods to implement mapped to their HTTP method and route.
 
-| Provider method | HTTP Method | Route            |
-| ---             | ---         | ---              |
-| Records         | GET         | /records         |
-| AdjustEndpoints | POST        | /adjustendpoints |
-| ApplyChanges    | POST        | /records         |
-| K8s probe       | GET         | /healthz         |
+
+### Provider endpoints
+
+| Provider method | HTTP Method | Route            | Description                              |
+| --------------- | ----------- | ---------------- | ---------------------------------------- |
+| Negotiate       | GET         | /                | Negotiate `DomainFilter`                 |
+| Records         | GET         | /records         | Get records                              |
+| AdjustEndpoints | POST        | /adjustendpoints | Provider specific adjustments of records |
+| ApplyChanges    | POST        | /records         | Apply record                             |
 
 ExternalDNS will also make requests to the `/` endpoint for negotiation and for deserialization of the `DomainFilter`.
 
 The server needs to respond to those requests by reading the `Accept` header and responding with a corresponding `Content-Type` header specifying the supported media type format and version.
 
-The default recommended port is 8888, and should listen only on localhost (ie: only accessible for k8s probes and external-dns).
+The default recommended port for the provider endpoints is `8888`, and should listen only on `localhost` (ie: only accessible for external-dns).
 
 **NOTE**: only `5xx` responses will be retried and only `20x` will be considered as successful. All status codes different from those will be considered a failure on ExternalDNS's side.
 
-## Metrics support
+### Exposed endpoints
 
-The metrics should listen ":8080" on `/metrics` following [Open Metrics](https://github.com/OpenObservability/OpenMetrics) format.
+| Provider method | HTTP Method | Route    | Description                                                                                  |
+| --------------- | ----------- | -------- | -------------------------------------------------------------------------------------------- |
+| K8s probe       | GET         | /healthz | Used by `livenessProbe` and `readinessProbe`                                                 |
+| Open Metrics    | GET         | /metrics | Optional endpoint to expose [Open Metrics](https://github.com/OpenObservability/OpenMetrics) |
+
+The default recommended port for the exposed endpoints is `8080`, and it should be bound to all interfaces (`0.0.0.0`)
 
 ## Custom Annotations
 


### PR DESCRIPTION
**Description**

The current doc for the webhook provider expect the k8s probe to call localhost but the normal Kubernetes behavior is to call the pods IP so the current doc doesn't work.

Some implementers work around this by expecting users to override the `livenessProbe` and `readinessProbe` (see example [external-dns-ionos-webhook](https://github.com/ionos-cloud/external-dns-ionos-webhook/blob/6d6a95f787f1bd2594ecb44c36a9e6d8840a226f/README.md?plain=1#L49-L62)) but this might as well be upstreamed

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
