### PR TITLE
test(domain-filter): simple filters on domain exclusion

### DIFF
--- a/endpoint/domain_filter_test.go
+++ b/endpoint/domain_filter_test.go
@@ -44,299 +44,280 @@ type regexDomainFilterTest struct {
 }
 
 var domainFilterTests = []domainFilterTest{
-	// {
-	// 	[]string{"google.com.", "exaring.de", "inovex.de"},
-	// 	[]string{},
-	// 	[]string{"google.com", "exaring.de", "inovex.de"},
-	// 	true,
-	// 	map[string][]string{
-	// 		"include": {"exaring.de", "google.com", "inovex.de"},
-	// 	},
-	// },
-	// {
-	// 	[]string{"google.com.", "exaring.de", "inovex.de"},
-	// 	[]string{},
-	// 	[]string{"google.com", "exaring.de", "inovex.de"},
-	// 	true,
-	// 	map[string][]string{
-	// 		"include": {"exaring.de", "google.com", "inovex.de"},
-	// 	},
-	// },
-	// {
-	// 	[]string{"google.com.", "exaring.de.", "inovex.de"},
-	// 	[]string{},
-	// 	[]string{"google.com", "exaring.de", "inovex.de"},
-	// 	true,
-	// 	map[string][]string{
-	// 		"include": {"exaring.de", "google.com", "inovex.de"},
-	// 	},
-	// },
-	// {
-	// 	[]string{"foo.org.      "},
-	// 	[]string{},
-	// 	[]string{"foo.org"},
-	// 	true,
-	// 	map[string][]string{
-	// 		"include": {"foo.org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{"   foo.org"},
-	// 	[]string{},
-	// 	[]string{"foo.org"},
-	// 	true,
-	// 	map[string][]string{
-	// 		"include": {"foo.org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{"foo.org."},
-	// 	[]string{},
-	// 	[]string{"foo.org"},
-	// 	true,
-	// 	map[string][]string{
-	// 		"include": {"foo.org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{"foo.org."},
-	// 	[]string{},
-	// 	[]string{"baz.org"},
-	// 	false,
-	// 	map[string][]string{
-	// 		"include": {"foo.org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{"baz.foo.org."},
-	// 	[]string{},
-	// 	[]string{"foo.org"},
-	// 	false,
-	// 	map[string][]string{
-	// 		"include": {"baz.foo.org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{"", "foo.org."},
-	// 	[]string{},
-	// 	[]string{"foo.org"},
-	// 	true,
-	// 	map[string][]string{
-	// 		"include": {"foo.org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{"", "foo.org."},
-	// 	[]string{},
-	// 	[]string{},
-	// 	true,
-	// 	map[string][]string{
-	// 		"include": {"foo.org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{""},
-	// 	[]string{},
-	// 	[]string{"foo.org"},
-	// 	true,
-	// 	map[string][]string{},
-	// },
-	// {
-	// 	[]string{""},
-	// 	[]string{},
-	// 	[]string{},
-	// 	true,
-	// 	map[string][]string{},
-	// },
-	// {
-	// 	[]string{" "},
-	// 	[]string{},
-	// 	[]string{},
-	// 	true,
-	// 	map[string][]string{},
-	// },
-	// {
-	// 	[]string{"bar.sub.example.org"},
-	// 	[]string{},
-	// 	[]string{"foo.bar.sub.example.org"},
-	// 	true,
-	// 	map[string][]string{
-	// 		"include": {"bar.sub.example.org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{"example.org"},
-	// 	[]string{},
-	// 	[]string{"anexample.org", "test.anexample.org"},
-	// 	false,
-	// 	map[string][]string{
-	// 		"include": {"example.org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{".example.org"},
-	// 	[]string{},
-	// 	[]string{"anexample.org", "test.anexample.org"},
-	// 	false,
-	// 	map[string][]string{
-	// 		"include": {".example.org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{".example.org"},
-	// 	[]string{},
-	// 	[]string{"example.org"},
-	// 	false,
-	// 	map[string][]string{
-	// 		"include": {".example.org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{".example.org"},
-	// 	[]string{},
-	// 	[]string{"test.example.org"},
-	// 	true,
-	// 	map[string][]string{
-	// 		"include": {".example.org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{"anexample.org"},
-	// 	[]string{},
-	// 	[]string{"example.org", "test.example.org"},
-	// 	false,
-	// 	map[string][]string{
-	// 		"include": {"anexample.org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{".org"},
-	// 	[]string{},
-	// 	[]string{"example.org", "test.example.org", "foo.test.example.org"},
-	// 	true,
-	// 	map[string][]string{
-	// 		"include": {".org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{"example.org"},
-	// 	[]string{"api.example.org"},
-	// 	[]string{"example.org", "test.example.org", "foo.test.example.org"},
-	// 	true,
-	// 	map[string][]string{
-	// 		"include": {"example.org"},
-	// 		"exclude": {"api.example.org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{"example.org"},
-	// 	[]string{"api.example.org"},
-	// 	[]string{"foo.api.example.org", "api.example.org"},
-	// 	false,
-	// 	map[string][]string{
-	// 		"include": {"example.org"},
-	// 		"exclude": {"api.example.org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{"   example.org. "},
-	// 	[]string{"   .api.example.org    "},
-	// 	[]string{"foo.api.example.org", "bar.baz.api.example.org."},
-	// 	false,
-	// 	map[string][]string{
-	// 		"include": {"example.org"},
-	// 		"exclude": {".api.example.org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{"example.org."},
-	// 	[]string{"api.example.org"},
-	// 	[]string{"dev-api.example.org", "qa-api.example.org"},
-	// 	true,
-	// 	map[string][]string{
-	// 		"include": {"example.org"},
-	// 		"exclude": {"api.example.org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{"example.org."},
-	// 	[]string{"api.example.org"},
-	// 	[]string{"dev.api.example.org", "qa.api.example.org"},
-	// 	false,
-	// 	map[string][]string{
-	// 		"include": {"example.org"},
-	// 		"exclude": {"api.example.org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{"example.org", "api.example.org"},
-	// 	[]string{"internal.api.example.org"},
-	// 	[]string{"foo.api.example.org"},
-	// 	true,
-	// 	map[string][]string{
-	// 		"include": {"api.example.org", "example.org"},
-	// 		"exclude": {"internal.api.example.org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{"example.org", "api.example.org"},
-	// 	[]string{"internal.api.example.org"},
-	// 	[]string{"foo.internal.api.example.org"},
-	// 	false,
-	// 	map[string][]string{
-	// 		"include": {"api.example.org", "example.org"},
-	// 		"exclude": {"internal.api.example.org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{"eXaMPle.ORG", "API.example.ORG"},
-	// 	[]string{"Foo-Bar.Example.Org"},
-	// 	[]string{"FoOoo.Api.Example.Org"},
-	// 	true,
-	// 	map[string][]string{
-	// 		"include": {"api.example.org", "example.org"},
-	// 		"exclude": {"foo-bar.example.org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{"eXaMPle.ORG", "API.example.ORG"},
-	// 	[]string{"api.example.org"},
-	// 	[]string{"foobar.Example.Org"},
-	// 	true,
-	// 	map[string][]string{
-	// 		"include": {"api.example.org", "example.org"},
-	// 		"exclude": {"api.example.org"},
-	// 	},
-	// },
-	// {
-	// 	[]string{"eXaMPle.ORG", "API.example.ORG"},
-	// 	[]string{"api.example.org"},
-	// 	[]string{"foobar.API.Example.Org"},
-	// 	false,
-	// 	map[string][]string{
-	// 		"include": {"api.example.org", "example.org"},
-	// 		"exclude": {"api.example.org"},
-	// 	},
-	// },
 	{
-		[]string{"ex.com"},
-		[]string{"subdomain.ex.com"},
-		[]string{"subdomain.ex.com", "ex.com", "two.subdomain.ex.com", "one.subdomain.ex.com"},
+		[]string{"google.com.", "exaring.de", "inovex.de"},
+		[]string{},
+		[]string{"google.com", "exaring.de", "inovex.de"},
 		true,
 		map[string][]string{
-			"include": {"ex.com"},
-			"exclude": {"subdomain.ex.com"},
+			"include": {"exaring.de", "google.com", "inovex.de"},
 		},
 	},
-	// {
-	// 	[]string{"ex.com"},
-	// 	[]string{},
-	// 	[]string{"subdomain.ex.com", "ex.com", "two.subdomain.ex.com", "one.subdomain.ex.com"},
-	// 	true,
-	// 	map[string][]string{
-	// 		"include": {"ex.com"},
-	// 	},
-	// },
+	{
+		[]string{"google.com.", "exaring.de", "inovex.de"},
+		[]string{},
+		[]string{"google.com", "exaring.de", "inovex.de"},
+		true,
+		map[string][]string{
+			"include": {"exaring.de", "google.com", "inovex.de"},
+		},
+	},
+	{
+		[]string{"google.com.", "exaring.de.", "inovex.de"},
+		[]string{},
+		[]string{"google.com", "exaring.de", "inovex.de"},
+		true,
+		map[string][]string{
+			"include": {"exaring.de", "google.com", "inovex.de"},
+		},
+	},
+	{
+		[]string{"foo.org.      "},
+		[]string{},
+		[]string{"foo.org"},
+		true,
+		map[string][]string{
+			"include": {"foo.org"},
+		},
+	},
+	{
+		[]string{"   foo.org"},
+		[]string{},
+		[]string{"foo.org"},
+		true,
+		map[string][]string{
+			"include": {"foo.org"},
+		},
+	},
+	{
+		[]string{"foo.org."},
+		[]string{},
+		[]string{"foo.org"},
+		true,
+		map[string][]string{
+			"include": {"foo.org"},
+		},
+	},
+	{
+		[]string{"foo.org."},
+		[]string{},
+		[]string{"baz.org"},
+		false,
+		map[string][]string{
+			"include": {"foo.org"},
+		},
+	},
+	{
+		[]string{"baz.foo.org."},
+		[]string{},
+		[]string{"foo.org"},
+		false,
+		map[string][]string{
+			"include": {"baz.foo.org"},
+		},
+	},
+	{
+		[]string{"", "foo.org."},
+		[]string{},
+		[]string{"foo.org"},
+		true,
+		map[string][]string{
+			"include": {"foo.org"},
+		},
+	},
+	{
+		[]string{"", "foo.org."},
+		[]string{},
+		[]string{},
+		true,
+		map[string][]string{
+			"include": {"foo.org"},
+		},
+	},
+	{
+		[]string{""},
+		[]string{},
+		[]string{"foo.org"},
+		true,
+		map[string][]string{},
+	},
+	{
+		[]string{""},
+		[]string{},
+		[]string{},
+		true,
+		map[string][]string{},
+	},
+	{
+		[]string{" "},
+		[]string{},
+		[]string{},
+		true,
+		map[string][]string{},
+	},
+	{
+		[]string{"bar.sub.example.org"},
+		[]string{},
+		[]string{"foo.bar.sub.example.org"},
+		true,
+		map[string][]string{
+			"include": {"bar.sub.example.org"},
+		},
+	},
+	{
+		[]string{"example.org"},
+		[]string{},
+		[]string{"anexample.org", "test.anexample.org"},
+		false,
+		map[string][]string{
+			"include": {"example.org"},
+		},
+	},
+	{
+		[]string{".example.org"},
+		[]string{},
+		[]string{"anexample.org", "test.anexample.org"},
+		false,
+		map[string][]string{
+			"include": {".example.org"},
+		},
+	},
+	{
+		[]string{".example.org"},
+		[]string{},
+		[]string{"example.org"},
+		false,
+		map[string][]string{
+			"include": {".example.org"},
+		},
+	},
+	{
+		[]string{".example.org"},
+		[]string{},
+		[]string{"test.example.org"},
+		true,
+		map[string][]string{
+			"include": {".example.org"},
+		},
+	},
+	{
+		[]string{"anexample.org"},
+		[]string{},
+		[]string{"example.org", "test.example.org"},
+		false,
+		map[string][]string{
+			"include": {"anexample.org"},
+		},
+	},
+	{
+		[]string{".org"},
+		[]string{},
+		[]string{"example.org", "test.example.org", "foo.test.example.org"},
+		true,
+		map[string][]string{
+			"include": {".org"},
+		},
+	},
+	{
+		[]string{"example.org"},
+		[]string{"api.example.org"},
+		[]string{"example.org", "test.example.org", "foo.test.example.org"},
+		true,
+		map[string][]string{
+			"include": {"example.org"},
+			"exclude": {"api.example.org"},
+		},
+	},
+	{
+		[]string{"example.org"},
+		[]string{"api.example.org"},
+		[]string{"foo.api.example.org", "api.example.org"},
+		false,
+		map[string][]string{
+			"include": {"example.org"},
+			"exclude": {"api.example.org"},
+		},
+	},
+	{
+		[]string{"   example.org. "},
+		[]string{"   .api.example.org    "},
+		[]string{"foo.api.example.org", "bar.baz.api.example.org."},
+		false,
+		map[string][]string{
+			"include": {"example.org"},
+			"exclude": {".api.example.org"},
+		},
+	},
+	{
+		[]string{"example.org."},
+		[]string{"api.example.org"},
+		[]string{"dev-api.example.org", "qa-api.example.org"},
+		true,
+		map[string][]string{
+			"include": {"example.org"},
+			"exclude": {"api.example.org"},
+		},
+	},
+	{
+		[]string{"example.org."},
+		[]string{"api.example.org"},
+		[]string{"dev.api.example.org", "qa.api.example.org"},
+		false,
+		map[string][]string{
+			"include": {"example.org"},
+			"exclude": {"api.example.org"},
+		},
+	},
+	{
+		[]string{"example.org", "api.example.org"},
+		[]string{"internal.api.example.org"},
+		[]string{"foo.api.example.org"},
+		true,
+		map[string][]string{
+			"include": {"api.example.org", "example.org"},
+			"exclude": {"internal.api.example.org"},
+		},
+	},
+	{
+		[]string{"example.org", "api.example.org"},
+		[]string{"internal.api.example.org"},
+		[]string{"foo.internal.api.example.org"},
+		false,
+		map[string][]string{
+			"include": {"api.example.org", "example.org"},
+			"exclude": {"internal.api.example.org"},
+		},
+	},
+	{
+		[]string{"eXaMPle.ORG", "API.example.ORG"},
+		[]string{"Foo-Bar.Example.Org"},
+		[]string{"FoOoo.Api.Example.Org"},
+		true,
+		map[string][]string{
+			"include": {"api.example.org", "example.org"},
+			"exclude": {"foo-bar.example.org"},
+		},
+	},
+	{
+		[]string{"eXaMPle.ORG", "API.example.ORG"},
+		[]string{"api.example.org"},
+		[]string{"foobar.Example.Org"},
+		true,
+		map[string][]string{
+			"include": {"api.example.org", "example.org"},
+			"exclude": {"api.example.org"},
+		},
+	},
+	{
+		[]string{"eXaMPle.ORG", "API.example.ORG"},
+		[]string{"api.example.org"},
+		[]string{"foobar.API.Example.Org"},
+		false,
+		map[string][]string{
+			"include": {"api.example.org", "example.org"},
+			"exclude": {"api.example.org"},
+		},
+	},
 }
 
 var regexDomainFilterTests = []regexDomainFilterTest{

--- a/endpoint/domain_filter_test.go
+++ b/endpoint/domain_filter_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,280 +44,299 @@ type regexDomainFilterTest struct {
 }
 
 var domainFilterTests = []domainFilterTest{
+	// {
+	// 	[]string{"google.com.", "exaring.de", "inovex.de"},
+	// 	[]string{},
+	// 	[]string{"google.com", "exaring.de", "inovex.de"},
+	// 	true,
+	// 	map[string][]string{
+	// 		"include": {"exaring.de", "google.com", "inovex.de"},
+	// 	},
+	// },
+	// {
+	// 	[]string{"google.com.", "exaring.de", "inovex.de"},
+	// 	[]string{},
+	// 	[]string{"google.com", "exaring.de", "inovex.de"},
+	// 	true,
+	// 	map[string][]string{
+	// 		"include": {"exaring.de", "google.com", "inovex.de"},
+	// 	},
+	// },
+	// {
+	// 	[]string{"google.com.", "exaring.de.", "inovex.de"},
+	// 	[]string{},
+	// 	[]string{"google.com", "exaring.de", "inovex.de"},
+	// 	true,
+	// 	map[string][]string{
+	// 		"include": {"exaring.de", "google.com", "inovex.de"},
+	// 	},
+	// },
+	// {
+	// 	[]string{"foo.org.      "},
+	// 	[]string{},
+	// 	[]string{"foo.org"},
+	// 	true,
+	// 	map[string][]string{
+	// 		"include": {"foo.org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{"   foo.org"},
+	// 	[]string{},
+	// 	[]string{"foo.org"},
+	// 	true,
+	// 	map[string][]string{
+	// 		"include": {"foo.org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{"foo.org."},
+	// 	[]string{},
+	// 	[]string{"foo.org"},
+	// 	true,
+	// 	map[string][]string{
+	// 		"include": {"foo.org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{"foo.org."},
+	// 	[]string{},
+	// 	[]string{"baz.org"},
+	// 	false,
+	// 	map[string][]string{
+	// 		"include": {"foo.org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{"baz.foo.org."},
+	// 	[]string{},
+	// 	[]string{"foo.org"},
+	// 	false,
+	// 	map[string][]string{
+	// 		"include": {"baz.foo.org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{"", "foo.org."},
+	// 	[]string{},
+	// 	[]string{"foo.org"},
+	// 	true,
+	// 	map[string][]string{
+	// 		"include": {"foo.org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{"", "foo.org."},
+	// 	[]string{},
+	// 	[]string{},
+	// 	true,
+	// 	map[string][]string{
+	// 		"include": {"foo.org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{""},
+	// 	[]string{},
+	// 	[]string{"foo.org"},
+	// 	true,
+	// 	map[string][]string{},
+	// },
+	// {
+	// 	[]string{""},
+	// 	[]string{},
+	// 	[]string{},
+	// 	true,
+	// 	map[string][]string{},
+	// },
+	// {
+	// 	[]string{" "},
+	// 	[]string{},
+	// 	[]string{},
+	// 	true,
+	// 	map[string][]string{},
+	// },
+	// {
+	// 	[]string{"bar.sub.example.org"},
+	// 	[]string{},
+	// 	[]string{"foo.bar.sub.example.org"},
+	// 	true,
+	// 	map[string][]string{
+	// 		"include": {"bar.sub.example.org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{"example.org"},
+	// 	[]string{},
+	// 	[]string{"anexample.org", "test.anexample.org"},
+	// 	false,
+	// 	map[string][]string{
+	// 		"include": {"example.org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{".example.org"},
+	// 	[]string{},
+	// 	[]string{"anexample.org", "test.anexample.org"},
+	// 	false,
+	// 	map[string][]string{
+	// 		"include": {".example.org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{".example.org"},
+	// 	[]string{},
+	// 	[]string{"example.org"},
+	// 	false,
+	// 	map[string][]string{
+	// 		"include": {".example.org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{".example.org"},
+	// 	[]string{},
+	// 	[]string{"test.example.org"},
+	// 	true,
+	// 	map[string][]string{
+	// 		"include": {".example.org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{"anexample.org"},
+	// 	[]string{},
+	// 	[]string{"example.org", "test.example.org"},
+	// 	false,
+	// 	map[string][]string{
+	// 		"include": {"anexample.org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{".org"},
+	// 	[]string{},
+	// 	[]string{"example.org", "test.example.org", "foo.test.example.org"},
+	// 	true,
+	// 	map[string][]string{
+	// 		"include": {".org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{"example.org"},
+	// 	[]string{"api.example.org"},
+	// 	[]string{"example.org", "test.example.org", "foo.test.example.org"},
+	// 	true,
+	// 	map[string][]string{
+	// 		"include": {"example.org"},
+	// 		"exclude": {"api.example.org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{"example.org"},
+	// 	[]string{"api.example.org"},
+	// 	[]string{"foo.api.example.org", "api.example.org"},
+	// 	false,
+	// 	map[string][]string{
+	// 		"include": {"example.org"},
+	// 		"exclude": {"api.example.org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{"   example.org. "},
+	// 	[]string{"   .api.example.org    "},
+	// 	[]string{"foo.api.example.org", "bar.baz.api.example.org."},
+	// 	false,
+	// 	map[string][]string{
+	// 		"include": {"example.org"},
+	// 		"exclude": {".api.example.org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{"example.org."},
+	// 	[]string{"api.example.org"},
+	// 	[]string{"dev-api.example.org", "qa-api.example.org"},
+	// 	true,
+	// 	map[string][]string{
+	// 		"include": {"example.org"},
+	// 		"exclude": {"api.example.org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{"example.org."},
+	// 	[]string{"api.example.org"},
+	// 	[]string{"dev.api.example.org", "qa.api.example.org"},
+	// 	false,
+	// 	map[string][]string{
+	// 		"include": {"example.org"},
+	// 		"exclude": {"api.example.org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{"example.org", "api.example.org"},
+	// 	[]string{"internal.api.example.org"},
+	// 	[]string{"foo.api.example.org"},
+	// 	true,
+	// 	map[string][]string{
+	// 		"include": {"api.example.org", "example.org"},
+	// 		"exclude": {"internal.api.example.org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{"example.org", "api.example.org"},
+	// 	[]string{"internal.api.example.org"},
+	// 	[]string{"foo.internal.api.example.org"},
+	// 	false,
+	// 	map[string][]string{
+	// 		"include": {"api.example.org", "example.org"},
+	// 		"exclude": {"internal.api.example.org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{"eXaMPle.ORG", "API.example.ORG"},
+	// 	[]string{"Foo-Bar.Example.Org"},
+	// 	[]string{"FoOoo.Api.Example.Org"},
+	// 	true,
+	// 	map[string][]string{
+	// 		"include": {"api.example.org", "example.org"},
+	// 		"exclude": {"foo-bar.example.org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{"eXaMPle.ORG", "API.example.ORG"},
+	// 	[]string{"api.example.org"},
+	// 	[]string{"foobar.Example.Org"},
+	// 	true,
+	// 	map[string][]string{
+	// 		"include": {"api.example.org", "example.org"},
+	// 		"exclude": {"api.example.org"},
+	// 	},
+	// },
+	// {
+	// 	[]string{"eXaMPle.ORG", "API.example.ORG"},
+	// 	[]string{"api.example.org"},
+	// 	[]string{"foobar.API.Example.Org"},
+	// 	false,
+	// 	map[string][]string{
+	// 		"include": {"api.example.org", "example.org"},
+	// 		"exclude": {"api.example.org"},
+	// 	},
+	// },
 	{
-		[]string{"google.com.", "exaring.de", "inovex.de"},
-		[]string{},
-		[]string{"google.com", "exaring.de", "inovex.de"},
+		[]string{"ex.com"},
+		[]string{"subdomain.ex.com"},
+		[]string{"subdomain.ex.com", "ex.com", "two.subdomain.ex.com", "one.subdomain.ex.com"},
 		true,
 		map[string][]string{
-			"include": {"exaring.de", "google.com", "inovex.de"},
+			"include": {"ex.com"},
+			"exclude": {"subdomain.ex.com"},
 		},
 	},
-	{
-		[]string{"google.com.", "exaring.de", "inovex.de"},
-		[]string{},
-		[]string{"google.com", "exaring.de", "inovex.de"},
-		true,
-		map[string][]string{
-			"include": {"exaring.de", "google.com", "inovex.de"},
-		},
-	},
-	{
-		[]string{"google.com.", "exaring.de.", "inovex.de"},
-		[]string{},
-		[]string{"google.com", "exaring.de", "inovex.de"},
-		true,
-		map[string][]string{
-			"include": {"exaring.de", "google.com", "inovex.de"},
-		},
-	},
-	{
-		[]string{"foo.org.      "},
-		[]string{},
-		[]string{"foo.org"},
-		true,
-		map[string][]string{
-			"include": {"foo.org"},
-		},
-	},
-	{
-		[]string{"   foo.org"},
-		[]string{},
-		[]string{"foo.org"},
-		true,
-		map[string][]string{
-			"include": {"foo.org"},
-		},
-	},
-	{
-		[]string{"foo.org."},
-		[]string{},
-		[]string{"foo.org"},
-		true,
-		map[string][]string{
-			"include": {"foo.org"},
-		},
-	},
-	{
-		[]string{"foo.org."},
-		[]string{},
-		[]string{"baz.org"},
-		false,
-		map[string][]string{
-			"include": {"foo.org"},
-		},
-	},
-	{
-		[]string{"baz.foo.org."},
-		[]string{},
-		[]string{"foo.org"},
-		false,
-		map[string][]string{
-			"include": {"baz.foo.org"},
-		},
-	},
-	{
-		[]string{"", "foo.org."},
-		[]string{},
-		[]string{"foo.org"},
-		true,
-		map[string][]string{
-			"include": {"foo.org"},
-		},
-	},
-	{
-		[]string{"", "foo.org."},
-		[]string{},
-		[]string{},
-		true,
-		map[string][]string{
-			"include": {"foo.org"},
-		},
-	},
-	{
-		[]string{""},
-		[]string{},
-		[]string{"foo.org"},
-		true,
-		map[string][]string{},
-	},
-	{
-		[]string{""},
-		[]string{},
-		[]string{},
-		true,
-		map[string][]string{},
-	},
-	{
-		[]string{" "},
-		[]string{},
-		[]string{},
-		true,
-		map[string][]string{},
-	},
-	{
-		[]string{"bar.sub.example.org"},
-		[]string{},
-		[]string{"foo.bar.sub.example.org"},
-		true,
-		map[string][]string{
-			"include": {"bar.sub.example.org"},
-		},
-	},
-	{
-		[]string{"example.org"},
-		[]string{},
-		[]string{"anexample.org", "test.anexample.org"},
-		false,
-		map[string][]string{
-			"include": {"example.org"},
-		},
-	},
-	{
-		[]string{".example.org"},
-		[]string{},
-		[]string{"anexample.org", "test.anexample.org"},
-		false,
-		map[string][]string{
-			"include": {".example.org"},
-		},
-	},
-	{
-		[]string{".example.org"},
-		[]string{},
-		[]string{"example.org"},
-		false,
-		map[string][]string{
-			"include": {".example.org"},
-		},
-	},
-	{
-		[]string{".example.org"},
-		[]string{},
-		[]string{"test.example.org"},
-		true,
-		map[string][]string{
-			"include": {".example.org"},
-		},
-	},
-	{
-		[]string{"anexample.org"},
-		[]string{},
-		[]string{"example.org", "test.example.org"},
-		false,
-		map[string][]string{
-			"include": {"anexample.org"},
-		},
-	},
-	{
-		[]string{".org"},
-		[]string{},
-		[]string{"example.org", "test.example.org", "foo.test.example.org"},
-		true,
-		map[string][]string{
-			"include": {".org"},
-		},
-	},
-	{
-		[]string{"example.org"},
-		[]string{"api.example.org"},
-		[]string{"example.org", "test.example.org", "foo.test.example.org"},
-		true,
-		map[string][]string{
-			"include": {"example.org"},
-			"exclude": {"api.example.org"},
-		},
-	},
-	{
-		[]string{"example.org"},
-		[]string{"api.example.org"},
-		[]string{"foo.api.example.org", "api.example.org"},
-		false,
-		map[string][]string{
-			"include": {"example.org"},
-			"exclude": {"api.example.org"},
-		},
-	},
-	{
-		[]string{"   example.org. "},
-		[]string{"   .api.example.org    "},
-		[]string{"foo.api.example.org", "bar.baz.api.example.org."},
-		false,
-		map[string][]string{
-			"include": {"example.org"},
-			"exclude": {".api.example.org"},
-		},
-	},
-	{
-		[]string{"example.org."},
-		[]string{"api.example.org"},
-		[]string{"dev-api.example.org", "qa-api.example.org"},
-		true,
-		map[string][]string{
-			"include": {"example.org"},
-			"exclude": {"api.example.org"},
-		},
-	},
-	{
-		[]string{"example.org."},
-		[]string{"api.example.org"},
-		[]string{"dev.api.example.org", "qa.api.example.org"},
-		false,
-		map[string][]string{
-			"include": {"example.org"},
-			"exclude": {"api.example.org"},
-		},
-	},
-	{
-		[]string{"example.org", "api.example.org"},
-		[]string{"internal.api.example.org"},
-		[]string{"foo.api.example.org"},
-		true,
-		map[string][]string{
-			"include": {"api.example.org", "example.org"},
-			"exclude": {"internal.api.example.org"},
-		},
-	},
-	{
-		[]string{"example.org", "api.example.org"},
-		[]string{"internal.api.example.org"},
-		[]string{"foo.internal.api.example.org"},
-		false,
-		map[string][]string{
-			"include": {"api.example.org", "example.org"},
-			"exclude": {"internal.api.example.org"},
-		},
-	},
-	{
-		[]string{"eXaMPle.ORG", "API.example.ORG"},
-		[]string{"Foo-Bar.Example.Org"},
-		[]string{"FoOoo.Api.Example.Org"},
-		true,
-		map[string][]string{
-			"include": {"api.example.org", "example.org"},
-			"exclude": {"foo-bar.example.org"},
-		},
-	},
-	{
-		[]string{"eXaMPle.ORG", "API.example.ORG"},
-		[]string{"api.example.org"},
-		[]string{"foobar.Example.Org"},
-		true,
-		map[string][]string{
-			"include": {"api.example.org", "example.org"},
-			"exclude": {"api.example.org"},
-		},
-	},
-	{
-		[]string{"eXaMPle.ORG", "API.example.ORG"},
-		[]string{"api.example.org"},
-		[]string{"foobar.API.Example.Org"},
-		false,
-		map[string][]string{
-			"include": {"api.example.org", "example.org"},
-			"exclude": {"api.example.org"},
-		},
-	},
+	// {
+	// 	[]string{"ex.com"},
+	// 	[]string{},
+	// 	[]string{"subdomain.ex.com", "ex.com", "two.subdomain.ex.com", "one.subdomain.ex.com"},
+	// 	true,
+	// 	map[string][]string{
+	// 		"include": {"ex.com"},
+	// 	},
+	// },
 }
 
 var regexDomainFilterTests = []regexDomainFilterTest{
@@ -418,13 +438,22 @@ func TestDomainFilterWithExclusions(t *testing.T) {
 				"exclude": tt.exclusions,
 			})
 
+			result := []string{}
+			excluded := []string{}
+
 			for _, domain := range tt.domains {
+				if domainFilter.Match(domain) {
+					result = append(result, domain)
+				} else {
+					excluded = append(excluded, domain)
+				}
 				assert.Equal(t, tt.expected, domainFilter.Match(domain), "%v", domain)
 				assert.Equal(t, tt.expected, domainFilter.Match(domain+"."), "%v", domain+".")
 
 				assert.Equal(t, tt.expected, deserialized.Match(domain), "deserialized %v", domain)
 				assert.Equal(t, tt.expected, deserialized.Match(domain+"."), "deserialized %v", domain+".")
 			}
+			fmt.Println(result, "excluded:", excluded)
 		})
 	}
 }
