### PR TITLE
fix(rfc2136): credential and realm issue when using active directory

### DIFF
--- a/provider/rfc2136/rfc2136_test.go
+++ b/provider/rfc2136/rfc2136_test.go
@@ -886,10 +886,25 @@ func contains(arr []*endpoint.Endpoint, name string) bool {
 	return false
 }
 
+// TestCreateRfc2136StubProviderWithHosts validates the stub provider initializes with multiple nameservers.
+func TestCreateRfc2136StubProviderWithHosts(t *testing.T) {
+	stub := newStub()
+	provider, err := createRfc2136StubProviderWithHosts(stub)
+	assert.NoError(t, err)
+
+	rawProvider, ok := provider.(*rfc2136Provider)
+	assert.True(t, ok, "expected provider to be of type *rfc2136Provider")
+
+	assert.Equal(t, 3, len(rawProvider.nameservers))
+	assert.Equal(t, "rfc2136-host1:0", rawProvider.nameservers[0])
+	assert.Equal(t, "rfc2136-host2:0", rawProvider.nameservers[1])
+	assert.Equal(t, "rfc2136-host3:0", rawProvider.nameservers[2])
+}
+
 // TestRoundRobinLoadBalancing tests the round-robin load balancing strategy.
 func TestRoundRobinLoadBalancing(t *testing.T) {
 	stub := newStubLB("round-robin", []string{"rfc2136-host1", "rfc2136-host2", "rfc2136-host3"})
-	_, err := createRfc2136StubProviderWithHosts(stub)
+	_, err := createRfc2136StubProviderWithStrategy(stub, "round-robin")
 	assert.NoError(t, err)
 
 	m := new(dns.Msg)
@@ -908,7 +923,7 @@ func TestRoundRobinLoadBalancing(t *testing.T) {
 // TestRandomLoadBalancing tests the random load balancing strategy.
 func TestRandomLoadBalancing(t *testing.T) {
 	stub := newStubLB("random", []string{"rfc2136-host1", "rfc2136-host2", "rfc2136-host3"})
-	_, err := createRfc2136StubProvider(stub)
+	_, err := createRfc2136StubProviderWithStrategy(stub, "random")
 	assert.NoError(t, err)
 
 	m := new(dns.Msg)


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
This closes #5240, and fixes RFC3645 issues.

This removes `krb5Realm` updates in apply changes, and removes storing the credentials handle due to issues with handle loosing ctx which stores the credentials during updates, causing the next update to always fail.
```go
---
r.krb5Realm = strings.ToUpper(zone)
```

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #5240

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
