### PR TITLE
fix flaky aws sd test

### DIFF
--- a/provider/awssd/aws_sd_test.go
+++ b/provider/awssd/aws_sd_test.go
@@ -1004,6 +1004,6 @@ func TestAWSSDProvider_awsTags(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.EqualValues(t, test.Expectation, awsTags(test.Input))
+		require.ElementsMatch(t, test.Expectation, awsTags(test.Input))
 	}
 }


### PR DESCRIPTION
**Description**

This PR fixes the flaky test on AWS SD. The test is wrong because the order of iterations on maps in Go is not deterministic so the wrong assertion was used. This also switches to `require` which is a stronger guarantee than `assert` and will fail the test immediately if the assertion is not met.

Fixes #4825


**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
