### PR TITLE
feat: configure arbitrary provider-specific properties via annotations

### DIFF
--- a/docs/annotations/annotations.md
+++ b/docs/annotations/annotations.md
@@ -10,7 +10,7 @@ The following table documents which sources support which annotations:
 | Connector    |            |          |                   |         |         |                     |
 | Contour      | Yes        | Yes[^1]  |                   | Yes     | Yes     | Yes                 |
 | CloudFoundry |            |          |                   |         |         |                     |
-| CRD          |            |          |                   |         |         |                     |
+| CRD          |            | Yes      |                   | Yes     | Yes     | Yes                 |
 | F5           |            |          |                   | Yes     | Yes     |                     |
 | Gateway      | Yes        | Yes[^1]  |                   | Yes[^4] | Yes     | Yes                 |
 | Gloo         |            |          |                   | Yes     | Yes[^5] | Yes[^5]             |
@@ -101,7 +101,13 @@ It must be between 1 and 2,147,483,647 seconds.
 
 ## Provider-specific annotations
 
-Some providers define their own annotations. Cloud-specific annotations have keys prefixed as follows:
+Provider-specific annotations are prefixed by `external-dns.alpha.kubernetes.io/`
+and the provider's name, for example `external-dns.alpha.kubernetes.io/aws-`.
+
+Individual provider implementations should be examined to identify the additional
+configuration offered via supported annotations.
+
+Currently, supported Cloud-specific annotations include the following prefixes:
 
 | Cloud      | Annotation prefix                              |
 |------------|------------------------------------------------|

--- a/docs/sources/crd/dnsendpoint-aws-example.yaml
+++ b/docs/sources/crd/dnsendpoint-aws-example.yaml
@@ -2,17 +2,10 @@ apiVersion: externaldns.k8s.io/v1alpha1
 kind: DNSEndpoint
 metadata:
   name: examplednsrecord
-spec:
-  endpoints:
-  - dnsName: subdomain.foo.bar.com
-    providerSpecific:
-      - name: "aws/failover"
-        value: "PRIMARY"
-      - name: "aws/health-check-id"
-        value: "asdf1234-as12-as12-as12-asdf12345678"
-      - name: "aws/evaluate-target-health"
-        value: "true"
-    recordType: CNAME
-    setIdentifier: some-unique-id
-    targets:
-    - other-subdomain.foo.bar.com
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: "subdomain.foo.bar.com"
+    external-dns.alpha.kubernetes.io/target: "other-subdomain.foo.bar.com"
+    external-dns.alpha.kubernetes.io/set-identifier: "some-unique-id"
+    external-dns.alpha.kubernetes.io/aws-failover: "PRIMARY"
+    external-dns.alpha.kubernetes.io/aws-health-check-id: "asdf1234-as12-as12-as12-asdf12345678"
+    external-dns.alpha.kubernetes.io/aws-evaluate-target-health: "true"

--- a/docs/sources/crd/dnsendpoint-example.yaml
+++ b/docs/sources/crd/dnsendpoint-example.yaml
@@ -2,14 +2,8 @@ apiVersion: externaldns.k8s.io/v1alpha1
 kind: DNSEndpoint
 metadata:
   name: examplednsrecord
-spec:
-  endpoints:
-  - dnsName: foo.bar.com
-    recordTTL: 180
-    recordType: A
-    targets:
-    - 192.168.99.216
-    # Provider specific configurations are set like an annotation would on other sources
-    providerSpecific:
-      - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
-        value: "true"
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: foo.bar.com
+    external-dns.alpha.kubernetes.io/target: 192.168.99.216
+    external-dns.alpha.kubernetes.io/ttl: "180"
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"

--- a/docs/tutorials/webhook-provider.md
+++ b/docs/tutorials/webhook-provider.md
@@ -47,12 +47,6 @@ The default recommended port for the provider endpoints is `8888`, and should li
 
 The default recommended port for the exposed endpoints is `8080`, and it should be bound to all interfaces (`0.0.0.0`)
 
