### PR TITLE
fix(node): logger test fixed

### DIFF
--- a/source/node.go
+++ b/source/node.go
@@ -33,6 +33,8 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 )
 
+const warningMsg = "The default behavior of exposing internal IPv6 addresses will change in the next minor version. Use --no-expose-internal-ipv6 flag to opt-in to the new behavior."
+
 type nodeSource struct {
 	client             kubernetes.Interface
 	annotationFilter   string
@@ -189,6 +191,7 @@ func (ns *nodeSource) nodeAddresses(node *v1.Node) ([]string, error) {
 
 	if len(addresses[v1.NodeExternalIP]) > 0 {
 		if ns.exposeInternalIPV6 {
+			log.Warn(warningMsg)
 			return append(addresses[v1.NodeExternalIP], internalIpv6Addresses...), nil
 		}
 		return addresses[v1.NodeExternalIP], nil


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Relates https://github.com/kubernetes-sigs/external-dns/pull/5192
Relates https://github.com/kubernetes-sigs/external-dns/pull/5207#issuecomment-2758574147

I actually did e-2-e test but not on final solution. 

Moved log.Warning to actual code, as we have no warnings anymore

**Checklist**

- [X] Unit tests updated
- [ ] End user documentation updated
