### PR TITLE
Add support to selectively enable or disable the webhook container

### DIFF
--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -131,6 +131,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | priorityClassName | string | `nil` | Priority class name for the `Pod`. |
 | provider.name | string | `"aws"` | _ExternalDNS_ provider name; for the available providers and how to configure them see [README](https://github.com/kubernetes-sigs/external-dns/blob/master/charts/external-dns/README.md#providers). |
 | provider.webhook.args | list | `[]` | Extra arguments to provide for the `webhook` container. |
+| provider.webhook.enabled | bool | `true` | Enable the `webhook` container. |
 | provider.webhook.env | list | `[]` | [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `webhook` container. |
 | provider.webhook.extraVolumeMounts | list | `[]` | Extra [volume mounts](https://kubernetes.io/docs/concepts/storage/volumes/) for the `webhook` container. |
 | provider.webhook.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the `webhook` container. |

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -170,6 +170,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- if eq $providerName "webhook" }}
+        {{- if .Values.provider.webhook.enabled }}
         {{- with .Values.provider.webhook }}
         - name: webhook
           image: {{ include "external-dns.webhookImage" . }}
@@ -204,6 +205,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- end }}
         {{- end }}
         {{- end }}
       {{- if or .Values.secretConfiguration.enabled .Values.extraVolumes }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -248,6 +248,8 @@ provider:  # @schema type: [object, string];
       tag:  # @schema type:[string, null]; default: null
       # -- Image pull policy for the `webhook` container.
       pullPolicy: IfNotPresent
+    # -- Enable the `webhook` container.
+    enabled: true
     # -- [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `webhook` container.
     env: []
     # -- Extra arguments to provide for the `webhook` container.


### PR DESCRIPTION
**Description**
Currently there is no way to not start a `webhook` container when deploying the chart with `webhook` as a provider. The changes proposed here add an `enabled` boolean to enable starting the container conditionally. Default is set to `true` to keep the default behavior unchanged.

For our site this is helpful as we want to run only one centralized webhook on our intranet for our internal DNS system which has a cumbersome way to renew its access tokens and we have many clusters. Having only one webhook that takes *authenticated* requests from multiple `external-dns` instances on our intranet makes our life easier. Luckily the `--webhook-provider-url` option supports URLs with username:password so we can identify and authenticate requests from multiple instances.

Our current workaround is to start a dummy container that only provides /healthz to have no errors.

**Checklist**

- [ -] Unit tests updated
- [X ] End user documentation updated
