### PR TITLE
chore: upgrade ExternalDNS to go 1.23

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22.4'
+        go-version-file: go.mod
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,14 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     - name: Install CI
       run: |

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Install go version
       uses: actions/setup-go@v5
       with:
-        go-version: '^1.22.4'
+        go-version-file: go.mod
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,10 +25,6 @@ jobs:
           cache: "pip"
           cache-dependency-path: "./docs/scripts/requirements.txt"
 
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
-        with:
-          go-version-file: 'go.mod'
-
       - run: |
           pip install -r docs/scripts/requirements.txt
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,9 +28,9 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
-      id: go
 
     - name: Lint
       uses: golangci/golangci-lint-action@v6
       with:
+        args: --timeout=30m
         version: v1.60

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22.4'
+        go-version-file: go.mod
       id: go
 
     - name: Check out code into the Go module directory
@@ -31,5 +31,5 @@ jobs:
 
     - name: Lint
       run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.57.2
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.60.1
         make lint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read  #  to fetch code (actions/checkout)
+  checks: write
 
 jobs:
 
@@ -20,16 +21,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
       id: go
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
     - name: Lint
-      run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.60.1
-        make lint
+      uses: golangci/golangci-lint-action@v6
+      with:
+        version: v1.60

--- a/.github/workflows/staging-image-tester.yaml
+++ b/.github/workflows/staging-image-tester.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22.4'
+        go-version-file: go.mod
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/staging-image-tester.yaml
+++ b/.github/workflows/staging-image-tester.yaml
@@ -20,14 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     - name: Install CI
       run: |

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ CONTROLLER_GEN=$(shell which controller-gen)
 endif
 
 golangci-lint:
-	@command -v golangci-lint > /dev/null || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.60.1
+	@command -v golangci-lint > /dev/null || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.60.3
 
 # Run the golangci-lint tool
 .PHONY: go-lint

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ CONTROLLER_GEN=$(shell which controller-gen)
 endif
 
 golangci-lint:
-	@command -v golangci-lint > /dev/null || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.57.2
+	@command -v golangci-lint > /dev/null || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.60.1
 
 # Run the golangci-lint tool
 .PHONY: go-lint

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'docker.io/library/golang:1.22.4-bookworm'
+  - name: 'docker.io/library/golang:1.23-bookworm'
     entrypoint: make
     env:
       - VERSION=$_GIT_TAG

