### PR TITLE
docs(github): update pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,18 @@
+## What does it do ?
+
+<!-- A brief description of the change being made with this pull request. -->
+
+## Motivation
+
+<!-- What inspired you to submit this pull request? -->
+
+## More
+
+- [ ] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+- [ ] Yes, I added unit tests
+- [ ] Yes, I updated end user documentation accordingly
+
 <!--
     Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
     your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
 -->
-
-**Description**
-
-<!-- Please provide a summary of the change here. -->
-
-<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
-Fixes #ISSUE
-
-**Checklist**
-
-- [ ] Unit tests updated
-- [ ] End user documentation updated


### PR DESCRIPTION
## What does it do ?

It updates the PR template for GitHub.

## Motivation

* The current template does not follow markdown convention
* Put in front the hidden comment for newcomers
* Does not enforce ownership

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
