### PR TITLE
Add Nomad Services as a Source

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -17,7 +17,11 @@
 | `--cf-password=""` | The password to log into the cloud foundry API |
 | `--gloo-namespace=gloo-system` | The Gloo Proxy namespace; specify multiple times for multiple namespaces. (default: gloo-system) |
 | `--skipper-routegroup-groupversion="zalando.org/v1"` | The resource version for skipper routegroup |
-| `--source=source` | The resource types that are queried for endpoints; specify multiple times for multiple sources (required, options: service, ingress, node, pod, fake, connector, gateway-httproute, gateway-grpcroute, gateway-tlsroute, gateway-tcproute, gateway-udproute, istio-gateway, istio-virtualservice, cloudfoundry, contour-httpproxy, gloo-proxy, crd, empty, skipper-routegroup, openshift-route, ambassador-host, kong-tcpingress, f5-virtualserver, f5-transportserver, traefik-proxy) |
+| `--nomad-address=""` | Nomad endpoint address, if empty it defaults to NOMAD_ADDR or http://127.0.0.1:4646 |
+| `--nomad-region=""` | Nomad region to use. If not provided, the default agent region is used |
+| `--nomad-token=NOMAD-TOKEN` | Nomad per-request ACL token |
+| `--nomad-wait-time=0s` | WaitTime limits how long a Watch will block. If not provided, the agent default values will be used |
+| `--source=source` | The resource types that are queried for endpoints; specify multiple times for multiple sources (required, options: service, ingress, node, pod, fake, connector, gateway-httproute, gateway-grpcroute, gateway-tlsroute, gateway-tcproute, gateway-udproute, istio-gateway, istio-virtualservice, cloudfoundry, contour-httpproxy, gloo-proxy, crd, empty, skipper-routegroup, openshift-route, ambassador-host, kong-tcpingress, f5-virtualserver, f5-transportserver, traefik-proxy, nomad-service) |
 | `--openshift-router-name=OPENSHIFT-ROUTER-NAME` | if source is openshift-route then you can pass the ingress controller name. Based on this name external-dns will select the respective router from the route status and map that routerCanonicalHostname to the route host while creating a CNAME record. |
 | `--namespace=""` | Limit resources queried for endpoints to a specific namespace (default: all namespaces) |
 | `--annotation-filter=""` | Filter resources queried for endpoints by annotation, using label selector semantics |

