### PR TITLE
fix(aws): add soft error

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -422,7 +422,7 @@ func (p *AWSProvider) records(ctx context.Context, zones map[string]*profiledZon
 		for paginator.HasMorePages() {
 			resp, err := paginator.NextPage(ctx)
 			if err != nil {
-				return nil, fmt.Errorf("failed to list resource records sets for zone %s using aws profile %q: %w", *z.zone.Id, z.profile, err)
+				return nil, provider.NewSoftError(fmt.Errorf("failed to list resource records sets for zone %s using aws profile %q: %w", *z.zone.Id, z.profile, err))
 			}
 
 			for _, r := range resp.ResourceRecordSets {


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes (again) #4067 because it was partly revert by #3973.

Add the ability to have a soft error when it fails to list resource records sets for zone. For example, if the cause of the error is the throttling of the AWS Route53 API `Throttling: Rate exceeded' status code: 400` , it is certainly not helpful if it is not a soft error and flags to improve the situation such as `--min-event-sync-interval` can not work.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
-> Both are not needed