### PR TITLE
Fixes issue #4888. Include record type in dedupe key.

### DIFF
--- a/source/dedupsource.go
+++ b/source/dedupsource.go
@@ -45,7 +45,7 @@ func (ms *dedupSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, err
 	}
 
 	for _, ep := range endpoints {
-		identifier := ep.DNSName + " / " + ep.SetIdentifier + " / " + ep.Targets.String()
+		identifier := ep.RecordType + " / " + ep.DNSName + " / " + ep.SetIdentifier + " / " + ep.Targets.String()
 
 		if _, ok := collected[identifier]; ok {
 			log.Debugf("Removing duplicate endpoint %s", ep)

--- a/source/dedupsource_test.go
+++ b/source/dedupsource_test.go
@@ -90,6 +90,27 @@ func testDedupEndpoints(t *testing.T) {
 				{DNSName: "foo.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
+		{
+			"two endpoints with same dnsname, same type, and same target return one endpoint",
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", RecordType: "A", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: "A", Targets: endpoint.Targets{"1.2.3.4"}},
+			},
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", RecordType: "A", Targets: endpoint.Targets{"1.2.3.4"}},
+			},
+		},
+		{
+			"two endpoints with same dnsname, different record type, and same target return two endpoints",
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", RecordType: "A", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: "AAAA", Targets: endpoint.Targets{"1.2.3.4"}},
+			},
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", RecordType: "A", Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: "AAAA", Targets: endpoint.Targets{"1.2.3.4"}},
+			},
+		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
 			mockSource := new(testutils.MockSource)


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

RecordType is not included in deduplication key and therefore records with same name, setid, and targets but with different recordtype currently are treated as duplicates.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4888

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
