### PR TITLE
chore(ci): fix failing test, upgrade to go 1.23.5 and linter to v1.63

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,7 +33,7 @@ jobs:
       uses: golangci/golangci-lint-action@v6
       with:
         args: --timeout=30m
-        version: v1.60
+        version: v1.63
 
       # Run Spectral
     - name: Lint OpenAPI spec

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ CONTROLLER_GEN=$(shell which controller-gen)
 endif
 
 golangci-lint:
-	@command -v golangci-lint > /dev/null || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.60.3
+	@command -v golangci-lint > /dev/null || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.63.4
 
 # Run the golangci-lint tool
 .PHONY: go-lint

--- a/endpoint/domain_filter_test.go
+++ b/endpoint/domain_filter_test.go
@@ -321,7 +321,7 @@ var domainFilterTests = []domainFilterTest{
 
 var regexDomainFilterTests = []regexDomainFilterTest{
 	{
-		regexp.MustCompile("\\.org$"),
+		regexp.MustCompile(`\.org$`),
 		regexp.MustCompile(""),
 		[]string{"foo.org", "bar.org", "foo.bar.org"},
 		true,
@@ -330,7 +330,7 @@ var regexDomainFilterTests = []regexDomainFilterTest{
 		},
 	},
 	{
-		regexp.MustCompile("\\.bar\\.org$"),
+		regexp.MustCompile(`\.bar\.org$`),
 		regexp.MustCompile(""),
 		[]string{"foo.org", "bar.org", "example.com"},
 		false,
@@ -339,7 +339,7 @@ var regexDomainFilterTests = []regexDomainFilterTest{
 		},
 	},
 	{
-		regexp.MustCompile("(?:foo|bar)\\.org$"),
+		regexp.MustCompile(`(?:foo|bar)\.org$`),
 		regexp.MustCompile(""),
 		[]string{"foo.org", "bar.org", "example.foo.org", "example.bar.org", "a.example.foo.org", "a.example.bar.org"},
 		true,
@@ -348,18 +348,18 @@ var regexDomainFilterTests = []regexDomainFilterTest{
 		},
 	},
 	{
-		regexp.MustCompile("(?:foo|bar)\\.org$"),
-		regexp.MustCompile("^example\\.(?:foo|bar)\\.org$"),
+		regexp.MustCompile(`(?:foo|bar)\.org$`),
+		regexp.MustCompile(`^example\.(?:foo|bar)\.org$`),
 		[]string{"foo.org", "bar.org", "a.example.foo.org", "a.example.bar.org"},
 		true,
 		map[string]string{
-			"regexInclude": "(?:foo|bar)\\.org$",
-			"regexExclude": "^example\\.(?:foo|bar)\\.org$",
+			"regexInclude": `(?:foo|bar)\.org$`,
+			"regexExclude": `^example\.(?:foo|bar)\.org$`,
 		},
 	},
 	{
-		regexp.MustCompile("(?:foo|bar)\\.org$"),
-		regexp.MustCompile("^example\\.(?:foo|bar)\\.org$"),
+		regexp.MustCompile(`(?:foo|bar)\.org$`),
+		regexp.MustCompile(`^example\.(?:foo|bar)\.org$`),
 		[]string{"example.foo.org", "example.bar.org"},
 		false,
 		map[string]string{
@@ -368,8 +368,8 @@ var regexDomainFilterTests = []regexDomainFilterTest{
 		},
 	},
 	{
-		regexp.MustCompile("(?:foo|bar)\\.org$"),
-		regexp.MustCompile("^example\\.(?:foo|bar)\\.org$"),
+		regexp.MustCompile(`(?:foo|bar)\.org$`),
+		regexp.MustCompile(`^example\.(?:foo|bar)\.org$`),
 		[]string{"foo.org", "bar.org", "a.example.foo.org", "a.example.bar.org"},
 		true,
 		map[string]string{

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -66,6 +66,14 @@ func NewTargets(target ...string) Targets {
 	return t
 }
 
+func NewTargetsFromAddr(targets []netip.Addr) Targets {
+	t := make(Targets, 0, len(targets))
+	for _, target := range targets {
+		t = append(t, target.String())
+	}
+	return t
+}
+
 func (t Targets) String() string {
 	return strings.Join(t, ";")
 }

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -66,14 +66,6 @@ func NewTargets(target ...string) Targets {
 	return t
 }
 
-func NewTargetsFromAddr(targets []netip.Addr) Targets {
-	t := make(Targets, 0, len(targets))
-	for _, target := range targets {
-		t = append(t, target.String())
-	}
-	return t
-}
-
 func (t Targets) String() string {
 	return strings.Join(t, ";")
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/external-dns
 
-go 1.23.3
+go 1.23.5
 
 require (
 	cloud.google.com/go/compute/metadata v0.6.0

--- a/internal/testutils/endpoint.go
+++ b/internal/testutils/endpoint.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testutils
 
 import (
+	"net/netip"
 	"reflect"
 	"sort"
 
@@ -121,4 +122,13 @@ func SameProviderSpecific(a, b endpoint.ProviderSpecific) bool {
 	sort.Sort(byNames(sa))
 	sort.Sort(byNames(sb))
 	return reflect.DeepEqual(sa, sb)
+}
+
+// NewTargetsFromAddr convert an array of netip.Addr to Targets (array of string)
+func NewTargetsFromAddr(targets []netip.Addr) endpoint.Targets {
+	t := make(endpoint.Targets, len(targets))
+	for i, target := range targets {
+		t[i] = target.String()
+	}
+	return t
 }

--- a/source/nat64source.go
+++ b/source/nat64source.go
@@ -45,7 +45,7 @@ func (s *nat64Source) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, erro
 		}
 
 		if pPrefix.Bits() != 96 {
-			return nil, fmt.Errorf("NAT64 prefixes need to be /96 prefixes.")
+			return nil, fmt.Errorf("NAT64 prefixes need to be /96 prefixes")
 		}
 		parsedNAT64Prefixes = append(parsedNAT64Prefixes, pPrefix)
 	}
@@ -88,7 +88,7 @@ func (s *nat64Source) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, erro
 
 			v4Addr, isOk := netip.AddrFromSlice(v4AddrBytes)
 			if !isOk {
-				return nil, fmt.Errorf("Could not parse %v to IPv4 address", v4AddrBytes)
+				return nil, fmt.Errorf("could not parse %v to IPv4 address", v4AddrBytes)
 			}
 
 			v4Targets = append(v4Targets, v4Addr.String())

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
 )
 
 type ServiceSuite struct {
@@ -411,8 +412,8 @@ func testServiceSourceEndpoints(t *testing.T) {
 			serviceTypesFilter:          []string{},
 			resolveLoadBalancerHostname: true,
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.NewTargetsFromAddr(exampleDotComIP4)},
-				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.NewTargetsFromAddr(exampleDotComIP6)},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: testutils.NewTargetsFromAddr(exampleDotComIP4)},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: testutils.NewTargetsFromAddr(exampleDotComIP6)},
 			},
 		},
 		{

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -411,8 +411,8 @@ func testServiceSourceEndpoints(t *testing.T) {
 			serviceTypesFilter:          []string{},
 			resolveLoadBalancerHostname: true,
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{exampleDotComIP4[0].String()}},
-				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{exampleDotComIP6[0].String()}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.NewTargetsFromAddr(exampleDotComIP4)},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.NewTargetsFromAddr(exampleDotComIP6)},
 			},
 		},
 		{


### PR DESCRIPTION
# What does it do ?

1. Fix failing test on TestServiceSource/Endpoints with _example.com_
2. Update go version to 1.23.5
3. Update linter version to 1.63.4

# Motivation

Latest security fixes and working CI.