### PR TITLE
test(log): fix random race detection

### DIFF
--- a/internal/testutils/log.go
+++ b/internal/testutils/log.go
@@ -18,11 +18,9 @@ package testutils
 
 import (
 	"bytes"
-	"flag"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
-	"k8s.io/klog/v2"
 )
 
 // LogsToBuffer redirects log(s) output to a buffer for testing purposes
@@ -38,12 +36,5 @@ func LogsToBuffer(level log.Level, t *testing.T) *bytes.Buffer {
 	buf := new(bytes.Buffer)
 	log.SetOutput(buf)
 	log.SetLevel(level)
-	klog.SetOutput(buf)
-	flags := &flag.FlagSet{}
-	klog.InitFlags(flags)
-	// make sure klog doesn't write to stderr by default in tests
-	_ = flags.Set("logtostderr", "false")
-	_ = flags.Set("alsologtostderr", "false")
-	_ = flags.Set("stderrthreshold", "4")
 	return buf
 }

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package source
 
 import (
-	"bytes"
 	"context"
 	"testing"
 
@@ -1506,10 +1505,8 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			src, err := NewGatewayHTTPRouteSource(clients, &tt.config)
 			require.NoError(t, err, "failed to create Gateway HTTPRoute Source")
 
-			var b *bytes.Buffer
-			if len(tt.logExpectations) > 0 {
-				b = testutils.LogsToBuffer(log.DebugLevel, t)
-			}
+			b := testutils.LogsToBuffer(log.DebugLevel, t)
+
 			endpoints, err := src.Endpoints(ctx)
 			require.NoError(t, err, "failed to get Endpoints")
 			validateEndpoints(t, endpoints, tt.endpoints)

--- a/source/node_test.go
+++ b/source/node_test.go
@@ -394,10 +394,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
-			var buf *bytes.Buffer
-			if len(tc.expectedLogs) != 0 || len(tc.expectedAbsentLogs) != 0 {
-				buf = testutils.LogsToBuffer(log.DebugLevel, t)
-			}
+			buf := testutils.LogsToBuffer(log.DebugLevel, t)
 
 			labelSelector := labels.Everything()
 			if tc.labelSelector != "" {


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Resolves issues like this one https://github.com/kubernetes-sigs/external-dns/pull/5268

Capturing both logs that behave differently not a great idea as it looks. At the moment we not testing klogs logs, so not loosing much.

If the problem persist, I debug more. Example next step to try similar stuff https://github.com/sirupsen/logrus/blob/master/internal/testutils/testutils.go, why we not using it, it's in internal package

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
