### PR TITLE
chore(deps): build with go 1.24.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module sigs.k8s.io/external-dns
 
 go 1.24.0
 
+toolchain go1.24.2
+
 require (
 	cloud.google.com/go/compute/metadata v0.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0


### PR DESCRIPTION
**Description**

Build external-dns with latest release of go.

It fixes security issues and is [required](https://github.com/kubernetes-sigs/external-dns/actions/runs/14484351586/job/40627130676?pr=5302) by latest version of [gqlgenc](github.com/Yamashou/gqlgenc). 

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
