### PR TITLE
chore(code-quality): reduce cyclomatic complexity of validation.ValidateConfig

### DIFF
--- a/pkg/apis/externaldns/validation/validation.go
+++ b/pkg/apis/externaldns/validation/validation.go
@@ -28,57 +28,13 @@ import (
 // ValidateConfig performs validation on the Config object
 func ValidateConfig(cfg *externaldns.Config) error {
 	// TODO: Should probably return field.ErrorList
-	if cfg.LogFormat != "text" && cfg.LogFormat != "json" {
-		return fmt.Errorf("unsupported log format: %s", cfg.LogFormat)
-	}
-	if len(cfg.Sources) == 0 {
-		return errors.New("no sources specified")
-	}
-	if cfg.Provider == "" {
-		return errors.New("no provider specified")
+
+	if err := preValidateConfig(cfg); err != nil {
+		return err
 	}
 
-	// Azure provider specific validations
-	if cfg.Provider == "azure" {
-		if cfg.AzureConfigFile == "" {
-			return errors.New("no Azure config file specified")
-		}
-	}
-
-	// Akamai provider specific validations
-	if cfg.Provider == "akamai" {
-		if cfg.AkamaiServiceConsumerDomain == "" && cfg.AkamaiEdgercPath != "" {
-			return errors.New("no Akamai ServiceConsumerDomain specified")
-		}
-		if cfg.AkamaiClientToken == "" && cfg.AkamaiEdgercPath != "" {
-			return errors.New("no Akamai client token specified")
-		}
-		if cfg.AkamaiClientSecret == "" && cfg.AkamaiEdgercPath != "" {
-			return errors.New("no Akamai client secret specified")
-		}
-		if cfg.AkamaiAccessToken == "" && cfg.AkamaiEdgercPath != "" {
-			return errors.New("no Akamai access token specified")
-		}
-	}
-
-	if cfg.Provider == "rfc2136" {
-		if cfg.RFC2136MinTTL < 0 {
-			return errors.New("TTL specified for rfc2136 is negative")
-		}
-
-		if cfg.RFC2136Insecure && cfg.RFC2136GSSTSIG {
-			return errors.New("--rfc2136-insecure and --rfc2136-gss-tsig are mutually exclusive arguments")
-		}
-
-		if cfg.RFC2136GSSTSIG {
-			if cfg.RFC2136KerberosPassword == "" || cfg.RFC2136KerberosUsername == "" || cfg.RFC2136KerberosRealm == "" {
-				return errors.New("--rfc2136-kerberos-realm, --rfc2136-kerberos-username, and --rfc2136-kerberos-password are required when specifying --rfc2136-gss-tsig option")
-			}
-		}
-
-		if cfg.RFC2136BatchChangeSize < 1 {
-			return errors.New("batch size specified for rfc2136 cannot be less than 1")
-		}
+	if err := validateConfigForProvider(cfg); err != nil {
+		return err
 	}
 
 	if cfg.IgnoreHostnameAnnotation && cfg.FQDNTemplate == "" {
@@ -92,6 +48,73 @@ func ValidateConfig(cfg *externaldns.Config) error {
 	_, err := labels.Parse(cfg.LabelFilter)
 	if err != nil {
 		return errors.New("--label-filter does not specify a valid label selector")
+	}
+	return nil
+}
+
+func preValidateConfig(cfg *externaldns.Config) error {
+	if cfg.LogFormat != "text" && cfg.LogFormat != "json" {
+		return fmt.Errorf("unsupported log format: %s", cfg.LogFormat)
+	}
+	if len(cfg.Sources) == 0 {
+		return errors.New("no sources specified")
+	}
+	if cfg.Provider == "" {
+		return errors.New("no provider specified")
+	}
+	return nil
+}
+
+func validateConfigForProvider(cfg *externaldns.Config) error {
+	switch cfg.Provider {
+	case "azure":
+		return validateConfigForAzure(cfg)
+	case "akamai":
+		return validateConfigForAkamai(cfg)
+	case "rfc2136":
+		return validateConfigForRfc2136(cfg)
+	default:
+		return nil
+	}
+}
+
+func validateConfigForAzure(cfg *externaldns.Config) error {
+	if cfg.AzureConfigFile == "" {
+		return errors.New("no Azure config file specified")
+	}
+	return nil
+}
+
+func validateConfigForAkamai(cfg *externaldns.Config) error {
+	if cfg.AkamaiServiceConsumerDomain == "" && cfg.AkamaiEdgercPath != "" {
+		return errors.New("no Akamai ServiceConsumerDomain specified")
+	}
+	if cfg.AkamaiClientToken == "" && cfg.AkamaiEdgercPath != "" {
+		return errors.New("no Akamai client token specified")
+	}
+	if cfg.AkamaiClientSecret == "" && cfg.AkamaiEdgercPath != "" {
+		return errors.New("no Akamai client secret specified")
+	}
+	if cfg.AkamaiAccessToken == "" && cfg.AkamaiEdgercPath != "" {
+		return errors.New("no Akamai access token specified")
+	}
+	return nil
+}
+
+func validateConfigForRfc2136(cfg *externaldns.Config) error {
+	if cfg.RFC2136MinTTL < 0 {
+		return errors.New("TTL specified for rfc2136 is negative")
+	}
+	if cfg.RFC2136Insecure && cfg.RFC2136GSSTSIG {
+		return errors.New("--rfc2136-insecure and --rfc2136-gss-tsig are mutually exclusive arguments")
+	}
+	if cfg.RFC2136GSSTSIG {
+		if cfg.RFC2136KerberosPassword == "" || cfg.RFC2136KerberosUsername == "" || cfg.RFC2136KerberosRealm == "" {
+			return errors.New("--rfc2136-kerberos-realm, --rfc2136-kerberos-username, and --rfc2136-kerberos-password are required when specifying --rfc2136-gss-tsig option")
+		}
+	}
+	if cfg.RFC2136BatchChangeSize < 1 {
+		return errors.New("batch size specified for rfc2136 cannot be less than 1")
 	}
 	return nil
 }


### PR DESCRIPTION
## What does it do ?

Reduce cyclomatic complexity of `validation.ValidateConfig()` (cylcop=30) function by splitting it into functions.

Also add new tests to cover every cases.

## Motivation

See https://github.com/kubernetes-sigs/external-dns/issues/5419
<!-- What inspired you to submit this pull request? -->

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