-## Custom Annotations
-
-The Webhook provider supports custom annotations for DNS records. This feature allows users to define additional configuration options for DNS records managed by the Webhook provider. Custom annotations are defined using the annotation format `external-dns.alpha.kubernetes.io/webhook-<custom-annotation>`.
-
-Custom annotations can be used to influence DNS record creation and updates. Providers implementing the Webhook API should document the custom annotations they support and how they affect DNS record management.
-
 ## Provider registry
 
 To simplify the discovery of providers, we will accept pull requests that will add links to providers in this documentation.

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -49,19 +49,19 @@ const (
 	route53PageSize int32 = 300
 	// providerSpecificAlias specifies whether a CNAME endpoint maps to an AWS ALIAS record.
 	providerSpecificAlias            = "alias"
-	providerSpecificTargetHostedZone = "aws/target-hosted-zone"
+	providerSpecificTargetHostedZone = "aws-target-hosted-zone"
 	// providerSpecificEvaluateTargetHealth specifies whether an AWS ALIAS record
 	// has the EvaluateTargetHealth field set to true. Present iff the endpoint
 	// has a `providerSpecificAlias` value of `true`.
-	providerSpecificEvaluateTargetHealth       = "aws/evaluate-target-health"
-	providerSpecificWeight                     = "aws/weight"
-	providerSpecificRegion                     = "aws/region"
-	providerSpecificFailover                   = "aws/failover"
-	providerSpecificGeolocationContinentCode   = "aws/geolocation-continent-code"
-	providerSpecificGeolocationCountryCode     = "aws/geolocation-country-code"
-	providerSpecificGeolocationSubdivisionCode = "aws/geolocation-subdivision-code"
-	providerSpecificMultiValueAnswer           = "aws/multi-value-answer"
-	providerSpecificHealthCheckID              = "aws/health-check-id"
+	providerSpecificEvaluateTargetHealth       = "aws-evaluate-target-health"
+	providerSpecificWeight                     = "aws-weight"
+	providerSpecificRegion                     = "aws-region"
+	providerSpecificFailover                   = "aws-failover"
+	providerSpecificGeolocationContinentCode   = "aws-geolocation-continent-code"
+	providerSpecificGeolocationCountryCode     = "aws-geolocation-country-code"
+	providerSpecificGeolocationSubdivisionCode = "aws-geolocation-subdivision-code"
+	providerSpecificMultiValueAnswer           = "aws-multi-value-answer"
+	providerSpecificHealthCheckID              = "aws-health-check-id"
 	sameZoneAlias                              = "same-zone"
 	// Currently supported up to 10 health checks or hosted zones.
 	// https://docs.aws.amazon.com/Route53/latest/APIReference/API_ListTagsForResources.html#API_ListTagsForResources_RequestSyntax

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -523,7 +523,7 @@ func TestCloudflareProxiedOverrideTrue(t *testing.T) {
 			Targets:    endpoint.Targets{"127.0.0.1"},
 			ProviderSpecific: endpoint.ProviderSpecific{
 				endpoint.ProviderSpecificProperty{
-					Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
+					Name:  providerSpecificProxied,
 					Value: "true",
 				},
 			},
@@ -555,7 +555,7 @@ func TestCloudflareProxiedOverrideFalse(t *testing.T) {
 			Targets:    endpoint.Targets{"127.0.0.1"},
 			ProviderSpecific: endpoint.ProviderSpecific{
 				endpoint.ProviderSpecificProperty{
-					Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
+					Name:  providerSpecificProxied,
 					Value: "false",
 				},
 			},
@@ -587,7 +587,7 @@ func TestCloudflareProxiedOverrideIllegal(t *testing.T) {
 			Targets:    endpoint.Targets{"127.0.0.1"},
 			ProviderSpecific: endpoint.ProviderSpecific{
 				endpoint.ProviderSpecificProperty{
-					Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
+					Name:  providerSpecificProxied,
 					Value: "asfasdfa",
 				},
 			},
@@ -638,7 +638,7 @@ func TestCloudflareSetProxied(t *testing.T) {
 				Targets:    endpoint.Targets{"127.0.0.1"},
 				ProviderSpecific: endpoint.ProviderSpecific{
 					endpoint.ProviderSpecificProperty{
-						Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
+						Name:  providerSpecificProxied,
 						Value: "true",
 					},
 				},
@@ -1008,7 +1008,7 @@ func TestCloudflareGroupByNameAndType(t *testing.T) {
 					Labels:     endpoint.Labels{},
 					ProviderSpecific: endpoint.ProviderSpecific{
 						{
-							Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
+							Name:  providerSpecificProxied,
 							Value: "false",
 						},
 					},
@@ -1042,7 +1042,7 @@ func TestCloudflareGroupByNameAndType(t *testing.T) {
 					Labels:     endpoint.Labels{},
 					ProviderSpecific: endpoint.ProviderSpecific{
 						{
-							Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
+							Name:  providerSpecificProxied,
 							Value: "false",
 						},
 					},
@@ -1090,7 +1090,7 @@ func TestCloudflareGroupByNameAndType(t *testing.T) {
 					Labels:     endpoint.Labels{},
 					ProviderSpecific: endpoint.ProviderSpecific{
 						{
-							Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
+							Name:  providerSpecificProxied,
 							Value: "false",
 						},
 					},
@@ -1103,7 +1103,7 @@ func TestCloudflareGroupByNameAndType(t *testing.T) {
 					Labels:     endpoint.Labels{},
 					ProviderSpecific: endpoint.ProviderSpecific{
 						{
-							Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
+							Name:  providerSpecificProxied,
 							Value: "false",
 						},
 					},
@@ -1144,7 +1144,7 @@ func TestCloudflareGroupByNameAndType(t *testing.T) {
 					Labels:     endpoint.Labels{},
 					ProviderSpecific: endpoint.ProviderSpecific{
 						{
-							Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
+							Name:  providerSpecificProxied,
 							Value: "false",
 						},
 					},
@@ -1157,7 +1157,7 @@ func TestCloudflareGroupByNameAndType(t *testing.T) {
 					Labels:     endpoint.Labels{},
 					ProviderSpecific: endpoint.ProviderSpecific{
 						{
-							Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
+							Name:  providerSpecificProxied,
 							Value: "false",
 						},
 					},
@@ -1198,7 +1198,7 @@ func TestCloudflareGroupByNameAndType(t *testing.T) {
 					Labels:     endpoint.Labels{},
 					ProviderSpecific: endpoint.ProviderSpecific{
 						{
-							Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
+							Name:  providerSpecificProxied,
 							Value: "false",
 						},
 					},
@@ -1338,7 +1338,7 @@ func TestCloudflareComplexUpdate(t *testing.T) {
 			Labels:     endpoint.Labels{},
 			ProviderSpecific: endpoint.ProviderSpecific{
 				{
-					Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
+					Name:  providerSpecificProxied,
 					Value: "true",
 				},
 			},
@@ -1423,7 +1423,7 @@ func TestCustomTTLWithEnabledProxyNotChanged(t *testing.T) {
 			Labels:     endpoint.Labels{},
 			ProviderSpecific: endpoint.ProviderSpecific{
 				{
-					Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
+					Name:  providerSpecificProxied,
 					Value: "true",
 				},
 			},
@@ -1653,7 +1653,7 @@ func TestCloudflareCustomHostnameOperations(t *testing.T) {
 					Labels:     endpoint.Labels{},
 					ProviderSpecific: endpoint.ProviderSpecific{
 						{
-							Name:  "external-dns.alpha.kubernetes.io/cloudflare-custom-hostname",
+							Name:  providerSpecificCustomHostnameKey,
 							Value: "a.foo.fancybar.com",
 						},
 					},
@@ -1666,7 +1666,7 @@ func TestCloudflareCustomHostnameOperations(t *testing.T) {
 					Labels:     endpoint.Labels{},
 					ProviderSpecific: endpoint.ProviderSpecific{
 						{
-							Name:  "external-dns.alpha.kubernetes.io/cloudflare-custom-hostname",
+							Name:  providerSpecificCustomHostnameKey,
 							Value: "txt.foo.fancybar.com",
 						},
 					},
@@ -1688,7 +1688,7 @@ func TestCloudflareCustomHostnameOperations(t *testing.T) {
 					Labels:     endpoint.Labels{},
 					ProviderSpecific: endpoint.ProviderSpecific{
 						{
-							Name:  "external-dns.alpha.kubernetes.io/cloudflare-custom-hostname",
+							Name:  providerSpecificCustomHostnameKey,
 							Value: "a2.foo.fancybar.com",
 						},
 					},

--- a/provider/ibmcloud/ibmcloud.go
+++ b/provider/ibmcloud/ibmcloud.go
@@ -965,7 +965,7 @@ func shouldBeProxied(endpoint *endpoint.Endpoint, proxiedByDefault bool) bool {
 		if v.Name == proxyFilter {
 			b, err := strconv.ParseBool(v.Value)
 			if err != nil {
-				log.Errorf("Failed to parse annotation [%s]: %v", proxyFilter, err)
+				log.Errorf("Failed parsing value of %s: %v", proxyFilter, err)
 			} else {
 				proxied = b
 			}

--- a/provider/ibmcloud/ibmcloud_test.go
+++ b/provider/ibmcloud/ibmcloud_test.go
@@ -161,7 +161,7 @@ func newTestIBMCloudProvider(private bool) *IBMCloudProvider {
 			Targets: endpoint.Targets{"4.3.2.1"},
 			ProviderSpecific: endpoint.ProviderSpecific{
 				{
-					Name:  "ibmcloud-vpc",
+					Name:  vpcFilter,
 					Value: "crn:v1:staging:public:is:us-south:a/0821fa9f9ebcc7b7c9a0d6e9bf9442a4::vpc:be33cdad-9a03-4bfa-82ca-eadb9f1de688",
 				},
 			},
@@ -223,7 +223,7 @@ func TestPublic_ApplyChanges(t *testing.T) {
 				Targets:    endpoint.NewTargets("4.3.2.1"),
 				ProviderSpecific: endpoint.ProviderSpecific{
 					{
-						Name:  "ibmcloud-proxied",
+						Name:  proxyFilter,
 						Value: "false",
 					},
 				},
@@ -237,7 +237,7 @@ func TestPublic_ApplyChanges(t *testing.T) {
 				Targets:    endpoint.NewTargets("1.2.3.4"),
 				ProviderSpecific: endpoint.ProviderSpecific{
 					{
-						Name:  "ibmcloud-proxied",
+						Name:  proxyFilter,
 						Value: "false",
 					},
 				},
@@ -251,7 +251,7 @@ func TestPublic_ApplyChanges(t *testing.T) {
 				Targets:    endpoint.NewTargets("1.2.3.4", "5.6.7.8"),
 				ProviderSpecific: endpoint.ProviderSpecific{
 					{
-						Name:  "ibmcloud-proxied",
+						Name:  proxyFilter,
 						Value: "true",
 					},
 				},
@@ -284,7 +284,7 @@ func TestPrivate_ApplyChanges(t *testing.T) {
 			Targets:    endpoint.NewTargets("4.3.2.1"),
 			ProviderSpecific: endpoint.ProviderSpecific{
 				{
-					Name:  "ibmcloud-vpc",
+					Name:  vpcFilter,
 					Value: "crn:v1:staging:public:is:us-south:a/0821fa9f9ebcc7b7c9a0d6e9bf9442a4::vpc:be33cdad-9a03-4bfa-82ca-eadb9f1de688",
 				},
 			},
@@ -352,7 +352,7 @@ func TestAdjustEndpoints(t *testing.T) {
 			Labels:     endpoint.Labels{},
 			ProviderSpecific: endpoint.ProviderSpecific{
 				{
-					Name:  "ibmcloud-proxied",
+					Name:  proxyFilter,
 					Value: "1",
 				},
 			},
@@ -364,7 +364,7 @@ func TestAdjustEndpoints(t *testing.T) {
 
 	assert.Equal(t, endpoint.TTL(0), ep[0].RecordTTL)
 	assert.Equal(t, "test.example.com", ep[0].DNSName)
-	proxied, _ := ep[0].GetProviderSpecificProperty("ibmcloud-proxied")
+	proxied, _ := ep[0].GetProviderSpecificProperty(proxyFilter)
 	assert.Equal(t, "true", proxied)
 }
 

--- a/provider/scaleway/scaleway.go
+++ b/provider/scaleway/scaleway.go
@@ -36,7 +36,7 @@ import (
 const (
 	scalewyRecordTTL        uint32 = 300
 	scalewayDefaultPriority uint32 = 0
-	scalewayPriorityKey     string = "scw/priority"
+	scalewayPriorityKey     string = "scw-priority"
 )
 
 // ScalewayProvider implements the DNS provider for Scaleway DNS

--- a/source/ambassador_host_test.go
+++ b/source/ambassador_host_test.go
@@ -246,8 +246,8 @@ func TestAmbassadorHostSource(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "basic-host",
 					Annotations: map[string]string{
-						ambHostAnnotation:    hostAnnotation,
-						CloudflareProxiedKey: "true",
+						ambHostAnnotation: hostAnnotation,
+						"external-dns.alpha.kubernetes.io/cloudflare-proxied": "true",
 					},
 				},
 				Spec: &ambassador.HostSpec{
@@ -272,7 +272,7 @@ func TestAmbassadorHostSource(t *testing.T) {
 					RecordType: endpoint.RecordTypeA,
 					Targets:    endpoint.Targets{"1.1.1.1"},
 					ProviderSpecific: endpoint.ProviderSpecific{{
-						Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
+						Name:  "cloudflare-proxied",
 						Value: "true",
 					}},
 				},

--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -157,7 +157,7 @@ func testCRDSourceEndpoints(t *testing.T) {
 					},
 				},
 			},
-			expectError:     true,
+			expectError: true,
 		},
 		{
 			title:                "invalid crd kind",
@@ -175,7 +175,38 @@ func testCRDSourceEndpoints(t *testing.T) {
 					},
 				},
 			},
-			expectError:     true,
+			expectError: true,
+		},
+		{
+			title:                "endpoint with annotations",
+			registeredAPIVersion: "test.k8s.io/v1alpha1",
+			apiVersion:           "test.k8s.io/v1alpha1",
+			registeredKind:       "DNSEndpoint",
+			kind:                 "DNSEndpoint",
+			namespace:            "namespace",
+			registeredNamespace:  "namespace",
+			annotations: map[string]string{
+				hostnameAnnotationKey:            "example.com",
+				targetAnnotationKey:              "1.2.3.4",
+				ttlAnnotationKey:                 "180",
+				annotationKeyPrefix + "property": "value",
+			},
+			spec: &endpoint.DNSEndpointSpec{},
+			endpoints: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.com",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+					RecordTTL:  180,
+					ProviderSpecific: endpoint.ProviderSpecific{
+						endpoint.ProviderSpecificProperty{
+							Name:  "property",
+							Value: "value",
+						},
+					},
+				},
+			},
+			expectError: false,
 		},
 		{
 			title:                "endpoint with provider property",
@@ -185,6 +216,10 @@ func testCRDSourceEndpoints(t *testing.T) {
 			kind:                 "DNSEndpoint",
 			namespace:            "namespace",
 			registeredNamespace:  "namespace",
+			annotations: map[string]string{
+				annotationKeyPrefix + "override": "ignored",
+				annotationKeyPrefix + "property": "value",
+			},
 			spec: &endpoint.DNSEndpointSpec{
 				Endpoints: []*endpoint.Endpoint{
 					{
@@ -194,19 +229,19 @@ func testCRDSourceEndpoints(t *testing.T) {
 						RecordTTL:  180,
 						ProviderSpecific: endpoint.ProviderSpecific{
 							endpoint.ProviderSpecificProperty{
-								Name: "property",
+								Name:  "override",
 								Value: "value",
 							},
 							endpoint.ProviderSpecificProperty{
-								Name: "aws/property",
+								Name:  "aws/property",
 								Value: "value",
 							},
 							endpoint.ProviderSpecificProperty{
-								Name: "scw/property",
+								Name:  "scw/property",
 								Value: "value",
 							},
 							endpoint.ProviderSpecificProperty{
-								Name: "webhook/property",
+								Name:  "webhook/property",
 								Value: "value",
 							},
 						},
@@ -221,25 +256,29 @@ func testCRDSourceEndpoints(t *testing.T) {
 					RecordTTL:  180,
 					ProviderSpecific: endpoint.ProviderSpecific{
 						endpoint.ProviderSpecificProperty{
-							Name: "property",
+							Name:  "override",
 							Value: "value",
 						},
 						endpoint.ProviderSpecificProperty{
-							Name: "aws/property",
+							Name:  "aws-property",
 							Value: "value",
 						},
 						endpoint.ProviderSpecificProperty{
-							Name: "scw/property",
+							Name:  "scw-property",
 							Value: "value",
 						},
 						endpoint.ProviderSpecificProperty{
-							Name: "webhook/property",
+							Name:  "webhook/property",
+							Value: "value",
+						},
+						endpoint.ProviderSpecificProperty{
+							Name:  "property",
 							Value: "value",
 						},
 					},
 				},
 			},
-			expectError:     false,
+			expectError: false,
 		},
 		{
 			title:                "endpoints within a specific namespace",
@@ -267,7 +306,7 @@ func testCRDSourceEndpoints(t *testing.T) {
 					RecordTTL:  180,
 				},
 			},
-			expectError:     false,
+			expectError: false,
 		},
 		{
 			title:                "no endpoints within a specific namespace",
@@ -287,7 +326,7 @@ func testCRDSourceEndpoints(t *testing.T) {
 					},
 				},
 			},
-			expectError:     false,
+			expectError: false,
 		},
 		{
 			title:                "invalid crd with no targets",
@@ -307,7 +346,7 @@ func testCRDSourceEndpoints(t *testing.T) {
 					},
 				},
 			},
-			expectError:     false,
+			expectError: false,
 		},
 		{
 			title:                "valid crd gvk with single endpoint",
@@ -335,7 +374,7 @@ func testCRDSourceEndpoints(t *testing.T) {
 					RecordTTL:  180,
 				},
 			},
-			expectError:     false,
+			expectError: false,
 		},
 		{
 			title:                "valid crd gvk with multiple endpoints",
@@ -375,7 +414,7 @@ func testCRDSourceEndpoints(t *testing.T) {
 					RecordTTL:  180,
 				},
 			},
-			expectError:     false,
+			expectError: false,
 		},
 		{
 			title:                "valid crd gvk with annotation and non matching annotation filter",
@@ -397,7 +436,7 @@ func testCRDSourceEndpoints(t *testing.T) {
 					},
 				},
 			},
-			expectError:     false,
+			expectError: false,
 		},
 		{
 			title:                "valid crd gvk with annotation and matching annotation filter",
@@ -427,7 +466,7 @@ func testCRDSourceEndpoints(t *testing.T) {
 					RecordTTL:  180,
 				},
 			},
-			expectError:     false,
+			expectError: false,
 		},
 		// TODO: Label based Selectors are implemented by the REST client
 		//       Therefore this test case predominantly exercises the fake REST client,
@@ -452,7 +491,7 @@ func testCRDSourceEndpoints(t *testing.T) {
 		//			},
 		//		},
 		//	},
-		//	expectError:     false,
+		//	expectError: false,
 		//},
 		{
 			title:                "valid crd gvk with label and matching label filter",
@@ -482,7 +521,7 @@ func testCRDSourceEndpoints(t *testing.T) {
 					RecordTTL:  180,
 				},
 			},
-			expectError:     false,
+			expectError: false,
 		},
 		{
 			title:                "Create NS record",
@@ -512,7 +551,7 @@ func testCRDSourceEndpoints(t *testing.T) {
 					RecordTTL:  180,
 				},
 			},
-			expectError:     false,
+			expectError: false,
 		},
 		{
 			title:                "Create SRV record",
@@ -542,7 +581,7 @@ func testCRDSourceEndpoints(t *testing.T) {
 					RecordTTL:  180,
 				},
 			},
-			expectError:     false,
+			expectError: false,
 		},
 		{
 			title:                "Create NAPTR record",
@@ -572,7 +611,7 @@ func testCRDSourceEndpoints(t *testing.T) {
 					RecordTTL:  180,
 				},
 			},
-			expectError:     false,
+			expectError: false,
 		},
 		{
 			title:                "illegal target CNAME",
@@ -594,7 +633,7 @@ func testCRDSourceEndpoints(t *testing.T) {
 					},
 				},
 			},
-			expectError:     false,
+			expectError: false,
 		},
 		{
 			title:                "illegal target NAPTR",
@@ -616,7 +655,7 @@ func testCRDSourceEndpoints(t *testing.T) {
 					},
 				},
 			},
-			expectError:     false,
+			expectError: false,
 		},
 	} {
 		ti := ti

--- a/source/gloo_proxy_test.go
+++ b/source/gloo_proxy_test.go
@@ -508,7 +508,7 @@ func TestGlooSource(t *testing.T) {
 			Labels:        endpoint.Labels{},
 			ProviderSpecific: endpoint.ProviderSpecific{
 				endpoint.ProviderSpecificProperty{
-					Name:  "aws/geolocation-country-code",
+					Name:  "aws-geolocation-country-code",
 					Value: "LU",
 				},
 			},
@@ -530,7 +530,7 @@ func TestGlooSource(t *testing.T) {
 			Labels:        endpoint.Labels{},
 			ProviderSpecific: endpoint.ProviderSpecific{
 				endpoint.ProviderSpecificProperty{
-					Name:  "aws/geolocation-country-code",
+					Name:  "aws-geolocation-country-code",
 					Value: "JP",
 				},
 			},
@@ -560,7 +560,7 @@ func TestGlooSource(t *testing.T) {
 			Labels:        endpoint.Labels{},
 			ProviderSpecific: endpoint.ProviderSpecific{
 				endpoint.ProviderSpecificProperty{
-					Name:  "aws/geolocation-country-code",
+					Name:  "aws-geolocation-country-code",
 					Value: "ES",
 				},
 			},
@@ -581,7 +581,7 @@ func TestGlooSource(t *testing.T) {
 			Labels:        endpoint.Labels{},
 			ProviderSpecific: endpoint.ProviderSpecific{
 				endpoint.ProviderSpecificProperty{
-					Name:  "aws/geolocation-country-code",
+					Name:  "aws-geolocation-country-code",
 					Value: "IT",
 				},
 			},

--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -40,7 +40,7 @@ import (
 
 // IstioGatewayIngressSource is the annotation used to determine if the gateway is implemented by an Ingress object
 // instead of a standard LoadBalancer service type
-const IstioGatewayIngressSource = "external-dns.alpha.kubernetes.io/ingress"
+const IstioGatewayIngressSource = annotationKeyPrefix + "ingress"
 
 // gatewaySource is an implementation of Source for Istio Gateway objects.
 // The gateway implementation uses the spec.servers.hosts values for the hostnames.

--- a/source/source_test.go
+++ b/source/source_test.go
@@ -26,6 +26,105 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 )
 
+func TestGetProviderSpecificAnnotations(t *testing.T) {
+	for _, test := range []struct {
+		title       string
+		annotations map[string]string
+		properties  endpoint.ProviderSpecific
+		identifier  *string
+	}{
+		{
+			title: "None",
+			annotations: map[string]string{},
+			properties: endpoint.ProviderSpecific{},
+		},
+		{
+			title: "Native",
+			annotations: map[string]string{
+				aliasAnnotationKey: "true",
+				SetIdentifierKey: "identifier",
+			},
+			identifier: &[]string{"identifier"}[0],
+			properties: endpoint.ProviderSpecific{
+				endpoint.ProviderSpecificProperty{
+					Name: "alias",
+					Value: "true",
+				},
+			},
+		},
+		{
+			title: "ProviderAWS",
+			annotations: map[string]string{
+				"external-dns.alpha.kubernetes.io/aws-property": "value",
+			},
+			properties: endpoint.ProviderSpecific{
+				endpoint.ProviderSpecificProperty{
+					Name: "aws/property",
+					Value: "value",
+				},
+			},
+		},
+		{
+			title: "ProviderCloudflare",
+			annotations: map[string]string{
+				CloudflareProxiedKey: "true",
+			},
+			properties: endpoint.ProviderSpecific{
+				endpoint.ProviderSpecificProperty{
+					Name: CloudflareProxiedKey,
+					Value: "true",
+				},
+			},
+		},
+		{
+			title: "ProviderIBMCloud",
+			annotations: map[string]string{
+				"external-dns.alpha.kubernetes.io/ibmcloud-property": "value",
+			},
+			properties: endpoint.ProviderSpecific{
+				endpoint.ProviderSpecificProperty{
+					Name: "ibmcloud-property",
+					Value: "value",
+				},
+			},
+		},
+		{
+			title: "ProviderSCW",
+			annotations: map[string]string{
+				"external-dns.alpha.kubernetes.io/scw-property": "value",
+			},
+			properties: endpoint.ProviderSpecific{
+				endpoint.ProviderSpecificProperty{
+					Name: "scw/property",
+					Value: "value",
+				},
+			},
+		},
+		{
+			title: "ProviderWebhook",
+			annotations: map[string]string{
+				"external-dns.alpha.kubernetes.io/webhook-property": "value",
+			},
+			properties: endpoint.ProviderSpecific{
+				endpoint.ProviderSpecificProperty{
+					Name: "webhook/property",
+					Value: "value",
+				},
+			},
+		},
+	} {
+		t.Run(test.title, func(t *testing.T) {
+			properties, identifier := getProviderSpecificAnnotations(test.annotations)
+			assert.Equal(t, test.properties, properties)
+			if test.identifier != nil {
+				assert.Equal(t, *test.identifier, identifier)
+			} else {
+				assert.Equal(t, "", identifier)
+			}
+		})
+	}
+}
+
 func TestGetTTLFromAnnotations(t *testing.T) {
 	for _, tc := range []struct {
 		title       string


### PR DESCRIPTION
**Description**

Support for [provider-specific annotations](https://github.com/kubernetes-sigs/external-dns/blob/7343cb99e098074da3dcbd9f7e3cda708e723ec6/docs/annotations/annotations.md#provider-specific-annotations), that manifest as [Endpoint.ProviderSpecific](https://github.com/kubernetes-sigs/external-dns/blob/7343cb99e098074da3dcbd9f7e3cda708e723ec6/endpoint/endpoint.go#L189L196) properties, is currently restricted to a subset of pre-defined providers. This functionality should be available to all providers, without requirement for special-case registration within the [getProviderSpecificAnnotations(…)](https://github.com/kubernetes-sigs/external-dns/blob/7343cb99e098074da3dcbd9f7e3cda708e723ec6/source/source.go#L189L237) function.

The proposed changes include:
* Inversion of logic within the `getProviderSpecificAnnotations(…)` function so as to treat all annotations prefixed with `external-dns.alpha.kubernetes.io/`, but that are not otherwise recognised, as provider-specific properties

Notes:
* The existing allocation of annotations (i.e. whether they might be considered provider-specific or not) is somewhat unfortunate; but it is appreciated that any efforts to tidy-up annotations are likely constrained by concerns regarding backwards-compatibility
* It is assumed that the naming of provider-specific properties (i.e. whether they should be of the form `provider/property` or `provider-property`) is an internal implementation detail, and therefore the proposed renaming does not represent any backwards-incompatibility 
* The documented suggestion for adopting annotations of the form `…/webhook-<custom-annotation>` is considered unwise - provider-specific properties are considered to be provider-specific, whereas the [Webhook provider](https://github.com/kubernetes-sigs/external-dns/blob/7343cb99e098074da3dcbd9f7e3cda708e723ec6/docs/tutorials/webhook-provider.md) is considered to be a wrapper of providers, rather than a provider in and of itself (see: #4347)
  * The renaming of Webhook related  provider-specific properties (i.e. from `webhook-property` to `webhook/property` has not been implemented - implementation would be trivial, but given the conclusion that provider-specific properties associated with a Webhook provider are nonsensical, such an implementation is not being initially proposed
    * It is not clear to me, but seems unlikely, that anyone will have adopted the Webhook framework _and_ are relying upon provider-specific properties

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
