### PR TITLE
fix(aes-encryption): support plain txt and url safe base64 strings

### DIFF
--- a/docs/registry/txt.md
+++ b/docs/registry/txt.md
@@ -29,8 +29,8 @@ wildcard domains will have invalid domain syntax and be rejected by most provide
 Registry TXT records may contain information, such as the internal ingress name or namespace, considered sensitive, , which attackers could exploit to gather information about your infrastructure.
 By encrypting TXT records, you can protect this information from unauthorized access.
 
-Encryption is enabled by setting the `--txt-encrypt-enabled` flag to `true`. The 32-byte AES-256-GCM encryption
-key must be specified in URL-safe base64 form (recommended) or be a plain text, using the `--txt-encrypt-aes-key` flag.
+Encryption is enabled by setting the `--txt-encrypt-enabled`. The 32-byte AES-256-GCM encryption
+key must be specified in URL-safe base64 form (recommended) or be a plain text, using the `--txt-encrypt-aes-key=<key>` flag.
 
 Note that the key used for encryption should be a secure key and properly managed to ensure the security of your TXT records.
 

--- a/docs/registry/txt.md
+++ b/docs/registry/txt.md
@@ -26,7 +26,7 @@ wildcard domains will have invalid domain syntax and be rejected by most provide
 
 ## Encryption
 
-Registry TXT records may contain information, such as the internal ingress name or namespace, considered sensitive, , which attackers could exploit to gather information about your infrastructure. 
+Registry TXT records may contain information, such as the internal ingress name or namespace, considered sensitive, , which attackers could exploit to gather information about your infrastructure.
 By encrypting TXT records, you can protect this information from unauthorized access.
 
 Encryption is enabled by using the `--txt-encrypt-enabled` flag. The 32-byte AES-256-GCM encryption
