### PR TITLE
Fix spelling in webhook OpenAPI spec

### DIFF
--- a/api/webhook.yaml
+++ b/api/webhook.yaml
@@ -44,7 +44,7 @@ paths:
                   - example.com
         '500':
           description: |
-            Negociation failed.
+            Negotiation failed.
 
   /records:
     get:


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Webhook OpenAPI spec misspelled "negotiation." This PR fixes that.

**Checklist**

- [ ] Unit tests updated
- [X] End user documentation updated
