### PR TITLE
fix(pihole): crash when multiple targets are present with pihole API V6

### DIFF
--- a/provider/pihole/clientV6.go
+++ b/provider/pihole/clientV6.go
@@ -286,12 +286,12 @@ func (p *piholeClientV6) apply(ctx context.Context, action string, ep *endpoint.
 
 	switch ep.RecordType {
 	case endpoint.RecordTypeA, endpoint.RecordTypeAAAA:
-		apiUrl = p.generateApiUrl(apiUrl, fmt.Sprintf("%s %s", ep.Targets, ep.DNSName))
+		apiUrl = p.generateApiUrl(apiUrl, fmt.Sprintf("%s %s", ep.Targets[0], ep.DNSName))
 	case endpoint.RecordTypeCNAME:
 		if ep.RecordTTL.IsConfigured() {
-			apiUrl = p.generateApiUrl(apiUrl, fmt.Sprintf("%s,%s,%d", ep.DNSName, ep.Targets, ep.RecordTTL))
+			apiUrl = p.generateApiUrl(apiUrl, fmt.Sprintf("%s,%s,%d", ep.DNSName, ep.Targets[0], ep.RecordTTL))
 		} else {
-			apiUrl = p.generateApiUrl(apiUrl, fmt.Sprintf("%s,%s", ep.DNSName, ep.Targets))
+			apiUrl = p.generateApiUrl(apiUrl, fmt.Sprintf("%s,%s", ep.DNSName, ep.Targets[0]))
 		}
 	}
 

--- a/provider/pihole/clientV6_test.go
+++ b/provider/pihole/clientV6_test.go
@@ -716,7 +716,8 @@ func TestCreateRecordV6(t *testing.T) {
 		if r.Method == "PUT" && (r.URL.Path == "/api/config/dns/hosts/192.168.1.1 test.example.com" ||
 			r.URL.Path == "/api/config/dns/hosts/fc00::1:192:168:1:1 test.example.com" ||
 			r.URL.Path == "/api/config/dns/cnameRecords/source1.example.com,target1.domain.com" ||
-			r.URL.Path == "/api/config/dns/cnameRecords/source2.example.com,target2.domain.com,500") {
+			r.URL.Path == "/api/config/dns/cnameRecords/source2.example.com,target2.domain.com,500" ||
+			r.URL.Path == "/api/config/dns/cnameRecords/source3.example.com,target3.domain.com") {
 
 			// Return A records
 			w.WriteHeader(http.StatusCreated)
@@ -747,10 +748,30 @@ func TestCreateRecordV6(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Test create A record with multiple targets present and ensure only the first is added
+	ep = &endpoint.Endpoint{
+		DNSName:    "test.example.com",
+		Targets:    []string{"192.168.1.1", "192.168.1.2"},
+		RecordType: endpoint.RecordTypeA,
+	}
+	if err := cl.createRecord(context.Background(), ep); err != nil {
+		t.Fatal(err)
+	}
+
 	// Test create AAAA record
 	ep = &endpoint.Endpoint{
 		DNSName:    "test.example.com",
 		Targets:    []string{"fc00::1:192:168:1:1"},
+		RecordType: endpoint.RecordTypeAAAA,
+	}
+	if err := cl.createRecord(context.Background(), ep); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test create AAAA record with multiple targets present and ensure only the first is added
+	ep = &endpoint.Endpoint{
+		DNSName:    "test.example.com",
+		Targets:    []string{"fc00::1:192:168:1:1", "fc00::1:192:168:1:2"},
 		RecordType: endpoint.RecordTypeAAAA,
 	}
 	if err := cl.createRecord(context.Background(), ep); err != nil {
@@ -772,6 +793,16 @@ func TestCreateRecordV6(t *testing.T) {
 		DNSName:    "source2.example.com",
 		Targets:    []string{"target2.domain.com"},
 		RecordTTL:  endpoint.TTL(500),
+		RecordType: endpoint.RecordTypeCNAME,
+	}
+	if err := cl.createRecord(context.Background(), ep); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test create CNAME record with multiple targets present and ensure only the first is added
+	ep = &endpoint.Endpoint{
+		DNSName:    "source3.example.com",
+		Targets:    []string{"target3.domain.com", "target4.domain.com"},
 		RecordType: endpoint.RecordTypeCNAME,
 	}
 	if err := cl.createRecord(context.Background(), ep); err != nil {


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

Hello,

While trying to set up external-dns (**v0.17.0**) with Pi-hole (**v6.0.6**) in my homelab I've come across the following error, placing my pod into `CrashLoopBackOff` state:

```text
time="2025-05-18T20:57:16Z" level=debug msg="Endpoints generated from ingress: networking/pihole: [pihole.home 0 IN A  10.0.1.10;10.0.1.11 []]"
time="2025-05-18T20:57:16Z" level=info msg="PUT pihole.home IN A -> 10.0.1.10"
time="2025-05-18T20:57:16Z" level=debug msg="Error on request http://pihole-web.networking.svc.cluster.local/api/config/dns/hosts/10.0.1.10%3B10.0.1.11%20pihole.home"
```

This was with:

```yaml
env:
  - name: EXTERNAL_DNS_PIHOLE_SERVER
    value: http://pihole-web.networking.svc.cluster.local
  - name: EXTERNAL_DNS_PIHOLE_API_VERSION
    value: "6"
```

The error happens because all targets [are being passed to the generateApiUrl function](https://github.com/kubernetes-sigs/external-dns/blob/master/provider/pihole/clientV6.go#L289), even though Pi-hole only supports one target per record and one record per domain. In my case, the targets `[10.0.1.10 10.0.1.11]` resulted in the API url ending in `config/dns/hosts/10.0.1.10%3B10.0.1.11%20pihole.home` which the V6 API does not accept.

In the previous implementation, we seemingly have [only passed the first of multiple targets](https://github.com/kubernetes-sigs/external-dns/blob/master/provider/pihole/client.go#L304).  This PR restores that implementation for V6.


**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
