### PR TITLE
chore(code-quality): providers linter warnings fixes

### DIFF
--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -51,11 +51,12 @@ const (
 // We have to use pointers to bools now, as the upstream cloudflare-go library requires them
 // see: https://github.com/cloudflare/cloudflare-go/pull/595
 
-// proxyEnabled is a pointer to a bool true showing the record should be proxied through cloudflare
-var proxyEnabled *bool = boolPtr(true)
-
-// proxyDisabled is a pointer to a bool false showing the record should not be proxied through cloudflare
-var proxyDisabled *bool = boolPtr(false)
+var (
+	// proxyEnabled is a pointer to a bool true showing the record should be proxied through cloudflare
+	proxyEnabled *bool = boolPtr(true)
+	// proxyDisabled is a pointer to a bool false showing the record should not be proxied through cloudflare
+	proxyDisabled *bool = boolPtr(false)
+)
 
 // for faster getRecordID() lookup
 type DNSRecordIndex struct {
@@ -279,8 +280,8 @@ func NewCloudFlareProvider(domainFilter endpoint.DomainFilter, zoneIDFilter prov
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize cloudflare provider: %w", err)
 	}
-	provider := &CloudFlareProvider{
-		// Client: config,
+
+	return &CloudFlareProvider{
 		Client:                zoneService{config},
 		domainFilter:          domainFilter,
 		zoneIDFilter:          zoneIDFilter,
@@ -289,13 +290,12 @@ func NewCloudFlareProvider(domainFilter endpoint.DomainFilter, zoneIDFilter prov
 		DryRun:                dryRun,
 		DNSRecordsPerPage:     dnsRecordsPerPage,
 		RegionKey:             regionKey,
-	}
-	return provider, nil
+	}, nil
 }
 
 // Zones returns the list of hosted zones.
 func (p *CloudFlareProvider) Zones(ctx context.Context) ([]cloudflare.Zone, error) {
-	result := []cloudflare.Zone{}
+	var result []cloudflare.Zone
 
 	// if there is a zoneIDfilter configured
 	// && if the filter isn't just a blank string (used in tests)
@@ -349,7 +349,7 @@ func (p *CloudFlareProvider) Records(ctx context.Context) ([]*endpoint.Endpoint,
 		return nil, err
 	}
 
-	endpoints := []*endpoint.Endpoint{}
+	var endpoints []*endpoint.Endpoint
 	for _, zone := range zones {
 		records, err := p.listDNSRecordsWithAutoPagination(ctx, zone.ID)
 		if err != nil {
@@ -373,7 +373,7 @@ func (p *CloudFlareProvider) Records(ctx context.Context) ([]*endpoint.Endpoint,
 
 // ApplyChanges applies a given set of changes in a given zone.
 func (p *CloudFlareProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
-	cloudflareChanges := []*cloudFlareChange{}
+	var cloudflareChanges []*cloudFlareChange
 
 	// if custom hostnames are enabled, deleting first allows to avoid conflicts with the new ones
 	if p.CustomHostnamesConfig.Enabled {
@@ -425,7 +425,7 @@ func (p *CloudFlareProvider) submitCustomHostnameChanges(ctx context.Context, zo
 	failedChange := false
 	// return early if disabled
 	if !p.CustomHostnamesConfig.Enabled {
-		return !failedChange
+		return true
 	}
 
 	switch change.Action {
@@ -730,7 +730,7 @@ func (p *CloudFlareProvider) submitChanges(ctx context.Context, changes []*cloud
 
 // AdjustEndpoints modifies the endpoints as needed by the specific provider
 func (p *CloudFlareProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
-	adjustedEndpoints := []*endpoint.Endpoint{}
+	var adjustedEndpoints []*endpoint.Endpoint
 	for _, e := range endpoints {
 		proxied := shouldBeProxied(e, p.proxiedByDefault)
 		if proxied {
@@ -969,7 +969,7 @@ func getEndpointCustomHostnames(ep *endpoint.Endpoint) []string {
 }
 
 func groupByNameAndTypeWithCustomHostnames(records DNSRecordsMap, chs CustomHostnamesMap) []*endpoint.Endpoint {
-	endpoints := []*endpoint.Endpoint{}
+	var endpoints []*endpoint.Endpoint
 
 	// group supported records by name and type
 	groups := map[string][]cloudflare.DNSRecord{}
@@ -994,7 +994,7 @@ func groupByNameAndTypeWithCustomHostnames(records DNSRecordsMap, chs CustomHost
 		customHostnames[c.CustomOriginServer] = append(customHostnames[c.CustomOriginServer], c.Hostname)
 	}
 
-	// create single endpoint with all the targets for each name/type
+	// create a single endpoint with all the targets for each name/type
 	for _, records := range groups {
 		if len(records) == 0 {
 			return endpoints
@@ -1016,7 +1016,7 @@ func groupByNameAndTypeWithCustomHostnames(records DNSRecordsMap, chs CustomHost
 			continue
 		}
 		e = e.WithProviderSpecific(source.CloudflareProxiedKey, strconv.FormatBool(proxied))
-		// noop (customHostnames is empty) if custom hostnames feature is not in use
+		// noop (customHostnames is empty) if the custom hostnames feature is not in use
 		if customHostnames, ok := customHostnames[records[0].Name]; ok {
 			sort.Strings(customHostnames)
 			e = e.WithProviderSpecific(source.CloudflareCustomHostnameKey, strings.Join(customHostnames, ","))

--- a/provider/coredns/coredns.go
+++ b/provider/coredns/coredns.go
@@ -92,7 +92,7 @@ type etcdClient struct {
 
 var _ coreDNSClient = etcdClient{}
 
-// GetService return all Service records stored in etcd stored anywhere under the given key (recursively)
+// GetServices GetService return all Service records stored in etcd stored anywhere under the given key (recursively)
 func (c etcdClient) GetServices(prefix string) ([]*Service, error) {
 	ctx, cancel := context.WithTimeout(c.ctx, etcdTimeout)
 	defer cancel()

--- a/provider/dnsimple/dnsimple.go
+++ b/provider/dnsimple/dnsimple.go
@@ -33,7 +33,13 @@ import (
 	"sigs.k8s.io/external-dns/provider"
 )
 
-const dnsimpleRecordTTL = 3600 // Default TTL of 1 hour if not set (DNSimple's default)
+const (
+	dnsimpleCreate = "CREATE"
+	dnsimpleDelete = "DELETE"
+	dnsimpleUpdate = "UPDATE"
+
+	dnsimpleRecordTTL = 3600 // Default TTL of 1 hour if not set (DNSimple's default)
+)
 
 type dnsimpleIdentityService struct {
 	service *dnsimple.IdentityService
@@ -91,12 +97,6 @@ type dnsimpleChange struct {
 	ResourceRecordSet dnsimple.ZoneRecord
 }
 
-const (
-	dnsimpleCreate = "CREATE"
-	dnsimpleDelete = "DELETE"
-	dnsimpleUpdate = "UPDATE"
-)
-
 // NewDnsimpleProvider initializes a new Dnsimple based provider
 func NewDnsimpleProvider(domainFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, dryRun bool) (provider.Provider, error) {
 	oauthToken := os.Getenv("DNSIMPLE_OAUTH")
@@ -149,7 +149,7 @@ func ZonesFromZoneString(zonestring string) map[string]dnsimple.Zone {
 	return zones
 }
 
-// Returns a list of filtered Zones
+// Zones Return a list of filtered Zones
 func (p *dnsimpleProvider) Zones(ctx context.Context) (map[string]dnsimple.Zone, error) {
 	zones := make(map[string]dnsimple.Zone)
 

--- a/provider/exoscale/exoscale.go
+++ b/provider/exoscale/exoscale.go
@@ -181,7 +181,7 @@ func (ep *ExoscaleProvider) ApplyChanges(ctx context.Context, changes *plan.Chan
 	}
 
 	for _, epoint := range changes.UpdateOld {
-		// Since Exoscale "Patches", we ignore UpdateOld
+		// Since Exoscale "Patches", we've ignored UpdateOld
 		// We leave this logging here for information
 		log.Debugf("UPDATE-OLD (ignored) for epoint: %+v", epoint)
 	}

--- a/provider/godaddy/client.go
+++ b/provider/godaddy/client.go
@@ -34,17 +34,15 @@ import (
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 )
 
-// DefaultTimeout api requests after 180s
-const DefaultTimeout = 180 * time.Second
-
 // Errors
 var (
 	ErrAPIDown = errors.New("godaddy: the GoDaddy API is down")
 )
 
-// error codes
 const (
 	ErrCodeQuotaExceeded = "QUOTA_EXCEEDED"
+	// DefaultTimeout api requests after 180s
+	DefaultTimeout = 180 * time.Second
 )
 
 // APIError error

--- a/provider/godaddy/godaddy.go
+++ b/provider/godaddy/godaddy.go
@@ -36,6 +36,8 @@ const (
 	gdCreate     = 0
 	gdReplace    = 1
 	gdDelete     = 2
+
+	domainsURI = "/v1/domains?statuses=ACTIVE,PENDING_DNS_ACTIVE"
 )
 
 var actionNames = []string{
@@ -43,8 +45,6 @@ var actionNames = []string{
 	"replace",
 	"delete",
 }
-
-const domainsURI = "/v1/domains?statuses=ACTIVE,PENDING_DNS_ACTIVE"
 
 type gdClient interface {
 	Patch(string, interface{}, interface{}) error

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -154,7 +154,7 @@ func NewGoogleProvider(ctx context.Context, project string, domainFilter endpoin
 
 	zoneTypeFilter := provider.NewZoneTypeFilter(zoneVisibility)
 
-	provider := &GoogleProvider{
+	return &GoogleProvider{
 		project:                  project,
 		dryRun:                   dryRun,
 		batchChangeSize:          batchChangeSize,
@@ -166,9 +166,7 @@ func NewGoogleProvider(ctx context.Context, project string, domainFilter endpoin
 		managedZonesClient:       managedZonesService{dnsClient.ManagedZones},
 		changesClient:            changesService{dnsClient.Changes},
 		ctx:                      ctx,
-	}
-
-	return provider, nil
+	}, nil
 }
 
 // Zones returns the list of hosted zones.
@@ -261,11 +259,11 @@ func (p *GoogleProvider) SupportedRecordType(recordType string) bool {
 
 // newFilteredRecords returns a collection of RecordSets based on the given endpoints and domainFilter.
 func (p *GoogleProvider) newFilteredRecords(endpoints []*endpoint.Endpoint) []*dns.ResourceRecordSet {
-	records := []*dns.ResourceRecordSet{}
+	var records []*dns.ResourceRecordSet
 
-	for _, endpoint := range endpoints {
-		if p.domainFilter.Match(endpoint.DNSName) {
-			records = append(records, newRecord(endpoint))
+	for _, ep := range endpoints {
+		if p.domainFilter.Match(ep.DNSName) {
+			records = append(records, newRecord(ep))
 		}
 	}
 
@@ -314,7 +312,7 @@ func (p *GoogleProvider) submitChange(ctx context.Context, change *dns.Change) e
 
 // batchChange separates a zone in multiple transaction.
 func batchChange(change *dns.Change, batchSize int) []*dns.Change {
-	changes := []*dns.Change{}
+	var changes []*dns.Change
 
 	if batchSize == 0 {
 		return append(changes, change)

--- a/provider/ibmcloud/ibmcloud.go
+++ b/provider/ibmcloud/ibmcloud.go
@@ -322,7 +322,7 @@ func NewIBMCloudProvider(configFile string, domainFilter endpoint.DomainFilter, 
 		return nil, err
 	}
 
-	provider := &IBMCloudProvider{
+	return &IBMCloudProvider{
 		Client:           client,
 		source:           source,
 		domainFilter:     domainFilter,
@@ -331,8 +331,7 @@ func NewIBMCloudProvider(configFile string, domainFilter endpoint.DomainFilter, 
 		privateZone:      isPrivate,
 		proxiedByDefault: proxiedByDefault,
 		DryRun:           dryRun,
-	}
-	return provider, nil
+	}, nil
 }
 
 // Records gets the current records.
@@ -680,8 +679,8 @@ func (p *IBMCloudProvider) privateRecords(ctx context.Context) ([]*endpoint.Endp
 		return nil, err
 	}
 	// Filter VPC annoation for private zone active
-	for _, source := range sources {
-		vpc = checkVPCAnnotation(source)
+	for _, src := range sources {
+		vpc = checkVPCAnnotation(src)
 		if len(vpc) > 0 {
 			log.Debugf("VPC found: %s", vpc)
 			break
@@ -984,7 +983,7 @@ func checkVPCAnnotation(endpoint *endpoint.Endpoint) string {
 	for _, v := range endpoint.ProviderSpecific {
 		if v.Name == vpcFilter {
 			vpcCrn, err := crn.Parse(v.Value)
-			if vpcCrn.ResourceType != "vpc" || err != nil {
+			if err != nil || vpcCrn.ResourceType != "vpc" {
 				log.Errorf("Failed to parse vpc [%s]: %v", v.Value, err)
 			} else {
 				vpc = v.Value
@@ -1002,6 +1001,7 @@ func isNil(i interface{}) bool {
 	switch reflect.TypeOf(i).Kind() {
 	case reflect.Ptr, reflect.Map, reflect.Array, reflect.Chan, reflect.Slice:
 		return reflect.ValueOf(i).IsNil()
+	default:
+		return false
 	}
-	return false
 }

--- a/provider/linode/linode.go
+++ b/provider/linode/linode.go
@@ -96,15 +96,14 @@ func NewLinodeProvider(domainFilter endpoint.DomainFilter, dryRun bool) (*Linode
 	linodeClient := linodego.NewClient(oauth2Client)
 	linodeClient.SetUserAgent(fmt.Sprintf("%s linodego/%s", externaldns.UserAgent(), linodego.Version))
 
-	provider := &LinodeProvider{
+	return &LinodeProvider{
 		Client:       &linodeClient,
 		domainFilter: domainFilter,
 		DryRun:       dryRun,
-	}
-	return provider, nil
+	}, nil
 }
 
-// Zones returns the list of hosted zones.
+// Zones return the list of hosted zones.
 func (p *LinodeProvider) Zones(ctx context.Context) ([]linodego.Domain, error) {
 	zones, err := p.fetchZones(ctx)
 	if err != nil {

--- a/provider/ns1/ns1.go
+++ b/provider/ns1/ns1.go
@@ -136,13 +136,12 @@ func newNS1ProviderWithHTTPClient(config NS1Config, client *http.Client) (*NS1Pr
 
 	apiClient := api.NewClient(client, clientArgs...)
 
-	provider := &NS1Provider{
+	return &NS1Provider{
 		client:        NS1DomainService{apiClient},
 		domainFilter:  config.DomainFilter,
 		zoneIDFilter:  config.ZoneIDFilter,
 		minTTLSeconds: config.MinTTLSeconds,
-	}
-	return provider, nil
+	}, nil
 }
 
 // Records returns the endpoints this provider knows about
@@ -257,7 +256,7 @@ func (p *NS1Provider) zonesFiltered() ([]*dns.Zone, error) {
 		return nil, err
 	}
 
-	toReturn := []*dns.Zone{}
+	var toReturn []*dns.Zone
 
 	for _, z := range zones {
 		if p.domainFilter.Match(z.Zone) && p.zoneIDFilter.Match(z.ID) {
@@ -292,10 +291,10 @@ func (p *NS1Provider) ApplyChanges(ctx context.Context, changes *plan.Changes) e
 func newNS1Changes(action string, endpoints []*endpoint.Endpoint) []*ns1Change {
 	changes := make([]*ns1Change, 0, len(endpoints))
 
-	for _, endpoint := range endpoints {
+	for _, ep := range endpoints {
 		changes = append(changes, &ns1Change{
 			Action:   action,
-			Endpoint: endpoint,
+			Endpoint: ep,
 		},
 		)
 	}

--- a/provider/oci/oci.go
+++ b/provider/oci/oci.go
@@ -186,13 +186,13 @@ func mergeEndpointsMultiTargets(endpoints []*endpoint.Endpoint) []*endpoint.Endp
 
 	// Otherwise, create a new list of endpoints with the consolidated targets.
 	var mergedEndpoints []*endpoint.Endpoint
-	for _, endpoints := range endpointsByNameType {
-		dnsName := endpoints[0].DNSName
-		recordType := endpoints[0].RecordType
-		recordTTL := endpoints[0].RecordTTL
+	for _, ep := range endpointsByNameType {
+		dnsName := ep[0].DNSName
+		recordType := ep[0].RecordType
+		recordTTL := ep[0].RecordTTL
 
-		targets := make([]string, len(endpoints))
-		for i, e := range endpoints {
+		targets := make([]string, len(ep))
+		for i, e := range ep {
 			targets[i] = e.Targets[0]
 		}
 

--- a/provider/ovh/ovh.go
+++ b/provider/ovh/ovh.go
@@ -324,9 +324,9 @@ func (p *OVHProvider) change(ctx context.Context, change ovhChange) error {
 			return nil
 		}
 		return p.client.PutWithContext(ctx, fmt.Sprintf("/domain/zone/%s/record/%d", url.PathEscape(change.Zone), change.ID), change.ovhRecordFieldUpdate, nil)
+	default:
+		return nil
 	}
-
-	return nil
 }
 
 func (p *OVHProvider) invalidateCache(zone string) {
@@ -357,8 +357,8 @@ func (p *OVHProvider) zonesRecords(ctx context.Context) ([]string, []ovhRecord, 
 }
 
 func (p *OVHProvider) zones(ctx context.Context) ([]string, error) {
-	zones := []string{}
-	filteredZones := []string{}
+	var zones []string
+	var filteredZones []string
 
 	p.apiRateLimiter.Take()
 	if err := p.client.GetWithContext(ctx, "/domain/zone", &zones); err != nil {
@@ -476,25 +476,25 @@ func ovhGroupByNameAndType(records []ovhRecord) []*endpoint.Endpoint {
 
 	// create single endpoint with all the targets for each name/type
 	for _, records := range groups {
-		targets := []string{}
+		var targets []string
 		for _, record := range records {
 			targets = append(targets, record.Target)
 		}
-		endpoint := endpoint.NewEndpointWithTTL(
+		ep := endpoint.NewEndpointWithTTL(
 			strings.TrimPrefix(records[0].SubDomain+"."+records[0].Zone, "."),
 			records[0].FieldType,
 			endpoint.TTL(records[0].TTL),
 			targets...,
 		)
-		endpoints = append(endpoints, endpoint)
+		endpoints = append(endpoints, ep)
 	}
 
 	return endpoints
 }
 
 func (p OVHProvider) newOvhChangeCreateDelete(action int, endpoints []*endpoint.Endpoint, zone string, existingRecords []ovhRecord) ([]ovhChange, []ovhRecord) {
-	ovhChanges := []ovhChange{}
-	toDeleteIds := []int{}
+	var ovhChanges []ovhChange
+	var toDeleteIds []int
 
 	for _, e := range endpoints {
 		for _, target := range e.Targets {
@@ -579,13 +579,13 @@ func (p OVHProvider) newOvhChangeUpdate(endpointsOld []*endpoint.Endpoint, endpo
 		}
 	}
 
-	changes := []ovhChange{}
+	var changes []ovhChange
 
 	for id := range oldEndpointByTypeAndName {
 		oldRecords := slices.Clone(oldRecordsInZone[id])
 		endpointsNew := newEndpointByTypeAndName[id]
 
-		toInsertTarget := []string{}
+		var toInsertTarget []string
 
 		for _, target := range endpointsNew.Targets {
 			var toDelete = -1

--- a/provider/plural/plural.go
+++ b/provider/plural/plural.go
@@ -45,7 +45,6 @@ type RecordChange struct {
 
 func NewPluralProvider(cluster, provider string) (*PluralProvider, error) {
 	token := os.Getenv("PLURAL_ACCESS_TOKEN")
-	endpoint := os.Getenv("PLURAL_ENDPOINT")
 
 	if token == "" {
 		return nil, fmt.Errorf("no plural access token provided, you must set the PLURAL_ACCESS_TOKEN env var")
@@ -53,21 +52,19 @@ func NewPluralProvider(cluster, provider string) (*PluralProvider, error) {
 
 	config := &Config{
 		Token:    token,
-		Endpoint: endpoint,
+		Endpoint: os.Getenv("PLURAL_ENDPOINT"),
 		Cluster:  cluster,
 		Provider: provider,
 	}
 
-	client, err := NewClient(config)
+	cl, err := NewClient(config)
 	if err != nil {
 		return nil, err
 	}
 
-	prov := &PluralProvider{
-		Client: client,
-	}
-
-	return prov, nil
+	return &PluralProvider{
+		Client: cl,
+	}, nil
 }
 
 func (p *PluralProvider) Records(_ context.Context) (endpoints []*endpoint.Endpoint, err error) {
@@ -89,8 +86,8 @@ func (p *PluralProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*end
 
 func (p *PluralProvider) ApplyChanges(_ context.Context, diffs *plan.Changes) error {
 	var changes []*RecordChange
-	for _, endpoint := range diffs.Create {
-		changes = append(changes, makeChange(CreateAction, endpoint.Targets, endpoint))
+	for _, ep := range diffs.Create {
+		changes = append(changes, makeChange(CreateAction, ep.Targets, ep))
 	}
 
 	for _, desired := range diffs.UpdateNew {

--- a/provider/tencentcloud/tencent_cloud_test.go
+++ b/provider/tencentcloud/tencent_cloud_test.go
@@ -32,8 +32,6 @@ import (
 
 func NewMockTencentCloudProvider(domainFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, zoneType string) *TencentCloudProvider {
 	cfg := tencentCloudConfig{
-		// SecretId:  "",
-		// SecretKey: "",
 		RegionId: "ap-shanghai",
 		VPCId:    "vpc-abcdefg",
 	}

--- a/provider/ultradns/ultradns.go
+++ b/provider/ultradns/ultradns.go
@@ -39,22 +39,19 @@ const (
 	rdPoolOrder    = "ROUND_ROBIN"
 )
 
-// global variables
-var sbPoolRunProbes = true
-
 var (
 	sbPoolActOnProbes = true
 	ultradnsPoolType  = "rdpool"
 	accountName       string
+	sbPoolRunProbes   = true
+	// Setting custom headers for ultradns api calls
+	customHeader = []udnssdk.CustomHeader{
+		{
+			Key:   "UltraClient",
+			Value: "kube-client",
+		},
+	}
 )
-
-// Setting custom headers for ultradns api calls
-var customHeader = []udnssdk.CustomHeader{
-	{
-		Key:   "UltraClient",
-		Value: "kube-client",
-	},
-}
 
 // UltraDNSProvider struct
 type UltraDNSProvider struct {
@@ -128,13 +125,11 @@ func NewUltraDNSProvider(domainFilter endpoint.DomainFilter, dryRun bool) (*Ultr
 		return nil, fmt.Errorf("connection cannot be established")
 	}
 
-	provider := &UltraDNSProvider{
+	return &UltraDNSProvider{
 		client:       *client,
 		domainFilter: domainFilter,
 		dryRun:       dryRun,
-	}
-
-	return provider, nil
+	}, nil
 }
 
 // Zones returns list of hosted zones
@@ -216,7 +211,7 @@ func (p *UltraDNSProvider) fetchRecords(ctx context.Context, k udnssdk.RRSetKey)
 	maxerrs := 5
 	waittime := 5 * time.Second
 
-	rrsets := []udnssdk.RRSet{}
+	var rrsets []udnssdk.RRSet
 	errcnt := 0
 	offset := 0
 	limit := 1000


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Slicing pull request https://github.com/kubernetes-sigs/external-dns/pull/5312

target is to make sure pull requst 5312 only contain `defaultTTL` changes

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated


Linter warnings

![Screenshot 2025-04-23 at 21 32 26](https://github.com/user-attachments/assets/8c4eec1c-1a72-4630-9458-3bc628050d6a)
![Screenshot 2025-04-23 at 21 32 30](https://github.com/user-attachments/assets/cc21695e-77a5-4039-8195-806f3b9bc324)
![Screenshot 2025-04-23 at 21 35 17](https://github.com/user-attachments/assets/e4645da5-61db-4c60-93df-58bce7c96baa)
![Screenshot 2025-04-23 at 21 35 41](https://github.com/user-attachments/assets/ae47cad4-135a-4aae-bc61-0ff039ff07ab)
![Screenshot 2025-04-23 at 21 44 51](https://github.com/user-attachments/assets/240b2e94-5166-4bf2-8449-ea3bc32dc160)
![Screenshot 2025-04-23 at 21 48 17](https://github.com/user-attachments/assets/b63e65e8-e93e-48bb-8b5a-0d3ca255f593)

