### PR TITLE
chore: upgrade ExternalDNS to go 1.24

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,7 +33,7 @@ jobs:
       uses: golangci/golangci-lint-action@v6
       with:
         args: --timeout=30m
-        version: v1.63
+        version: v1.64
 
       # Run Spectral
     - name: Lint OpenAPI spec

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ CONTROLLER_GEN=$(shell which controller-gen)
 endif
 
 golangci-lint:
-	@command -v golangci-lint > /dev/null || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.63.4
+	@command -v golangci-lint > /dev/null || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.5
 
 # Run the golangci-lint tool
 .PHONY: go-lint

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'docker.io/library/golang:1.23-bookworm'
+  - name: 'docker.io/library/golang:1.24-bookworm'
     entrypoint: make
     env:
       - VERSION=$_GIT_TAG

--- a/docs/contributing/dev-guide.md
+++ b/docs/contributing/dev-guide.md
@@ -7,7 +7,7 @@ The `external-dns` is the work of thousands of contributors, and is maintained b
 Building and/or testing `external-dns` requires additional tooling.
 
 - [Git](https://git-scm.com/downloads)
-- [Go 1.23+](https://golang.org/dl/)
+- [Go 1.24+](https://golang.org/dl/)
 - [Go modules](https://github.com/golang/go/wiki/Modules)
 - [golangci-lint](https://github.com/golangci/golangci-lint)
 - [ko](https://ko.build/)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/external-dns
 
-go 1.23.5
+go 1.24.0
 
 require (
 	cloud.google.com/go/compute/metadata v0.6.0

--- a/provider/azure/cache_test.go
+++ b/provider/azure/cache_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestzonesCache(t *testing.T) {
+func TestZonesCache(t *testing.T) {
 	now := time.Now()
 	zoneName := "example.com"
 	var testCases = map[string]struct {


### PR DESCRIPTION
**Description**

This update external dns to go 1.24.
Inspired by #4698

It also upgrade linter to latest version, v1.64.5.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated