### PR TITLE
Skip endpoint creation if VirtualServer is not considered ready

### DIFF
--- a/source/f5_virtualserver.go
+++ b/source/f5_virtualserver.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -147,6 +148,12 @@ func (vs *f5VirtualServerSource) endpointsFromVirtualServers(virtualServers []*f
 	var endpoints []*endpoint.Endpoint
 
 	for _, virtualServer := range virtualServers {
+		if !isVirtualServerReady(virtualServer) {
+			log.Infof("F5 VirtualServer %s/%s is not ready or is missing an IP address, skipping endpoint creation.",
+				virtualServer.Namespace, virtualServer.Name)
+			continue
+		}
+
 		resource := fmt.Sprintf("f5-virtualserver/%s/%s", virtualServer.Namespace, virtualServer.Name)
 
 		ttl := getTTLFromAnnotations(virtualServer.Annotations, resource)
@@ -155,6 +162,7 @@ func (vs *f5VirtualServerSource) endpointsFromVirtualServers(virtualServers []*f
 		if len(targets) == 0 && virtualServer.Spec.VirtualServerAddress != "" {
 			targets = append(targets, virtualServer.Spec.VirtualServerAddress)
 		}
+
 		if len(targets) == 0 && virtualServer.Status.VSAddress != "" {
 			targets = append(targets, virtualServer.Status.VSAddress)
 		}
@@ -210,4 +218,11 @@ func (vs *f5VirtualServerSource) filterByAnnotations(virtualServers []*f5.Virtua
 	}
 
 	return filteredList, nil
+}
+
+func isVirtualServerReady(vs *f5.VirtualServer) bool {
+	normalizedStatus := strings.ToLower(vs.Status.Status)
+	normalizedAddress := strings.ToLower(vs.Status.VSAddress)
+
+	return normalizedStatus == "ok" && (normalizedAddress != "none" && normalizedAddress != "")
 }

--- a/source/f5_virtualserver_test.go
+++ b/source/f5_virtualserver_test.go
@@ -65,6 +65,7 @@ func TestF5VirtualServerEndpoints(t *testing.T) {
 				},
 				Status: f5.VirtualServerStatus{
 					VSAddress: "192.168.1.200",
+					Status:    "OK",
 				},
 			},
 			expected: []*endpoint.Endpoint{
@@ -97,6 +98,7 @@ func TestF5VirtualServerEndpoints(t *testing.T) {
 				},
 				Status: f5.VirtualServerStatus{
 					VSAddress: "192.168.1.200",
+					Status:    "OK",
 				},
 			},
 			expected: []*endpoint.Endpoint{
@@ -128,6 +130,7 @@ func TestF5VirtualServerEndpoints(t *testing.T) {
 				},
 				Status: f5.VirtualServerStatus{
 					VSAddress: "192.168.1.100",
+					Status:    "OK",
 				},
 			},
 			expected: []*endpoint.Endpoint{
@@ -182,6 +185,10 @@ func TestF5VirtualServerEndpoints(t *testing.T) {
 					Host:                 "www.example.com",
 					VirtualServerAddress: "192.168.1.100",
 				},
+				Status: f5.VirtualServerStatus{
+					VSAddress: "192.168.1.100",
+					Status:    "OK",
+				},
 			},
 			expected: []*endpoint.Endpoint{
 				{
@@ -214,6 +221,10 @@ func TestF5VirtualServerEndpoints(t *testing.T) {
 					Host:                 "www.example.com",
 					VirtualServerAddress: "192.168.1.100",
 				},
+				Status: f5.VirtualServerStatus{
+					VSAddress: "192.168.1.100",
+					Status:    "OK",
+				},
 			},
 			expected: nil,
 		},
@@ -235,6 +246,10 @@ func TestF5VirtualServerEndpoints(t *testing.T) {
 					Host:                 "www.example.com",
 					VirtualServerAddress: "192.168.1.100",
 				},
+				Status: f5.VirtualServerStatus{
+					VSAddress: "192.168.1.100",
+					Status:    "OK",
+				},
 			},
 			expected: []*endpoint.Endpoint{
 				{
@@ -247,6 +262,57 @@ func TestF5VirtualServerEndpoints(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name: "F5 VirtualServer with error status",
+			virtualServer: f5.VirtualServer{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: f5VirtualServerGVR.GroupVersion().String(),
+					Kind:       "VirtualServer",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vs",
+					Namespace: defaultF5VirtualServerNamespace,
+					Annotations: map[string]string{
+						"external-dns.alpha.kubernetes.io/ttl": "600",
+					},
+				},
+				Spec: f5.VirtualServerSpec{
+					Host:                 "www.example.com",
+					VirtualServerAddress: "192.168.1.100",
+				},
+				Status: f5.VirtualServerStatus{
+					VSAddress: "",
+					Status:    "ERROR",
+					Error:     "Some error status message",
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "F5 VirtualServer with missing IP address and OK status",
+			virtualServer: f5.VirtualServer{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: f5VirtualServerGVR.GroupVersion().String(),
+					Kind:       "VirtualServer",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vs",
+					Namespace: defaultF5VirtualServerNamespace,
+					Annotations: map[string]string{
+						"external-dns.alpha.kubernetes.io/ttl": "600",
+					},
+				},
+				Spec: f5.VirtualServerSpec{
+					Host:      "www.example.com",
+					IPAMLabel: "test",
+				},
+				Status: f5.VirtualServerStatus{
+					VSAddress: "None",
+					Status:    "OK",
+				},
+			},
+			expected: nil,
 		},
 	}
 


### PR DESCRIPTION
**Description**

Due to changes in logic in the [controller](https://github.com/F5Networks/k8s-bigip-ctlr/tree/2.18-stable) that operates on `VirtualServer` objects the `VirtualServer` external-dns `Source` needs to determine if the `VirtualServer` object is ready or not. This PR adds a check to determine if the `VirtualServer` is ready and if not skips endpoint creation for that particular object.

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
