### PR TITLE
feat: Become IDNA aware in Plan and DomainFilter

### DIFF
--- a/endpoint/domain_filter_test.go
+++ b/endpoint/domain_filter_test.go
@@ -248,6 +248,26 @@ var domainFilterTests = []domainFilterTest{
 		},
 	},
 	{
+		[]string{"æøå.org"},
+		[]string{"api.æøå.org"},
+		[]string{"foo.api.æøå.org", "api.æøå.org"},
+		false,
+		map[string][]string{
+			"include": {"æøå.org"},
+			"exclude": {"api.æøå.org"},
+		},
+	},
+	{
+		[]string{"   æøå.org. "},
+		[]string{"   .api.æøå.org    "},
+		[]string{"foo.api.æøå.org", "bar.baz.api.æøå.org."},
+		false,
+		map[string][]string{
+			"include": {"æøå.org"},
+			"exclude": {".api.æøå.org"},
+		},
+	},
+	{
 		[]string{"example.org."},
 		[]string{"api.example.org"},
 		[]string{"dev-api.example.org", "qa-api.example.org"},
@@ -295,6 +315,16 @@ var domainFilterTests = []domainFilterTest{
 		map[string][]string{
 			"include": {"api.example.org", "example.org"},
 			"exclude": {"foo-bar.example.org"},
+		},
+	},
+	{
+		[]string{"sTOnks📈.ORG", "API.xn--StonkS-u354e.ORG"},
+		[]string{"Foo-Bar.stoNks📈.Org"},
+		[]string{"FoOoo.Api.Stonks📈.Org"},
+		true,
+		map[string][]string{
+			"include": {"api.stonks📈.org", "stonks📈.org"},
+			"exclude": {"foo-bar.stonks📈.org"},
 		},
 	},
 	{
@@ -348,8 +378,27 @@ var regexDomainFilterTests = []regexDomainFilterTest{
 		},
 	},
 	{
-		regexp.MustCompile(`(?:foo|bar)\.org$`),
-		regexp.MustCompile(`^example\.(?:foo|bar)\.org$`),
+		regexp.MustCompile("(?:😍|🤩)\\.org$"),
+		regexp.MustCompile(""),
+		[]string{"😍.org", "xn--r28h.org", "🤩.org", "example.😍.org", "example.🤩.org", "a.example.xn--r28h.org", "a.example.🤩.org"},
+		true,
+		map[string]string{
+			"regexInclude": "(?:😍|🤩)\\.org$",
+		},
+	},
+	{
+		regexp.MustCompile("(?:😍|🤩)\\.org$"),
+		regexp.MustCompile("^example\\.(?:😍|🤩)\\.org$"),
+		[]string{"example.😍.org", "example.🤩.org"},
+		false,
+		map[string]string{
+			"regexInclude": "(?:😍|🤩)\\.org$",
+			"regexExclude": "^example\\.(?:😍|🤩)\\.org$",
+		},
+	},
+	{
+		regexp.MustCompile("(?:foo|bar)\\.org$"),
+		regexp.MustCompile("^example\\.(?:foo|bar)\\.org$"),
 		[]string{"foo.org", "bar.org", "a.example.foo.org", "a.example.bar.org"},
 		true,
 		map[string]string{
@@ -479,8 +528,8 @@ func TestPrepareFiltersStripsWhitespaceAndDotSuffix(t *testing.T) {
 			nil,
 		},
 		{
-			[]string{"  foo   ", "  bar. ", "baz."},
-			[]string{"foo", "bar", "baz"},
+			[]string{"  foo   ", "  bar. ", "baz.", "xn--bar-zna"},
+			[]string{"foo", "bar", "baz", "øbar"},
 		},
 		{
 			[]string{"foo.bar", "  foo.bar.  ", " foo.bar.baz ", " foo.bar.baz.  "},
@@ -715,6 +764,24 @@ func TestDomainFilterMatchParent(t *testing.T) {
 			},
 		},
 		{
+			[]string{"a.xn--c1yn36f.æøå.", "b.點看.xn--5cab8c", "c.點看.æøå"},
+			[]string{},
+			[]string{"xn--c1yn36f.xn--5cab8c"},
+			true,
+			map[string][]string{
+				"include": {"a.點看.æøå", "b.點看.æøå", "c.點看.æøå"},
+			},
+		},
+		{
+			[]string{"punycode.xn--c1yn36f.local", "å.點看.local.", "ø.點看.local"},
+			[]string{},
+			[]string{"點看.local"},
+			true,
+			map[string][]string{
+				"include": {"punycode.點看.local", "å.點看.local", "ø.點看.local"},
+			},
+		},
+		{
 			[]string{"a.example.com"},
 			[]string{},
 			[]string{"b.example.com"},
@@ -767,5 +834,69 @@ func TestDomainFilterMatchParent(t *testing.T) {
 				assert.Equal(t, tt.expected, deserialized.MatchParent(domain+"."), "deserialized %v", domain+".")
 			}
 		})
+	}
+}
+
+func TestDomainFilterNormalizeDomain(t *testing.T) {
+	records := []struct {
+		dnsName string
+		expect  string
+	}{
+		{
+			"3AAAA.FOO.BAR.COM",
+			"3aaaa.foo.bar.com",
+		},
+		{
+			"example.foo.com.",
+			"example.foo.com",
+		},
+		{
+			"example123.foo.com",
+			"example123.foo.com",
+		},
+		{
+			"foo.com.",
+			"foo.com",
+		},
+		{
+			"foo123.COM",
+			"foo123.com",
+		},
+		{
+			"my-exaMple3.FOO.BAR.COM",
+			"my-example3.foo.bar.com",
+		},
+		{
+			"my-example1214.FOO-1235.BAR-foo.COM",
+			"my-example1214.foo-1235.bar-foo.com",
+		},
+		{
+			"my-example-my-example-1214.FOO-1235.BAR-foo.COM",
+			"my-example-my-example-1214.foo-1235.bar-foo.com",
+		},
+		{
+			"xn--c1yn36f.org.",
+			"點看.org",
+		},
+		{
+			"xn--nordic--w1a.xn--xn--kItty-pd34d-hn01b3542b.com",
+			"nordic-ø.xn--kitty-點看pd34d.com",
+		},
+		{
+			"xn--nordic--w1a.xn--kItty-pd34d.com",
+			"nordic-ø.kitty😸.com",
+		},
+		{
+			"nordic-ø.kitty😸.COM",
+			"nordic-ø.kitty😸.com",
+		},
+		{
+			"xn--nordic--w1a.kiTTy😸.com.",
+			"nordic-ø.kitty😸.com",
+		},
+	}
+	for _, r := range records {
+		gotName := normalizeDomain(r.dnsName)
+		assert.Equal(t, r.expect, gotName)
 	}
 }

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/idna"
 
 	"sigs.k8s.io/external-dns/endpoint"
 )
