### PR TITLE
fix(chart): add missing types for empty values

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Add missing types in the schema for empty values ([#5207](https://github.com/kubernetes-sigs/external-dns/pull/5207)) _@t3mi_
+
 ## [v1.16.0] - 2025-03-20
 
 ### Added

--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Changed
+
+- Set defaults for `automountServiceAccountToken` and `serviceAccount.automountServiceAccountToken` to `true` in helm chart values ([#5207](https://github.com/kubernetes-sigs/external-dns/pull/5207)) _@t3mi_
+
 ### Fixed
 
 - Add missing types in the schema for empty values ([#5207](https://github.com/kubernetes-sigs/external-dns/pull/5207)) _@t3mi_

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -92,7 +92,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity settings for `Pod` [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels. |
-| automountServiceAccountToken | bool | `nil` | Set this to `false` to [opt out of API credential automounting](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting) for the `Pod`. |
+| automountServiceAccountToken | bool | `true` | Set this to `false` to [opt out of API credential automounting](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting) for the `Pod`. |
 | commonLabels | object | `{}` | Labels to add to all chart resources. |
 | deploymentAnnotations | object | `{}` | Annotations to add to the `Deployment`. |
 | deploymentStrategy | object | `{"type":"Recreate"}` | [Deployment Strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy). |
@@ -155,7 +155,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | service.ipFamilyPolicy | string | `nil` | Service IP family policy. |
 | service.port | int | `7979` | Service HTTP port. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. Templates are allowed in both the key and the value. Example: `example.com/annotation/{{ .Values.nameOverride }}: {{ .Values.nameOverride }}` |
-| serviceAccount.automountServiceAccountToken | string | `nil` | Set this to `false` to [opt out of API credential automounting](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting) for the `ServiceAccount`. |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Set this to `false` to [opt out of API credential automounting](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting) for the `ServiceAccount`. |
 | serviceAccount.create | bool | `true` | If `true`, create a new `ServiceAccount`. |
 | serviceAccount.labels | object | `{}` | Labels to add to the service account. |
 | serviceAccount.name | string | `nil` | If this is set and `serviceAccount.create` is `true` this will be used for the created `ServiceAccount` name, if set and `serviceAccount.create` is `false` then this will define an existing `ServiceAccount` to use. |

--- a/charts/external-dns/tests/deployment-config_test.yaml
+++ b/charts/external-dns/tests/deployment-config_test.yaml
@@ -19,8 +19,9 @@ tests:
       - equal:
           path: metadata.namespace
           value: default
-      - notExists:
+      - equal:
           path: spec.template.spec.automountServiceAccountToken
+          value: true
 
   - it: should provide expected defaults for securityContext
     asserts:

--- a/charts/external-dns/tests/serviceaccount_test.yaml
+++ b/charts/external-dns/tests/serviceaccount_test.yaml
@@ -12,7 +12,7 @@ tests:
           count: 1
       - equal:
           path: automountServiceAccountToken
-          value: null
+          value: true
 
   - it: should provide a way to disable service account
     set:

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -7,10 +7,7 @@
       "type": "object"
     },
     "automountServiceAccountToken": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": "boolean"
     },
     "commonLabels": {
       "properties": {},
@@ -618,10 +615,7 @@
           "type": "object"
         },
         "automountServiceAccountToken": {
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "type": "boolean"
         },
         "create": {
           "type": "boolean"

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -7,7 +7,10 @@
       "type": "object"
     },
     "automountServiceAccountToken": {
-      "type": "null"
+      "type": [
+        "boolean",
+        "null"
+      ]
     },
     "commonLabels": {
       "properties": {},
@@ -33,10 +36,16 @@
       "type": "object"
     },
     "dnsConfig": {
-      "type": "null"
+      "type": [
+        "object",
+        "null"
+      ]
     },
     "dnsPolicy": {
-      "type": "null"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "domainFilters": {
       "type": "array"
@@ -68,7 +77,10 @@
       "type": "array"
     },
     "fullnameOverride": {
-      "type": "null"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "global": {
       "properties": {
@@ -188,7 +200,10 @@
       "uniqueItems": true
     },
     "nameOverride": {
-      "type": "null"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "namespaced": {
       "type": "boolean"
@@ -235,7 +250,10 @@
       ]
     },
     "priorityClassName": {
-      "type": "null"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "provider": {
       "properties": {
@@ -259,10 +277,16 @@
                   "type": "string"
                 },
                 "repository": {
-                  "type": "null"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "tag": {
-                  "type": "null"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 }
               },
               "type": "object"
@@ -594,7 +618,10 @@
           "type": "object"
         },
         "automountServiceAccountToken": {
-          "type": "null"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "create": {
           "type": "boolean"
@@ -604,7 +631,10 @@
           "type": "object"
         },
         "name": {
-          "type": "null"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "type": "object"
@@ -620,28 +650,43 @@
           "type": "object"
         },
         "bearerTokenFile": {
-          "type": "null"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "enabled": {
           "type": "boolean"
         },
         "interval": {
-          "type": "null"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "metricRelabelings": {
           "type": "array"
         },
         "namespace": {
-          "type": "null"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "relabelings": {
           "type": "array"
         },
         "scheme": {
-          "type": "null"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "scrapeTimeout": {
-          "type": "null"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "targetLabels": {
           "type": "array"
@@ -663,7 +708,10 @@
       "type": "array"
     },
     "terminationGracePeriodSeconds": {
-      "type": "null"
+      "type": [
+        "integer",
+        "null"
+      ]
     },
     "tolerations": {
       "type": "array"

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -36,7 +36,7 @@ serviceAccount:
   # -- (string) If this is set and `serviceAccount.create` is `true` this will be used for the created `ServiceAccount` name, if set and `serviceAccount.create` is `false` then this will define an existing `ServiceAccount` to use.
   name:  # @schema type:[string, null]; default: null
   # -- Set this to `false` to [opt out of API credential automounting](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting) for the `ServiceAccount`.
-  automountServiceAccountToken:  # @schema type:[boolean, null]; default: null
+  automountServiceAccountToken: true
 
 service:
   # -- Service annotations.
@@ -76,7 +76,7 @@ podLabels: {}
 podAnnotations: {}
 
 # -- (bool) Set this to `false` to [opt out of API credential automounting](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting) for the `Pod`.
-automountServiceAccountToken:  # @schema type:[boolean, null]; default: null
+automountServiceAccountToken: true
 
 # -- If `true`, the `Pod` will have [process namespace sharing](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/) enabled.
 shareProcessNamespace: false

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -18,10 +18,10 @@ image:  # @schema additionalProperties: false
 imagePullSecrets: []  # @schema item: object
 
 # -- (string) Override the name of the chart.
-nameOverride:
+nameOverride: # @schema type:[string, null]; default: null
 
 # -- (string) Override the full name of the chart.
-fullnameOverride:
+fullnameOverride: # @schema type:[string, null]; default: null
 
 # -- Labels to add to all chart resources.
 commonLabels: {}
@@ -34,9 +34,9 @@ serviceAccount:
   # -- Annotations to add to the service account. Templates are allowed in both the key and the value. Example: `example.com/annotation/{{ .Values.nameOverride }}: {{ .Values.nameOverride }}`
   annotations: {}
   # -- (string) If this is set and `serviceAccount.create` is `true` this will be used for the created `ServiceAccount` name, if set and `serviceAccount.create` is `false` then this will define an existing `ServiceAccount` to use.
-  name:
+  name: # @schema type:[string, null]; default: null
   # -- Set this to `false` to [opt out of API credential automounting](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting) for the `ServiceAccount`.
-  automountServiceAccountToken:
+  automountServiceAccountToken: # @schema type:[boolean, null]; default: null
 
 service:
   # -- Service annotations.
@@ -76,7 +76,7 @@ podLabels: {}
 podAnnotations: {}
 
 # -- (bool) Set this to `false` to [opt out of API credential automounting](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting) for the `Pod`.
-automountServiceAccountToken:
+automountServiceAccountToken: # @schema type:[boolean, null]; default: null
 
 # -- If `true`, the `Pod` will have [process namespace sharing](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/) enabled.
 shareProcessNamespace: false
@@ -90,16 +90,16 @@ podSecurityContext:
     type: RuntimeDefault
 
 # -- (string) Priority class name for the `Pod`.
-priorityClassName:
+priorityClassName: # @schema type:[string, null]; default: null
 
 # -- (int) Termination grace period for the `Pod` in seconds.
-terminationGracePeriodSeconds:
+terminationGracePeriodSeconds: # @schema type:[integer, null]
 
 # -- (string) [DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) for the pod, if not set the default will be used.
-dnsPolicy:
+dnsPolicy: # @schema type:[string, null]; default: null
 
 # -- (object) [DNS config](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config) for the pod, if not set the default will be used.
-dnsConfig:
+dnsConfig: # @schema type:[object, null]; default: null
 
 # -- [Init containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) to add to the `Pod` definition.
 initContainers: []
@@ -172,17 +172,17 @@ serviceMonitor:
   # -- Annotations to add to the `ServiceMonitor`.
   annotations: {}
   # -- (string) If set create the `ServiceMonitor` in an alternate namespace.
-  namespace:
+  namespace: # @schema type:[string, null]; default: null
   # -- (string) If set override the _Prometheus_ default interval.
-  interval:
+  interval: # @schema type:[string, null]; default: null
   # -- (string) If set override the _Prometheus_ default scrape timeout.
-  scrapeTimeout:
+  scrapeTimeout: # @schema type:[string, null]; default: null
   # -- (string) If set overrides the _Prometheus_ default scheme.
-  scheme:
+  scheme: # @schema type:[string, null]; default: null
   # -- Configure the `ServiceMonitor` [TLS config](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig).
   tlsConfig: {}
   # -- (string) Provide a bearer token file for the `ServiceMonitor`.
-  bearerTokenFile:
+  bearerTokenFile: # @schema type:[string, null]; default: null
   # -- [Relabel configs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) to apply to samples before ingestion.
   relabelings: []
   # -- [Metric relabel configs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs) to apply to samples before ingestion.
@@ -243,9 +243,9 @@ provider:
   webhook:
     image:
       # -- (string) Image repository for the `webhook` container.
-      repository:
+      repository: # @schema type:[string, null]; default: null
       # -- (string) Image tag for the `webhook` container.
-      tag:
+      tag: # @schema type:[string, null]; default: null
       # -- Image pull policy for the `webhook` container.
       pullPolicy: IfNotPresent
     # -- [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `webhook` container.

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -18,10 +18,10 @@ image:  # @schema additionalProperties: false
 imagePullSecrets: []  # @schema item: object
 
 # -- (string) Override the name of the chart.
-nameOverride: # @schema type:[string, null]; default: null
+nameOverride:  # @schema type:[string, null]; default: null
 
 # -- (string) Override the full name of the chart.
-fullnameOverride: # @schema type:[string, null]; default: null
+fullnameOverride:  # @schema type:[string, null]; default: null
 
 # -- Labels to add to all chart resources.
 commonLabels: {}
@@ -34,9 +34,9 @@ serviceAccount:
   # -- Annotations to add to the service account. Templates are allowed in both the key and the value. Example: `example.com/annotation/{{ .Values.nameOverride }}: {{ .Values.nameOverride }}`
   annotations: {}
   # -- (string) If this is set and `serviceAccount.create` is `true` this will be used for the created `ServiceAccount` name, if set and `serviceAccount.create` is `false` then this will define an existing `ServiceAccount` to use.
-  name: # @schema type:[string, null]; default: null
+  name:  # @schema type:[string, null]; default: null
   # -- Set this to `false` to [opt out of API credential automounting](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting) for the `ServiceAccount`.
-  automountServiceAccountToken: # @schema type:[boolean, null]; default: null
+  automountServiceAccountToken:  # @schema type:[boolean, null]; default: null
 
 service:
   # -- Service annotations.
@@ -76,7 +76,7 @@ podLabels: {}
 podAnnotations: {}
 
 # -- (bool) Set this to `false` to [opt out of API credential automounting](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting) for the `Pod`.
-automountServiceAccountToken: # @schema type:[boolean, null]; default: null
+automountServiceAccountToken:  # @schema type:[boolean, null]; default: null
 
 # -- If `true`, the `Pod` will have [process namespace sharing](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/) enabled.
 shareProcessNamespace: false
@@ -90,16 +90,16 @@ podSecurityContext:
     type: RuntimeDefault
 
 # -- (string) Priority class name for the `Pod`.
-priorityClassName: # @schema type:[string, null]; default: null
+priorityClassName:  # @schema type:[string, null]; default: null
 
 # -- (int) Termination grace period for the `Pod` in seconds.
-terminationGracePeriodSeconds: # @schema type:[integer, null]
+terminationGracePeriodSeconds:  # @schema type:[integer, null]
 
 # -- (string) [DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) for the pod, if not set the default will be used.
-dnsPolicy: # @schema type:[string, null]; default: null
+dnsPolicy:  # @schema type:[string, null]; default: null
 
 # -- (object) [DNS config](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config) for the pod, if not set the default will be used.
-dnsConfig: # @schema type:[object, null]; default: null
+dnsConfig:  # @schema type:[object, null]; default: null
 
 # -- [Init containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) to add to the `Pod` definition.
 initContainers: []
@@ -172,17 +172,17 @@ serviceMonitor:
   # -- Annotations to add to the `ServiceMonitor`.
   annotations: {}
   # -- (string) If set create the `ServiceMonitor` in an alternate namespace.
-  namespace: # @schema type:[string, null]; default: null
+  namespace:  # @schema type:[string, null]; default: null
   # -- (string) If set override the _Prometheus_ default interval.
-  interval: # @schema type:[string, null]; default: null
+  interval:  # @schema type:[string, null]; default: null
   # -- (string) If set override the _Prometheus_ default scrape timeout.
-  scrapeTimeout: # @schema type:[string, null]; default: null
+  scrapeTimeout:  # @schema type:[string, null]; default: null
   # -- (string) If set overrides the _Prometheus_ default scheme.
-  scheme: # @schema type:[string, null]; default: null
+  scheme:  # @schema type:[string, null]; default: null
   # -- Configure the `ServiceMonitor` [TLS config](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig).
   tlsConfig: {}
   # -- (string) Provide a bearer token file for the `ServiceMonitor`.
-  bearerTokenFile: # @schema type:[string, null]; default: null
+  bearerTokenFile:  # @schema type:[string, null]; default: null
   # -- [Relabel configs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) to apply to samples before ingestion.
   relabelings: []
   # -- [Metric relabel configs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs) to apply to samples before ingestion.
@@ -243,9 +243,9 @@ provider:
   webhook:
     image:
       # -- (string) Image repository for the `webhook` container.
-      repository: # @schema type:[string, null]; default: null
+      repository:  # @schema type:[string, null]; default: null
       # -- (string) Image tag for the `webhook` container.
-      tag: # @schema type:[string, null]; default: null
+      tag:  # @schema type:[string, null]; default: null
       # -- Image pull policy for the `webhook` container.
       pullPolicy: IfNotPresent
     # -- [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `webhook` container.


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

Its not possible to use latest helm chart if customisation is required for some properties like 
fullnameOverride, serviceAccount name, priorityClassName etc due to the fact that schema allows only null values. This change adds additional allowed value types.

```bash
Error: UPGRADE FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
external-dns:
- serviceAccount.name: Invalid type. Expected: null, given: string
- priorityClassName: Invalid type. Expected: null, given: string
```
<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #5206 #5209 #5212 #5230

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
