### PR TITLE
docs(README): fix link to dev guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ would have at least two maintainers. It would be nice if the maintainers run the
 is not strictly required. Provider listed [here](https://github.com/kubernetes-sigs/external-dns#status-of-in-tree-providers)
 that do not have a maintainer listed are in need of assistance.
 
-Read the [contributing guidelines](CONTRIBUTING.md) and have a look at [the contributing docs](docs/contributing/getting-started.md) to learn about building the project, the project structure, and the purpose of each package.
+Read the [contributing guidelines](CONTRIBUTING.md) and have a look at [the contributing docs](docs/contributing/dev-guide.md) to learn about building the project, the project structure, and the purpose of each package.
 
 For an overview on how to write new Sources and Providers check out [Sources and Providers](docs/contributing/sources-and-providers.md).
 


### PR DESCRIPTION
resolves a 404 in the readme pointed to https://github.com/kubernetes-sigs/external-dns/blob/master/docs/contributing/getting-started.md