### PR TITLE
fix(godday): panic when retryAfter is 0

### DIFF
--- a/provider/godaddy/client.go
+++ b/provider/godaddy/client.go
@@ -232,7 +232,10 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	for i := 1; i < 3 && err == nil && resp.StatusCode == 429; i++ {
 		retryAfter, _ := strconv.ParseInt(resp.Header.Get("Retry-After"), 10, 0)
 
-		jitter := rand.Int63n(retryAfter)
+		var jitter int64
+		if retryAfter > 0 {
+			jitter = rand.Int63n(retryAfter)
+		}
 		retryAfterSec := retryAfter + jitter/2
 
 		sleepTime := time.Duration(retryAfterSec) * time.Second


### PR DESCRIPTION
… process

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Handles panic when the retryAfter header is parsed as 0 or less or blank when responding 429 from GoDaddy API.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE
This is a code fix for the issue [#4864 ](https://github.com/kubernetes-sigs/external-dns/issues/4864) 

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