--- a/docs/sources/nomad-source.md
+++ b/docs/sources/nomad-source.md
@@ -1,0 +1,196 @@
+# Nomad Service Source
+
+This tutorial explains how to configure ExternalDNS to use Nomad services as a source.
+
+The Nomad service source reads metadata from services registered with the Nomad agent and uses it to determine DNS configuration.
+
+By using `--source=nomad-service`, ExternalDNS can discover DNS endpoints from applications registered in a [HashiCorp Nomad](https://www.nomadproject.io/) cluster. This allows DNS records to be dynamically created and updated based on the state of Nomad services, similar to how ExternalDNS works with Kubernetes resources.
+
+## CLI Flags
+
+This source respects these external-dns CLI flags:
+
+```bash
+--namespace=""                     # Limit resources queried for endpoints to a specific namespace (default: all namespaces)
+--fqdn-template=""                 # A templated string that's used to generate DNS names from sources that don't define a hostname themselves
+--[no-]combine-fqdn-annotation     # Combine FQDN template and Annotations instead of overwriting
+--[no-]ignore-hostname-annotation  # Ignore hostname annotation when generating DNS names, valid only when --fqdn-template is set
+```
+
+The following flags are available for customizing Nomad integration (all optional):
+
+```bash
+--nomad-address=""         # Nomad API address. Defaults to $NOMAD_ADDR or http://127.0.0.1:4646
+--nomad-region=""          # Nomad region. Defaults to agent's configured region
+--nomad-token=NOMAD-TOKEN  # Nomad ACL token for authentication
+--nomad-wait-time=0s       # API blocking timeout (Watch WaitTime)
+```
+
+Also, Nomad agent connection and authentication options can be configured via environment variables (e.g., `NOMAD_ADDR`, `NOMAD_REGION`, `NOMAD_TOKEN`, etc.)
+
+### Example: Run ExternalDNS with Nomad source
+
+You can run ExternalDNS with the Nomad service source and any supported DNS provider:
+
+```bash
+external-dns \
+  --source=nomad-service \
+  --provider=inmemory \
+  --nomad-address=http://127.0.0.1:4646
+```
+
+## Nomad Service Tags
+
+The `nomad-service` source uses Nomad [service tags](https://developer.hashicorp.com/nomad/docs/job-specification/service#tags) to define configuration that is typically specified using Kubernetes annotations in other sources.
+
+Unlike Kubernetes annotations, which are a key-value map, Nomad tags are represented as a flat array of strings. To work around this difference, the implementation expects tags to follow a `key=value` format under the `external-dns.` prefix.
+
+For example:
+
+```hcl
+tags = [
+  "external-dns.hostname=example.nomad.internal.",
+  "external-dns.ttl=300",
+  "external-dns.controller=dns-controller",
+  "external-dns.set-identifier=my-id"
+]
+```
+
+These tags are interpreted by ExternalDNS in the same way it would interpret Kubernetes annotations:
+
+```yaml
+annotations:
+  external-dns.alpha.kubernetes.io/hostname: "example.nomad.internal."
+  external-dns.alpha.kubernetes.io/ttl: "300"
+  external-dns.alpha.kubernetes.io/controller: "dns-controller"
+  external-dns.alpha.kubernetes.io/set-identifier: "my-id"
+```
+
+To reduce verbosity and improve clarity, the Nomad tag keys are shortened versions of their corresponding Kubernetes annotations. This source supports next ExternalDNS annotation equivalents set via service tags:
+
+| Nomad Tag | Kubernetes Annotation Equivalent |
+|-----------|----------------------------------|
+| external-dns.hostname | external-dns.alpha.kubernetes.io/hostname |
+| external-dns.target	| external-dns.alpha.kubernetes.io/target |
+| external-dns.ttl | external-dns.alpha.kubernetes.io/ttl |
+| external-dns.controller | external-dns.alpha.kubernetes.io/controller |
+| external-dns.set-identifier | external-dns.alpha.kubernetes.io/set-identifier |
+
+Additionally, provider-specific configuration is also supported via tags. For example:
+
+```hcl
+tags = [
+  "external-dns.hostname=app.example.org.",
+  "external-dns.aws-weight=100",
+  "external-dns.cloudflare-proxied=true"
+]
+```
+
+### Example service block in a Nomad job:
+
+```hcl
+service {
+  name = "whoami-demo"
+  port = "http"
+  provider = "nomad"
+  tags = [
+    "external-dns.hostname=whoami.example.org.",
+    "external-dns.target=${attr.unique.network.ip-address}",
+  ]
+}
+```
+
+This configuration will result in an A record for whoami.example.org. pointing to the IP of the service port.
+
+## Example Nomad Job
+
+Here's a complete job spec to demonstrate usage:
+
+```hcl
+job "whoami" {
+  group "demo" {
+    network {
+      mode = "host"
+
+      port "http" {
+        static = 80
+      }
+    }
+
+    service {
+      name = "whoami-demo"
+      port = "http"
+      provider = "nomad"
+      tags = [
+        "external-dns.alpha.kubernetes.io/hostname=whoami.example.org.",
+        "external-dns.alpha.kubernetes.io/ttl=60"
+      ]
+    }
+
+    task "server" {
+      driver = "docker"
+
+      config {
+        image = "traefik/whoami"
+        ports = ["http"]
+      }
+
+      env {
+        WHOAMI_PORT_NUMBER = "${NOMAD_PORT_http}"
+      }
+    }
+  }
+}
+```
+
+The ExternalDNS itself can be deployed to a Nomad cluster as a regular job:
+
+```hcl
+job "external-dns" {
+  group "external-dns" {
+    network {
+      mode = "bridge"
+
+      port "http" {
+        to = 7979
+      }
+    }
+
+    task "controller" {
+      driver = "docker"
+
+      config {
+        image = "registry.k8s.io/external-dns/external-dns:latest"
+        ports = ["http"]
+
+        args = [
+          "--source=nomad-service",
+          "--nomad-address=http://${attr.unique.network.ip-address}:4646",
+        ]
+      }
+
+      resources {
+        cpu    = 50
+        memory = 32
+      }
+
+      service {
+        provider = "nomad"
+        port = "http"
+
+        check {
+          type = "http"
+          path = "/healthz"
+          interval = "10s"
+          timeout = "3s"
+        }
+      }
+    }
+  }
+}
+```
+
+## Notes
+
+* This source does not require Kubernetes; it works directly with the Nomad HTTP API.
+* Integration with DNS providers (e.g., AWS Route 53, Cloudflare, etc.) is handled the same as with other ExternalDNS sources.

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/nomad/api v0.0.0-20250321175057-34ae5d5ae66b
 	github.com/linki/instrumented_http v0.3.0
 	github.com/linode/linodego v1.49.0
 	github.com/maxatome/go-testdeep v1.14.0
@@ -140,10 +141,13 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
 	github.com/gopherjs/gopherjs v1.17.2 // indirect
+	github.com/gorilla/websocket v1.5.1 // indirect
+	github.com/hashicorp/cronexpr v1.1.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
+	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
 	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -548,6 +548,8 @@ github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/z
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
+github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/gosuri/uitable v0.0.4/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -559,6 +561,8 @@ github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslC
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
+github.com/hashicorp/cronexpr v1.1.2 h1:wG/ZYIKT+RT3QkOdgYc+xsKWVRgnxJ1OJtjjy84fJ9A=
+github.com/hashicorp/cronexpr v1.1.2/go.mod h1:P4wA0KBl9C5q2hABiMO7cp6jcIg96CDh1Efb3g1PWA4=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
@@ -577,6 +581,8 @@ github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9
 github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU=
 github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
+github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
+github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -593,6 +599,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
+github.com/hashicorp/nomad/api v0.0.0-20250321175057-34ae5d5ae66b h1:R7hwhe8P7Fg3NVZiYwdBl+w/QglPbSxRDeWdiWnVyG8=
+github.com/hashicorp/nomad/api v0.0.0-20250321175057-34ae5d5ae66b/go.mod h1:svtxn6QnrQ69P23VvIWMR34tg3vmwLz4UdUzm1dSCgE=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -214,6 +214,10 @@ type Config struct {
 	TraefikDisableNew                             bool
 	NAT64Networks                                 []string
 	ExcludeUnschedulable                          bool
+	NomadAddress                                  string
+	NomadRegion                                   string
+	NomadToken                                    string `secure:"yes"`
+	NomadWaitTime                                 time.Duration
 }
 
 var defaultConfig = &Config{
@@ -378,6 +382,10 @@ var defaultConfig = &Config{
 	TraefikDisableNew:                             false,
 	NAT64Networks:                                 []string{},
 	ExcludeUnschedulable:                          true,
+	NomadAddress:                                  "",
+	NomadRegion:                                   "",
+	NomadToken:                                    "",
+	NomadWaitTime:                                 0,
 }
 
 // NewConfig returns new Config object
@@ -452,8 +460,15 @@ func App(cfg *Config) *kingpin.Application {
 	// Flags related to Skipper RouteGroup
 	app.Flag("skipper-routegroup-groupversion", "The resource version for skipper routegroup").Default(defaultConfig.SkipperRouteGroupVersion).StringVar(&cfg.SkipperRouteGroupVersion)
 
+	// Flags related to Nomad
+	app.Flag("nomad-address", "Nomad endpoint address, if empty it defaults to NOMAD_ADDR or http://127.0.0.1:4646").Default(defaultConfig.NomadAddress).StringVar(&cfg.NomadAddress)
+	app.Flag("nomad-region", "Nomad region to use. If not provided, the default agent region is used").Default(defaultConfig.NomadRegion).StringVar(&cfg.NomadRegion)
+	// app.Flag("nomad-namespace", "Nomad namespace to use. If not provided the default namespace is used").Default(defaultConfig.NomadNamespace).StringVar(&cfg.NomadNamespace)
+	app.Flag("nomad-token", "Nomad per-request ACL token").StringVar(&cfg.NomadToken)
+	app.Flag("nomad-wait-time", "WaitTime limits how long a Watch will block. If not provided, the agent default values will be used").Default(defaultConfig.NomadWaitTime.String()).DurationVar(&cfg.NomadWaitTime)
+
 	// Flags related to processing source
-	app.Flag("source", "The resource types that are queried for endpoints; specify multiple times for multiple sources (required, options: service, ingress, node, pod, fake, connector, gateway-httproute, gateway-grpcroute, gateway-tlsroute, gateway-tcproute, gateway-udproute, istio-gateway, istio-virtualservice, cloudfoundry, contour-httpproxy, gloo-proxy, crd, empty, skipper-routegroup, openshift-route, ambassador-host, kong-tcpingress, f5-virtualserver, f5-transportserver, traefik-proxy)").Required().PlaceHolder("source").EnumsVar(&cfg.Sources, "service", "ingress", "node", "pod", "gateway-httproute", "gateway-grpcroute", "gateway-tlsroute", "gateway-tcproute", "gateway-udproute", "istio-gateway", "istio-virtualservice", "cloudfoundry", "contour-httpproxy", "gloo-proxy", "fake", "connector", "crd", "empty", "skipper-routegroup", "openshift-route", "ambassador-host", "kong-tcpingress", "f5-virtualserver", "f5-transportserver", "traefik-proxy")
+	app.Flag("source", "The resource types that are queried for endpoints; specify multiple times for multiple sources (required, options: service, ingress, node, pod, fake, connector, gateway-httproute, gateway-grpcroute, gateway-tlsroute, gateway-tcproute, gateway-udproute, istio-gateway, istio-virtualservice, cloudfoundry, contour-httpproxy, gloo-proxy, crd, empty, skipper-routegroup, openshift-route, ambassador-host, kong-tcpingress, f5-virtualserver, f5-transportserver, traefik-proxy, nomad-service)").Required().PlaceHolder("source").EnumsVar(&cfg.Sources, "service", "ingress", "node", "pod", "gateway-httproute", "gateway-grpcroute", "gateway-tlsroute", "gateway-tcproute", "gateway-udproute", "istio-gateway", "istio-virtualservice", "cloudfoundry", "contour-httpproxy", "gloo-proxy", "fake", "connector", "crd", "empty", "skipper-routegroup", "openshift-route", "ambassador-host", "kong-tcpingress", "f5-virtualserver", "f5-transportserver", "traefik-proxy", "nomad-service")
 	app.Flag("openshift-router-name", "if source is openshift-route then you can pass the ingress controller name. Based on this name external-dns will select the respective router from the route status and map that routerCanonicalHostname to the route host while creating a CNAME record.").StringVar(&cfg.OCPRouterName)
 	app.Flag("namespace", "Limit resources queried for endpoints to a specific namespace (default: all namespaces)").Default(defaultConfig.Namespace).StringVar(&cfg.Namespace)
 	app.Flag("annotation-filter", "Filter resources queried for endpoints by annotation, using label selector semantics").Default(defaultConfig.AnnotationFilter).StringVar(&cfg.AnnotationFilter)

--- a/source/nomad_service.go
+++ b/source/nomad_service.go
@@ -1,0 +1,286 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"text/template"
+	"unicode"
+
+	nomad "github.com/hashicorp/nomad/api"
+	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/external-dns/endpoint"
+)
+
+const (
+	tagPrefix = "external-dns"
+)
+
+// nomadServiceSource is an implementation of Source for Nomad services.
+type nomadServiceSource struct {
+	client    *nomad.Client
+	namespace string
+
+	fqdnTemplate             *template.Template
+	combineFQDNAnnotation    bool
+	ignoreHostnameAnnotation bool
+}
+
+// NewNomadServiceSource creates a new nomadSource.
+func NewNomadServiceSource(ctx context.Context, nomadClient *nomad.Client, namespace, fqdnTemplate string, combineFqdnAnnotation bool, ignoreHostnameAnnotation bool) (Source, error) {
+	tmpl, err := parseTemplate(fqdnTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	return &nomadServiceSource{
+		client:                   nomadClient,
+		namespace:                namespace,
+		fqdnTemplate:             tmpl,
+		combineFQDNAnnotation:    combineFqdnAnnotation,
+		ignoreHostnameAnnotation: ignoreHostnameAnnotation,
+	}, nil
+}
+
+// Endpoints collects endpoints of all nested Sources and returns them in a single slice.
+func (ns *nomadServiceSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	namespace := ns.namespace
+	if namespace == "" {
+		namespace = "*"
+	}
+
+	opts := &nomad.QueryOptions{Namespace: namespace}
+	opts = opts.WithContext(ctx)
+
+	svcLists, _, err := ns.client.Services().List(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoints := []*endpoint.Endpoint{}
+
+	for _, svcList := range svcLists {
+		for _, svc := range svcList.Services {
+			annotations := ns.tagsToAnnotations(svc.Tags)
+
+			controller, ok := annotations[controllerAnnotationKey]
+			if ok && controller != controllerAnnotationValue {
+				log.Debugf("Skipping service %s/%s because controller value does not match, found: %s, required: %s",
+					svcList.Namespace, svc.ServiceName, controller, controllerAnnotationValue)
+				continue
+			}
+
+			svcEndpoints, err := ns.endpoints(ctx, svcList.Namespace, svc.ServiceName, annotations)
+			if err != nil {
+				return nil, err
+			}
+
+			// apply template if none of the above is found
+			if (ns.combineFQDNAnnotation || len(svcEndpoints) == 0) && ns.fqdnTemplate != nil {
+				sEndpoints, err := ns.endpointsFromTemplate(ctx, svcList.Namespace, svc.ServiceName, annotations)
+
+				if err != nil {
+					return nil, err
+				}
+
+				if ns.combineFQDNAnnotation {
+					svcEndpoints = append(svcEndpoints, sEndpoints...)
+				} else {
+					svcEndpoints = sEndpoints
+				}
+			}
+
+			if len(svcEndpoints) == 0 {
+				log.Debugf("No endpoints could be generated from service %s/%s", svcList.Namespace, svc.ServiceName)
+				continue
+			}
+
+			log.Debugf("Endpoints generated from service: %s/%s: %v", svcList.Namespace, svc.ServiceName, svcEndpoints)
+			ns.setResourceLabel(svcList.Namespace, svc.ServiceName, svcEndpoints)
+			endpoints = append(endpoints, svcEndpoints...)
+		}
+	}
+
+	// this sorting is required to make merging work.
+	// after we merge endpoints that have same DNS, we want to ensure that we end up with the same service being an "owner"
+	// of all those records, as otherwise each time we update, we will end up with a different service that gets data merged in
+	// and that will cause external-dns to recreate dns record due to different service owner in TXT record.
+	// if new service is added or old one removed, that might cause existing record to get re-created due to potentially new
+	// owner being selected. Which is fine, since it shouldn't happen often and shouldn't cause any disruption.
+	if len(endpoints) > 1 {
+		sort.Slice(endpoints, func(i, j int) bool {
+			return endpoints[i].Labels[endpoint.ResourceLabelKey] < endpoints[j].Labels[endpoint.ResourceLabelKey]
+		})
+		// Use stable sort to not disrupt the order of services
+		sort.SliceStable(endpoints, func(i, j int) bool {
+			if endpoints[i].DNSName != endpoints[j].DNSName {
+				return endpoints[i].DNSName < endpoints[j].DNSName
+			}
+			return endpoints[i].RecordType < endpoints[j].RecordType
+		})
+		mergedEndpoints := []*endpoint.Endpoint{}
+		mergedEndpoints = append(mergedEndpoints, endpoints[0])
+		for i := 1; i < len(endpoints); i++ {
+			lastMergedEndpoint := len(mergedEndpoints) - 1
+			if mergedEndpoints[lastMergedEndpoint].DNSName == endpoints[i].DNSName &&
+				mergedEndpoints[lastMergedEndpoint].RecordType == endpoints[i].RecordType &&
+				mergedEndpoints[lastMergedEndpoint].RecordType != endpoint.RecordTypeCNAME && // It is against RFC-1034 for CNAME records to have multiple targets, so skip merging
+				mergedEndpoints[lastMergedEndpoint].SetIdentifier == endpoints[i].SetIdentifier &&
+				mergedEndpoints[lastMergedEndpoint].RecordTTL == endpoints[i].RecordTTL {
+				mergedEndpoints[lastMergedEndpoint].Targets = append(mergedEndpoints[lastMergedEndpoint].Targets, endpoints[i].Targets[0])
+			} else {
+				mergedEndpoints = append(mergedEndpoints, endpoints[i])
+			}
+
+			if mergedEndpoints[lastMergedEndpoint].DNSName == endpoints[i].DNSName &&
+				mergedEndpoints[lastMergedEndpoint].RecordType == endpoints[i].RecordType &&
+				mergedEndpoints[lastMergedEndpoint].RecordType == endpoint.RecordTypeCNAME {
+				log.Debugf("CNAME %s with multiple targets found", endpoints[i].DNSName)
+			}
+		}
+		endpoints = mergedEndpoints
+	}
+
+	for _, ep := range endpoints {
+		sort.Sort(ep.Targets)
+	}
+
+	return endpoints, nil
+}
+
+func (ns *nomadServiceSource) tagsToAnnotations(tags []string) map[string]string {
+	annotations := make(map[string]string, len(tags))
+	for _, tag := range tags {
+		if strings.HasPrefix(tag, tagPrefix) {
+			if parts := strings.SplitN(tag, "=", 2); len(parts) == 2 {
+				left, right := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+				key := "external-dns.alpha.kubernetes.io/" + strings.TrimPrefix(left, tagPrefix+".")
+				annotations[key] = right
+			}
+		}
+	}
+	return annotations
+}
+
+func (ns *nomadServiceSource) endpoints(ctx context.Context, namespace string, serviceName string, annotations map[string]string) ([]*endpoint.Endpoint, error) {
+	var endpoints []*endpoint.Endpoint
+
+	if !ns.ignoreHostnameAnnotation {
+		providerSpecific, setIdentifier := getProviderSpecificAnnotations(annotations)
+		var hostnameList []string
+
+		hostnameList = getHostnamesFromAnnotations(annotations)
+		for _, hostname := range hostnameList {
+			hnEndpoints, err := ns.generateEndpoints(ctx, namespace, serviceName, annotations, hostname, providerSpecific, setIdentifier)
+			if err != nil {
+				return nil, err
+			}
+
+			endpoints = append(endpoints, hnEndpoints...)
+		}
+	}
+
+	return endpoints, nil
+}
+
+func (ns *nomadServiceSource) endpointsFromTemplate(ctx context.Context, namespace string, serviceName string, annotations map[string]string) ([]*endpoint.Endpoint, error) {
+	hostnames, err := ns.execTemplate(ns.fqdnTemplate, nomadServiceMetadata{Namespace: namespace, Name: serviceName})
+	if err != nil {
+		return nil, err
+	}
+
+	providerSpecific, setIdentifier := getProviderSpecificAnnotations(annotations)
+
+	var endpoints []*endpoint.Endpoint
+	for _, hostname := range hostnames {
+		hnEndpoints, err := ns.generateEndpoints(ctx, namespace, serviceName, annotations, hostname, providerSpecific, setIdentifier)
+		if err != nil {
+			return nil, err
+		}
+		endpoints = append(endpoints, hnEndpoints...)
+	}
+
+	return endpoints, nil
+
+}
+
+type nomadServiceMetadata struct {
+	Namespace string
+	Name      string
+}
+
+func (ns *nomadServiceSource) execTemplate(tmpl *template.Template, obj nomadServiceMetadata) (hostnames []string, err error) {
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, obj); err != nil {
+		return nil, fmt.Errorf("failed to apply template on service %s/%s: %w", obj.Namespace, obj.Name, err)
+	}
+	for _, name := range strings.Split(buf.String(), ",") {
+		name = strings.TrimFunc(name, unicode.IsSpace)
+		name = strings.TrimSuffix(name, ".")
+		hostnames = append(hostnames, name)
+	}
+	return hostnames, nil
+}
+
+func (ns *nomadServiceSource) generateEndpoints(ctx context.Context, namespace string, serviceName string, annotations map[string]string, hostname string, providerSpecific endpoint.ProviderSpecific, setIdentifier string) (endpoints []*endpoint.Endpoint, _ error) {
+	hostname = strings.TrimSuffix(hostname, ".")
+
+	resource := fmt.Sprintf("service/%s/%s", namespace, serviceName)
+
+	ttl := getTTLFromAnnotations(annotations, resource)
+
+	targets := getTargetsFromTargetAnnotation(annotations)
+
+	if len(targets) == 0 {
+		opts := &nomad.QueryOptions{Namespace: namespace}
+		opts = opts.WithContext(ctx)
+
+		svcRegs, _, err := ns.client.Services().Get(serviceName, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		// Collect unique service addresses
+		svcAddrs := make(map[string]struct{})
+		for _, svcReg := range svcRegs {
+			svcAddrs[svcReg.Address] = struct{}{}
+		}
+
+		for addr := range svcAddrs {
+			targets = append(targets, addr)
+		}
+	}
+
+	endpoints = append(endpoints, endpointsForHostname(hostname, targets, ttl, providerSpecific, setIdentifier, resource)...)
+
+	return endpoints, nil
+}
+
+func (sc *nomadServiceSource) setResourceLabel(namespace string, serviceName string, endpoints []*endpoint.Endpoint) {
+	for _, ep := range endpoints {
+		ep.Labels[endpoint.ResourceLabelKey] = fmt.Sprintf("service/%s/%s", namespace, serviceName)
+	}
+}
+
+func (ns *nomadServiceSource) AddEventHandler(ctx context.Context, handler func()) {
+	// TODO: Implement event listener logic
+}

--- a/source/nomad_service_test.go
+++ b/source/nomad_service_test.go
@@ -1,0 +1,801 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"context"
+	"encoding/json"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"sigs.k8s.io/external-dns/endpoint"
+)
+
+type NomadServiceSuite struct {
+	suite.Suite
+	helloService *api.ServiceRegistration
+	ts           *httptest.Server
+	sc           Source
+}
+
+func (suite *NomadServiceSuite) SetupTest() {
+	suite.helloService = &api.ServiceRegistration{
+		ID:          "_nomad-task-71a63a80-a98a-93ee-4fd7-73b808577c20-group-foo-foo-http",
+		ServiceName: "foo",
+		Namespace:   "default",
+		NodeID:      "6d7f412e-e7ff-2e66-d47b-867b0e9d8726",
+		Datacenter:  "dc1",
+		JobID:       "echo",
+		AllocID:     "71a63a80-a98a-93ee-4fd7-73b808577c20",
+		Tags:        []string{},
+		Address:     "127.0.0.1",
+		Port:        20627,
+		CreateIndex: 18,
+		ModifyIndex: 18,
+	}
+
+	fakeClient, ts, err := fakeNomadClient([]*api.ServiceRegistration{suite.helloService})
+	suite.ts = ts
+
+	suite.sc, err = NewNomadServiceSource(
+		context.TODO(),
+		fakeClient,
+		"",
+		"{{.Name}}",
+		false,
+		false,
+	)
+	suite.NoError(err, "should initialize nomad-service source")
+}
+
+func (suite *NomadServiceSuite) TearDownTest() {
+	suite.ts.Close()
+}
+
+func (suite *NomadServiceSuite) TestResourceLabelIsSet() {
+	endpoints, _ := suite.sc.Endpoints(context.Background())
+	for _, ep := range endpoints {
+		suite.Equal("service/default/foo", ep.Labels[endpoint.ResourceLabelKey], "should set correct resource label")
+	}
+}
+
+func TestNomadServiceSource(t *testing.T) {
+	t.Parallel()
+
+	suite.Run(t, new(NomadServiceSuite))
+	t.Run("Interface", testNomadServiceSourceImplementsSource)
+	t.Run("NewServiceSource", testNomadServiceSourceNewServiceSource)
+	t.Run("Endpoints", testNomadServiceSourceEndpoints)
+	t.Run("MultipleServices", testMultipleNomadServicesEndpoints)
+}
+
+// testNomadServiceSourceImplementsSource tests that serviceSource is a valid Source.
+func testNomadServiceSourceImplementsSource(t *testing.T) {
+	assert.Implements(t, (*Source)(nil), new(nomadServiceSource))
+}
+
+// testNomadServiceSourceNewServiceSource tests that NewServiceSource doesn't return an error.
+func testNomadServiceSourceNewServiceSource(t *testing.T) {
+	t.Parallel()
+
+	for _, ti := range []struct {
+		title              string
+		annotationFilter   string
+		fqdnTemplate       string
+		serviceTypesFilter []string
+		expectError        bool
+	}{
+		{
+			title:        "invalid template",
+			expectError:  true,
+			fqdnTemplate: "{{.Name",
+		},
+		{
+			title:       "valid empty template",
+			expectError: false,
+		},
+		{
+			title:        "valid template",
+			expectError:  false,
+			fqdnTemplate: "{{.Name}}-{{.Namespace}}.ext-dns.test.com",
+		},
+		// {
+		// 	title:            "non-empty annotation filter label",
+		// 	expectError:      false,
+		// 	annotationFilter: "kubernetes.io/ingress.class=nginx",
+		// },
+	} {
+		ti := ti
+		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
+
+			fakeClient, ts, err := fakeNomadClient([]*api.ServiceRegistration{})
+			t.Cleanup(ts.Close)
+			require.NoError(t, err)
+
+			_, err = NewNomadServiceSource(
+				context.TODO(),
+				fakeClient,
+				"",
+				ti.fqdnTemplate,
+				false,
+				false,
+			)
+
+			if ti.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// testNomadServiceSourceEndpoints tests that various services generate the correct endpoints.
+func testNomadServiceSourceEndpoints(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		title                    string
+		targetNamespace          string
+		svcNamespace             string
+		svcName                  string
+		fqdnTemplate             string
+		combineFQDNAndAnnotation bool
+		ignoreHostnameAnnotation bool
+		tags                     []string
+		address                  string
+		expected                 []*endpoint.Endpoint
+		expectError              bool
+	}{
+		{
+			title:        "no annotated services return no endpoints",
+			svcNamespace: "testing",
+			svcName:      "foo",
+			tags:         []string{},
+			address:      "1.2.3.4",
+			expected:     []*endpoint.Endpoint{},
+		},
+		{
+			title:                    "no annotated services return no endpoints when ignoring annotations",
+			svcNamespace:             "testing",
+			svcName:                  "foo",
+			ignoreHostnameAnnotation: true,
+			tags:                     []string{},
+			address:                  "1.2.3.4",
+			expected:                 []*endpoint.Endpoint{},
+		},
+		{
+			title:        "annotated services return an endpoint with target IP",
+			svcNamespace: "testing",
+			svcName:      "foo",
+			tags: []string{
+				"external-dns.hostname=foo.example.org.",
+			},
+			address: "1.2.3.4",
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+			},
+		},
+		{
+			title:                    "hostname annotation on services is ignored",
+			svcNamespace:             "testing",
+			svcName:                  "foo",
+			ignoreHostnameAnnotation: true,
+			tags: []string{
+				"external-dns.hostname=foo.example.org.",
+			},
+			address:  "1.2.3.4",
+			expected: []*endpoint.Endpoint{},
+		},
+		{
+			title:        "FQDN template with multiple hostnames return an endpoint with target IP",
+			svcNamespace: "testing",
+			svcName:      "foo",
+			fqdnTemplate: "{{.Name}}.fqdn.org,{{.Name}}.fqdn.com",
+			address:      "1.2.3.4",
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foo.fqdn.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.fqdn.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+			},
+		},
+		{
+			title:                    "FQDN template with multiple hostnames return an endpoint with target IP when ignoring annotations",
+			svcNamespace:             "testing",
+			svcName:                  "foo",
+			fqdnTemplate:             "{{.Name}}.fqdn.org,{{.Name}}.fqdn.com",
+			ignoreHostnameAnnotation: true,
+			address:                  "1.2.3.4",
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foo.fqdn.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.fqdn.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+			},
+		},
+		{
+			title:                    "FQDN template and annotation both with multiple hostnames return an endpoint with target IP",
+			svcNamespace:             "testing",
+			svcName:                  "foo",
+			fqdnTemplate:             "{{.Name}}.fqdn.org,{{.Name}}.fqdn.com",
+			combineFQDNAndAnnotation: true,
+			tags: []string{
+				"external-dns.hostname=foo.example.org., bar.example.org.",
+			},
+			address: "1.2.3.4",
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "bar.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.fqdn.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.fqdn.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+			},
+		},
+		{
+			title:                    "FQDN template and annotation both with multiple hostnames while ignoring annotations will only return FQDN endpoints",
+			svcNamespace:             "testing",
+			svcName:                  "foo",
+			fqdnTemplate:             "{{.Name}}.fqdn.org,{{.Name}}.fqdn.com",
+			combineFQDNAndAnnotation: true,
+			ignoreHostnameAnnotation: true,
+			tags: []string{
+				"external-dns.hostname=foo.example.org., bar.example.org.",
+			},
+			address: "1.2.3.4",
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foo.fqdn.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.fqdn.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+			},
+		},
+		{
+			title:        "annotated services with multiple hostnames return an endpoint with target IP",
+			svcNamespace: "testing",
+			svcName:      "foo",
+			tags: []string{
+				"external-dns.hostname=foo.example.org., bar.example.org.",
+			},
+			address: "1.2.3.4",
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "bar.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+			},
+		},
+		{
+			title:        "annotated services with multiple hostnames and without trailing period return an endpoint with target IP",
+			svcNamespace: "testing",
+			svcName:      "foo",
+			tags: []string{
+				"external-dns.hostname=foo.example.org, bar.example.org",
+			},
+			address: "1.2.3.4",
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "bar.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+			},
+		},
+		{
+			title:        "our controller type is kops dns controller",
+			svcNamespace: "testing",
+			svcName:      "foo",
+			tags: []string{
+				"external-dns.controller=" + controllerAnnotationValue,
+				"external-dns.hostname=foo.example.org.",
+			},
+			address: "1.2.3.4",
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+			},
+		},
+		{
+			title:        "different controller types are ignored even (with template specified)",
+			svcNamespace: "testing",
+			svcName:      "foo",
+			fqdnTemplate: "{{.Name}}.ext-dns.test.com",
+			tags: []string{
+				"external-dns.controller=some-other-tool",
+				"external-dns.hostname=foo.example.org.",
+			},
+			address:  "1.2.3.4",
+			expected: []*endpoint.Endpoint{},
+		},
+		{
+			title:           "services are found in target namespace",
+			targetNamespace: "testing",
+			svcNamespace:    "testing",
+			svcName:         "foo",
+			tags: []string{
+				"external-dns.hostname=foo.example.org.",
+			},
+			address: "1.2.3.4",
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+			},
+		},
+		{
+			title:           "services that are not in target namespace are ignored",
+			targetNamespace: "testing",
+			svcNamespace:    "other-testing",
+			svcName:         "foo",
+			tags: []string{
+				"external-dns.hostname=foo.example.org.",
+			},
+			address:  "1.2.3.4",
+			expected: []*endpoint.Endpoint{},
+		},
+		{
+			title:        "services are found in all namespaces",
+			svcNamespace: "other-testing",
+			svcName:      "foo",
+			tags: []string{
+				"external-dns.hostname=foo.example.org.",
+			},
+			address: "1.2.3.4",
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+			},
+		},
+		{
+			title:        "not annotated services with set fqdnTemplate return an endpoint with target IP",
+			svcNamespace: "testing",
+			svcName:      "foo",
+			fqdnTemplate: "{{.Name}}.bar.example.com",
+			tags:         []string{},
+			address:      "1.2.3.4",
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foo.bar.example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+			},
+		},
+		{
+			title:        "annotated services with set fqdnTemplate annotation takes precedence",
+			svcNamespace: "testing",
+			svcName:      "foo",
+			fqdnTemplate: "{{.Name}}.bar.example.com",
+			tags: []string{
+				"external-dns.hostname=foo.example.org.",
+			},
+			address: "1.2.3.4",
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+			},
+		},
+		{
+			title:        "not annotated services with unknown tmpl field should not return anything",
+			svcNamespace: "testing",
+			svcName:      "foo",
+			fqdnTemplate: "{{.Calibre}}.bar.example.com",
+			tags:         []string{},
+			address:      "1.2.3.4",
+			expected:     []*endpoint.Endpoint{},
+			expectError:  true,
+		},
+		{
+			title:        "ttl not annotated should have RecordTTL.IsConfigured set to false",
+			svcNamespace: "testing",
+			svcName:      "foo",
+			tags: []string{
+				"external-dns.hostname=foo.example.org.",
+			},
+			address: "1.2.3.4",
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}, RecordTTL: endpoint.TTL(0)},
+			},
+		},
+		{
+			title:        "ttl annotated but invalid should have RecordTTL.IsConfigured set to false",
+			svcNamespace: "testing",
+			svcName:      "foo",
+			tags: []string{
+				"external-dns.hostname=foo.example.org.",
+				"external-dns.ttl=foo",
+			},
+			address: "1.2.3.4",
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}, RecordTTL: endpoint.TTL(0)},
+			},
+		},
+		{
+			title:        "ttl annotated and is valid should set Record.TTL",
+			svcNamespace: "testing",
+			svcName:      "foo",
+			tags: []string{
+				"external-dns.hostname=foo.example.org.",
+				"external-dns.ttl=10",
+			},
+			address: "1.2.3.4",
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}, RecordTTL: endpoint.TTL(10)},
+			},
+		},
+		{
+			title:        "ttl annotated (in duration format) and is valid should set Record.TTL",
+			svcNamespace: "testing",
+			svcName:      "foo",
+			tags: []string{
+				"external-dns.hostname=foo.example.org.",
+				"external-dns.ttl=1m",
+			},
+			address: "1.2.3.4",
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}, RecordTTL: endpoint.TTL(60)},
+			},
+		},
+		{
+			title:        "Negative ttl is not valid",
+			svcNamespace: "testing",
+			svcName:      "foo",
+			tags: []string{
+				"external-dns.hostname=foo.example.org.",
+				"external-dns.ttl=-10",
+			},
+			address: "1.2.3.4",
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}, RecordTTL: endpoint.TTL(0)},
+			},
+		},
+		{
+			title:        "IPv6 service gets IPv6 endpoint",
+			svcNamespace: "testing",
+			svcName:      "foobar-v6",
+			tags: []string{
+				"external-dns.hostname=foobar-v6.example.org",
+			},
+			address: "2001:db8::2",
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foobar-v6.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:db8::2"}},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
+			var service = &api.ServiceRegistration{
+				ID:          "_nomad-task-71a63a80-a98a-93ee-4fd7-73b808577c20-group-foo-foo-http",
+				ServiceName: tc.svcName,
+				Namespace:   tc.svcNamespace,
+				NodeID:      "6d7f412e-e7ff-2e66-d47b-867b0e9d8726",
+				Datacenter:  "dc1",
+				JobID:       "echo",
+				AllocID:     "71a63a80-a98a-93ee-4fd7-73b808577c20",
+				Tags:        tc.tags,
+				Address:     tc.address,
+				Port:        20627,
+				CreateIndex: 18,
+				ModifyIndex: 18,
+			}
+
+			fakeClient, ts, err := fakeNomadClient([]*api.ServiceRegistration{service})
+			t.Cleanup(ts.Close)
+			require.NoError(t, err)
+
+			// Create our object under test and get the endpoints.
+			client, err := NewNomadServiceSource(
+				context.TODO(),
+				fakeClient,
+				tc.targetNamespace,
+				tc.fqdnTemplate,
+				tc.combineFQDNAndAnnotation,
+				tc.ignoreHostnameAnnotation,
+			)
+
+			require.NoError(t, err)
+
+			res, err := client.Endpoints(context.Background())
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Validate returned endpoints against desired endpoints.
+			validateEndpoints(t, res, tc.expected)
+		})
+	}
+}
+
+// testMultipleNomadServicesEndpoints tests that multiple services generate correct merged endpoints
+func testMultipleNomadServicesEndpoints(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		title                    string
+		targetNamespace          string
+		svcNamespace             string
+		svcName                  string
+		fqdnTemplate             string
+		combineFQDNAndAnnotation bool
+		ignoreHostnameAnnotation bool
+		tags                     []string
+		services                 map[string][]string
+		expected                 []*endpoint.Endpoint
+		expectError              bool
+	}{
+		{
+			title:                    "test service returns a correct end point",
+			targetNamespace:          "",
+			svcNamespace:             "testing",
+			svcName:                  "foo",
+			fqdnTemplate:             "",
+			combineFQDNAndAnnotation: false,
+			ignoreHostnameAnnotation: false,
+			services: map[string][]string{
+				"1.2.3.4": {"external-dns.hostname=foo.example.org"},
+			},
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/foo1.2.3.4"}},
+			},
+			expectError: false,
+		},
+		{
+			title:                    "multiple services that share same DNS should be merged into one endpoint",
+			targetNamespace:          "",
+			svcNamespace:             "testing",
+			svcName:                  "foo",
+			fqdnTemplate:             "",
+			combineFQDNAndAnnotation: false,
+			ignoreHostnameAnnotation: false,
+			services: map[string][]string{
+				"1.2.3.4": {"external-dns.hostname=foo.example.org"},
+				"1.2.3.5": {"external-dns.hostname=foo.example.org"},
+				"1.2.3.6": {"external-dns.hostname=foo.example.org"},
+			},
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4", "1.2.3.5", "1.2.3.6"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/foo1.2.3.4"}},
+			},
+			expectError: false,
+		},
+		{
+			title:                    "test that services with different hostnames do not get merged together",
+			targetNamespace:          "",
+			svcNamespace:             "testing",
+			svcName:                  "foo",
+			fqdnTemplate:             "",
+			combineFQDNAndAnnotation: false,
+			ignoreHostnameAnnotation: false,
+			services: map[string][]string{
+				"1.2.3.5":  {"external-dns.hostname=foo.example.org"},
+				"10.1.1.3": {"external-dns.hostname=bar.example.org"},
+				"10.1.1.1": {"external-dns.hostname=bar.example.org"},
+				"1.2.3.4":  {"external-dns.hostname=foo.example.org"},
+				"10.1.1.2": {"external-dns.hostname=bar.example.org"},
+				"20.1.1.1": {"external-dns.hostname=foobar.example.org"},
+				"1.2.3.6":  {"external-dns.hostname=foo.example.org"},
+			},
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4", "1.2.3.5", "1.2.3.6"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/foo1.2.3.4"}},
+				{DNSName: "bar.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"10.1.1.1", "10.1.1.2", "10.1.1.3"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/foo10.1.1.1"}},
+				{DNSName: "foobar.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"20.1.1.1"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/foo20.1.1.1"}},
+			},
+			expectError: false,
+		},
+		{
+			title:                    "test that services with different set-identifier do not get merged together",
+			targetNamespace:          "",
+			svcNamespace:             "testing",
+			svcName:                  "foo",
+			fqdnTemplate:             "",
+			combineFQDNAndAnnotation: false,
+			ignoreHostnameAnnotation: false,
+			services: map[string][]string{
+				"1.2.3.5": {
+					"external-dns.hostname=foo.example.org",
+					"external-dns.set-identifier=a",
+				},
+				"10.1.1.3": {
+					"external-dns.hostname=foo.example.org",
+					"external-dns.set-identifier=b",
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.5"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/foo1.2.3.5"}, SetIdentifier: "a"},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"10.1.1.3"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/foo10.1.1.3"}, SetIdentifier: "b"},
+			},
+			expectError: false,
+		},
+		{
+			title:                    "test that services with CNAME types do not get merged together",
+			targetNamespace:          "",
+			svcNamespace:             "testing",
+			svcName:                  "foo",
+			fqdnTemplate:             "",
+			combineFQDNAndAnnotation: false,
+			ignoreHostnameAnnotation: false,
+			services: map[string][]string{
+				"1.2.3.4": []string{
+					"external-dns.hostname=foo.example.org",
+					"external-dns.target=a.elb.com",
+				},
+				"1.2.3.5": []string{
+					"external-dns.hostname=foo.example.org",
+					"external-dns.target=b.elb.com",
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeCNAME, Targets: endpoint.Targets{"a.elb.com"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/foo1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeCNAME, Targets: endpoint.Targets{"b.elb.com"}, Labels: map[string]string{endpoint.ResourceLabelKey: "service/testing/foo1.2.3.5"}},
+			},
+			expectError: false,
+		},
+	} {
+		tc := tc
+		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
+			serviceRegistrations := make([]*api.ServiceRegistration, 0, len(tc.services))
+
+			// Create services to test against
+			for address, tags := range tc.services {
+				serviceRegistrations = append(serviceRegistrations, &api.ServiceRegistration{
+					ID:          "_nomad-task-71a63a80-a98a-93ee-4fd7-73b808577c20-group-foo-foo-http",
+					ServiceName: tc.svcName + address,
+					Namespace:   tc.svcNamespace,
+					NodeID:      "6d7f412e-e7ff-2e66-d47b-867b0e9d8726",
+					Datacenter:  "dc1",
+					JobID:       "echo",
+					AllocID:     "71a63a80-a98a-93ee-4fd7-73b808577c20",
+					Tags:        tags,
+					Address:     address,
+					Port:        20627,
+					CreateIndex: 18,
+					ModifyIndex: 18,
+				})
+			}
+
+			fakeClient, ts, err := fakeNomadClient(serviceRegistrations)
+			t.Cleanup(ts.Close)
+			require.NoError(t, err)
+
+			// Create our object under test and get the endpoints.
+			client, err := NewNomadServiceSource(
+				context.TODO(),
+				fakeClient,
+				tc.targetNamespace,
+				tc.fqdnTemplate,
+				tc.combineFQDNAndAnnotation,
+				tc.ignoreHostnameAnnotation,
+			)
+			require.NoError(t, err)
+
+			res, err := client.Endpoints(context.Background())
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Validate returned endpoints against desired endpoints.
+			validateEndpoints(t, res, tc.expected)
+			// Test that endpoint resourceLabelKey matches desired endpoint
+			sort.SliceStable(res, func(i, j int) bool {
+				return strings.Compare(res[i].DNSName, res[j].DNSName) < 0
+			})
+			sort.SliceStable(tc.expected, func(i, j int) bool {
+				return strings.Compare(tc.expected[i].DNSName, tc.expected[j].DNSName) < 0
+			})
+
+			for i := range res {
+				if res[i].Labels[endpoint.ResourceLabelKey] != tc.expected[i].Labels[endpoint.ResourceLabelKey] {
+					t.Errorf("expected %s, got %s", tc.expected[i].Labels[endpoint.ResourceLabelKey], res[i].Labels[endpoint.ResourceLabelKey])
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkNomadServiceEndpoints(b *testing.B) {
+	serviceRegistration := &api.ServiceRegistration{
+		ID:          "_nomad-task-71a63a80-a98a-93ee-4fd7-73b808577c20-group-foo-foo-http",
+		ServiceName: "foo",
+		Namespace:   "testing",
+		NodeID:      "6d7f412e-e7ff-2e66-d47b-867b0e9d8726",
+		Datacenter:  "dc1",
+		JobID:       "echo",
+		AllocID:     "71a63a80-a98a-93ee-4fd7-73b808577c20",
+		Tags:        []string{"external-dns.hostname=foo.example.org."},
+		Address:     "1.2.3.4",
+		Port:        20627,
+		CreateIndex: 18,
+		ModifyIndex: 18,
+	}
+
+	fakeClient, ts, err := fakeNomadClient([]*api.ServiceRegistration{serviceRegistration})
+	b.Cleanup(ts.Close)
+	require.NoError(b, err)
+
+	client, err := NewNomadServiceSource(
+		context.TODO(),
+		fakeClient,
+		"",
+		"",
+		false,
+		false,
+	)
+	require.NoError(b, err)
+
+	for i := 0; i < b.N; i++ {
+		_, err := client.Endpoints(context.Background())
+		require.NoError(b, err)
+	}
+}
+
+func fakeNomadClient(services []*api.ServiceRegistration) (*api.Client, *httptest.Server, error) {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/v1/services", func(w http.ResponseWriter, r *http.Request) {
+		namespaceFilter := r.FormValue("namespace")
+		if namespaceFilter == "" {
+			namespaceFilter = "default"
+		}
+
+		// Service stubs grouped by namespace and service name
+		uniqueServices := make(map[string]map[string]*api.ServiceRegistrationStub)
+		for _, service := range services {
+			if _, ok := uniqueServices[service.Namespace]; !ok {
+				uniqueServices[service.Namespace] = make(map[string]*api.ServiceRegistrationStub)
+			}
+
+			if _, ok := uniqueServices[service.Namespace][service.ServiceName]; !ok {
+				uniqueServices[service.Namespace][service.ServiceName] = &api.ServiceRegistrationStub{
+					ServiceName: service.ServiceName,
+					Tags:        service.Tags,
+				}
+			}
+		}
+
+		resp := make([]*api.ServiceRegistrationListStub, 0, len(uniqueServices))
+		for svcNamespace, services := range uniqueServices {
+			if svcNamespace == namespaceFilter || namespaceFilter == "*" {
+				resp = append(resp, &api.ServiceRegistrationListStub{
+					Namespace: svcNamespace,
+					Services:  slices.Collect(maps.Values(services)),
+				})
+			}
+		}
+		respBytes, _ := json.Marshal(resp)
+		_, _ = w.Write(respBytes)
+	})
+
+	mux.HandleFunc("/v1/service/{serviceName}", func(w http.ResponseWriter, r *http.Request) {
+		namespaceFilter := r.FormValue("namespace")
+		serviceName := r.PathValue("serviceName")
+
+		resp := make([]*api.ServiceRegistration, 0)
+		for _, service := range services {
+			if service.Namespace == namespaceFilter && service.ServiceName == serviceName {
+				resp = append(resp, service)
+			}
+		}
+		respBytes, _ := json.Marshal(resp)
+		_, _ = w.Write(respBytes)
+	})
+
+	ts := httptest.NewServer(mux)
+
+	fakeClient, err := NewNomadClient(ts.URL, "", "", 0)
+
+	if err != nil {
+		return nil, ts, err
+	}
+
+	return fakeClient, ts, nil
+}

--- a/source/store.go
+++ b/source/store.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/cloudfoundry-community/go-cfclient"
+	nomad "github.com/hashicorp/nomad/api"
 	"github.com/linki/instrumented_http"
 	openshift "github.com/openshift/client-go/route/clientset/versioned"
 	"github.com/pkg/errors"
@@ -84,6 +85,10 @@ type Config struct {
 	TraefikDisableNew              bool
 	ExcludeUnschedulable           bool
 	ExposeInternalIPv6             bool
+	NomadAddress                   string
+	NomadRegion                    string
+	NomadToken                     string
+	NomadWaitTime                  time.Duration
 }
 
 func NewSourceConfig(cfg *externaldns.Config) *Config {
@@ -129,6 +134,10 @@ func NewSourceConfig(cfg *externaldns.Config) *Config {
 		TraefikDisableNew:              cfg.TraefikDisableNew,
 		ExcludeUnschedulable:           cfg.ExcludeUnschedulable,
 		ExposeInternalIPv6:             cfg.ExposeInternalIPV6,
+		NomadAddress:                   cfg.NomadAddress,
+		NomadRegion:                    cfg.NomadRegion,
+		NomadToken:                     cfg.NomadToken,
+		NomadWaitTime:                  cfg.NomadWaitTime,
 	}
 }
 
@@ -140,6 +149,7 @@ type ClientGenerator interface {
 	CloudFoundryClient(cfAPPEndpoint string, cfUsername string, cfPassword string) (*cfclient.Client, error)
 	DynamicKubernetesClient() (dynamic.Interface, error)
 	OpenShiftClient() (openshift.Interface, error)
+	NomadClient(address string, region string, token string, waitTime time.Duration) (*nomad.Client, error)
 }
 
 // SingletonClientGenerator stores provider clients and guarantees that only one instance of client
@@ -154,12 +164,14 @@ type SingletonClientGenerator struct {
 	cfClient        *cfclient.Client
 	dynKubeClient   dynamic.Interface
 	openshiftClient openshift.Interface
+	nomadClient     *nomad.Client
 	kubeOnce        sync.Once
 	gatewayOnce     sync.Once
 	istioOnce       sync.Once
 	cfOnce          sync.Once
 	dynCliOnce      sync.Once
 	openshiftOnce   sync.Once
+	nomadOnce       sync.Once
 }
 
 // KubeClient generates a kube client if it was not created before
@@ -242,6 +254,15 @@ func (p *SingletonClientGenerator) OpenShiftClient() (openshift.Interface, error
 		p.openshiftClient, err = NewOpenShiftClient(p.KubeConfig, p.APIServerURL, p.RequestTimeout)
 	})
 	return p.openshiftClient, err
