### PR TITLE
docs: fix reference to wrong field in service

### DIFF
--- a/docs/sources/service.md
+++ b/docs/sources/service.md
@@ -76,7 +76,7 @@ or the `--publish-host-ip` flag was specified, uses the Pod's `status.hostIP` fi
 ### ClusterIP (not headless)
 
 1. If the hostname came from an `external-dns.alpha.kubernetes.io/internal-hostname` annotation
-or the `--publish-internal-services` flag was specified, uses the `spec.ServiceIP`.
+or the `--publish-internal-services` flag was specified, uses the `spec.ClusterIP`.
 
 2. Otherwise, does not create any targets.
 


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Documentation references ServiceIP as a field inside of spec, but this field does not exist and it's actually meant to reference to ClusterIP

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4868

**Checklist**


- [x] End user documentation updated
