### PR TITLE
feat(chart): add ability to specify extra kubernetes manifests

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added option to configure `extraObjects` via helm values ([#4916](https://github.com/kubernetes-sigs/external-dns/pull/4916)) _@thenickfish_
 - Ability to configure `imagePullSecrets` via helm `global` value ([#4667](https://github.com/kubernetes-sigs/external-dns/pull/4667)) _@jkroepke_
 - Added options to configure `labelFilter` and `managedRecordTypes` via dedicated helm values ([#4849](https://github.com/kubernetes-sigs/external-dns/pull/4849)) _@abaguas_
 

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -102,6 +102,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | excludeDomains | list | `[]` | Intentionally exclude domains from being managed. |
 | extraArgs | list | `[]` | Extra arguments to provide to _ExternalDNS_. |
 | extraContainers | object | `{}` | Extra containers to add to the `Deployment`. |
+| extraObjects | list | `[]` | Extra K8s manifests to deploy |
 | extraVolumeMounts | list | `[]` | Extra [volume mounts](https://kubernetes.io/docs/concepts/storage/volumes/) for the `external-dns` container. |
 | extraVolumes | list | `[]` | Extra [volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the `Pod`. |
 | fullnameOverride | string | `nil` | Override the full name of the chart. |

--- a/charts/external-dns/templates/extra-objects.yaml
+++ b/charts/external-dns/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -296,6 +296,15 @@ provider:
 # -- Extra arguments to provide to _ExternalDNS_.
 extraArgs: []
 
+# extraObjects -- Extra kubernetes manifests to deploy
+extraObjects: []
+#  - apiVersion: v1
+#    kind: ConfigMap
+#    metadata:
+#      name: my-configmap
+#    data:
+#      key: "value"
+
 secretConfiguration:
   # -- If `true`, create a `Secret` to store sensitive provider configuration (**DEPRECATED**).
   enabled: false


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This pull requests add the ability to provide `extraObjects` to the helm chart. An example of a use-case this change supports: I need to provide a secret to the webhook for external-dns and would like to do so using external-secrets-operator. This means I need to create an appropriate `ExternalSecret` object and would prefer to do that at the same time as the install for this chart if possible.

Here is a related Helm issue for discussion around this pattern: https://github.com/helm/helm/issues/12653
and another kubernetes PR I tried to parallel: https://github.com/kubernetes/autoscaler/pull/7243

Thanks maintainers!

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->


**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
