### PR TITLE
fix(f5): validate virtualservers and transportservers based on IP only

### DIFF
--- a/source/f5_transportserver.go
+++ b/source/f5_transportserver.go
@@ -145,8 +145,8 @@ func (ts *f5TransportServerSource) endpointsFromTransportServers(transportServer
 	var endpoints []*endpoint.Endpoint
 
 	for _, transportServer := range transportServers {
-		if !isTransportServerReady(transportServer) {
-			log.Warnf("F5 TransportServer %s/%s is not ready or is missing an IP address, skipping endpoint creation.",
+		if !hasValidTransportServerIP(transportServer) {
+			log.Warnf("F5 TransportServer %s/%s is missing a valid IP address, skipping endpoint creation.",
 				transportServer.Namespace, transportServer.Name)
 			continue
 		}
@@ -213,11 +213,7 @@ func (ts *f5TransportServerSource) filterByAnnotations(transportServers []*f5.Tr
 	return filteredList, nil
 }
 
-func isTransportServerReady(vs *f5.TransportServer) bool {
-	if strings.ToLower(vs.Status.Status) != "ok" {
-		return false
-	}
-
+func hasValidTransportServerIP(vs *f5.TransportServer) bool {
 	normalizedAddress := strings.ToLower(vs.Status.VSAddress)
 	return normalizedAddress != "none" && normalizedAddress != ""
 }

--- a/source/f5_transportserver_test.go
+++ b/source/f5_transportserver_test.go
@@ -265,7 +265,7 @@ func TestF5TransportServerEndpoints(t *testing.T) {
 			},
 		},
 		{
-			name: "F5 TransportServer with error status",
+			name: "F5 TransportServer with error status but valid IP",
 			transportServer: f5.TransportServer{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: f5TransportServerGVR.GroupVersion().String(),
@@ -283,12 +283,22 @@ func TestF5TransportServerEndpoints(t *testing.T) {
 					VirtualServerAddress: "192.168.1.100",
 				},
 				Status: f5.CustomResourceStatus{
-					VSAddress: "",
+					VSAddress: "192.168.1.100",
 					Status:    "ERROR",
 					Error:     "Some error status message",
 				},
 			},
-			expected: nil,
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "www.example.com",
+					Targets:    []string{"192.168.1.100"},
+					RecordType: endpoint.RecordTypeA,
+					RecordTTL:  600,
+					Labels: endpoint.Labels{
+						"resource": "f5-transportserver/transportserver/test-ts",
+					},
+				},
+			},
 		},
 		{
 			name: "F5 TransportServer with missing IP address and OK status",

--- a/source/f5_virtualserver.go
+++ b/source/f5_virtualserver.go
@@ -150,8 +150,8 @@ func (vs *f5VirtualServerSource) endpointsFromVirtualServers(virtualServers []*f
 	var endpoints []*endpoint.Endpoint
 
 	for _, virtualServer := range virtualServers {
-		if !isVirtualServerReady(virtualServer) {
-			log.Warnf("F5 VirtualServer %s/%s is not ready or is missing an IP address, skipping endpoint creation.",
+		if !hasValidVirtualServerIP(virtualServer) {
+			log.Warnf("F5 VirtualServer %s/%s is missing a valid IP address, skipping endpoint creation.",
 				virtualServer.Namespace, virtualServer.Name)
 			continue
 		}
@@ -219,11 +219,7 @@ func (vs *f5VirtualServerSource) filterByAnnotations(virtualServers []*f5.Virtua
 	return filteredList, nil
 }
 
-func isVirtualServerReady(vs *f5.VirtualServer) bool {
-	if strings.ToLower(vs.Status.Status) != "ok" {
-		return false
-	}
-
+func hasValidVirtualServerIP(vs *f5.VirtualServer) bool {
 	normalizedAddress := strings.ToLower(vs.Status.VSAddress)
 	return normalizedAddress != "none" && normalizedAddress != ""
 }

--- a/source/f5_virtualserver_test.go
+++ b/source/f5_virtualserver_test.go
@@ -265,7 +265,7 @@ func TestF5VirtualServerEndpoints(t *testing.T) {
 			},
 		},
 		{
-			name: "F5 VirtualServer with error status",
+			name: "F5 VirtualServer with error status but valid IP",
 			virtualServer: f5.VirtualServer{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: f5VirtualServerGVR.GroupVersion().String(),
@@ -283,12 +283,22 @@ func TestF5VirtualServerEndpoints(t *testing.T) {
 					VirtualServerAddress: "192.168.1.100",
 				},
 				Status: f5.CustomResourceStatus{
-					VSAddress: "",
+					VSAddress: "192.168.1.100",
 					Status:    "ERROR",
 					Error:     "Some error status message",
 				},
 			},
-			expected: nil,
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "www.example.com",
+					Targets:    []string{"192.168.1.100"},
+					RecordType: endpoint.RecordTypeA,
+					RecordTTL:  600,
+					Labels: endpoint.Labels{
+						"resource": "f5-virtualserver/virtualserver/test-vs",
+					},
+				},
+			},
 		},
 		{
 			name: "F5 VirtualServer with missing IP address and OK status",


### PR DESCRIPTION
## What does it do ?

This PR makes sure that we only validate the `vsAddress` field of a (F5 Networks) `VirtualServer` and `TransportServer` in the respective sources. Earlier we _also_ checked the `status` field (and only passed through a VS/TS that had a `status` of `ok`). What we've realized is that a `VirtualServer` (or `TransportServer`) can end up in e.g. an `error` state which leaves the `vsAddress` intact.

More info here: https://github.com/F5Networks/k8s-bigip-ctlr/issues/3723

This partially reverts: https://github.com/kubernetes-sigs/external-dns/pull/4996.

I've updated the unit tests to reflect that we now only valide the presence of a valid IP address, regardless of the `status` field.

## Motivation

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly
