### PR TITLE
fix(chart): regression with affinity.nodeAffinity getting ignored

### DIFF
--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -204,6 +204,10 @@ spec:
       {{- end }}
       {{- with .Values.affinity }}
       affinity:
+      {{- with .nodeAffinity }}
+        nodeAffinity:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
       {{- with .podAffinity }}
         podAffinity:
           {{- with .preferredDuringSchedulingIgnoredDuringExecution }}


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

Allow affinity.nodeAffinity to be passed through from values.yaml.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #5037