### PR TITLE
feat(Gateway API): improve annotations support

### DIFF
--- a/docs/sources/gateway.md
+++ b/docs/sources/gateway.md
@@ -29,12 +29,12 @@ The set of domain names from a \*Route is sourced from the following places:
 - Adds the hostnames from any `external-dns.alpha.kubernetes.io/hostname` annotation on the \*Route.
   This behavior is suppressed if the `--ignore-hostname-annotation` flag was specified.
 
+- Adds the hostnames from any `external-dns.alpha.kubernetes.io/hostname` annotation on associated Listeners' Gateways.
+  This behavior is suppressed if the `--ignore-hostname-annotation` flag was specified.
+
 - If no endpoints were produced by the previous steps
   or the `--combine-fqdn-annotation` flag was specified, then adds hostnames
   generated from any`--fqdn-template` flag.
-
-- If no endpoints were produced by the previous steps, each
-  attached Gateway listener will use its `hostname`, if present.
 
 ### Matching Gateways
 

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -251,6 +251,12 @@ func NewEndpointWithTTL(dnsName, recordType string, ttl TTL, targets ...string) 
 	}
 }
 
+// WithLabel attaches a label key/value pair to the Endpoint and returns the Endpoint.
+func (e *Endpoint) WithLabel(key, value string) *Endpoint {
+	e.Labels[key] = value
+	return e
+}
+
 // WithSetIdentifier applies the given set identifier to the endpoint.
 func (e *Endpoint) WithSetIdentifier(setIdentifier string) *Endpoint {
 	e.SetIdentifier = setIdentifier

--- a/source/gateway_grpcroute_test.go
+++ b/source/gateway_grpcroute_test.go
@@ -91,8 +91,11 @@ func TestGatewayGRPCRouteSourceEndpoints(t *testing.T) {
 	endpoints, err := src.Endpoints(ctx)
 	require.NoError(t, err, "failed to get Endpoints")
 	validateEndpoints(t, endpoints, []*endpoint.Endpoint{
-		newTestEndpoint("api-annotation.foobar.internal", "A", ips...),
-		newTestEndpoint("api-hostnames.foobar.internal", "A", ips...),
-		newTestEndpoint("api-template.foobar.internal", "A", ips...),
+		newTestEndpoint("api-annotation.foobar.internal", "A", ips...).
+			WithLabel(endpoint.ResourceLabelKey, "grpcroute/default/api"),
+		newTestEndpoint("api-hostnames.foobar.internal", "A", ips...).
+			WithLabel(endpoint.ResourceLabelKey, "grpcroute/default/api"),
+		newTestEndpoint("api-template.foobar.internal", "A", ips...).
+			WithLabel(endpoint.ResourceLabelKey, "grpcroute/default/api"),
 	})
 }

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -485,7 +485,6 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			},
 		},
 		{
-			// EXPERIMENTAL: https://gateway-api.sigs.k8s.io/geps/gep-957/
 			title:      "PortNumberMatch",
 			config:     Config{},
 			namespaces: namespaces("default"),

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -105,6 +105,7 @@ func newTestEndpointWithTTL(dnsName, recordType string, ttl int64, targets ...st
 		DNSName:    dnsName,
 		Targets:    append([]string(nil), targets...), // clone targets
 		RecordType: recordType,
+		Labels:     endpoint.NewLabels(),
 		RecordTTL:  endpoint.TTL(ttl),
 	}
 }
@@ -178,7 +179,8 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				),
 			}},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("test.example.internal", "A", "1.2.3.4"),
+				newTestEndpoint("test.example.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/route-namespace/test"),
 			},
 		},
 		{
@@ -214,7 +216,8 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 			},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("route-namespace.example.internal", "A", "1.2.3.4"),
+				newTestEndpoint("route-namespace.example.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/route-namespace/test"),
 			},
 		},
 		{
@@ -258,7 +261,8 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				),
 			}},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("test.example.internal", "A", "1.2.3.4"),
+				newTestEndpoint("test.example.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/test"),
 			},
 		},
 		{
@@ -299,7 +303,8 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 			},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("labels-match.example.internal", "A", "1.2.3.4"),
+				newTestEndpoint("labels-match.example.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/labels-match"),
 			},
 		},
 		{
@@ -340,7 +345,8 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 			},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("annotations-match.example.internal", "A", "1.2.3.4"),
+				newTestEndpoint("annotations-match.example.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/annotations-match"),
 			},
 		},
 		{
@@ -400,7 +406,8 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				),
 			}},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("test.example.internal", "A", "1.2.3.4", "2.3.4.5"),
