### PR TITLE
chore(source): move cache informer to dedicated folder

### DIFF
--- a/source/ambassador_host.go
+++ b/source/ambassador_host.go
@@ -32,20 +32,22 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
-	"k8s.io/client-go/informers"
+	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source/annotations"
+	"sigs.k8s.io/external-dns/source/informers"
 )
 
-// ambHostAnnotation is the annotation in the Host that maps to a Service
-const ambHostAnnotation = "external-dns.ambassador-service"
-
-// groupName is the group name for the Ambassador API
-const groupName = "getambassador.io"
+const (
+	// ambHostAnnotation is the annotation in the Host that maps to a Service
+	ambHostAnnotation = "external-dns.ambassador-service"
+	// groupName is the group name for the Ambassador API
+	groupName = "getambassador.io"
+)
 
 var schemeGroupVersion = schema.GroupVersion{Group: groupName, Version: "v2"}
 
@@ -59,7 +61,7 @@ type ambassadorHostSource struct {
 	kubeClient             kubernetes.Interface
 	namespace              string
 	annotationFilter       string
-	ambassadorHostInformer informers.GenericInformer
+	ambassadorHostInformer kubeinformers.GenericInformer
 	unstructuredConverter  *unstructuredConverter
 	labelSelector          labels.Selector
 }
