### PR TITLE
chore: update maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,6 +9,7 @@
 # https://github.com/kubernetes/org/blob/main/config/kubernetes-sigs/sig-network/teams.yaml
 
 approvers:
+  - ivankatliarchuk
   - mloiseleur
   - raffo
   - szuecs


### PR DESCRIPTION
## What does it do ?

It updates OWNERS file with a new maintainer: @ivankatliarchuk 

## Motivation

I ran [monocle](https://github.com/change-metrics/monocle) on external-dns for the last year with this config:

```yaml
---
workspaces:
  - name: monocle
    crawlers:
      - name: github-external-dns
        provider:
          github_organization: kubernetes-sigs
          github_repositories:
            - external-dns
        update_since: '2024-06-01'
```

I saw on monocle that:

![image](https://github.com/user-attachments/assets/7fc08f9c-27ad-42c4-8547-bc9000e50608)

![image](https://github.com/user-attachments/assets/bd753d31-7443-4373-9fd1-b3559804498d)

It seems to me that Ivan has clearly passed the [requirements](https://github.com/kubernetes/community/blob/master/community-membership.md#requirements-2):

- [x] Reviewer of the codebase for at least 3 months
- [x] Primary reviewer for at least 10 substantial PRs to the codebase
- [x] Reviewed or merged at least 30 PRs to the codebase

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
