### PR TITLE
BREAKING CHANGE: Improve default targets management

### DIFF
--- a/controller/execute.go
+++ b/controller/execute.go
@@ -126,7 +126,7 @@ func Execute() {
 	targetFilter := endpoint.NewTargetNetFilterWithExclusions(cfg.TargetNetFilter, cfg.ExcludeTargetNets)
 
 	// Combine multiple sources into a single, deduplicated source.
-	endpointsSource := source.NewDedupSource(source.NewMultiSource(sources, sourceCfg.DefaultTargets))
+	endpointsSource := source.NewDedupSource(source.NewMultiSource(sources, sourceCfg.DefaultTargets, cfg.ForceDefaultTargets))
 	endpointsSource = source.NewNAT64Source(endpointsSource, cfg.NAT64Networks)
 	endpointsSource = source.NewTargetFilterSource(endpointsSource, targetFilter)
 

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -46,6 +46,7 @@
 | `--default-targets=DEFAULT-TARGETS` | Set globally default host/IP that will apply as a target instead of source addresses. Specify multiple times for multiple targets (optional) |
 | `--target-net-filter=TARGET-NET-FILTER` | Limit possible targets by a net filter; specify multiple times for multiple possible nets (optional) |
 | `--exclude-target-net=EXCLUDE-TARGET-NET` | Exclude target nets (optional) |
+| `--[no-]force-default-targets` | Force the application of --default-targets, overriding any targets provided by the source (DEPRECATED: This reverts to legacy behavior, default is false) |
 | `--[no-]traefik-disable-legacy` | Disable listeners on Resources under the traefik.containo.us API Group |
 | `--[no-]traefik-disable-new` | Disable listeners on Resources under the traefik.io API Group |
 | `--nat64-networks=NAT64-NETWORKS` | Adding an A record for each AAAA record in NAT64-enabled networks; specify multiple times for multiple possible nets (optional) |

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -214,6 +214,7 @@ type Config struct {
 	TraefikDisableNew                             bool
 	NAT64Networks                                 []string
 	ExcludeUnschedulable                          bool
+	ForceDefaultTargets                           bool
 }
 
 var defaultConfig = &Config{
@@ -378,6 +379,7 @@ var defaultConfig = &Config{
 	TraefikDisableNew:                             false,
 	NAT64Networks:                                 []string{},
 	ExcludeUnschedulable:                          true,
+	ForceDefaultTargets:                           false,
 }
 
 // NewConfig returns new Config object
@@ -482,6 +484,7 @@ func App(cfg *Config) *kingpin.Application {
 	app.Flag("default-targets", "Set globally default host/IP that will apply as a target instead of source addresses. Specify multiple times for multiple targets (optional)").StringsVar(&cfg.DefaultTargets)
 	app.Flag("target-net-filter", "Limit possible targets by a net filter; specify multiple times for multiple possible nets (optional)").StringsVar(&cfg.TargetNetFilter)
 	app.Flag("exclude-target-net", "Exclude target nets (optional)").StringsVar(&cfg.ExcludeTargetNets)
+	app.Flag("force-default-targets", "Force the application of --default-targets, overriding any targets provided by the source (DEPRECATED: This reverts to legacy behavior, default is false)").Default(strconv.FormatBool(defaultConfig.ForceDefaultTargets)).BoolVar(&cfg.ForceDefaultTargets)
 	app.Flag("traefik-disable-legacy", "Disable listeners on Resources under the traefik.containo.us API Group").Default(strconv.FormatBool(defaultConfig.TraefikDisableLegacy)).BoolVar(&cfg.TraefikDisableLegacy)
 	app.Flag("traefik-disable-new", "Disable listeners on Resources under the traefik.io API Group").Default(strconv.FormatBool(defaultConfig.TraefikDisableNew)).BoolVar(&cfg.TraefikDisableNew)
 	app.Flag("nat64-networks", "Adding an A record for each AAAA record in NAT64-enabled networks; specify multiple times for multiple possible nets (optional)").StringsVar(&cfg.NAT64Networks)

--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -235,6 +235,25 @@ func testCRDSourceEndpoints(t *testing.T) {
 			expectError:     false,
 		},
 		{
+			title:                "valid crd with no targets (relies on default-targets)",
+			registeredAPIVersion: "test.k8s.io/v1alpha1",
+			apiVersion:           "test.k8s.io/v1alpha1",
+			registeredKind:       "DNSEndpoint",
+			kind:                 "DNSEndpoint",
+			namespace:            "foo",
+			registeredNamespace:  "foo",
+			endpoints: []*endpoint.Endpoint{
+				{
+					DNSName:    "no-targets.example.org",
+					Targets:    endpoint.Targets{}, // Empty targets, should rely on default-targets later
+					RecordType: endpoint.RecordTypeA,
+					RecordTTL:  180,
+				},
+			},
+			expectEndpoints: true, // Expect the endpoint to be processed, default targets applied later
+			expectError:     false,
+		},
+		{
 			title:                "valid crd gvk with single endpoint",
 			registeredAPIVersion: "test.k8s.io/v1alpha1",
 			apiVersion:           "test.k8s.io/v1alpha1",

--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -216,25 +216,6 @@ func testCRDSourceEndpoints(t *testing.T) {
 			expectError:     false,
 		},
 		{
-			title:                "invalid crd with no targets",
-			registeredAPIVersion: "test.k8s.io/v1alpha1",
-			apiVersion:           "test.k8s.io/v1alpha1",
-			registeredKind:       "DNSEndpoint",
-			kind:                 "DNSEndpoint",
-			namespace:            "foo",
-			registeredNamespace:  "foo",
-			endpoints: []*endpoint.Endpoint{
-				{
-					DNSName:    "abc.example.org",
-					Targets:    endpoint.Targets{},
-					RecordType: endpoint.RecordTypeA,
-					RecordTTL:  180,
-				},
-			},
-			expectEndpoints: false,
-			expectError:     false,
-		},
-		{
 			title:                "valid crd with no targets (relies on default-targets)",
 			registeredAPIVersion: "test.k8s.io/v1alpha1",
 			apiVersion:           "test.k8s.io/v1alpha1",

--- a/source/multisource_test.go
+++ b/source/multisource_test.go
@@ -89,7 +89,7 @@ func testMultiSourceEndpoints(t *testing.T) {
 			}
 
 			// Create our object under test and get the endpoints.
-			source := NewMultiSource(sources, nil)
+			source := NewMultiSource(sources, nil, false)
 
 			// Get endpoints from the source.
 			endpoints, err := source.Endpoints(context.Background())
@@ -116,7 +116,7 @@ func testMultiSourceEndpointsWithError(t *testing.T) {
 	src.On("Endpoints").Return(nil, errSomeError)
 
 	// Create our object under test and get the endpoints.
-	source := NewMultiSource([]Source{src}, nil)
+	source := NewMultiSource([]Source{src}, nil, false)
 
 	// Get endpoints from our source.
 	_, err := source.Endpoints(context.Background())
@@ -127,44 +127,109 @@ func testMultiSourceEndpointsWithError(t *testing.T) {
 }
 
 func testMultiSourceEndpointsDefaultTargets(t *testing.T) {
-	// Create the expected default targets
-	defaultTargetsA := []string{"127.0.0.1", "127.0.0.2"}
-	defaultTargetsAAAA := []string{"2001:db8::1"}
-	defaultTargetsCName := []string{"foo.example.org"}
-	defaultTargets := append(defaultTargetsA, defaultTargetsCName...)
-	defaultTargets = append(defaultTargets, defaultTargetsAAAA...)
-	labels := endpoint.Labels{"foo": "bar"}
+	t.Run("Defaults applied when source targets are empty", func(t *testing.T) {
+		defaultTargetsA := []string{"127.0.0.1", "127.0.0.2"}
+		defaultTargetsAAAA := []string{"2001:db8::1"}
+		defaultTargetsCName := []string{"foo.example.org"}
+		defaultTargets := append(defaultTargetsA, defaultTargetsCName...)
+		defaultTargets = append(defaultTargets, defaultTargetsAAAA...)
+		labels := endpoint.Labels{"foo": "bar"}
 
-	// Create the expected endpoints
-	expectedEndpoints := []*endpoint.Endpoint{
-		{DNSName: "foo", Targets: defaultTargetsA, RecordType: "A", Labels: labels},
-		{DNSName: "bar", Targets: defaultTargetsA, RecordType: "A", Labels: labels},
-		{DNSName: "foo", Targets: defaultTargetsAAAA, RecordType: "AAAA", Labels: labels},
-		{DNSName: "bar", Targets: defaultTargetsAAAA, RecordType: "AAAA", Labels: labels},
-		{DNSName: "foo", Targets: defaultTargetsCName, RecordType: "CNAME", Labels: labels},
-		{DNSName: "bar", Targets: defaultTargetsCName, RecordType: "CNAME", Labels: labels},
-	}
+		// Endpoints FROM SOURCE have NO targets
+		sourceEndpoints := []*endpoint.Endpoint{
+			{DNSName: "foo", Targets: endpoint.Targets{}, Labels: labels},
+			{DNSName: "bar", Targets: endpoint.Targets{}, Labels: labels},
+		}
 
-	// Create the source endpoints with different targets
-	sourceEndpoints := []*endpoint.Endpoint{
-		{DNSName: "foo", Targets: endpoint.Targets{"8.8.8.8"}, Labels: labels},
-		{DNSName: "bar", Targets: endpoint.Targets{"8.8.4.4"}, Labels: labels},
-	}
+		// Expected endpoints SHOULD HAVE the default targets applied
+		expectedEndpoints := []*endpoint.Endpoint{
+			{DNSName: "foo", Targets: defaultTargetsA, RecordType: "A", Labels: labels},
+			{DNSName: "bar", Targets: defaultTargetsA, RecordType: "A", Labels: labels},
+			{DNSName: "foo", Targets: defaultTargetsAAAA, RecordType: "AAAA", Labels: labels},
+			{DNSName: "bar", Targets: defaultTargetsAAAA, RecordType: "AAAA", Labels: labels},
+			{DNSName: "foo", Targets: defaultTargetsCName, RecordType: "CNAME", Labels: labels},
+			{DNSName: "bar", Targets: defaultTargetsCName, RecordType: "CNAME", Labels: labels},
+		}
 
-	// Create a mocked source returning source targets
-	src := new(testutils.MockSource)
-	src.On("Endpoints").Return(sourceEndpoints, nil)
+		src := new(testutils.MockSource)
+		src.On("Endpoints").Return(sourceEndpoints, nil)
 
-	// Create our object under test with non-empty defaultTargets and get the endpoints.
-	source := NewMultiSource([]Source{src}, defaultTargets)
+		// Test with forceDefaultTargets=false (default behavior)
+		source := NewMultiSource([]Source{src}, defaultTargets, false)
 
-	// Get endpoints from our source.
-	endpoints, err := source.Endpoints(context.Background())
-	require.NoError(t, err)
+		endpoints, err := source.Endpoints(context.Background())
+		require.NoError(t, err)
 
-	// Validate returned endpoints against desired endpoints.
-	validateEndpoints(t, endpoints, expectedEndpoints)
+		validateEndpoints(t, endpoints, expectedEndpoints)
 
-	// Validate that the nested sources were called.
-	src.AssertExpectations(t)
+		src.AssertExpectations(t)
+	})
+
+	t.Run("Defaults NOT applied when source targets exist", func(t *testing.T) {
+		defaultTargets := []string{"127.0.0.1"} // Default target
+		labels := endpoint.Labels{"foo": "bar"}
+
+		// Endpoints FROM SOURCE HAVE targets
+		sourceEndpoints := []*endpoint.Endpoint{
+			{DNSName: "foo", Targets: endpoint.Targets{"8.8.8.8"}, Labels: labels},
+			{DNSName: "bar", Targets: endpoint.Targets{"8.8.4.4"}, Labels: labels},
+		}
+
+		// Expected endpoints SHOULD MATCH the source endpoints (defaults ignored)
+		expectedEndpoints := []*endpoint.Endpoint{
+			{DNSName: "foo", Targets: endpoint.Targets{"8.8.8.8"}, Labels: labels},
+			{DNSName: "bar", Targets: endpoint.Targets{"8.8.4.4"}, Labels: labels},
+		}
+
+		src := new(testutils.MockSource)
+		src.On("Endpoints").Return(sourceEndpoints, nil)
+
+		// Test with forceDefaultTargets=false (default behavior)
+		source := NewMultiSource([]Source{src}, defaultTargets, false)
+
+		endpoints, err := source.Endpoints(context.Background())
+		require.NoError(t, err)
+
+		validateEndpoints(t, endpoints, expectedEndpoints)
+
+		src.AssertExpectations(t)
+	})
+
+	t.Run("Defaults forced when source targets exist and flag is set", func(t *testing.T) {
+		defaultTargetsA := []string{"127.0.0.1", "127.0.0.2"}
+		defaultTargetsAAAA := []string{"2001:db8::1"}
+		defaultTargetsCName := []string{"foo.example.org"}
+		defaultTargets := append(defaultTargetsA, defaultTargetsCName...)
+		defaultTargets = append(defaultTargets, defaultTargetsAAAA...)
+		labels := endpoint.Labels{"foo": "bar"}
+
+		// Endpoints FROM SOURCE HAVE targets
+		sourceEndpoints := []*endpoint.Endpoint{
+			{DNSName: "foo", Targets: endpoint.Targets{"8.8.8.8"}, Labels: labels},
+			{DNSName: "bar", Targets: endpoint.Targets{"8.8.4.4"}, Labels: labels},
+		}
+
+		// Expected endpoints SHOULD HAVE the default targets applied (old behavior)
+		expectedEndpoints := []*endpoint.Endpoint{
+			{DNSName: "foo", Targets: defaultTargetsA, RecordType: "A", Labels: labels},
+			{DNSName: "bar", Targets: defaultTargetsA, RecordType: "A", Labels: labels},
+			{DNSName: "foo", Targets: defaultTargetsAAAA, RecordType: "AAAA", Labels: labels},
+			{DNSName: "bar", Targets: defaultTargetsAAAA, RecordType: "AAAA", Labels: labels},
+			{DNSName: "foo", Targets: defaultTargetsCName, RecordType: "CNAME", Labels: labels},
+			{DNSName: "bar", Targets: defaultTargetsCName, RecordType: "CNAME", Labels: labels},
+		}
+
+		src := new(testutils.MockSource)
+		src.On("Endpoints").Return(sourceEndpoints, nil)
+
+		// Test with forceDefaultTargets=true (legacy behavior)
+		source := NewMultiSource([]Source{src}, defaultTargets, true)
+
+		endpoints, err := source.Endpoints(context.Background())
+		require.NoError(t, err)
+
+		validateEndpoints(t, endpoints, expectedEndpoints)
+
+		src.AssertExpectations(t)
+	})
 }


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

⚠️ BREAKING CHANGE, but with mitigation strategy.

Improved `default-targets` behavior to allow empty CRD `targets` section in case default targets are set. Default targets are overridden if it's set anywhere else. Since it introduces breaking change in situations where targets are set, we offer `force-default-targets` flag to keep current behavior (hopefully easing migration).

Breaking change should be stated in release documentation.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #3163

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
