### PR TITLE
fix(registry): handle empty targets in TXT records logging an error

### DIFF
--- a/registry/txt.go
+++ b/registry/txt.go
@@ -146,6 +146,11 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 			continue
 		}
 		// We simply assume that TXT records for the registry will always have only one target.
+		// If there are no targets (e.g for routing policy based records in google), direct targets will be empty
+		if len(record.Targets) == 0 {
+			log.Errorf("TXT record has no targets", record.DNSName)
+			continue
+		}
 		labels, err := endpoint.NewLabelsFromString(record.Targets[0], im.txtEncryptAESKey)
 		if errors.Is(err, endpoint.ErrInvalidHeritage) {
 			// if no heritage is found or it is invalid

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -148,7 +148,7 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 		// We simply assume that TXT records for the registry will always have only one target.
 		// If there are no targets (e.g for routing policy based records in google), direct targets will be empty
 		if len(record.Targets) == 0 {
-			log.Errorf("TXT record has no targets", record.DNSName)
+			log.Errorf("TXT record has no targets %s", record.DNSName)
 			continue
 		}
 		labels, err := endpoint.NewLabelsFromString(record.Targets[0], im.txtEncryptAESKey)

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	log "github.com/sirupsen/logrus"
+
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/internal/testutils"
 	"sigs.k8s.io/external-dns/plan"
@@ -1819,6 +1821,7 @@ func TestTXTRegistryRecordsWithEmptyTargets(t *testing.T) {
 	})
 
 	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour, "", []string{}, []string{}, false, nil, false)
+	b := testutils.LogsToBuffer(log.ErrorLevel, t)
 	records, err := r.Records(ctx)
 	require.NoError(t, err)
 
@@ -1832,4 +1835,5 @@ func TestTXTRegistryRecordsWithEmptyTargets(t *testing.T) {
 	}
 
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
+	assert.Contains(t, b.String(), "TXT record has no targets empty-targets.test-zone.example.org")
 }


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #5129 

Context: `TXT` record with routing policy on GCP has no direct single target, as a result, the direct index access to first element fails. (Such routing policy based records not necessarily be part of the external dns management area, it could be created or updated manually that can cause this issue.)

How to test manually:
Let the external-dns run as is , the google DNS zone you are using , create a TXT record with weighted routing policy.
Current version should crash with the error in the issue.
in the PR changes will make sure it gets passed by, with a error line like below
```
ERRO[0002] TXT record <DNS> has no targets
```
**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated