### PR TITLE
fix(cloudflare): adding softerror for ZoneDetails

### DIFF
--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -274,7 +274,7 @@ func (p *CloudFlareProvider) Zones(ctx context.Context) ([]cloudflare.Zone, erro
 			detailResponse, err := p.Client.ZoneDetails(ctx, zoneID)
 			if err != nil {
 				log.Errorf("zone %q lookup failed, %v", zoneID, err)
-				return result, err
+				return result, provider.NewSoftErrorf("zone %q lookup failed %w", zoneID, err)
 			}
 			log.WithFields(log.Fields{
 				"zoneName": detailResponse.Name,

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -814,7 +814,7 @@ func TestCloudflareListZoneInternalErrors(t *testing.T) {
 	client := NewMockCloudFlareClient()
 	client.listZonesContextError = &cloudflare.Error{
 		StatusCode: 500,
-		ErrorCodes: []int{20000},
+		ErrorCodes: []int{500},
 		Type:       cloudflare.ErrorTypeService,
 	}
 	p := &CloudFlareProvider{Client: client}
@@ -834,7 +834,7 @@ func TestCloudflareListZoneDetailsBadGatewayErrors(t *testing.T) {
 	client := NewMockCloudFlareClient()
 	client.listZonesContextError = &cloudflare.Error{
 		StatusCode: 502,
-		ErrorCodes: []int{20000},
+		ErrorCodes: []int{502},
 		Type:       cloudflare.ErrorTypeService,
 	}
 	p := &CloudFlareProvider{Client: client}

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -829,6 +829,25 @@ func TestCloudflareListZoneInternalErrors(t *testing.T) {
 	}
 }
 
+func TestCloudflareListZoneDetailsBadGatewayErrors(t *testing.T) {
+	// Create a mock client that returns a bad gateway error
+	client := NewMockCloudFlareClient()
+	client.listZonesContextError = &cloudflare.Error{
+		StatusCode: 502,
+		ErrorCodes: []int{20000},
+		Type:       cloudflare.ErrorTypeService,
+	}
+	p := &CloudFlareProvider{Client: client}
+
+	// Call the Zones function
+	_, err := p.Zones(context.Background())
+
+	// Assert that a soft error was returned
+	if !errors.Is(err, provider.SoftError) {
+		t.Error("expected a bad gateway error")
+	}
+}
+
 func TestCloudflareRecords(t *testing.T) {
 	client := NewMockCloudFlareClientWithRecords(map[string][]cloudflare.DNSRecord{
 		"001": ExampleDomain,


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR addresses a bug in the cloudflare provider where returning a 502 crashes the external dns. It returns a softerror. Added a unit test for the same too. Nothing changes from a provider perspective.

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #5225 

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
