### PR TITLE
fix: internal ipv6 being used as external

### DIFF
--- a/source/compatibility.go
+++ b/source/compatibility.go
@@ -158,11 +158,9 @@ func legacyEndpointsFromDNSControllerNodePortService(svc *v1.Service, sc *servic
 			}
 			for _, address := range node.Status.Addresses {
 				recordType := suitableType(address.Address)
-				// IPv6 addresses are labeled as NodeInternalIP despite being usable externally as well.
-				if isExternal && (address.Type == v1.NodeExternalIP || (address.Type == v1.NodeInternalIP && recordType == endpoint.RecordTypeAAAA)) {
+				if isExternal && address.Type == v1.NodeExternalIP {
 					endpoints = append(endpoints, endpoint.NewEndpoint(hostname, recordType, address.Address))
-				}
-				if isInternal && address.Type == v1.NodeInternalIP {
+				} else if isInternal && address.Type == v1.NodeInternalIP {
 					endpoints = append(endpoints, endpoint.NewEndpoint(hostname, recordType, address.Address))
 				}
 			}

--- a/source/node.go
+++ b/source/node.go
@@ -174,18 +174,9 @@ func (ns *nodeSource) nodeAddresses(node *v1.Node) ([]string, error) {
 		v1.NodeExternalIP: {},
 		v1.NodeInternalIP: {},
 	}
-	var ipv6Addresses []string
 
 	for _, addr := range node.Status.Addresses {
 		addresses[addr.Type] = append(addresses[addr.Type], addr.Address)
-		// IPv6 addresses are labeled as NodeInternalIP despite being usable externally as well.
-		if addr.Type == v1.NodeInternalIP && suitableType(addr.Address) == endpoint.RecordTypeAAAA {
-			ipv6Addresses = append(ipv6Addresses, addr.Address)
-		}
-	}
-
-	if len(addresses[v1.NodeExternalIP]) > 0 {
-		return append(addresses[v1.NodeExternalIP], ipv6Addresses...), nil
 	}
 
 	if len(addresses[v1.NodeInternalIP]) > 0 {

--- a/source/pod.go
+++ b/source/pod.go
@@ -112,7 +112,7 @@ func (ps *podSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 					for _, address := range node.Status.Addresses {
 						recordType := suitableType(address.Address)
 						// IPv6 addresses are labeled as NodeInternalIP despite being usable externally as well.
-						if address.Type == corev1.NodeExternalIP || (address.Type == corev1.NodeInternalIP && recordType == endpoint.RecordTypeAAAA) {
+						if address.Type == corev1.NodeExternalIP {
 							addToEndpointMap(endpointMap, domain, recordType, address.Address)
 						}
 					}
@@ -139,7 +139,7 @@ func (ps *podSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 					for _, address := range node.Status.Addresses {
 						recordType := suitableType(address.Address)
 						// IPv6 addresses are labeled as NodeInternalIP despite being usable externally as well.
-						if address.Type == corev1.NodeExternalIP || (address.Type == corev1.NodeInternalIP && recordType == endpoint.RecordTypeAAAA) {
+						if address.Type == corev1.NodeExternalIP {
 							addToEndpointMap(endpointMap, domain, recordType, address.Address)
 						}
 					}


### PR DESCRIPTION
**Description**

<!-- Please provide a summary of the change here. -->

This change undoes a check for internal IPv6 addresses to be used when External IP has been requested.

Closes #4807

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
