### PR TITLE
*Route DNS entry uses longest matching suffix of all attached gateways

### DIFF
--- a/docs/sources/gateway.md
+++ b/docs/sources/gateway.md
@@ -109,7 +109,11 @@ The targets of the DNS entries created from a \*Route are sourced from the follo
 1. If a matching parent Gateway has an `external-dns.alpha.kubernetes.io/target` annotation, uses
    the values from that.
 
-2. Otherwise, iterates over that parent Gateway's `status.addresses`,
+2. If a route has multiple, overlapping hostnames is attached to multiple Gateways whose hostnames 
+   overlap with the routes hostnames then the routes hostname uses which ever gateway has the longest
+   match.
+
+3. Otherwise, iterates over that parent Gateway's `status.addresses`,
    adding each address's `value`.
 
 The targets from each parent Gateway matching the \*Route are then combined and de-duplicated.

--- a/source/gateway_test.go
+++ b/source/gateway_test.go
@@ -28,6 +28,7 @@ func TestGatewayMatchingHost(t *testing.T) {
 		desc string
 		a, b string
 		host string
+		matchedCharacters int
 		ok   bool
 	}{
 		{
@@ -62,6 +63,7 @@ func TestGatewayMatchingHost(t *testing.T) {
 			a:    "*.example.net",
 			b:    "test.example.net",
 			host: "test.example.net",
+			matchedCharacters: 4,
 			ok:   true,
 		},
 		{
@@ -69,6 +71,7 @@ func TestGatewayMatchingHost(t *testing.T) {
 			a:    "*.example.net",
 			b:    "a.example.net",
 			host: "a.example.net",
+			matchedCharacters: 1,
 			ok:   true,
 		},
 		{
@@ -76,6 +79,7 @@ func TestGatewayMatchingHost(t *testing.T) {
 			a:    "*.example.net",
 			b:    "foo.bar.test.example.net",
 			host: "foo.bar.test.example.net",
+			matchedCharacters: 12,
 			ok:   true,
 		},
 		{
@@ -94,10 +98,10 @@ func TestGatewayMatchingHost(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			for i := 0; i < 2; i++ {
-				if host, ok := gwMatchingHost(tt.a, tt.b); host != tt.host || ok != tt.ok {
+				if host, matchedCharacters, ok := gwMatchingHost(tt.a, tt.b); host != tt.host || matchedCharacters != tt.matchedCharacters || ok != tt.ok {
 					t.Errorf(
-						"gwMatchingHost(%q, %q); got: %q, %v; want: %q, %v",
-						tt.a, tt.b, host, ok, tt.host, tt.ok,
+						"gwMatchingHost(%q, %q); got: %q, %d, %v; want: %q, %d, %v",
+						tt.a, tt.b, host, matchedCharacters, ok, tt.host, tt.matchedCharacters, tt.ok,
 					)
 				}
 				tt.a, tt.b = tt.b, tt.a


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Currently if an HTTPRoute is attached to multiple Gateways whose hostnames overlap with each of the hostnames in the HTTPRoute, but at different lengths, it returns a Multivalue of the sorted gateway addresses. In my opinion in cases like this where the DNS entries will be CNAMEs or Alias records where Multivalue doesn't make sense (AFAIA) if there is a "more correct" answer that one should be used. So in this case the gateway that has the longer overlap with a given httproute hostname is used as the value for the DNS record.
<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->

**Checklist**

- [X] Unit tests updated
- [X] End user documentation updated
