### PR TITLE
test(source): fix data race on node_test

### DIFF
--- a/source/node_test.go
+++ b/source/node_test.go
@@ -97,8 +97,6 @@ func testNodeSourceNewNodeSource(t *testing.T) {
 
 // testNodeSourceEndpoints tests that various node generate the correct endpoints.
 func testNodeSourceEndpoints(t *testing.T) {
-	t.Parallel()
-
 	for _, tc := range []struct {
 		title                string
 		annotationFilter     string
@@ -392,7 +390,6 @@ func testNodeSourceEndpoints(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
 			buf := testutils.LogsToBuffer(log.DebugLevel, t)
 


### PR DESCRIPTION
**Description**

The data race is still here, for example [this fail](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_external-dns/5333/pull-external-dns-unit-test/1916572832632934400) is on a documentation PR.

* With `t.Parallel()`: 2.910s
* Without `t.Parallel()`: 3.052s

This is a second attempt for a simple fix, after #5268,  until we have a better solution on log testing.

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
