### PR TITLE
test(tlsconfig): add unit tests

### DIFF
--- a/pkg/tlsutils/tlsconfig_test.go
+++ b/pkg/tlsutils/tlsconfig_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package tlsutils
 
 import (
@@ -74,7 +90,7 @@ func TestCreateTLSConfig(t *testing.T) {
 			},
 		},
 		{
-			"Valid cert and key return a valid tls.Config with certificates",
+			"Valid cert and key return a valid tls.Config with a certificate",
 			"prefix",
 			"",
 			rsaCertPEM,
@@ -84,7 +100,7 @@ func TestCreateTLSConfig(t *testing.T) {
 			func(actual *tls.Config, err error) {
 				assert.Nil(t, err)
 				assert.Equal(t, actual.ServerName, "server-name")
-				assert.NotNil(t, actual.Certificates)
+				assert.NotNil(t, actual.Certificates[0])
 				assert.Equal(t, actual.InsecureSkipVerify, false)
 				assert.Equal(t, actual.MinVersion, uint16(defaultMinVersion))
 			},

--- a/pkg/tlsutils/tlsconfig_test.go
+++ b/pkg/tlsutils/tlsconfig_test.go
@@ -1,0 +1,131 @@
+package tlsutils
+
+import (
+	"crypto/tls"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/external-dns/internal/gen/docs/utils"
+)
+
+var rsaCertPEM = `-----BEGIN CERTIFICATE-----
+MIIB0zCCAX2gAwIBAgIJAI/M7BYjwB+uMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV
+BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX
+aWRnaXRzIFB0eSBMdGQwHhcNMTIwOTEyMjE1MjAyWhcNMTUwOTEyMjE1MjAyWjBF
+MQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50
+ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANLJ
+hPHhITqQbPklG3ibCVxwGMRfp/v4XqhfdQHdcVfHap6NQ5Wok/4xIA+ui35/MmNa
+rtNuC+BdZ1tMuVCPFZcCAwEAAaNQME4wHQYDVR0OBBYEFJvKs8RfJaXTH08W+SGv
+zQyKn0H8MB8GA1UdIwQYMBaAFJvKs8RfJaXTH08W+SGvzQyKn0H8MAwGA1UdEwQF
+MAMBAf8wDQYJKoZIhvcNAQEFBQADQQBJlffJHybjDGxRMqaRmDhX0+6v02TUKZsW
+r5QuVbpQhH6u+0UgcW0jp9QwpxoPTLTWGXEWBBBurxFwiCBhkQ+V
+-----END CERTIFICATE-----
+`
+
+var rsaKeyPEM = testingKey(`-----BEGIN RSA TESTING KEY-----
+MIIBOwIBAAJBANLJhPHhITqQbPklG3ibCVxwGMRfp/v4XqhfdQHdcVfHap6NQ5Wo
+k/4xIA+ui35/MmNartNuC+BdZ1tMuVCPFZcCAwEAAQJAEJ2N+zsR0Xn8/Q6twa4G
+6OB1M1WO+k+ztnX/1SvNeWu8D6GImtupLTYgjZcHufykj09jiHmjHx8u8ZZB/o1N
+MQIhAPW+eyZo7ay3lMz1V01WVjNKK9QSn1MJlb06h/LuYv9FAiEA25WPedKgVyCW
+SmUwbPw8fnTcpqDWE3yTO3vKcebqMSsCIBF3UmVue8YU3jybC3NxuXq3wNm34R8T
+xVLHwDXh/6NJAiEAl2oHGGLz64BuAfjKrqwz7qMYr9HCLIe/YsoWq/olzScCIQDi
+D2lWusoe2/nEqfDVVWGWlyJ7yOmqaVm/iNUN9B2N2g==
+-----END RSA TESTING KEY-----
+`)
+
+func testingKey(s string) string { return strings.ReplaceAll(s, "TESTING KEY", "PRIVATE KEY") }
+
+func TestCreateTLSConfig(t *testing.T) {
+
+	tests := []struct {
+		title         string
+		prefix        string
+		caFile        string
+		certFile      string
+		keyFile       string
+		isInsecureStr string
+		serverName    string
+		assertions    func(actual *tls.Config, err error)
+	}{
+		{
+			"Provide only CA returns error",
+			"prefix",
+			"",
+			rsaCertPEM,
+			"",
+			"",
+			"",
+			func(actual *tls.Config, err error) {
+				assert.Contains(t, err.Error(), "either both cert and key or none must be provided")
+			},
+		},
+		{
+			"Invalid cert and key returns error",
+			"prefix",
+			"",
+			"invalid-cert",
+			"invalid-key",
+			"",
+			"",
+			func(actual *tls.Config, err error) {
+				assert.Contains(t, err.Error(), "could not load TLS cert")
+			},
+		},
+		{
+			"Valid cert and key return a valid tls.Config with certificates",
+			"prefix",
+			"",
+			rsaCertPEM,
+			rsaKeyPEM,
+			"",
+			"server-name",
+			func(actual *tls.Config, err error) {
+				assert.Nil(t, err)
+				assert.Equal(t, actual.ServerName, "server-name")
+				assert.NotNil(t, actual.Certificates)
+				assert.Equal(t, actual.InsecureSkipVerify, false)
+				assert.Equal(t, actual.MinVersion, uint16(defaultMinVersion))
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.title, func(t *testing.T) {
+			// setup
+			dir := t.TempDir()
+
+			if tc.caFile != "" {
+				path := fmt.Sprintf("%s/caFile", dir)
+				utils.WriteToFile(path, tc.caFile)
+				t.Setenv(fmt.Sprintf("%s_CA_FILE", tc.prefix), path)
+			}
+
+			if tc.certFile != "" {
+				path := fmt.Sprintf("%s/certFile", dir)
+				utils.WriteToFile(path, tc.certFile)
+				t.Setenv(fmt.Sprintf("%s_CERT_FILE", tc.prefix), path)
+			}
+
+			if tc.keyFile != "" {
+				path := fmt.Sprintf("%s/keyFile", dir)
+				utils.WriteToFile(path, tc.keyFile)
+				t.Setenv(fmt.Sprintf("%s_KEY_FILE", tc.prefix), path)
+			}
+
+			if tc.serverName != "" {
+				t.Setenv(fmt.Sprintf("%s_TLS_SERVER_NAME", tc.prefix), tc.serverName)
+			}
+
+			if tc.isInsecureStr != "" {
+				t.Setenv(fmt.Sprintf("%s_INSECURE", tc.prefix), tc.isInsecureStr)
+			}
+
+			// test
+			actual, err := CreateTLSConfig(tc.prefix)
+			tc.assertions(actual, err)
+		})
+	}
+
+}


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

Improve code coverage of the tlsconfig package from 0 to 90%
The test key and certificate were retrieved from the [Go crypto package](https://github.com/golang/go/blob/00b63486583ef8055c821fa16a87017e04dc2920/src/crypto/tls/tls_test.go)

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Linked to #5150

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
