### PR TITLE
docs(typo): grcp → grpc

### DIFF
--- a/docs/sources/gateway.md
+++ b/docs/sources/gateway.md
@@ -1,6 +1,6 @@
 # Gateway sources
 
-The gateway-grcproute, gateway-httproute, gateway-tcproute, gateway-tlsroute, and gateway-udproute
+The gateway-grpcroute, gateway-httproute, gateway-tcproute, gateway-tlsroute, and gateway-udproute
 sources create DNS entries based on their respective `gateway.networking.k8s.io` resources.
 
 ## Filtering the Routes considered


### PR DESCRIPTION
**Description**

Fix a typo in the "Gateway sources" page. Two characters were twisted, saying `gateway-grcproute` instead of `gateway-grpcroute`.

**Checklist**

- [ ] Unit tests updated
  - *n/a* 
- [x] End user documentation updated
