### PR TITLE
feat: add new flags to allow migration of OwnerID

### DIFF
--- a/controller/execute.go
+++ b/controller/execute.go
@@ -404,7 +404,7 @@ func selectRegistry(cfg *externaldns.Config, p provider.Provider) (registry.Regi
 	case "noop":
 		r, err = registry.NewNoopRegistry(p)
 	case "txt":
-		r, err = registry.NewTXTRegistry(p, cfg.TXTPrefix, cfg.TXTSuffix, cfg.TXTOwnerID, cfg.TXTCacheInterval, cfg.TXTWildcardReplacement, cfg.ManagedDNSRecordTypes, cfg.ExcludeDNSRecordTypes, cfg.TXTEncryptEnabled, []byte(cfg.TXTEncryptAESKey), cfg.TXTNewFormatOnly)
+		r, err = registry.NewTXTRegistry(p, cfg.TXTPrefix, cfg.TXTSuffix, cfg.TXTOwnerID, cfg.TXTCacheInterval, cfg.TXTWildcardReplacement, cfg.ManagedDNSRecordTypes, cfg.ExcludeDNSRecordTypes, cfg.TXTEncryptEnabled, []byte(cfg.TXTEncryptAESKey), cfg.TXTNewFormatOnly, cfg.TXTOwnerMigrate, cfg.TXTOwnerOld)
 	case "aws-sd":
 		r, err = registry.NewAWSSDRegistry(p, cfg.TXTOwnerID)
 	default:

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -138,6 +138,8 @@ type Config struct {
 	Policy                                        string
 	Registry                                      string
 	TXTOwnerID                                    string
+	TXTOwnerOld                                   string
+	TXTOwnerMigrate                               bool
 	TXTPrefix                                     string
 	TXTSuffix                                     string
 	TXTEncryptEnabled                             bool
@@ -370,6 +372,8 @@ var defaultConfig = &Config{
 	TXTEncryptEnabled:            false,
 	TXTNewFormatOnly:             false,
 	TXTOwnerID:                   "default",
+	TXTOwnerOld:                  "default",
+	TXTOwnerMigrate:              false,
 	TXTPrefix:                    "",
 	TXTSuffix:                    "",
 	TXTWildcardReplacement:       "",
@@ -619,6 +623,8 @@ func App(cfg *Config) *kingpin.Application {
 	// Flags related to the registry
 	app.Flag("registry", "The registry implementation to use to keep track of DNS record ownership (default: txt, options: txt, noop, dynamodb, aws-sd)").Default(defaultConfig.Registry).EnumVar(&cfg.Registry, "txt", "noop", "dynamodb", "aws-sd")
 	app.Flag("txt-owner-id", "When using the TXT or DynamoDB registry, a name that identifies this instance of ExternalDNS (default: default)").Default(defaultConfig.TXTOwnerID).StringVar(&cfg.TXTOwnerID)
+	app.Flag("from-txt-owner", "Old txt-owner-id that needs to be overwritten (default: default)").StringVar(&cfg.TXTOwnerOld)
+	app.Flag("migrate-txt-owner", "When enabled, modify the previous txt-owner to the current txt-owner (default: disabled)").BoolVar(&cfg.TXTOwnerMigrate)
 	app.Flag("txt-prefix", "When using the TXT registry, a custom string that's prefixed to each ownership DNS record (optional). Could contain record type template like '%{record_type}-prefix-'. Mutual exclusive with txt-suffix!").Default(defaultConfig.TXTPrefix).StringVar(&cfg.TXTPrefix)
 	app.Flag("txt-suffix", "When using the TXT registry, a custom string that's suffixed to the host portion of each ownership DNS record (optional). Could contain record type template like '-%{record_type}-suffix'. Mutual exclusive with txt-prefix!").Default(defaultConfig.TXTSuffix).StringVar(&cfg.TXTSuffix)
 	app.Flag("txt-wildcard-replacement", "When using the TXT registry, a custom string that's used instead of an asterisk for TXT records corresponding to wildcard DNS records (optional)").Default(defaultConfig.TXTWildcardReplacement).StringVar(&cfg.TXTWildcardReplacement)

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -59,6 +59,10 @@ type TXTRegistry struct {
 	txtEncryptEnabled bool
 	txtEncryptAESKey  []byte
 
+	//Handle Owner ID migration
+	isMigrationEnabled bool
+	oldOwnerID         string
+
 	newFormatOnly bool
 }
 
@@ -69,7 +73,7 @@ func NewTXTRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID st
 	cacheInterval time.Duration, txtWildcardReplacement string,
 	managedRecordTypes, excludeRecordTypes []string,
 	txtEncryptEnabled bool, txtEncryptAESKey []byte,
-	newFormatOnly bool) (*TXTRegistry, error) {
+	newFormatOnly bool, isMigrationEnabled bool, oldOwnerID string) (*TXTRegistry, error) {
 	if ownerID == "" {
 		return nil, errors.New("owner id cannot be empty")
 	}
@@ -103,6 +107,8 @@ func NewTXTRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID st
 		excludeRecordTypes:  excludeRecordTypes,
 		txtEncryptEnabled:   txtEncryptEnabled,
 		txtEncryptAESKey:    txtEncryptAESKey,
+		isMigrationEnabled:  isMigrationEnabled,
+		oldOwnerID:          oldOwnerID,
 		newFormatOnly:       newFormatOnly,
 	}, nil
 }
@@ -272,6 +278,10 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 		UpdateNew: endpoint.FilterEndpointsByOwnerID(im.ownerID, changes.UpdateNew),
 		UpdateOld: endpoint.FilterEndpointsByOwnerID(im.ownerID, changes.UpdateOld),
 		Delete:    endpoint.FilterEndpointsByOwnerID(im.ownerID, changes.Delete),
+	}
+	if im.isMigrationEnabled {
+		filteredChanges.UpdateOld = append(filteredChanges.UpdateOld, endpoint.FilterEndpointsByOwnerID(im.oldOwnerID, changes.UpdateOld)...)
+		filteredChanges.Delete = append(filteredChanges.Delete, endpoint.FilterEndpointsByOwnerID(im.oldOwnerID, changes.Delete)...)
 	}
 	for _, r := range filteredChanges.Create {
 		if r.Labels == nil {


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This pull requests aims to complete the work initiated in these PR : https://github.com/kubernetes-sigs/external-dns/pull/2466 and https://github.com/kubernetes-sigs/external-dns/pull/3631

Most credits go to the creators of the initial work, as I mostly just rebased their work on the current state of master

Initial PR description:

> When changing --txt-owner-id on an existing external-dns resource, it does not update the existing TXT records it owns, therefore losing ownership. Meaning that we have to manually delete the records in order to have external-dns take ownership again. To solve this problem, I added the ability to update the original txt-owner by setting -- migrate-txt-owner to overwrite the old txt-owner. I have successfully modified thousands of pieces of data using this code, so far without any bugs

As for me I've successfully managed records without any issue using the newly added flags on the OVH provider
If anyone is willing to try these changes on other providers I'd be happy to troubleshoot their issues

Regarding the documentation I'm not sure either in which category these changes are relevant, so taking any recommendations on that 

Note: this is my first contribution to such a project and first time using Go aswell, I've went through the contribution guidelines but if I missed something please let me know so that I can fix it


<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2036 

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
