### PR TITLE
feat(cloudflare): add support for MX records

### DIFF
--- a/docs/sources/mx-record.md
+++ b/docs/sources/mx-record.md
@@ -1,7 +1,7 @@
 # MX record with CRD source
 
-You can create and manage MX records with the help of [CRD source](../sources/crd.md)
-and `DNSEndpoint` CRD. Currently, this feature is only supported by `aws`, `azure`, `google` and `digitalocean` providers.
+You can create and manage MX records with the help of [CRD source](../contributing/crd-source.md)
+and `DNSEndpoint` CRD. Currently, this feature is only supported by `aws`, `azure`, `google`, `digitalocean` and `cloudflare` providers.
 
 In order to start managing MX records you need to set the `--managed-record-types=MX` flag.
 

--- a/docs/sources/mx-record.md
+++ b/docs/sources/mx-record.md
@@ -1,7 +1,7 @@
 # MX record with CRD source
 
 You can create and manage MX records with the help of [CRD source](../sources/crd.md)
-and `DNSEndpoint` CRD. Currently, this feature is only supported by `aws`, `azure`, `google`, `digitalocean` and `cloudflare` providers.
+and `DNSEndpoint` CRD. Currently, this feature is only supported by `aws`, `azure`, `cloudflare`, `digitalocean` and `google` providers.
 
 In order to start managing MX records you need to set the `--managed-record-types=MX` flag.
 

--- a/docs/sources/mx-record.md
+++ b/docs/sources/mx-record.md
@@ -1,6 +1,6 @@
 # MX record with CRD source
 
