### PR TITLE
Update aws.md for guidance on latest EKS Auto Mode

### DIFF
--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -339,6 +339,8 @@ kubectl patch serviceaccount "external-dns" --namespace ${EXTERNALDNS_NS:-"defau
  "{\"metadata\": { \"annotations\": { \"eks.amazonaws.com/role-arn\": \"$ROLE_ARN\" }}}"
 ```
 
+> NOTE: For AWS EKS clusters with auto-mode enabled where the [authentication mode](https://www.eksworkshop.com/docs/security/cluster-access-management/managing) is `API` (recommended), the condition on `trust.json` on `$OIDC_PROVIDER:sub` will cause the external-dns pods to error with: "Not authorized to perform sts:AssumeRoleWithWebIdentity". Simply remove that condition and rely just on the `$OIDC_PROVIDER:aud` condition. This is because `API` authentication mode does not leverage RBAC configuration. 
+
 If any part of this step is misconfigured, such as the role with incorrect namespace configured in the trust relationship, annotation pointing the the wrong role, etc., you will see errors like `WebIdentityErr: failed to retrieve credentials`. Check the configuration and make corrections.
 
 When the service account annotations are updated, then the current running pods will have to be terminated, so that new pod(s) with proper configuration (environment variables) will be created automatically.


### PR DESCRIPTION
AWS EKS Auto Mode recommends an authentication mode of `API` only, which does not leverage the older RBAC config map that this document was referencing. 

This adds a note for any users coming to this page (with the relevant error that is thrown for SEO) so that users have guidance on EKS Auto Mode.

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Simply updating the documentation to provide a warning and guidance for users on EKS Auto-Mode on how to modify the `trust.json` example for IRSA based authentication (production recommended approach) to work with `API` authentication mode (recommended on AWS EKS Auto Mode).

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