+				newTestEndpoint("test.example.internal", "A", "1.2.3.4", "2.3.4.5").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/test"),
 			},
 		},
 		{
@@ -435,8 +442,10 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				),
 			}},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("foo.example.internal", "A", "1.2.3.4"),
-				newTestEndpoint("bar.example.internal", "A", "1.2.3.4"),
+				newTestEndpoint("foo.example.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/test"),
+				newTestEndpoint("bar.example.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/test"),
 			},
 		},
 		{
@@ -471,7 +480,8 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				),
 			}},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("foo.example.internal", "A", "1.2.3.4"),
+				newTestEndpoint("foo.example.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/test"),
 			},
 		},
 		{
@@ -515,8 +525,10 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				),
 			}},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("foo.example.internal", "A", "1.2.3.4"),
-				newTestEndpoint("bar.example.internal", "A", "1.2.3.4"),
+				newTestEndpoint("foo.example.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/test"),
+				newTestEndpoint("bar.example.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/test"),
 			},
 		},
 		{
@@ -543,7 +555,8 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				Status: httpRouteStatus(gwParentRef("default", "test")),
 			}},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("foo.example.internal", "A", "1.2.3.4"),
+				newTestEndpoint("foo.example.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/no-hostname"),
 			},
 		},
 		{
@@ -570,7 +583,8 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				Status: httpRouteStatus(gwParentRef("default", "test")),
 			}},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("foo.example.internal", "A", "1.2.3.4"),
+				newTestEndpoint("foo.example.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/no-hostname"),
 			},
 		},
 		{
@@ -597,7 +611,8 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				Status: httpRouteStatus(gwParentRef("default", "test")),
 			}},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("*.example.internal", "A", "1.2.3.4"),
+				newTestEndpoint("*.example.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/no-hostname"),
 			},
 		},
 		{
@@ -622,7 +637,8 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				Status: httpRouteStatus(gwParentRef("default", "test")),
 			}},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("foo.example.internal", "A", "1.2.3.4"),
+				newTestEndpoint("foo.example.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/no-hostname"),
 			},
 		},
 		{
@@ -673,7 +689,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			routes: []*v1beta1.HTTPRoute{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "without-hostame",
+						Name:      "without-hostname",
 						Namespace: "default",
 						Annotations: map[string]string{
 							hostnameAnnotationKey: "annotation.without-hostname.internal",
@@ -686,7 +702,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "with-hostame",
+						Name:      "with-hostname",
 						Namespace: "default",
 						Annotations: map[string]string{
 							hostnameAnnotationKey: "annotation.with-hostname.internal",
@@ -699,9 +715,12 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 			},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("annotation.without-hostname.internal", "A", "1.2.3.4"),
-				newTestEndpoint("annotation.with-hostname.internal", "A", "1.2.3.4"),
-				newTestEndpoint("with-hostname.internal", "A", "1.2.3.4"),
+				newTestEndpoint("annotation.without-hostname.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/without-hostname"),
+				newTestEndpoint("annotation.with-hostname.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/with-hostname"),
+				newTestEndpoint("with-hostname.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/with-hostname"),
 			},
 		},
 		{
@@ -719,7 +738,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			}},
 			routes: []*v1beta1.HTTPRoute{{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "with-hostame",
+					Name:      "test",
 					Namespace: "default",
 					Annotations: map[string]string{
 						hostnameAnnotationKey: "annotation.with-hostname.internal",
@@ -731,7 +750,8 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				Status: httpRouteStatus(gwParentRef("default", "test")),
 			}},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("with-hostname.internal", "A", "1.2.3.4"),
+				newTestEndpoint("with-hostname.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/test"),
 			},
 		},
 		{
@@ -764,10 +784,14 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 			},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("fqdn-without-hostnames.zero.internal", "A", "1.2.3.4"),
-				newTestEndpoint("fqdn-without-hostnames.one.internal", "A", "1.2.3.4"),
-				newTestEndpoint("fqdn-without-hostnames.two.internal", "A", "1.2.3.4"),
-				newTestEndpoint("fqdn-with-hostnames.internal", "A", "1.2.3.4"),
+				newTestEndpoint("fqdn-without-hostnames.zero.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/fqdn-without-hostnames"),
+				newTestEndpoint("fqdn-without-hostnames.one.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/fqdn-without-hostnames"),
+				newTestEndpoint("fqdn-without-hostnames.two.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/fqdn-without-hostnames"),
+				newTestEndpoint("fqdn-with-hostnames.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/fqdn-with-hostnames"),
 			},
 		},
 		{
@@ -792,8 +816,10 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				Status: httpRouteStatus(gwParentRef("default", "test")),
 			}},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("fqdn-with-hostnames.internal", "A", "1.2.3.4"),
