### PR TITLE
fix(aws-provider): ListTagsForResource incorrect zone-id handling

### DIFF
--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -994,18 +994,21 @@ Please refer to the [CRD source documentation](../sources/crd.md#example) for mo
 
 ## Strategies for Scoping Zones
 
+[//]: <> (consider moving this into it's own .)
+
 > Without specifying these flags, management applies to all zones.
 
 In order to achieve the required results, you may need to combine multiple options
 
-* Following flags supported to limit zones
-  * `--zone-id-filter=ABCDEF12345678` - specify multiple times if needed
-  * `--domain-filter=example.com` by domain suffix - specify multiple times if needed
-  * `--regex-domain-filter=example*` by domain suffix but as a regex - overrides domain-filter
-  * `--exclude-domains=ignore.this.example.com` to exclude a domain or subdomain
-  * `--regex-domain-exclusion=ignore*` subtracts it's matches from `regex-domain-filter`'s matches
-  * `--aws-zone-type=public` only sync zones of this type `[public|private]`
-  * `--aws-zone-tags=owner=k8s` only sync zones with this tag
+| Argument                    | Description                                                                 | Flow Control |
+|:----------------------------|:----------------------------------------------------------------------------|:------------:|
+| `--zone-id-filter`          | Specify multiple times if needed                                            |      OR      |
+| `--domain-filter`           | By domain suffix - specify multiple times if needed                         |      OR      |
+| `--regex-domain-filter`     | By domain suffix but as a regex - overrides domain-filter                   |     AND      |
+| `--exclude-domains`         | To exclude a domain or subdomain                                            |      OR      |
+| `--regex-domain-exclusion`  | Subtracts its matches from `regex-domain-filter`'s matches                  |     AND      |
+| `--aws-zone-type`           | Only sync zones of this type `[public\|private]`                            |      OR      |
+| `--aws-zone-tags`           | Only sync zones with this tag                                               |     AND      |
 
 Minimum required configuration
 

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -1024,10 +1024,13 @@ args:
 
 ### Filter by Domain
 
+> Specify multiple times if needed
+
 ```sh
 args:
     --domain-filter=example.com
     --domain-filter=.paradox.example.com
+    ...
 ```
 
 Example `--domain-filter=example.com` will allow for zone `example.com` and any zones that end in `.example.com`, including `an.example.com`, i.e., the subdomains of example.com.
@@ -1040,19 +1043,20 @@ And if the filter is prepended with `.` e.g., `--domain-filter=.example.com` it 
 
 ### Filter by Zone ID
 
-The filters could be specified multiple times, the flow logic is OR
+> Specify multiple times if needed, the flow logic is OR
 
 ```sh
 args:
     --zone-id-filter=ABCDEF12345678
     --zone-id-filter=XYZDEF12345888
+    ...
 ```
 
 ### Filter by Tag
 
-The filters could be specified multiple times, the flow logic is AND
+> Specify multiple times if needed, the flow logic is AND
 
-Specify on keys
+Keys only
 
 ```sh
 args:

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -994,6 +994,8 @@ Please refer to the [CRD source documentation](../sources/crd.md#example) for mo
 
 ## Strategies for Scoping Zones
 
+> Without specifying these flags, management applies to all zones.
+
 In order to achieve the required results, you may need to combine multiple options
 
 * Following flags supported to limit zones
@@ -1016,6 +1018,8 @@ args:
 
 ### Filter by Zone Type
 
+> If this flag is not specified, management applies to both public and private zones.
+
 ```sh
 args:
     --aws-zone-type=private|public # choose between public or private
@@ -1024,7 +1028,7 @@ args:
 
 ### Filter by Domain
 
-> Specify multiple times if needed
+> Specify multiple times if needed.
 
 ```sh
 args:

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -994,11 +994,9 @@ Please refer to the [CRD source documentation](../sources/crd.md#example) for mo
 
 ## Strategies for Scoping Zones
 
-[//]: <> (consider moving this into it's own .)
-
 > Without specifying these flags, management applies to all zones.
 
-In order to achieve the required results, you may need to combine multiple options
+In order to manage specific zones,  you may need to combine multiple options
 
 | Argument                    | Description                                                                 | Flow Control |
 |:----------------------------|:----------------------------------------------------------------------------|:------------:|

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -928,7 +928,7 @@ Running several fast polling ExternalDNS instances in a given account can easily
   * `--ingress-class=nginx-external`
 * Limit services watched by type (not applicable to ingress or other types)
   * `--service-type-filter=LoadBalancer` default `all`
-  * Limit the hosted zones considered
+* Limit the hosted zones considered
   * `--zone-id-filter=ABCDEF12345678` - specify multiple times if needed
   * `--domain-filter=example.com` by domain suffix - specify multiple times if needed
   * `--regex-domain-filter=example*` by domain suffix but as a regex - overrides domain-filter

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -378,7 +378,7 @@ This should yield something similar this:
 
 ```
 ns-695.awsdns-22.net.
-ns-1313.awsdns-36.com.
+ns-1313.awsdns-36.org.
 ns-350.awsdns-43.com.
 ns-1805.awsdns-33.co.uk.
 ```
@@ -667,7 +667,7 @@ For more information about ALIAS record, see [Choosing between alias and non-ali
 Let's check that we can resolve this DNS name. We'll ask the nameservers assigned to your zone first.
 
 ```bash
-dig +short @ns-5514.awsdns-53.com. nginx.example.com.
+dig +short @ns-5514.awsdns-53.org. nginx.example.com.
 ```
 
 This should return 1+ IP addresses that correspond to the ELB FQDN, i.e. `ae11c2360188411e7951602725593fd1-1224345803.eu-central-1.elb.amazonaws.com.`.
@@ -762,7 +762,7 @@ aws route53 list-resource-record-sets --output json --hosted-zone-id $ZONE_ID \
   --query "ResourceRecordSets[?Name == 'server.example.com.']"
 
 # query using a route53 name server
-dig +short @ns-5514.awsdns-53.com. server.example.com.
+dig +short @ns-5514.awsdns-53.org. server.example.com.
 # query using the default name server
 dig +short server.example.com.
 

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -199,7 +199,7 @@ var canonicalHostedZones = map[string]string{
 }
 
 // Route53API is the subset of the AWS Route53 API that we actually use.  Add methods as required. Signatures must match exactly.
-// mostly taken from: https://github.com/kubernetes/kubernetes/blob/853167624edb6bc0cfdcdfb88e746e178f5db36c/federation/pkg/dnsprovider/providers/aws/route53/stubs/route53api.go
+// https://github.com/aws/aws-sdk-go-v2/tree/main/service/route53
 type Route53API interface {
 	ListResourceRecordSets(ctx context.Context, input *route53.ListResourceRecordSetsInput, optFns ...func(options *route53.Options)) (*route53.ListResourceRecordSetsOutput, error)
 	ChangeResourceRecordSets(ctx context.Context, input *route53.ChangeResourceRecordSetsInput, optFns ...func(options *route53.Options)) (*route53.ChangeResourceRecordSetsOutput, error)
@@ -208,7 +208,7 @@ type Route53API interface {
 	ListTagsForResource(ctx context.Context, input *route53.ListTagsForResourceInput, optFns ...func(options *route53.Options)) (*route53.ListTagsForResourceOutput, error)
 }
 
-// wrapper to handle ownership relation throughout the provider implementation
+// Route53Change wrapper to handle ownership relation throughout the provider implementation
 type Route53Change struct {
 	route53types.Change
 	OwnedRecord string
@@ -948,7 +948,7 @@ func (p *AWSProvider) tagsForZone(ctx context.Context, zoneID string, profile st
 		ResourceId:   aws.String(cleanZoneID(zoneID)),
 	})
 	if err != nil {
-		return nil, provider.NewSoftError(fmt.Errorf("failed to list tags for zone %s: %w", zoneID, err))
+		return nil, provider.NewSoftErrorf("failed to list tags for zone %s: %w", zoneID, err)
 	}
 	tagMap := map[string]string{}
 	for _, tag := range response.ResourceTagSet.Tags {

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -944,7 +944,7 @@ func (p *AWSProvider) tagsForZone(ctx context.Context, zoneID string, profile st
 	client := p.clients[profile]
 
 	// TODO: this will make single API request for each zone, which consumes API requests
-	// more effective way is to batch requets https://github.com/aws/aws-sdk-go-v2/blob/ed8a3caa0df9ce36a5b60aebeee201187098d205/service/route53/api_op_ListTagsForResources.go#L37
+	// more effective way is to batch requests https://github.com/aws/aws-sdk-go-v2/blob/ed8a3caa0df9ce36a5b60aebeee201187098d205/service/route53/api_op_ListTagsForResources.go#L37
 	response, err := client.ListTagsForResource(ctx, &route53.ListTagsForResourceInput{
 		ResourceType: route53types.TagResourceTypeHostedzone,
 		ResourceId:   aws.String(cleanZoneID(zoneID)),

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -379,7 +379,7 @@ func (p *AWSProvider) zones(ctx context.Context) (map[string]*profiledZone, erro
 			}
 		}
 		if tagErr != nil {
-			return nil, provider.NewSoftError(fmt.Errorf("failed to list zones tags: %w", tagErr))
+			return nil, provider.NewSoftErrorf("failed to list zones tags: %w", tagErr)
 		}
 	}
 
@@ -427,7 +427,7 @@ func containsOctalSequence(domain string) bool {
 func (p *AWSProvider) Records(ctx context.Context) (endpoints []*endpoint.Endpoint, _ error) {
 	zones, err := p.zones(ctx)
 	if err != nil {
-		return nil, provider.NewSoftError(fmt.Errorf("records retrieval failed: %w", err))
+		return nil, provider.NewSoftErrorf("records retrieval failed: %w", err)
 	}
 
 	return p.records(ctx, zones)
@@ -447,7 +447,7 @@ func (p *AWSProvider) records(ctx context.Context, zones map[string]*profiledZon
 		for paginator.HasMorePages() {
 			resp, err := paginator.NextPage(ctx)
 			if err != nil {
-				return nil, provider.NewSoftError(fmt.Errorf("failed to list resource records sets for zone %s using aws profile %q: %w", *z.zone.Id, z.profile, err))
+				return nil, provider.NewSoftErrorf("failed to list resource records sets for zone %s using aws profile %q: %w", *z.zone.Id, z.profile, err)
 			}
 
 			for _, r := range resp.ResourceRecordSets {
@@ -608,7 +608,7 @@ func (p *AWSProvider) GetDomainFilter() endpoint.DomainFilterInterface {
 func (p *AWSProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
 	zones, err := p.zones(ctx)
 	if err != nil {
-		return provider.NewSoftError(fmt.Errorf("failed to list zones, not applying changes: %w", err))
+		return provider.NewSoftErrorf("failed to list zones, not applying changes: %w", err)
 	}
 
 	updateChanges := p.createUpdateChanges(changes.UpdateNew, changes.UpdateOld)
@@ -718,7 +718,7 @@ func (p *AWSProvider) submitChanges(ctx context.Context, changes Route53Changes,
 	}
 
 	if len(failedZones) > 0 {
-		return provider.NewSoftError(fmt.Errorf("failed to submit all changes for the following zones: %v", failedZones))
+		return provider.NewSoftErrorf("failed to submit all changes for the following zones: %v", failedZones)
 	}
 
 	return nil

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -945,7 +945,7 @@ func (p *AWSProvider) tagsForZone(ctx context.Context, zoneID string, profile st
 
 	response, err := client.ListTagsForResource(ctx, &route53.ListTagsForResourceInput{
 		ResourceType: route53types.TagResourceTypeHostedzone,
-		ResourceId:   aws.String(zoneID),
+		ResourceId:   aws.String(cleanZoneID(zoneID)),
 	})
 	if err != nil {
 		return nil, provider.NewSoftError(fmt.Errorf("failed to list tags for zone %s: %w", zoneID, err))

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -943,6 +943,8 @@ func groupChangesByNameAndOwnershipRelation(cs Route53Changes) map[string]Route5
 func (p *AWSProvider) tagsForZone(ctx context.Context, zoneID string, profile string) (map[string]string, error) {
 	client := p.clients[profile]
 
+	// TODO: this will make single API request for each zone, which consumes API requests
+	// more effective way is to batch requets https://github.com/aws/aws-sdk-go-v2/blob/ed8a3caa0df9ce36a5b60aebeee201187098d205/service/route53/api_op_ListTagsForResources.go#L37
 	response, err := client.ListTagsForResource(ctx, &route53.ListTagsForResourceInput{
 		ResourceType: route53types.TagResourceTypeHostedzone,
 		ResourceId:   aws.String(cleanZoneID(zoneID)),

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -1985,7 +1985,6 @@ func setAWSRecords(t *testing.T, provider *AWSProvider, records []route53types.R
 
 	zones, err := provider.zones(ctx)
 	require.NoError(t, err)
-
 	err = provider.submitChanges(ctx, changes, zones)
 	require.NoError(t, err)
 

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -334,11 +334,9 @@ func TestAWSZones(t *testing.T) {
 		{"tag filter", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), provider.NewZoneTagFilter([]string{"zone=3"}), privateZones},
 	} {
 		t.Run(ti.msg, func(t *testing.T) {
-			provider, _ := newAWSProviderWithTagFilter(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), ti.zoneIDFilter, ti.zoneTypeFilter, ti.zoneTagFilter, defaultEvaluateTargetHealth, false, nil, true)
-
+			provider, _ := newAWSProviderWithTagFilter(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), ti.zoneIDFilter, ti.zoneTypeFilter, ti.zoneTagFilter, defaultEvaluateTargetHealth, false, nil)
 			zones, err := provider.Zones(context.Background())
 			require.NoError(t, err)
-
 			validateAWSZones(t, zones, ti.expectedZones)
 		})
 	}
@@ -346,7 +344,6 @@ func TestAWSZones(t *testing.T) {
 
 func TestAWSZonesWithTagFilterError(t *testing.T) {
 	client := NewRoute53APIStub(t)
-
 	provider := &AWSProvider{
 		clients:       map[string]Route53API{defaultAWSProfile: client},
 		zoneTagFilter: provider.NewZoneTagFilter([]string{"zone=2"}),
@@ -2007,10 +2004,10 @@ func listAWSRecords(t *testing.T, client Route53API, zone string) []route53types
 }
 
 func newAWSProvider(t *testing.T, domainFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, zoneTypeFilter provider.ZoneTypeFilter, evaluateTargetHealth, dryRun bool, records []route53types.ResourceRecordSet) (*AWSProvider, *Route53APIStub) {
-	return newAWSProviderWithTagFilter(t, domainFilter, zoneIDFilter, zoneTypeFilter, provider.NewZoneTagFilter([]string{}), evaluateTargetHealth, dryRun, records, true)
+	return newAWSProviderWithTagFilter(t, domainFilter, zoneIDFilter, zoneTypeFilter, provider.NewZoneTagFilter([]string{}), evaluateTargetHealth, dryRun, records)
 }
 
-func newAWSProviderWithTagFilter(t *testing.T, domainFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, zoneTypeFilter provider.ZoneTypeFilter, zoneTagFilter provider.ZoneTagFilter, evaluateTargetHealth, dryRun bool, records []route53types.ResourceRecordSet, validateErrors bool) (*AWSProvider, *Route53APIStub) {
+func newAWSProviderWithTagFilter(t *testing.T, domainFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, zoneTypeFilter provider.ZoneTypeFilter, zoneTagFilter provider.ZoneTagFilter, evaluateTargetHealth, dryRun bool, records []route53types.ResourceRecordSet) (*AWSProvider, *Route53APIStub) {
 	client := NewRoute53APIStub(t)
 
 	provider := &AWSProvider{

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -161,7 +161,8 @@ func specialCharactersEscape(s string) string {
 
 func (r *Route53APIStub) ListTagsForResource(ctx context.Context, input *route53.ListTagsForResourceInput, optFns ...func(options *route53.Options)) (*route53.ListTagsForResourceOutput, error) {
 	if input.ResourceType == route53types.TagResourceTypeHostedzone {
-		tags := r.zoneTags[*input.ResourceId]
+		zoneId := fmt.Sprintf("/%s/%s", input.ResourceType, *input.ResourceId)
+		tags := r.zoneTags[zoneId]
 		return &route53.ListTagsForResourceOutput{
 			ResourceTagSet: &route53types.ResourceTagSet{
 				ResourceId:   input.ResourceId,

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -19,6 +19,7 @@ package provider
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"strings"
 
@@ -30,6 +31,11 @@ import (
 // of fatal. It is meant for error propagation from providers to tell
 // that this is a transient error.
 var SoftError error = errors.New("soft error")
+
+// NewSoftErrorf creates a SoftError with formats according to a format specifier and returns the string as a
+func NewSoftErrorf(format string, a ...any) error {
+	return NewSoftError(fmt.Errorf(format, a...))
+}
 
 // NewSoftError creates a SoftError from the given error
 func NewSoftError(err error) error {


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #5012

> Version 0.15.1 is currently experiencing reliability issues for users who rely on zone tags. 
```
--aws-zone-tags=
...
```

- Fixed incorrect behaviour for ListTagsForResource. AWS SDK for Go v2 backwards compatibility issue
- Added `provider.NewSoftErrorf` method
- Refresh/update documentation for domain filtering strategies. Is not full, just few filters that I recently validated working

For follow-up what worth to consider:
- support --aws-zone-tags can specify multiple or separate values with commas: key1=val1,key2=val2
- support --aws-zone-tags can specify exclusion with `!`: !key1=val1,key2=val2
- instead of ListTagsForResource do batching ListTagsForResources

The interface for go-aws-sdk-v2 https://github.com/aws/aws-sdk-go-v2/blob/ed8a3caa0df9ce36a5b60aebeee201187098d205/service/route53/api_op_ListTagsForResource.go#L37 it require 

```
1. resource type
  - The resource type for health checks is healthcheck .
  - The resource type for hosted zones is hostedzone .
2. resource id without the type
3. added failure/negative test
```

example aws cli command https://docs.aws.amazon.com/cli/latest/reference/route53/list-tags-for-resource.html

Command `tagsForZone` is not affective it does API request for each zone, and Route53 rate limit is 10 requests per second. The better approach is to use https://docs.aws.amazon.com/Route53/latest/APIReference/API_ListTagsForResources.html as it does bulk checks, up to 10 zones per request. I will do an improvement in follow-up

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
