### PR TITLE
chore(provider-aws): improve canonicalHostedZone handling

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -1161,8 +1161,10 @@ func isAWSAlias(ep *endpoint.Endpoint) string {
 
 // canonicalHostedZone returns the matching canonical zone for a given hostname.
 func canonicalHostedZone(hostname string) string {
-	for suffix, zone := range canonicalHostedZones {
-		if strings.HasSuffix(hostname, suffix) {
+	parts := strings.Split(hostname, ".")
+	for i := 0; i < len(parts); i++ {
+		suffix := strings.Join(parts[i:], ".")
+		if zone, exists := canonicalHostedZones[suffix]; exists {
 			return zone
 		}
 	}

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -1164,6 +1164,7 @@ func canonicalHostedZone(hostname string) string {
 	// strings.HasSuffix is optimized for this specific task and avoids the overhead associated with compiling and executing a regular expression.
 	if strings.HasSuffix(hostname, "aws.com") || strings.HasSuffix(hostname, "aws.com.cn") || strings.HasSuffix(hostname, "tor.com") || strings.HasSuffix(hostname, "ont.com") || strings.HasSuffix(hostname, "ont.net") {
 		parts := strings.Split(hostname, ".")
+		// iterate from the second-last part (zone) towards the beginning
 		for i := len(parts) - 2; i >= 0; i-- {
 			suffix := strings.Join(parts[i:], ".")
 			if zone, exists := canonicalHostedZones[suffix]; exists {

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -1159,13 +1159,10 @@ func isAWSAlias(ep *endpoint.Endpoint) string {
 	return ""
 }
 
-var regex = regexp.MustCompile(`(aws.com(.cn)?|tor.com|ont.(com|net))$`)
-
 // canonicalHostedZone returns the matching canonical zone for a given hostname.
 func canonicalHostedZone(hostname string) string {
 	// strings.HasSuffix is optimized for this specific task and avoids the overhead associated with compiling and executing a regular expression.
-	if regex.MatchString(hostname) {
-		// if strings.HasSuffix(hostname, "aws.com") || strings.HasSuffix(hostname, "aws.com.cn") || strings.HasSuffix(hostname, "tor.com") || strings.HasSuffix(hostname, "ont.com") || strings.HasSuffix(hostname, "ont.net") {
+	if strings.HasSuffix(hostname, "aws.com") || strings.HasSuffix(hostname, "aws.com.cn") || strings.HasSuffix(hostname, "tor.com") || strings.HasSuffix(hostname, "ont.com") || strings.HasSuffix(hostname, "ont.net") {
 		parts := strings.Split(hostname, ".")
 		// iterate from the second-last part (zone) towards the beginning
 		for i := len(parts) - 2; i >= 0; i-- {

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -64,7 +64,7 @@ const (
 	sameZoneAlias                              = "same-zone"
 )
 
-// see: https://docs.aws.amazon.com/general/latest/gr/elb.html
+// see elb: https://docs.aws.amazon.com/general/latest/gr/elb.html
 var canonicalHostedZones = map[string]string{
 	// Application Load Balancers and Classic Load Balancers
 	"us-east-2.elb.amazonaws.com":         "Z3AADJGX6KTTL2",
@@ -101,7 +101,7 @@ var canonicalHostedZones = map[string]string{
 	"me-south-1.elb.amazonaws.com":        "ZS929ML54UICD",
 	"af-south-1.elb.amazonaws.com":        "Z268VQBMOI5EKX",
 	"il-central-1.elb.amazonaws.com":      "Z09170902867EHPV2DABU",
-	// Network Load Balancers
+	// Network Load Balancers https://docs.aws.amazon.com/general/latest/gr/elb.html#elb_region
 	"elb.us-east-2.amazonaws.com":         "ZLMOA37VPKANP",
 	"elb.us-east-1.amazonaws.com":         "Z26RNL4JYFTOTI",
 	"elb.us-west-1.amazonaws.com":         "Z24FKFUX50B4VW",
@@ -140,7 +140,7 @@ var canonicalHostedZones = map[string]string{
 	"awsglobalaccelerator.com": "Z2BJ6XQ5FK7U4H",
 	// Cloudfront and AWS API Gateway edge-optimized endpoints
 	"cloudfront.net": "Z2FDTNDATAQYW2",
-	// VPC Endpoint (PrivateLink)
+	// VPC Endpoint (PrivateLink) https://github.com/kubernetes-sigs/external-dns/issues/3429#issuecomment-1440415806
 	"eu-west-2.vpce.amazonaws.com":      "Z7K1066E3PUKB",
 	"us-east-2.vpce.amazonaws.com":      "ZC8PG0KIFKBRI",
 	"af-south-1.vpce.amazonaws.com":     "Z09302161J80N9A7UTP7U",
@@ -1159,10 +1159,13 @@ func isAWSAlias(ep *endpoint.Endpoint) string {
 	return ""
 }
 
+var regex = regexp.MustCompile(`(aws.com(.cn)?|tor.com|ont.(com|net))$`)
+
 // canonicalHostedZone returns the matching canonical zone for a given hostname.
 func canonicalHostedZone(hostname string) string {
 	// strings.HasSuffix is optimized for this specific task and avoids the overhead associated with compiling and executing a regular expression.
-	if strings.HasSuffix(hostname, "aws.com") || strings.HasSuffix(hostname, "aws.com.cn") || strings.HasSuffix(hostname, "tor.com") || strings.HasSuffix(hostname, "ont.com") || strings.HasSuffix(hostname, "ont.net") {
+	if regex.MatchString(hostname) {
+		// if strings.HasSuffix(hostname, "aws.com") || strings.HasSuffix(hostname, "aws.com.cn") || strings.HasSuffix(hostname, "tor.com") || strings.HasSuffix(hostname, "ont.com") || strings.HasSuffix(hostname, "ont.net") {
 		parts := strings.Split(hostname, ".")
 		// iterate from the second-last part (zone) towards the beginning
 		for i := len(parts) - 2; i >= 0; i-- {

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -1161,11 +1161,14 @@ func isAWSAlias(ep *endpoint.Endpoint) string {
 
 // canonicalHostedZone returns the matching canonical zone for a given hostname.
 func canonicalHostedZone(hostname string) string {
-	parts := strings.Split(hostname, ".")
-	for i := 0; i < len(parts); i++ {
-		suffix := strings.Join(parts[i:], ".")
-		if zone, exists := canonicalHostedZones[suffix]; exists {
-			return zone
+	// strings.HasSuffix is optimized for this specific task and avoids the overhead associated with compiling and executing a regular expression.
+	if strings.HasSuffix(hostname, "aws.com") || strings.HasSuffix(hostname, "aws.com.cn") || strings.HasSuffix(hostname, "tor.com") || strings.HasSuffix(hostname, "ont.com") || strings.HasSuffix(hostname, "ont.net") {
+		parts := strings.Split(hostname, ".")
+		for i := len(parts) - 2; i >= 0; i-- {
+			suffix := strings.Join(parts[i:], ".")
+			if zone, exists := canonicalHostedZones[suffix]; exists {
+				return zone
+			}
 		}
 	}
 

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -1875,7 +1875,7 @@ func TestAWSisAWSAlias(t *testing.T) {
 func TestAWSCanonicalHostedZone(t *testing.T) {
 	for suffix, id := range canonicalHostedZones {
 		zone := canonicalHostedZone(fmt.Sprintf("foo.%s", suffix))
-		assert.Equal(t, id, zone)
+		assert.Equal(t, id, zone, "zone suffix: %s", suffix)
 	}
 
 	zone := canonicalHostedZone("foo.example.org")
@@ -1886,6 +1886,14 @@ func BenchmarkTestAWSCanonicalHostedZone(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for suffix, _ := range canonicalHostedZones {
 			_ = canonicalHostedZone(fmt.Sprintf("foo.%s", suffix))
+		}
+	}
+}
+
+func BenchmarkTestAWSNonCanonicalHostedZone(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, _ = range canonicalHostedZones {
+			_ = canonicalHostedZone("extremely.long.zone-2.ext.dns.test.zone.non.canonical.example.com")
 		}
 	}
 }

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -1882,6 +1882,14 @@ func TestAWSCanonicalHostedZone(t *testing.T) {
 	assert.Equal(t, "", zone, "no canonical zone should be returned for a non-aws hostname")
 }
 
+func BenchmarkTestAWSCanonicalHostedZone(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for suffix, _ := range canonicalHostedZones {
+			_ = canonicalHostedZone(fmt.Sprintf("foo.%s", suffix))
+		}
+	}
+}
+
 func TestAWSSuitableZones(t *testing.T) {
 	zones := map[string]*profiledZone{
 		// Public domain

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package aws
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -29,6 +30,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -1880,6 +1882,14 @@ func TestAWSCanonicalHostedZone(t *testing.T) {
 
 	zone := canonicalHostedZone("foo.example.org")
 	assert.Equal(t, "", zone, "no canonical zone should be returned for a non-aws hostname")
+}
+
+func TestAWSCanonicalHostedZoneNotExist(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	host := "foo.elb.eastwest-1.amazonaws.com"
+	_ = canonicalHostedZone(host)
+	assert.Containsf(t, buf.String(), "Could not find canonical hosted zone for domain", host)
 }
 
 func BenchmarkTestAWSCanonicalHostedZone(b *testing.B) {


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
No issue to date.

Just a small improvements  to how canonicalHostedZone handled.



Current number of known canonical hosted zones is 130+ and is increasing, in worth case scenario current logic does 130+ iteration to validate where or not the record is a canonical hosted zone. 
```
results for canonical

before
BenchmarkTestAWSCanonicalHostedZone-16    	    7012	    171223 ns/op

now
BenchmarkTestAWSCanonicalHostedZone-16    	   16812	     68977 ns/op

results for long non-canonical hosted zone

before
enchmarkTestAWSNonCanonicalHostedZone-16    	    4869	    225384 ns/op

with new algo
BenchmarkTestAWSNonCanonicalHostedZone-16    	  277828	      4135 ns/op
```
Comparison
- Algorithm: `canonicalHostedZoneNew uses a more targeted approach by first filtering hostnames based on specific suffixes, while canonicalHostedZoneOld checks all possible suffixes in the map.
- Efficiency: This approach is optimized for hostnames with specific suffixes, as it avoids unnecessary checks for other domains. The use of strings.HasSuffix is efficient for this task vs regex pattern matching.
- Use Case: `canonicalHostedZoneN` might be more efficient if the `canonicalHostedZonesOld` map is getting large, as it reduces the number of lookups. `canonicalHostedZoneOld`  might be more efficient for a more general solution. This new function is suitable when you have a predefined set of suffixes and you want to quickly find the canonical hosted zone for hostnames matching those suffixes.

Another improvement could be: to create a cache, so that it checked hostname once and store a result, but this require additional memory proportional to the number of hostnames.

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
