### PR TITLE
Add support for TXT record type

### DIFF
--- a/docs/registry/txt.md
+++ b/docs/registry/txt.md
@@ -15,6 +15,7 @@ By default, the TXT registry creates records in both formats for backwards compa
 Note: The following record types always use only the new format regardless of this setting:
 
 - AAAA records
+- TXT records
 - Encrypted TXT records (when using `--txt-encrypt-enabled`)
 
 Example:

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -108,7 +108,7 @@ func NewTXTRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID st
 }
 
 func getSupportedTypes() []string {
-	return []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME, endpoint.RecordTypeNS}
+	return []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME, endpoint.RecordTypeNS, endpoint.RecordTypeTXT }
 }
 
 func (im *TXTRegistry) GetDomainFilter() endpoint.DomainFilterInterface {
@@ -196,7 +196,7 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 
 		// Handle both new and old registry format with the preference for the new one
 		labels, labelsExist := labelMap[key]
-		if !labelsExist && ep.RecordType != endpoint.RecordTypeAAAA {
+		if !labelsExist && ep.RecordType != endpoint.RecordTypeAAAA && ep.RecordType != endpoint.RecordTypeTXT {
 			key.RecordType = ""
 			labels, labelsExist = labelMap[key]
 		}
@@ -237,7 +237,7 @@ func (im *TXTRegistry) generateTXTRecord(r *endpoint.Endpoint) []*endpoint.Endpo
 	endpoints := make([]*endpoint.Endpoint, 0)
 
 	// Create legacy format record by default unless newFormatOnly is true
-	if !im.newFormatOnly && !im.txtEncryptEnabled && !im.mapper.recordTypeInAffix() && r.RecordType != endpoint.RecordTypeAAAA {
+	if !im.newFormatOnly && !im.txtEncryptEnabled && !im.mapper.recordTypeInAffix() && r.RecordType != endpoint.RecordTypeAAAA && r.RecordType != endpoint.RecordTypeTXT {
 		// old TXT record format
 		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true, im.txtEncryptEnabled, im.txtEncryptAESKey))
 		if txt != nil {


### PR DESCRIPTION
**Description**

Adds support for deleting TXT records after the CRD is deleted.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #5254 
Fixes #5279

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
