### PR TITLE
feat(source/node): fqdn support combineFQDNAnnotation

### DIFF
--- a/docs/advanced/fqdn-templating.md
+++ b/docs/advanced/fqdn-templating.md
@@ -54,7 +54,7 @@ The template uses the following data from the source object (e.g., a `Service` o
 | `istio-gateway`        | Queries Istio Gateway resources for endpoints.                  |       ✅        |      ✅       |
 | `istio-virtualservice` | Queries Istio VirtualService resources for endpoints.           |       ✅        |      ✅       |
 | `kong-tcpingress`      | Queries Kong TCPIngress resources for endpoints.                |       ❌        |      ❌       |
-| `node`                 | Queries Kubernetes Node resources for endpoints.                |       ✅        |      ❌       |
+| `node`                 | Queries Kubernetes Node resources for endpoints.                |       ✅        |      ✅       |
 | `openshift-route`      | Queries OpenShift Route resources for endpoints.                |       ✅        |      ✅       |
 | `pod`                  | Queries Kubernetes Pod resources for endpoints.                 |       ✅        |      ✅       |
 | `service`              | Queries Kubernetes Service resources for endpoints.             |       ✅        |      ✅       |

--- a/source/node_test.go
+++ b/source/node_test.go
@@ -95,6 +95,7 @@ func testNodeSourceNewNodeSource(t *testing.T) {
 				labels.Everything(),
 				true,
 				true,
+				false,
 			)
 
 			if ti.expectError {
@@ -440,6 +441,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 				labelSelector,
 				tc.exposeInternalIPv6,
 				tc.excludeUnschedulable,
+				false,
 			)
 			require.NoError(t, err)
 
@@ -557,6 +559,7 @@ func testNodeEndpointsWithIPv6(t *testing.T) {
 			labelSelector,
 			tc.exposeInternalIPv6,
 			tc.excludeUnschedulable,
+			false,
 		)
 		require.NoError(t, err)
 
@@ -604,6 +607,7 @@ func TestResourceLabelIsSetForEachNodeEndpoint(t *testing.T) {
 		labels.Everything(),
 		false,
 		true,
+		false,
 	)
 	require.NoError(t, err)
 

--- a/source/store.go
+++ b/source/store.go
@@ -267,7 +267,7 @@ func BuildWithConfig(ctx context.Context, source string, p ClientGenerator, cfg 
 		if err != nil {
 			return nil, err
 		}
-		return NewNodeSource(ctx, client, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.LabelFilter, cfg.ExposeInternalIPv6, cfg.ExcludeUnschedulable)
+		return NewNodeSource(ctx, client, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.LabelFilter, cfg.ExposeInternalIPv6, cfg.ExcludeUnschedulable, cfg.CombineFQDNAndAnnotation)
 	case "service":
 		client, err := p.KubeClient()
 		if err != nil {


### PR DESCRIPTION
## What does it do ?

Adds support for nodes source and FQDN Combine.

## Motivation

Follow up for PR https://github.com/kubernetes-sigs/external-dns/pull/5498

follow-up:
- review a FQDN framework, maybe to have an interface or something bit better
- review what's left in PR to add/fix https://github.com/kubernetes-sigs/external-dns/pull/5498

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
