### PR TITLE
chore(provider/coredns): improve code coverage and reduce complexity

### DIFF
--- a/provider/coredns/coredns.go
+++ b/provider/coredns/coredns.go
@@ -124,7 +124,6 @@ func (c etcdClient) GetServices(prefix string) ([]*Service, error) {
 		}
 		svcs = append(svcs, svc)
 	}
-
 	return svcs, nil
 }
 
@@ -281,9 +280,24 @@ func (p coreDNSProvider) Records(_ context.Context) ([]*endpoint.Endpoint, error
 	return result, nil
 }
 
-// ApplyChanges stores changes back to etcd converting them to CoreDNS format and aggregating A/CNAME and TXT records
-func (p coreDNSProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
-	grouped := map[string][]*endpoint.Endpoint{}
+func (p coreDNSProvider) ApplyChanges(_ context.Context, changes *plan.Changes) error {
+	grouped := p.groupEndpoints(changes)
+
+	for dnsName, group := range grouped {
+		if !p.domainFilter.Match(dnsName) {
+			log.Debugf("Skipping record %q due to domain filter", dnsName)
+			continue
+		}
+		if err := p.applyGroup(dnsName, group); err != nil {
+			return err
+		}
+	}
+
+	return p.deleteEndpoints(changes.Delete)
+}
+
+func (p coreDNSProvider) groupEndpoints(changes *plan.Changes) map[string][]*endpoint.Endpoint {
+	grouped := make(map[string][]*endpoint.Endpoint)
 	for _, ep := range changes.Create {
 		grouped[ep.DNSName] = append(grouped[ep.DNSName], ep)
 	}
@@ -292,112 +306,125 @@ func (p coreDNSProvider) ApplyChanges(ctx context.Context, changes *plan.Changes
 		log.Debugf("Updating labels (%s) with old labels(%s)", ep.Labels, changes.UpdateOld[i].Labels)
 		grouped[ep.DNSName] = append(grouped[ep.DNSName], ep)
 	}
-	for dnsName, group := range grouped {
-		if !p.domainFilter.Match(dnsName) {
-			log.Debugf("Skipping record %s because it was filtered out by the specified --domain-filter", dnsName)
-			continue
-		}
-		var services []Service
-		for _, ep := range group {
-			if ep.RecordType == endpoint.RecordTypeTXT {
-				continue
-			}
+	return grouped
+}
 
-			for _, target := range ep.Targets {
-				prefix := ep.Labels[target]
-				log.Debugf("Getting prefix(%s) from label(%s)", prefix, target)
-				if prefix == "" {
-					prefix = fmt.Sprintf("%08x", rand.Int31())
-					log.Infof("Generating new prefix: (%s)", prefix)
-				}
+func (p coreDNSProvider) applyGroup(dnsName string, group []*endpoint.Endpoint) error {
+	var services []*Service
 
-				service := Service{
-					Host:        target,
-					Text:        ep.Labels["originalText"],
-					Key:         p.etcdKeyFor(prefix + "." + dnsName),
-					TargetStrip: strings.Count(prefix, ".") + 1,
-					TTL:         uint32(ep.RecordTTL),
-				}
-				services = append(services, service)
-				ep.Labels[target] = prefix
-				log.Debugf("Putting prefix(%s) to label(%s)", prefix, target)
-				log.Debugf("Ep labels structure now: (%v)", ep.Labels)
+	for _, ep := range group {
+		if ep.RecordType != endpoint.RecordTypeTXT {
+			srvs, err := p.createServicesForEndpoint(dnsName, ep)
+			if err != nil {
+				return err
 			}
-
-			// Clean outdated targets
-			for label, labelPrefix := range ep.Labels {
-				// Skip non Target related labels
-				labelsToSkip := []string{"originalText", "prefix", "resource"}
-				if _, ok := findLabelInTargets(labelsToSkip, label); ok {
-					continue
-				}
-
-				log.Debugf("Finding label (%s) in targets(%v)", label, ep.Targets)
-				if _, ok := findLabelInTargets(ep.Targets, label); !ok {
-					log.Debugf("Found non existing label(%s) in targets(%v)", label, ep.Targets)
-					dnsName := ep.DNSName
-					dnsName = labelPrefix + "." + dnsName
-					key := p.etcdKeyFor(dnsName)
-					log.Infof("Delete key %s", key)
-					if !p.dryRun {
-						err := p.client.DeleteService(key)
-						if err != nil {
-							return err
-						}
-					}
-				}
-			}
-		}
-		index := 0
-		for _, ep := range group {
-			if ep.RecordType != endpoint.RecordTypeTXT {
-				continue
-			}
-			if index >= len(services) {
-				prefix := ep.Labels[randomPrefixLabel]
-				if prefix == "" {
-					prefix = fmt.Sprintf("%08x", rand.Int31())
-				}
-				services = append(services, Service{
-					Key:         p.etcdKeyFor(prefix + "." + dnsName),
-					TargetStrip: strings.Count(prefix, ".") + 1,
-					TTL:         uint32(ep.RecordTTL),
-				})
-			}
-			services[index].Text = ep.Targets[0]
-			index++
-		}
-
-		for i := index; index > 0 && i < len(services); i++ {
-			services[i].Text = ""
-		}
-
-		for _, service := range services {
-			log.Infof("Add/set key %s to Host=%s, Text=%s, TTL=%d", service.Key, service.Host, service.Text, service.TTL)
-			if !p.dryRun {
-				err := p.client.SaveService(&service)
-				if err != nil {
-					return err
-				}
-			}
+			services = append(services, srvs...)
 		}
 	}
 
-	for _, ep := range changes.Delete {
+	services = p.updateTXTRecords(dnsName, group, services)
+
+	for _, service := range services {
+		log.Infof("Add/set key %s to Host=%s, Text=%s, TTL=%d", service.Key, service.Host, service.Text, service.TTL)
+		if p.dryRun {
+			continue
+		}
+		if err := p.client.SaveService(service); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p coreDNSProvider) createServicesForEndpoint(dnsName string, ep *endpoint.Endpoint) ([]*Service, error) {
+	var services []*Service
+
+	for _, target := range ep.Targets {
+		prefix := ep.Labels[target]
+		if prefix == "" {
+			prefix = fmt.Sprintf("%08x", rand.Int31())
+			log.Infof("Generating new prefix: (%s)", prefix)
+		}
+		service := Service{
+			Host:        target,
+			Text:        ep.Labels["originalText"],
+			Key:         p.etcdKeyFor(prefix + "." + dnsName),
+			TargetStrip: strings.Count(prefix, ".") + 1,
+			TTL:         uint32(ep.RecordTTL),
+		}
+		services = append(services, &service)
+		ep.Labels[target] = prefix
+	}
+
+	// Clean outdated labels
+	for label, labelPrefix := range ep.Labels {
+		if shouldSkipLabel(label) {
+			continue
+		}
+		if _, ok := findLabelInTargets(ep.Targets, label); !ok {
+			key := p.etcdKeyFor(labelPrefix + "." + dnsName)
+			log.Infof("Delete key %s", key)
+			if p.dryRun {
+				continue
+			}
+			if err := p.client.DeleteService(key); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return services, nil
+}
+
+func shouldSkipLabel(label string) bool {
+	skip := []string{"originalText", "prefix", "resource"}
+	_, ok := findLabelInTargets(skip, label)
+	return ok
+}
+
+// updateTXTRecords updates the TXT records in the provided services slice based on the given group of endpoints.
+func (p coreDNSProvider) updateTXTRecords(dnsName string, group []*endpoint.Endpoint, services []*Service) []*Service {
+	index := 0
+	for _, ep := range group {
+		if ep.RecordType != endpoint.RecordTypeTXT {
+			continue
+		}
+		if index >= len(services) {
+			prefix := ep.Labels[randomPrefixLabel]
+			if prefix == "" {
+				prefix = fmt.Sprintf("%08x", rand.Int31())
+			}
+			services = append(services, &Service{
+				Key:         p.etcdKeyFor(prefix + "." + dnsName),
+				TargetStrip: strings.Count(prefix, ".") + 1,
+				TTL:         uint32(ep.RecordTTL),
+			})
+		}
+		services[index].Text = ep.Targets[0]
+		index++
+	}
+
+	for i := index; index > 0 && i < len(services); i++ {
+		services[i].Text = ""
+	}
+	return services
+}
+
+func (p coreDNSProvider) deleteEndpoints(endpoints []*endpoint.Endpoint) error {
+	for _, ep := range endpoints {
 		dnsName := ep.DNSName
 		if ep.Labels[randomPrefixLabel] != "" {
 			dnsName = ep.Labels[randomPrefixLabel] + "." + dnsName
 		}
 		key := p.etcdKeyFor(dnsName)
 		log.Infof("Delete key %s", key)
-		if !p.dryRun {
-			err := p.client.DeleteService(key)
-			if err != nil {
-				return err
-			}
+		if p.dryRun {
+			continue
+		}
+		if err := p.client.DeleteService(key); err != nil {
+			return err
 		}
 	}
-
 	return nil
 }
 
@@ -415,7 +442,7 @@ func guessRecordType(target string) string {
 }
 
 func reverse(slice []string) {
-	for i := 0; i < len(slice)/2; i++ {
+	for i := range len(slice) / 2 {
 		j := len(slice) - i - 1
 		slice[i], slice[j] = slice[j], slice[i]
 	}

--- a/provider/coredns/coredns_test.go
+++ b/provider/coredns/coredns_test.go
@@ -18,12 +18,18 @@ package coredns
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.etcd.io/etcd/api/v3/mvccpb"
 	etcdcv3 "go.etcd.io/etcd/client/v3"
+
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/internal/testutils"
 	"sigs.k8s.io/external-dns/plan"
@@ -57,6 +63,26 @@ func (c fakeETCDClient) SaveService(service *Service) error {
 func (c fakeETCDClient) DeleteService(key string) error {
 	delete(c.services, key)
 	return nil
+}
+
+type MockEtcdKV struct {
+	etcdcv3.KV
+	mock.Mock
+}
+
+func (m *MockEtcdKV) Put(ctx context.Context, key, input string, _ ...etcdcv3.OpOption) (*etcdcv3.PutResponse, error) {
+	args := m.Called(ctx, key, input)
+	return args.Get(0).(*etcdcv3.PutResponse), args.Error(1)
+}
+
+func (m *MockEtcdKV) Get(ctx context.Context, key string, _ ...etcdcv3.OpOption) (*etcdcv3.GetResponse, error) {
+	args := m.Called(ctx, key)
+	return args.Get(0).(*etcdcv3.GetResponse), args.Error(1)
+}
+
+func (m *MockEtcdKV) Delete(ctx context.Context, key string, opts ...etcdcv3.OpOption) (*etcdcv3.DeleteResponse, error) {
+	args := m.Called(ctx, key, opts[0])
+	return args.Get(0).(*etcdcv3.DeleteResponse), args.Error(1)
 }
 
 func TestETCDConfig(t *testing.T) {
@@ -382,6 +408,33 @@ func TestCoreDNSApplyChanges(t *testing.T) {
 	validateServices(client.services, expectedServices4, t, 4)
 }
 
+func TestCoreDNSApplyChanges_DomainDoNotMatch(t *testing.T) {
+	client := fakeETCDClient{
+		map[string]Service{},
+	}
+	coredns := coreDNSProvider{
+		client:        client,
+		coreDNSPrefix: defaultCoreDNSPrefix,
+		domainFilter: endpoint.DomainFilter{
+			Filters: []string{"example.local"},
+		},
+	}
+
+	changes1 := &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("domain1.local", endpoint.RecordTypeA, "5.5.5.5"),
+			endpoint.NewEndpoint("example.local", endpoint.RecordTypeTXT, "string1"),
+			endpoint.NewEndpoint("domain2.local", endpoint.RecordTypeCNAME, "site.local"),
+		},
+	}
+	hook := testutils.LogsUnderTestWithLogLevel(log.DebugLevel, t)
+	err := coredns.ApplyChanges(context.Background(), changes1)
+	require.NoError(t, err)
+
+	testutils.TestHelperLogContains("Skipping record \"domain1.local\" due to domain filter", hook, t)
+	testutils.TestHelperLogContains("Skipping record \"domain2.local\" due to domain filter", hook, t)
+}
+
 func applyServiceChanges(provider coreDNSProvider, changes *plan.Changes) error {
 	ctx := context.Background()
 	records, _ := provider.Records(ctx)
@@ -436,4 +489,378 @@ func mergeLabels(e *endpoint.Endpoint, labels map[string]string) {
 			e.Labels[k] = v
 		}
 	}
+}
+
+func TestGetServices_Success(t *testing.T) {
+	svc := Service{Host: "example.com", Port: 80, Priority: 1, Weight: 10, Text: "hello"}
+	value, err := json.Marshal(svc)
+	require.NoError(t, err)
+	mockKV := new(MockEtcdKV)
+	mockKV.On("Get", mock.Anything, "/prefix").Return(&etcdcv3.GetResponse{
+		Kvs: []*mvccpb.KeyValue{
+			{
+				Key:   []byte("/prefix/1"),
+				Value: value,
+			},
+		},
+	}, nil)
+
+	c := etcdClient{
+		client: &etcdcv3.Client{
+			KV: mockKV,
+		},
+		ctx: context.TODO(),
+	}
+
+	result, err := c.GetServices("/prefix")
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "example.com", result[0].Host)
+}
+
+func TestGetServices_Duplicate(t *testing.T) {
+	mockKV := new(MockEtcdKV)
+	c := etcdClient{
+		client: &etcdcv3.Client{
+			KV: mockKV,
+		},
+		ctx: context.TODO(),
+	}
+
+	svc := Service{Host: "example.com", Port: 80, Priority: 1, Weight: 10, Text: "hello"}
+	value, _ := json.Marshal(svc)
+
+	mockKV.On("Get", mock.Anything, "/prefix").Return(&etcdcv3.GetResponse{
+		Kvs: []*mvccpb.KeyValue{
+			{
+				Key:   []byte("/prefix/1"),
+				Value: value,
+			},
+			{
+				Key:   []byte("/prefix/1"),
+				Value: value,
+			},
+		},
+	}, nil)
+
+	result, err := c.GetServices("/prefix")
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+}
+
+func TestGetServices_Multiple(t *testing.T) {
+	mockKV := new(MockEtcdKV)
+	c := etcdClient{
+		client: &etcdcv3.Client{
+			KV: mockKV,
+		},
+		ctx: context.TODO(),
+	}
+
+	svc := Service{Host: "example.com", Port: 80, Priority: 1, Weight: 10, Text: "hello"}
+	value, err := json.Marshal(svc)
+	require.NoError(t, err)
+	svc2 := Service{Host: "example.com", Port: 80, Priority: 0, Weight: 10, Text: "hello"}
+	value2, err := json.Marshal(svc2)
+	require.NoError(t, err)
+
+	mockKV.On("Get", mock.Anything, "/prefix").Return(&etcdcv3.GetResponse{
+		Kvs: []*mvccpb.KeyValue{
+			{
+				Key:   []byte("/prefix/1"),
+				Value: value,
+			},
+			{
+				Key:   []byte("/prefix/2"),
+				Value: value2,
+			},
+		},
+	}, nil)
+
+	result, err := c.GetServices("/prefix")
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, priority, result[1].Priority)
+}
+
+func TestGetServices_UnmarshalError(t *testing.T) {
+	mockKV := new(MockEtcdKV)
+	c := etcdClient{
+		client: &etcdcv3.Client{
+			KV: mockKV,
+		},
+		ctx: context.TODO(),
+	}
+
+	mockKV.On("Get", mock.Anything, "/prefix").Return(&etcdcv3.GetResponse{
+		Kvs: []*mvccpb.KeyValue{
+			{
+				Key:   []byte("/prefix/1"),
+				Value: []byte("invalid-json"),
+			},
+			{
+				Key:   []byte("/prefix/1"),
+				Value: []byte("invalid-json"),
+			},
+		},
+	}, nil)
+
+	_, err := c.GetServices("/prefix")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "/prefix/1")
+}
+
+func TestGetServices_GetError(t *testing.T) {
+	mockKV := new(MockEtcdKV)
+	c := etcdClient{
+		client: &etcdcv3.Client{
+			KV: mockKV,
+		},
+		ctx: context.TODO(),
+	}
+
+	mockKV.On("Get", mock.Anything, "/prefix").Return(&etcdcv3.GetResponse{}, errors.New("etcd failure"))
+
+	_, err := c.GetServices("/prefix")
+	assert.Error(t, err)
+	assert.EqualError(t, err, "etcd failure")
+}
+
+func TestDeleteService(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		mockErr error
+		wantErr bool
+	}{
+		{
+			name: "successful deletion",
+			key:  "/skydns/local/test",
+		},
+		{
+			name:    "etcd error",
+			key:     "/skydns/local/test",
+			mockErr: errors.New("etcd failure"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockKV := new(MockEtcdKV)
+			mockKV.On("Delete", mock.Anything, mock.Anything, mock.AnythingOfType("clientv3.OpOption")).
+				Return(&etcdcv3.DeleteResponse{}, tt.mockErr)
+
+			c := etcdClient{
+				client: &etcdcv3.Client{
+					KV: mockKV,
+				},
+				ctx: context.Background(),
+			}
+
+			err := c.DeleteService(tt.key)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Equal(t, tt.mockErr, err)
+			} else {
+				require.NoError(t, err)
+			}
+			mockKV.AssertExpectations(t)
+		})
+	}
+}
+
+func TestSaveService(t *testing.T) {
+	type testCase struct {
+		name       string
+		service    *Service
+		mockPutErr error
+		wantErr    bool
+	}
+	tests := []testCase{
+		{
+			name: "success",
+			service: &Service{
+				Host:     "example.com",
+				Port:     80,
+				Priority: 1,
+				Weight:   10,
+				Text:     "hello",
+				Key:      "/prefix/1",
+			},
+		},
+		{
+			name: "etcd put error",
+			service: &Service{
+				Host: "example.com",
+				Key:  "/prefix/2",
+			},
+			mockPutErr: errors.New("etcd failure"),
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockKV := new(MockEtcdKV)
+			value, err := json.Marshal(&tt.service)
+			require.NoError(t, err)
+			mockKV.On("Put", mock.Anything, tt.service.Key, string(value)).
+				Return(&etcdcv3.PutResponse{}, tt.mockPutErr)
+
+			c := etcdClient{
+				client: &etcdcv3.Client{
+					KV: mockKV,
+				},
+				ctx: context.TODO(),
+			}
+
+			err = c.SaveService(tt.service)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			mockKV.AssertExpectations(t)
+		})
+	}
+}
+
+func TestNewCoreDNSProvider(t *testing.T) {
+	tests := []struct {
+		name    string
+		envs    map[string]string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "default config",
+			envs: map[string]string{},
+		},
+		{
+			name: "config with ETCD_URLS",
+			envs: map[string]string{"ETCD_URLS": "http://example.com:2379"},
+		},
+		{
+			name:    "config with unsupported protocol",
+			envs:    map[string]string{"ETCD_URLS": "ftp://example.com:20"},
+			wantErr: true,
+			errMsg:  "etcd URLs must start with either http:// or https://",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testutils.TestHelperEnvSetter(t, tt.envs)
+
+			provider, err := NewCoreDNSProvider(endpoint.DomainFilter{}, "/prefix/", false)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.EqualError(t, err, tt.errMsg)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, provider)
+			}
+		})
+	}
+}
+
+func TestFindEp(t *testing.T) {
+	tests := []struct {
+		name     string
+		slice    []*endpoint.Endpoint
+		dnsName  string
+		want     *endpoint.Endpoint
+		wantBool bool
+	}{
+		{
+			name: "found",
+			slice: []*endpoint.Endpoint{
+				{DNSName: "foo.example.com"},
+				{DNSName: "bar.example.com"},
+			},
+			dnsName:  "bar.example.com",
+			want:     &endpoint.Endpoint{DNSName: "bar.example.com"},
+			wantBool: true,
+		},
+		{
+			name: "not found",
+			slice: []*endpoint.Endpoint{
+				{DNSName: "foo.example.com"},
+			},
+			dnsName:  "baz.example.com",
+			want:     nil,
+			wantBool: false,
+		},
+		{
+			name:     "empty slice",
+			slice:    []*endpoint.Endpoint{},
+			dnsName:  "foo.example.com",
+			want:     nil,
+			wantBool: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := findEp(tt.slice, tt.dnsName)
+			assert.Equal(t, tt.wantBool, ok)
+			if ok {
+				assert.Equal(t, tt.dnsName, got.DNSName)
+			} else {
+				assert.Nil(t, got)
+			}
+		})
+	}
+}
+
+func TestCoreDNSProvider_updateTXTRecords_WithEdpoints(t *testing.T) {
+	provider := coreDNSProvider{coreDNSPrefix: "/prefix/"}
+	dnsName := "foo.example.com"
+
+	group := []*endpoint.Endpoint{
+		{
+			RecordType: endpoint.RecordTypeTXT,
+			Targets:    endpoint.Targets{"txt-value"},
+			Labels:     map[string]string{randomPrefixLabel: "pfx"},
+			RecordTTL:  60,
+		},
+		{
+			RecordType: endpoint.RecordTypeTXT,
+			Targets:    endpoint.Targets{"txt-value-2"},
+			Labels:     map[string]string{randomPrefixLabel: ""},
+			RecordTTL:  60,
+		},
+	}
+
+	services := provider.updateTXTRecords(dnsName, group, []*Service{})
+	assert.Len(t, services, 2)
+	assert.Equal(t, "txt-value", services[0].Text)
+	assert.Equal(t, "txt-value-2", services[1].Text)
+}
+
+func TestCoreDNSProvider_updateTXTRecords_ClearsExtraText(t *testing.T) {
+	provider := coreDNSProvider{coreDNSPrefix: "/prefix/"}
+	dnsName := "foo.example.com"
+
+	group := []*endpoint.Endpoint{
+		{
+			RecordType: endpoint.RecordTypeTXT,
+			Targets:    endpoint.Targets{"txt-value"},
+			Labels:     map[string]string{randomPrefixLabel: "pfx"},
+			RecordTTL:  60,
+		},
+	}
+
+	var services []*Service
+	services = append(services, &Service{Key: "/prefix/1", Text: "should-be-txt-value"})
+	services = append(services, &Service{Key: "/prefix/2", Text: "should-be-empty"})
+	services = append(services, &Service{Key: "/prefix/3", Text: "should-be-empty"})
+
+	services = provider.updateTXTRecords(dnsName, group, services)
+	assert.Len(t, services, 3)
+
+	assert.Equal(t, "txt-value", services[0].Text)
+	assert.Empty(t, services[1].Text)
 }


### PR DESCRIPTION
## What does it do ?

Improves code coverage for provider coredns, and reduce code complexity for certain functions

## Motivation

- https://github.com/kubernetes-sigs/external-dns/issues/5419
- https://github.com/kubernetes-sigs/external-dns/issues/5150

Complexity from 27 to 10
![Screenshot 2025-05-23 at 09 30 27](https://github.com/user-attachments/assets/fd387901-7203-4beb-ac7b-20107ca20218)

Before 66% coverage
![Screenshot 2025-05-23 at 09 49 04](https://github.com/user-attachments/assets/83a913c1-ca3a-40b7-8ce5-6ae6d61f5b72)

After 92% coverage

![Screenshot 2025-05-23 at 12 25 07](https://github.com/user-attachments/assets/e0e80033-a406-42f5-8ee8-d0bbf623debf)


## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