@@ -337,9 +338,12 @@ func filterRecordsForPlan(records []*endpoint.Endpoint, domainFilter endpoint.Ma
 }
 
 // normalizeDNSName converts a DNS name to a canonical form, so that we can use string equality
-// it: removes space, converts to lower case, ensures there is a trailing dot
+// it: removes space, get ASCII version of dnsName complient with Section 5 of RFC 5891, ensures there is a trailing dot
 func normalizeDNSName(dnsName string) string {
-	s := strings.TrimSpace(strings.ToLower(dnsName))
+	s, err := idna.Lookup.ToASCII(strings.TrimSpace(dnsName))
+	if err != nil {
+		log.Warnf(`Got error while parsing DNSName %s: %v`, dnsName, err)
+	}
 	if !strings.HasSuffix(s, ".") {
 		s += "."
 	}

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -1018,6 +1018,26 @@ func TestNormalizeDNSName(t *testing.T) {
 			"my-example-my-example-1214.FOO-1235.BAR-foo.COM",
 			"my-example-my-example-1214.foo-1235.bar-foo.com.",
 		},
+		{
+			"點看.org.",
+			"xn--c1yn36f.org.",
+		},
+		{
+			"nordic-ø.xn--kitty-點看pd34d.com",
+			"xn--nordic--w1a.xn--xn--kitty-pd34d-hn01b3542b.com.",
+		},
+		{
+			"nordic-ø.kitty😸.com.",
+			"xn--nordic--w1a.xn--kitty-pd34d.com.",
+		},
+		{
+			"  nordic-ø.kitty😸.COM",
+			"xn--nordic--w1a.xn--kitty-pd34d.com.",
+		},
+		{
+			"xn--nordic--w1a.kitty😸.com.",
+			"xn--nordic--w1a.xn--kitty-pd34d.com.",
+		},
 	}
 	for _, r := range records {
 		gotName := normalizeDNSName(r.dnsName)


### PR DESCRIPTION
**Description**

Ensure support for Internationalized Domain Names for Applications (aka. domains using Unicode) using [golang.org/x/net/idna](https://pkg.go.dev/golang.org/x/net/idna)

Disclaimer, this is my first Go code so please look at it with extra skepticism

This PR replaces #4689 as I have no longer access to the [neticdk](https://github.com/neticdk) organization

**Checklist**

- [x] Unit tests updated
- [ ] ~~End user documentation updated~~
