### PR TITLE
Add serviceMonitor field to Helm values.schema.json

### DIFF
--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -89,6 +89,52 @@
           "type": "integer"
         }
       }
+    },
+    "serviceMonitor": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "interval": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "port": {
+          "type": "string"
+        },
+        "scheme": {
+          "type": "string"
+        },
+        "tlsConfig": {
+          "type": "object",
+          "properties": {
+            "insecureSkipVerify": {
+              "type": "boolean"
+            },
+            "caFile": {
+              "type": "string"
+            },
+            "certFile": {
+              "type": "string"
+            },
+            "keyFile": {
+              "type": "string"
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

Completed bug fix for: Helm chart values schema is missing an entry for the serviceMonitor property. #4860

serviceMonitor property was added to the helm chart

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4860
https://github.com/kubernetes-sigs/external-dns/issues/4860

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
