### PR TITLE
fix(gen/docs/metrics/main_test): flaky test by replacing random value with a static value

### DIFF
--- a/internal/gen/docs/metrics/main_test.go
+++ b/internal/gen/docs/metrics/main_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 	"io/fs"
-	"math/rand/v2"
 	"os"
 	"testing"
 
@@ -57,7 +56,7 @@ func TestGenerateMarkdownTableWithSingleMetric(t *testing.T) {
 	reg.MustRegister(metrics.NewGaugeWithOpts(
 		prometheus.GaugeOpts{
 			Namespace: "external_dns",
-			Subsystem: fmt.Sprintf("controller_%d", rand.IntN(100)),
+			Subsystem: "controller_0",
 			Name:      "verified_aaaa_records",
 			Help:      "This is just a test.",
 		},
@@ -95,7 +94,7 @@ func TestMetricsMdExtraMetricAdded(t *testing.T) {
 	reg.MustRegister(metrics.NewGaugeWithOpts(
 		prometheus.GaugeOpts{
 			Namespace: "external_dns",
-			Subsystem: fmt.Sprintf("controller_%d", rand.IntN(100)),
+			Subsystem: "controller_1",
 			Name:      "verified_aaaa_records",
 			Help:      "This is just a test.",
 		},


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->
This PR replaces the randomly generated `Subsystem` names in `internal/gen/docs/metrics/main_test.go` with static, unique values.

Previously, `rand.IntN(100)` was used to reduce the chance of collision, but this still introduced a 1% chance of flaky test failures due to duplicate names.

## Motivation
In [#5459](https://github.com/kubernetes-sigs/external-dns/pull/5459), we discussed improving test stability by adding +100 to the second `rand.IntN` call.
While that suggestion would reduce the collision probability, I opted for static values instead.
This eliminates the chance of collision entirely and ensures that if a conflicting test is added in the future, it will fail deterministically and be immediately detectable during development or CI.
<!-- What inspired you to submit this pull request? -->

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
