### PR TITLE
fix(chart): non-string types on svcaccount annotations

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Fixed handling of non-string types in `serviceAccount.metadata.annotations` field. @hjoshi123
+
 ## [v1.15.1] - 2023-09-10
 
 ### Added

--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed handling of non-string types in `serviceAccount.metadata.annotations` field. @hjoshi123
+- Fixed handling of non-string types in `serviceAccount.metadata.annotations` field. ([#5067](https://github.com/kubernetes-sigs/external-dns/pull/5067)) _@hjoshi123_
 
 ## [v1.15.1] - 2023-09-10
 

--- a/charts/external-dns/ci/ci-values.yaml
+++ b/charts/external-dns/ci/ci-values.yaml
@@ -40,3 +40,4 @@ serviceAccount:
     notTemplated/version: "v1.2.3"
     justValueTemplated/version: "{{ .Chart.Version }}"
     "{{ .Chart.Name }}/chart": "{{ .Chart.Version }}"
+    booleanVersion: "true"

--- a/charts/external-dns/ci/ci-values.yaml
+++ b/charts/external-dns/ci/ci-values.yaml
@@ -41,3 +41,4 @@ serviceAccount:
     justValueTemplated/version: "{{ .Chart.Version }}"
     "{{ .Chart.Name }}/chart": "{{ .Chart.Version }}"
     booleanVersion: "true"
+    number: "1"

--- a/charts/external-dns/templates/serviceaccount.yaml
+++ b/charts/external-dns/templates/serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- range $k, $v := . }}
-      {{- printf "%s: %s" (tpl $k $) (tpl $v $) | nindent 4 }}
+      {{- printf "%s: %s" (toYaml (tpl $k $)) (toYaml (tpl $v $)) | nindent 4 }}
     {{- end }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}


### PR DESCRIPTION
**Description**

Added toYaml to convert non string types rendered by `tpl` back to string. For ex: "true".
This change restores the previous behavior to allow boolean/numeric annotations through strings.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #5039 

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
