### PR TITLE
chore(source/node): added resouce labels for nodes

### DIFF
--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -1460,6 +1460,11 @@ func testIngressEndpoints(t *testing.T) {
 				require.NoError(t, err)
 			}
 			validateEndpoints(t, res, ti.expected)
+
+			// TODO; when all resources have the resource label, we could add this check to the validateEndpoints function.
+			for _, ep := range res {
+				require.Contains(t, ep.Labels, endpoint.ResourceLabelKey)
+			}
 		})
 	}
 }

--- a/source/node.go
+++ b/source/node.go
@@ -102,7 +102,7 @@ func (ns *nodeSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, erro
 
 	// create endpoints for all nodes
 	for _, node := range nodes {
-		// Check controller annotation to see if we are responsible.
+		// Check the controller annotation to see if we are responsible.
 		if controller, ok := node.Annotations[controllerAnnotationKey]; ok && controller != controllerAnnotationValue {
 			log.Debugf("Skipping node %s because controller value does not match, found: %s, required: %s",
 				node.Name, controller, controllerAnnotationValue)
@@ -149,6 +149,8 @@ func (ns *nodeSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, erro
 
 			for _, addr := range addrs {
 				ep := endpoint.NewEndpointWithTTL(dns, suitableType(addr), ttl)
+				ep.WithLabel(endpoint.ResourceLabelKey, fmt.Sprintf("node/%s", node.Name))
+
 				log.Debugf("adding endpoint %s target %s", ep, addr)
 				key := endpoint.EndpointKey{
 					DNSName:    ep.DNSName,

--- a/source/node_test.go
+++ b/source/node_test.go
@@ -573,6 +573,11 @@ func testNodeEndpointsWithIPv6(t *testing.T) {
 
 		// Validate returned endpoints against desired endpoints.
 		validateEndpoints(t, endpoints, tc.expected)
+
+		// TODO; when all resources have the resource label, we could add this check to the validateEndpoints function.
+		for _, ep := range endpoints {
+			require.Contains(t, ep.Labels, endpoint.ResourceLabelKey)
+		}
 	}
 }
 
@@ -605,9 +610,8 @@ func TestResourceLabelIsSetForEachNodeEndpoint(t *testing.T) {
 	got, err := client.Endpoints(t.Context())
 	require.NoError(t, err)
 	for _, ep := range got {
-		// TODO: node source should always set the resource label key. currently not supported by the node source.
-		assert.Empty(t, ep.Labels, "Labels should not be empty for endpoint %s", ep.DNSName)
-		assert.NotContains(t, ep.Labels, endpoint.ResourceLabelKey)
+		assert.NotEmpty(t, ep.Labels, "Labels should not be empty for endpoint %s", ep.DNSName)
+		assert.Contains(t, ep.Labels, endpoint.ResourceLabelKey)
 	}
 }
 


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->

## Motivation

- add resource labels for node source
  - use cases
    - visibility, as currently difficult to debug why node enpoint is not accessible, the node could be unscedulable, but there is no way to trace DNS back to a node
    - visibility, it clearly shows that endpoint is created from the node
 
The more standart we have config accross different sources, easier to maintain them

## More

- [X] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
