### PR TITLE
fix(godaddy): Handle missing Retry-After header gracefully

### DIFF
--- a/provider/godaddy/client.go
+++ b/provider/godaddy/client.go
@@ -152,56 +152,56 @@ func NewClient(useOTE bool, apiKey, apiSecret string) (*Client, error) {
 
 // Get is a wrapper for the GET method
 func (c *Client) Get(url string, resType interface{}) error {
-	return c.CallAPI("GET", url, nil, resType, true)
+	return c.CallAPI("GET", url, nil, resType)
 }
 
 // Patch is a wrapper for the PATCH method
 func (c *Client) Patch(url string, reqBody, resType interface{}) error {
-	return c.CallAPI("PATCH", url, reqBody, resType, true)
+	return c.CallAPI("PATCH", url, reqBody, resType)
 }
 
 // Post is a wrapper for the POST method
 func (c *Client) Post(url string, reqBody, resType interface{}) error {
-	return c.CallAPI("POST", url, reqBody, resType, true)
+	return c.CallAPI("POST", url, reqBody, resType)
 }
 
 // Put is a wrapper for the PUT method
 func (c *Client) Put(url string, reqBody, resType interface{}) error {
-	return c.CallAPI("PUT", url, reqBody, resType, true)
+	return c.CallAPI("PUT", url, reqBody, resType)
 }
 
 // Delete is a wrapper for the DELETE method
 func (c *Client) Delete(url string, resType interface{}) error {
-	return c.CallAPI("DELETE", url, nil, resType, true)
+	return c.CallAPI("DELETE", url, nil, resType)
 }
 
 // GetWithContext is a wrapper for the GET method
 func (c *Client) GetWithContext(ctx context.Context, url string, resType interface{}) error {
-	return c.CallAPIWithContext(ctx, "GET", url, nil, resType, true)
+	return c.CallAPIWithContext(ctx, "GET", url, nil, resType)
 }
 
 // PatchWithContext is a wrapper for the PATCH method
 func (c *Client) PatchWithContext(ctx context.Context, url string, reqBody, resType interface{}) error {
-	return c.CallAPIWithContext(ctx, "PATCH", url, reqBody, resType, true)
+	return c.CallAPIWithContext(ctx, "PATCH", url, reqBody, resType)
 }
 
 // PostWithContext is a wrapper for the POST method
 func (c *Client) PostWithContext(ctx context.Context, url string, reqBody, resType interface{}) error {
-	return c.CallAPIWithContext(ctx, "POST", url, reqBody, resType, true)
+	return c.CallAPIWithContext(ctx, "POST", url, reqBody, resType)
 }
 
 // PutWithContext is a wrapper for the PUT method
 func (c *Client) PutWithContext(ctx context.Context, url string, reqBody, resType interface{}) error {
-	return c.CallAPIWithContext(ctx, "PUT", url, reqBody, resType, true)
+	return c.CallAPIWithContext(ctx, "PUT", url, reqBody, resType)
 }
 
 // DeleteWithContext is a wrapper for the DELETE method
 func (c *Client) DeleteWithContext(ctx context.Context, url string, resType interface{}) error {
-	return c.CallAPIWithContext(ctx, "DELETE", url, nil, resType, true)
+	return c.CallAPIWithContext(ctx, "DELETE", url, nil, resType)
 }
 
 // NewRequest returns a new HTTP request
-func (c *Client) NewRequest(method, path string, reqBody interface{}, needAuth bool) (*http.Request, error) {
+func (c *Client) NewRequest(method, path string, reqBody interface{}) (*http.Request, error) {
 	var body []byte
 	var err error
 
@@ -240,8 +240,11 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 
 	c.Ratelimiter.Wait(req.Context())
 	resp, err := c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
 	// In case of several clients behind NAT we still can hit rate limit
-	for i := 1; i < 3 && err == nil && resp.StatusCode == 429; i++ {
+	for i := 1; i < 3 && resp != nil && resp.StatusCode == 429; i++ {
 		retryAfter, err := strconv.ParseInt(resp.Header.Get("Retry-After"), 10, 0)
 		if err != nil {
 			log.Error("Rate-limited response did not contain a valid Retry-After header, quota likely exceeded")
@@ -256,9 +259,6 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 
 		c.Ratelimiter.Wait(req.Context())
 		resp, err = c.Client.Do(req)
-	}
-	if err != nil {
-		return nil, err
 	}
 	if c.Logger != nil {
 		c.Logger.LogResponse(resp)
@@ -284,8 +284,8 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 //
 // If everything went fine, unmarshall response into resType and return nil
 // otherwise, return the error
-func (c *Client) CallAPI(method, path string, reqBody, resType interface{}, needAuth bool) error {
-	return c.CallAPIWithContext(context.Background(), method, path, reqBody, resType, needAuth)
+func (c *Client) CallAPI(method, path string, reqBody, resType interface{}) error {
+	return c.CallAPIWithContext(context.Background(), method, path, reqBody, resType)
 }
 
 // CallAPIWithContext is the lowest level call helper. If needAuth is true,
@@ -308,8 +308,8 @@ func (c *Client) CallAPI(method, path string, reqBody, resType interface{}, need
 //
 // If everything went fine, unmarshall response into resType and return nil
 // otherwise, return the error
-func (c *Client) CallAPIWithContext(ctx context.Context, method, path string, reqBody, resType interface{}, needAuth bool) error {
-	req, err := c.NewRequest(method, path, reqBody, needAuth)
+func (c *Client) CallAPIWithContext(ctx context.Context, method, path string, reqBody, resType interface{}) error {
+	req, err := c.NewRequest(method, path, reqBody)
 	if err != nil {
 		return err
 	}

--- a/provider/godaddy/client.go
+++ b/provider/godaddy/client.go
@@ -259,6 +259,9 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 
 		c.Ratelimiter.Wait(req.Context())
 		resp, err = c.Client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("doing request after waiting for retry after: %w", err)
+		}
 	}
 	if c.Logger != nil {
 		c.Logger.LogResponse(resp)

--- a/provider/godaddy/client_test.go
+++ b/provider/godaddy/client_test.go
@@ -1,0 +1,56 @@
+package godaddy
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/time/rate"
+)
+
+// Tests that
+func TestClient_DoWhenQuotaExceeded(t *testing.T) {
+	assert := assert.New(t)
+
+	// Mock server to return 429 with a JSON payload
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, err := w.Write([]byte(`{"code": "QUOTA_EXCEEDED", "message": "rate limit exceeded"}`))
+		if err != nil {
+			t.Fatalf("Failed to write response: %v", err)
+		}
+	}))
+	defer mockServer.Close()
+
+	client := Client{
+		APIKey:      "",
+		APISecret:   "",
+		APIEndPoint: mockServer.URL,
+		Client:      &http.Client{},
+		// Add one token every second
+		Ratelimiter: rate.NewLimiter(rate.Every(time.Second), 60),
+		Timeout:     DefaultTimeout,
+	}
+
+	req, err := client.NewRequest("GET", "/v1/domains/example.net/records", nil, false)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	resp, err := client.Do(req)
+	assert.Nil(err, "A CODE_EXCEEDED response should not return an error")
+	assert.Equal(http.StatusTooManyRequests, resp.StatusCode, "Expected a 429 response")
+
+	respContents := GDErrorResponse{}
+	err = client.UnmarshalResponse(resp, &respContents)
+	if assert.NotNil(err) {
+		var apiErr *APIError
+		errors.As(err, &apiErr)
+		assert.Equal("QUOTA_EXCEEDED", apiErr.Code)
+		assert.Equal("rate limit exceeded", apiErr.Message)
+	}
+}

--- a/provider/godaddy/client_test.go
+++ b/provider/godaddy/client_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package godaddy
 
 import (

--- a/provider/godaddy/client_test.go
+++ b/provider/godaddy/client_test.go
@@ -36,7 +36,7 @@ func TestClient_DoWhenQuotaExceeded(t *testing.T) {
 		Timeout:     DefaultTimeout,
 	}
 
-	req, err := client.NewRequest("GET", "/v1/domains/example.net/records", nil, false)
+	req, err := client.NewRequest("GET", "/v1/domains/example.net/records", nil)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

Based on some testing, it seems GoDaddy has an undocumented, per-endpoint quota.

During startup, the client calls the endpoint `https://api.godaddy.com/v1/domains?statuses=ACTIVE,PENDING_DNS_ACTIVE1` to test and validate that the credentials are working. Calling that endpoint with the same API key manually, I was able to reproduce the `429` response the API sends, which did not include the `Retry-After` header and thus caused the panic on startup.

However, I was able to call other endpoints, ex: `https://api.godaddy.com/v1/domains/<domain>/records`, leading me to believe there is an undocumented, per-endpoint quota.

With this in mind, I updated the request handler to gracefully fail without panicing when the header is missing, so that other requests can still be attempted. 

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4864

**Checklist**

- [x] Unit tests updated
- [N/A] End user documentation updated
