### PR TITLE
fix(cli): Default `ignore-non-host-network-pods` CLI flag to true.

### DIFF
--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -294,6 +294,7 @@ var defaultConfig = &Config{
 	IgnoreHostnameAnnotation:     false,
 	IgnoreIngressRulesSpec:       false,
 	IgnoreIngressTLSSpec:         false,
+	IgnoreNonHostNetworkPods:     true,
 	IngressClassNames:            nil,
 	InMemoryZones:                []string{},
 	Interval:                     time.Minute,
@@ -473,7 +474,7 @@ func App(cfg *Config) *kingpin.Application {
 	app.Flag("ignore-hostname-annotation", "Ignore hostname annotation when generating DNS names, valid only when --fqdn-template is set (default: false)").BoolVar(&cfg.IgnoreHostnameAnnotation)
 	app.Flag("ignore-ingress-rules-spec", "Ignore the spec.rules section in Ingress resources (default: false)").BoolVar(&cfg.IgnoreIngressRulesSpec)
 	app.Flag("ignore-ingress-tls-spec", "Ignore the spec.tls section in Ingress resources (default: false)").BoolVar(&cfg.IgnoreIngressTLSSpec)
-	app.Flag("ignore-non-host-network-pods", "Ignore pods not running on host network when using pod source (default: true)").BoolVar(&cfg.IgnoreNonHostNetworkPods)
+	app.Flag("ignore-non-host-network-pods", "Ignore pods not running on host network when using pod source (default: true)").Default(strconv.FormatBool(defaultConfig.IgnoreNonHostNetworkPods)).BoolVar(&cfg.IgnoreNonHostNetworkPods)
 	app.Flag("ingress-class", "Require an Ingress to have this class name (defaults to any class; specify multiple times to allow more than one class)").StringsVar(&cfg.IngressClassNames)
 	app.Flag("label-filter", "Filter resources queried for endpoints by label selector; currently supported by source types crd, gateway-httproute, gateway-grpcroute, gateway-tlsroute, gateway-tcproute, gateway-udproute, ingress, node, openshift-route, service and ambassador-host").Default(defaultConfig.LabelFilter).StringVar(&cfg.LabelFilter)
 	managedRecordTypesHelp := fmt.Sprintf("Record types to manage; specify multiple times to include many; (default: %s) (supported records: A, AAAA, CNAME, NS, SRV, TXT)", strings.Join(defaultConfig.ManagedDNSRecordTypes, ","))


### PR DESCRIPTION
**Description**

Flag  `ignore-non-host-network-pod` description and pod source docs say it should be defaulted to true, but it wasn't.

- [ ] Unit tests updated
- [ ] End user documentation updated
