### PR TITLE
update to latest ko version

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,4 @@
-defaultBaseImage: gcr.io/distroless/static-debian11:latest
+defaultBaseImage: gcr.io/distroless/static-debian12:latest
 builds:
 - env:
   - CGO_ENABLED=0

--- a/scripts/install-ko.sh
+++ b/scripts/install-ko.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if ! command -v ko &> /dev/null; then
   cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
-  go install github.com/google/ko@v0.14.1
+  go install github.com/google/ko@v0.17.1
 fi


### PR DESCRIPTION
**Description**

This PR update to the latest KO version. The current version that we are using is defaulting to an old debian image which has an unrated vulnerability with tzdata, picked up by my scanner.

This seems to work. Had to also switch to debian 12. 

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