-				newTestEndpoint("combine-fqdn-with-hostnames.internal", "A", "1.2.3.4"),
+				newTestEndpoint("fqdn-with-hostnames.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/fqdn-with-hostnames"),
+				newTestEndpoint("combine-fqdn-with-hostnames.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/fqdn-with-hostnames"),
 			},
 		},
 		{
@@ -832,8 +858,10 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 			},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("invalid-ttl.internal", "A", "1.2.3.4"),
-				newTestEndpointWithTTL("valid-ttl.internal", "A", 15, "1.2.3.4"),
+				newTestEndpoint("invalid-ttl.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/invalid-ttl"),
+				newTestEndpointWithTTL("valid-ttl.internal", "A", 15, "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/valid-ttl"),
 			},
 		},
 		{
@@ -863,6 +891,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			}},
 			endpoints: []*endpoint.Endpoint{
 				newTestEndpoint("provider-annotations.com", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/provider-annotations").
 					WithProviderSpecific("alias", "true").
 					WithSetIdentifier("test-set-identifier"),
 			},
@@ -904,8 +933,10 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				),
 			}},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("test.one.internal", "A", "1.2.3.4"),
-				newTestEndpoint("test.two.internal", "A", "2.3.4.5"),
+				newTestEndpoint("test.one.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/test"),
+				newTestEndpoint("test.two.internal", "A", "2.3.4.5").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/test"),
 			},
 		},
 		{
@@ -943,7 +974,8 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 			},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("same-namespace.example.internal", "A", "1.2.3.4"),
+				newTestEndpoint("same-namespace.example.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/same-namespace/test"),
 			},
 		},
 		{
@@ -1002,7 +1034,8 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 			},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("foo.example.internal", "A", "1.2.3.4"),
+				newTestEndpoint("foo.example.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/foo/test"),
 			},
 		},
 		{
@@ -1070,11 +1103,12 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				),
 			}},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("test.example.internal", "A", "4.3.2.1"),
+				newTestEndpoint("test.example.internal", "A", "4.3.2.1").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/route-namespace/test"),
 			},
 		},
 		{
-			title: "MutlipleGatewaysOneAnnotationOverride",
+			title: "MultipleGatewaysOneAnnotationOverride",
 			config: Config{
 				GatewayNamespace: "gateway-namespace",
 			},
@@ -1118,7 +1152,8 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				),
 			}},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("test.example.internal", "A", "4.3.2.1", "2.3.4.5"),
