### PR TITLE
chore(code-quality): webhook increase code coverage

### DIFF
--- a/provider/webhook/api/httpapi.go
+++ b/provider/webhook/api/httpapi.go
@@ -33,6 +33,9 @@ import (
 const (
 	MediaTypeFormatAndVersion = "application/external.dns.webhook+json;version=1"
 	ContentTypeHeader         = "Content-Type"
+	UrlAdjustEndpoints        = "/adjustendpoints"
+	UrlApplyChanges           = "/applychanges"
+	UrlRecords                = "/records"
 )
 
 type WebhookServer struct {
@@ -121,8 +124,8 @@ func StartHTTPApi(provider provider.Provider, startedChan chan struct{}, readTim
 
 	m := http.NewServeMux()
 	m.HandleFunc("/", p.NegotiateHandler)
-	m.HandleFunc("/records", p.RecordsHandler)
-	m.HandleFunc("/adjustendpoints", p.AdjustEndpointsHandler)
+	m.HandleFunc(UrlRecords, p.RecordsHandler)
+	m.HandleFunc(UrlAdjustEndpoints, p.AdjustEndpointsHandler)
 
 	s := &http.Server{
 		Addr:         providerPort,

--- a/provider/webhook/api/httpapi_test.go
+++ b/provider/webhook/api/httpapi_test.go
@@ -77,7 +77,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestRecordsHandlerRecords(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/records", nil)
+	req := httptest.NewRequest(http.MethodGet, UrlRecords, nil)
 	w := httptest.NewRecorder()
 
 	providerAPIServer := &WebhookServer{
@@ -99,7 +99,7 @@ func TestRecordsHandlerRecords(t *testing.T) {
 }
 
 func TestRecordsHandlerRecordsWithErrors(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/records", nil)
+	req := httptest.NewRequest(http.MethodGet, UrlRecords, nil)
 	w := httptest.NewRecorder()
 
 	providerAPIServer := &WebhookServer{
@@ -139,7 +139,7 @@ func TestRecordsHandlerApplyChangesWithValidRequest(t *testing.T) {
 
 	reader := bytes.NewReader(j)
 
-	req := httptest.NewRequest(http.MethodPost, "/applychanges", reader)
+	req := httptest.NewRequest(http.MethodPost, UrlApplyChanges, reader)
 	w := httptest.NewRecorder()
 
 	providerAPIServer := &WebhookServer{
@@ -165,7 +165,7 @@ func TestRecordsHandlerApplyChangesWithErrors(t *testing.T) {
 
 	reader := bytes.NewReader(j)
 
-	req := httptest.NewRequest(http.MethodPost, "/applychanges", reader)
+	req := httptest.NewRequest(http.MethodPost, UrlApplyChanges, reader)
 	w := httptest.NewRecorder()
 
 	providerAPIServer := &WebhookServer{
@@ -191,7 +191,7 @@ func TestRecordsHandlerWithWrongHTTPMethod(t *testing.T) {
 }
 
 func TestAdjustEndpointsHandlerWithInvalidRequest(t *testing.T) {
-	req := httptest.NewRequest(http.MethodPost, "/adjustendpoints", nil)
+	req := httptest.NewRequest(http.MethodPost, UrlAdjustEndpoints, nil)
 	w := httptest.NewRecorder()
 
 	providerAPIServer := &WebhookServer{
@@ -201,7 +201,7 @@ func TestAdjustEndpointsHandlerWithInvalidRequest(t *testing.T) {
 	res := w.Result()
 	require.Equal(t, http.StatusBadRequest, res.StatusCode)
 
-	req = httptest.NewRequest(http.MethodGet, "/adjustendpoints", nil)
+	req = httptest.NewRequest(http.MethodGet, UrlAdjustEndpoints, nil)
 
 	providerAPIServer.AdjustEndpointsHandler(w, req)
 	res = w.Result()
@@ -222,7 +222,7 @@ func TestAdjustEndpointsHandlerWithValidRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	reader := bytes.NewReader(j)
-	req := httptest.NewRequest(http.MethodPost, "/adjustendpoints", reader)
+	req := httptest.NewRequest(http.MethodPost, UrlAdjustEndpoints, reader)
 	w := httptest.NewRecorder()
 
 	providerAPIServer := &WebhookServer{
@@ -248,7 +248,7 @@ func TestAdjustEndpointsHandlerWithError(t *testing.T) {
 	require.NoError(t, err)
 
 	reader := bytes.NewReader(j)
-	req := httptest.NewRequest(http.MethodPost, "/adjustendpoints", reader)
+	req := httptest.NewRequest(http.MethodPost, UrlAdjustEndpoints, reader)
 	w := httptest.NewRecorder()
 
 	providerAPIServer := &WebhookServer{

--- a/provider/webhook/webhook_test.go
+++ b/provider/webhook/webhook_test.go
@@ -22,14 +22,65 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
 	webhookapi "sigs.k8s.io/external-dns/provider/webhook/api"
 )
+
+func TestNewWebhookProvider_InvalidURL(t *testing.T) {
+	_, err := NewWebhookProvider("://invalid-url")
+	require.Error(t, err)
+}
+
+func TestNewWebhookProvider_HTTPRequestFailure(t *testing.T) {
+	_, err := NewWebhookProvider("http://nonexistent.url")
+	require.Error(t, err)
+}
+
+func TestNewWebhookProvider_InvalidResponseBody(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(webhookapi.ContentTypeHeader, webhookapi.MediaTypeFormatAndVersion)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("invalid-json")) // Invalid JSON
+	}))
+	defer svr.Close()
+
+	_, err := NewWebhookProvider(svr.URL)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to unmarshal response body of DomainFilter")
+}
+
+func TestNewWebhookProvider_Non2XXStatusCode(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer svr.Close()
+
+	_, err := NewWebhookProvider(svr.URL)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "status code < 500")
+}
+
+func TestNewWebhookProvider_WrongContentTypeHeader(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			w.Header().Set(webhookapi.ContentTypeHeader, webhookapi.MediaTypeFormatAndVersion+"wrong")
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+	}))
+	defer svr.Close()
+
+	_, err := NewWebhookProvider(svr.URL)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "wrong content type returned from server")
+}
 
 func TestInvalidDomainFilter(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -108,6 +159,68 @@ func TestRecordsWithErrors(t *testing.T) {
 	require.ErrorIs(t, err, provider.SoftError)
 }
 
+func TestRecords_HTTPRequestErrorMissingHost0(t *testing.T) {
+	wpr := WebhookProvider{
+		remoteServerURL: &url.URL{Scheme: "http", Host: "example\\x00.com", Path: "\\x00"},
+		client:          &http.Client{},
+	}
+
+	_, err := wpr.Records(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid URL escape")
+}
+
+func TestRecords_HTTPRequestErrorMissingHost(t *testing.T) {
+	wpr := WebhookProvider{
+		remoteServerURL: &url.URL{Host: "example.com", Path: "\\x00"},
+		client:          &http.Client{},
+	}
+
+	_, err := wpr.Records(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported protocol scheme")
+}
+
+func TestRecords_DecodeError(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == webhookapi.UrlRecords {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("invalid-json")) // Simulate invalid JSON response
+			return
+		}
+	}))
+	defer svr.Close()
+
+	parsedURL, _ := url.Parse(svr.URL)
+	p := WebhookProvider{
+		remoteServerURL: parsedURL,
+		client:          &http.Client{},
+	}
+
+	_, err := p.Records(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid character 'i' looking for beginning of value")
+}
+
+func TestRecords_NonOKStatusCode(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNetworkAuthenticationRequired)
+		return
+	}))
+	defer svr.Close()
+
+	parsedURL, _ := url.Parse(svr.URL)
+
+	p := WebhookProvider{
+		remoteServerURL: &url.URL{Scheme: parsedURL.Scheme, Host: parsedURL.Host},
+		client:          &http.Client{},
+	}
+
+	_, err := p.Records(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get records with code 511")
+}
+
 func TestApplyChanges(t *testing.T) {
 	successfulApplyChanges := true
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -137,6 +250,49 @@ func TestApplyChanges(t *testing.T) {
 	require.ErrorIs(t, err, provider.SoftError)
 }
 
+func TestApplyChanges_HTTPNewRequestErrorWrongHost(t *testing.T) {
+	wpr := WebhookProvider{
+		remoteServerURL: &url.URL{Host: "exa\\x00mple.com"},
+		client:          &http.Client{},
+	}
+
+	err := wpr.ApplyChanges(context.Background(), nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid URL escape")
+}
+
+func TestApplyChanges_GetFailed(t *testing.T) {
+	p := WebhookProvider{
+		remoteServerURL: &url.URL{Host: "localhost"},
+		client:          &http.Client{},
+	}
+
+	err := p.ApplyChanges(context.TODO(), &plan.Changes{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported protocol scheme")
+}
+
+func TestApplyChanges_StatusCodeError(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			w.Header().Set(webhookapi.ContentTypeHeader, webhookapi.MediaTypeFormatAndVersion)
+			w.Write([]byte(`{}`))
+			return
+		}
+		require.Equal(t, webhookapi.UrlRecords, r.URL.Path)
+		w.WriteHeader(http.StatusNetworkAuthenticationRequired)
+	}))
+	defer svr.Close()
+
+	p, err := NewWebhookProvider(svr.URL)
+	require.NoError(t, err)
+
+	err = p.ApplyChanges(context.TODO(), nil)
+	require.NotNil(t, err)
+	require.NotErrorIs(t, err, provider.SoftError)
+	assert.Contains(t, err.Error(), "failed to apply changes with code 511")
+}
+
 func TestAdjustEndpoints(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/" {
@@ -144,7 +300,7 @@ func TestAdjustEndpoints(t *testing.T) {
 			w.Write([]byte(`{}`))
 			return
 		}
-		require.Equal(t, "/adjustendpoints", r.URL.Path)
+		require.Equal(t, webhookapi.UrlAdjustEndpoints, r.URL.Path)
 
 		var endpoints []*endpoint.Endpoint
 		defer r.Body.Close()
@@ -162,7 +318,6 @@ func TestAdjustEndpoints(t *testing.T) {
 		}
 		j, _ := json.Marshal(endpoints)
 		w.Write(j)
-
 	}))
 	defer svr.Close()
 
@@ -197,7 +352,7 @@ func TestAdjustendpointsWithError(t *testing.T) {
 			w.Write([]byte(`{}`))
 			return
 		}
-		require.Equal(t, "/adjustendpoints", r.URL.Path)
+		require.Equal(t, webhookapi.UrlAdjustEndpoints, r.URL.Path)
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer svr.Close()
@@ -268,4 +423,77 @@ func TestApplyChangesWithProviderSpecificProperty(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+}
+
+func TestAdjustEndpoints_JoinPathError(t *testing.T) {
+	wpr := WebhookProvider{
+		remoteServerURL: &url.URL{Scheme: "http", Host: "example\\x00.com"},
+	}
+
+	_, err := wpr.AdjustEndpoints(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid URL escape")
+}
+
+func TestAdjustEndpoints_HTTPRequestErrorMissingHost(t *testing.T) {
+	wpr := WebhookProvider{
+		remoteServerURL: &url.URL{Host: "example.com", Path: "\\x00"},
+		client:          &http.Client{},
+	}
+
+	_, err := wpr.AdjustEndpoints(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported protocol scheme") // Ensure the "BINGO" log is triggered
+}
+
+func TestAdjustEndpoints_NonOKStatusCode(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNetworkAuthenticationRequired)
+		return
+	}))
+	defer svr.Close()
+
+	parsedURL, _ := url.Parse(svr.URL)
+
+	p := WebhookProvider{
+		remoteServerURL: &url.URL{Scheme: parsedURL.Scheme, Host: parsedURL.Host},
+		client:          &http.Client{},
+	}
+
+	endpoints := []*endpoint.Endpoint{
+		{
+			DNSName:    "test.example.com",
+			RecordTTL:  10,
+			RecordType: "A",
+			Targets:    endpoint.Targets{""},
+		},
+	}
+
+	_, err := p.AdjustEndpoints(endpoints)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to AdjustEndpoints with code  511")
+}
+
+func TestAdjustEndpoints_DecodeError(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == webhookapi.UrlAdjustEndpoints {
+			w.Header().Set(webhookapi.ContentTypeHeader, webhookapi.MediaTypeFormatAndVersion)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("invalid-json")) // Simulate invalid JSON response
+			return
+		}
+	}))
+	defer svr.Close()
+
+	parsedURL, _ := url.Parse(svr.URL)
+	p := WebhookProvider{
+		remoteServerURL: parsedURL,
+		client:          &http.Client{},
+	}
+
+	var endpoints []*endpoint.Endpoint
+
+	_, err := p.AdjustEndpoints(endpoints)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid character 'i' looking for beginning of value")
 }


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
- Increase code coverage for provider/webhook
- use http constants for methods and error codes

Error cases mainly covered. Not error cases could be easy covered, so stopped at 90% coverage

From ~65% to 92%

![Screenshot 2025-04-27 at 23 52 32](https://github.com/user-attachments/assets/215df001-54f0-4b4b-941c-2538ce2fc6ac)

![Screenshot 2025-04-28 at 10 31 17](https://github.com/user-attachments/assets/dc37a72e-765f-452f-b4ee-b62c04533e85)

Follow-up, bump "github.com/cenkalti/backoff/v4" to "github.com/cenkalti/backoff/v5" 


**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
