### PR TITLE
fix(helm): Add install CRDs option

### DIFF
--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -115,6 +115,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | image.tag | string | `nil` | Image tag for the `external-dns` container, this will default to `.Chart.AppVersion` if not set. |
 | imagePullSecrets | list | `[]` | Image pull secrets. |
 | initContainers | list | `[]` | [Init containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) to add to the `Pod` definition. |
+| installCRDs | bool | `true` | Set this to `false` to disable the installation of the _Custom Resource Definitions_ (CRDs) for _ExternalDNS_. |
 | interval | string | `"1m"` | Interval for DNS updates. |
 | labelFilter | string | `nil` | Filter resources queried for endpoints by label selector |
 | livenessProbe | object | See _values.yaml_ | [Liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `external-dns` container. |

--- a/charts/external-dns/crds/dnsendpoint.yaml
+++ b/charts/external-dns/crds/dnsendpoint.yaml
@@ -1,4 +1,4 @@
----
+{{- if .Values.installCRDs -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -101,3 +101,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end -}}

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -130,6 +130,9 @@
     "initContainers": {
       "type": "array"
     },
+    "installCRDs": {
+      "type": "boolean"
+    },
     "interval": {
       "type": "string"
     },

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -14,6 +14,9 @@ image:  # @schema additionalProperties: false
   # -- Image pull policy for the `external-dns` container.
   pullPolicy: IfNotPresent  # @schema enum:[IfNotPresent, Always];
 
+# -- Set this to `false` to disable the installation of the _Custom Resource Definitions_ (CRDs) for _ExternalDNS_.
+installCRDs: true
+
 # -- Image pull secrets.
 imagePullSecrets: []  # @schema item: object
 


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->

Allow's users to disable CRD installation when using Helm

## Motivation

<!-- What inspired you to submit this pull request? -->

We run multiple ext dns charts for Azure, these resources get duplicated.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
