### PR TITLE
fix: output the name of the worker to console when added

### DIFF
--- a/source/node.go
+++ b/source/node.go
@@ -57,7 +57,12 @@ func NewNodeSource(ctx context.Context, kubeClient kubernetes.Interface, annotat
 	nodeInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				log.Debug("node added")
+				node, ok := obj.(*v1.Node)
+				if !ok {
+					log.Errorf("expect *v1.Node, but got: %T", obj)
+					return
+				}
+				log.Debugf("node added: %s", node.ObjectMeta.Name)
 			},
 		},
 	)


### PR DESCRIPTION
**Description**

Change the output in the console for debugging purpose.

```
time="2025-02-24T05:59:44+01:00" level=debug msg="node added"
time="2025-02-24T05:59:44+01:00" level=debug msg="node added"
time="2025-02-24T05:59:44+01:00" level=debug msg="node added"
```

vs.

```
time="2025-02-24T05:59:44+01:00" level=debug msg="Node added: myworker1"
time="2025-02-24T05:59:44+01:00" level=debug msg="Node added: myworker2"
time="2025-02-24T05:59:44+01:00" level=debug msg="Node added: myworker3"
```

The output is rather fun if there are 400+ workers and you only see `node added`.

**Checklist**

- [ ] Unit tests updated
- [X] End user documentation updated
