### PR TITLE
fix(source): allow ipv4-mapped ipv6 addresses

### DIFF
--- a/source/source_test.go
+++ b/source/source_test.go
@@ -85,6 +85,7 @@ func TestSuitableType(t *testing.T) {
 	}{
 		{"8.8.8.8", "", "A"},
 		{"2001:db8::1", "", "AAAA"},
+		{"::ffff:c0a8:101", "", "AAAA"},
 		{"foo.example.org", "", "CNAME"},
 		{"bar.eu-central-1.elb.amazonaws.com", "", "CNAME"},
 	} {


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Updates `suitableType` to allow _all_ valid IPv6 addresses, including IPv4-mapped IPv6 addresses.

https://pkg.go.dev/net/netip#Addr.Is6

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4942

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
