### PR TITLE
feat(pihole): add support for IPv6 Dual format

### DIFF
--- a/provider/pihole/clientV6.go
+++ b/provider/pihole/clientV6.go
@@ -163,17 +163,18 @@ func (p *piholeClientV6) listRecords(ctx context.Context, rtype string) ([]*endp
 		DNSName, Target = recs[1], recs[0]
 		switch rtype {
 		case endpoint.RecordTypeA:
+			//PiHole return A and AAAA records. Filter to only keep the A records
 			if !isValidIPv4(Target) {
-				log.Warnf("skipping A record %s: invalid format received from PiHole", rec)
 				continue
 			}
 		case endpoint.RecordTypeAAAA:
+			//PiHole return A and AAAA records. Filter to only keep the AAAA records
 			if !isValidIPv6(Target) {
-				log.Warnf("skipping AAAA record %s: invalid format received from PiHole", rec)
 				continue
 			}
 		case endpoint.RecordTypeCNAME:
-			// CNAME format is DNSName,target
+			//PiHole return only CNAME records. 
+			// CNAME format is DNSName,target, ttl?
 			DNSName, Target = recs[0], recs[1]
 			if len(recs) == 3 { // TTL is present
 				// Parse string to int64 first

--- a/provider/pihole/clientV6.go
+++ b/provider/pihole/clientV6.go
@@ -113,11 +113,24 @@ func (p *piholeClientV6) getConfigValue(ctx context.Context, rtype string) ([]st
 	return results, nil
 }
 
+/**
+ * isValidIPv4 checks if the given IP address is a valid IPv4 address.
+ * It returns true if the IP address is valid, false otherwise.
+ * If the IP address is in IPv6 format, it will return false.
+ */
 func isValidIPv4(ip string) bool {
+	if strings.Contains(ip, ":") {
+		return false
+	}
 	parsedIP := net.ParseIP(ip)
 	return parsedIP != nil && parsedIP.To4() != nil
 }
 
+/**
+ * isValidIPv6 checks if the given IP address is a valid IPv6 address.
+ * It returns true if the IP address is valid, false otherwise.
+ * If the IP address is in IPv6 with dual format y:y:y:y:y:y:x.x.x.x. , it will return true.
+ */
 func isValidIPv6(ip string) bool {
 	parsedIP := net.ParseIP(ip)
 	validIpv6 := strings.Contains(ip, ":") && parsedIP != nil && parsedIP.To16() != nil
@@ -149,7 +162,7 @@ func (p *piholeClientV6) listRecords(ctx context.Context, rtype string) ([]*endp
 			return r == ' ' || r == ','
 		})
 		if len(recs) < 2 {
-			log.Warnf("skipping record %s: invalid format", rec)
+			log.Warnf("skipping record %s: invalid format received from PiHole", rec)
 			continue
 		}
 		var DNSName, Target string
@@ -160,12 +173,12 @@ func (p *piholeClientV6) listRecords(ctx context.Context, rtype string) ([]*endp
 		switch rtype {
 		case endpoint.RecordTypeA:
 			if !isValidIPv4(Target) {
-				log.Warnf("skipping A record %s: invalid format", rec)
+				log.Warnf("skipping A record %s: invalid format received from PiHole", rec)
 				continue
 			}
 		case endpoint.RecordTypeAAAA:
 			if !isValidIPv6(Target) {
-				log.Warnf("skipping AAAA record %s: invalid format", rec)
+				log.Warnf("skipping AAAA record %s: invalid format received from PiHole", rec)
 				continue
 			}
 		case endpoint.RecordTypeCNAME:
@@ -176,7 +189,7 @@ func (p *piholeClientV6) listRecords(ctx context.Context, rtype string) ([]*endp
 				if ttlInt, err := strconv.ParseInt(recs[2], 10, 64); err == nil {
 					Ttl = endpoint.TTL(ttlInt)
 				} else {
-					log.Warnf("failed to parse TTL value '%s': %v; using a TTL of %d", recs[2], err, Ttl)
+					log.Warnf("failed to parse TTL value received from PiHole '%s': %v; using a TTL of %d", recs[2], err, Ttl)
 				}
 			}
 		}

--- a/provider/pihole/clientV6.go
+++ b/provider/pihole/clientV6.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/linki/instrumented_http"
 	"io"
 	"net/http"
 	"net/netip"
@@ -31,6 +30,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/linki/instrumented_http"
 	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/external-dns/endpoint"

--- a/provider/pihole/clientV6.go
+++ b/provider/pihole/clientV6.go
@@ -30,7 +30,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/linki/instrumented_http"
 	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/external-dns/endpoint"
@@ -64,11 +63,10 @@ func newPiholeClientV6(cfg PiholeConfig) (piholeAPI, error) {
 			},
 		},
 	}
-	cl := instrumented_http.NewClient(httpClient, &instrumented_http.Callbacks{})
 
 	p := &piholeClientV6{
 		cfg:        cfg,
-		httpClient: cl,
+		httpClient: httpClient,
 	}
 
 	if cfg.Password != "" {

--- a/provider/pihole/clientV6.go
+++ b/provider/pihole/clientV6.go
@@ -173,7 +173,7 @@ func (p *piholeClientV6) listRecords(ctx context.Context, rtype string) ([]*endp
 				continue
 			}
 		case endpoint.RecordTypeCNAME:
-			//PiHole return only CNAME records. 
+			//PiHole return only CNAME records.
 			// CNAME format is DNSName,target, ttl?
 			DNSName, Target = recs[0], recs[1]
 			if len(recs) == 3 { // TTL is present

--- a/provider/pihole/clientV6_test.go
+++ b/provider/pihole/clientV6_test.go
@@ -29,6 +29,61 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 )
 
+func TestIsValidIPv4(t *testing.T) {
+	tests := []struct {
+		ip       string
+		expected bool
+	}{
+		{"192.168.1.1", true},
+		{"255.255.255.255", true},
+		{"0.0.0.0", true},
+		{"", false},
+		{"256.256.256.256", false},
+		{"192.168.0.1/22", false},
+		{"192.168.1", false},
+		{"abc.def.ghi.jkl", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.ip, func(t *testing.T) {
+			if got := isValidIPv4(test.ip); got != test.expected {
+				t.Errorf("isValidIPv4(%s) = %v; want %v", test.ip, got, test.expected)
+			}
+		})
+	}
+}
+
+func TestIsValidIPv6(t *testing.T) {
+	tests := []struct {
+		ip       string
+		expected bool
+	}{
+		{"2001:0db8:85a3:0000:0000:8a2e:0370:7334", true},
+		{"2001:db8:85a3::8a2e:370:7334", true},
+		//IPV6 dual, the format is y:y:y:y:y:y:x.x.x.x.
+		{"::ffff:192.168.20.3", true},
+		{"::1", true},
+		{"::", true},
+		{"2001:db8::", true},
+		{"", false},
+		{":", false},
+		{"::ffff:", false},
+		{"192.168.20.3", false},
+		{"2001:db8:85a3:0:0:8a2e:370:7334:1234", false},
+		{"2001:db8:85a3::8a2e:370g:7334", false},
+		{"2001:db8:85a3::8a2e:370:7334::", false},
+		{"2001:db8:85a3::8a2e:370:7334::1", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.ip, func(t *testing.T) {
+			if got := isValidIPv6(test.ip); got != test.expected {
+				t.Errorf("isValidIPv6(%s) = %v; want %v", test.ip, got, test.expected)
+			}
+		})
+	}
+}
+
 func newTestServerV6(t *testing.T, hdlr http.HandlerFunc) *httptest.Server {
 	t.Helper()
 	svr := httptest.NewServer(hdlr)


### PR DESCRIPTION
**Description**

Fixes #5251 

This PR add support for IPv6 Dual with the following format : **y:y:y:y:y:y:x.x.x.x**

PiHole support such IPs but previous implementations did not take it in account. 
External DNS was able to push such record, but can not read it from the provider (the record was filtered out because mark as IPV6 but containing a '.' . Finally External DNS try to push again the record but the provider return an error because the record is duplicated.

This implementation fix this and the test used to determine if it is an IPv4 or IPv6 is more robust.

Also get rid of **instrumented_http**, httpClient is enough. See https://github.com/kubernetes-sigs/external-dns/pull/5226#issuecomment-2777868810 .

No change done on the V5 implementation as it is now deprecated.



**Checklist**

- [X] Unit tests updated
- [X] End user documentation updated
