### PR TITLE
Fix helm schema and regenerate with helm plugin schema

### DIFF
--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -259,20 +259,9 @@
                   "type": "string"
                 },
                 "repository": {
-                  "type": "null"
-                },
-                "tag": {
-                  "type": "null"
-                }
-              },
-              "type": "object"
-            },
-            "limits": {
-              "properties": {
-                "cpu": {
                   "type": "string"
                 },
-                "memory": {
+                "tag": {
                   "type": "string"
                 }
               },
@@ -336,17 +325,6 @@
                 },
                 "timeoutSeconds": {
                   "type": "integer"
-                }
-              },
-              "type": "object"
-            },
-            "requests": {
-              "properties": {
-                "cpu": {
-                  "type": "string"
-                },
-                "memory": {
-                  "type": "string"
                 }
               },
               "type": "object"
@@ -454,30 +432,7 @@
       "type": "string"
     },
     "resources": {
-      "properties": {
-        "limits": {
-          "properties": {
-            "cpu": {
-              "type": "string"
-            },
-            "memory": {
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "requests": {
-          "properties": {
-            "cpu": {
-              "type": "string"
-            },
-            "memory": {
-              "type": "string"
-            }
-          },
-          "type": "object"
-        }
-      },
+      "properties": {},
       "type": "object"
     },
     "revisionHistoryLimit": {
@@ -604,7 +559,7 @@
           "type": "object"
         },
         "name": {
-          "type": "null"
+          "type": "string"
         }
       },
       "type": "object"

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -34,7 +34,7 @@ serviceAccount:
   # -- Annotations to add to the service account. Templates are allowed in both the key and the value. Example: `example.com/annotation/{{ .Values.nameOverride }}: {{ .Values.nameOverride }}`
   annotations: {}
   # -- (string) If this is set and `serviceAccount.create` is `true` this will be used for the created `ServiceAccount` name, if set and `serviceAccount.create` is `false` then this will define an existing `ServiceAccount` to use.
-  name:
+  name: ""
   # -- Set this to `false` to [opt out of API credential automounting](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting) for the `ServiceAccount`.
   automountServiceAccountToken:
 
@@ -243,9 +243,9 @@ provider:
   webhook:
     image:
       # -- (string) Image repository for the `webhook` container.
-      repository:
+      repository: ""
       # -- (string) Image tag for the `webhook` container.
-      tag:
+      tag: ""
       # -- Image pull policy for the `webhook` container.
       pullPolicy: IfNotPresent
     # -- [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `webhook` container.


### PR DESCRIPTION
This fixes:
```
helm template -n external-dns external-dns/external-dns --version 1.16.0 -f values.yaml
Error: values don't meet the specifications of the schema(s) in the following chart(s):
external-dns:
- provider.webhook.image.repository: Invalid type. Expected: null, given: string
- provider.webhook.image.tag: Invalid type. Expected: null, given: string
- serviceAccount.name: Invalid type. Expected: null, given: string
```

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
