### PR TITLE
fix(ovh): cache refresh and duplicates processing

### DIFF
--- a/provider/ovh/ovh.go
+++ b/provider/ovh/ovh.go
@@ -161,12 +161,10 @@ func (p *OVHProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) (
 	}()
 
 	allChanges := make([]ovhChange, 0, countTargets(changes.Create, changes.UpdateNew, changes.UpdateOld, changes.Delete))
-
-
-	allChanges = append(allChanges, newOvhChange(ovhCreate, changes.Create, zones, records))
-	allChanges = append(allChanges, newOvhChange(ovhCreate, changes.UpdateNew, zones, records))
-	allChanges = append(allChanges, newOvhChange(ovhCreate, changes.UpdateOld, zones, records))
-	allChanges = append(allChanges, newOvhChange(ovhCreate, changes.Delete, zones, records))
+	allChanges = append(allChanges, newOvhChange(ovhCreate, changes.Create, zones, records)...)
+	allChanges = append(allChanges, newOvhChange(ovhCreate, changes.UpdateNew, zones, records)...)
+	allChanges = append(allChanges, newOvhChange(ovhCreate, changes.UpdateOld, zones, records)...)
+	allChanges = append(allChanges, newOvhChange(ovhCreate, changes.Delete, zones, records)...)
 
 	log.Infof("OVH: %d changes will be done", len(allChanges))
 

