### PR TITLE
revert: fix on gateway-api that ensure to use only latest generation with HTTPRoutes

### DIFF
--- a/source/gateway.go
+++ b/source/gateway.go
@@ -336,7 +336,7 @@ func (c *gatewayRouteResolver) resolve(rt gatewayRoute) (map[string]endpoint.Tar
 		}
 
 		// Confirm the Gateway has accepted the Route.
-		if !gwRouteIsAccepted(rps.Conditions, meta) {
+		if !gwRouteIsAccepted(rps.Conditions) {
 			log.Debugf("Gateway %s/%s has not accepted the current generation %s %s/%s", namespace, ref.Name, c.src.rtKind, meta.Namespace, meta.Name)
 			continue
 		}
@@ -498,10 +498,10 @@ func gwRouteHasParentRef(routeParentRefs []v1.ParentReference, ref v1.ParentRefe
 	return false
 }
 
-func gwRouteIsAccepted(conds []metav1.Condition, meta *metav1.ObjectMeta) bool {
+func gwRouteIsAccepted(conds []metav1.Condition) bool {
 	for _, c := range conds {
 		if v1.RouteConditionType(c.Type) == v1.RouteConditionAccepted {
-			return c.Status == metav1.ConditionTrue && c.ObservedGeneration == meta.Generation
+			return c.Status == metav1.ConditionTrue
 		}
 	}
 	return false

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -225,46 +225,6 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			},
 		},
 		{
-			title: "GatewayNameOldGeneration",
-			config: Config{
-				GatewayName: "gateway-name",
-			},
-			namespaces: namespaces("gateway-namespace", "route-namespace"),
-			gateways: []*v1beta1.Gateway{
-				{
-					ObjectMeta: omWithGeneration(objectMeta("gateway-namespace", "gateway-name"), 2),
-					Spec: v1.GatewaySpec{
-						Listeners: []v1.Listener{{
-							Protocol:      v1.HTTPProtocolType,
-							AllowedRoutes: allowAllNamespaces,
-						}},
-					},
-					Status: gatewayStatus("1.2.3.4"),
-				},
-			},
-			routes: []*v1beta1.HTTPRoute{{
-				ObjectMeta: omWithGeneration(objectMeta("route-namespace", "old-test"), 5),
-				Spec: v1.HTTPRouteSpec{
-					Hostnames: hostnames("test.example.internal"),
-					CommonRouteSpec: v1.CommonRouteSpec{
-						ParentRefs: []v1.ParentReference{
-							gwParentRef("gateway-namespace", "gateway-name"),
-						},
-					},
-				},
-				Status: rsWithGeneration(httpRouteStatus( // The route was previously attached in a different generation
-					gwParentRef("gateway-namespace", "gateway-name"),
-					gwParentRef("gateway-namespace", "gateway-name"),
-				), 5, 4),
-			}},
-			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("test.example.internal", "A", "1.2.3.4"),
-			},
-			logExpectations: []string{
-				"Gateway gateway-namespace/gateway-name has not accepted the current generation HTTPRoute route-namespace/old-test",
-			},
-		},
-		{
 			title: "GatewayNameNoneAccepted",
 			config: Config{
 				GatewayName: "gateway-name",
@@ -1582,7 +1542,6 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-
 		t.Run(tt.title, func(t *testing.T) {
 			if len(tt.logExpectations) == 0 {
 				t.Parallel()


### PR DESCRIPTION
## What does it do ?

It reverts 
- https://github.com/kubernetes-sigs/external-dns/pull/5349

## Motivation

As @abursavich suspected:
> If we don't have matching generations when generating the endpoints, the sync could delete the DNS records.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
