### PR TITLE
fix(txt-suffix): avoid crash on domain without dot

### DIFF
--- a/registry/txt.go
+++ b/registry/txt.go
@@ -392,18 +392,15 @@ func (pr affixNameMapper) isSuffix() bool {
 }
 
 func (pr affixNameMapper) toEndpointName(txtDNSName string) (endpointName string, recordType string) {
-	log.Debug("Getting endpoint from TXT record.")
 	lowerDNSName := strings.ToLower(txtDNSName)
 
 	// drop prefix
 	if pr.isPrefix() {
-		log.Debug("TXT record has a prefix.")
 		return pr.dropAffixExtractType(lowerDNSName)
 	}
 
 	// drop suffix
 	if pr.isSuffix() {
-		log.Debug("TXT record has a suffix.")
 		dc := strings.Count(pr.suffix, ".")
 		DNSName := strings.SplitN(lowerDNSName, ".", 2+dc)
 		domainWithSuffix := strings.Join(DNSName[:1+dc], ".")

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -392,20 +392,26 @@ func (pr affixNameMapper) isSuffix() bool {
 }
 
 func (pr affixNameMapper) toEndpointName(txtDNSName string) (endpointName string, recordType string) {
+	log.Debug("Getting endpoint from TXT record.")
 	lowerDNSName := strings.ToLower(txtDNSName)
 
 	// drop prefix
 	if pr.isPrefix() {
+		log.Debug("TXT record has a prefix.")
 		return pr.dropAffixExtractType(lowerDNSName)
 	}
 
 	// drop suffix
 	if pr.isSuffix() {
+		log.Debug("TXT record has a suffix.")
 		dc := strings.Count(pr.suffix, ".")
 		DNSName := strings.SplitN(lowerDNSName, ".", 2+dc)
 		domainWithSuffix := strings.Join(DNSName[:1+dc], ".")
 
 		r, rType := pr.dropAffixExtractType(domainWithSuffix)
+		if !strings.Contains(lowerDNSName, ".") {
+			return r, rType
+		}
 		return r + "." + DNSName[1+dc], rType
 	}
 	return "", ""

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -1303,6 +1303,13 @@ func TestToEndpointNameNewTXT(t *testing.T) {
 		{
 			name:       "suffix",
 			mapper:     newaffixNameMapper("", "foo", ""),
+			domain:     "example",
+			recordType: "AAAA",
+			txtDomain:  "aaaa-examplefoo",
+		},
+		{
+			name:       "suffix",
+			mapper:     newaffixNameMapper("", "foo", ""),
 			domain:     "example.com",
 			recordType: "AAAA",
 			txtDomain:  "aaaa-examplefoo.com",


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
This PR fix issue when suffix is used and the domain has no dot

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #1668

**Checklist**

- [X] Unit tests updated
- [N/A] End user documentation updated