@@ -91,7 +93,7 @@ func NewAmbassadorHostSource(
 	informerFactory.Start(ctx.Done())
 
 	// wait for the local cache to be populated.
-	if err := waitForDynamicCacheSync(context.Background(), informerFactory); err != nil {
+	if err := informers.WaitForDynamicCacheSync(context.Background(), informerFactory); err != nil {
 		return nil, err
 	}
 

--- a/source/contour_httpproxy.go
+++ b/source/contour_httpproxy.go
@@ -30,13 +30,13 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
-	"k8s.io/client-go/informers"
+	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
-
-	"sigs.k8s.io/external-dns/source/fqdn"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source/annotations"
+	"sigs.k8s.io/external-dns/source/fqdn"
+	"sigs.k8s.io/external-dns/source/informers"
 )
 
 // HTTPProxySource is an implementation of Source for ProjectContour HTTPProxy objects.
@@ -49,7 +49,7 @@ type httpProxySource struct {
 	fqdnTemplate             *template.Template
 	combineFQDNAnnotation    bool
 	ignoreHostnameAnnotation bool
-	httpProxyInformer        informers.GenericInformer
+	httpProxyInformer        kubeinformers.GenericInformer
 	unstructuredConverter    *UnstructuredConverter
 }
 
@@ -84,7 +84,7 @@ func NewContourHTTPProxySource(
 	informerFactory.Start(ctx.Done())
 
 	// wait for the local cache to be populated.
-	if err := waitForDynamicCacheSync(context.Background(), informerFactory); err != nil {
+	if err := informers.WaitForDynamicCacheSync(context.Background(), informerFactory); err != nil {
 		return nil, err
 	}
 
@@ -113,7 +113,6 @@ func (sc *httpProxySource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint,
 		return nil, err
 	}
 
-	// Convert to []*projectcontour.HTTPProxy
 	var httpProxies []*projectcontour.HTTPProxy
 	for _, hp := range hps {
 		unstructuredHP, ok := hp.(*unstructured.Unstructured)

--- a/source/f5_transportserver.go
+++ b/source/f5_transportserver.go
@@ -30,12 +30,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
-	"k8s.io/client-go/informers"
+	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
 
 	f5 "github.com/F5Networks/k8s-bigip-ctlr/v2/config/apis/cis/v1"
+
+	"sigs.k8s.io/external-dns/source/informers"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source/annotations"
@@ -50,7 +52,7 @@ var f5TransportServerGVR = schema.GroupVersionResource{
 // transportServerSource is an implementation of Source for F5 TransportServer objects.
 type f5TransportServerSource struct {
 	dynamicKubeClient       dynamic.Interface
-	transportServerInformer informers.GenericInformer
+	transportServerInformer kubeinformers.GenericInformer
 	kubeClient              kubernetes.Interface
 	annotationFilter        string
 	namespace               string
@@ -77,7 +79,7 @@ func NewF5TransportServerSource(
 	informerFactory.Start(ctx.Done())
 
 	// wait for the local cache to be populated.
-	if err := waitForDynamicCacheSync(context.Background(), informerFactory); err != nil {
+	if err := informers.WaitForDynamicCacheSync(context.Background(), informerFactory); err != nil {
 		return nil, err
 	}
 

--- a/source/f5_virtualserver.go
+++ b/source/f5_virtualserver.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
-	"k8s.io/client-go/informers"
+	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
@@ -40,6 +40,7 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source/annotations"
+	"sigs.k8s.io/external-dns/source/informers"
 )
 
 var f5VirtualServerGVR = schema.GroupVersionResource{
@@ -51,7 +52,7 @@ var f5VirtualServerGVR = schema.GroupVersionResource{
 // virtualServerSource is an implementation of Source for F5 VirtualServer objects.
 type f5VirtualServerSource struct {
 	dynamicKubeClient     dynamic.Interface
-	virtualServerInformer informers.GenericInformer
+	virtualServerInformer kubeinformers.GenericInformer
 	kubeClient            kubernetes.Interface
 	annotationFilter      string
 	namespace             string
@@ -78,7 +79,7 @@ func NewF5VirtualServerSource(
 	informerFactory.Start(ctx.Done())
 
 	// wait for the local cache to be populated.
-	if err := waitForDynamicCacheSync(context.Background(), informerFactory); err != nil {
+	if err := informers.WaitForDynamicCacheSync(context.Background(), informerFactory); err != nil {
 		return nil, err
 	}
 

--- a/source/informers/informers.go
+++ b/source/informers/informers.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informers
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	defaultRequestTimeout = 60
+)
+
+type informerFactory interface {
+	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
+}
+
+func WaitForCacheSync(ctx context.Context, factory informerFactory) error {
+	timeout := defaultRequestTimeout * time.Second
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	for typ, done := range factory.WaitForCacheSync(ctx.Done()) {
+		if !done {
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("failed to sync %v: %w with timeout %s", typ, ctx.Err(), timeout)
+			default:
+				return fmt.Errorf("failed to sync %v with timeout %s", typ, timeout)
+			}
+		}
+	}
+	return nil
+}
+
+type dynamicInformerFactory interface {
+	WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersionResource]bool
+}
+
+func WaitForDynamicCacheSync(ctx context.Context, factory dynamicInformerFactory) error {
+	timeout := defaultRequestTimeout * time.Second
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	for typ, done := range factory.WaitForCacheSync(ctx.Done()) {
+		if !done {
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("failed to sync %v: %w with timeout %s", typ, ctx.Err(), timeout)
+			default:
+				return fmt.Errorf("failed to sync %v with timeout %s", typ, timeout)
+			}
+		}
+	}
+	return nil
+}

--- a/source/informers/informers_test.go
+++ b/source/informers/informers_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informers
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type mockInformerFactory struct {
+	syncResults map[reflect.Type]bool
+}
+
+func (m *mockInformerFactory) WaitForCacheSync(_ <-chan struct{}) map[reflect.Type]bool {
+	return m.syncResults
+}
+
+type mockDynamicInformerFactory struct {
+	syncResults map[schema.GroupVersionResource]bool
+}
+
+func (m *mockDynamicInformerFactory) WaitForCacheSync(_ <-chan struct{}) map[schema.GroupVersionResource]bool {
+	return m.syncResults
+}
+
+func TestWaitForCacheSync(t *testing.T) {
+	tests := []struct {
+		name        string
+		syncResults map[reflect.Type]bool
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "all caches synced",
+			syncResults: map[reflect.Type]bool{reflect.TypeOf(""): true},
+		},
+		{
+			name:        "some caches not synced",
+			syncResults: map[reflect.Type]bool{reflect.TypeOf(""): false},
+			expectError: true,
+			errorMsg:    "failed to sync string with timeout 1m0s",
+		},
+		{
+			name:        "context timeout",
+			syncResults: map[reflect.Type]bool{reflect.TypeOf(""): false},
+			expectError: true,
+			errorMsg:    "failed to sync string with timeout 1m0s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			factory := &mockInformerFactory{syncResults: tt.syncResults}
+			err := WaitForCacheSync(ctx, factory)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Errorf(t, err, tt.errorMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestWaitForDynamicCacheSync(t *testing.T) {
+	tests := []struct {
+		name        string
+		syncResults map[schema.GroupVersionResource]bool
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "all caches synced",
+			syncResults: map[schema.GroupVersionResource]bool{schema.GroupVersionResource{}: true},
+		},
+		{
+			name:        "some caches not synced",
+			syncResults: map[schema.GroupVersionResource]bool{schema.GroupVersionResource{}: false},
+			expectError: true,
+			errorMsg:    "failed to sync string with timeout 1m0s",
+		},
+		{
+			name:        "context timeout",
+			syncResults: map[schema.GroupVersionResource]bool{schema.GroupVersionResource{}: false},
+			expectError: true,
+			errorMsg:    "failed to sync string with timeout 1m0s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			factory := &mockDynamicInformerFactory{syncResults: tt.syncResults}
+			err := WaitForDynamicCacheSync(ctx, factory)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Errorf(t, err, tt.errorMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/source/ingress.go
+++ b/source/ingress.go
@@ -33,6 +33,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
+	"sigs.k8s.io/external-dns/source/informers"
+
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/source/fqdn"
@@ -102,7 +104,7 @@ func NewIngressSource(ctx context.Context, kubeClient kubernetes.Interface, name
 	informerFactory.Start(ctx.Done())
 
 	// wait for the local cache to be populated.
-	if err := waitForCacheSync(context.Background(), informerFactory); err != nil {
+	if err := informers.WaitForCacheSync(context.Background(), informerFactory); err != nil {
 		return nil, err
 	}
 

--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -35,10 +35,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
-	"sigs.k8s.io/external-dns/source/fqdn"
-
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source/annotations"
+	"sigs.k8s.io/external-dns/source/fqdn"
+	"sigs.k8s.io/external-dns/source/informers"
 )
 
 // IstioGatewayIngressSource is the annotation used to determine if the gateway is implemented by an Ingress object
@@ -104,10 +104,10 @@ func NewIstioGatewaySource(
 	istioInformerFactory.Start(ctx.Done())
 
 	// wait for the local cache to be populated.
-	if err := waitForCacheSync(context.Background(), informerFactory); err != nil {
+	if err := informers.WaitForCacheSync(context.Background(), informerFactory); err != nil {
 		return nil, err
 	}
-	if err := waitForCacheSync(context.Background(), istioInformerFactory); err != nil {
+	if err := informers.WaitForCacheSync(context.Background(), istioInformerFactory); err != nil {
 		return nil, err
 	}
 

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/source/fqdn"
+	"sigs.k8s.io/external-dns/source/informers"
 )
 
 // IstioMeshGateway is the built in gateway for all sidecars
@@ -114,10 +115,10 @@ func NewIstioVirtualServiceSource(
 	istioInformerFactory.Start(ctx.Done())
 
 	// wait for the local cache to be populated.
-	if err := waitForCacheSync(context.Background(), informerFactory); err != nil {
+	if err := informers.WaitForCacheSync(context.Background(), informerFactory); err != nil {
 		return nil, err
 	}
-	if err := waitForCacheSync(context.Background(), istioInformerFactory); err != nil {
+	if err := informers.WaitForCacheSync(context.Background(), istioInformerFactory); err != nil {
 		return nil, err
 	}
 

--- a/source/kong_tcpingress.go
+++ b/source/kong_tcpingress.go
@@ -31,13 +31,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
-	"k8s.io/client-go/informers"
+	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source/annotations"
+	"sigs.k8s.io/external-dns/source/informers"
 )
 
 var kongGroupdVersionResource = schema.GroupVersionResource{
@@ -51,7 +52,7 @@ type kongTCPIngressSource struct {
 	annotationFilter         string
 	ignoreHostnameAnnotation bool
 	dynamicKubeClient        dynamic.Interface
-	kongTCPIngressInformer   informers.GenericInformer
+	kongTCPIngressInformer   kubeinformers.GenericInformer
 	kubeClient               kubernetes.Interface
 	namespace                string
 	unstructuredConverter    *unstructuredConverter
@@ -77,7 +78,7 @@ func NewKongTCPIngressSource(ctx context.Context, dynamicKubeClient dynamic.Inte
 	informerFactory.Start(ctx.Done())
 
 	// wait for the local cache to be populated.
-	if err := waitForDynamicCacheSync(context.Background(), informerFactory); err != nil {
+	if err := informers.WaitForDynamicCacheSync(context.Background(), informerFactory); err != nil {
 		return nil, err
 	}
 

--- a/source/node.go
+++ b/source/node.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/source/fqdn"
+	"sigs.k8s.io/external-dns/source/informers"
 )
 
 const warningMsg = "The default behavior of exposing internal IPv6 addresses will change in the next minor version. Use --no-expose-internal-ipv6 flag to opt-in to the new behavior."
@@ -70,7 +71,7 @@ func NewNodeSource(ctx context.Context, kubeClient kubernetes.Interface, annotat
 	informerFactory.Start(ctx.Done())
 
 	// wait for the local cache to be populated.
-	if err := waitForCacheSync(context.Background(), informerFactory); err != nil {
+	if err := informers.WaitForCacheSync(context.Background(), informerFactory); err != nil {
 		return nil, err
 	}
 

--- a/source/openshift_route.go
+++ b/source/openshift_route.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/source/fqdn"
+	"sigs.k8s.io/external-dns/source/informers"
 )
 
 // ocpRouteSource is an implementation of Source for OpenShift Route objects.
@@ -87,7 +88,7 @@ func NewOcpRouteSource(
 	informerFactory.Start(ctx.Done())
 
 	// wait for the local cache to be populated.
-	if err := waitForCacheSync(context.Background(), informerFactory); err != nil {
+	if err := informers.WaitForCacheSync(context.Background(), informerFactory); err != nil {
 		return nil, err
 	}
 

--- a/source/pod.go
+++ b/source/pod.go
@@ -19,8 +19,6 @@ package source
 import (
 	"context"
 
-	"sigs.k8s.io/external-dns/endpoint"
-
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -29,7 +27,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
+	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source/annotations"
+	"sigs.k8s.io/external-dns/source/informers"
 )
 
 type podSource struct {
@@ -64,7 +64,7 @@ func NewPodSource(ctx context.Context, kubeClient kubernetes.Interface, namespac
 	informerFactory.Start(ctx.Done())
 
 	// wait for the local cache to be populated.
-	if err := waitForCacheSync(context.Background(), informerFactory); err != nil {
+	if err := informers.WaitForCacheSync(context.Background(), informerFactory); err != nil {
 		return nil, err
 	}
 

--- a/source/service.go
+++ b/source/service.go
@@ -33,6 +33,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
+	"sigs.k8s.io/external-dns/source/informers"
+
 	"sigs.k8s.io/external-dns/source/annotations"
 
 	"sigs.k8s.io/external-dns/endpoint"
@@ -112,7 +114,7 @@ func NewServiceSource(ctx context.Context, kubeClient kubernetes.Interface, name
 	informerFactory.Start(ctx.Done())
 
 	// wait for the local cache to be populated.
-	if err := waitForCacheSync(context.Background(), informerFactory); err != nil {
+	if err := informers.WaitForCacheSync(context.Background(), informerFactory); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->

## Motivation

I was looking at issues, example
- https://github.com/kubernetes-sigs/external-dns/issues/4955
- https://github.com/kubernetes-sigs/external-dns/issues/3173
- https://github.com/kubernetes-sigs/external-dns/issues/3169

Most of them related timeouts. This PR is not a fix for any of them. There is a flag https://github.com/kubernetes-sigs/external-dns/blob/36bc7d6bc47d4d8862aa02f88ac57d0608919a2a/docs/flags.md?plain=1#L12C1-L12C2 `--request-timeout=`, but the config is not respected, the timeout is static.

In this PR I've
- added more unit tests
- moved cache to dedicated folder
- different source do use different aliases for imports, fixed this
- added more units tests

This will simplify in follow-up to
- support sync request timeout in cache sync with the flag
- will simplify in fiture to move sources to specific folders
- create an interface, to simplify unit testing

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