--- a/provider/ovh/ovh.go
+++ b/provider/ovh/ovh.go
@@ -151,6 +151,8 @@ func (p *OVHProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) (
 
 		eg, _ := errgroup.WithContext(ctx)
 		for zone := range zonesChangeUniques {
+			// This is necessary because the loop variable zone is reused in each iteration of the loop,
+			// and without this line, the goroutines launched by eg.Go would all reference the same zone variable.
 			zone := zone
 			eg.Go(func() error { return p.refresh(zone) })
 		}

--- a/provider/ovh/ovh.go
+++ b/provider/ovh/ovh.go
@@ -147,7 +147,7 @@ func (p *OVHProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) (
 
 	// Always refresh zones even in case of errors.
 	defer func() {
-		log.Infof("OVH: %d zones will be refreshed", len(zonesChangeUniques))
+		log.Debugf("OVH: %d zones will be refreshed", len(zonesChangeUniques))
 
 		eg, _ := errgroup.WithContext(ctx)
 		for zone := range zonesChangeUniques {

--- a/provider/ovh/ovh.go
+++ b/provider/ovh/ovh.go
@@ -172,7 +172,6 @@ func (p *OVHProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) (
 	allChanges = append(allChanges, changesUpdateOld...)
 	allChanges = append(allChanges, changesDelete...)
 
-
 	log.Infof("OVH: %d changes will be done", len(allChanges))
 
 	eg, _ := errgroup.WithContext(ctx)

--- a/provider/ovh/ovh.go
+++ b/provider/ovh/ovh.go
@@ -162,10 +162,6 @@ func (p *OVHProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) (
 
 	allChanges := make([]ovhChange, 0, countTargets(changes.Create, changes.UpdateNew, changes.UpdateOld, changes.Delete))
 
-	changesCreate := newOvhChange(ovhCreate, changes.Create, zones, records)
-	changesUpdateNew := newOvhChange(ovhCreate, changes.UpdateNew, zones, records)
-	changesUpdateOld := newOvhChange(ovhDelete, changes.UpdateOld, zones, records)
-	changesDelete := newOvhChange(ovhDelete, changes.Delete, zones, records)
 
 	allChanges = append(allChanges, newOvhChange(ovhCreate, changes.Create, zones, records))
 	allChanges = append(allChanges, newOvhChange(ovhCreate, changes.UpdateNew, zones, records))

--- a/provider/ovh/ovh.go
+++ b/provider/ovh/ovh.go
@@ -167,10 +167,10 @@ func (p *OVHProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) (
 	changesUpdateOld := newOvhChange(ovhDelete, changes.UpdateOld, zones, records)
 	changesDelete := newOvhChange(ovhDelete, changes.Delete, zones, records)
 
-	allChanges = append(allChanges, changesCreate...)
-	allChanges = append(allChanges, changesUpdateNew...)
-	allChanges = append(allChanges, changesUpdateOld...)
-	allChanges = append(allChanges, changesDelete...)
+	allChanges = append(allChanges, newOvhChange(ovhCreate, changes.Create, zones, records))
+	allChanges = append(allChanges, newOvhChange(ovhCreate, changes.UpdateNew, zones, records))
+	allChanges = append(allChanges, newOvhChange(ovhCreate, changes.UpdateOld, zones, records))
+	allChanges = append(allChanges, newOvhChange(ovhCreate, changes.Delete, zones, records))
 
 	log.Infof("OVH: %d changes will be done", len(allChanges))
 

--- a/provider/ovh/ovh.go
+++ b/provider/ovh/ovh.go
@@ -163,8 +163,8 @@ func (p *OVHProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) (
 	allChanges := make([]ovhChange, 0, countTargets(changes.Create, changes.UpdateNew, changes.UpdateOld, changes.Delete))
 	allChanges = append(allChanges, newOvhChange(ovhCreate, changes.Create, zones, records)...)
 	allChanges = append(allChanges, newOvhChange(ovhCreate, changes.UpdateNew, zones, records)...)
-	allChanges = append(allChanges, newOvhChange(ovhCreate, changes.UpdateOld, zones, records)...)
-	allChanges = append(allChanges, newOvhChange(ovhCreate, changes.Delete, zones, records)...)
+	allChanges = append(allChanges, newOvhChange(ovhDelete, changes.UpdateOld, zones, records)...)
+	allChanges = append(allChanges, newOvhChange(ovhDelete, changes.Delete, zones, records)...)
 
 	log.Infof("OVH: %d changes will be done", len(allChanges))
 

--- a/provider/ovh/ovh.go
+++ b/provider/ovh/ovh.go
@@ -172,18 +172,6 @@ func (p *OVHProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) (
 	allChanges = append(allChanges, changesUpdateOld...)
 	allChanges = append(allChanges, changesDelete...)
 
-	// Changes debug
-	if log.IsLevelEnabled(log.DebugLevel) {
-		debugF := func(changeType string, changes []ovhChange) {
-			for _, c := range changes {
-				log.Debugf("OVH: change type %s - %s", changeType, c.String())
-			}
-		}
-		debugF("OVH: (ovhCreate) Create", changesCreate)
-		debugF("OVH: (ovhCreate) UpdateNew", changesUpdateNew)
-		debugF("OVH: (ovhDelete) UpdateOld", changesUpdateOld)
-		debugF("OVH: (ovhDelete) Delete", changesDelete)
-	}
 
 	log.Infof("OVH: %d changes will be done", len(allChanges))
 

--- a/provider/ovh/ovh_test.go
+++ b/provider/ovh/ovh_test.go
@@ -324,14 +324,18 @@ func TestOvhNewChange(t *testing.T) {
 
 	// Delete change
 	endpoints = []*endpoint.Endpoint{
-		{DNSName: "ovh.example.net", RecordType: "A", Targets: []string{"203.0.113.42"}},
+		{DNSName: "ovh.example.net", RecordType: "A", Targets: []string{"203.0.113.42", "203.0.113.42", "203.0.113.42"}},
 	}
 	records := []ovhRecord{
 		{ID: 42, Zone: "example.net", ovhRecordFields: ovhRecordFields{FieldType: "A", SubDomain: "ovh", Target: "203.0.113.42"}},
+		{ID: 43, Zone: "example.net", ovhRecordFields: ovhRecordFields{FieldType: "A", SubDomain: "ovh", Target: "203.0.113.42"}},
+		{ID: 44, Zone: "example.net", ovhRecordFields: ovhRecordFields{FieldType: "A", SubDomain: "ovh", Target: "203.0.113.42"}},
 	}
 	changes = newOvhChange(ovhDelete, endpoints, []string{"example.net"}, records)
 	assert.ElementsMatch(changes, []ovhChange{
 		{Action: ovhDelete, ovhRecord: ovhRecord{ID: 42, Zone: "example.net", ovhRecordFields: ovhRecordFields{SubDomain: "ovh", FieldType: "A", TTL: ovhDefaultTTL, Target: "203.0.113.42"}}},
+		{Action: ovhDelete, ovhRecord: ovhRecord{ID: 43, Zone: "example.net", ovhRecordFields: ovhRecordFields{SubDomain: "ovh", FieldType: "A", TTL: ovhDefaultTTL, Target: "203.0.113.42"}}},
+		{Action: ovhDelete, ovhRecord: ovhRecord{ID: 44, Zone: "example.net", ovhRecordFields: ovhRecordFields{SubDomain: "ovh", FieldType: "A", TTL: ovhDefaultTTL, Target: "203.0.113.42"}}},
 	})
 }
 
@@ -368,6 +372,7 @@ func TestOvhApplyChanges(t *testing.T) {
 	client.On("Get", "/domain/zone").Return([]string{"example.net"}, nil).Once()
 	client.On("Get", "/domain/zone/example.net/record").Return([]uint64{}, nil).Once()
 	client.On("Post", "/domain/zone/example.net/record", ovhRecordFields{SubDomain: "", FieldType: "A", TTL: 10, Target: "203.0.113.42"}).Return(nil, ovh.ErrAPIDown).Once()
+	client.On("Post", "/domain/zone/example.net/refresh", nil).Return(nil, nil).Once()
 	assert.Error(provider.ApplyChanges(context.TODO(), &plan.Changes{
 		Create: []*endpoint.Endpoint{
 			{DNSName: ".example.net", RecordType: "A", RecordTTL: 10, Targets: []string{"203.0.113.42"}},


### PR DESCRIPTION
**Description**

- Cache was not updated when a change occurred which resulted in a change to be redone at each loop
- OVH DNS can have multiple times the exact same entry. Make sure we process all the IDs (instead of picking indefinitely the first one and trying to delete it multiple times resulting in 404).
- Using soft errors instead of hard errors

This PR Fixes all that and make the provider more resilient (all the errors were not soft resulting in the binary to exit).
This also makes #4844  irrelevant as this bug was produced by :

- the cache not being refreshed after changes.
- the list of duplicates not being processed correctly.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated