### PR TITLE
fix(Traefik Proxy): missing IgnoreIngressRulesSpec check

### DIFF
--- a/source/store.go
+++ b/source/store.go
@@ -305,7 +305,7 @@ func BuildWithConfig(ctx context.Context, source string, p ClientGenerator, cfg 
 		if err != nil {
 			return nil, err
 		}
-		return NewTraefikSource(ctx, dynamicClient, kubernetesClient, cfg.Namespace, cfg.AnnotationFilter, cfg.IgnoreHostnameAnnotation, cfg.TraefikDisableLegacy, cfg.TraefikDisableNew)
+		return NewTraefikSource(ctx, dynamicClient, kubernetesClient, cfg.Namespace, cfg.AnnotationFilter, cfg.IgnoreHostnameAnnotation, cfg.IgnoreIngressRulesSpec, cfg.TraefikDisableLegacy, cfg.TraefikDisableNew)
 	case "openshift-route":
 		ocpClient, err := p.OpenShiftClient()
 		if err != nil {


### PR DESCRIPTION
**Description**

When setting the `ingress-hostname-source` annotation to `annotation-only`, ExternalDNS still inspects the IngressRoute spec for hostnames.  This change adds a check for the `IgnoreIngressRulesSpec` configuration value and, if set to true, will skip inspecting the IngressRoute spec.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated (not needed)
