### PR TITLE
Add options `labelFilter` and `managedRecordTypes` in Helm Chart

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -20,9 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added options to configure `labelFilter` and `managedRecordTypes` via dedicated helm values ([#4849](https://github.com/kubernetes-sigs/external-dns/pull/4849)) _@abaguas_
-
 - Ability to configure `imagePullSecrets` via helm `global` value ([#4667](https://github.com/kubernetes-sigs/external-dns/pull/4667)) _@jkroepke_
+- Added options to configure `labelFilter` and `managedRecordTypes` via dedicated helm values ([#4849](https://github.com/kubernetes-sigs/external-dns/pull/4849)) _@abaguas_
 
 ## [v1.15.0] - 2023-09-10
 

--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added options to configure `labelFilter` and `managedRecordTypes` via dedicated helm values ([#4849](https://github.com/kubernetes-sigs/external-dns/pull/4849)) _@abaguas_
+
 - Ability to configure `imagePullSecrets` via helm `global` value ([#4667](https://github.com/kubernetes-sigs/external-dns/pull/4667)) _@jkroepke_
 
 ## [v1.15.0] - 2023-09-10

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -112,9 +112,11 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | imagePullSecrets | list | `[]` | Image pull secrets. |
 | initContainers | list | `[]` | [Init containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) to add to the `Pod` definition. |
 | interval | string | `"1m"` | Interval for DNS updates. |
+| labelFilter | string | `nil` |  |
 | livenessProbe | object | See _values.yaml_ | [Liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `external-dns` container. |
 | logFormat | string | `"text"` | Log format. |
 | logLevel | string | `"info"` | Log level. |
+| managedRecordTypes | list | `[]` |  |
 | nameOverride | string | `nil` | Override the name of the chart. |
 | namespaced | bool | `false` | if `true`, _ExternalDNS_ will run in a namespaced scope (`Role`` and `Rolebinding`` will be namespaced too). |
 | nodeSelector | object | `{}` | Node labels to match for `Pod` [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). |

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -97,9 +97,9 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | deploymentStrategy | object | `{"type":"Recreate"}` | [Deployment Strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy). |
 | dnsConfig | object | `nil` | [DNS config](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config) for the pod, if not set the default will be used. |
 | dnsPolicy | string | `nil` | [DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) for the pod, if not set the default will be used. |
-| domainFilters | list | `[]` |  |
+| domainFilters | list | `[]` | Limit possible target zones by domain suffixes. |
 | env | list | `[]` | [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `external-dns` container. |
-| excludeDomains | list | `[]` |  |
+| excludeDomains | list | `[]` | Intentionally exclude domains from being managed. |
 | extraArgs | list | `[]` | Extra arguments to provide to _ExternalDNS_. |
 | extraContainers | object | `{}` | Extra containers to add to the `Deployment`. |
 | extraVolumeMounts | list | `[]` | Extra [volume mounts](https://kubernetes.io/docs/concepts/storage/volumes/) for the `external-dns` container. |
@@ -112,11 +112,11 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | imagePullSecrets | list | `[]` | Image pull secrets. |
 | initContainers | list | `[]` | [Init containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) to add to the `Pod` definition. |
 | interval | string | `"1m"` | Interval for DNS updates. |
-| labelFilter | string | `nil` |  |
+| labelFilter | string | `nil` | Filter resources queried for endpoints by label selector |
 | livenessProbe | object | See _values.yaml_ | [Liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `external-dns` container. |
 | logFormat | string | `"text"` | Log format. |
 | logLevel | string | `"info"` | Log level. |
-| managedRecordTypes | list | `[]` |  |
+| managedRecordTypes | list | `[]` | Record types to manage (default: A, AAAA, CNAME) |
 | nameOverride | string | `nil` | Override the name of the chart. |
 | namespaced | bool | `false` | if `true`, _ExternalDNS_ will run in a namespaced scope (`Role`` and `Rolebinding`` will be namespaced too). |
 | nodeSelector | object | `{}` | Node labels to match for `Pod` [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). |

--- a/charts/external-dns/ci/ci-values.yaml
+++ b/charts/external-dns/ci/ci-values.yaml
@@ -1,4 +1,4 @@
-labelFilter:
+labelFilter: foo=bar
 managedRecordTypes: []
 provider:
   name: inmemory

--- a/charts/external-dns/ci/ci-values.yaml
+++ b/charts/external-dns/ci/ci-values.yaml
@@ -1,2 +1,4 @@
+labelFilter:
+managedRecordTypes: []
 provider:
   name: inmemory

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -114,6 +114,12 @@ spec:
             {{- range .Values.excludeDomains }}
             - --exclude-domains={{ . }}
             {{- end }}
+            {{- if .Values.labelFilter }}
+            - --label-filter={{ .Values.labelFilter }}
+            {{- end }}
+            {{- range .Values.managedRecordTypes }}
+            - --managed-record-types={{ . }}
+            {{- end }}
             - --provider={{ $providerName }}
           {{- range .Values.extraArgs }}
             - {{ tpl . $ }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -229,6 +229,12 @@ domainFilters: []
 ## -- Intentionally exclude domains from being managed.
 excludeDomains: []
 
+## -- (string) Filter resources queried for endpoints by label selector
+labelFilter:
+
+## -- Record types to manage (default: A, AAAA, CNAME)
+managedRecordTypes: []
+
 provider:
   # -- _ExternalDNS_ provider name; for the available providers and how to configure them see [README](https://github.com/kubernetes-sigs/external-dns/blob/master/charts/external-dns/README.md#providers).
   name: aws

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -223,16 +223,16 @@ txtPrefix:
 # Mutually exclusive with `txtPrefix`.
 txtSuffix:
 
-## - Limit possible target zones by domain suffixes.
+# -- Limit possible target zones by domain suffixes.
 domainFilters: []
 
-## -- Intentionally exclude domains from being managed.
+# -- Intentionally exclude domains from being managed.
 excludeDomains: []
 
-## -- (string) Filter resources queried for endpoints by label selector
+# -- (string) Filter resources queried for endpoints by label selector
 labelFilter:
 
-## -- Record types to manage (default: A, AAAA, CNAME)
+# -- Record types to manage (default: A, AAAA, CNAME)
 managedRecordTypes: []
 
 provider:


### PR DESCRIPTION
**Description**

By promoting this options to dedicated values they no longer have to be configured via `extraArgs`.

**Motivation**

In the [K8GB project](https://github.com/k8gb-io/k8gb), a DNS based load balancer, we use external-dns as a chart dependency. We would like to configure all values specific to the controller in the default values of our Chart, and leave to the users the provider configuration. This provider configuration usually includes `extraArgs`. Since `extraArgs` is a list that would be overwritten we would like to keep it empty, otherwise users will have to copy paste our base configuration.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