@@ -766,6 +795,54 @@ func TestDomainFilterMatchParent(t *testing.T) {
 				assert.Equal(t, tt.expected, deserialized.MatchParent(domain), "deserialized %v", domain)
 				assert.Equal(t, tt.expected, deserialized.MatchParent(domain+"."), "deserialized %v", domain+".")
 			}
+		})
+	}
+}
+
+func TestDomainFilterWithExclusion(t *testing.T) {
+	test := []struct {
+		domainFilter    []string
+		exclusionFilter []string
+		domains         []string
+		want            []string
+	}{
+		{
+			domainFilter:    []string{"ex.com"},
+			exclusionFilter: []string{"subdomain.ex.com"},
+			domains:         []string{"subdomain.ex.com", "ex.com", "subdomain.ex.com.", ".subdomain.ex.com", "one.subdomain.ex.com", "ex.com."},
+			want:            []string{"ex.com", "ex.com."},
+		},
+		{
+			domainFilter:    []string{"ex.com"},
+			exclusionFilter: []string{},
+			domains:         []string{"subdomain.ex.com", "ex.com", "subdomain.ex.com.", ".subdomain.ex.com", "one.subdomain.ex.com", "ex.com."},
+			want:            []string{"subdomain.ex.com", "ex.com", "subdomain.ex.com.", ".subdomain.ex.com", "one.subdomain.ex.com", "ex.com."},
+		},
+		{
+			domainFilter:    []string{"ex.com"},
+			exclusionFilter: []string{"one.subdomain.ex.com"},
+			domains:         []string{"subdomain.ex.com", "ex.com", "subdomain.ex.com.", ".subdomain.ex.com", "one.subdomain.ex.com", "ex.com."},
+			want:            []string{"subdomain.ex.com", "ex.com", "subdomain.ex.com.", ".subdomain.ex.com", "ex.com."},
+		},
+		{
+			domainFilter:    []string{"ex.com"},
+			exclusionFilter: []string{".ex.com"},
+			domains:         []string{"subdomain.ex.com", "ex.com", "subdomain.ex.com.", ".subdomain.ex.com", "one.subdomain.ex.com", "ex.com."},
+			want:            []string{"ex.com", "ex.com."},
+		},
+	}
+
+	for _, tt := range test {
+		t.Run(fmt.Sprintf("include:%s-exclude:%s", strings.Join(tt.domainFilter, "_"), strings.Join(tt.exclusionFilter, "_")), func(t *testing.T) {
+			domainFilter := NewDomainFilterWithExclusions(tt.domainFilter, tt.exclusionFilter)
+			var got []string
+			for _, domain := range tt.domains {
+				if domainFilter.Match(domain) {
+					got = append(got, domain)
+				}
+			}
+			assert.Equal(t, len(got), len(tt.want))
+			assert.Equal(t, got, tt.want)
 		})
 	}
 }