+}
+
+// NomadClient generates a nomad client if it was not created before
+func (p *SingletonClientGenerator) NomadClient(address string, region string, token string, waitTime time.Duration) (*nomad.Client, error) {
+	var err error
+	p.nomadOnce.Do(func() {
+		p.nomadClient, err = NewNomadClient(address, region, token, waitTime)
+	})
+	return p.nomadClient, err
 }
 
 // ByNames returns multiple Sources given multiple names.
@@ -418,6 +439,12 @@ func BuildWithConfig(ctx context.Context, source string, p ClientGenerator, cfg 
 			return nil, err
 		}
 		return NewF5TransportServerSource(ctx, dynamicClient, kubernetesClient, cfg.Namespace, cfg.AnnotationFilter)
+	case "nomad-service":
+		nomadClient, err := p.NomadClient(cfg.NomadAddress, cfg.NomadRegion, cfg.NomadToken, cfg.NomadWaitTime)
+		if err != nil {
+			return nil, err
+		}
+		return NewNomadServiceSource(ctx, nomadClient, cfg.Namespace, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.IgnoreHostnameAnnotation)
 	}
 
 	return nil, ErrSourceNotFound
@@ -544,5 +571,29 @@ func NewOpenShiftClient(kubeConfig, apiServerURL string, requestTimeout time.Dur
 		return nil, err
 	}
 	log.Infof("Created OpenShift client %s", config.Host)
