### PR TITLE
Do not expose the AWS role external id in the logs

### DIFF
--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -86,7 +86,7 @@ type Config struct {
 	AWSZoneTagFilter                   []string
 	AWSAssumeRole                      string
 	AWSProfiles                        []string
-	AWSAssumeRoleExternalID            string
+	AWSAssumeRoleExternalID            string `secure:"yes"`
 	AWSBatchChangeSize                 int
 	AWSBatchChangeSizeBytes            int
 	AWSBatchChangeSizeValues           int

--- a/provider/aws/config.go
+++ b/provider/aws/config.go
@@ -102,7 +102,8 @@ func newV2Config(awsConfig AWSSessionConfig) (awsv2.Config, error) {
 		stsSvc := sts.NewFromConfig(cfg)
 		var assumeRoleOpts []func(*stscredsv2.AssumeRoleOptions)
 		if awsConfig.AssumeRoleExternalID != "" {
-			logrus.Infof("Assuming role: %s with external id %s", awsConfig.AssumeRole, awsConfig.AssumeRoleExternalID)
+			logrus.Infof("Assuming role %s with external id", awsConfig.AssumeRole)
+			logrus.Debugf("External id: %s", awsConfig.AssumeRoleExternalID)
 			assumeRoleOpts = []func(*stscredsv2.AssumeRoleOptions){
 				func(opts *stscredsv2.AssumeRoleOptions) {
 					opts.ExternalID = &awsConfig.AssumeRoleExternalID


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
This change conceals the AWS `ExternalId` from application logs to mitigate security risks, as exposing this identifier could enable attackers to exploit it for unauthorized cross-account access or privilege escalation.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes https://github.com/kubernetes-sigs/external-dns/issues/4277

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
