### PR TITLE
Fix typo in Cloudflare tutorial

### DIFF
--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -129,17 +129,17 @@ spec:
             - --provider=cloudflare
             - --cloudflare-proxied # (optional) enable the proxy feature of Cloudflare (DDOS protection, CDN...)
             - --cloudflare-dns-records-per-page=5000 # (optional) configure how many DNS records to fetch per request
-      env:
-        - name: CF_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: cloudflare-api-key
-              key: apiKey
-        - name: CF_API_EMAIL
-          valueFrom:
-            secretKeyRef:
-              name: cloudflare-api-key
-              key: email
+          env:
+            - name: CF_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflare-api-key
+                  key: apiKey
+            - name: CF_API_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflare-api-key
+                  key: email
 ```
 
 ### Manifest (for clusters with RBAC enabled)


### PR DESCRIPTION
**Description**

I just spent 2 hours trying to figure out why my API key didn't work.

Fixes indentation issue in documentation.

**Checklist**

- [ ] Unit tests updated
- [X] End user documentation updated
