### PR TITLE
add: auto label source and providers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -22,3 +22,32 @@ emeritus_approvers:
   - linki
   - njuettner
   - seanmalloy
+
+filters:
+  "source/":
+    labels:
+    - source
+  "provider/aws(|sd)":
+    labels:
+    - provider/aws
+  "provider/azure":
+    labels:
+    - provider/azure
+  "provider/google":
+    labels:
+    - provider/google
+  "provider/coredns":
+    labels:
+    - provider/coredns
+  "provider/rfc2136":
+    labels:
+    - provider/rfc2136
+  "provider/pdns":
+    labels:
+    - provider/powerdns
+  "provider/cloudflare":
+    labels:
+    - provider/cloudflare
+  "provider/(akamai|alibabacloud|civo|designate|digitalocean|dnsimple|exoscale|gandi|godaddy|ibmcloud|linode|ns1|oci|ovh|pihole|plural|scaleway|tencentcloud|transip|ultradns)":
+    labels:
+    - provider


### PR DESCRIPTION
based on https://www.kubernetes.dev/docs/guide/owners/ add automatically labels for "provider" and "source". Some providers have already their own labels so I added these specifically and rest is just "provider" label 