### PR TITLE
Allow replica count to be set to zero

### DIFF
--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -139,6 +139,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | rbac.create | bool | `true` | If `true`, create a `ClusterRole` & `ClusterRoleBinding` with access to the Kubernetes API. |
 | readinessProbe | object | See _values.yaml_ | [Readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `external-dns` container. |
 | registry | string | `"txt"` | Specify the registry for storing ownership and labels. Valid values are `txt`, `aws-sd`, `dynamodb` & `noop`. |
+| replicaCount | int | `1` | Number of replicas to run. external-dns does not support more than one replica. This can be used to deploy to a failover cluster with zero replicas. |
 | resources | object | `{}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the `external-dns` container. |
 | revisionHistoryLimit | int | `nil` | Specify the number of old `ReplicaSets` to retain to allow rollback of the `Deployment``. |
 | secretConfiguration.data | object | `{}` | `Secret` data. |

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       {{- include "external-dns.selectorLabels" . | nindent 6 }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# -- Number of replicas to run. external-dns does not support more than one replica. This can be used to deploy to a failover cluster with zero replicas.
+replicaCount: 1
+
 image:
   # -- Image repository for the `external-dns` container.
   repository: registry.k8s.io/external-dns/external-dns


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**
Allows the replica count for external-dns deployments to be configurable as zero. external-dns helm installs can be done in secondary regions with zero replicas waiting to be scaled up during a failover event.  See #4783 

The helm chart values.yaml was commented to reflect that external-dns does not support more than one replica.

**Checklist**

- [ ] Unit tests updated
- [X] End user documentation updated
