### PR TITLE
feat(gateway-api): add ability to override target on *Route resources

### DIFF
--- a/docs/sources/gateway.md
+++ b/docs/sources/gateway.md
@@ -106,10 +106,12 @@ Iterates over all listeners for the parent's `parentRef.sectionName`:
 
 The targets of the DNS entries created from a \*Route are sourced from the following places:
 
-1. If a matching parent Gateway has an `external-dns.alpha.kubernetes.io/target` annotation, uses
-   the values from that.
+1. If a matching parent Gateway has the `external-dns.alpha.kubernetes.io/target` annotation, uses
+   the values from that unless the route has the `external-dns.alpha.kubernetes.io/target: ""` annotation in which case it iterates over that parent Gateway's `status.addresses` adding each address's `value`.
 
-2. Otherwise, iterates over that parent Gateway's `status.addresses`,
+2. If the route has the route has the `external-dns.alpha.kubernetes.io/target` annotation with a non-empty value, uses the value from that.
+
+3. Otherwise, iterates over that parent Gateway's `status.addresses`,
    adding each address's `value`.
 
 The targets from each parent Gateway matching the \*Route are then combined and de-duplicated.

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -373,7 +373,15 @@ func (c *gatewayRouteResolver) resolve(rt gatewayRoute) (map[string]endpoint.Tar
 				if !ok {
 					continue
 				}
-				override := getTargetsFromTargetAnnotation(gw.gateway.Annotations)
+				var override endpoint.Targets
+				targetAnnotation, exists := meta.Annotations[targetAnnotationKey]
+				if exists && targetAnnotation != "" {
+					override = getTargetsFromTargetAnnotation(meta.Annotations)
+					hostTargets[host] = append(hostTargets[host], override...)
+				} else if !exists {
+					override = getTargetsFromTargetAnnotation(gw.gateway.Annotations)
+					hostTargets[host] = append(hostTargets[host], override...)
+				}
 				hostTargets[host] = append(hostTargets[host], override...)
 				if len(override) == 0 {
 					for _, addr := range gw.gateway.Status.Addresses {

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -1296,6 +1296,144 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			},
 		},
 		{
+			title: "RouteAnnotationOverride",
+			config: Config{
+				GatewayNamespace: "gateway-namespace",
+			},
+			namespaces: namespaces("gateway-namespace", "route-namespace"),
+			gateways: []*v1beta1.Gateway{
+				{
+					ObjectMeta: objectMeta("gateway-namespace", "test"),
+					Spec: v1.GatewaySpec{
+						Listeners: []v1.Listener{{
+							Protocol:      v1.HTTPProtocolType,
+							AllowedRoutes: allowAllNamespaces,
+						}},
+					},
+					Status: gatewayStatus("1.2.3.4"),
+				},
+			},
+			routes: []*v1beta1.HTTPRoute{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "route-namespace",
+					Annotations: map[string]string{
+						targetAnnotationKey: "4.3.2.1",
+					},
+				},
+				Spec: v1.HTTPRouteSpec{
+					Hostnames: hostnames("test.example.internal"),
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("gateway-namespace", "test"),
+						},
+					},
+				},
+				Status: httpRouteStatus(
+					gwParentRef("gateway-namespace", "test"),
+				),
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("test.example.internal", "A", "4.3.2.1"),
+			},
+		},
+		{
+			title: "RouteAnnotationGatewayOverride",
+			config: Config{
+				GatewayNamespace: "gateway-namespace",
+			},
+			namespaces: namespaces("gateway-namespace", "route-namespace"),
+			gateways: []*v1beta1.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "overriden-gateway",
+						Namespace: "gateway-namespace",
+						Annotations: map[string]string{
+							targetAnnotationKey: "4.3.2.1",
+						},
+					},
+					Spec: v1.GatewaySpec{
+						Listeners: []v1.Listener{{
+							Protocol:      v1.HTTPProtocolType,
+							AllowedRoutes: allowAllNamespaces,
+						}},
+					},
+					Status: gatewayStatus("1.2.3.4"),
+				},
+			},
+			routes: []*v1beta1.HTTPRoute{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "route-namespace",
+					Annotations: map[string]string{
+						targetAnnotationKey: "2.3.4.5",
+					},
+				},
+				Spec: v1.HTTPRouteSpec{
+					Hostnames: hostnames("test.example.internal"),
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("gateway-namespace", "overriden-gateway"),
+						},
+					},
+				},
+				Status: httpRouteStatus(
+					gwParentRef("gateway-namespace", "overriden-gateway"),
+				),
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("test.example.internal", "A", "2.3.4.5"),
+			},
+		},
+		{
+			title: "RouteAnnotationGatewayOverrideEmpty",
+			config: Config{
+				GatewayNamespace: "gateway-namespace",
+			},
+			namespaces: namespaces("gateway-namespace", "route-namespace"),
+			gateways: []*v1beta1.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "overriden-gateway",
+						Namespace: "gateway-namespace",
+						Annotations: map[string]string{
+							targetAnnotationKey: "4.3.2.1",
+						},
+					},
+					Spec: v1.GatewaySpec{
+						Listeners: []v1.Listener{{
+							Protocol:      v1.HTTPProtocolType,
+							AllowedRoutes: allowAllNamespaces,
+						}},
+					},
+					Status: gatewayStatus("1.2.3.4"),
+				},
+			},
+			routes: []*v1beta1.HTTPRoute{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "route-namespace",
+					Annotations: map[string]string{
+						targetAnnotationKey: "",
+					},
+				},
+				Spec: v1.HTTPRouteSpec{
+					Hostnames: hostnames("test.example.internal"),
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("gateway-namespace", "overriden-gateway"),
+						},
+					},
+				},
+				Status: httpRouteStatus(
+					gwParentRef("gateway-namespace", "overriden-gateway"),
+				),
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("test.example.internal", "A", "1.2.3.4"),
+			},
+		},
+		{
 			title: "MutlipleGatewaysOneAnnotationOverride",
 			config: Config{
 				GatewayNamespace: "gateway-namespace",


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR adds the ability to use the `external-dns.alpha.kubernetes.io/target` annotation on *Route (like HTTPRoute) resources to override the target coming from the Gateway. A special case is included where if the gateway also includes the `external-dns.alpha.kubernetes.io/target` annotation and the *Route has the `external-dns.alpha.kubernetes.io/target` set to `""` the target annotation from the Gateway isn't used and the normal flow gathering the listener address from the gateway is used.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #4779

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
