### PR TITLE
fix(provider/coredns): errjson linter

### DIFF
--- a/provider/coredns/coredns_test.go
+++ b/provider/coredns/coredns_test.go
@@ -528,7 +528,8 @@ func TestGetServices_Duplicate(t *testing.T) {
 	}
 
 	svc := Service{Host: "example.com", Port: 80, Priority: 1, Weight: 10, Text: "hello"}
-	value, _ := json.Marshal(svc)
+	value, err := json.Marshal(svc)
+	require.NoError(t, err)
 
 	mockKV.On("Get", mock.Anything, "/prefix").Return(&etcdcv3.GetResponse{
 		Kvs: []*mvccpb.KeyValue{


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->

## Motivation

To fix failing linter
- https://github.com/kubernetes-sigs/external-dns/pull/5504
  - https://github.com/kubernetes-sigs/external-dns/actions/runs/15481955682/job/43589279291?pr=5504

Most likely missed in initial pr, not sure

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
