### PR TITLE
Add option to toggle CRD installation

### DIFF
--- a/charts/external-dns/templates/crds/dnsendpoint.yaml
+++ b/charts/external-dns/templates/crds/dnsendpoint.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.crd.create }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -100,3 +101,4 @@ spec:
       storage: true
       subresources:
         status: {}
+{{- end }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -305,3 +305,7 @@ secretConfiguration:
   subPath:
   # -- `Secret` data.
   data: {}
+
+crd:
+  # --- Install and use the integrated DNSEndpoint CRD
+  create: true


### PR DESCRIPTION
**Description**
Add helm value to helm chart to enable or disable CRD installation.

This would allow and simplify installing multiple instances of external-dns to one cluster. Also in multi-tenant clusters, where CRD installation is not allowed, this would be an great enabler. Default value is enabled, to not introduce any breaking changes, while allowing an override to disable the installation.

Fixes #4850 

