### PR TITLE
chore(codebase): enable linter recvcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - ineffassign
     - misspell
     - revive
+    - recvcheck # Checks for receiver type consistency. https://golangci-lint.run/usage/linters/#recvcheck
     - rowserrcheck # Checks whether Rows.Err of rows is checked successfully.
     - errchkjson # Checks types passed to the json encoding functions. ref: https://golangci-lint.run/usage/linters/#errchkjson
     - errorlint # Checking for unchecked errors in Go code https://golangci-lint.run/usage/linters/#errcheck
@@ -38,6 +39,13 @@ linters:
       rules:
         - name: confusing-naming
           disabled: true
+    recvcheck:
+      # User-defined method exclusions.
+      # The format is `struct_name.method_name` (ex: `Foo.MethodName`).
+      # A wildcard `*` can use as a struct name (ex: `*.MethodName`).
+      # Default: []
+      exclusions:
+        - "DomainFilter.UnmarshalJSON"
     cyclop: # Lower cyclomatic complexity threshold after the max complexity is lowered
       max-complexity: 52
     testifylint:

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -124,13 +124,13 @@ func (t planTableRow) String() string {
 	return fmt.Sprintf("planTableRow{current=%v, candidates=%v}", t.current, t.candidates)
 }
 
-func (t planTable) addCurrent(e *endpoint.Endpoint) {
+func (t *planTable) addCurrent(e *endpoint.Endpoint) {
 	key := t.newPlanKey(e)
 	t.rows[key].current = append(t.rows[key].current, e)
 	t.rows[key].records[e.RecordType].current = e
 }
 
-func (t planTable) addCandidate(e *endpoint.Endpoint) {
+func (t *planTable) addCandidate(e *endpoint.Endpoint) {
 	key := t.newPlanKey(e)
 	t.rows[key].candidates = append(t.rows[key].candidates, e)
 	t.rows[key].records[e.RecordType].candidates = append(t.rows[key].records[e.RecordType].candidates, e)
@@ -316,7 +316,7 @@ func (p *Plan) shouldUpdateProviderSpecific(desired, current *endpoint.Endpoint)
 }
 
 // filterRecordsForPlan removes records that are not relevant to the planner.
-// Currently this just removes TXT records to prevent them from being
+// Currently, this just removes TXT records to prevent them from being
 // deleted erroneously by the planner (only the TXT registry should do this.)
 //
 // Per RFC 1034, CNAME records conflict with all other records - it is the

--- a/provider/ovh/ovh.go
+++ b/provider/ovh/ovh.go
@@ -195,7 +195,7 @@ func planChangesByZoneName(zones []string, changes *plan.Changes) map[string]*pl
 	return output
 }
 
-func (p OVHProvider) computeSingleZoneChanges(_ context.Context, zoneName string, existingRecords []ovhRecord, changes *plan.Changes) ([]ovhChange, error) {
+func (p *OVHProvider) computeSingleZoneChanges(_ context.Context, zoneName string, existingRecords []ovhRecord, changes *plan.Changes) ([]ovhChange, error) {
 	allChanges := []ovhChange{}
 	var computedChanges []ovhChange
 
@@ -496,7 +496,7 @@ func ovhGroupByNameAndType(records []ovhRecord) []*endpoint.Endpoint {
 	return endpoints
 }
 
-func (p OVHProvider) newOvhChangeCreateDelete(action int, endpoints []*endpoint.Endpoint, zone string, existingRecords []ovhRecord) ([]ovhChange, []ovhRecord) {
+func (p *OVHProvider) newOvhChangeCreateDelete(action int, endpoints []*endpoint.Endpoint, zone string, existingRecords []ovhRecord) ([]ovhChange, []ovhRecord) {
 	var ovhChanges []ovhChange
 	var toDeleteIds []int
 
@@ -564,7 +564,7 @@ func normalizeDNSName(dnsName string) string {
 	return strings.TrimSpace(strings.ToLower(dnsName))
 }
 
-func (p OVHProvider) newOvhChangeUpdate(endpointsOld []*endpoint.Endpoint, endpointsNew []*endpoint.Endpoint, zone string, existingRecords []ovhRecord) ([]ovhChange, error) {
+func (p *OVHProvider) newOvhChangeUpdate(endpointsOld []*endpoint.Endpoint, endpointsNew []*endpoint.Endpoint, zone string, existingRecords []ovhRecord) ([]ovhChange, error) {
 	zoneNameIDMapper := provider.ZoneIDName{}
 	zoneNameIDMapper.Add(zone, zone)
 
@@ -709,7 +709,7 @@ func (c *ovhChange) String() string {
 	return fmt.Sprintf("%s zone action(%s) : %s %d IN %s %s", c.Zone, action, c.SubDomain, c.TTL, c.FieldType, c.Target)
 }
 
-func (p OVHProvider) formatCNAMETarget(change *ovhChange) {
+func (p *OVHProvider) formatCNAMETarget(change *ovhChange) {
 	if change.FieldType != endpoint.RecordTypeCNAME {
 		return
 	}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -64,7 +64,7 @@ func (b BaseProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoi
 }
 
 func (b BaseProvider) GetDomainFilter() endpoint.DomainFilterInterface {
-	return endpoint.DomainFilter{}
+	return &endpoint.DomainFilter{}
 }
 
 type contextKey struct {

--- a/provider/transip/transip_test.go
+++ b/provider/transip/transip_test.go
@@ -202,31 +202,31 @@ func (f *fakeClient) Get(request rest.Request, dest interface{}) error {
 	return f.getFunc(request, dest)
 }
 
-func (f fakeClient) Put(request rest.Request) error {
+func (f *fakeClient) Put(request rest.Request) error {
 	return errors.New("PUT not implemented")
 }
 
-func (f fakeClient) Post(request rest.Request) error {
+func (f *fakeClient) Post(request rest.Request) error {
 	return errors.New("POST not implemented")
 }
 
-func (f fakeClient) Delete(request rest.Request) error {
+func (f *fakeClient) Delete(request rest.Request) error {
 	return errors.New("DELETE not implemented")
 }
 
-func (f fakeClient) Patch(request rest.Request) error {
+func (f *fakeClient) Patch(request rest.Request) error {
 	return errors.New("PATCH not implemented")
 }
 
-func (f fakeClient) PatchWithResponse(request rest.Request) (rest.Response, error) {
+func (f *fakeClient) PatchWithResponse(request rest.Request) (rest.Response, error) {
 	return rest.Response{}, errors.New("PATCH with response not implemented")
 }
 
-func (f fakeClient) PostWithResponse(request rest.Request) (rest.Response, error) {
+func (f *fakeClient) PostWithResponse(request rest.Request) (rest.Response, error) {
 	return rest.Response{}, errors.New("POST with response not implemented")
 }
 
-func (f fakeClient) PutWithResponse(request rest.Request) (rest.Response, error) {
+func (f *fakeClient) PutWithResponse(request rest.Request) (rest.Response, error) {
 	return rest.Response{}, errors.New("PUT with response not implemented")
 }
 


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->

## Motivation

Enable `revcheck` linter. [recvcheck](https://golangci-lint.run/usage/linters/#recvcheck)

Most IDE flagging this by default

Enabling it reveal following linter inconsistencies
<img width="1305" alt="Screenshot 2025-06-13 at 07 49 13" src="https://github.com/user-attachments/assets/0a79e758-9c65-4922-a3be-ace25d5e7a98" />

I've excluded one method for DomainFilter, as fixing this file pointer issue is a bit tricky
<img width="882" alt="Screenshot 2025-06-13 at 08 02 59" src="https://github.com/user-attachments/assets/2217610f-424f-4577-ac4a-527ab2ebc87d" />

follow-up:
- review what to do with endpoint/domain_filter.go

## More

- [X] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
