### PR TITLE
fix(rfc2136): collect existing records from all configured zones

### DIFF
--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -318,7 +318,7 @@ func (r *rfc2136Provider) List() ([]dns.RR, error) {
 			}
 			// If records were fetched successfully, break out of the loop
 			if len(records) > 0 {
-				return records, nil
+				break
 			}
 		}
 

--- a/provider/rfc2136/rfc2136_test.go
+++ b/provider/rfc2136/rfc2136_test.go
@@ -152,7 +152,24 @@ func (r *rfc2136Stub) IncomeTransfer(m *dns.Msg, a string) (env chan *dns.Envelo
 	outChan := make(chan *dns.Envelope)
 	go func() {
 		for _, e := range r.output {
-			outChan <- e
+
+			var responseEnvelope *dns.Envelope
+			for _, record := range e.RR {
+				for _, q := range m.Question {
+					if strings.HasSuffix(record.Header().Name, q.Name) {
+						if responseEnvelope == nil {
+							responseEnvelope = &dns.Envelope{}
+						}
+						responseEnvelope.RR = append(responseEnvelope.RR, record)
+						break
+					}
+				}
+			}
+
+			if responseEnvelope == nil {
+				continue
+			}
+			outChan <- responseEnvelope
 		}
 		close(outChan)
 	}()
@@ -160,7 +177,7 @@ func (r *rfc2136Stub) IncomeTransfer(m *dns.Msg, a string) (env chan *dns.Envelo
 	return outChan, nil
 }
 
-func createRfc2136StubProvider(stub *rfc2136Stub) (provider.Provider, error) {
+func createRfc2136StubProvider(stub *rfc2136Stub, zoneNames ...string) (provider.Provider, error) {
 	tlsConfig := TLSConfig{
 		UseTLS:                false,
 		SkipTLSVerify:         false,
@@ -168,7 +185,7 @@ func createRfc2136StubProvider(stub *rfc2136Stub) (provider.Provider, error) {
 		ClientCertFilePath:    "",
 		ClientCertKeyFilePath: "",
 	}
-	return NewRfc2136Provider([]string{""}, 0, nil, false, "key", "secret", "hmac-sha512", true, endpoint.DomainFilter{}, false, 300*time.Second, false, false, "", "", "", 50, tlsConfig, "", stub)
+	return NewRfc2136Provider([]string{""}, 0, zoneNames, false, "key", "secret", "hmac-sha512", true, endpoint.DomainFilter{}, false, 300*time.Second, false, false, "", "", "", 50, tlsConfig, "", stub)
 }
 
 func createRfc2136StubProviderWithHosts(stub *rfc2136Stub) (provider.Provider, error) {
@@ -505,7 +522,7 @@ func TestRfc2136GetRecords(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	provider, err := createRfc2136StubProvider(stub)
+	provider, err := createRfc2136StubProvider(stub, "barfoo.com", "foo.com", "bar.com", "foobar.com")
 	assert.NoError(t, err)
 
 	recs, err := provider.Records(context.Background())


### PR DESCRIPTION
**Description**

Recap from #5261:

> When multiple zones are configured for the RFC2136 provider with --rfc2136-zone, the provider only reads zone data with AXFR from each zone in sequence until it reaches a zone that returns > 0 records, and stops reading.
> 
> This results in the zones that are not read via AXFR re-adding their RR records every sync interval, regardless of whether they exist in the server (properly-read zones do not do this).

In addition to this behavior, when the TXT record registry is used with encryption, many duplicate TXT records are created over time as the values differ, leading to increased load on the DNS server.

Fixes #5261

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
