### PR TITLE
feat(chart): allow to run tpl on `ServiceAccount` annotations

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed automatic addition of pod selector labels to `affinity` and `topologySpreadConstraints` if not defined. _@pvickery-ParamountCommerce_
 
+### Changed
+
+- Allow templatizing `serviceaccount.annotations` in values, by rendering them using `tpl` built-in function: [#4958](https://github.com/kubernetes-sigs/external-dns/pull/4958) @fcrespofastly
+
 ## [v1.15.0] - 2023-09-10
 
 ### Changed

--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Allow templatizing `serviceaccount.annotations` in values, by rendering them using `tpl` built-in function: [#4958](https://github.com/kubernetes-sigs/external-dns/pull/4958) @fcrespofastly
+- Allow templating `serviceaccount.annotations` keys and values, by rendering them using the `tpl` built-in function. [#4958](https://github.com/kubernetes-sigs/external-dns/pull/4958) _@fcrespofastly_
 
 ## [v1.15.0] - 2023-09-10
 

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -153,7 +153,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | service.ipFamilies | list | `[]` | Service IP families. |
 | service.ipFamilyPolicy | string | `nil` | Service IP family policy. |
 | service.port | int | `7979` | Service HTTP port. |
-| serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account. Templates are allowed here. Example: annotations:   example.com/annotation: {{ .Values.nameOverride }} |
 | serviceAccount.automountServiceAccountToken | string | `nil` | Set this to `false` to [opt out of API credential automounting](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting) for the `ServiceAccount`. |
 | serviceAccount.create | bool | `true` | If `true`, create a new `ServiceAccount`. |
 | serviceAccount.labels | object | `{}` | Labels to add to the service account. |

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -153,7 +153,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | service.ipFamilies | list | `[]` | Service IP families. |
 | service.ipFamilyPolicy | string | `nil` | Service IP family policy. |
 | service.port | int | `7979` | Service HTTP port. |
-| serviceAccount.annotations | object | `{}` | Annotations to add to the service account. Templates are allowed here. Example: annotations:   example.com/annotation: {{ .Values.nameOverride }} |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account. Templates are allowed in both the key and the value. Example: `example.com/annotation/{{ .Values.nameOverride }}: {{ .Values.nameOverride }}` |
 | serviceAccount.automountServiceAccountToken | string | `nil` | Set this to `false` to [opt out of API credential automounting](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting) for the `ServiceAccount`. |
 | serviceAccount.create | bool | `true` | If `true`, create a new `ServiceAccount`. |
 | serviceAccount.labels | object | `{}` | Labels to add to the service account. |

--- a/charts/external-dns/ci/ci-values.yaml
+++ b/charts/external-dns/ci/ci-values.yaml
@@ -34,3 +34,7 @@ topologySpreadConstraints:
   - maxSkew: 1
     topologyKey: "topology.kubernetes.io/zone"
     whenUnsatisfiable: "ScheduleAnyway"
+
+serviceAccount:
+  annotations:
+    "{{ .Chart.Name }}/chart": "{{ .Chart.Version }}"

--- a/charts/external-dns/ci/ci-values.yaml
+++ b/charts/external-dns/ci/ci-values.yaml
@@ -37,4 +37,6 @@ topologySpreadConstraints:
 
 serviceAccount:
   annotations:
+    notTemplated/version: "true"
+    justValueTemplated/version: "{{ .Chart.Version }}"
     "{{ .Chart.Name }}/chart": "{{ .Chart.Version }}"

--- a/charts/external-dns/ci/ci-values.yaml
+++ b/charts/external-dns/ci/ci-values.yaml
@@ -37,6 +37,6 @@ topologySpreadConstraints:
 
 serviceAccount:
   annotations:
-    notTemplated/version: "true"
+    notTemplated/version: "v1.2.3"
     justValueTemplated/version: "{{ .Chart.Version }}"
     "{{ .Chart.Name }}/chart": "{{ .Chart.Version }}"

--- a/charts/external-dns/templates/serviceaccount.yaml
+++ b/charts/external-dns/templates/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/external-dns/templates/serviceaccount.yaml
+++ b/charts/external-dns/templates/serviceaccount.yaml
@@ -11,7 +11,9 @@ metadata:
   {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
-    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- range $k, $v := . }}
+      {{- printf "%s: %s" (tpl $k $) (tpl $v $) | nindent 4 }}
+    {{- end }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -31,7 +31,9 @@ serviceAccount:
   create: true
   # -- Labels to add to the service account.
   labels: {}
-  # -- Annotations to add to the service account.
+  # -- Annotations to add to the service account. Templates are allowed here. Example:
+  # annotations:
+  #   example.com/annotation: {{ .Values.nameOverride }}
   annotations: {}
   # -- (string) If this is set and `serviceAccount.create` is `true` this will be used for the created `ServiceAccount` name, if set and `serviceAccount.create` is `false` then this will define an existing `ServiceAccount` to use.
   name:

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -31,9 +31,7 @@ serviceAccount:
   create: true
   # -- Labels to add to the service account.
   labels: {}
-  # -- Annotations to add to the service account. Templates are allowed here. Example:
-  # annotations:
-  #   example.com/annotation: {{ .Values.nameOverride }}
+  # -- Annotations to add to the service account. Templates are allowed in both the key and the value. Example: `example.com/annotation/{{ .Values.nameOverride }}: {{ .Values.nameOverride }}`
   annotations: {}
   # -- (string) If this is set and `serviceAccount.create` is `true` this will be used for the created `ServiceAccount` name, if set and `serviceAccount.create` is `false` then this will define an existing `ServiceAccount` to use.
   name:


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

The basic use-case is to add dynamic environmental metadata to external-dns KSA so we can take advantage of advanced cloud IAM features such as IRSA or Workload Identity. We already provide the necessary metadata through values so we could DRY those values and render them in values files. For instance:

```yaml
serviceAccount:
  annotations:
    iam.gke.io/gcp-service-account: "external-dns@{{ .Values.metadata.gcpProject }}.iam.gserviceaccount"
```

This change doesn't break any previous behavior.