--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -1,7 +1,7 @@
 # Quick Start
 
 - [Git](https://git-scm.com/downloads)
-- [Go 1.22+](https://golang.org/dl/)
+- [Go 1.23+](https://golang.org/dl/)
 - [Go modules](https://github.com/golang/go/wiki/Modules)
 - [golangci-lint](https://github.com/golangci/golangci-lint)
 - [ko](https://ko.build/)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/external-dns
 
-go 1.22.4
+go 1.23
 
 require (
 	cloud.google.com/go/compute/metadata v0.5.0

--- a/provider/tencentcloud/cloudapi/mockapi.go
+++ b/provider/tencentcloud/cloudapi/mockapi.go
@@ -71,7 +71,7 @@ func (api *mockAPIService) DeletePrivateZoneRecord(request *privatedns.DeletePri
 	}
 	for _, privateZoneRecord := range api.privateZoneRecords[*request.ZoneId] {
 		deleteflag := false
-		if request.RecordIdSet != nil && len(request.RecordIdSet) != 0 {
+		if len(request.RecordIdSet) != 0 {
 			for _, recordId := range request.RecordIdSet {
 				if *privateZoneRecord.RecordId == *recordId {
 					deleteflag = true

--- a/provider/tencentcloud/cloudapi/tencentapi.go
+++ b/provider/tencentcloud/cloudapi/tencentapi.go
@@ -258,16 +258,16 @@ func dealWithError(action Action, request string, err error) bool {
 }
 
 func APIErrorRecord(apiAction Action, request string, response string, err error) {
-	log.Infof(fmt.Sprintf("APIError API: %s/%s Request: %s, Response: %s, Error: %s", apiAction.Service, apiAction.Name, request, response, err.Error()))
+	log.Infof("APIError API: %s/%s Request: %s, Response: %s, Error: %s", apiAction.Service, apiAction.Name, request, response, err.Error())
 }
 
 func APIRecord(apiAction Action, request string, response string) {
 	message := fmt.Sprintf("APIRecord API: %s/%s Request: %s, Response: %s", apiAction.Service, apiAction.Name, request, response)
 
 	if apiAction.ReadOnly {
-		// log.Infof(message)
+		// log.Info(message)
 	} else {
-		log.Infof(message)
+		log.Info(message)
 	}
 }
 

--- a/provider/tencentcloud/dnspod.go
+++ b/provider/tencentcloud/dnspod.go
@@ -89,7 +89,7 @@ func (p *TencentCloudProvider) getDomainList() ([]*dnspod.DomainListItem, error)
 		if err != nil {
 			return nil, err
 		}
-		if response.Response.DomainList != nil && len(response.Response.DomainList) > 0 {
+		if len(response.Response.DomainList) > 0 {
 			if !p.domainFilter.IsConfigured() {
 				domainList = append(domainList, response.Response.DomainList...)
 			} else {
@@ -119,7 +119,7 @@ func (p *TencentCloudProvider) getDomainRecordList(domain string) ([]*dnspod.Rec
 		if err != nil {
 			return nil, err
 		}
-		if response.Response.RecordList != nil && len(response.Response.RecordList) > 0 {
+		if len(response.Response.RecordList) > 0 {
 			for _, record := range response.Response.RecordList {
 				if *record.Name == "@" && *record.Type == "NS" { // Special Record, Skip it.
 					continue

--- a/provider/tencentcloud/privatedns.go
+++ b/provider/tencentcloud/privatedns.go
@@ -110,7 +110,7 @@ func (p *TencentCloudProvider) getPrivateZones() ([]*privatedns.PrivateZone, err
 		if err != nil {
 			return nil, err
 		}
-		if response.Response.PrivateZoneSet != nil && len(response.Response.PrivateZoneSet) > 0 {
+		if len(response.Response.PrivateZoneSet) > 0 {
 			privateZones = append(privateZones, response.Response.PrivateZoneSet...)
 		}
 		totalCount = *response.Response.TotalCount
@@ -140,7 +140,7 @@ func (p *TencentCloudProvider) getPrivateZoneRecords(zoneId string) ([]*privated
 		if err != nil {
 			return nil, err
 		}
-		if response.Response.RecordSet != nil && len(response.Response.RecordSet) > 0 {
+		if len(response.Response.RecordSet) > 0 {
 			privateZoneRecords = append(privateZoneRecords, response.Response.RecordSet...)
 		}
 		totalCount = *response.Response.TotalCount

--- a/provider/vinyldns/vinyldns.go
+++ b/provider/vinyldns/vinyldns.go
@@ -92,7 +92,7 @@ func (p *vinyldnsProvider) Records(ctx context.Context) (endpoints []*endpoint.E
 			continue
 		}
 
-		log.Infof(fmt.Sprintf("Zone: [%s:%s]", zone.ID, zone.Name))
+		log.Infof("Zone: [%s:%s]", zone.ID, zone.Name)
 		records, err := p.client.RecordSets(zone.ID)
 		if err != nil {
 			return nil, err
@@ -101,7 +101,7 @@ func (p *vinyldnsProvider) Records(ctx context.Context) (endpoints []*endpoint.E
 		for _, r := range records {
 			if provider.SupportedRecordType(r.Type) {
 				recordsCount := len(r.Records)
-				log.Debugf(fmt.Sprintf("%s.%s.%d.%s", r.Name, r.Type, recordsCount, zone.Name))
+				log.Debugf("%s.%s.%d.%s", r.Name, r.Type, recordsCount, zone.Name)
 
 				// TODO: AAAA Records
 				if len(r.Records) > 0 {


### PR DESCRIPTION
**Description**

This update external dns to go 1.23.
Inspired by #4318

It also upgrade linter to latest version, v1.60.1.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
