### PR TITLE
chore(ci): fix random data race failure on source/node test

### DIFF
--- a/source/node_test.go
+++ b/source/node_test.go
@@ -395,9 +395,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
 			var buf *bytes.Buffer
-			if len(tc.expectedLogs) == 0 && len(tc.expectedAbsentLogs) == 0 {
-				t.Parallel()
-			} else {
+			if len(tc.expectedLogs) != 0 || len(tc.expectedAbsentLogs) != 0 {
 				buf = testutils.LogsToBuffer(log.DebugLevel, t)
 			}
 


### PR DESCRIPTION
**Description**

Fix Data Race on source test like [this one](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_external-dns/5241/pull-external-dns-unit-test/1909782199490580480):

![image](https://github.com/user-attachments/assets/8b2ca24f-2d8b-443d-8073-e2d9091e6e11)

It should unblock the other PRs.

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
