### PR TITLE
docs(contributing): add conventional commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,6 @@ We have full documentation on how to get started contributing here:
 
 This project follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification. The explicit commit history is used, among other things, to provide a readable changelog in release notes.
 
-
 ## Mentorship
 
 - [Mentoring Initiatives](https://git.k8s.io/community/mentoring) - We have a diverse set of mentorship programs available that are always looking for volunteers!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ We have full documentation on how to get started contributing here:
 - [Kubernetes Contributor Guide](https://git.k8s.io/community/contributors/guide) - Main contributor documentation, or you can just jump directly to the [contributing section](https://git.k8s.io/community/contributors/guide#contributing)
 - [Contributor Cheat Sheet](https://git.k8s.io/community/contributors/guide/contributor-cheatsheet) - Common resources for existing developers
 
-This project follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification. The explicit commit history is used, among other things, to provide a readable changelog in release notes.
+This project follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification on PR title. The explicit commit history is used, among other things, to provide a readable changelog in release notes.
 
 ## Mentorship
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,9 @@ We have full documentation on how to get started contributing here:
 - [Kubernetes Contributor Guide](https://git.k8s.io/community/contributors/guide) - Main contributor documentation, or you can just jump directly to the [contributing section](https://git.k8s.io/community/contributors/guide#contributing)
 - [Contributor Cheat Sheet](https://git.k8s.io/community/contributors/guide/contributor-cheatsheet) - Common resources for existing developers
 
+This project follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification. The explicit commit history is used, among other things, to provide a readable changelog in release notes.
+
+
 ## Mentorship
 
 - [Mentoring Initiatives](https://git.k8s.io/community/mentoring) - We have a diverse set of mentorship programs available that are always looking for volunteers!


### PR DESCRIPTION
**Description**

Some contributors are confused with current situation, where we use conventional commits and it's explicitly detailed in contributing guide, see [here](https://github.com/kubernetes-sigs/external-dns/pull/5271#issuecomment-2818655239).

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
