### PR TITLE
feat(metrics): consecutiveSoftErrors

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -743,7 +743,7 @@ func TestAAAARecords(t *testing.T) {
 
 type toggleRegistry struct {
 	registry.NoopRegistry
-	failCount int
+	failCount	int
 	failCountMu sync.Mutex // protects failCount
 }
 

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -743,7 +743,7 @@ func TestAAAARecords(t *testing.T) {
 
 type toggleRegistry struct {
 	registry.NoopRegistry
-	failCount	int
+	failCount   int
 	failCountMu sync.Mutex // protects failCount
 }
 

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -20,6 +20,7 @@ curl https://localhost:7979/metrics
 
 | Name                             | Metric Type | Subsystem   |  Help                                                 |
 |:---------------------------------|:------------|:------------|:------------------------------------------------------|
+| consecutive_soft_errors | Gauge | controller | Number of consecutive soft errors in reconciliation loop. |
 | last_reconcile_timestamp_seconds | Gauge | controller | Timestamp of last attempted sync with the DNS provider |
 | last_sync_timestamp_seconds | Gauge | controller | Timestamp of last successful sync with the DNS provider |
 | no_op_runs_total | Counter | controller | Number of reconcile loops ending up with no changes on the DNS provider side. |
@@ -87,5 +88,3 @@ curl https://localhost:7979/metrics
 | process_start_time_seconds |
 | process_virtual_memory_bytes |
 | process_virtual_memory_max_bytes |
-| process_network_receive_bytes_total |
-| process_network_transmit_bytes_total |

--- a/internal/gen/docs/metrics/main_test.go
+++ b/internal/gen/docs/metrics/main_test.go
@@ -37,7 +37,7 @@ func TestComputeMetrics(t *testing.T) {
 		t.Errorf("Expected not empty metrics registry, got %d", len(reg.Metrics))
 	}
 
-	assert.Len(t, reg.Metrics, 21)
+	assert.Len(t, reg.Metrics, 22)
 }
 
 func TestGenerateMarkdownTableRenderer(t *testing.T) {


### PR DESCRIPTION
## What does it do ?

- **New Metric Added**
  - Added a Prometheus gauge metric: `external_dns_controller_consecutive_soft_errors`
  - This metric tracks the number of consecutive soft errors (non-fatal, retryable errors) encountered during the controller’s reconciliation loop.

- **Metric Registration**
  - Registered the new `consecutiveSoftErrors` metric with the existing set of metrics.

- **Enhanced Error Handling in Controller Loop**
  - Introduced a `softErrorCount` counter to track consecutive soft errors.
  - On each soft error:
    - Increment the counter.
    - Update the Prometheus metric.
    - Log the error including the current consecutive count.
  - On successful reconciliation after soft errors:
    - Log the recovery and count of previous consecutive soft errors.
    - Reset the counter and metric to zero.

**Benefit:**  
These changes provide improved observability for persistent, non-fatal issues in the controller’s reconciliation loop, making it easier to detect and troubleshoot recurring problems.


## Motivation

#5499 

## More

- [X] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Yes, I added unit tests
- [X] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
