### PR TITLE
feat(helm): allow extraArgs to also be a map enabling overrides of individual values

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Changed
+
+- Allow extraArgs to also be a map enabling overrides of individual values ([#5293](https://github.com/kubernetes-sigs/external-dns/pull/5293)) _@frittentheke
+
 ### Fixed
 
 - Fixed wrong type definitions for webhook probes. ([#5297](https://github.com/kubernetes-sigs/external-dns/pull/5297)) _@semnell_

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -104,7 +104,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | enabled | bool | `nil` | No effect - reserved for use in sub-charting. |
 | env | list | `[]` | [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `external-dns` container. |
 | excludeDomains | list | `[]` | Intentionally exclude domains from being managed. |
-| extraArgs | list | `[]` | Extra arguments to provide to _ExternalDNS_. |
+| extraArgs | object | `{}` | Extra arguments to provide to _ExternalDNS_. An array or map can be used, with maps allowing for value overrides; maps also support slice values to use the same arg multiple times. |
 | extraContainers | object | `{}` | Extra containers to add to the `Deployment`. |
 | extraVolumeMounts | list | `[]` | Extra [volume mounts](https://kubernetes.io/docs/concepts/storage/volumes/) for the `external-dns` container. |
 | extraVolumes | list | `[]` | Extra [volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the `Pod`. |

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -124,9 +124,26 @@ spec:
             - --managed-record-types={{ . }}
             {{- end }}
             - --provider={{ $providerName }}
-          {{- range .Values.extraArgs }}
+            {{- if kindIs "map" .Values.extraArgs }}
+            {{- range $key, $value := .Values.extraArgs }}
+            {{- if not (kindIs "invalid" $value) }}
+            {{- if kindIs "slice" $value }}
+            {{- range $value }}
+            - --{{ $key }}={{ tpl (. | toString) $ }}
+            {{- end }}
+            {{- else }}
+            - --{{ $key }}={{ tpl ($value | toString) $ }}
+            {{- end }}
+            {{- else }}
+            - --{{ $key }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- if kindIs "slice" .Values.extraArgs }}
+            {{- range .Values.extraArgs }}
             - {{ tpl . $ }}
-          {{- end }}
+            {{- end }}
+            {{- end }}
           ports:
             - name: http
               protocol: TCP

--- a/charts/external-dns/tests/deployment-flags_test.yaml
+++ b/charts/external-dns/tests/deployment-flags_test.yaml
@@ -103,6 +103,60 @@ tests:
             - --zone-id-filter=/hostedzone/Z00004
             - --zone-id-filter=/hostedzone/Z00005
 
+
+  - it: should allow 'extraArgs' to be a slice
+    set:
+      extraArgs:
+       - --extraArgA=valueA
+       - --extraArgB=valueB
+       - --extraArgC=valueC-1
+       - --extraArgC=valueC-2
+
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "external-dns")].args
+          value:
+            - --log-level=info
+            - --log-format=text
+            - --interval=1m
+            - --source=service
+            - --source=ingress
+            - --policy=upsert-only
+            - --registry=txt
+            - --provider=aws
+            - --extraArgA=valueA
+            - --extraArgB=valueB
+            - --extraArgC=valueC-1
+            - --extraArgC=valueC-2
+
+
+  - it: should allow 'extraArgs' to be a map with its entries potentially being slices (lists) themselves
+    set:
+      extraArgs:
+        extraArgA: valueA
+        extraArgB: valueB
+        extraArgC:
+          - valueC-1
+          - valueC-2
+
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "external-dns")].args
+          value:
+            - --log-level=info
+            - --log-format=text
+            - --interval=1m
+            - --source=service
+            - --source=ingress
+            - --policy=upsert-only
+            - --registry=txt
+            - --provider=aws
+            - --extraArgA=valueA
+            - --extraArgB=valueB
+            - --extraArgC=valueC-1
+            - --extraArgC=valueC-2
+
+
   - it: should throw error when txtPrefix and txtSuffix are set
     set:
         txtPrefix: "test-prefix"
@@ -110,3 +164,4 @@ tests:
     asserts:
      - failedTemplate:
           errorMessage: "'txtPrefix' and 'txtSuffix' are mutually exclusive"
+

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -64,9 +64,11 @@
       "items": {
         "type": "string"
       },
+      "properties": {},
       "type": [
         "array",
-        "null"
+        "null",
+        "object"
       ],
       "uniqueItems": true
     },

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -296,7 +296,8 @@ provider:  # @schema type: [object, string];
       relabelings: []
 
 # -- Extra arguments to provide to _ExternalDNS_.
-extraArgs: []  # @schema type: [array, null]; item: string; uniqueItems: true;
+# An array or map can be used, with maps allowing for value overrides; maps also support slice values to use the same arg multiple times.
+extraArgs: {}  # @schema type: [array, null, object]; item: string; uniqueItems: true;
 
 secretConfiguration:
   # -- If `true`, create a `Secret` to store sensitive provider configuration (**DEPRECATED**).


### PR DESCRIPTION
**Description**

With external-dns relying a lot on `extraArgs` for its configuration using a map (key: value) data structure for extraArgs enables a lot more versatility. Multiple values files can be used to e.g. configure common values in one and then only specific values in another. 

Also setting certain values via `--set` is then possible - e.g to only change a single setting per environment or inject some value dynamically from CI.

**Checklist**

- [?] Unit tests updated

I did update the schema file

- [?] End user documentation updated

Maybe it makes sense to change the documented value type of `extraArgs` to map?