+				newTestEndpoint("test.example.internal", "A", "4.3.2.1", "2.3.4.5").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/route-namespace/test"),
 			},
 		},
 		{
@@ -1162,8 +1197,10 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 			},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("test.one.internal", "A", "1.2.3.4"),
-				newTestEndpoint("test.two.internal", "A", "2.3.4.5"),
+				newTestEndpoint("test.one.internal", "A", "1.2.3.4").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/one"),
+				newTestEndpoint("test.two.internal", "A", "2.3.4.5").
+					WithLabel(endpoint.ResourceLabelKey, "httproute/default/two"),
 			},
 			logExpectations: []string{
 				"level=debug msg=\"Endpoints generated from HTTPRoute default/one: [test.one.internal 0 IN A  1.2.3.4 []]\"",

--- a/source/gateway_tcproute_test.go
+++ b/source/gateway_tcproute_test.go
@@ -90,7 +90,9 @@ func TestGatewayTCPRouteSourceEndpoints(t *testing.T) {
 	endpoints, err := src.Endpoints(ctx)
 	require.NoError(t, err, "failed to get Endpoints")
 	validateEndpoints(t, endpoints, []*endpoint.Endpoint{
-		newTestEndpoint("api-annotation.foobar.internal", "A", ips...),
-		newTestEndpoint("api-template.foobar.internal", "A", ips...),
+		newTestEndpoint("api-annotation.foobar.internal", "A", ips...).
+			WithLabel(endpoint.ResourceLabelKey, "tcproute/default/api"),
+		newTestEndpoint("api-template.foobar.internal", "A", ips...).
+			WithLabel(endpoint.ResourceLabelKey, "tcproute/default/api"),
 	})
 }

--- a/source/gateway_tlsroute_test.go
+++ b/source/gateway_tlsroute_test.go
@@ -92,8 +92,11 @@ func TestGatewayTLSRouteSourceEndpoints(t *testing.T) {
 	endpoints, err := src.Endpoints(ctx)
 	require.NoError(t, err, "failed to get Endpoints")
 	validateEndpoints(t, endpoints, []*endpoint.Endpoint{
-		newTestEndpoint("api-annotation.foobar.internal", "A", ips...),
-		newTestEndpoint("api-hostnames.foobar.internal", "A", ips...),
-		newTestEndpoint("api-template.foobar.internal", "A", ips...),
+		newTestEndpoint("api-annotation.foobar.internal", "A", ips...).
+			WithLabel(endpoint.ResourceLabelKey, "tlsroute/default/api"),
+		newTestEndpoint("api-hostnames.foobar.internal", "A", ips...).
+			WithLabel(endpoint.ResourceLabelKey, "tlsroute/default/api"),
+		newTestEndpoint("api-template.foobar.internal", "A", ips...).
+			WithLabel(endpoint.ResourceLabelKey, "tlsroute/default/api"),
 	})
 }

--- a/source/gateway_udproute_test.go
+++ b/source/gateway_udproute_test.go
@@ -90,7 +90,9 @@ func TestGatewayUDPRouteSourceEndpoints(t *testing.T) {
 	endpoints, err := src.Endpoints(ctx)
 	require.NoError(t, err, "failed to get Endpoints")
 	validateEndpoints(t, endpoints, []*endpoint.Endpoint{
-		newTestEndpoint("api-annotation.foobar.internal", "A", ips...),
-		newTestEndpoint("api-template.foobar.internal", "A", ips...),
+		newTestEndpoint("api-annotation.foobar.internal", "A", ips...).
+			WithLabel(endpoint.ResourceLabelKey, "udproute/default/api"),
+		newTestEndpoint("api-template.foobar.internal", "A", ips...).
+			WithLabel(endpoint.ResourceLabelKey, "udproute/default/api"),
 	})
 }


### PR DESCRIPTION
**Description**

The generation of DNS records from [Gateway API](https://gateway-api.sigs.k8s.io/) resources involves combining information from a […Route](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.CommonRouteSpec) resource and a [Gateway](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Gateway) resource. The current [implementation](https://github.com/kubernetes-sigs/external-dns/blob/7343cb99e098074da3dcbd9f7e3cda708e723ec6/source/gateway.go#L195L247), for the most part, only considers [annotations](https://github.com/kubernetes-sigs/external-dns/blob/7343cb99e098074da3dcbd9f7e3cda708e723ec6/source/gateway.go#L238) from the Route resource. There are potential scenarios whereby it may be more convenient to assign annotations to the Gateway resource, thus ensuring that all DNS records associated with the given Gateway are similarly effected. An extreme example of such a scenario being when no [Hostname](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Hostname) information is specified (i.e. the given Gateway should accept any communication, irrespective of the DNS name used to establish it) but that a DNS record is desired to cover all Routes associated with the Gateway; in which case it would be convenient to apply an `external-dns.alpha.kubernetes.io/hostname` annotation to the Gateway itself, rather than having to apply annotations to every associated Route and having to deal with the potential confusion arising from precisely which Route _owns_ the _shared_ DNS record.

The proposed changes include:
* Adding validation of `resource` endpoint label _ownership_ to all of the Gateway related unit-tests
* Refactor the process of `Endpoint` generation in order to preserve the relationship between Route and Gateway resources
* Consider annotations from both Route and Gateway resources when generating an `Endpoint`
  * In cases where the same annotation is present on both Route and Gateway resources, the Route derived value is used in preference
  * `external-dns.alpha.kubernetes.io/ttl` annotations are _merged_ to yield the lowest specified value
  * In the case where `external-dns.alpha.kubernetes.io/hostname` is specified on a Gateway and that Gateway is the only Gateway contributing to an `Endpoint` the resource label is recorded as referring to the Gateway rather than the Route

No changes to the [documentation](https://github.com/kubernetes-sigs/external-dns/blob/7343cb99e098074da3dcbd9f7e3cda708e723ec6/docs/annotations/annotations.md) are proposed because it currently implies that annotations on [Gateway](https://github.com/kubernetes-sigs/external-dns/blob/7343cb99e098074da3dcbd9f7e3cda708e723ec6/docs/annotations/annotations.md?plain=1#L15) resources are supported, whereas in reality such annotations are only honoured when specified on Route resources.

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
