### PR TITLE
Support SRV record creation with cloudflare provider

### DIFF
--- a/docs/sources/srv-record.md
+++ b/docs/sources/srv-record.md
@@ -1,0 +1,29 @@
+# SRV record with CRD source
+
+You can create and manage SRV records with the help of [CRD source](../contributing/crd-source.md)
+and `DNSEndpoint` CRD. The implementation of this feature depends on provider API support, this feature is currently known to be supported supported by `akamai`, `civo`, `cloudflare`, `ibmcloud`, `linode`, `rfc2136` and `pdns` providers.
+
+In order to start managing MX records you need to set the `--managed-record-types SRV` flag.
+
+```console
+external-dns --source crd --provider {akamai|civo|cloudflare|ibmcloud|linode|rfc2136|pdns} --managed-record-types A --managed-record-types CNAME --managed-record-types SRV
+```
+
+Targets within the CRD need to be specified according to the RFC 2782. Below is an example of
+`example.com` DNS SRV record. It specifies a `sip` service of `udp` protocol. It has two targets
+of identical priority but with different weights. They point to different backend servers.
+
+```yaml
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: examplesrvrecord
+spec:
+  endpoints:
+    - dnsName: _sip._udp.example.com
+      recordTTL: 180
+      recordType: SRV
+      targets:
+        - 10 10 5060 sip1.example.com
+        - 10 20 5060 sip2.example.com
+```

--- a/docs/sources/srv-record.md
+++ b/docs/sources/srv-record.md
@@ -1,7 +1,7 @@
 # SRV record with CRD source
 
 You can create and manage SRV records with the help of [CRD source](../contributing/crd-source.md)
-and `DNSEndpoint` CRD. The implementation of this feature depends on provider API support, this feature is currently known to be supported supported by `akamai`, `civo`, `cloudflare`, `ibmcloud`, `linode`, `rfc2136` and `pdns` providers.
+and `DNSEndpoint` CRD. The implementation of this feature depends on provider API support, this feature is currently known to be supported (at least) by `akamai`, `civo`, `cloudflare`, `ibmcloud`, `linode`, `rfc2136` and `pdns` providers.
 
 In order to start managing MX records you need to set the `--managed-record-types SRV` flag.
 

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -171,7 +171,7 @@ type RecordParamsTypes interface {
 }
 
 // updateDNSRecordParam is a function that returns the appropriate Record Param based on the cloudFlareChange passed in
