### PR TITLE
feat(service): optionally create DNS entry for each pod

### DIFF
--- a/docs/sources/service.md
+++ b/docs/sources/service.md
@@ -33,6 +33,10 @@ a Pod that has a non-empty `spec.hostname` field, additional DNS entries are cre
 For each domain name created for the Service, the additional DNS entry for the Pod has that domain name prefixed with
 the value of the Pod's `spec.hostname` field and a `.`.
 
+Another way to create per-pod DNS entries is to annotate headless service with
+`external-dns.alpha.kubernetes.io/service-pod-endpoints: true`,  this will prefix service domain name with pod name.
+
+
 ## Targets
 
 If the Service has an `external-dns.alpha.kubernetes.io/target` annotation, uses

--- a/source/service.go
+++ b/source/service.go
@@ -276,6 +276,8 @@ func (sc *serviceSource) extractHeadlessEndpoints(svc *v1.Service, hostname stri
 
 	endpointsType := getEndpointsTypeFromAnnotations(svc.Annotations)
 
+	_, perPodDNS := svc.Annotations[servicePodEndpointsKey]
+
 	targetsByHeadlessDomainAndType := make(map[endpoint.EndpointKey]endpoint.Targets)
 	for _, subset := range endpointsObject.Subsets {
 		addresses := subset.Addresses
@@ -304,6 +306,10 @@ func (sc *serviceSource) extractHeadlessEndpoints(svc *v1.Service, hostname stri
 			headlessDomains := []string{hostname}
 			if pod.Spec.Hostname != "" {
 				headlessDomains = append(headlessDomains, fmt.Sprintf("%s.%s", pod.Spec.Hostname, hostname))
+			}
+
+			if perPodDNS {
+				headlessDomains = append(headlessDomains, fmt.Sprintf("%s.%s", pod.Name, hostname))
 			}
 
 			for _, headlessDomain := range headlessDomains {

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -2892,6 +2892,61 @@ func TestHeadlessServices(t *testing.T) {
 			false,
 		},
 		{
+			"annotated Headless services create DNS name for each pod",
+			"",
+			"testing",
+			"foo",
+			v1.ServiceTypeClusterIP,
+			"",
+			"",
+			false,
+			map[string]string{"component": "foo"},
+			map[string]string{
+				servicePodEndpointsKey:     "true",
+				hostnameAnnotationKey:      "service.example.org",
+				endpointsTypeAnnotationKey: EndpointsTypeNodeExternalIP,
+			},
+			map[string]string{},
+			v1.ClusterIPNone,
+			[]string{"1.1.1.1", "1.1.1.2", "1.1.1.3"},
+			[]string{"", "", ""},
+			map[string]string{
+				"component": "foo",
+			},
+			[]string{},
+			[]string{"foo1", "foo2", "foo3"},
+			[]string{"", "", ""},
+			[]bool{true, true, true},
+			false,
+			[]v1.Node{
+				{
+					Status: v1.NodeStatus{
+						Addresses: []v1.NodeAddress{
+							{
+								Type:    v1.NodeExternalIP,
+								Address: "1.2.3.4",
+							},
+							{
+								Type:    v1.NodeInternalIP,
+								Address: "2001:db8::4",
+							},
+						},
+					},
+				},
+			},
+			[]*endpoint.Endpoint{
+				{DNSName: "service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "service.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:db8::4"}},
+				{DNSName: "foo1.service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo1.service.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:db8::4"}},
+				{DNSName: "foo2.service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo2.service.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:db8::4"}},
+				{DNSName: "foo3.service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo3.service.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:db8::4"}},
+			},
+			false,
+		},
+		{
 			"annotated Headless services return dual-stack targets from node external IP if endpoints-type annotation is set",
 			"",
 			"testing",

--- a/source/source.go
+++ b/source/source.go
@@ -60,6 +60,8 @@ const (
 	controllerAnnotationValue = "dns-controller"
 	// The annotation used for defining the desired hostname
 	internalHostnameAnnotationKey = "external-dns.alpha.kubernetes.io/internal-hostname"
+	// Create endpoint for each pod in the service.
+	servicePodEndpointsKey = "external-dns.alpha.kubernetes.io/service-pod-endpoints"
 )
 
 const (


### PR DESCRIPTION
**Description**

headless service already supported mode where DNS entry is created for each pod when `spec.hostName` is present. Not all controllers populate that field, but it is sometimes desireable to create DNS entry per pod nevertheless.

This commit adds new annotation `service-pod-endpoints` , which when set on a headless service makes external-dns to create endpoint per pod using pod name as a prefix.

**Checklist**

- [x ] Unit tests updated
- [x] End user documentation updated
