### PR TITLE
(fix) update helm values schema for `fullnameOverride` and `nameOverride`

### DIFF
--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -68,7 +68,10 @@
       "type": "array"
     },
     "fullnameOverride": {
-      "type": "null"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "global": {
       "properties": {
@@ -188,7 +191,10 @@
       "uniqueItems": true
     },
     "nameOverride": {
-      "type": "null"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "namespaced": {
       "type": "boolean"

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -18,10 +18,10 @@ image:  # @schema additionalProperties: false
 imagePullSecrets: []  # @schema item: object
 
 # -- (string) Override the name of the chart.
-nameOverride:
+nameOverride: # @schema type:[string, null]
 
 # -- (string) Override the full name of the chart.
-fullnameOverride:
+fullnameOverride: # @schema type:[string, null]
 
 # -- Labels to add to all chart resources.
 commonLabels: {}


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

The schema is broken which was added as part of https://github.com/kubernetes-sigs/external-dns/pull/5075
There are many fields which now cannot be set.

This PR updates the schema to allow `fullnameOverride` and `nameOverride`

This fixes the below exception thrown when attempting to set those to strings:
```
>helm template --values=values.yaml .
Error: values don't meet the specifications of the schema(s) in the following chart(s):
external-dns:
- fullnameOverride: Invalid type. Expected: null, given: string
```

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
