### PR TITLE
test(controller): increase timeout and refactor toggle registry test

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -747,10 +747,12 @@ type toggleRegistry struct {
 	failCountMu sync.Mutex // protects failCount
 }
 
+const toggleRegistryFailureCount = 3
+
 func (r *toggleRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
 	r.failCountMu.Lock()
 	defer r.failCountMu.Unlock()
-	if r.failCount < 3 {
+	if r.failCount < toggleRegistryFailureCount {
 		r.failCount++
 		return nil, provider.SoftError
 	}
@@ -766,12 +768,13 @@ func TestToggleRegistry(t *testing.T) {
 	cfg := getTestConfig()
 	r := &toggleRegistry{}
 
+	interval := 10 * time.Millisecond
 	ctrl := &Controller{
 		Source:             source,
 		Registry:           r,
 		Policy:             &plan.SyncPolicy{},
 		ManagedRecordTypes: cfg.ManagedDNSRecordTypes,
-		Interval:           10 * time.Millisecond,
+		Interval:           interval,
 	}
 	ctrl.nextRunAt = time.Now().Add(-time.Millisecond)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -781,19 +784,23 @@ func TestToggleRegistry(t *testing.T) {
 		close(stopped)
 	}()
 
-	// Wait up to 2 seconds for failCount to reach at least 3
-	deadline := time.Now().Add(2 * time.Second)
+	// Wait up to 1 minute for failCount to reach at least 3
+	// The timeout serves as a safety net against infinite loops while being
+	// sufficiently large to accommodate slow CI environments
+	deadline := time.Now().Add(1 * time.Minute)
 	for {
 		r.failCountMu.Lock()
 		count := r.failCount
 		r.failCountMu.Unlock()
-		if count >= 3 {
+		if count >= toggleRegistryFailureCount {
 			break
 		}
 		if time.Now().After(deadline) {
 			break
 		}
-		time.Sleep(10 * time.Millisecond)
+		// Sleep for the controller interval to avoid busy waiting
+		// since the controller won't run again until the interval passes
+		time.Sleep(interval)
 	}
 	cancel()
 	<-stopped
@@ -801,7 +808,5 @@ func TestToggleRegistry(t *testing.T) {
 	r.failCountMu.Lock()
 	finalCount := r.failCount
 	r.failCountMu.Unlock()
-	if finalCount < 3 {
-		t.Fatalf("failCount should be at least 3 after waiting up to 2s, got %d", finalCount)
-	}
+	assert.Equal(t, toggleRegistryFailureCount, finalCount, "failCount should be at least %d", toggleRegistryFailureCount)
 }

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -787,7 +787,7 @@ func TestToggleRegistry(t *testing.T) {
 	// Wait up to 1 minute for failCount to reach at least 3
 	// The timeout serves as a safety net against infinite loops while being
 	// sufficiently large to accommodate slow CI environments
-	deadline := time.Now().Add(1 * time.Minute)
+	deadline := time.Now().Add(15 * time.Second)
 	for {
 		r.failCountMu.Lock()
 		count := r.failCount


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->
Fix flaky `TestToggleRegistry` test by increasing timeout from 2 seconds to 15 seconds.

Example of the race condition failure: [link](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_external-dns/5459/pull-external-dns-unit-test/1932571764517244928)
## Motivation

<!-- What inspired you to submit this pull request? -->

The `TestToggleRegistry` test was experiencing intermittent failures in CI environments due to an insufficient 2-second timeout. 
The test validates that a controller continues retrying after soft errors, but slow CI environments couldn't consistently complete 3 retry attempts within the tight deadline.

**Solution**: Increase timeout to 1 minute as a safety net against infinite loops while being generous enough for any reasonable CI environment. 
Additionally, improve test efficiency by:
- Extracting magic number `3` to `toggleRegistryFailureCount` constant
for maintainability
- Using precise assertion for exact failure count validation


## More

- [ ] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
