### PR TITLE
feat: support envFrom in Chart

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added helm testing framework `helm plugin unittest`. ([#5137](https://github.com/kubernetes-sigs/external-dns/pull/5137)) _@ivankatliarchuk_
 - Added ability to generate schema with `helm plugin schema`. ([#5075](https://github.com/kubernetes-sigs/external-dns/pull/5075)) _@ivankatliarchuk_
 - Added `docs/contributing/dev-guide.md#helm-values` guide. ([#5075](https://github.com/kubernetes-sigs/external-dns/pull/5075)) _@ivankatliarchuk_
+- Added envFrom support. ([#5170](https://github.com/kubernetes-sigs/external-dns/pull/5170)) _@buroa_
 
 ### Changed
 

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -100,6 +100,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | dnsPolicy | string | `nil` | [DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) for the pod, if not set the default will be used. |
 | domainFilters | list | `[]` | Limit possible target zones by domain suffixes. |
 | env | list | `[]` | [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `external-dns` container. |
+| envFrom | list | `[]` | [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) from config maps or secrets for the `external-dns` container. |
 | excludeDomains | list | `[]` | Intentionally exclude domains from being managed. |
 | extraArgs | list | `[]` | Extra arguments to provide to _ExternalDNS_. |
 | extraContainers | object | `{}` | Extra containers to add to the `Deployment`. |
@@ -129,6 +130,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | provider.name | string | `"aws"` | _ExternalDNS_ provider name; for the available providers and how to configure them see [README](https://github.com/kubernetes-sigs/external-dns/blob/master/charts/external-dns/README.md#providers). |
 | provider.webhook.args | list | `[]` | Extra arguments to provide for the `webhook` container. |
 | provider.webhook.env | list | `[]` | [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `webhook` container. |
+| provider.webhook.envFrom | list | `[]` | [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) from config maps or secrets for the `webhook` container. |
 | provider.webhook.extraVolumeMounts | list | `[]` | Extra [volume mounts](https://kubernetes.io/docs/concepts/storage/volumes/) for the `webhook` container. |
 | provider.webhook.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the `webhook` container. |
 | provider.webhook.image.repository | string | `nil` | Image repository for the `webhook` container. |

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -85,6 +85,10 @@ spec:
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args:
             - --log-level={{ .Values.logLevel }}
             - --log-format={{ .Values.logFormat }}
@@ -157,6 +161,10 @@ spec:
           imagePullPolicy: {{ .image.pullPolicy }}
           {{- with .env }}
           env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .envFrom }}
+          envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .args }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -119,6 +119,9 @@ securityContext:
 # -- [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `external-dns` container.
 env: []
 
+# -- [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) from a `ConfigMap` or `Secret` for the `external-dns` container.
+envFrom: []
+
 # -- [Liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `external-dns` container.
 # @default -- See _values.yaml_
 livenessProbe:
@@ -250,6 +253,8 @@ provider:
       pullPolicy: IfNotPresent
     # -- [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `webhook` container.
     env: []
+    # -- [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) from a `ConfigMap` or `Secret` for the `webhook` container.
+    envFrom: []
     # -- Extra arguments to provide for the `webhook` container.
     args: []
     # -- Extra [volume mounts](https://kubernetes.io/docs/concepts/storage/volumes/) for the `webhook` container.


### PR DESCRIPTION
Adds `envFrom` support in both the deployment and sidecar provider.

https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/

For example, this is extremely redundant:

```
    env:
      - name: &name CF_API_TOKEN
        valueFrom:
          secretKeyRef:
            name: &secret external-dns-cloudflare-secret
            key: *name
      - name: &name CF_ZONE_ID
        valueFrom:
          secretKeyRef:
            name: *secret
            key: *name
```

When we can just do a simple:

```
    envFrom:
      - secretRef:
          name: external-dns-cloudflare-secret
```