### PR TITLE
imp: improved test coverage from 66.7 to 100%

### DIFF
--- a/provider/zone_id_filter_test.go
+++ b/provider/zone_id_filter_test.go
@@ -28,12 +28,22 @@ type zoneIDFilterTest struct {
 	expected     bool
 }
 
+type zoneIdFilterTestIsConfigured struct {
+	zoneIDFilter []string
+	expected     bool
+}
+
 func TestZoneIDFilterMatch(t *testing.T) {
 	zone := "/hostedzone/ZTST1"
 
 	for _, tt := range []zoneIDFilterTest{
 		{
 			[]string{},
+			zone,
+			true,
+		},
+		{
+			[]string{""},
 			zone,
 			true,
 		},
@@ -75,5 +85,33 @@ func TestZoneIDFilterMatch(t *testing.T) {
 	} {
 		zoneIDFilter := NewZoneIDFilter(tt.zoneIDFilter)
 		assert.Equal(t, tt.expected, zoneIDFilter.Match(tt.zone))
+	}
+}
+
+func TestZoneIDFilterIsConfigured(t *testing.T) {
+	for _, tt := range []zoneIdFilterTestIsConfigured{
+		{
+			[]string{""},
+			false,
+		},
+		{
+			[]string{},
+			false,
+		},
+		{
+			[]string{"/hostedzone/ZTST2"},
+			true,
+		},
+		{
+			[]string{"/hostedzone/ZTST2", "hostedzone/ZTST2"},
+			true,
+		},
+		{
+			[]string{"/ZSTS2"},
+			true,
+		},
+	} {
+		zoneIDFilter := NewZoneIDFilter(tt.zoneIDFilter)
+		assert.Equal(t, tt.expected, zoneIDFilter.IsConfigured())
 	}
 }


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #5150 
this PR improves test coverage for ``zone-id-filter.go`` from 66.7 to 100%.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated