### PR TITLE
fix(webhook): api json object plan.Changes case

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -54,13 +54,13 @@ type Plan struct {
 // Changes holds lists of actions to be executed by dns providers
 type Changes struct {
 	// Records that need to be created
-	Create []*endpoint.Endpoint
+	Create []*endpoint.Endpoint `json:"create,,omitempty"`
 	// Records that need to be updated (current data)
-	UpdateOld []*endpoint.Endpoint
+	UpdateOld []*endpoint.Endpoint `json:"updateOld,omitempty"`
 	// Records that need to be updated (desired data)
-	UpdateNew []*endpoint.Endpoint
+	UpdateNew []*endpoint.Endpoint `json:"updateNew,omitempty"`
 	// Records that need to be deleted
-	Delete []*endpoint.Endpoint
+	Delete []*endpoint.Endpoint `json:"delete,omitempty"`
 }
 
 // planKey is a key for a row in `planTable`.

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -54,7 +54,7 @@ type Plan struct {
 // Changes holds lists of actions to be executed by dns providers
 type Changes struct {
 	// Records that need to be created
-	Create []*endpoint.Endpoint `json:"create,,omitempty"`
+	Create []*endpoint.Endpoint `json:"create,omitempty"`
 	// Records that need to be updated (current data)
 	UpdateOld []*endpoint.Endpoint `json:"updateOld,omitempty"`
 	// Records that need to be updated (desired data)

--- a/provider/webhook/api/httpapi.go
+++ b/provider/webhook/api/httpapi.go
@@ -85,7 +85,7 @@ func (p *WebhookServer) AdjustEndpointsHandler(w http.ResponseWriter, req *http.
 		return
 	}
 
-	pve := []*endpoint.Endpoint{}
+	var pve []*endpoint.Endpoint
 	if err := json.NewDecoder(req.Body).Decode(&pve); err != nil {
 		log.Errorf("Failed to decode in adjustEndpointsHandler: %v", err)
 		w.WriteHeader(http.StatusBadRequest)
@@ -104,7 +104,7 @@ func (p *WebhookServer) AdjustEndpointsHandler(w http.ResponseWriter, req *http.
 	}
 }
 
-func (p *WebhookServer) NegotiateHandler(w http.ResponseWriter, req *http.Request) {
+func (p *WebhookServer) NegotiateHandler(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set(ContentTypeHeader, MediaTypeFormatAndVersion)
 	json.NewEncoder(w).Encode(p.Provider.GetDomainFilter())
 }

--- a/provider/webhook/webhook.go
+++ b/provider/webhook/webhook.go
@@ -200,7 +200,7 @@ func (p WebhookProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, err
 }
 
 // ApplyChanges will make a POST to remoteServerURL/records with the changes
-func (p WebhookProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
+func (p WebhookProvider) ApplyChanges(_ context.Context, changes *plan.Changes) error {
 	applyChangesRequestsGauge.Gauge.Inc()
 	u := p.remoteServerURL.JoinPath(webhookapi.UrlRecords).String()
 


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #5177 #5110

- In this pull request I've added an explicit support for casing.
- I've also added unit tests for lower and mixed casing

this is a follow up for https://github.com/kubernetes-sigs/external-dns/pull/5337


**Checklist**

- [X] Unit tests updated
- [ ] End user documentation updated
