### PR TITLE
feat(Azure DNS): add NS record support

### DIFF
--- a/provider/azure/azure_privatedns_test.go
+++ b/provider/azure/azure_privatedns_test.go
@@ -354,9 +354,9 @@ func TestAzurePrivateDNSApplyChanges(t *testing.T) {
 }
 
 func TestAzurePrivateDNSApplyChangesDryRun(t *testing.T) {
-	recordsClient := mockRecordSetsClient{}
+	recordsClient := mockPrivateRecordSetsClient{}
 
-	testAzureApplyChangesInternal(t, true, &recordsClient)
+	testAzurePrivateDNSApplyChangesInternal(t, true, &recordsClient)
 
 	validateAzureEndpoints(t, recordsClient.deletedEndpoints, []*endpoint.Endpoint{})
 
@@ -471,9 +471,9 @@ func TestAzurePrivateDNSNameFilter(t *testing.T) {
 }
 
 func TestAzurePrivateDNSApplyChangesZoneName(t *testing.T) {
-	recordsClient := mockRecordSetsClient{}
+	recordsClient := mockPrivateRecordSetsClient{}
 
-	testAzureApplyChangesInternalZoneName(t, false, &recordsClient)
+	testAzurePrivateDNSApplyChangesInternalZoneName(t, false, &recordsClient)
 
 	validateAzureEndpoints(t, recordsClient.deletedEndpoints, []*endpoint.Endpoint{
 		endpoint.NewEndpoint("deleted.foo.example.com", endpoint.RecordTypeA, ""),


### PR DESCRIPTION

**Description**

Azure supports NS records on public DNS zones: https://learn.microsoft.com/en-us/rest/api/dns/record-sets/create-or-update?view=rest-dns-2018-05-01&tabs=HTTP#create-ns-recordset This PR adds this support to external dns. The implementation is similar to the other records.

Besides the unit tests this PR was also tested by creating a DNSEndpoint with the following spec:
```
    endpoints:
    - dnsName: cloud.k8gb.io
      recordTTL: 5
      recordType: NS
      targets:
      - gslb-ns-eu-cloud.k8gb.io
      - gslb-ns-us-cloud.k8gb.io
```
The creation of the NS record in Azure was successful:
```
az network dns record-set ns list --resource-group rg-k8gb  --zone-name "$EDGE_DNS_ZONE" --output json
[
  {...},
  {
    "NSRecords": [
      {
        "nsdname": "gslb-ns-eu-cloud.k8gb.io"
      },
      {
        "nsdname": "gslb-ns-us-cloud.k8gb.io"
      }
    ],
    "TTL": 5,
    "etag": "97a7199f-3be9-47bd-ab00-37013b775180",
    "fqdn": "cloud.k8gb.io.",
    "id": "/subscriptions/<redacted>/resourceGroups/rg-k8gb/providers/Microsoft.Network/dnszones/k8gb.io/NS/cloud",
    "name": "cloud",
    "provisioningState": "Succeeded",
    "resourceGroup": "rg-k8gb",
    "targetResource": {},
    "trafficManagementProfile": {},
    "type": "Microsoft.Network/dnszones/NS"
  }
]
```
Fixes #2835. This change was already attempted in #2835, but it was never merged due to inactivity.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
