### PR TITLE
chore(makefile): simplify coverage script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,16 +17,11 @@
 .DEFAULT_GOAL := build
 
 cover:
-	go get github.com/wadey/gocovmerge
-	$(eval PKGS := $(shell go list ./... | grep -v /vendor/))
-	$(eval PKGS_DELIM := $(shell echo $(PKGS) | tr / -'))
-	go list -f '{{if or (len .TestGoFiles) (len .XTestGoFiles)}}go test -test.v -test.timeout=120s -covermode=count -coverprofile={{.Name}}_{{len .Imports}}_{{len .Deps}}.coverprofile -coverpkg $(PKGS_DELIM) {{.ImportPath}}{{end}}' $(PKGS) | xargs -0 sh -c
-	gocovmerge `ls *.coverprofile` > cover.out
-	rm *.coverprofile
+	@go test -cover -coverprofile=cover.out -v ./...
 
 #? cover-html: Run tests with coverage and open coverage report in the browser
 cover-html: cover
-	go tool cover -html cover.out
+	@go tool cover -html=cover.out
 
 #? controller-gen: download controller-gen if necessary
 controller-gen:


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

not sure how many of us using coverage from local, the up-to-date practice does not require any external toolings to be installed 

Result is the same

![Screenshot 2025-02-19 at 08 25 50](https://github.com/user-attachments/assets/5085b83c-d80b-4411-af4e-44b8e352909f)

current tool used, was a hack that is 10 years old))

![Screenshot 2025-02-19 at 08 28 11](https://github.com/user-attachments/assets/216bcebe-f3fa-40a6-9db4-cca6dd77df9d)


**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
