### PR TITLE
fix(chart): allows to read ingress with istio source

### DIFF
--- a/charts/external-dns/templates/clusterrole.yaml
+++ b/charts/external-dns/templates/clusterrole.yaml
@@ -21,7 +21,7 @@ rules:
     resources: ["services","endpoints"]
     verbs: ["get","watch","list"]
 {{- end }}
-{{- if or (has "ingress" .Values.sources) (has "contour-httpproxy" .Values.sources) (has "openshift-route" .Values.sources) (has "skipper-routegroup" .Values.sources) }}
+{{- if or (has "ingress" .Values.sources) (has "istio-gateway" .Values.sources) (has "istio-virtualservice" .Values.sources) (has "contour-httpproxy" .Values.sources) (has "openshift-route" .Values.sources) (has "skipper-routegroup" .Values.sources) }}
   - apiGroups: ["extensions","networking.k8s.io"]
     resources: ["ingresses"]
     verbs: ["get","watch","list"]


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Fixes the use of the `external-dns.alpha.kubernetes.io/ingress` annotation when only istio resources are enabled as sources.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