@@ -78,14 +78,25 @@ import (
 )
 
 func main() {
-	key := []byte("testtesttesttesttesttesttesttest")
-	encrypted, _ := endpoint.EncryptText(
-		"heritage=external-dns,external-dns/owner=example,external-dns/resource=ingress/default/example",
-		key,
-		nil,
-	)
-	decrypted, _, _ := endpoint.DecryptText(encrypted, key)
-	fmt.Println(decrypted)
+	keys := []string{
+		"ZPitL0NGVQBZbTD6DwXJzD8RiStSazzYXQsdUowLURY=", // safe base64 url encoded 44 bytes and 32 when decoded
+		"01234567890123456789012345678901",             // plain txt 32 bytes
+		"passphrasewhichneedstobe32bytes!",             // plain txt 32 bytes
+	}
+
+	for _, k := range keys {
+		key := []byte(k)
+		encrypted, _ := endpoint.EncryptText(
+			"heritage=external-dns,external-dns/owner=example,external-dns/resource=ingress/default/example",
+			key,
+			nil,
+		)
+		decrypted, _, err := endpoint.DecryptText(encrypted, key)
+		if err != nil {
+			fmt.Println("Error decrypting:", err, "for key:", k)
+		}
+		fmt.Println(decrypted)
+	}
 }
 ```
 

--- a/docs/registry/txt.md
+++ b/docs/registry/txt.md
@@ -86,6 +86,13 @@ func main() {
 
 	for _, k := range keys {
 		key := []byte(k)
+		if len(key) != 32 {
+			// if key is not a plain txt let's decode
+			var err error
+			if key, err = b64.StdEncoding.DecodeString(string(key)); err != nil || len(key) != 32 {
+				fmt.Errorf("the AES Encryption key must have a length of 32 byte")
+			}
+		}
 		encrypted, _ := endpoint.EncryptText(
 			"heritage=external-dns,external-dns/owner=example,external-dns/resource=ingress/default/example",
 			key,

--- a/docs/registry/txt.md
+++ b/docs/registry/txt.md
@@ -29,8 +29,8 @@ wildcard domains will have invalid domain syntax and be rejected by most provide
 Registry TXT records may contain information, such as the internal ingress name or namespace, considered sensitive, , which attackers could exploit to gather information about your infrastructure.
 By encrypting TXT records, you can protect this information from unauthorized access.
 
-Encryption is enabled by using the `--txt-encrypt-enabled` flag. The 32-byte AES-256-GCM encryption
-key must be specified in URL-safe base64 form, using the `--txt-encrypt-aes-key` flag.
+Encryption is enabled by setting the `--txt-encrypt-enabled` flag to `true`. The 32-byte AES-256-GCM encryption
+key must be specified in URL-safe base64 form (recommended) or be a plain text, using the `--txt-encrypt-aes-key` flag.
 
 Note that the key used for encryption should be a secure key and properly managed to ensure the security of your TXT records.
 

--- a/endpoint/labels.go
+++ b/endpoint/labels.go
@@ -137,7 +137,7 @@ func (l Labels) Serialize(withQuotes bool, txtEncryptEnabled bool, aesKey []byte
 	}
 
 	var encryptionNonce []byte
-	if extractedNonce, nonceExists := l[TxtEncryptionNonce]; nonceExists {
+	if extractedNonce, nonceExists := l[txtEncryptionNonce]; nonceExists {
 		encryptionNonce = []byte(extractedNonce)
 	} else {
 		var err error
@@ -145,7 +145,7 @@ func (l Labels) Serialize(withQuotes bool, txtEncryptEnabled bool, aesKey []byte
 		if err != nil {
 			log.Fatalf("Failed to generate cryptographic nonce %#v.", err)
 		}
-		l[TxtEncryptionNonce] = string(encryptionNonce)
+		l[txtEncryptionNonce] = string(encryptionNonce)
 	}
 
 	text := l.SerializePlain(false)

--- a/endpoint/labels.go
+++ b/endpoint/labels.go
@@ -44,8 +44,8 @@ const (
 	// DualstackLabelKey is the name of the label that identifies dualstack endpoints
 	DualstackLabelKey = "dualstack"
 
-	// TxtEncryptionNonce label for keep same nonce for same txt records, for prevent different result of encryption for same txt record, it can cause issues for some providers
-	TxtEncryptionNonce = "txt-encryption-nonce"
+	// txtEncryptionNonce label for keep same nonce for same txt records, for prevent different result of encryption for same txt record, it can cause issues for some providers
+	txtEncryptionNonce = "txt-encryption-nonce"
 )
 
 // Labels store metadata related to the endpoint
@@ -98,7 +98,7 @@ func NewLabelsFromString(labelText string, aesKey []byte) (Labels, error) {
 		if err == nil {
 			labels, err := NewLabelsFromStringPlain(decryptedText)
 			if err == nil {
-				labels[TxtEncryptionNonce] = encryptionNonce
+				labels[txtEncryptionNonce] = encryptionNonce
 			}
 
 			return labels, err
@@ -119,7 +119,7 @@ func (l Labels) SerializePlain(withQuotes bool) string {
 	sort.Strings(keys) // sort for consistency
 
 	for _, key := range keys {
-		if key == TxtEncryptionNonce {
+		if key == txtEncryptionNonce {
 			continue
 		}
 		tokens = append(tokens, fmt.Sprintf("%s/%s=%s", heritage, key, l[key]))
@@ -154,7 +154,6 @@ func (l Labels) Serialize(withQuotes bool, txtEncryptEnabled bool, aesKey []byte
 	text, err = EncryptText(text, aesKey, encryptionNonce)
 	if err != nil {
 		// if encryption failed, the external-dns will crash
-		fmt.Println("GINBO")
 		log.Fatalf("Failed to encrypt the text %#v using the encryption key %#v. Got error %#v.", text, aesKey, err)
 	}
 

--- a/endpoint/labels_test.go
+++ b/endpoint/labels_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package endpoint
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -77,6 +79,32 @@ func (suite *LabelsSuite) TestEncryptionNonceReUsage() {
 	suite.NoError(err, "should succeed for valid label text")
 	serialized := foo.Serialize(false, true, suite.aesKey)
 	suite.Equal(serialized, suite.fooAsTextEncrypted, "serialized result should be equal")
+}
+
+func (suite *LabelsSuite) TestEncryptionKeyChanged() {
+	foo, err := NewLabelsFromString(suite.fooAsTextEncrypted, suite.aesKey)
+	suite.NoError(err, "should succeed for valid label text")
+
+	serialised := foo.Serialize(false, true, []byte("passphrasewhichneedstobe32bytes!"))
+	suite.NotEqual(serialised, suite.fooAsTextEncrypted, "serialized result should be equal")
+}
+
+func (suite *LabelsSuite) TestEncryptionFailed() {
+	foo, err := NewLabelsFromString(suite.fooAsTextEncrypted, suite.aesKey)
+	suite.NoError(err, "should succeed for valid label text")
+
+	defer func() { log.StandardLogger().ExitFunc = nil }()
+
+	b := new(bytes.Buffer)
+
+	var fatalCrash bool
+	log.StandardLogger().ExitFunc = func(int) { fatalCrash = true }
+	log.StandardLogger().SetOutput(b)
+
+	_ = foo.Serialize(false, true, []byte("wrong-key"))
+	
+	suite.True(fatalCrash, "should fail if encryption key is wrong")
+	suite.Contains(b.String(), "Failed to encrypt the text")
 }
 
 func (suite *LabelsSuite) TestDeserialize() {

--- a/registry/dynamodb.go
+++ b/registry/dynamodb.go
@@ -18,6 +18,7 @@ package registry
 
 import (
 	"context"
+	b64 "encoding/base64"
 	"errors"
 	"fmt"
 	"strings"
@@ -84,7 +85,10 @@ func NewDynamoDBRegistry(provider provider.Provider, ownerID string, dynamodbAPI
 	if len(txtEncryptAESKey) == 0 {
 		txtEncryptAESKey = nil
 	} else if len(txtEncryptAESKey) != 32 {
-		return nil, errors.New("the AES Encryption key must have a length of 32 bytes")
+		var err error
+		if txtEncryptAESKey, err = b64.StdEncoding.DecodeString(string(txtEncryptAESKey)); err != nil || len(txtEncryptAESKey) != 32 {
+			return nil, errors.New("the AES Encryption key must have a length of 32 bytes")
+		}
 	}
 	if len(txtPrefix) > 0 && len(txtSuffix) > 0 {
 		return nil, errors.New("txt-prefix and txt-suffix are mutually exclusive")

--- a/registry/dynamodb.go
+++ b/registry/dynamodb.go
@@ -87,7 +87,7 @@ func NewDynamoDBRegistry(provider provider.Provider, ownerID string, dynamodbAPI
 	} else if len(txtEncryptAESKey) != 32 {
 		var err error
 		if txtEncryptAESKey, err = b64.StdEncoding.DecodeString(string(txtEncryptAESKey)); err != nil || len(txtEncryptAESKey) != 32 {
-			return nil, errors.New("the AES Encryption key must have a length of 32 bytes")
+			return nil, errors.New("the AES Encryption key must be 32 bytes long, in either plain text or base64-encoded format")
 		}
 	}
 	if len(txtPrefix) > 0 && len(txtSuffix) > 0 {

--- a/registry/dynamodb_test.go
+++ b/registry/dynamodb_test.go
@@ -61,7 +61,7 @@ func TestDynamoDBRegistryNew(t *testing.T) {
 	require.EqualError(t, err, "table cannot be empty")
 
 	_, err = NewDynamoDBRegistry(p, "test-owner", api, "test-table", "", "", "", []string{}, []string{}, []byte(";k&l)nUC/33:{?d{3)54+,AD?]SX%yh^x"), time.Hour)
-	require.EqualError(t, err, "the AES Encryption key must have a length of 32 bytes")
+	require.EqualError(t, err, "the AES Encryption key must be 32 bytes long, in either plain text or base64-encoded format")
 
 	_, err = NewDynamoDBRegistry(p, "test-owner", api, "test-table", "testPrefix", "testSuffix", "", []string{}, []string{}, []byte(""), time.Hour)
 	require.EqualError(t, err, "txt-prefix and txt-suffix are mutually exclusive")

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"time"
 
+	b64 "encoding/base64"
+
 	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/external-dns/endpoint"
@@ -63,11 +65,16 @@ func NewTXTRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID st
 	if ownerID == "" {
 		return nil, errors.New("owner id cannot be empty")
 	}
+
 	if len(txtEncryptAESKey) == 0 {
 		txtEncryptAESKey = nil
 	} else if len(txtEncryptAESKey) != 32 {
-		return nil, errors.New("the AES Encryption key must have a length of 32 bytes")
+		var err error
+		if txtEncryptAESKey, err = b64.StdEncoding.DecodeString(string(txtEncryptAESKey)); err != nil || len(txtEncryptAESKey) != 32 {
+			return nil, errors.New("the AES Encryption key must have a length of 32 bytes")
+		}
 	}
+
 	if txtEncryptEnabled && txtEncryptAESKey == nil {
 		return nil, errors.New("the AES Encryption key must be set when TXT record encryption is enabled")
 	}

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -71,7 +71,7 @@ func NewTXTRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID st
 	} else if len(txtEncryptAESKey) != 32 {
 		var err error
 		if txtEncryptAESKey, err = b64.StdEncoding.DecodeString(string(txtEncryptAESKey)); err != nil || len(txtEncryptAESKey) != 32 {
-			return nil, errors.New("the AES Encryption key must have a length of 32 bytes")
+			return nil, errors.New("the AES Encryption key must be 32 bytes long, in either plain text or base64-encoded format")
 		}
 	}
 

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -138,7 +138,7 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 		}
 		// We simply assume that TXT records for the registry will always have only one target.
 		labels, err := endpoint.NewLabelsFromString(record.Targets[0], im.txtEncryptAESKey)
-		if err == endpoint.ErrInvalidHeritage {
+		if errors.Is(err, endpoint.ErrInvalidHeritage) {
 			// if no heritage is found or it is invalid
 			// case when value of txt record cannot be identified
 			// record will not be removed as it will have empty owner
@@ -244,7 +244,6 @@ func (im *TXTRegistry) generateTXTRecord(r *endpoint.Endpoint) []*endpoint.Endpo
 		txtNew.ProviderSpecific = r.ProviderSpecific
 		endpoints = append(endpoints, txtNew)
 	}
-
 	return endpoints
 }
 

--- a/registry/txt_encryption_test.go
+++ b/registry/txt_encryption_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider/inmemory"
+)
+
+func TestNewTXTRegistryEncryptionConfig(t *testing.T) {
+	p := inmemory.NewInMemoryProvider()
+	tests := []struct {
+		encEnabled      bool
+		aesKeyRaw       []byte
+		aesKeySanitized []byte
+		errorExpected   bool
+	}{
+		{
+			encEnabled:      true,
+			aesKeyRaw:       []byte("123456789012345678901234567890asdfasdfasdfasdfa12"),
+			aesKeySanitized: []byte{},
+			errorExpected:   true,
+		},
+		{
+			encEnabled:      true,
+			aesKeyRaw:       []byte("passphrasewhichneedstobe32bytes!"),
+			aesKeySanitized: []byte("passphrasewhichneedstobe32bytes!"),
+			errorExpected:   false,
+		},
+		{
+			encEnabled:      true,
+			aesKeyRaw:       []byte("ZPitL0NGVQBZbTD6DwXJzD8RiStSazzYXQsdUowLURY="),
+			aesKeySanitized: []byte{100, 248, 173, 47, 67, 70, 85, 0, 89, 109, 48, 250, 15, 5, 201, 204, 63, 17, 137, 43, 82, 107, 60, 216, 93, 11, 29, 82, 140, 11, 81, 22},
+			errorExpected:   false,
+		},
+	}
+	for _, test := range tests {
+		actual, err := NewTXTRegistry(p, "txt.", "", "owner", time.Hour, "", []string{}, []string{}, test.encEnabled, test.aesKeyRaw)
+		if test.errorExpected {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			assert.Equal(t, test.aesKeySanitized, actual.txtEncryptAESKey)
+		}
+	}
+}
+
+func TestGenerateTXTGenerateTextRecordEncryptionWihDecryption(t *testing.T) {
+	p := inmemory.NewInMemoryProvider()
+	_ = p.CreateZone(testZone)
+
+	tests := []struct {
+		record    *endpoint.Endpoint
+		decrypted string
+	}{
+		{
+			record:    newEndpointWithOwner("foo.test-zone.example.org", "new-foo.loadbalancer.com", endpoint.RecordTypeCNAME, "owner-2"),
+			decrypted: "heritage=external-dns,external-dns/owner=owner-2",
+		},
+		{
+			record:    newEndpointWithOwnerAndLabels("foo.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "owner-1", endpoint.Labels{endpoint.OwnedRecordLabelKey: "foo.test-zone.example.org"}),
+			decrypted: "heritage=external-dns,external-dns/ownedRecord=foo.test-zone.example.org,external-dns/owner=owner-1",
+		},
+		{
+			record:    newEndpointWithOwnerAndLabels("bar.test-zone.example.org", "cluster-b", endpoint.RecordTypeCNAME, "owner-1", endpoint.Labels{endpoint.ResourceLabelKey: "ingress/default/foo-127"}),
+			decrypted: "heritage=external-dns,external-dns/owner=owner-1,external-dns/resource=ingress/default/foo-127",
+		},
+		{
+			record:    newEndpointWithOwner("dualstack.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA, "owner-0"),
+			decrypted: "heritage=external-dns,external-dns/owner=owner-0",
+		},
+	}
+
+	withEncryptionKeys := []string{
+		"passphrasewhichneedstobe32bytes!",
+		"ZPitL0NGVQBZbTD6DwXJzD8RiStSazzYXQsdUowLURY=",
+		"01234567890123456789012345678901",
+	}
+
+	for _, test := range tests {
+		for _, k := range withEncryptionKeys {
+			t.Run(fmt.Sprintf("key '%s' with decrypted result '%s'", k, test.decrypted), func(t *testing.T) {
+				key := []byte(k)
+				r, err := NewTXTRegistry(p, "", "", "owner", time.Minute, "", []string{}, []string{}, true, key)
+				assert.NoError(t, err, "Error creating TXT registry")
+				txtRecords := r.generateTXTRecord(test.record)
+				assert.Len(t, txtRecords, len(test.record.Targets))
+
+				for _, txt := range txtRecords {
+					// should return a TXT record with the encryption nonce label. At the moment nonce is not set as label.
+					assert.NotContains(t, txt.Labels, "txt-encryption-nonce")
+
+					assert.Len(t, txt.Targets, 1)
+					assert.LessOrEqual(t, len(txt.Targets), 1)
+
+					// decrypt targets
+					for _, target := range txtRecords[0].Targets {
+						encryptedText, errUnquote := strconv.Unquote(target)
+						assert.NoError(t, errUnquote, "Error unquoting the encrypted text")
+
+						actual, nonce, errDecrypt := endpoint.DecryptText(encryptedText, r.txtEncryptAESKey)
+						assert.NoError(t, errDecrypt, "Error decrypting the encrypted text")
+
+						assert.True(t, strings.HasPrefix(encryptedText, nonce),
+							fmt.Sprintf("Nonce '%s' should be a prefix of the encrypted text: '%s'", nonce, encryptedText))
+						assert.Equal(t, test.decrypted, actual)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestGenerateRecordsWithEncryption(t *testing.T) {
+	ctx := context.Background()
+	p := inmemory.NewInMemoryProvider()
+	_ = p.CreateZone("org")
+
+	key := []byte("ZPitL0NGVQBZbTD6DwXJzD8RiStSazzYXQsdUowLURY=")
+
+	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour, "", []string{}, []string{}, true, key)
+
+	_ = r.ApplyChanges(ctx, &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			newEndpointWithOwner("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "owner"),
+			newEndpointWithOwnerAndOwnedRecord("new-record-2.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "", "new-record-1.test-zone.example.org"),
+			newEndpointWithOwner("example.org", "new-loadbalancer-3.org", endpoint.RecordTypeCNAME, "owner"),
+			newEndpointWithOwnerAndOwnedRecord("main.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "", "example"),
+			newEndpointWithOwner("tar.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner-2"),
+			newEndpointWithOwner("thing3.org", "1.2.3.4", endpoint.RecordTypeA, "owner"),
+			newEndpointWithOwner("thing4.org", "2001:DB8::2", endpoint.RecordTypeAAAA, "owner"),
+		},
+	})
+
+	allPlainTextTargetsToAssert := []string{
+		"heritage=external-dns,external-dns/",
+		"tar.loadbalancer.com",
+		"new-loadbalancer-1.lb.com",
+		"2001:DB8::2",
+		"new-loadbalancer-3.org",
+		"1.2.3.4",
+	}
+
+	records, _ := p.Records(ctx)
+	for _, r := range records {
+		if r.RecordType == endpoint.RecordTypeTXT && (strings.HasPrefix(r.DNSName, "cname-") || strings.HasPrefix(r.DNSName, "txt-new-")) {
+			assert.NotContains(t, r.Labels, "txt-encryption-nonce")
+			// assuming single target, it should be not a plain text
+			assert.NotContains(t, r.Targets[0], "heritage=external-dns")
+		}
+		// All TXT records with new- prefix should have the encryption nonce label and be in plain text
+		if r.RecordType == endpoint.RecordTypeTXT && strings.HasPrefix(r.DNSName, "new-") {
+			assert.Contains(t, r.Labels, "txt-encryption-nonce")
+			// assuming single target, it should be in a plain text
+			assert.Contains(t, r.Targets[0], "heritage=external-dns,external-dns/")
+		}
+		// All CNAME, A and AAAA TXT records should have the encryption nonce label
+		if slices.Contains([]string{"CNAME", "A", "AAAA"}, r.RecordType) {
+			assert.Contains(t, r.Labels, "txt-encryption-nonce")
+			// validate that target is in plain text
+			assert.Contains(t, allPlainTextTargetsToAssert, r.Targets[0])
+		}
+	}
+}

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -1591,44 +1591,6 @@ func TestTXTRegistryApplyChangesEncrypt(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestNewTXTRegistryEncryptionConfig(t *testing.T) {
-	p := inmemory.NewInMemoryProvider()
-	tests := []struct {
-		encEnabled      bool
-		aesKeyRaw       []byte
-		aesKeySanitized []byte
-		errorExpected   bool
-	}{
-		{
-			encEnabled:      true,
-			aesKeyRaw:       []byte("123456789012345678901234567890asdfasdfasdfasdfa12"),
-			aesKeySanitized: []byte{},
-			errorExpected:   true,
-		},
-		{
-			encEnabled:      true,
-			aesKeyRaw:       []byte("passphrasewhichneedstobe32bytes!"),
-			aesKeySanitized: []byte("passphrasewhichneedstobe32bytes!"),
-			errorExpected:   false,
-		},
-		{
-			encEnabled:      true,
-			aesKeyRaw:       []byte("ZPitL0NGVQBZbTD6DwXJzD8RiStSazzYXQsdUowLURY="),
-			aesKeySanitized: []byte{100, 248, 173, 47, 67, 70, 85, 0, 89, 109, 48, 250, 15, 5, 201, 204, 63, 17, 137, 43, 82, 107, 60, 216, 93, 11, 29, 82, 140, 11, 81, 22},
-			errorExpected:   false,
-		},
-	}
-	for _, test := range tests {
-		actual, err := NewTXTRegistry(p, "txt.", "", "owner", time.Hour, "", []string{}, []string{}, test.encEnabled, test.aesKeyRaw)
-		if test.errorExpected {
-			require.Error(t, err)
-		} else {
-			require.NoError(t, err)
-			assert.Equal(t, test.aesKeySanitized, actual.txtEncryptAESKey)
-		}
-	}
-}
-
 // TestMultiClusterDifferentRecordTypeOwnership validates the registry handles environments where the same zone is managed by
 // external-dns in different clusters and the ingress record type is different. For example one uses A records and the other
 // uses CNAME. In this environment the first cluster that establishes the owner record should maintain ownership even

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -1591,6 +1591,44 @@ func TestTXTRegistryApplyChangesEncrypt(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestNewTXTRegistryEncryptionConfig(t *testing.T) {
+	p := inmemory.NewInMemoryProvider()
+	tests := []struct {
+		encEnabled      bool
+		aesKeyRaw       []byte
+		aesKeySanitized []byte
+		errorExpected   bool
+	}{
+		{
+			encEnabled:      true,
+			aesKeyRaw:       []byte("123456789012345678901234567890asdfasdfasdfasdfa12"),
+			aesKeySanitized: []byte{},
+			errorExpected:   true,
+		},
+		{
+			encEnabled:      true,
+			aesKeyRaw:       []byte("passphrasewhichneedstobe32bytes!"),
+			aesKeySanitized: []byte("passphrasewhichneedstobe32bytes!"),
+			errorExpected:   false,
+		},
+		{
+			encEnabled:      true,
+			aesKeyRaw:       []byte("ZPitL0NGVQBZbTD6DwXJzD8RiStSazzYXQsdUowLURY="),
+			aesKeySanitized: []byte{100, 248, 173, 47, 67, 70, 85, 0, 89, 109, 48, 250, 15, 5, 201, 204, 63, 17, 137, 43, 82, 107, 60, 216, 93, 11, 29, 82, 140, 11, 81, 22},
+			errorExpected:   false,
+		},
+	}
+	for _, test := range tests {
+		actual, err := NewTXTRegistry(p, "txt.", "", "owner", time.Hour, "", []string{}, []string{}, test.encEnabled, test.aesKeyRaw)
+		if test.errorExpected {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			assert.Equal(t, test.aesKeySanitized, actual.txtEncryptAESKey)
+		}
+	}
+}
+
 // TestMultiClusterDifferentRecordTypeOwnership validates the registry handles environments where the same zone is managed by
 // external-dns in different clusters and the ingress record type is different. For example one uses A records and the other
 // uses CNAME. In this environment the first cluster that establishes the owner record should maintain ownership even


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4975
Fixes #3992

> The primary change in behavior is that the service will now successfully start when an AES key is provided as outlined in the documentation (text or base64 form). The core business logic related to encryption remains unchanged.

- added tests to cover missing branches for endpoint.{labels,crypto}
- added tests to cover logic when AES keys is base64 form
- added tests to cover current label encryption logic for records
- updated/rephrased documentation


While was working on a fix, found a bug, where Dynamodb not encrypting labels https://github.com/kubernetes-sigs/external-dns/blob/e964a66153763860670283bbaf02d0e3348c4d7e/registry/dynamodb.go#L239

Trying to keep the scope of this pull request small. And could tweak DynamoDB encryption in follow up if required.

When TXT registry behaves correctly https://github.com/kubernetes-sigs/external-dns/blob/e964a66153763860670283bbaf02d0e3348c4d7e/registry/txt.go#L270


Look's like the feature is not in use as was not able to find a single issue to date

Added tests

![Screenshot 2024-12-29 at 12 40 43](https://github.com/user-attachments/assets/5e5a5c12-88ff-42e4-b87b-c235ab60ff0b)

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
