### PR TITLE
docs: fix typos in tutorials

### DIFF
--- a/docs/sources/service.md
+++ b/docs/sources/service.md
@@ -76,7 +76,7 @@ or the `--publish-host-ip` flag was specified, uses the Pod's `status.hostIP` fi
 ### ClusterIP (not headless)
 
 1. If the hostname came from an `external-dns.alpha.kubernetes.io/internal-hostname` annotation
-or the `--publish-internal-services` flag was specified, uses the `spec.ServiceIP`.
+or the `--publish-internal-services` flag was specified, uses the `spec.ClusterIP`.
 
 2. Otherwise, does not create any targets.
 

--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -130,17 +130,17 @@ spec:
             - --cloudflare-proxied # (optional) enable the proxy feature of Cloudflare (DDOS protection, CDN...)
             - --cloudflare-dns-records-per-page=5000 # (optional) configure how many DNS records to fetch per request
             - --cloudflare-region-key="eu" # (optional) configure which region can decrypt HTTPS requests
-      env:
-        - name: CF_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: cloudflare-api-key
-              key: apiKey
-        - name: CF_API_EMAIL
-          valueFrom:
-            secretKeyRef:
-              name: cloudflare-api-key
-              key: email
+         env:
+            - name: CF_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflare-api-key
+                  key: apiKey
+            - name: CF_API_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflare-api-key
+                  key: email
 ```
 
 ### Manifest (for clusters with RBAC enabled)


### PR DESCRIPTION
**Description**

1. Documentation references ServiceIP as a field inside of spec, but this field does not exist and it's actually meant to reference to ClusterIP
2. Fixes indentation issue in cloudflare tutorial

Fixes https://github.com/kubernetes-sigs/external-dns/issues/4868
Supersedes #4869
Supersedes #4803

**Checklist**

- [x] End user documentation updated
