### PR TITLE
source node: Skip unschedulable nodes

### DIFF
--- a/docs/sources/nodes.md
+++ b/docs/sources/nodes.md
@@ -7,6 +7,9 @@ The node source adds an `A` record per each node `externalIP` (if not found, any
 It also adds an `AAAA` record per each node IPv6 `internalIP`.
 The TTL of the records can be set with the `external-dns.alpha.kubernetes.io/ttl` node annotation.
 
+Nodes marked as **Unschedulable** as per [core/v1/NodeSpec](https://pkg.go.dev/k8s.io/api@v0.31.1/core/v1#NodeSpec) are excluded.
+This avoid exposing Unhealthy, NotReady or SchedulingDisabled (cordon) nodes.
+
 ## Manifest (for cluster without RBAC enabled)
 
 ```

--- a/source/node.go
+++ b/source/node.go
@@ -102,6 +102,11 @@ func (ns *nodeSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, erro
 			continue
 		}
 
+		if node.Spec.Unschedulable {
+			log.Debugf("Skipping node %s because it is unschedulable", node.Name)
+			continue
+		}
+
 		log.Debugf("creating endpoint for node %s", node.Name)
 
 		ttl := getTTLFromAnnotations(node.Annotations, fmt.Sprintf("node/%s", node.Name))

--- a/source/node_test.go
+++ b/source/node_test.go
@@ -101,6 +101,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 		nodeAddresses    []v1.NodeAddress
 		labels           map[string]string
 		annotations      map[string]string
+		unschedulable    bool // default to false
 		expected         []*endpoint.Endpoint
 		expectError      bool
 	}{
@@ -321,6 +322,13 @@ func testNodeSourceEndpoints(t *testing.T) {
 				{RecordType: "A", DNSName: "node1", Targets: endpoint.Targets{"1.2.3.4"}, RecordTTL: endpoint.TTL(10)},
 			},
 		},
+		{
+			title:         "unschedulable node return nothing",
+			nodeName:      "node1",
+			nodeAddresses: []v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}},
+			unschedulable: true,
+			expected:      []*endpoint.Endpoint{},
+		},
 	} {
 		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
@@ -341,6 +349,9 @@ func testNodeSourceEndpoints(t *testing.T) {
 					Name:        tc.nodeName,
 					Labels:      tc.labels,
 					Annotations: tc.annotations,
+				},
+				Spec: v1.NodeSpec{
+					Unschedulable: tc.unschedulable,
 				},
 				Status: v1.NodeStatus{
 					Addresses: tc.nodeAddresses,


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

Skip unschedulable nodes to avoid adding nodes to a DNS round robin entry.

<!-- Please provide a summary of the change here. -->

Added in source/node.go a simple test regarding Node.Spec.Unschedulable.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes [#ISSUE](https://github.com/kubernetes-sigs/external-dns/issues/1112)

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
