### PR TITLE
Ensure that we only use HTTPRoutes with the latest generation

### DIFF
--- a/source/gateway.go
+++ b/source/gateway.go
@@ -307,7 +307,13 @@ func (c *gatewayRouteResolver) resolve(rt gatewayRoute) (map[string]endpoint.Tar
 	for _, rps := range rt.RouteStatus().Parents {
 		// Confirm the Parent is the standard Gateway kind.
 		ref := rps.ParentRef
+
 		namespace := strVal((*string)(ref.Namespace), meta.Namespace)
+		if rps.Conditions[0].ObservedGeneration != meta.Generation {
+			log.Debugf("Ignoring parent %s/%s of %s/%s as generation %d does not match current generation %d", namespace, ref.Name, meta.Namespace, meta.Name, rps.Conditions[0].ObservedGeneration, meta.Generation)
+			continue
+		}
+
 		// Ensure that the parent reference is in the routeParentRefs list
 		if !gwRouteHasParentRef(routeParentRefs, ref, meta) {
 			log.Debugf("Parent reference %s/%s not found in routeParentRefs for %s %s/%s", namespace, string(ref.Name), c.src.rtKind, meta.Namespace, meta.Name)


### PR DESCRIPTION
**Description**

Adds a check to ensure that the parent of route is the current generation.
Fixes #5348

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
