### PR TITLE
feat: don't discard klog logs at the highest log levels (debug and trace)

### DIFF
--- a/main.go
+++ b/main.go
@@ -100,10 +100,12 @@ func main() {
 	}
 	log.SetLevel(ll)
 
-	// Klog V2 is used by k8s.io/apimachinery/pkg/labels and can throw (a lot) of irrelevant logs
-	// See https://github.com/kubernetes-sigs/external-dns/issues/2348
-	defer klog.ClearLogger()
-	klog.SetLogger(logr.Discard())
+	if ll >= log.DebugLevel {
+		// Klog V2 is used by k8s.io/apimachinery/pkg/labels and can throw (a lot) of irrelevant logs
+		// See https://github.com/kubernetes-sigs/external-dns/issues/2348
+		defer klog.ClearLogger()
+		klog.SetLogger(logr.Discard())
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func main() {
 	}
 	log.SetLevel(ll)
 
-	if ll >= log.DebugLevel {
+	if ll < log.DebugLevel {
 		// Klog V2 is used by k8s.io/apimachinery/pkg/labels and can throw (a lot) of irrelevant logs
 		// See https://github.com/kubernetes-sigs/external-dns/issues/2348
 		defer klog.ClearLogger()


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Don't discard klog logs at the higest logging levels (debug and trace), as they are necessary to be able to troubleshoot various underlying connectivity / authorization issues.

Fixes #4960

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
