### PR TITLE
fix(aws-sd): service instances registration and deregistration

### DIFF
--- a/provider/awssd/aws_sd.go
+++ b/provider/awssd/aws_sd.go
@@ -222,13 +222,6 @@ func (p *AWSSDProvider) ApplyChanges(ctx context.Context, changes *plan.Changes)
 		return err
 	}
 
-	// Deletes must be executed first to support update case.
-	// When just list of targets is updated `[1.2.3.4] -> [1.2.3.4, 1.2.3.5]` it is translated to:
-	// ```
-	// deletes = [1.2.3.4]
-	// creates = [1.2.3.4, 1.2.3.5]
-	// ```
-	// then when deletes are executed after creates it will miss the `1.2.3.4` instance.
 	err = p.submitDeletes(ctx, namespaces, changes.Delete)
 	if err != nil {
 		return err
@@ -252,7 +245,22 @@ func (p *AWSSDProvider) updatesToCreates(changes *plan.Changes) (creates []*endp
 		current := updateNewMap[old.DNSName]
 
 		if !old.Targets.Same(current.Targets) {
-			// when targets differ the old instances need to be de-registered first
+			// if targets changed, only deregister removed targets (i.e. in `UpdateOld` but not in `UpdateNew`)
+			targets_to_remove := make(endpoint.Targets, 0)
+			for _, old_target := range old.Targets {
+				found := false
+				for _, new_target := range current.Targets {
+					if old_target == new_target {
+						found = true
+						break
+					}
+				}
+				if !found {
+					targets_to_remove = append(targets_to_remove, old_target)
+				}
+			}
+
+			old.Targets = targets_to_remove
 			deletes = append(deletes, old)
 		}
 

--- a/provider/awssd/aws_sd.go
+++ b/provider/awssd/aws_sd.go
@@ -246,19 +246,19 @@ func (p *AWSSDProvider) updatesToCreates(changes *plan.Changes) (creates []*endp
 
 		if !old.Targets.Same(current.Targets) {
 			currentTargetsMap := make(map[string]struct{}, len(current.Targets))
-			for _, new_target := range current.Targets {
-				currentTargetsMap[new_target] = struct{}{}
+			for _, newTarget := range current.Targets {
+				currentTargetsMap[newTarget] = struct{}{}
 			}
 
 			// If targets changed, only deregister removed targets (i.e. in `UpdateOld` but not in `UpdateNew`)
-			targets_to_remove := make(endpoint.Targets, 0)
-			for _, old_target := range old.Targets {
-				if _, found := currentTargetsMap[old_target]; !found {
-					targets_to_remove = append(targets_to_remove, old_target)
+			targetsToRemove := make(endpoint.Targets, 0)
+			for _, oldTarget := range old.Targets {
+				if _, found := currentTargetsMap[oldTarget]; !found {
+					targetsToRemove = append(targetsToRemove, oldTarget)
 				}
 			}
 
-			old.Targets = targets_to_remove
+			old.Targets = targetsToRemove
 			deletes = append(deletes, old)
 		}
 

--- a/provider/awssd/aws_sd.go
+++ b/provider/awssd/aws_sd.go
@@ -245,17 +245,15 @@ func (p *AWSSDProvider) updatesToCreates(changes *plan.Changes) (creates []*endp
 		current := updateNewMap[old.DNSName]
 
 		if !old.Targets.Same(current.Targets) {
-			// if targets changed, only deregister removed targets (i.e. in `UpdateOld` but not in `UpdateNew`)
+			currentTargetsMap := make(map[string]struct{}, len(current.Targets))
+			for _, new_target := range current.Targets {
+				currentTargetsMap[new_target] = struct{}{}
+			}
+
+			// If targets changed, only deregister removed targets (i.e. in `UpdateOld` but not in `UpdateNew`)
 			targets_to_remove := make(endpoint.Targets, 0)
 			for _, old_target := range old.Targets {
-				found := false
-				for _, new_target := range current.Targets {
-					if old_target == new_target {
-						found = true
-						break
-					}
-				}
-				if !found {
+				if _, found := currentTargetsMap[old_target]; !found {
 					targets_to_remove = append(targets_to_remove, old_target)
 				}
 			}


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This improves how registration and deregistration of targets is performed, which incidentally fixes an occasional race condition with the AWS API in this process.

This is a resubmission of this fix, now as a bug fix. Bug was discovered as upgrading from a patched version containing this fix to 0.15.1 was unsuccessful. Old PR is here: https://github.com/kubernetes-sigs/external-dns/pull/3123


<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #5134

**Checklist**

- [ x ] Unit tests updated
- [ x ] End user documentation updated
