### PR TITLE
Release Helm chart for `v0.15.1`

### DIFF
--- a/.github/workflows/lint-test-chart.yaml
+++ b/.github/workflows/lint-test-chart.yaml
@@ -70,13 +70,13 @@ jobs:
       - name: Check for changes
         id: changes
         run: |
-          changed=$(ct list-changed)
+          changed=$(ct list-changed --target-branch=master)
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Run chart-testing lint
-        run: ct lint --check-version-increment=false
+        run: ct lint --target-branch=master --check-version-increment=false
 
       - name: Create Kind cluster
         if: steps.changes.outputs.changed == 'true'
@@ -86,4 +86,4 @@ jobs:
 
       - name: Run chart-testing install
         if: steps.changes.outputs.changed == 'true'
-        run: ct install
+        run: ct install --target-branch=master

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -53,7 +53,6 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           version: latest
 
       - name: Run chart-releaser

--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,24 +18,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+## [v1.15.1] - 2023-09-10
+
 ### Added
 
-- Ability to configure `imagePullSecrets` via helm `global` value ([#4667](https://github.com/kubernetes-sigs/external-dns/pull/4667)) _@jkroepke_
-- Added options to configure `labelFilter` and `managedRecordTypes` via dedicated helm values ([#4849](https://github.com/kubernetes-sigs/external-dns/pull/4849)) _@abaguas_
+- Added ability to configure `imagePullSecrets` via helm `global` value. ([#4667](https://github.com/kubernetes-sigs/external-dns/pull/4667)) _@jkroepke_
+- Added options to configure `labelFilter` and `managedRecordTypes` via dedicated helm values. ([#4849](https://github.com/kubernetes-sigs/external-dns/pull/4849)) _@abaguas_
+
+### Changed
+
+- Allow templating `serviceaccount.annotations` keys and values, by rendering them using the `tpl` built-in function. ([#4958](https://github.com/kubernetes-sigs/external-dns/pull/4958)) _@fcrespofastly_
+- Updated _ExternalDNS_ OCI image version to [v0.15.1](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.15.1). ([#5028](https://github.com/kubernetes-sigs/external-dns/pull/5028)) _@stevehipwell_
 
 ### Fixed
 
-- Fixed automatic addition of pod selector labels to `affinity` and `topologySpreadConstraints` if not defined. _@pvickery-ParamountCommerce_
+- Fixed automatic addition of pod selector labels to `affinity` and `topologySpreadConstraints` if not defined. ([#4666](https://github.com/kubernetes-sigs/external-dns/pull/4666)) _@pvickery-ParamountCommerce_
+- Fixed missing Ingress permissions when using Istio sources. ([#4845](https://github.com/kubernetes-sigs/external-dns/pull/4845)) _@joekhoobyar_
+
+## [v1.15.0] - 2024-09-11
 
 ### Changed
 
-- Allow templating `serviceaccount.annotations` keys and values, by rendering them using the `tpl` built-in function. [#4958](https://github.com/kubernetes-sigs/external-dns/pull/4958) _@fcrespofastly_
-
-## [v1.15.0] - 2023-09-10
-
-### Changed
-
-- Updated _ExternalDNS_ OCI image version to [v0.15.0](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.15.0). ([#xxxx](https://github.com/kubernetes-sigs/external-dns/pull/xxxx)) _@stevehipwell_
+- Updated _ExternalDNS_ OCI image version to [v0.15.0](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.15.0). ([#4735](https://github.com/kubernetes-sigs/external-dns/pull/4735)) _@stevehipwell_
 
 ### Fixed
 
@@ -44,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed to add correct webhook metric port to `Service` and `ServiceMonitor`. ([#4643](https://github.com/kubernetes-sigs/external-dns/pull/4643)) _@kimsondrup_
 - Fixed to no longer require the unauthenticated webhook provider port to be exposed for health probes. ([#4691](https://github.com/kubernetes-sigs/external-dns/pull/4691)) _@kimsondrup_ & _@hatrx_
 
-## [v1.14.5] - 2023-06-10
+## [v1.14.5] - 2024-06-10
 
 ### Added
 
@@ -61,7 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed the `ServiceMonitor` job name to correctly use the instance label. ([#4541](https://github.com/kubernetes-sigs/external-dns/pull/4541)) _@stevehipwell_
 
-## [v1.14.4] - 2023-04-03
+## [v1.14.4] - 2024-04-05
 
 ### Added
 
@@ -72,7 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated _ExternalDNS_ OCI image version to [v0.14.1](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.14.1). ([#4357](https://github.com/kubernetes-sigs/external-dns/pull/4357)) _@stevehipwell_
 
-## [v1.14.3] - 2023-01-26
+## [v1.14.3] - 2024-01-26
 
 ### Fixed
 
@@ -86,7 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Restore template support in `.Values.provider` and `.Values.provider.name`
 
-## [v1.14.1] - 2024-01-11
+## [v1.14.1] - 2024-01-12
 
 ### Fixed
 
@@ -110,7 +114,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `secretConfiguration` value has been deprecated in favour of creating secrets external to the Helm chart and configuring their use via the `extraVolumes` & `extraVolumeMounts` values. ([#4161](https://github.com/kubernetes-sigs/external-dns/pull/4161)) [@stevehipwell](https://github.com/stevehipwell)
 
-## [v1.13.1] - 2023-09-07
+## [v1.13.1] - 2023-09-08
 
 ### Added
 
@@ -213,6 +217,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 RELEASE LINKS
 -->
 [UNRELEASED]: https://github.com/kubernetes-sigs/external-dns/tree/master/charts/external-dns
+[v1.15.1]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.15.1
 [v1.15.0]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.15.0
 [v1.14.5]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.14.5
 [v1.14.4]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.14.4

--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: external-dns
 description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 type: application
-version: 1.15.0
-appVersion: 0.15.0
+version: 1.15.1
+appVersion: 0.15.1
 keywords:
   - kubernetes
   - externaldns
@@ -20,13 +20,15 @@ maintainers:
     email: steve.hipwell@gmail.com
 annotations:
   artifacthub.io/changes: |
+    - kind: added
+      description: "Added ability to configure `imagePullSecrets` via helm `global` value."
+    - kind: added
+      description: "Added options to configure `labelFilter` and `managedRecordTypes` via dedicated helm values."
     - kind: changed
-      description: "Updated _ExternalDNS_ OCI image version to [v0.15.0](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.15.0)."
+      description: "Allow templating `serviceaccount.annotations` keys and values, by rendering them using the `tpl` built-in function."
+    - kind: changed
+      description: "Updated _ExternalDNS_ OCI image version to [v0.15.1](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.15.1)."
     - kind: fixed
-      description: "Fixed `provider.webhook.resources` behavior to correctly leverage resource limits."
+      description: "Fixed automatic addition of pod selector labels to `affinity` and `topologySpreadConstraints` if not defined."
     - kind: fixed
-      description: "Fixed `provider.webhook.imagePullPolicy` behavior to correctly leverage pull policy."
-    - kind: fixed
-      description: "Fixed to add correct webhook metric port to `Service` and `ServiceMonitor`."
-    - kind: fixed
-      description: "Fixed to no longer require the unauthenticated webhook provider port to be exposed for health probes."
+      description: "Fixed missing Ingress permissions when using Istio sources."

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -1,6 +1,6 @@
 # external-dns
 
-![Version: 1.15.0](https://img.shields.io/badge/Version-1.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.0](https://img.shields.io/badge/AppVersion-0.15.0-informational?style=flat-square)
+![Version: 1.15.1](https://img.shields.io/badge/Version-1.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.1](https://img.shields.io/badge/AppVersion-0.15.1-informational?style=flat-square)
 
 ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 
@@ -27,7 +27,7 @@ helm repo add external-dns https://kubernetes-sigs.github.io/external-dns/
 After you've installed the repo you can install the chart.
 
 ```shell
-helm upgrade --install external-dns external-dns/external-dns --version 1.15.0
+helm upgrade --install external-dns external-dns/external-dns --version 1.15.1
 ```
 
 ## Providers

--- a/charts/external-dns/templates/clusterrole.yaml
+++ b/charts/external-dns/templates/clusterrole.yaml
@@ -21,7 +21,7 @@ rules:
     resources: ["services","endpoints"]
     verbs: ["get","watch","list"]
 {{- end }}
-{{- if or (has "ingress" .Values.sources) (has "contour-httpproxy" .Values.sources) (has "openshift-route" .Values.sources) (has "skipper-routegroup" .Values.sources) }}
+{{- if or (has "ingress" .Values.sources) (has "istio-gateway" .Values.sources) (has "istio-virtualservice" .Values.sources) (has "contour-httpproxy" .Values.sources) (has "openshift-route" .Values.sources) (has "skipper-routegroup" .Values.sources) }}
   - apiGroups: ["extensions","networking.k8s.io"]
     resources: ["ingresses"]
     verbs: ["get","watch","list"]


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR updates the Helm chart to use the latest [v0.15.1](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.15.1) version and includes all of the other chart changes since the last release. It also includes the code from #4845 as that PR hasn't been able to be merged.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4967
Closes #4845

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
