### PR TITLE
httproute generations gap toleration

### DIFF
--- a/docs/sources/gateway.md
+++ b/docs/sources/gateway.md
@@ -84,6 +84,8 @@ Matching Gateways are discovered by iterating over the \*Route's `status.parents
 
 - Ignores parents whose Gateway either does not exist or has not accepted the route.
 
+- By default, if a route's generation doesn't match the generation accepted by its parent, the route is ignored. This can trigger unnecessary DNS name recreation with `--policy=sync`, especially due to known gateway lags (e.g., GKE). The `--httproute-generations-gap` flag allows you to tolerate a maximum number of generations of drift, preventing premature DNS record changes caused by temporary inconsistencies.
+
 ### Matching listeners
 
 Iterates over all listeners for the parent's `parentRef.sectionName`:

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -60,6 +60,7 @@ type Config struct {
 	GatewayName                                   string
 	GatewayNamespace                              string
 	GatewayLabelFilter                            string
+	HTTPRouteGenerationsGap                       int64
 	Compatibility                                 string
 	PodSourceDomain                               string
 	PublishInternal                               bool
@@ -277,9 +278,10 @@ var defaultConfig = &Config{
 	ExoscaleAPIZone:              "ch-gva-2",
 	ExposeInternalIPV6:           true,
 	FQDNTemplate:                 "",
-	GatewayLabelFilter:           "",
 	GatewayName:                  "",
 	GatewayNamespace:             "",
+	GatewayLabelFilter:           "",
+	HTTPRouteGenerationsGap:      0,
 	GlooNamespaces:               []string{"gloo-system"},
 	GoDaddyAPIKey:                "",
 	GoDaddyOTE:                   false,
@@ -470,6 +472,7 @@ func App(cfg *Config) *kingpin.Application {
 	app.Flag("ignore-ingress-rules-spec", "Ignore the spec.rules section in Ingress resources (default: false)").BoolVar(&cfg.IgnoreIngressRulesSpec)
 	app.Flag("ignore-ingress-tls-spec", "Ignore the spec.tls section in Ingress resources (default: false)").BoolVar(&cfg.IgnoreIngressTLSSpec)
 	app.Flag("ignore-non-host-network-pods", "Ignore pods not running on host network when using pod source (default: false)").BoolVar(&cfg.IgnoreNonHostNetworkPods)
+	app.Flag("httproute-generations-gap", "Maximum allowed difference between an observed gateway route's generation and its accepted generation. The route remains valid within this threshold. (default: 0)").Default("0").Int64Var(&cfg.HTTPRouteGenerationsGap)
 	app.Flag("ingress-class", "Require an Ingress to have this class name (defaults to any class; specify multiple times to allow more than one class)").StringsVar(&cfg.IngressClassNames)
 	app.Flag("label-filter", "Filter resources queried for endpoints by label selector; currently supported by source types crd, gateway-httproute, gateway-grpcroute, gateway-tlsroute, gateway-tcproute, gateway-udproute, ingress, node, openshift-route, service and ambassador-host").Default(defaultConfig.LabelFilter).StringVar(&cfg.LabelFilter)
 	managedRecordTypesHelp := fmt.Sprintf("Record types to manage; specify multiple times to include many; (default: %s) (supported records: A, AAAA, CNAME, NS, SRV, TXT)", strings.Join(defaultConfig.ManagedDNSRecordTypes, ","))

--- a/source/store.go
+++ b/source/store.go
@@ -60,6 +60,7 @@ type Config struct {
 	GatewayName                    string
 	GatewayNamespace               string
 	GatewayLabelFilter             string
+	HTTPRouteGenerationsGap        int64
 	Compatibility                  string
 	PodSourceDomain                string
 	PublishInternal                bool
@@ -105,6 +106,7 @@ func NewSourceConfig(cfg *externaldns.Config) *Config {
 		GatewayName:                    cfg.GatewayName,
 		GatewayNamespace:               cfg.GatewayNamespace,
 		GatewayLabelFilter:             cfg.GatewayLabelFilter,
+		HTTPRouteGenerationsGap:        cfg.HTTPRouteGenerationsGap,
 		Compatibility:                  cfg.Compatibility,
 		PodSourceDomain:                cfg.PodSourceDomain,
 		PublishInternal:                cfg.PublishInternal,


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->
Allows collection of HTTPRoute endpoints whose generation does not match the gateway's accepted generation, provided the difference is within the configured threshold.

## Motivation

<!-- What inspired you to submit this pull request? -->
We've observed scenarios where gateways introduce a delay in accepting route changes. For example, it commonly takes a minute or two for GKE to update `observedGeneration` in `status.parents.conditions` after `spec.hostnames` is modified in an HTTPRoute.

When using `--policy=sync`, this lag triggers the deletion and subsequent recreation of DNS names. While a 5-minute TTL often mitigates this for most setups, it can lead to significant impact in certain environments. A notable example is with Cloudflare custom hostnames, where frequent DNS record recreation can result in a temporary Let's Encrypt ban (typically for a couple of days).

This behavior highlights the need for an optional mechanism to tolerate temporary inconsistencies in gateway status, preventing unnecessary and potentially disruptive DNS reconfigurations.

Note that this implementation doesn't guarantee eventual consistency. This is due to the httproute's generation lacking a change timestamp. Therefore, potential issues where the gateway never accepts a change must be monitored separately.


## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