+	return client, nil
+}
+
+func NewNomadClient(address string, region string, token string, waitTime time.Duration) (*nomad.Client, error) {
+	config := nomad.DefaultConfig()
+	if address != "" {
+		config.Address = address
+	}
+	if region != "" {
+		config.Region = region
+	}
+	if token != "" {
+		config.SecretID = token
+	}
+	if waitTime.Nanoseconds() > 0 {
+		config.WaitTime = waitTime
+	}
+
+	client, err := nomad.NewClient(config)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Infof("Created Nomad client %s", config.Address)
 	return client, nil
 }

--- a/source/store_test.go
+++ b/source/store_test.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	cfclient "github.com/cloudfoundry-community/go-cfclient"
+	nomad "github.com/hashicorp/nomad/api"
 	openshift "github.com/openshift/client-go/route/clientset/versioned"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -44,6 +46,7 @@ type MockClientGenerator struct {
 	cloudFoundryClient      *cfclient.Client
 	dynamicKubernetesClient dynamic.Interface
 	openshiftClient         openshift.Interface
+	nomadClient             *nomad.Client
 }
 
 func (m *MockClientGenerator) KubeClient() (kubernetes.Interface, error) {
@@ -96,6 +99,15 @@ func (m *MockClientGenerator) OpenShiftClient() (openshift.Interface, error) {
 	if args.Error(1) == nil {
 		m.openshiftClient = args.Get(0).(openshift.Interface)
 		return m.openshiftClient, nil
+	}
+	return nil, args.Error(1)
+}
+
+func (m *MockClientGenerator) NomadClient(address string, region string, token string, waitTime time.Duration) (*nomad.Client, error) {
+	args := m.Called()
+	if args.Error(1) == nil {
+		m.nomadClient = args.Get(0).(*nomad.Client)
+		return m.nomadClient, nil
 	}
 	return nil, args.Error(1)
 }


### PR DESCRIPTION
**Description**

This PR introduces a new source for ExternalDNS: `nomad-service`.

The purpose of this source is to allow ExternalDNS to discover DNS endpoints from services registered in [HashiCorp Nomad](https://www.nomadproject.io/), a flexible workload orchestrator. This enables ExternalDNS users to manage DNS records for workloads orchestrated by Nomad using the same toolset they already use for Kubernetes and other platforms.

Nomad provides native service discovery and a metadata-rich API. This source leverages the service metadata—specifically, service **tags**—to configure DNS endpoints.

#### Example

Here's an example of a Nomad job that registers a service with DNS configuration:

```hcl
job "whoami" {
  group "demo" {
    network {
      mode = "host"

      port "http" {
        static = 80
      }
    }

    service {
      name = "whoami-demo"
      port = "http"
      provider = "nomad"
      tags = [
        "external-dns.hostname=whoami.example.org.",
      ]
    }

    task "server" {
      driver = "docker"

      config {
        image = "traefik/whoami"
        ports = ["http"]
      }

      env {
        WHOAMI_PORT_NUMBER = "${NOMAD_PORT_http}"
      }
    }
  }
}
```

This job will result in ExternalDNS creating a DNS record for `whoami.example.org.` pointing to the service's IP address.

#### CLI Flags

The following optional command-line flags were introduced to configure the Nomad client used by the source:

```
--nomad-address=""             Nomad endpoint address. If empty, defaults to $NOMAD_ADDR or http://127.0.0.1:4646
--nomad-region=""              Nomad region to use. If not provided, the default agent region is used
--nomad-token=NOMAD-TOKEN      Nomad per-request ACL token
--nomad-wait-time=0s           WaitTime limits how long a Watch will block. If not provided, the agent default values will be used
```

#### Example Usage

To run ExternalDNS with the `nomad-service` source and an in-memory provider:

```bash
external-dns \
  --source=nomad-service \
  --provider=inmemory \
  --nomad-address=http://127.0.0.1:4646
```

#### Note on Nomad Tags vs Kubernetes Annotations

Nomad does not have annotations like Kubernetes, so ExternalDNS-specific configuration is done through [service tags](https://developer.hashicorp.com/nomad/docs/job-specification/service#tags).

Unlike Kubernetes annotations, which are a key-value map, Nomad tags are represented as a flat array of strings. To work around this difference, the implementation expects tags to follow a `key=value` format under the `external-dns.` prefix.

For example:

```hcl
tags = [
  "external-dns.hostname=example.nomad.internal.",
  "external-dns.ttl=300",
  "external-dns.controller=dns-controller",
  "external-dns.set-identifier=my-id"
]
```

Most of ExternalDNS annotations are supported via tags (e.g., hostname, TTL, target, etc.), provider-specific configuration is also supported.

---

This integration:

- Provides a consistent developer experience across platforms like Kubernetes and Nomad
- Enables automated DNS record management for Nomad-deployed services
- Uses the pluggable ExternalDNS architecture to extend support to non-Kubernetes orchestrators

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
