### PR TITLE
test(source): fix flakyness on pod_test.go

### DIFF
--- a/source/pod_test.go
+++ b/source/pod_test.go
@@ -643,10 +643,7 @@ func TestPodSource(t *testing.T) {
 			},
 		},
 	} {
-
 		t.Run(tc.title, func(t *testing.T) {
-			t.Parallel()
-
 			kubernetes := fake.NewClientset()
 			ctx := context.Background()
 


### PR DESCRIPTION
## What does it do ?

Removes a second call to `t.Parallel()`.
There is already a first one at the beginning of the test, L36.

## Motivation

Fix CI.

## More

- [ ] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