-You can create and manage MX records with the help of [CRD source](../contributing/crd-source.md)
+You can create and manage MX records with the help of [CRD source](../sources/crd.md)
 and `DNSEndpoint` CRD. Currently, this feature is only supported by `aws`, `azure`, `google`, `digitalocean` and `cloudflare` providers.
 
 In order to start managing MX records you need to set the `--managed-record-types=MX` flag.

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -408,7 +408,7 @@ func (e *Endpoint) CheckEndpoint() bool {
 
 func (t Targets) ValidateMXRecord() bool {
 	for _, target := range t {
-		_, err := ParseMXRecord(target)
+		_, err := NewMXTarget(target)
 		if err != nil {
 			log.Debugf("Invalid MX record target: %s. %v", target, err)
 			return false
@@ -418,21 +418,19 @@ func (t Targets) ValidateMXRecord() bool {
 	return true
 }
 
-func ParseMXRecord(target string) (MXTarget, error) {
+func NewMXTarget(target string) (MXTarget, error) {
 	var mxTarget MXTarget
 	// MX records must have a preference value to indicate priority, e.g. "10 example.com"
 	// as per https://www.rfc-editor.org/rfc/rfc974.txt
 	targetParts := strings.Fields(strings.TrimSpace(target))
 	if len(targetParts) != 2 {
 		err := fmt.Errorf("invalid MX record target: %s. MX records must have a preference value and a host, e.g. '10 example.com'", target)
-		log.Debug(err)
 		return MXTarget{}, err
 	}
 
 	parsedPriority, err := strconv.ParseUint(targetParts[0], 10, 16)
 	if err != nil {
 		err := fmt.Errorf("invalid integer value in target: %s", target)
-		log.Debug(err)
 		return MXTarget{}, err
 	}
 

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -438,9 +438,10 @@ func (t Targets) ParseMXRecord() ([]MXTarget, error) {
 }
 
 func (t Targets) ParseSRVRecord() ([]SRVTarget, error) {
-	var srvTarget SRVTarget
+	var srvTargets []SRVTarget
 
 	for _, target := range t {
+		var srvTarget SRVTarget
 		// SRV records must have a priority, weight, and port value, e.g. "10 5 5060 example.com"
 		// as per https://www.rfc-editor.org/rfc/rfc2782.txt
 		targetParts := strings.Fields(strings.TrimSpace(target))
@@ -475,7 +476,9 @@ func (t Targets) ParseSRVRecord() ([]SRVTarget, error) {
 		srvTarget.Weight = uint16(parsedWeight)
 		srvTarget.Port = uint16(parsedPort)
 		srvTarget.Host = targetParts[3]
+
+		srvTargets = append(srvTargets, srvTarget)
 	}
 
-	return []SRVTarget{srvTarget}, nil
+	return srvTargets, nil
 }

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -400,9 +400,9 @@ func (e *Endpoint) CheckEndpoint() bool {
 	return true
 }
 
-// NewMXTarget parses a string representation of an MX record target (e.g., "10 mail.example.com")
+// NewMXRecord parses a string representation of an MX record target (e.g., "10 mail.example.com")
 // and returns an MXTarget struct. Returns an error if the input is invalid.
-func NewMXTarget(target string) (*MXTarget, error) {
+func NewMXRecord(target string) (*MXTarget, error) {
 	parts := strings.Fields(strings.TrimSpace(target))
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("invalid MX record target: %s. MX records must have a preference value and a host, e.g. '10 example.com'", target)
@@ -431,7 +431,7 @@ func (m *MXTarget) GetHost() *string {
 
 func (t Targets) ValidateMXRecord() bool {
 	for _, target := range t {
-		_, err := NewMXTarget(target)
+		_, err := NewMXRecord(target)
 		if err != nil {
 			log.Debugf("Invalid MX record target: %s. %v", target, err)
 			return false

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -77,14 +77,6 @@ type MXTarget struct {
 	host     string
 }
 
-// SRVTarget represents a single SRV (Service) record target, including its priority, weight, port, and host.
-type SRVTarget struct {
-	priority uint16
-	weight   uint16
-	port     uint16
-	host     string
-}
-
 // NewTargets is a convenience method to create a new Targets object from a vararg of strings
 func NewTargets(target ...string) Targets {
 	t := make(Targets, 0, len(target))

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -71,11 +71,13 @@ func (ttl TTL) IsConfigured() bool {
 // Targets is a representation of a list of targets for an endpoint.
 type Targets []string
 
+// MXTarget represents a single MX (Mail Exchange) record target, including its priority and host.
 type MXTarget struct {
 	Priority uint16
 	Host     string
 }
 
+// SRVTarget represents a single SRV (Service) record target, including its priority, weight, port, and host.
 type SRVTarget struct {
 	Priority uint16
 	Weight   uint16
@@ -418,20 +420,22 @@ func (t Targets) ValidateMXRecord() bool {
 	return true
 }
 
-func NewMXTarget(target string) (MXTarget, error) {
-	var mxTarget MXTarget
+// NewMXTarget parses a string representation of an MX record target (e.g., "10 mail.example.com")
+// and returns an MXTarget struct. Returns an error if the input is invalid.
+func NewMXTarget(target string) (*MXTarget, error) {
+	mxTarget := &MXTarget{}
 	// MX records must have a preference value to indicate priority, e.g. "10 example.com"
 	// as per https://www.rfc-editor.org/rfc/rfc974.txt
 	targetParts := strings.Fields(strings.TrimSpace(target))
 	if len(targetParts) != 2 {
 		err := fmt.Errorf("invalid MX record target: %s. MX records must have a preference value and a host, e.g. '10 example.com'", target)
-		return MXTarget{}, err
+		return nil, err
 	}
 
 	parsedPriority, err := strconv.ParseUint(targetParts[0], 10, 16)
 	if err != nil {
 		err := fmt.Errorf("invalid integer value in target: %s", target)
-		return MXTarget{}, err
+		return nil, err
 	}
 
 	mxTarget.Priority = uint16(parsedPriority)

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -819,50 +819,39 @@ func TestPDNScheckEndpoint(t *testing.T) {
 func TestParseMXRecord(t *testing.T) {
 	tests := []struct {
 		description string
-		targets     Targets
-		expected    []MXTarget
+		target      string
+		expected    MXTarget
 		expectError bool
 	}{
 		{
 			description: "Valid MX record",
-			targets:     Targets{"10 example.com"},
-			expected: []MXTarget{
-				{Priority: 10, Host: "example.com"},
-			},
-			expectError: false,
-		},
-		{
-			description: "Valid MX record with multiple targets",
-			targets:     Targets{"10 example.com", "20 backup.example.com"},
-			expected: []MXTarget{
-				{Priority: 10, Host: "example.com"},
-				{Priority: 20, Host: "backup.example.com"},
-			},
+			target:      "10 example.com",
+			expected:    MXTarget{Priority: 10, Host: "example.com"},
 			expectError: false,
 		},
 		{
 			description: "Invalid MX record with missing priority",
-			targets:     Targets{"example.com"},
-			expected:    nil,
+			target:      "example.com",
+			expected:    MXTarget{},
 			expectError: true,
 		},
 		{
 			description: "Invalid MX record with non-integer priority",
-			targets:     Targets{"abc example.com"},
-			expected:    nil,
+			target:      "abc example.com",
+			expected:    MXTarget{},
 			expectError: true,
 		},
 		{
 			description: "Invalid MX record with too many parts",
-			targets:     Targets{"10 example.com extra"},
-			expected:    nil,
+			target:      "10 example.com extra",
+			expected:    MXTarget{},
 			expectError: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			actual, err := tt.targets.ParseMXRecord()
+			actual, err := ParseMXRecord(tt.target)
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {
@@ -873,74 +862,6 @@ func TestParseMXRecord(t *testing.T) {
 	}
 }
 
-func TestParseSRVRecord(t *testing.T) {
-	tests := []struct {
-		description string
-		targets     Targets
-		expected    []SRVTarget
-		expectError bool
-	}{
-		{
-			description: "Valid SRV record",
-			targets:     Targets{"10 5 5060 example.com"},
-			expected: []SRVTarget{
-				{Priority: 10, Weight: 5, Port: 5060, Host: "example.com"},
-			},
-			expectError: false,
-		},
-		{
-			description: "Valid SRV record with multiple targets",
-			targets:     Targets{"10 5 5060 example.com", "20 10 8080 backup.example.com"},
-			expected: []SRVTarget{
-				{Priority: 10, Weight: 5, Port: 5060, Host: "example.com"},
-				{Priority: 20, Weight: 10, Port: 8080, Host: "backup.example.com"},
-			},
-			expectError: false,
-		},
-		{
-			description: "Invalid SRV record with missing part",
-			targets:     Targets{"10 5 5060"},
-			expected:    nil,
-			expectError: true,
-		},
-		{
-			description: "Invalid SRV record with non-integer priority",
-			targets:     Targets{"abc 5 5060 example.com"},
-			expected:    nil,
-			expectError: true,
-		},
-		{
-			description: "Invalid SRV record with non-integer weight",
-			targets:     Targets{"10 abc 5060 example.com"},
-			expected:    nil,
-			expectError: true,
-		},
-		{
-			description: "Invalid SRV record with non-integer port",
-			targets:     Targets{"10 5 abc example.com"},
-			expected:    nil,
-			expectError: true,
-		},
-		{
-			description: "Invalid SRV record with too many parts",
-			targets:     Targets{"10 5 5060 example.com extra"},
-			expected:    nil,
-			expectError: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.description, func(t *testing.T) {
-			actual, err := tt.targets.ParseSRVRecord()
-			if tt.expectError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tt.expected, actual)
-			}
-		})
-	}
-}
 func TestCheckEndpoint(t *testing.T) {
 	tests := []struct {
 		description string

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -820,31 +820,31 @@ func TestNewMXTarget(t *testing.T) {
 	tests := []struct {
 		description string
 		target      string
-		expected    MXTarget
+		expected    *MXTarget
 		expectError bool
 	}{
 		{
 			description: "Valid MX record",
 			target:      "10 example.com",
-			expected:    MXTarget{Priority: 10, Host: "example.com"},
+			expected:    &MXTarget{Priority: 10, Host: "example.com"},
 			expectError: false,
 		},
 		{
 			description: "Invalid MX record with missing priority",
 			target:      "example.com",
-			expected:    MXTarget{},
+			expected:    &MXTarget{},
 			expectError: true,
 		},
 		{
 			description: "Invalid MX record with non-integer priority",
 			target:      "abc example.com",
-			expected:    MXTarget{},
+			expected:    &MXTarget{},
 			expectError: true,
 		},
 		{
 			description: "Invalid MX record with too many parts",
 			target:      "10 example.com extra",
-			expected:    MXTarget{},
+			expected:    &MXTarget{},
 			expectError: true,
 		},
 	}

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -826,25 +826,28 @@ func TestNewMXTarget(t *testing.T) {
 		{
 			description: "Valid MX record",
 			target:      "10 example.com",
-			expected:    &MXTarget{Priority: 10, Host: "example.com"},
+			expected:    &MXTarget{priority: 10, host: "example.com"},
 			expectError: false,
 		},
 		{
 			description: "Invalid MX record with missing priority",
 			target:      "example.com",
-			expected:    &MXTarget{},
 			expectError: true,
 		},
 		{
 			description: "Invalid MX record with non-integer priority",
 			target:      "abc example.com",
-			expected:    &MXTarget{},
 			expectError: true,
 		},
 		{
 			description: "Invalid MX record with too many parts",
 			target:      "10 example.com extra",
-			expected:    &MXTarget{},
+			expectError: true,
+		},
+		{
+			description: "Missing host",
+			target:      "10 ",
+			expected:    nil,
 			expectError: true,
 		},
 	}

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -816,7 +816,7 @@ func TestPDNScheckEndpoint(t *testing.T) {
 	}
 }
 
-func TestParseMXRecord(t *testing.T) {
+func TestNewMXTarget(t *testing.T) {
 	tests := []struct {
 		description string
 		target      string
@@ -851,7 +851,7 @@ func TestParseMXRecord(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			actual, err := ParseMXRecord(tt.target)
+			actual, err := NewMXTarget(tt.target)
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -854,7 +854,7 @@ func TestNewMXTarget(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			actual, err := NewMXTarget(tt.target)
+			actual, err := NewMXRecord(tt.target)
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -783,7 +783,7 @@ func (p *CloudFlareProvider) newCloudFlareChange(action changeAction, ep *endpoi
 	if ep.RecordType == "MX" {
 		mxRecord, err := endpoint.ParseMXRecord(target)
 		if err != nil {
-			log.Errorf("Failed to parse MX record target %q: %v", target, err)
+			return &cloudFlareChange{}, fmt.Errorf("Failed to parse MX record target %q: %v", target, err)
 		} else {
 			priority = &mxRecord.Priority
 			target = mxRecord.Host

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -233,16 +233,12 @@ type RecordParamsTypes interface {
 // updateDNSRecordParam is a function that returns the appropriate Record Param based on the cloudFlareChange passed in
 func updateDNSRecordParam(cfc cloudFlareChange) cloudflare.UpdateDNSRecordParams {
 	params := cloudflare.UpdateDNSRecordParams{
-		Name:    cfc.ResourceRecord.Name,
-		TTL:     cfc.ResourceRecord.TTL,
-		Proxied: cfc.ResourceRecord.Proxied,
-		Type:    cfc.ResourceRecord.Type,
-		Content: cfc.ResourceRecord.Content,
-	}
-
-	// Set priority only for MX records
-	if cfc.ResourceRecord.Type == "MX" {
-		params.Priority = cfc.ResourceRecord.Priority
+		Name:     cfc.ResourceRecord.Name,
+		TTL:      cfc.ResourceRecord.TTL,
+		Proxied:  cfc.ResourceRecord.Proxied,
+		Type:     cfc.ResourceRecord.Type,
+		Content:  cfc.ResourceRecord.Content,
+		Priority: cfc.ResourceRecord.Priority,
 	}
 
 	return params
@@ -251,16 +247,12 @@ func updateDNSRecordParam(cfc cloudFlareChange) cloudflare.UpdateDNSRecordParams
 // getCreateDNSRecordParam is a function that returns the appropriate Record Param based on the cloudFlareChange passed in
 func getCreateDNSRecordParam(cfc cloudFlareChange) cloudflare.CreateDNSRecordParams {
 	params := cloudflare.CreateDNSRecordParams{
-		Name:    cfc.ResourceRecord.Name,
-		TTL:     cfc.ResourceRecord.TTL,
-		Proxied: cfc.ResourceRecord.Proxied,
-		Type:    cfc.ResourceRecord.Type,
-		Content: cfc.ResourceRecord.Content,
-	}
-
-	// Set priority only for MX records
-	if cfc.ResourceRecord.Type == "MX" {
-		params.Priority = cfc.ResourceRecord.Priority
+		Name:     cfc.ResourceRecord.Name,
+		TTL:      cfc.ResourceRecord.TTL,
+		Proxied:  cfc.ResourceRecord.Proxied,
+		Type:     cfc.ResourceRecord.Type,
+		Content:  cfc.ResourceRecord.Content,
+		Priority: cfc.ResourceRecord.Priority,
 	}
 
 	return params
@@ -789,13 +781,12 @@ func (p *CloudFlareProvider) newCloudFlareChange(action changeAction, ep *endpoi
 
 	priority := (*uint16)(nil)
 	if ep.RecordType == "MX" {
-		mxTarget := endpoint.Targets{target}
-		mxRecords, err := mxTarget.ParseMXRecord()
+		mxRecord, err := endpoint.ParseMXRecord(target)
 		if err != nil {
 			log.Errorf("Failed to parse MX record target %q: %v", target, err)
 		} else {
-			priority = &mxRecords[0].Priority
-			target = mxRecords[0].Host
+			priority = &mxRecord.Priority
+			target = mxRecord.Host
 		}
 	}
 

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -781,7 +781,7 @@ func (p *CloudFlareProvider) newCloudFlareChange(action changeAction, ep *endpoi
 
 	priority := (*uint16)(nil)
 	if ep.RecordType == "MX" {
-		mxRecord, err := endpoint.ParseMXRecord(target)
+		mxRecord, err := endpoint.NewMXTarget(target)
 		if err != nil {
 			return &cloudFlareChange{}, fmt.Errorf("failed to parse MX record target %q: %w", target, err)
 		} else {

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -781,7 +781,7 @@ func (p *CloudFlareProvider) newCloudFlareChange(action changeAction, ep *endpoi
 
 	priority := (*uint16)(nil)
 	if ep.RecordType == "MX" {
-		mxRecord, err := endpoint.NewMXTarget(target)
+		mxRecord, err := endpoint.NewMXRecord(target)
 		if err != nil {
 			return &cloudFlareChange{}, fmt.Errorf("failed to parse MX record target %q: %w", target, err)
 		} else {

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -783,7 +783,7 @@ func (p *CloudFlareProvider) newCloudFlareChange(action changeAction, ep *endpoi
 	if ep.RecordType == "MX" {
 		mxRecord, err := endpoint.ParseMXRecord(target)
 		if err != nil {
-			return &cloudFlareChange{}, fmt.Errorf("Failed to parse MX record target %q: %v", target, err)
+			return &cloudFlareChange{}, fmt.Errorf("failed to parse MX record target %q: %w", target, err)
 		} else {
 			priority = &mxRecord.Priority
 			target = mxRecord.Host

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -37,6 +37,18 @@ import (
 	"sigs.k8s.io/external-dns/source/annotations"
 )
 
+// proxyEnabled is a pointer to a bool true showing the record should be proxied through cloudflare
+var proxyEnabled *bool = boolPtr(true)
+
+// proxyDisabled is a pointer to a bool false showing the record should not be proxied through cloudflare
+var proxyDisabled *bool = boolPtr(false)
+
+// boolPtr is used as a helper function to return a pointer to a boolean
+// Needed because some parameters require a pointer.
+func boolPtr(b bool) *bool {
+	return &b
+}
+
 type MockAction struct {
 	Name             string
 	ZoneId           string
@@ -1745,7 +1757,7 @@ func TestCloudFlareProvider_newCloudFlareChange(t *testing.T) {
 		Targets:    []string{"192.0.2.1"},
 	}
 
-	change := p.newCloudFlareChange(cloudFlareCreate, ep, ep.Targets[0], nil)
+	change, _ := p.newCloudFlareChange(cloudFlareCreate, ep, ep.Targets[0], nil)
 	if change.RegionalHostname.RegionKey != "us" {
 		t.Errorf("expected region key to be 'us', but got '%s'", change.RegionalHostname.RegionKey)
 	}
@@ -1857,7 +1869,7 @@ func TestCloudFlareProvider_newCloudFlareChange(t *testing.T) {
 
 	for _, test := range commentTestCases {
 		t.Run(test.name, func(t *testing.T) {
-			change := test.provider.newCloudFlareChange(cloudFlareCreate, test.endpoint, test.endpoint.Targets[0], nil)
+			change, _ := test.provider.newCloudFlareChange(cloudFlareCreate, test.endpoint, test.endpoint.Targets[0], nil)
 			if len(change.ResourceRecord.Comment) != test.expected {
 				t.Errorf("expected comment to be %d characters long, but got %d", test.expected, len(change.ResourceRecord.Comment))
 			}

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -37,17 +37,11 @@ import (
 	"sigs.k8s.io/external-dns/source/annotations"
 )
 
-// proxyEnabled is a pointer to a bool true showing the record should be proxied through cloudflare
-var proxyEnabled *bool = boolPtr(true)
-
-// proxyDisabled is a pointer to a bool false showing the record should not be proxied through cloudflare
-var proxyDisabled *bool = boolPtr(false)
-
-// boolPtr is used as a helper function to return a pointer to a boolean
-// Needed because some parameters require a pointer.
-func boolPtr(b bool) *bool {
-	return &b
-}
+// proxyEnabled and proxyDisabled are pointers to bool values used to set if a record should be proxied through Cloudflare.
+var (
+	proxyEnabled  *bool = testutils.ToPtr(true)
+	proxyDisabled *bool = testutils.ToPtr(false)
+)
 
 type MockAction struct {
 	Name             string

--- a/provider/digitalocean/digital_ocean.go
+++ b/provider/digitalocean/digital_ocean.go
@@ -301,7 +301,7 @@ func makeDomainEditRequest(domain, name, recordType, data string, ttl int) *godo
 	}
 
 	if recordType == endpoint.RecordTypeMX {
-		mxRecord, err := endpoint.NewMXTarget(data)
+		mxRecord, err := endpoint.NewMXRecord(data)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"domain":     domain,

--- a/provider/digitalocean/digital_ocean.go
+++ b/provider/digitalocean/digital_ocean.go
@@ -302,22 +302,18 @@ func makeDomainEditRequest(domain, name, recordType, data string, ttl int) *godo
 
 	if recordType == endpoint.RecordTypeMX {
 		mxRecord, err := endpoint.NewMXTarget(data)
-
-		if err == nil {
-			priority := mxRecord.Priority
-			host := mxRecord.Host
-			request.Priority = int(priority)
-			request.Data = provider.EnsureTrailingDot(host)
-		} else {
+		if err != nil {
 			log.WithFields(log.Fields{
 				"domain":     domain,
 				"dnsName":    name,
 				"recordType": recordType,
 				"data":       data,
 			}).Warn("Unable to parse MX target")
+			return request
 		}
+		request.Priority = int(*mxRecord.GetPriority())
+		request.Data = provider.EnsureTrailingDot(*mxRecord.GetHost())
 	}
-
 	return request
 }
 

--- a/provider/digitalocean/digital_ocean.go
+++ b/provider/digitalocean/digital_ocean.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/digitalocean/godo"
@@ -302,10 +301,14 @@ func makeDomainEditRequest(domain, name, recordType, data string, ttl int) *godo
 	}
 
 	if recordType == endpoint.RecordTypeMX {
-		priority, domain, err := parseMxTarget(data)
+		targets := endpoint.Targets([]string{data})
+		mxRecords, err := targets.ParseMXRecord()
+
 		if err == nil {
+			priority := mxRecords[0].Priority
+			host := mxRecords[0].Host
 			request.Priority = int(priority)
-			request.Data = provider.EnsureTrailingDot(domain)
+			request.Data = provider.EnsureTrailingDot(host)
 		} else {
 			log.WithFields(log.Fields{
 				"domain":     domain,
@@ -660,19 +663,4 @@ func (p *DigitalOceanProvider) ApplyChanges(ctx context.Context, planChanges *pl
 	}
 
 	return p.submitChanges(ctx, &changes)
-}
-
-func parseMxTarget(mxTarget string) (priority int64, exchange string, err error) {
-	targetParts := strings.SplitN(mxTarget, " ", 2)
-	if len(targetParts) != 2 {
-		return priority, exchange, fmt.Errorf("mx target needs to be of form '10 example.com'")
-	}
-
-	priorityRaw, exchange := targetParts[0], targetParts[1]
-	priority, err = strconv.ParseInt(priorityRaw, 10, 32)
-	if err != nil {
-		return priority, exchange, fmt.Errorf("invalid priority specified")
-	}
-
-	return priority, exchange, nil
 }

--- a/provider/digitalocean/digital_ocean.go
+++ b/provider/digitalocean/digital_ocean.go
@@ -301,7 +301,7 @@ func makeDomainEditRequest(domain, name, recordType, data string, ttl int) *godo
 	}
 
 	if recordType == endpoint.RecordTypeMX {
-		mxRecord, err := endpoint.ParseMXRecord(data)
+		mxRecord, err := endpoint.NewMXTarget(data)
 
 		if err == nil {
 			priority := mxRecord.Priority

--- a/provider/digitalocean/digital_ocean.go
+++ b/provider/digitalocean/digital_ocean.go
@@ -301,12 +301,11 @@ func makeDomainEditRequest(domain, name, recordType, data string, ttl int) *godo
 	}
 
 	if recordType == endpoint.RecordTypeMX {
-		targets := endpoint.Targets([]string{data})
-		mxRecords, err := targets.ParseMXRecord()
+		mxRecord, err := endpoint.ParseMXRecord(data)
 
 		if err == nil {
-			priority := mxRecords[0].Priority
-			host := mxRecords[0].Host
+			priority := mxRecord.Priority
+			host := mxRecord.Host
 			request.Priority = int(priority)
 			request.Data = provider.EnsureTrailingDot(host)
 		} else {

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -108,7 +108,7 @@ func NewTXTRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID st
 }
 
 func getSupportedTypes() []string {
-	return []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME, endpoint.RecordTypeNS}
+	return []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME, endpoint.RecordTypeNS, endpoint.RecordTypeMX, endpoint.RecordTypeTXT}
 }
 
 func (im *TXTRegistry) GetDomainFilter() endpoint.DomainFilterInterface {

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -108,7 +108,7 @@ func NewTXTRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID st
 }
 
 func getSupportedTypes() []string {
-	return []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME, endpoint.RecordTypeNS, endpoint.RecordTypeMX, endpoint.RecordTypeTXT}
+	return []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME, endpoint.RecordTypeNS, endpoint.RecordTypeMX}
 }
 
 func (im *TXTRegistry) GetDomainFilter() endpoint.DomainFilterInterface {

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -119,8 +119,6 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 			newEndpointWithOwner("txt.dualstack.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("dualstack.test-zone.example.org", "2001:DB8::1", endpoint.RecordTypeAAAA, ""),
 			newEndpointWithOwner("txt.aaaa-dualstack.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("info.test-zone.example.org", "example txt record content", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.txt-info.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("mail.test-zone.example.org", "10 onemail.example.com", endpoint.RecordTypeMX, ""),
 			newEndpointWithOwner("txt.mx-mail.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 		},
@@ -220,14 +218,6 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 			},
 		},
 		{
-			DNSName:    "info.test-zone.example.org",
-			Targets:    endpoint.Targets{"example txt record content"},
-			RecordType: endpoint.RecordTypeTXT,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
-			},
-		},
-		{
 			DNSName:    "mail.test-zone.example.org",
 			Targets:    endpoint.Targets{"10 onemail.example.com"},
 			RecordType: endpoint.RecordTypeMX,
@@ -272,8 +262,6 @@ func testTXTRegistryRecordsSuffixed(t *testing.T) {
 			newEndpointWithOwner("dualstack-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("dualstack.test-zone.example.org", "2001:DB8::1", endpoint.RecordTypeAAAA, ""),
 			newEndpointWithOwner("aaaa-dualstack-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("info.test-zone.example.org", "example txt record content", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("info-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("mail.test-zone.example.org", "10 onemail.example.com", endpoint.RecordTypeMX, ""),
 			newEndpointWithOwner("mx-mail-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 		},
@@ -365,14 +353,6 @@ func testTXTRegistryRecordsSuffixed(t *testing.T) {
 			},
 		},
 		{
-			DNSName:    "info.test-zone.example.org",
-			Targets:    endpoint.Targets{"example txt record content"},
-			RecordType: endpoint.RecordTypeTXT,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
-			},
-		},
-		{
 			DNSName:    "mail.test-zone.example.org",
 			Targets:    endpoint.Targets{"10 onemail.example.com"},
 			RecordType: endpoint.RecordTypeMX,
@@ -415,8 +395,6 @@ func testTXTRegistryRecordsNoPrefix(t *testing.T) {
 			newEndpointWithOwner("dualstack.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("dualstack.test-zone.example.org", "2001:DB8::1", endpoint.RecordTypeAAAA, ""),
 			newEndpointWithOwner("aaaa-dualstack.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("info.test-zone.example.org", "example txt record content", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt-info.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("mail.test-zone.example.org", "10 onemail.example.com", endpoint.RecordTypeMX, ""),
 			newEndpointWithOwner("mx-mail.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 		},
@@ -502,14 +480,6 @@ func testTXTRegistryRecordsNoPrefix(t *testing.T) {
 			},
 		},
 		{
-			DNSName:    "info.test-zone.example.org",
-			Targets:    endpoint.Targets{"example txt record content"},
-			RecordType: endpoint.RecordTypeTXT,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
-			},
-		},
-		{
 			DNSName:    "mail.test-zone.example.org",
 			Targets:    endpoint.Targets{"10 onemail.example.com"},
 			RecordType: endpoint.RecordTypeMX,
@@ -533,8 +503,6 @@ func testTXTRegistryRecordsPrefixedTemplated(t *testing.T) {
 		Create: []*endpoint.Endpoint{
 			newEndpointWithOwner("foo.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA, ""),
 			newEndpointWithOwner("txt-a.foo.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("foo.test-zone.example.org", "example txt record content", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt-txt.foo.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("mail.test-zone.example.org", "10 onemail.example.com", endpoint.RecordTypeMX, ""),
 			newEndpointWithOwner("txt-mx.mail.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 		},
@@ -544,14 +512,6 @@ func testTXTRegistryRecordsPrefixedTemplated(t *testing.T) {
 			DNSName:    "foo.test-zone.example.org",
 			Targets:    endpoint.Targets{"1.1.1.1"},
 			RecordType: endpoint.RecordTypeA,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
-			},
-		},
-		{
-			DNSName:    "foo.test-zone.example.org",
-			Targets:    endpoint.Targets{"example txt record content"},
-			RecordType: endpoint.RecordTypeTXT,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "owner",
 			},
@@ -585,8 +545,6 @@ func testTXTRegistryRecordsSuffixedTemplated(t *testing.T) {
 		Create: []*endpoint.Endpoint{
 			newEndpointWithOwner("bar.test-zone.example.org", "8.8.8.8", endpoint.RecordTypeCNAME, ""),
 			newEndpointWithOwner("bartxtcname.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("info.test-zone.example.org", "example txt record content", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("infotxttxt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("mail.test-zone.example.org", "10 onemail.example.com", endpoint.RecordTypeMX, ""),
 			newEndpointWithOwner("mailtxt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 		},
@@ -596,14 +554,6 @@ func testTXTRegistryRecordsSuffixedTemplated(t *testing.T) {
 			DNSName:    "bar.test-zone.example.org",
 			Targets:    endpoint.Targets{"8.8.8.8"},
 			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
-			},
-		},
-		{
-			DNSName:    "info.test-zone.example.org",
-			Targets:    endpoint.Targets{"example txt record content"},
-			RecordType: endpoint.RecordTypeTXT,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "owner",
 			},

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -119,6 +119,10 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 			newEndpointWithOwner("txt.dualstack.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("dualstack.test-zone.example.org", "2001:DB8::1", endpoint.RecordTypeAAAA, ""),
 			newEndpointWithOwner("txt.aaaa-dualstack.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("info.test-zone.example.org", "example txt record content", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("txt.txt-info.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("mail.test-zone.example.org", "10 onemail.example.com", endpoint.RecordTypeMX, ""),
+			newEndpointWithOwner("txt.mx-mail.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 		},
 	})
 	expectedRecords := []*endpoint.Endpoint{
@@ -215,6 +219,22 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 				endpoint.OwnerLabelKey: "owner-2",
 			},
 		},
+		{
+			DNSName:    "info.test-zone.example.org",
+			Targets:    endpoint.Targets{"example txt record content"},
+			RecordType: endpoint.RecordTypeTXT,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
+		{
+			DNSName:    "mail.test-zone.example.org",
+			Targets:    endpoint.Targets{"10 onemail.example.com"},
+			RecordType: endpoint.RecordTypeMX,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
 	}
 
 	r, _ := NewTXTRegistry(p, "txt.", "", "owner", time.Hour, "wc", []string{}, []string{}, false, nil, false)
@@ -252,6 +272,10 @@ func testTXTRegistryRecordsSuffixed(t *testing.T) {
 			newEndpointWithOwner("dualstack-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("dualstack.test-zone.example.org", "2001:DB8::1", endpoint.RecordTypeAAAA, ""),
 			newEndpointWithOwner("aaaa-dualstack-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("info.test-zone.example.org", "example txt record content", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("info-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("mail.test-zone.example.org", "10 onemail.example.com", endpoint.RecordTypeMX, ""),
+			newEndpointWithOwner("mx-mail-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 		},
 	})
 	expectedRecords := []*endpoint.Endpoint{
@@ -340,6 +364,22 @@ func testTXTRegistryRecordsSuffixed(t *testing.T) {
 				endpoint.OwnerLabelKey: "owner-2",
 			},
 		},
+		{
+			DNSName:    "info.test-zone.example.org",
+			Targets:    endpoint.Targets{"example txt record content"},
+			RecordType: endpoint.RecordTypeTXT,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
+		{
+			DNSName:    "mail.test-zone.example.org",
+			Targets:    endpoint.Targets{"10 onemail.example.com"},
+			RecordType: endpoint.RecordTypeMX,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
 	}
 
 	r, _ := NewTXTRegistry(p, "", "-txt", "owner", time.Hour, "", []string{}, []string{}, false, nil, false)
@@ -375,6 +415,10 @@ func testTXTRegistryRecordsNoPrefix(t *testing.T) {
 			newEndpointWithOwner("dualstack.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("dualstack.test-zone.example.org", "2001:DB8::1", endpoint.RecordTypeAAAA, ""),
 			newEndpointWithOwner("aaaa-dualstack.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("info.test-zone.example.org", "example txt record content", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("txt-info.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("mail.test-zone.example.org", "10 onemail.example.com", endpoint.RecordTypeMX, ""),
+			newEndpointWithOwner("mx-mail.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 		},
 	})
 	expectedRecords := []*endpoint.Endpoint{
@@ -457,6 +501,22 @@ func testTXTRegistryRecordsNoPrefix(t *testing.T) {
 				endpoint.OwnerLabelKey: "owner-2",
 			},
 		},
+		{
+			DNSName:    "info.test-zone.example.org",
+			Targets:    endpoint.Targets{"example txt record content"},
+			RecordType: endpoint.RecordTypeTXT,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
+		{
+			DNSName:    "mail.test-zone.example.org",
+			Targets:    endpoint.Targets{"10 onemail.example.com"},
+			RecordType: endpoint.RecordTypeMX,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
 	}
 
 	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour, "", []string{}, []string{}, false, nil, false)
@@ -473,6 +533,10 @@ func testTXTRegistryRecordsPrefixedTemplated(t *testing.T) {
 		Create: []*endpoint.Endpoint{
 			newEndpointWithOwner("foo.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA, ""),
 			newEndpointWithOwner("txt-a.foo.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("foo.test-zone.example.org", "example txt record content", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("txt-txt.foo.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("mail.test-zone.example.org", "10 onemail.example.com", endpoint.RecordTypeMX, ""),
+			newEndpointWithOwner("txt-mx.mail.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 		},
 	})
 	expectedRecords := []*endpoint.Endpoint{
@@ -480,6 +544,22 @@ func testTXTRegistryRecordsPrefixedTemplated(t *testing.T) {
 			DNSName:    "foo.test-zone.example.org",
 			Targets:    endpoint.Targets{"1.1.1.1"},
 			RecordType: endpoint.RecordTypeA,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
+		{
+			DNSName:    "foo.test-zone.example.org",
+			Targets:    endpoint.Targets{"example txt record content"},
+			RecordType: endpoint.RecordTypeTXT,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
+		{
+			DNSName:    "mail.test-zone.example.org",
+			Targets:    endpoint.Targets{"10 onemail.example.com"},
+			RecordType: endpoint.RecordTypeMX,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "owner",
 			},
@@ -505,6 +585,10 @@ func testTXTRegistryRecordsSuffixedTemplated(t *testing.T) {
 		Create: []*endpoint.Endpoint{
 			newEndpointWithOwner("bar.test-zone.example.org", "8.8.8.8", endpoint.RecordTypeCNAME, ""),
 			newEndpointWithOwner("bartxtcname.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("info.test-zone.example.org", "example txt record content", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("infotxttxt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("mail.test-zone.example.org", "10 onemail.example.com", endpoint.RecordTypeMX, ""),
+			newEndpointWithOwner("mailtxt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 		},
 	})
 	expectedRecords := []*endpoint.Endpoint{
@@ -512,6 +596,22 @@ func testTXTRegistryRecordsSuffixedTemplated(t *testing.T) {
 			DNSName:    "bar.test-zone.example.org",
 			Targets:    endpoint.Targets{"8.8.8.8"},
 			RecordType: endpoint.RecordTypeCNAME,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
+		{
+			DNSName:    "info.test-zone.example.org",
+			Targets:    endpoint.Targets{"example txt record content"},
+			RecordType: endpoint.RecordTypeTXT,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
+		{
+			DNSName:    "mail.test-zone.example.org",
+			Targets:    endpoint.Targets{"10 onemail.example.com"},
+			RecordType: endpoint.RecordTypeMX,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "owner",
 			},


### PR DESCRIPTION
<!-- Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks! -->
Hi there! 👋

Description

This PR introduces support for MX records for the Cloudflare provider.

- Cloudflare can now manage MX records via the DNSEndpoint CRD.
- Adds logic to parse MX records and extract priority and mail host
- Extends unit tests to validate proper MX record creation and priority 
- Updates the documentation to reflect support for cloudflare in MX record management.

<!-- Please link to all GitHub issues that this pull request implements (i.e., Fixes #123) -->

Fixes https://github.com/kubernetes-sigs/external-dns/issues/5282

Checklist

- [x] Unit tests updated
- [x] End user documentation updated (docs/sources/mx-record.md)

Thanks for checking this out! 🙏
Looking forward to your feedback — happy to make any changes if needed.