### PR TITLE
chore(code-quality): added linter errchkjson

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - misspell
     - revive
     - rowserrcheck # Checks whether Rows.Err of rows is checked successfully.
+    - errchkjson # Checks types passed to the json encoding functions. ref: https://golangci-lint.run/usage/linters/#errchkjson
     - errorlint # Checking for unchecked errors in Go code https://golangci-lint.run/usage/linters/#errcheck
     - staticcheck
     - unconvert

--- a/provider/akamai/akamai_test.go
+++ b/provider/akamai/akamai_test.go
@@ -160,7 +160,8 @@ func TestFetchZonesZoneIDFilter(t *testing.T) {
 	stub.setOutput("zone", []interface{}{"test1.testzone.com", "test2.testzone.com"})
 
 	x, _ := c.fetchZones()
-	y, _ := json.Marshal(x)
+	y, err := json.Marshal(x)
+	require.NoError(t, err)
 	if assert.NotNil(t, y) {
 		assert.JSONEq(t, "{\"zones\":[{\"contractId\":\"contract\",\"zone\":\"test1.testzone.com\"},{\"contractId\":\"contract\",\"zone\":\"test2.testzone.com\"}]}", string(y))
 	}
@@ -175,7 +176,8 @@ func TestFetchZonesEmpty(t *testing.T) {
 	stub.setOutput("zone", []interface{}{})
 
 	x, _ := c.fetchZones()
-	y, _ := json.Marshal(x)
+	y, err := json.Marshal(x)
+	require.NoError(t, err)
 	if assert.NotNil(t, y) {
 		assert.JSONEq(t, "{\"zones\":[]}", string(y))
 	}

--- a/provider/godaddy/godaddy_test.go
+++ b/provider/godaddy/godaddy_test.go
@@ -26,6 +26,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 )
@@ -49,40 +50,50 @@ var (
 func (c *mockGoDaddyClient) Post(endpoint string, input interface{}, output interface{}) error {
 	log.Infof("POST: %s - %v", endpoint, input)
 	stub := c.Called(endpoint, input)
-	data, _ := json.Marshal(stub.Get(0))
-	json.Unmarshal(data, output)
+	data, err := json.Marshal(stub.Get(0))
+	require.NoError(c.currentTest, err)
+	err = json.Unmarshal(data, output)
+	require.NoError(c.currentTest, err)
 	return stub.Error(1)
 }
 
 func (c *mockGoDaddyClient) Patch(endpoint string, input interface{}, output interface{}) error {
 	log.Infof("PATCH: %s - %v", endpoint, input)
 	stub := c.Called(endpoint, input)
-	data, _ := json.Marshal(stub.Get(0))
-	json.Unmarshal(data, output)
+	data, err := json.Marshal(stub.Get(0))
+	require.NoError(c.currentTest, err)
+	err = json.Unmarshal(data, output)
+	require.NoError(c.currentTest, err)
 	return stub.Error(1)
 }
 
 func (c *mockGoDaddyClient) Put(endpoint string, input interface{}, output interface{}) error {
 	log.Infof("PUT: %s - %v", endpoint, input)
 	stub := c.Called(endpoint, input)
-	data, _ := json.Marshal(stub.Get(0))
-	json.Unmarshal(data, output)
+	data, err := json.Marshal(stub.Get(0))
+	require.NoError(c.currentTest, err)
+	err = json.Unmarshal(data, output)
+	require.NoError(c.currentTest, err)
 	return stub.Error(1)
 }
 
 func (c *mockGoDaddyClient) Get(endpoint string, output interface{}) error {
 	log.Infof("GET: %s", endpoint)
 	stub := c.Called(endpoint)
-	data, _ := json.Marshal(stub.Get(0))
-	json.Unmarshal(data, output)
+	data, err := json.Marshal(stub.Get(0))
+	require.NoError(c.currentTest, err)
+	err = json.Unmarshal(data, output)
+	require.NoError(c.currentTest, err)
 	return stub.Error(1)
 }
 
 func (c *mockGoDaddyClient) Delete(endpoint string, output interface{}) error {
 	log.Infof("DELETE: %s", endpoint)
 	stub := c.Called(endpoint)
-	data, _ := json.Marshal(stub.Get(0))
-	json.Unmarshal(data, output)
+	data, err := json.Marshal(stub.Get(0))
+	require.NoError(c.currentTest, err)
+	err = json.Unmarshal(data, output)
+	require.NoError(c.currentTest, err)
 	return stub.Error(1)
 }
 

--- a/provider/ovh/ovh_test.go
+++ b/provider/ovh/ovh_test.go
@@ -41,28 +41,40 @@ type mockOvhClient struct {
 
 func (c *mockOvhClient) PostWithContext(ctx context.Context, endpoint string, input interface{}, output interface{}) error {
 	stub := c.Called(endpoint, input)
-	data, _ := json.Marshal(stub.Get(0))
+	data, err := json.Marshal(stub.Get(0))
+	if err != nil {
+		return err
+	}
 	json.Unmarshal(data, output)
 	return stub.Error(1)
 }
 
 func (c *mockOvhClient) PutWithContext(ctx context.Context, endpoint string, input interface{}, output interface{}) error {
 	stub := c.Called(endpoint, input)
-	data, _ := json.Marshal(stub.Get(0))
+	data, err := json.Marshal(stub.Get(0))
+	if err != nil {
+		return err
+	}
 	json.Unmarshal(data, output)
 	return stub.Error(1)
 }
 
 func (c *mockOvhClient) GetWithContext(ctx context.Context, endpoint string, output interface{}) error {
 	stub := c.Called(endpoint)
-	data, _ := json.Marshal(stub.Get(0))
+	data, err := json.Marshal(stub.Get(0))
+	if err != nil {
+		return err
+	}
 	json.Unmarshal(data, output)
 	return stub.Error(1)
 }
 
 func (c *mockOvhClient) DeleteWithContext(ctx context.Context, endpoint string, output interface{}) error {
 	stub := c.Called(endpoint)
-	data, _ := json.Marshal(stub.Get(0))
+	data, err := json.Marshal(stub.Get(0))
+	if err != nil {
+		return err
+	}
 	json.Unmarshal(data, output)
 	return stub.Error(1)
 }

--- a/provider/webhook/api/httpapi.go
+++ b/provider/webhook/api/httpapi.go
@@ -106,7 +106,10 @@ func (p *WebhookServer) AdjustEndpointsHandler(w http.ResponseWriter, req *http.
 
 func (p *WebhookServer) NegotiateHandler(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set(ContentTypeHeader, MediaTypeFormatAndVersion)
-	json.NewEncoder(w).Encode(p.Provider.GetDomainFilter())
+	err := json.NewEncoder(w).Encode(p.Provider.GetDomainFilter())
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
 }
 
 // StartHTTPApi starts a HTTP server given any provider.

--- a/provider/webhook/api/httpapi_test.go
+++ b/provider/webhook/api/httpapi_test.go
@@ -98,7 +98,7 @@ func TestRecordsHandlerRecords(t *testing.T) {
 	// require that the res has the same endpoints as the records slice
 	defer res.Body.Close()
 	require.NotNil(t, res.Body)
-	endpoints := []*endpoint.Endpoint{}
+	var endpoints []*endpoint.Endpoint
 	if err := json.NewDecoder(res.Body).Decode(&endpoints); err != nil {
 		t.Errorf("Failed to decode response body: %s", err.Error())
 	}
@@ -317,4 +317,41 @@ func TestStartHTTPApi(t *testing.T) {
 	b, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.NoError(t, df.UnmarshalJSON(b))
+}
+
+func TestNegotiateHandler_Success(t *testing.T) {
+	provider := &FakeWebhookProvider{
+		domainFilter: endpoint.NewDomainFilter([]string{"foo.bar.com"}),
+	}
+	server := &WebhookServer{Provider: provider}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	server.NegotiateHandler(w, req)
+	res := w.Result()
+	defer res.Body.Close()
+
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, MediaTypeFormatAndVersion, res.Header.Get(ContentTypeHeader))
+
+	var df endpoint.DomainFilter
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	require.NoError(t, df.UnmarshalJSON(body))
+	require.Equal(t, provider.domainFilter, df)
+}
+
+func TestNegotiateHandler_FiltersWithSpecialEncodings(t *testing.T) {
+	provider := &FakeWebhookProvider{
+		domainFilter: endpoint.NewDomainFilter([]string{"\\u001a", "\\Xfoo.\\u2028, \\u0000.com", "<invalid json>"}),
+	}
+	server := &WebhookServer{Provider: provider}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	server.NegotiateHandler(w, req)
+	res := w.Result()
+	defer res.Body.Close()
+
+	require.Equal(t, http.StatusOK, res.StatusCode)
 }


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->

## Motivation

Added errcheckjson linter.

Looks like the only fixes are in tests. This linter is still useful, as if tests swallowing errors, and then we validate for no error, it's not really a test.

![Screenshot 2025-05-22 at 09 10 39](https://github.com/user-attachments/assets/5fb5e653-8514-4b37-ba1e-7152b18ccf4c)

initial error https://github.com/kubernetes-sigs/external-dns/actions/runs/15182117601/job/42693734466?pr=5448

## More

- [ ] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
