### PR TITLE
Add GitHub CodeSpace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/go
+{
+	"name": "Go",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/go:1-1.22-bookworm",
+	"features": {
+		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+			"version": "latest",
+			"helm": "latest",
+			"minikube": "latest"
+		},
+		"ghcr.io/guiyomh/features/golangci-lint:0": {
+			"version": "latest"
+		},
+		"ghcr.io/robbert229/devcontainer-features/ko:1": {
+			"version": "0.14.1"
+		}
+	},
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": [
+		"go version",
+		"make build",
+		// login to remote k8s cluster
+		"./build/external-dns --source=service --provider=inmemory --once"
+	],
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"golang.go"
+			]
+		}
+	}
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,8 @@
 		"go version",
 		"make build",
 		// login to remote k8s cluster
-		"./build/external-dns --source=service --provider=inmemory --once"
+		"./build/external-dns --source=service --provider=inmemory --once",
+		"go install github.com/nektos/act@v0.2.24"
 	],
 	// Configure tool-specific properties.
 	"customizations": {

--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -58,3 +58,7 @@ Follow the installation instructions in the nektos/act [README.md](https://githu
 Afterwards just run `act` within the root folder of the project.
 
 For further usage of `act` refer to its documentation.
+
+# Editting in GitHub CodeSpaces
+
+[GitHub CodeSpaces](https://github.com/features/codespaces) gets you up and coding faster with fully configured, secure cloud development environments native to GitHub. The CodeSpace is configured with Golang 1.22, act, [Helm](helm.sh), [minikube](https://minikube.sigs.k8s.io), [kubectl](https://kubernetes.io/docs/reference/kubectl), and golangci-lint already installed.


### PR DESCRIPTION
**Description**

Add CodeSpace configuration that includes Go 1.22-bookworm, Helm, Minikube and golangci-lint. In order to make quick development easier and to reduce local complications.

Fixes #4742 

**Checklist**

- [ ] Unit tests updated
- [X] End user documentation updated
