### PR TITLE
fix(aws): typo on route53 IAM

### DIFF
--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -30,7 +30,7 @@ Hosted Zone IDs.
       "Action": [
         "route53:ListHostedZones",
         "route53:ListResourceRecordSets",
-        "route53:ListTagsForResource"
+        "route53:ListTagsForResources"
       ],
       "Resource": [
         "*"


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

I spotted a typo in the route53 IAM while trying to set it up in my environment. This updates the docs to use the plural `route53:ListTagsForResources`


<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->


**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
