### PR TITLE
fix(cloudflare): use softerror on internal server error with api

### DIFF
--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -244,7 +245,7 @@ func (p *CloudFlareProvider) Zones(ctx context.Context) ([]cloudflare.Zone, erro
 	if err != nil {
 		var apiErr *cloudflare.Error
 		if errors.As(err, &apiErr) {
-			if apiErr.ClientRateLimited() {
+			if apiErr.ClientRateLimited() || apiErr.StatusCode >= http.StatusInternalServerError {
 				// Handle rate limit error as a soft error
 				return nil, provider.NewSoftError(err)
 			}
@@ -498,7 +499,7 @@ func (p *CloudFlareProvider) listDNSRecordsWithAutoPagination(ctx context.Contex
 		if err != nil {
 			var apiErr *cloudflare.Error
 			if errors.As(err, &apiErr) {
-				if apiErr.ClientRateLimited() {
+				if apiErr.ClientRateLimited() || apiErr.StatusCode >= http.StatusInternalServerError {
 					// Handle rate limit error as a soft error
 					return nil, provider.NewSoftError(err)
 				}


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Updates the Cloudflare provider to raise SoftError on 5xx status code while interacting with Cloudflare API 

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4315

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated - None Needed