--- a/endpoint/domain_filter_test.go
+++ b/endpoint/domain_filter_test.go
@@ -771,7 +771,7 @@ func TestDomainFilterMatchParent(t *testing.T) {
 	}
 }
 
-func TestDomainFilterWithExclusion(t *testing.T) {
+func TestSimpleDomainFilterWithExclusion(t *testing.T) {
 	test := []struct {
 		domainFilter    []string
 		exclusionFilter []string

--- a/endpoint/domain_filter_test.go
+++ b/endpoint/domain_filter_test.go
@@ -419,22 +419,13 @@ func TestDomainFilterWithExclusions(t *testing.T) {
 				"exclude": tt.exclusions,
 			})
 
-			result := []string{}
-			excluded := []string{}
-
 			for _, domain := range tt.domains {
-				if domainFilter.Match(domain) {
-					result = append(result, domain)
-				} else {
-					excluded = append(excluded, domain)
-				}
 				assert.Equal(t, tt.expected, domainFilter.Match(domain), "%v", domain)
 				assert.Equal(t, tt.expected, domainFilter.Match(domain+"."), "%v", domain+".")
 
 				assert.Equal(t, tt.expected, deserialized.Match(domain), "deserialized %v", domain)
 				assert.Equal(t, tt.expected, deserialized.Match(domain+"."), "deserialized %v", domain+".")
 			}
-			fmt.Println(result, "excluded:", excluded)
 		})
 	}
 }


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Relates #3718 

The work relates to a bug in domain filter logic. I've added a test that focuses only on MATCH behaviour for a domain filters with include and exclude values, and validate against provided domains. This does not fix anything. The filters itself looks like works correctly. 

There is a slight design problem. We instantiate filters in main.go https://github.com/kubernetes-sigs/external-dns/blob/eb1949784e496edd13fac46c898479a0af739e23/main.go#L183, this could not be tested, hence the bug could be there. I keep digging.

Probably an option to consider is to create a composition filter or something. Move if/else filter creation logic away from main.go file. Any preferences, ideas?

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
