### PR TITLE
add ability to disable nodePort Support

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed automatic addition of pod selector labels to `affinity` and `topologySpreadConstraints` if not defined. ([#4666](https://github.com/kubernetes-sigs/external-dns/pull/4666)) _@pvickery-ParamountCommerce_
 - Fixed missing Ingress permissions when using Istio sources. ([#4845](https://github.com/kubernetes-sigs/external-dns/pull/4845)) _@joekhoobyar_
+- Added ability to disable nodePort support ([#4727](https://github.com/kubernetes-sigs/external-dns/pull/4727)) _@piperj_
 
 ## [v1.15.0] - 2024-09-11
 

--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -35,7 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed automatic addition of pod selector labels to `affinity` and `topologySpreadConstraints` if not defined. ([#4666](https://github.com/kubernetes-sigs/external-dns/pull/4666)) _@pvickery-ParamountCommerce_
 - Fixed missing Ingress permissions when using Istio sources. ([#4845](https://github.com/kubernetes-sigs/external-dns/pull/4845)) _@joekhoobyar_
-- Added ability to disable nodePort support ([#4727](https://github.com/kubernetes-sigs/external-dns/pull/4727)) _@piperj_
 
 ## [v1.15.0] - 2024-09-11
 

--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added ability to configure `imagePullSecrets` via helm `global` value. ([#4667](https://github.com/kubernetes-sigs/external-dns/pull/4667)) _@jkroepke_
 - Added options to configure `labelFilter` and `managedRecordTypes` via dedicated helm values. ([#4849](https://github.com/kubernetes-sigs/external-dns/pull/4849)) _@abaguas_
+- Added support for `ignore-nodeports` argument ([#4727](https://github.com/kubernetes-sigs/external-dns/pull/4727)) _@jpiper_
 
 ### Changed
 

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -58,8 +58,6 @@ For set up for a specific provider using the Helm chart, see the following links
 external-dns supports running on a namespaced only scope, too.
 If `namespaced=true` is defined, the helm chart will setup `Roles` and `RoleBindings` instead `ClusterRoles` and `ClusterRoleBindings`.
 
-Note that you might also need to set `ignoreNodePorts=true` if you do not have access to the `Node` resource in the cluster and you are using the `Pod` or `Service` source.
-
 ### Limited Supported
 
 Not all sources are supported in namespaced scope, since some sources depends on cluster-wide resources.
@@ -69,24 +67,24 @@ namespaces as `external-dns`.
 
 The annotation `external-dns.alpha.kubernetes.io/endpoints-type: NodeExternalIP` is not supported.
 
-If `namespaced` is set to `true`, please ensure that `sources` my only contains supported sources (Default: `service,ingress`).
+If `namespaced` is set to `true`, please ensure that `sources` only contains supported sources (Default: `service,ingress`).
 
 ### Support Matrix
 
-| Source                 | Supported  | Infos                  |
-|------------------------|------------|------------------------|
-| `ingress`              | ✅         |                        |
-| `istio-gateway`        | ✅         |                        |
-| `istio-virtualservice` | ✅         |                        |
-| `crd`                  | ✅         |                        |
-| `kong-tcpingress`      | ✅         |                        |
-| `openshift-route`      | ✅         |                        |
-| `skipper-routegroup`   | ✅         |                        |
-| `gloo-proxy`           | ✅         |                        |
-| `contour-httpproxy`    | ✅         |                        |
-| `pod`                  | ✅         |                        |
-| `service`              | ⚠️️         | NodePort not supported |
-| `node`                 | ❌         |                        |
+| Source                 | Supported  | Info                           |
+|------------------------|------------|--------------------------------|
+| `ingress`              | ✅         |                                |
+| `istio-gateway`        | ✅         |                                |
+| `istio-virtualservice` | ✅         |                                |
+| `crd`                  | ✅         |                                |
+| `kong-tcpingress`      | ✅         |                                |
+| `openshift-route`      | ✅         |                                |
+| `skipper-routegroup`   | ✅         |                                |
+| `gloo-proxy`           | ✅         |                                |
+| `contour-httpproxy`    | ✅         |                                |
+| `pod`                  | ⚠️         | hostNetwork pods not supported |
+| `service`              | ⚠️️         | NodePort not supported         |
+| `node`                 | ❌         |                                |
 
 ## Values
 

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -58,6 +58,8 @@ For set up for a specific provider using the Helm chart, see the following links
 external-dns supports running on a namespaced only scope, too.
 If `namespaced=true` is defined, the helm chart will setup `Roles` and `RoleBindings` instead `ClusterRoles` and `ClusterRoleBindings`.
 
+Note that you might also need to set `ignoreNodePorts=true` if you do not have access to the `Node` resource in the cluster and you are using the `Pod` or `Service` source.
+
 ### Limited Supported
 
 Not all sources are supported in namespaced scope, since some sources depends on cluster-wide resources.
@@ -82,9 +84,9 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | `skipper-routegroup`   | ✅         |                        |
 | `gloo-proxy`           | ✅         |                        |
 | `contour-httpproxy`    | ✅         |                        |
+| `pod`                  | ✅         |                        |
 | `service`              | ⚠️️         | NodePort not supported |
 | `node`                 | ❌         |                        |
-| `pod`                  | ❌         |                        |
 
 ## Values
 
@@ -106,6 +108,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | extraVolumes | list | `[]` | Extra [volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the `Pod`. |
 | fullnameOverride | string | `nil` | Override the full name of the chart. |
 | global.imagePullSecrets | list | `[]` | Global image pull secrets. |
+| ignoreNodePorts | bool | `false` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the `external-dns` container. |
 | image.repository | string | `"registry.k8s.io/external-dns/external-dns"` | Image repository for the `external-dns` container. |
 | image.tag | string | `nil` | Image tag for the `external-dns` container, this will default to `.Chart.AppVersion` if not set. |

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -106,7 +106,7 @@ If `namespaced` is set to `true`, please ensure that `sources` only contains sup
 | extraVolumes | list | `[]` | Extra [volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the `Pod`. |
 | fullnameOverride | string | `nil` | Override the full name of the chart. |
 | global.imagePullSecrets | list | `[]` | Global image pull secrets. |
-| ignoreNodePorts | bool | `false` |  |
+| ignoreNodePorts | bool | `false` | Disable nodePort support (for environments where access to Node resources is forbidden) |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the `external-dns` container. |
 | image.repository | string | `"registry.k8s.io/external-dns/external-dns"` | Image repository for the `external-dns` container. |
 | image.tag | string | `nil` | Image tag for the `external-dns` container, this will default to `.Chart.AppVersion` if not set. |

--- a/charts/external-dns/README.md.gotmpl
+++ b/charts/external-dns/README.md.gotmpl
@@ -53,6 +53,8 @@ For set up for a specific provider using the Helm chart, see the following links
 external-dns supports running on a namespaced only scope, too.
 If `namespaced=true` is defined, the helm chart will setup `Roles` and `RoleBindings` instead `ClusterRoles` and `ClusterRoleBindings`.
 
+Note that you might also need to set `ignoreNodePorts=true` if you do not have access to the `Node` resource in the cluster and you are using the `Pod` or `Service` source.
+
 ### Limited Supported
 
 Not all sources are supported in namespaced scope, since some sources depends on cluster-wide resources.
@@ -77,9 +79,9 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | `skipper-routegroup`   | ✅         |                        |
 | `gloo-proxy`           | ✅         |                        |
 | `contour-httpproxy`    | ✅         |                        |
+| `pod`                  | ✅         |                        |
 | `service`              | ⚠️️         | NodePort not supported |
 | `node`                 | ❌         |                        |
-| `pod`                  | ❌         |                        |
 
 
 {{ template "chart.requirementsSection" . }}

--- a/charts/external-dns/README.md.gotmpl
+++ b/charts/external-dns/README.md.gotmpl
@@ -53,8 +53,6 @@ For set up for a specific provider using the Helm chart, see the following links
 external-dns supports running on a namespaced only scope, too.
 If `namespaced=true` is defined, the helm chart will setup `Roles` and `RoleBindings` instead `ClusterRoles` and `ClusterRoleBindings`.
 
-Note that you might also need to set `ignoreNodePorts=true` if you do not have access to the `Node` resource in the cluster and you are using the `Pod` or `Service` source.
-
 ### Limited Supported
 
 Not all sources are supported in namespaced scope, since some sources depends on cluster-wide resources.
@@ -64,24 +62,24 @@ namespaces as `external-dns`.
 
 The annotation `external-dns.alpha.kubernetes.io/endpoints-type: NodeExternalIP` is not supported.
 
-If `namespaced` is set to `true`, please ensure that `sources` my only contains supported sources (Default: `service,ingress`).
+If `namespaced` is set to `true`, please ensure that `sources` only contains supported sources (Default: `service,ingress`).
 
 ### Support Matrix
 
-| Source                 | Supported  | Infos                  |
-|------------------------|------------|------------------------|
-| `ingress`              | ✅         |                        |
-| `istio-gateway`        | ✅         |                        |
-| `istio-virtualservice` | ✅         |                        |
-| `crd`                  | ✅         |                        |
-| `kong-tcpingress`      | ✅         |                        |
-| `openshift-route`      | ✅         |                        |
-| `skipper-routegroup`   | ✅         |                        |
-| `gloo-proxy`           | ✅         |                        |
-| `contour-httpproxy`    | ✅         |                        |
-| `pod`                  | ✅         |                        |
-| `service`              | ⚠️️         | NodePort not supported |
-| `node`                 | ❌         |                        |
+| Source                 | Supported  | Info                           |
+|------------------------|------------|--------------------------------|
+| `ingress`              | ✅         |                                |
+| `istio-gateway`        | ✅         |                                |
+| `istio-virtualservice` | ✅         |                                |
+| `crd`                  | ✅         |                                |
+| `kong-tcpingress`      | ✅         |                                |
+| `openshift-route`      | ✅         |                                |
+| `skipper-routegroup`   | ✅         |                                |
+| `gloo-proxy`           | ✅         |                                |
+| `contour-httpproxy`    | ✅         |                                |
+| `pod`                  | ⚠️         | hostNetwork pods not supported |
+| `service`              | ⚠️️         | NodePort not supported         |
+| `node`                 | ❌         |                                |
 
 
 {{ template "chart.requirementsSection" . }}

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -109,7 +109,7 @@ spec:
             {{- if .Values.namespaced }}
             - --namespace={{ .Release.Namespace }}
             {{- end }}
-            {{- if or (.Values.ignoreNodePorts .Values.namespaced)}}
+            {{- if or (eq .Values.ignoreNodePorts true) (eq .Values.namespaced true)}}
             - --ignore-nodeports=true
             {{- end }}
             {{- range .Values.domainFilters }}

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -109,7 +109,7 @@ spec:
             {{- if .Values.namespaced }}
             - --namespace={{ .Release.Namespace }}
             {{- end }}
-            {{- if .Values.ignoreNodePorts }}
+            {{- if or (.Values.ignoreNodePorts .Values.namespaced)}}
             - --ignore-nodeports=true
             {{- end }}
             {{- range .Values.domainFilters }}

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -109,6 +109,9 @@ spec:
             {{- if .Values.namespaced }}
             - --namespace={{ .Release.Namespace }}
             {{- end }}
+            {{- if .Values.ignoreNodePorts }}
+            - --ignore-nodeports=true
+            {{- end }}
             {{- range .Values.domainFilters }}
             - --domain-filter={{ . }}
             {{- end }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -235,6 +235,9 @@ labelFilter:
 # -- Record types to manage (default: A, AAAA, CNAME)
 managedRecordTypes: []
 
+# -- Disable nodePort support (for environments where access to Node resources is forbidden)
+ignoreNodePorts: false
+
 provider:
   # -- _ExternalDNS_ provider name; for the available providers and how to configure them see [README](https://github.com/kubernetes-sigs/external-dns/blob/master/charts/external-dns/README.md#providers).
   name: aws

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -44,6 +44,7 @@
 | `--[no-]traefik-disable-legacy` | Disable listeners on Resources under the traefik.containo.us API Group |
 | `--[no-]traefik-disable-new` | Disable listeners on Resources under the traefik.io API Group |
 | `--nat64-networks=NAT64-NETWORKS` | Adding an A record for each AAAA record in NAT64-enabled networks; specify multiple times for multiple possible nets (optional) |
+| `--[no-]ignore-nodeports` | Disables the nodeport functionality. Needed when source is set to service or pod in clusters where external-dns does not have permissions to watch node resources, with the caveat that you will not be able to sync node IPs (optional) |
 | `--provider=provider` | The DNS provider where the DNS records will be created (required, options: akamai, alibabacloud, aws, aws-sd, azure, azure-dns, azure-private-dns, civo, cloudflare, coredns, designate, digitalocean, dnsimple, exoscale, gandi, godaddy, google, ibmcloud, inmemory, linode, ns1, oci, ovh, pdns, pihole, plural, rfc2136, scaleway, skydns, tencentcloud, transip, ultradns, webhook) |
 | `--provider-cache-time=0s` | The time to cache the DNS provider record list requests. |
 | `--domain-filter=` | Limit possible target zones by a domain suffix; specify multiple times for multiple domains (optional) |

--- a/main.go
+++ b/main.go
@@ -150,6 +150,7 @@ func main() {
 		ResolveLoadBalancerHostname:    cfg.ResolveServiceLoadBalancerHostname,
 		TraefikDisableLegacy:           cfg.TraefikDisableLegacy,
 		TraefikDisableNew:              cfg.TraefikDisableNew,
+		IgnoreNodePorts:                cfg.IgnoreNodePorts,
 	}
 
 	// Lookup all the selected sources by names and pass them the desired configuration.

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -206,6 +206,7 @@ type Config struct {
 	TraefikDisableLegacy               bool
 	TraefikDisableNew                  bool
 	NAT64Networks                      []string
+	IgnoreNodePorts                    bool
 }
 
 var defaultConfig = &Config{
@@ -359,6 +360,7 @@ var defaultConfig = &Config{
 	TraefikDisableLegacy:        false,
 	TraefikDisableNew:           false,
 	NAT64Networks:               []string{},
+	IgnoreNodePorts:             false,
 }
 
 // NewConfig returns new Config object
@@ -462,6 +464,7 @@ func App(cfg *Config) *kingpin.Application {
 	app.Flag("traefik-disable-legacy", "Disable listeners on Resources under the traefik.containo.us API Group").Default(strconv.FormatBool(defaultConfig.TraefikDisableLegacy)).BoolVar(&cfg.TraefikDisableLegacy)
 	app.Flag("traefik-disable-new", "Disable listeners on Resources under the traefik.io API Group").Default(strconv.FormatBool(defaultConfig.TraefikDisableNew)).BoolVar(&cfg.TraefikDisableNew)
 	app.Flag("nat64-networks", "Adding an A record for each AAAA record in NAT64-enabled networks; specify multiple times for multiple possible nets (optional)").StringsVar(&cfg.NAT64Networks)
+	app.Flag("ignore-nodeports", "Disables the nodeport functionality. Needed when source is set to service or pod in clusters where external-dns does not have permissions to watch node resources, with the caveat that you will not be able to sync node IPs (optional)").Default(strconv.FormatBool(defaultConfig.IgnoreNodePorts)).BoolVar(&cfg.IgnoreNodePorts)
 
 	// Flags related to providers
 	providers := []string{"akamai", "alibabacloud", "aws", "aws-sd", "azure", "azure-dns", "azure-private-dns", "civo", "cloudflare", "coredns", "designate", "digitalocean", "dnsimple", "exoscale", "gandi", "godaddy", "google", "ibmcloud", "inmemory", "linode", "ns1", "oci", "ovh", "pdns", "pihole", "plural", "rfc2136", "scaleway", "skydns", "tencentcloud", "transip", "ultradns", "webhook"}

--- a/source/compatibility.go
+++ b/source/compatibility.go
@@ -19,6 +19,8 @@ package source
 import (
 	"strings"
 
+	log "github.com/sirupsen/logrus"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -123,6 +125,11 @@ func legacyEndpointsFromDNSControllerService(svc *v1.Service, sc *serviceSource)
 // It will use node role label to check if the node has the "node" role. This means control plane nodes and other
 // roles will not be used as targets.
 func legacyEndpointsFromDNSControllerNodePortService(svc *v1.Service, sc *serviceSource) ([]*endpoint.Endpoint, error) {
+	if sc.nodeInformer == nil {
+		log.Warnf("Unable to extract nodePort targets from service %s/%s as nodePort support is disabled", svc.Namespace, svc.Name)
+		return nil, nil
+	}
+
 	var endpoints []*endpoint.Endpoint
 
 	// Get the desired hostname of the service from the annotations.

--- a/source/pod.go
+++ b/source/pod.go
@@ -51,7 +51,7 @@ func NewPodSource(ctx context.Context, kubeClient kubernetes.Interface, namespac
 		},
 	)
 	if disableNodeInformer {
-		log.Warnln("host information (host IP/hostname) for pods is disabled as the node informer is disabled")
+		log.Infoln("host information (host IP/hostname) for pods is disabled as the node informer is disabled")
 	} else {
 		nodeInformer = informerFactory.Core().V1().Nodes()
 		nodeInformer.Informer().AddEventHandler(

--- a/source/pod_test.go
+++ b/source/pod_test.go
@@ -662,7 +662,7 @@ func TestPodSource(t *testing.T) {
 				}
 			}
 
-			client, err := NewPodSource(context.TODO(), kubernetes, tc.targetNamespace, tc.compatibility)
+			client, err := NewPodSource(context.TODO(), kubernetes, tc.targetNamespace, tc.compatibility, false)
 			require.NoError(t, err)
 
 			endpoints, err := client.Endpoints(ctx)

--- a/source/service.go
+++ b/source/service.go
@@ -98,7 +98,7 @@ func NewServiceSource(ctx context.Context, kubeClient kubernetes.Interface, name
 	)
 
 	if disableNodeInformer {
-		log.Warnln("host information (host IP/hostname) for services is disabled as the node informer is disabled")
+		log.Infoln("host information (host IP/hostname) for services is disabled as the node informer is disabled")
 	} else {
 		nodeInformer = informerFactory.Core().V1().Nodes()
 		nodeInformer.Informer().AddEventHandler(

--- a/source/service.go
+++ b/source/service.go
@@ -97,7 +97,9 @@ func NewServiceSource(ctx context.Context, kubeClient kubernetes.Interface, name
 		},
 	)
 
-	if !disableNodeInformer {
+	if disableNodeInformer {
+		log.Warnln("host information (host IP/hostname) for services is disabled as the node informer is disabled")
+	} else {
 		nodeInformer = informerFactory.Core().V1().Nodes()
 		nodeInformer.Informer().AddEventHandler(
 			cache.ResourceEventHandlerFuncs{
@@ -312,7 +314,7 @@ func (sc *serviceSource) extractHeadlessEndpoints(svc *v1.Service, hostname stri
 				if len(targets) == 0 {
 					if endpointsType == EndpointsTypeNodeExternalIP {
 						if sc.nodeInformer == nil {
-							log.Warnf("Unable to extract nodePort targets from service %s/%s as nodePort support is disabled", svc.Namespace, svc.Name)
+							log.Debugf("Unable to extract nodePort targets from service %s/%s as nodePort support is disabled", svc.Namespace, svc.Name)
 							continue
 						}
 						node, err := sc.nodeInformer.Lister().Get(pod.Spec.NodeName)
@@ -499,7 +501,7 @@ func (sc *serviceSource) generateEndpoints(svc *v1.Service, hostname string, pro
 		case v1.ServiceTypeNodePort:
 			// NodePort support is disabled
 			if sc.nodeInformer == nil {
-				log.Warnf("Unable to extract nodePort targets from service %s/%s as nodePort support is disabled", svc.Namespace, svc.Name)
+				log.Debugf("Unable to extract nodePort targets from service %s/%s as node informer is disabled", svc.Namespace, svc.Name)
 				return endpoints
 			}
 			// add the nodeTargets and extract an SRV endpoint

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -80,6 +80,7 @@ func (suite *ServiceSuite) SetupTest() {
 		false,
 		labels.Everything(),
 		false,
+		false,
 	)
 	suite.NoError(err, "should initialize service source")
 }
@@ -160,6 +161,7 @@ func testServiceSourceNewServiceSource(t *testing.T) {
 				ti.serviceTypesFilter,
 				false,
 				labels.Everything(),
+				false,
 				false,
 			)
 
@@ -1132,6 +1134,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				tc.ignoreHostnameAnnotation,
 				sourceLabel,
 				tc.resolveLoadBalancerHostname,
+				false,
 			)
 
 			require.NoError(t, err)
@@ -1345,6 +1348,7 @@ func testMultipleServicesEndpoints(t *testing.T) {
 				tc.serviceTypesFilter,
 				tc.ignoreHostnameAnnotation,
 				labels.Everything(),
+				false,
 				false,
 			)
 			require.NoError(t, err)
@@ -1648,6 +1652,7 @@ func TestClusterIpServices(t *testing.T) {
 				[]string{},
 				tc.ignoreHostnameAnnotation,
 				labelSelector,
+				false,
 				false,
 			)
 			require.NoError(t, err)
@@ -2366,6 +2371,7 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 				[]string{},
 				tc.ignoreHostnameAnnotation,
 				labels.Everything(),
+				false,
 				false,
 			)
 			require.NoError(t, err)
@@ -3095,6 +3101,7 @@ func TestHeadlessServices(t *testing.T) {
 				tc.ignoreHostnameAnnotation,
 				labels.Everything(),
 				false,
+				false,
 			)
 			require.NoError(t, err)
 
@@ -3554,6 +3561,7 @@ func TestHeadlessServicesHostIP(t *testing.T) {
 				tc.ignoreHostnameAnnotation,
 				labels.Everything(),
 				false,
+				false,
 			)
 			require.NoError(t, err)
 
@@ -3732,6 +3740,7 @@ func TestExternalServices(t *testing.T) {
 				tc.ignoreHostnameAnnotation,
 				labels.Everything(),
 				false,
+				false,
 			)
 			require.NoError(t, err)
 
@@ -3786,6 +3795,7 @@ func BenchmarkServiceEndpoints(b *testing.B) {
 		[]string{},
 		false,
 		labels.Everything(),
+		false,
 		false,
 	)
 	require.NoError(b, err)

--- a/source/store.go
+++ b/source/store.go
@@ -76,6 +76,7 @@ type Config struct {
 	ResolveLoadBalancerHostname    bool
 	TraefikDisableLegacy           bool
 	TraefikDisableNew              bool
+	IgnoreNodePorts                bool
 }
 
 // ClientGenerator provides clients
@@ -218,7 +219,7 @@ func BuildWithConfig(ctx context.Context, source string, p ClientGenerator, cfg 
 		if err != nil {
 			return nil, err
 		}
-		return NewServiceSource(ctx, client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.Compatibility, cfg.PublishInternal, cfg.PublishHostIP, cfg.AlwaysPublishNotReadyAddresses, cfg.ServiceTypeFilter, cfg.IgnoreHostnameAnnotation, cfg.LabelFilter, cfg.ResolveLoadBalancerHostname)
+		return NewServiceSource(ctx, client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.Compatibility, cfg.PublishInternal, cfg.PublishHostIP, cfg.AlwaysPublishNotReadyAddresses, cfg.ServiceTypeFilter, cfg.IgnoreHostnameAnnotation, cfg.LabelFilter, cfg.ResolveLoadBalancerHostname, cfg.IgnoreNodePorts)
 	case "ingress":
 		client, err := p.KubeClient()
 		if err != nil {
@@ -230,7 +231,7 @@ func BuildWithConfig(ctx context.Context, source string, p ClientGenerator, cfg 
 		if err != nil {
 			return nil, err
 		}
-		return NewPodSource(ctx, client, cfg.Namespace, cfg.Compatibility)
+		return NewPodSource(ctx, client, cfg.Namespace, cfg.Compatibility, cfg.IgnoreNodePorts)
 	case "gateway-httproute":
 		return NewGatewayHTTPRouteSource(p, cfg)
 	case "gateway-grpcroute":


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

When running external-dns in a multi-tenant environment (e.g. in `namespaced=true` mode in the helm chart), users may not be in a position to give access to the `Node` resource to the external-dns deployment. At the moment, external-dns will not function without access to the `Node` resource as a Node informer is always created by the `Pod` and `Service` sources.

In this PR I add the flag `--ignore-nodeports` that disables the Node informer and then ensures the `Pod` and `Service` sources makes no attempt to try and retrieve any information from the `Node` resource.