### PR TITLE
feat(source/node): Make exclusion of unschedulable Nodes configurable

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -46,6 +46,7 @@
 | `--[no-]traefik-disable-legacy` | Disable listeners on Resources under the traefik.containo.us API Group |
 | `--[no-]traefik-disable-new` | Disable listeners on Resources under the traefik.io API Group |
 | `--nat64-networks=NAT64-NETWORKS` | Adding an A record for each AAAA record in NAT64-enabled networks; specify multiple times for multiple possible nets (optional) |
+| `--[no-]exclude-unschedulable` | Exclude nodes that are considered unschedulable (default: true) |
 | `--provider=provider` | The DNS provider where the DNS records will be created (required, options: akamai, alibabacloud, aws, aws-sd, azure, azure-dns, azure-private-dns, civo, cloudflare, coredns, designate, digitalocean, dnsimple, exoscale, gandi, godaddy, google, ibmcloud, inmemory, linode, ns1, oci, ovh, pdns, pihole, plural, rfc2136, scaleway, skydns, tencentcloud, transip, ultradns, webhook) |
 | `--provider-cache-time=0s` | The time to cache the DNS provider record list requests. |
 | `--domain-filter=` | Limit possible target zones by a domain suffix; specify multiple times for multiple domains (optional) |

--- a/main.go
+++ b/main.go
@@ -152,6 +152,7 @@ func main() {
 		ResolveLoadBalancerHostname:    cfg.ResolveServiceLoadBalancerHostname,
 		TraefikDisableLegacy:           cfg.TraefikDisableLegacy,
 		TraefikDisableNew:              cfg.TraefikDisableNew,
+		ExcludeUnschedulable:           cfg.ExcludeUnschedulable,
 	}
 
 	// Lookup all the selected sources by names and pass them the desired configuration.

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -209,6 +209,7 @@ type Config struct {
 	TraefikDisableLegacy               bool
 	TraefikDisableNew                  bool
 	NAT64Networks                      []string
+	ExcludeUnschedulable               bool
 }
 
 var defaultConfig = &Config{
@@ -364,6 +365,7 @@ var defaultConfig = &Config{
 	TraefikDisableLegacy:        false,
 	TraefikDisableNew:           false,
 	NAT64Networks:               []string{},
+	ExcludeUnschedulable:        true,
 }
 
 // NewConfig returns new Config object
@@ -469,6 +471,7 @@ func App(cfg *Config) *kingpin.Application {
 	app.Flag("traefik-disable-legacy", "Disable listeners on Resources under the traefik.containo.us API Group").Default(strconv.FormatBool(defaultConfig.TraefikDisableLegacy)).BoolVar(&cfg.TraefikDisableLegacy)
 	app.Flag("traefik-disable-new", "Disable listeners on Resources under the traefik.io API Group").Default(strconv.FormatBool(defaultConfig.TraefikDisableNew)).BoolVar(&cfg.TraefikDisableNew)
 	app.Flag("nat64-networks", "Adding an A record for each AAAA record in NAT64-enabled networks; specify multiple times for multiple possible nets (optional)").StringsVar(&cfg.NAT64Networks)
+	app.Flag("exclude-unschedulable", "Exclude nodes that are considered unschedulable (default: true)").Default(strconv.FormatBool(defaultConfig.ExcludeUnschedulable)).BoolVar(&cfg.ExcludeUnschedulable)
 
 	// Flags related to providers
 	providers := []string{"akamai", "alibabacloud", "aws", "aws-sd", "azure", "azure-dns", "azure-private-dns", "civo", "cloudflare", "coredns", "designate", "digitalocean", "dnsimple", "exoscale", "gandi", "godaddy", "google", "ibmcloud", "inmemory", "linode", "ns1", "oci", "ovh", "pdns", "pihole", "plural", "rfc2136", "scaleway", "skydns", "tencentcloud", "transip", "ultradns", "webhook"}

--- a/pkg/apis/externaldns/types_test.go
+++ b/pkg/apis/externaldns/types_test.go
@@ -126,6 +126,7 @@ var (
 		WebhookProviderURL:          "http://localhost:8888",
 		WebhookProviderReadTimeout:  5 * time.Second,
 		WebhookProviderWriteTimeout: 10 * time.Second,
+		ExcludeUnschedulable:        true,
 	}
 
 	overriddenConfig = &Config{
@@ -235,6 +236,7 @@ var (
 		WebhookProviderURL:          "http://localhost:8888",
 		WebhookProviderReadTimeout:  5 * time.Second,
 		WebhookProviderWriteTimeout: 10 * time.Second,
+		ExcludeUnschedulable:        false,
 	}
 )
 
@@ -370,6 +372,7 @@ func TestParseFlags(t *testing.T) {
 				"--managed-record-types=AAAA",
 				"--managed-record-types=CNAME",
 				"--managed-record-types=NS",
+				"--no-exclude-unschedulable",
 				"--rfc2136-batch-change-size=100",
 				"--ibmcloud-proxied",
 				"--ibmcloud-config-file=ibmcloud.json",
@@ -482,6 +485,7 @@ func TestParseFlags(t *testing.T) {
 				"EXTERNAL_DNS_TRANSIP_KEYFILE":                 "/path/to/transip.key",
 				"EXTERNAL_DNS_DIGITALOCEAN_API_PAGE_SIZE":      "100",
 				"EXTERNAL_DNS_MANAGED_RECORD_TYPES":            "A\nAAAA\nCNAME\nNS",
+				"EXTERNAL_DNS_EXCLUDE_UNSCHEDULABLE":           "false",
 				"EXTERNAL_DNS_RFC2136_BATCH_CHANGE_SIZE":       "100",
 				"EXTERNAL_DNS_IBMCLOUD_PROXIED":                "1",
 				"EXTERNAL_DNS_IBMCLOUD_CONFIG_FILE":            "ibmcloud.json",

--- a/source/node.go
+++ b/source/node.go
@@ -34,15 +34,16 @@ import (
 )
 
 type nodeSource struct {
-	client           kubernetes.Interface
-	annotationFilter string
-	fqdnTemplate     *template.Template
-	nodeInformer     coreinformers.NodeInformer
-	labelSelector    labels.Selector
+	client               kubernetes.Interface
+	annotationFilter     string
+	fqdnTemplate         *template.Template
+	nodeInformer         coreinformers.NodeInformer
+	labelSelector        labels.Selector
+	excludeUnschedulable bool
 }
 
 // NewNodeSource creates a new nodeSource with the given config.
-func NewNodeSource(ctx context.Context, kubeClient kubernetes.Interface, annotationFilter, fqdnTemplate string, labelSelector labels.Selector) (Source, error) {
+func NewNodeSource(ctx context.Context, kubeClient kubernetes.Interface, annotationFilter, fqdnTemplate string, labelSelector labels.Selector, excludeUnschedulable bool) (Source, error) {
 	tmpl, err := parseTemplate(fqdnTemplate)
 	if err != nil {
 		return nil, err
@@ -70,11 +71,12 @@ func NewNodeSource(ctx context.Context, kubeClient kubernetes.Interface, annotat
 	}
 
 	return &nodeSource{
-		client:           kubeClient,
-		annotationFilter: annotationFilter,
-		fqdnTemplate:     tmpl,
-		nodeInformer:     nodeInformer,
-		labelSelector:    labelSelector,
+		client:               kubeClient,
+		annotationFilter:     annotationFilter,
+		fqdnTemplate:         tmpl,
+		nodeInformer:         nodeInformer,
+		labelSelector:        labelSelector,
+		excludeUnschedulable: excludeUnschedulable,
 	}, nil
 }
 
@@ -102,7 +104,7 @@ func (ns *nodeSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, erro
 			continue
 		}
 
-		if node.Spec.Unschedulable {
+		if node.Spec.Unschedulable && ns.excludeUnschedulable {
 			log.Debugf("Skipping node %s because it is unschedulable", node.Name)
 			continue
 		}

--- a/source/node_test.go
+++ b/source/node_test.go
@@ -77,6 +77,7 @@ func testNodeSourceNewNodeSource(t *testing.T) {
 				ti.annotationFilter,
 				ti.fqdnTemplate,
 				labels.Everything(),
+				true,
 			)
 
 			if ti.expectError {
@@ -93,17 +94,18 @@ func testNodeSourceEndpoints(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
-		title            string
-		annotationFilter string
-		labelSelector    string
-		fqdnTemplate     string
-		nodeName         string
-		nodeAddresses    []v1.NodeAddress
-		labels           map[string]string
-		annotations      map[string]string
-		unschedulable    bool // default to false
-		expected         []*endpoint.Endpoint
-		expectError      bool
+		title                string
+		annotationFilter     string
+		labelSelector        string
+		fqdnTemplate         string
+		nodeName             string
+		nodeAddresses        []v1.NodeAddress
+		labels               map[string]string
+		annotations          map[string]string
+		unschedulable        bool // default to false
+		excludeUnschedulable bool // default to false
+		expected             []*endpoint.Endpoint
+		expectError          bool
 	}{
 		{
 			title:         "node with short hostname returns one endpoint",
@@ -323,11 +325,22 @@ func testNodeSourceEndpoints(t *testing.T) {
 			},
 		},
 		{
-			title:         "unschedulable node return nothing",
-			nodeName:      "node1",
-			nodeAddresses: []v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}},
-			unschedulable: true,
-			expected:      []*endpoint.Endpoint{},
+			title:                "unschedulable node return nothing with excludeUnschedulable=true",
+			nodeName:             "node1",
+			nodeAddresses:        []v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}},
+			unschedulable:        true,
+			excludeUnschedulable: true,
+			expected:             []*endpoint.Endpoint{},
+		},
+		{
+			title:                "unschedulable node returns node with excludeUnschedulable=false",
+			nodeName:             "node1",
+			nodeAddresses:        []v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}},
+			unschedulable:        true,
+			excludeUnschedulable: false,
+			expected: []*endpoint.Endpoint{
+				{RecordType: "A", DNSName: "node1", Targets: endpoint.Targets{"1.2.3.4"}},
+			},
 		},
 	} {
 		tc := tc
@@ -368,6 +381,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 				tc.annotationFilter,
 				tc.fqdnTemplate,
 				labelSelector,
+				tc.excludeUnschedulable,
 			)
 			require.NoError(t, err)
 

--- a/source/store.go
+++ b/source/store.go
@@ -78,6 +78,7 @@ type Config struct {
 	ResolveLoadBalancerHostname    bool
 	TraefikDisableLegacy           bool
 	TraefikDisableNew              bool
+	ExcludeUnschedulable           bool
 }
 
 // ClientGenerator provides clients
@@ -214,7 +215,7 @@ func BuildWithConfig(ctx context.Context, source string, p ClientGenerator, cfg 
 		if err != nil {
 			return nil, err
 		}
-		return NewNodeSource(ctx, client, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.LabelFilter)
+		return NewNodeSource(ctx, client, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.LabelFilter, cfg.ExcludeUnschedulable)
 	case "service":
 		client, err := p.KubeClient()
 		if err != nil {


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This fixes a behavioral regression introduced in #4761, where nodes that were previously added to DNS are removed when they are considered unschedulable, for example due to automated maintenance tasks.

This change will introduce a new flag called `exclude-unschedulable`, which defaults to `true` in order to keep in line with the current behavior. However, it would also be reasonable to restore the initial behavior before #4761, which would mean to not exclude unschedulable nodes by default.

Fixes #4991

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
