### PR TITLE
fix(source): expose internal ipv6 flag on headless service

### DIFF
--- a/provider/pihole/clientV6_test.go
+++ b/provider/pihole/clientV6_test.go
@@ -61,7 +61,7 @@ func TestIsValidIPv6(t *testing.T) {
 	}{
 		{"2001:0db8:85a3:0000:0000:8a2e:0370:7334", true},
 		{"2001:db8:85a3::8a2e:370:7334", true},
-		//IPV6 dual, the format is y:y:y:y:y:y:x.x.x.x.
+		//IPv6 dual, the format is y:y:y:y:y:y:x.x.x.x.
 		{"::ffff:192.168.20.3", true},
 		{"::1", true},
 		{"::", true},

--- a/source/compatibility.go
+++ b/source/compatibility.go
@@ -159,7 +159,7 @@ func legacyEndpointsFromDNSControllerNodePortService(svc *v1.Service, sc *servic
 			for _, address := range node.Status.Addresses {
 				recordType := suitableType(address.Address)
 				// IPv6 addresses are labeled as NodeInternalIP despite being usable externally as well.
-				if isExternal && (address.Type == v1.NodeExternalIP || (address.Type == v1.NodeInternalIP && recordType == endpoint.RecordTypeAAAA)) {
+				if isExternal && (address.Type == v1.NodeExternalIP || (sc.exposeInternalIPv6 && address.Type == v1.NodeInternalIP && recordType == endpoint.RecordTypeAAAA)) {
 					endpoints = append(endpoints, endpoint.NewEndpoint(hostname, recordType, address.Address))
 				}
 				if isInternal && address.Type == v1.NodeInternalIP {

--- a/source/node.go
+++ b/source/node.go
@@ -43,7 +43,7 @@ type nodeSource struct {
 	nodeInformer         coreinformers.NodeInformer
 	labelSelector        labels.Selector
 	excludeUnschedulable bool
-	exposeInternalIPV6   bool
+	exposeInternalIPv6   bool
 }
 
 // NewNodeSource creates a new nodeSource with the given config.
@@ -81,7 +81,7 @@ func NewNodeSource(ctx context.Context, kubeClient kubernetes.Interface, annotat
 		nodeInformer:         nodeInformer,
 		labelSelector:        labelSelector,
 		excludeUnschedulable: excludeUnschedulable,
-		exposeInternalIPV6:   exposeInternalIPv6,
+		exposeInternalIPv6:   exposeInternalIPv6,
 	}, nil
 }
 
@@ -193,7 +193,7 @@ func (ns *nodeSource) nodeAddresses(node *v1.Node) ([]string, error) {
 	}
 
 	if len(addresses[v1.NodeExternalIP]) > 0 {
-		if ns.exposeInternalIPV6 {
+		if ns.exposeInternalIPv6 {
 			log.Warn(warningMsg)
 			return append(addresses[v1.NodeExternalIP], internalIpv6Addresses...), nil
 		}

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -82,6 +82,7 @@ func (suite *ServiceSuite) SetupTest() {
 		labels.Everything(),
 		false,
 		false,
+		false,
 	)
 	suite.NoError(err, "should initialize service source")
 }
@@ -162,6 +163,7 @@ func testServiceSourceNewServiceSource(t *testing.T) {
 				ti.serviceTypesFilter,
 				false,
 				labels.Everything(),
+				false,
 				false,
 				false,
 			)
@@ -1136,6 +1138,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				sourceLabel,
 				tc.resolveLoadBalancerHostname,
 				false,
+				false,
 			)
 
 			require.NoError(t, err)
@@ -1349,6 +1352,7 @@ func testMultipleServicesEndpoints(t *testing.T) {
 				tc.serviceTypesFilter,
 				tc.ignoreHostnameAnnotation,
 				labels.Everything(),
+				false,
 				false,
 				false,
 			)
@@ -1655,6 +1659,7 @@ func TestClusterIpServices(t *testing.T) {
 				labelSelector,
 				false,
 				false,
+				false,
 			)
 			require.NoError(t, err)
 
@@ -1686,6 +1691,7 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 		compatibility            string
 		fqdnTemplate             string
 		ignoreHostnameAnnotation bool
+		exposeInternalIPv6       bool
 		labels                   map[string]string
 		annotations              map[string]string
 		lbs                      []string
@@ -2207,12 +2213,13 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 			}},
 		},
 		{
-			title:            "node port services annotated with external DNS Controller annotations return an endpoint in compatibility mode",
-			svcNamespace:     "testing",
-			svcName:          "foo",
-			svcType:          v1.ServiceTypeNodePort,
-			svcTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
-			compatibility:    "kops-dns-controller",
+			title:              "node port services annotated with external DNS Controller annotations return an endpoint in compatibility mode with exposeInternalIPv6 flag set",
+			svcNamespace:       "testing",
+			svcName:            "foo",
+			svcType:            v1.ServiceTypeNodePort,
+			svcTrafficPolicy:   v1.ServiceExternalTrafficPolicyTypeCluster,
+			compatibility:      "kops-dns-controller",
+			exposeInternalIPv6: true,
 			annotations: map[string]string{
 				kopsDNSControllerHostnameAnnotationKey: "foo.example.org., bar.example.org",
 			},
@@ -2374,6 +2381,7 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 				labels.Everything(),
 				false,
 				false,
+				tc.exposeInternalIPv6,
 			)
 			require.NoError(t, err)
 
@@ -2403,6 +2411,7 @@ func TestHeadlessServices(t *testing.T) {
 		compatibility            string
 		fqdnTemplate             string
 		ignoreHostnameAnnotation bool
+		exposeInternalIPv6       bool
 		labels                   map[string]string
 		svcAnnotations           map[string]string
 		podAnnotations           map[string]string
@@ -2427,6 +2436,7 @@ func TestHeadlessServices(t *testing.T) {
 			v1.ServiceTypeClusterIP,
 			"",
 			"",
+			false,
 			false,
 			map[string]string{"component": "foo"},
 			map[string]string{
@@ -2461,6 +2471,7 @@ func TestHeadlessServices(t *testing.T) {
 			"",
 			"",
 			false,
+			false,
 			map[string]string{"component": "foo"},
 			map[string]string{
 				hostnameAnnotationKey: "service.example.org",
@@ -2494,6 +2505,7 @@ func TestHeadlessServices(t *testing.T) {
 			"",
 			"",
 			true,
+			false,
 			map[string]string{"component": "foo"},
 			map[string]string{
 				hostnameAnnotationKey: "service.example.org",
@@ -2522,6 +2534,7 @@ func TestHeadlessServices(t *testing.T) {
 			v1.ServiceTypeClusterIP,
 			"",
 			"",
+			false,
 			false,
 			map[string]string{"component": "foo"},
 			map[string]string{
@@ -2557,6 +2570,7 @@ func TestHeadlessServices(t *testing.T) {
 			"",
 			"",
 			false,
+			false,
 			map[string]string{"component": "foo"},
 			map[string]string{
 				hostnameAnnotationKey: "service.example.org",
@@ -2591,6 +2605,7 @@ func TestHeadlessServices(t *testing.T) {
 			"",
 			"",
 			false,
+			false,
 			map[string]string{"component": "foo"},
 			map[string]string{
 				hostnameAnnotationKey: "service.example.org",
@@ -2622,6 +2637,7 @@ func TestHeadlessServices(t *testing.T) {
 			v1.ServiceTypeClusterIP,
 			"",
 			"",
+			false,
 			false,
 			map[string]string{"component": "foo"},
 			map[string]string{
@@ -2656,6 +2672,7 @@ func TestHeadlessServices(t *testing.T) {
 			"",
 			"",
 			false,
+			false,
 			map[string]string{"component": "foo"},
 			map[string]string{
 				hostnameAnnotationKey: "service.example.org",
@@ -2686,6 +2703,7 @@ func TestHeadlessServices(t *testing.T) {
 			v1.ServiceTypeClusterIP,
 			"",
 			"",
+			false,
 			false,
 			map[string]string{"component": "foo"},
 			map[string]string{
@@ -2718,6 +2736,7 @@ func TestHeadlessServices(t *testing.T) {
 			"",
 			"",
 			false,
+			false,
 			map[string]string{"component": "foo"},
 			map[string]string{
 				hostnameAnnotationKey: "service.example.org",
@@ -2748,6 +2767,7 @@ func TestHeadlessServices(t *testing.T) {
 			v1.ServiceTypeClusterIP,
 			"",
 			"",
+			false,
 			false,
 			map[string]string{"component": "foo"},
 			map[string]string{
@@ -2782,6 +2802,7 @@ func TestHeadlessServices(t *testing.T) {
 			"",
 			"",
 			false,
+			false,
 			map[string]string{"component": "foo"},
 			map[string]string{
 				hostnameAnnotationKey: "service.example.org",
@@ -2814,6 +2835,7 @@ func TestHeadlessServices(t *testing.T) {
 			v1.ServiceTypeClusterIP,
 			"",
 			"",
+			false,
 			false,
 			map[string]string{"component": "foo"},
 			map[string]string{
@@ -2850,7 +2872,7 @@ func TestHeadlessServices(t *testing.T) {
 			false,
 		},
 		{
-			"annotated Headless services return IPv6 targets from node external IP if endpoints-type annotation is set",
+			"annotated Headless services return only external IPv6 targets from node IP if endpoints-type annotation is set and exposeInternalIPv6 flag is unset",
 			"",
 			"testing",
 			"foo",
@@ -2858,6 +2880,55 @@ func TestHeadlessServices(t *testing.T) {
 			"",
 			"",
 			false,
+			false,
+			map[string]string{"component": "foo"},
+			map[string]string{
+				hostnameAnnotationKey:      "service.example.org",
+				endpointsTypeAnnotationKey: EndpointsTypeNodeExternalIP,
+			},
+			map[string]string{},
+			v1.ClusterIPNone,
+			[]string{"2001:db8::1"},
+			[]string{""},
+			map[string]string{
+				"component": "foo",
+			},
+			[]string{},
+			[]string{"foo"},
+			[]string{"", "", ""},
+			[]bool{true, true, true},
+			false,
+			[]v1.Node{
+				{
+					Status: v1.NodeStatus{
+						Addresses: []v1.NodeAddress{
+							{
+								Type:    v1.NodeInternalIP,
+								Address: "2001:db8::4",
+							},
+							{
+								Type:    v1.NodeExternalIP,
+								Address: "2001:db8::5",
+							},
+						},
+					},
+				},
+			},
+			[]*endpoint.Endpoint{
+				{DNSName: "service.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:db8::5"}},
+			},
+			false,
+		},
+		{
+			"annotated Headless services return IPv6 targets from node external IP if endpoints-type annotation is set and exposeInternalIPv6 flag set",
+			"",
+			"testing",
+			"foo",
+			v1.ServiceTypeClusterIP,
+			"",
+			"",
+			false,
+			true,
 			map[string]string{"component": "foo"},
 			map[string]string{
 				hostnameAnnotationKey:      "service.example.org",
@@ -2893,7 +2964,7 @@ func TestHeadlessServices(t *testing.T) {
 			false,
 		},
 		{
-			"annotated Headless services return dual-stack targets from node external IP if endpoints-type annotation is set",
+			"annotated Headless services return dual-stack targets from node external IP if endpoints-type annotation is set and exposeInternalIPv6 flag set",
 			"",
 			"testing",
 			"foo",
@@ -2901,6 +2972,7 @@ func TestHeadlessServices(t *testing.T) {
 			"",
 			"",
 			false,
+			true,
 			map[string]string{"component": "foo"},
 			map[string]string{
 				hostnameAnnotationKey:      "service.example.org",
@@ -2949,6 +3021,7 @@ func TestHeadlessServices(t *testing.T) {
 			"",
 			"",
 			false,
+			false,
 			map[string]string{"component": "foo"},
 			map[string]string{
 				hostnameAnnotationKey:      "service.example.org",
@@ -2980,6 +3053,7 @@ func TestHeadlessServices(t *testing.T) {
 			v1.ServiceTypeClusterIP,
 			"",
 			"",
+			false,
 			false,
 			map[string]string{"component": "foo"},
 			map[string]string{
@@ -3103,6 +3177,7 @@ func TestHeadlessServices(t *testing.T) {
 				labels.Everything(),
 				false,
 				false,
+				tc.exposeInternalIPv6,
 			)
 			require.NoError(t, err)
 
@@ -3563,6 +3638,7 @@ func TestHeadlessServicesHostIP(t *testing.T) {
 				labels.Everything(),
 				false,
 				false,
+				false,
 			)
 			require.NoError(t, err)
 
@@ -3742,6 +3818,7 @@ func TestExternalServices(t *testing.T) {
 				labels.Everything(),
 				false,
 				false,
+				false,
 			)
 			require.NoError(t, err)
 
@@ -3796,6 +3873,7 @@ func BenchmarkServiceEndpoints(b *testing.B) {
 		[]string{},
 		false,
 		labels.Everything(),
+		false,
 		false,
 		false,
 	)

--- a/source/store.go
+++ b/source/store.go
@@ -273,7 +273,7 @@ func BuildWithConfig(ctx context.Context, source string, p ClientGenerator, cfg 
 		if err != nil {
 			return nil, err
 		}
-		return NewServiceSource(ctx, client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.Compatibility, cfg.PublishInternal, cfg.PublishHostIP, cfg.AlwaysPublishNotReadyAddresses, cfg.ServiceTypeFilter, cfg.IgnoreHostnameAnnotation, cfg.LabelFilter, cfg.ResolveLoadBalancerHostname, cfg.ListenEndpointEvents)
+		return NewServiceSource(ctx, client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.Compatibility, cfg.PublishInternal, cfg.PublishHostIP, cfg.AlwaysPublishNotReadyAddresses, cfg.ServiceTypeFilter, cfg.IgnoreHostnameAnnotation, cfg.LabelFilter, cfg.ResolveLoadBalancerHostname, cfg.ListenEndpointEvents, cfg.ExposeInternalIPv6)
 	case "ingress":
 		client, err := p.KubeClient()
 		if err != nil {


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

- Ensured consistency in naming of IPv6 variables (renamed all IPV6 -> IPv6 to be inline with Golang)
- Added already existing `exposeInternalIPv6` flag to service source
- Changed all two places where internal IPv6 were used as if they were external to take into account exposeInternalIPv6
  + `legacyEndpointsFromDNSControllerNodePortService`
  + `extractHeadlessEndpoints`
- **Modified all service tests to already default to unset `exposeInternalIPv6`** -> this only invalided three tests
  + These three tests had the `exposeInternalIPv6` flag set
- Added single test to ensure only external IPv6 are "exposed" when `exposeInternalIPv6` is **not** set

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #5377 

**Checklist**

- [X] Unit tests updated
- [X] End user documentation updated -> **not applicable**
