### PR TITLE
fix: Deny pihole apply requests containing wildcard

### DIFF
--- a/provider/pihole/client.go
+++ b/provider/pihole/client.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"sigs.k8s.io/external-dns/provider"
 	"strings"
 
 	"github.com/linki/instrumented_http"
@@ -224,6 +225,10 @@ func (p *piholeClient) apply(ctx context.Context, action string, ep *endpoint.En
 	log.Infof("%s %s IN %s -> %s", action, ep.DNSName, ep.RecordType, ep.Targets[0])
 
 	form := p.newDNSActionForm(action, ep)
+	if strings.Contains(ep.DNSName, "*") {
+		log.Errorf("UNSUPPORTED: Pihole DNS names cannot return wildcard")
+		return provider.SoftError
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(form.Encode()))
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

This PR is simply following in the footsteps of @alex4108's work and utilizes SoftError rather than return nil.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4622 

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