-func updateDNSRecordParam(cfc cloudFlareChange) (cloudflare.UpdateDNSRecordParams) {
+func updateDNSRecordParam(cfc cloudFlareChange) cloudflare.UpdateDNSRecordParams {
 	recordParam := cloudflare.UpdateDNSRecordParams{
 		Name:    cfc.ResourceRecord.Name,
 		TTL:     cfc.ResourceRecord.TTL,
@@ -197,7 +197,7 @@ func updateDataLocalizationRegionalHostnameParams(cfc cloudFlareChange) cloudfla
 }
 
 // getCreateDNSRecordParam is a function that returns the appropriate Record Param based on the cloudFlareChange passed in
-func getCreateDNSRecordParam(cfc cloudFlareChange) (cloudflare.CreateDNSRecordParams) {
+func getCreateDNSRecordParam(cfc cloudFlareChange) cloudflare.CreateDNSRecordParams {
 	recordParam := cloudflare.CreateDNSRecordParams{
 		Name:    cfc.ResourceRecord.Name,
 		TTL:     cfc.ResourceRecord.TTL,

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -171,14 +171,21 @@ type RecordParamsTypes interface {
 }
 
 // updateDNSRecordParam is a function that returns the appropriate Record Param based on the cloudFlareChange passed in
-func updateDNSRecordParam(cfc cloudFlareChange) cloudflare.UpdateDNSRecordParams {
-	return cloudflare.UpdateDNSRecordParams{
+func updateDNSRecordParam(cfc cloudFlareChange) (cloudflare.UpdateDNSRecordParams, error) {
+	recordParam := cloudflare.UpdateDNSRecordParams{
 		Name:    cfc.ResourceRecord.Name,
 		TTL:     cfc.ResourceRecord.TTL,
 		Proxied: cfc.ResourceRecord.Proxied,
 		Type:    cfc.ResourceRecord.Type,
-		Content: cfc.ResourceRecord.Content,
 	}
+
+	if cfc.ResourceRecord.Type == "SRV" {
+		recordParam.Data = cfc.ResourceRecord.Data
+	} else {
+		recordParam.Content = cfc.ResourceRecord.Content
+	}
+
+	return recordParam, nil
 }
 
 // updateDataLocalizationRegionalHostnameParams is a function that returns the appropriate RegionalHostname Param based on the cloudFlareChange passed in
@@ -190,14 +197,53 @@ func updateDataLocalizationRegionalHostnameParams(cfc cloudFlareChange) cloudfla
 }
 
 // getCreateDNSRecordParam is a function that returns the appropriate Record Param based on the cloudFlareChange passed in
-func getCreateDNSRecordParam(cfc cloudFlareChange) cloudflare.CreateDNSRecordParams {
-	return cloudflare.CreateDNSRecordParams{
+func getCreateDNSRecordParam(cfc cloudFlareChange) (cloudflare.CreateDNSRecordParams, error) {
+	recordParam := cloudflare.CreateDNSRecordParams{
 		Name:    cfc.ResourceRecord.Name,
 		TTL:     cfc.ResourceRecord.TTL,
 		Proxied: cfc.ResourceRecord.Proxied,
 		Type:    cfc.ResourceRecord.Type,
-		Content: cfc.ResourceRecord.Content,
 	}
+
+	if cfc.ResourceRecord.Type == "SRV" {
+		recordParam.Data = cfc.ResourceRecord.Data
+	} else {
+		recordParam.Content = cfc.ResourceRecord.Content
+	}
+
+	return recordParam, nil
+}
+
+// parseSRVContent parses the SRV record content string into the structured data required by the Cloudflare API
+func parseSRVContent(content string) (map[string]interface{}, error) {
+	parts := strings.Fields(content)
+	if len(parts) != 4 {
+		return nil, fmt.Errorf("invalid SRV record content: %s", content)
+	}
+
+	priority, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("invalid priority in SRV record content: %s", parts[0])
+	}
+
+	weight, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid weight in SRV record content: %s", parts[1])
+	}
+
+	port, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return nil, fmt.Errorf("invalid port in SRV record content: %s", parts[2])
+	}
+
+	target := parts[3]
+
+	return map[string]interface{}{
+		"priority": priority,
+		"weight":   weight,
+		"port":     port,
+		"target":   target,
+	}, nil
 }
 
 // NewCloudFlareProvider initializes a new CloudFlare DNS based Provider.
@@ -430,9 +476,14 @@ func (p *CloudFlareProvider) submitChanges(ctx context.Context, changes []*cloud
 					log.WithFields(logFields).Errorf("failed to find previous record: %v", change.ResourceRecord)
 					continue
 				}
-				recordParam := updateDNSRecordParam(*change)
+				recordParam, err := updateDNSRecordParam(*change)
+				if err != nil {
+					failedChange = true
+					log.WithFields(logFields).Errorf("failed to get update DNS record param: %v", err)
+					continue
+				}
 				recordParam.ID = recordID
-				err := p.Client.UpdateDNSRecord(ctx, resourceContainer, recordParam)
+				err = p.Client.UpdateDNSRecord(ctx, resourceContainer, recordParam)
 				if err != nil {
 					failedChange = true
 					log.WithFields(logFields).Errorf("failed to update record: %v", err)
@@ -465,8 +516,13 @@ func (p *CloudFlareProvider) submitChanges(ctx context.Context, changes []*cloud
 					log.WithFields(logFields).Errorf("failed to delete custom hostname %v/%v: %v", chID, oldCh, chErr)
 				}
 			} else if change.Action == cloudFlareCreate {
-				recordParam := getCreateDNSRecordParam(*change)
-				_, err := p.Client.CreateDNSRecord(ctx, resourceContainer, recordParam)
+				recordParam, err := getCreateDNSRecordParam(*change)
+				if err != nil {
+					failedChange = true
+					log.WithFields(logFields).Errorf("failed to get create DNS record param: %v", err)
+					continue
+				}
+				_, err = p.Client.CreateDNSRecord(ctx, resourceContainer, recordParam)
 				if err != nil {
 					failedChange = true
 					log.WithFields(logFields).Errorf("failed to create record: %v", err)
@@ -549,12 +605,11 @@ func (p *CloudFlareProvider) getCustomHostnameIDbyOrigin(chs []cloudflare.Custom
 func (p *CloudFlareProvider) newCloudFlareChange(action string, endpoint *endpoint.Endpoint, target string) *cloudFlareChange {
 	ttl := defaultCloudFlareRecordTTL
 	proxied := shouldBeProxied(endpoint, p.proxiedByDefault)
-
 	if endpoint.RecordTTL.IsConfigured() {
 		ttl = int(endpoint.RecordTTL)
 	}
 	dt := time.Now()
-	return &cloudFlareChange{
+	change := &cloudFlareChange{
 		Action: action,
 		ResourceRecord: cloudflare.DNSRecord{
 			Name: endpoint.DNSName,
@@ -587,6 +642,19 @@ func (p *CloudFlareProvider) newCloudFlareChange(action string, endpoint *endpoi
 			},
 		},
 	}
+
+	if endpoint.RecordType == "SRV" {
+		srvData, err := parseSRVContent(target)
+		if err != nil {
+			log.Errorf("Error parsing SRV content: %v", err)
+			return nil
+		}
+		change.ResourceRecord.Data = srvData
+	} else {
+		change.ResourceRecord.Content = target
+	}
+
+	return change
 }
 
 // listDNSRecordsWithAutoPagination performs automatic pagination of results on requests to cloudflare.ListDNSRecords with custom per_page values
@@ -707,7 +775,19 @@ func groupByNameAndTypeWithCustomHostnames(records []cloudflare.DNSRecord, chs [
 		}
 		targets := make([]string, len(records))
 		for i, record := range records {
-			targets[i] = record.Content
+			if record.Type == "SRV" {
+				if dataMap, ok := record.Data.(map[string]interface{}); ok {
+					priority, _ := dataMap["priority"].(float64)
+					weight, _ := dataMap["weight"].(float64)
+					port, _ := dataMap["port"].(float64)
+					target, _ := dataMap["target"].(string)
+					targets[i] = fmt.Sprintf("%d %d %d %s", int(priority), int(weight), int(port), target)
+				} else {
+					log.Errorf("SRV record data is not in the expected format for record %s", record.Name)
+				}
+			} else {
+				targets[i] = record.Content
+			}
 		}
 		ep := endpoint.NewEndpointWithTTL(
 			records[0].Name,

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -171,7 +171,7 @@ type RecordParamsTypes interface {
 }
 
 // updateDNSRecordParam is a function that returns the appropriate Record Param based on the cloudFlareChange passed in
-func updateDNSRecordParam(cfc cloudFlareChange) (cloudflare.UpdateDNSRecordParams, error) {
+func updateDNSRecordParam(cfc cloudFlareChange) (cloudflare.UpdateDNSRecordParams) {
 	recordParam := cloudflare.UpdateDNSRecordParams{
 		Name:    cfc.ResourceRecord.Name,
 		TTL:     cfc.ResourceRecord.TTL,
@@ -185,7 +185,7 @@ func updateDNSRecordParam(cfc cloudFlareChange) (cloudflare.UpdateDNSRecordParam
 		recordParam.Content = cfc.ResourceRecord.Content
 	}
 
-	return recordParam, nil
+	return recordParam
 }
 
 // updateDataLocalizationRegionalHostnameParams is a function that returns the appropriate RegionalHostname Param based on the cloudFlareChange passed in
@@ -197,7 +197,7 @@ func updateDataLocalizationRegionalHostnameParams(cfc cloudFlareChange) cloudfla
 }
 
 // getCreateDNSRecordParam is a function that returns the appropriate Record Param based on the cloudFlareChange passed in
-func getCreateDNSRecordParam(cfc cloudFlareChange) (cloudflare.CreateDNSRecordParams, error) {
+func getCreateDNSRecordParam(cfc cloudFlareChange) (cloudflare.CreateDNSRecordParams) {
 	recordParam := cloudflare.CreateDNSRecordParams{
 		Name:    cfc.ResourceRecord.Name,
 		TTL:     cfc.ResourceRecord.TTL,
@@ -211,7 +211,7 @@ func getCreateDNSRecordParam(cfc cloudFlareChange) (cloudflare.CreateDNSRecordPa
 		recordParam.Content = cfc.ResourceRecord.Content
 	}
 
-	return recordParam, nil
+	return recordParam
 }
 
 // parseSRVContent parses the SRV record content string into the structured data required by the Cloudflare API
@@ -476,12 +476,7 @@ func (p *CloudFlareProvider) submitChanges(ctx context.Context, changes []*cloud
 					log.WithFields(logFields).Errorf("failed to find previous record: %v", change.ResourceRecord)
 					continue
 				}
-				recordParam, err := updateDNSRecordParam(*change)
-				if err != nil {
-					failedChange = true
-					log.WithFields(logFields).Errorf("failed to get update DNS record param: %v", err)
-					continue
-				}
+				recordParam := updateDNSRecordParam(*change)
 				recordParam.ID = recordID
 				err = p.Client.UpdateDNSRecord(ctx, resourceContainer, recordParam)
 				if err != nil {
@@ -516,12 +511,7 @@ func (p *CloudFlareProvider) submitChanges(ctx context.Context, changes []*cloud
 					log.WithFields(logFields).Errorf("failed to delete custom hostname %v/%v: %v", chID, oldCh, chErr)
 				}
 			} else if change.Action == cloudFlareCreate {
-				recordParam, err := getCreateDNSRecordParam(*change)
-				if err != nil {
-					failedChange = true
-					log.WithFields(logFields).Errorf("failed to get create DNS record param: %v", err)
-					continue
-				}
+				recordParam := getCreateDNSRecordParam(*change)
 				_, err = p.Client.CreateDNSRecord(ctx, resourceContainer, recordParam)
 				if err != nil {
 					failedChange = true

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -111,21 +111,31 @@ func NewMockCloudFlareClientWithRecords(records map[string][]cloudflare.DNSRecor
 func getDNSRecordFromRecordParams(rp any) cloudflare.DNSRecord {
 	switch params := rp.(type) {
 	case cloudflare.CreateDNSRecordParams:
-		return cloudflare.DNSRecord{
+		record := cloudflare.DNSRecord{
 			Name:    params.Name,
 			TTL:     params.TTL,
 			Proxied: params.Proxied,
 			Type:    params.Type,
-			Content: params.Content,
 		}
+		if params.Type == "SRV" {
+			record.Data = params.Data
+		} else {
+			record.Content = params.Content
+		}
+		return record
 	case cloudflare.UpdateDNSRecordParams:
-		return cloudflare.DNSRecord{
+		record := cloudflare.DNSRecord{
 			Name:    params.Name,
 			TTL:     params.TTL,
 			Proxied: params.Proxied,
 			Type:    params.Type,
-			Content: params.Content,
 		}
+		if params.Type == "SRV" {
+			record.Data = params.Data
+		} else {
+			record.Content = params.Content
+		}
+		return record
 	default:
 		return cloudflare.DNSRecord{}
 	}
@@ -373,9 +383,9 @@ func AssertActions(t *testing.T, provider *CloudFlareProvider, endpoints []*endp
 
 	changes := plan.Calculate().Changes
 
-	// Records other than A, CNAME and NS are not supported by planner, just create them
+	// Records other than A, CNAME, SRV and NS are not supported by planner, just create them
 	for _, endpoint := range endpoints {
-		if endpoint.RecordType != "A" && endpoint.RecordType != "CNAME" && endpoint.RecordType != "NS" {
+		if endpoint.RecordType != "A" && endpoint.RecordType != "CNAME" && endpoint.RecordType != "NS" && endpoint.RecordType != "SRV" {
 			changes.Create = append(changes.Create, endpoint)
 		}
 	}
@@ -486,6 +496,60 @@ func TestCloudflareCustomTTL(t *testing.T) {
 		},
 	},
 		[]string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
+	)
+}
+
+func TestCloudflareSRVRecord(t *testing.T) {
+	endpoints := []*endpoint.Endpoint{
+		{
+			RecordType: "SRV",
+			DNSName:    "_sip._tcp.srv.bar.com",
+			Targets:    endpoint.Targets{"10 20 5060 sip.bar.com", "10 50 5060 sip2.bar.com"},
+			RecordTTL:  120,
+		},
+	}
+
+	expectedActions := []MockAction{
+		{
+			Name:   "Create",
+			ZoneId: "001",
+			RecordData: cloudflare.DNSRecord{
+				Type: "SRV",
+				Name: "_sip._tcp.srv.bar.com",
+				Data: map[string]interface{}{
+					"priority": 10,
+					"weight":   20,
+					"port":     5060,
+					"target":   "sip.bar.com",
+				},
+				TTL:     120,
+				Proxied: proxyDisabled,
+			},
+		},
+		{
+			Name:   "Create",
+			ZoneId: "001",
+			RecordData: cloudflare.DNSRecord{
+				Type: "SRV",
+				Name: "_sip._tcp.srv.bar.com",
+				Data: map[string]interface{}{
+					"priority": 10,
+					"weight":   50,
+					"port":     5060,
+					"target":   "sip2.bar.com",
+				},
+				TTL:     120,
+				Proxied: proxyDisabled,
+			},
+		},
+	}
+
+	AssertActions(
+		t,
+		&CloudFlareProvider{},
+		endpoints,
+		expectedActions,
+		[]string{endpoint.RecordTypeSRV},
 	)
 }
 
@@ -635,7 +699,12 @@ func TestCloudflareSetProxied(t *testing.T) {
 			{
 				RecordType: testCase.recordType,
 				DNSName:    testCase.domain,
-				Targets:    endpoint.Targets{"127.0.0.1"},
+				Targets: func() endpoint.Targets {
+					if testCase.recordType == "SRV" {
+						return endpoint.Targets{"0 0 8080 127.0.0.1"} // Example SRV format: priority weight port target
+					}
+					return endpoint.Targets{"127.0.0.1"}
+				}(),
 				ProviderSpecific: endpoint.ProviderSpecific{
 					endpoint.ProviderSpecificProperty{
 						Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
@@ -645,19 +714,31 @@ func TestCloudflareSetProxied(t *testing.T) {
 			},
 		}
 
+		expectedRecord := cloudflare.DNSRecord{
+			Type:    testCase.recordType,
+			Name:    testCase.domain,
+			TTL:     1,
+			Proxied: testCase.proxiable,
+		}
+
+		if testCase.recordType == "SRV" {
+			expectedRecord.Data = map[string]interface{}{
+				"priority": 0,
+				"weight":   0,
+				"port":     8080,
+				"target":   "127.0.0.1",
+			}
+		} else {
+			expectedRecord.Content = "127.0.0.1"
+		}
+
 		AssertActions(t, &CloudFlareProvider{}, endpoints, []MockAction{
 			{
-				Name:   "Create",
-				ZoneId: "001",
-				RecordData: cloudflare.DNSRecord{
-					Type:    testCase.recordType,
-					Name:    testCase.domain,
-					Content: "127.0.0.1",
-					TTL:     1,
-					Proxied: testCase.proxiable,
-				},
+				Name:       "Create",
+				ZoneId:     "001",
+				RecordData: expectedRecord,
 			},
-		}, []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME, endpoint.RecordTypeNS}, testCase.recordType+" record on "+testCase.domain)
+		}, []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME, endpoint.RecordTypeNS, endpoint.RecordTypeSRV}, testCase.recordType+" record on "+testCase.domain)
 	}
 }
 


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Implements SRV record creation when using the cloudflare provider. Cloudflare's API requires sending SRV record data in structured fields rather than a bare string with the record.

I'm not a Go developer and just did the bare minimum to get this working and tested, I've confirmed this works on my personal cluster. Feel free to suggest improvements.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4751 

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated


