### PR TITLE
feat(pod): respect endpoints-type annotation when used with pod-source-domain flag

### DIFF
--- a/docs/annotations/annotations.md
+++ b/docs/annotations/annotations.md
@@ -4,25 +4,25 @@ ExternalDNS sources support a number of annotations on the Kubernetes resources 
 
 The following table documents which sources support which annotations:
 
-| Source       | controller | hostname | internal-hostname | target  | ttl     | (provider-specific) |
-|--------------|------------|----------|-------------------|---------|---------|---------------------|
-| Ambassador   |            |          |                   | Yes     | Yes     | Yes                 |
-| Connector    |            |          |                   |         |         |                     |
-| Contour      | Yes        | Yes[^1]  |                   | Yes     | Yes     | Yes                 |
-| CloudFoundry |            |          |                   |         |         |                     |
-| CRD          |            |          |                   |         |         |                     |
-| F5           |            |          |                   | Yes     | Yes     |                     |
-| Gateway      | Yes        | Yes[^1]  |                   | Yes[^4] | Yes     | Yes                 |
-| Gloo         |            |          |                   | Yes     | Yes[^5] | Yes[^5]             |
-| Ingress      | Yes        | Yes[^1]  |                   | Yes     | Yes     | Yes                 |
-| Istio        | Yes        | Yes[^1]  |                   | Yes     | Yes     | Yes                 |
-| Kong         |            | Yes[^1]  |                   | Yes     | Yes     | Yes                 |
-| Node         | Yes        |          |                   | Yes     | Yes     |                     |
-| OpenShift    | Yes        | Yes[^1]  |                   | Yes     | Yes     | Yes                 |
-| Pod          |            | Yes      | Yes               | Yes     |         |                     |
-| Service      | Yes        | Yes[^1]  | Yes[^1][^2]       | Yes[^3] | Yes     | Yes                 |
-| Skipper      | Yes        | Yes[^1]  |                   | Yes     | Yes     | Yes                 |
-| Traefik      |            | Yes[^1]  |                   | Yes     | Yes     | Yes                 |
+| Source       | controller | hostname | internal-hostname | target  | ttl     | endpoints-type | (provider-specific) |
+|--------------|------------|----------|-------------------|---------|---------|----------------|---------------------|
+| Ambassador   |            |          |                   | Yes     | Yes     |                | Yes                 |
+| Connector    |            |          |                   |         |         |                |                     |
+| Contour      | Yes        | Yes[^1]  |                   | Yes     | Yes     |                | Yes                 |
+| CloudFoundry |            |          |                   |         |         |                |                     |
+| CRD          |            |          |                   |         |         |                |                     |
+| F5           |            |          |                   | Yes     | Yes     |                |                     |
+| Gateway      | Yes        | Yes[^1]  |                   | Yes[^4] | Yes     |                | Yes                 |
+| Gloo         |            |          |                   | Yes     | Yes[^5] |                | Yes[^5]             |
+| Ingress      | Yes        | Yes[^1]  |                   | Yes     | Yes     |                | Yes                 |
+| Istio        | Yes        | Yes[^1]  |                   | Yes     | Yes     |                | Yes                 |
+| Kong         |            | Yes[^1]  |                   | Yes     | Yes     |                | Yes                 |
+| Node         | Yes        |          |                   | Yes     | Yes     |                |                     |
+| OpenShift    | Yes        | Yes[^1]  |                   | Yes     | Yes     |                | Yes                 |
+| Pod          |            | Yes      | Yes               | Yes     |         | Yes            |                     |
+| Service      | Yes        | Yes[^1]  | Yes[^1][^2]       | Yes[^3] | Yes     | Yes            | Yes                 |
+| Skipper      | Yes        | Yes[^1]  |                   | Yes     | Yes     |                | Yes                 |
+| Traefik      |            | Yes[^1]  |                   | Yes     | Yes     |                | Yes                 |
 
 [^1]: Unless the `--ignore-hostname-annotation` flag is specified.
 [^2]: Only behaves differently than `hostname` for `Service`s of type `ClusterIP` or `LoadBalancer`.

--- a/docs/sources/pod.md
+++ b/docs/sources/pod.md
@@ -10,6 +10,11 @@ By default, the pod source will not consider the pods that aren't running with h
 
 By default, the pod source will look into the pod annotations to find the FQDN associated with a pod. You can also use the option `--pod-source-domain=example.org` to build the FQDN of the pods. The pod named "test-pod" will then be registered as "test-pod.example.org".
 
+Pod annotation `external-dns.alpha.kubernetes.io/endpoints-type` is supported by the pod source. It allows you to specify which type of addresses to use as a target for the DNS entry. The following values are supported:
+- `PodIP`: Use the Pod's `Status.PodIP` as the target. This is a default value if pod annotation is not set.
+- `HostIP`: Use the Pod's `Status.HostIP` as the target.
+- `NodeExternalIP`: Use the Pod's `Node`'s address of type `ExternalIP` plus each IPv6 address of type `InternalIP`.
+
 ## Configuration for registering all pods with their associated PTR record
 
 A use case where combining these options can be pertinent is when you are running on-premise Kubernetes clusters without SNAT enabled for the pod network.

--- a/source/source.go
+++ b/source/source.go
@@ -65,6 +65,7 @@ const (
 const (
 	EndpointsTypeNodeExternalIP = "NodeExternalIP"
 	EndpointsTypeHostIP         = "HostIP"
+	EndpointsTypePodIP          = "PodIP"
 )
 
 // Provider-specific annotations


### PR DESCRIPTION
**Description**

`pod-source-domain` flag makes external-dns to create unique DNS entry per pod. Reuse existing annotation `endpoints-type`, this time on a pod, to define which targets will be used.

This allows creating per-pod DNS name targeting node's external IP.


**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
