### PR TITLE
perf(source): benchmarks on EndpointTargetsFromServices

### DIFF
--- a/source/endpoint_benchmark_test.go
+++ b/source/endpoint_benchmark_test.go
@@ -112,7 +112,7 @@ func svcInformerWithServices(toLookup, underTest int) (coreinformers.ServiceInfo
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	go informerFactory.Start(stopCh)
+	informerFactory.Start(stopCh)
 	cache.WaitForCacheSync(stopCh, svcInformer.Informer().HasSynced)
 	return svcInformer, nil
 }

--- a/source/endpoint_benchmark_test.go
+++ b/source/endpoint_benchmark_test.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"math/rand/v2"
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeinformers "k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	v1alpha3 "istio.io/api/networking/v1alpha3"
+	istiov1a "istio.io/client-go/pkg/apis/networking/v1"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+func BenchmarkEndpointTargetsFromServicesMedium(b *testing.B) {
+	svcInformer, err := svcInformerWithServices(36, 1000)
+	assert.NoError(b, err)
+
+	sel := map[string]string{"app": "nginx", "env": "prod"}
+
+	for b.Loop() {
+		targets, _ := EndpointTargetsFromServices(svcInformer, "default", sel)
+		assert.Equal(b, 36, targets.Len())
+	}
+}
+
+func BenchmarkEndpointTargetsFromServicesMediumIterateOverGateways(b *testing.B) {
+	svcInformer, err := svcInformerWithServices(36, 500)
+	assert.NoError(b, err)
+
+	gateways := fixturesIstioGatewaySvcWithLabels(15, 70)
+
+	for b.Loop() {
+		for _, gateway := range gateways {
+			_, _ = EndpointTargetsFromServices(svcInformer, gateway.Namespace, gateway.Spec.Selector)
+		}
+	}
+}
+
+func BenchmarkEndpointTargetsFromServicesHigh(b *testing.B) {
+	svcInformer, err := svcInformerWithServices(36, 40000)
+	assert.NoError(b, err)
+	sel := map[string]string{"app": "nginx", "env": "prod"}
+
+	for b.Loop() {
+		targets, _ := EndpointTargetsFromServices(svcInformer, "default", sel)
+		assert.Equal(b, 36, targets.Len())
+	}
+}
+
+// This benchmark tests the performance of EndpointTargetsFromServices with a high number of services and gateways.
+func BenchmarkEndpointTargetsFromServicesHighIterateOverGateways(b *testing.B) {
+	svcInformer, err := svcInformerWithServices(36, 40000)
+	assert.NoError(b, err)
+
+	gateways := fixturesIstioGatewaySvcWithLabels(50, 1000)
+
+	for b.Loop() {
+		for _, gateway := range gateways {
+			_, _ = EndpointTargetsFromServices(svcInformer, gateway.Namespace, gateway.Spec.Selector)
+		}
+	}
+}
+
+// helperToPopulateFakeClientWithServices populates a fake Kubernetes client with a specified services.
+func svcInformerWithServices(toLookup, underTest int) (coreinformers.ServiceInformer, error) {
+	client := fake.NewClientset()
+	informerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(client, 0, kubeinformers.WithNamespace("default"))
+	svcInformer := informerFactory.Core().V1().Services()
+	ctx := context.Background()
+
+	_, err := svcInformer.Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+			},
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add event handler: %w", err)
+	}
+
+	services := fixturesSvcWithLabels(toLookup, underTest)
+	for _, svc := range services {
+		_, err := client.CoreV1().Services(svc.Namespace).Create(ctx, svc, metav1.CreateOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create service %s: %w", svc.Name, err)
+		}
+	}
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go informerFactory.Start(stopCh)
+	cache.WaitForCacheSync(stopCh, svcInformer.Informer().HasSynced)
+	return svcInformer, nil
+}
+
+// fixturesSvcWithLabels creates a list of Services for testing purposes.
+// It generates a specified number of services with static labels and random labels.
+// The first `toLookup` services have specific labels, while the next `underTest` services have random labels.
+func fixturesSvcWithLabels(toLookup, underTest int) []*corev1.Service {
+	var services []*corev1.Service
+
+	var randomLabels = func(input int) map[string]string {
+		if input%3 == 0 {
+			// every third service has no labels
+			return map[string]string{}
+		}
+		return map[string]string{
+			"app":                                fmt.Sprintf("service-%d", rand.IntN(100)),
+			fmt.Sprintf("key%d", rand.IntN(100)): fmt.Sprintf("value%d", rand.IntN(100)),
+		}
+	}
+
+	var randomIPs = func() []string {
+		ip := rand.Uint32()
+		buf := make([]byte, 4)
+		binary.LittleEndian.PutUint32(buf, ip)
+		return []string{net.IP(buf).String()}
+	}
+
+	var createService = func(name string, namespace string, selector map[string]string) *corev1.Service {
+		return &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: corev1.ServiceSpec{
+				Selector:    selector,
+				ExternalIPs: randomIPs(),
+			},
+		}
+	}
+
+	// services with specific labels
+	for i := 0; i < toLookup; i++ {
+		svc := createService("nginx-svc-"+strconv.Itoa(i), "default", map[string]string{"app": "nginx", "env": "prod"})
+		services = append(services, svc)
+	}
+
+	// services with random labels
+	for i := 0; i < underTest; i++ {
+		svc := createService("random-svc-"+strconv.Itoa(i), "default", randomLabels(i))
+		services = append(services, svc)
+	}
+
+	// Shuffle the services to ensure randomness
+	for i := 0; i < 3; i++ {
+		rand.Shuffle(len(services), func(i, j int) {
+			services[i], services[j] = services[j], services[i]
+		})
+	}
+
+	return services
+}
+
+// fixturesIstioGatewaySvcWithLabels creates a list of Services for testing purposes.
+// It generates a specified number of gateways with static labels and random labels.
+// The first `toLookup` services have specific labels, while the next `underTest` services have random labels.
+func fixturesIstioGatewaySvcWithLabels(toLookup, underTest int) []*istiov1a.Gateway {
+	var result []*istiov1a.Gateway
+
+	var randomLabels = func(input int) map[string]string {
+		if input%3 == 0 {
+			// every third service has no labels
+			return map[string]string{}
+		}
+		return map[string]string{
+			"app":                                fmt.Sprintf("service-%d", rand.IntN(100)),
+			fmt.Sprintf("key%d", rand.IntN(100)): fmt.Sprintf("value%d", rand.IntN(100)),
+		}
+	}
+
+	var createGateway = func(name string, namespace string, selector map[string]string) *istiov1a.Gateway {
+		return &istiov1a.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: v1alpha3.Gateway{
+				Selector: selector,
+				Servers: []*v1alpha3.Server{
+					{
+						Port:  &v1alpha3.Port{},
+						Hosts: []string{"*"},
+					},
+				},
+			},
+		}
+	}
+	// services with specific labels
+	for i := 0; i < toLookup; i++ {
+		svc := createGateway("istio-gw-"+strconv.Itoa(i), "default", map[string]string{"app": "nginx", "env": "prod"})
+		result = append(result, svc)
+	}
+
+	// services with random labels
+	for i := 0; i < underTest; i++ {
+		svc := createGateway("istio-random-svc-"+strconv.Itoa(i), "default", randomLabels(i))
+		result = append(result, svc)
+	}
+
+	// Shuffle the services to ensure randomness
+	for i := 0; i < 3; i++ {
+		rand.Shuffle(len(result), func(i, j int) {
+			result[i], result[j] = result[j], result[i]
+		})
+	}
+
+	return result
+}

--- a/source/endpoints.go
+++ b/source/endpoints.go
@@ -85,6 +85,7 @@ func EndpointTargetsFromServices(svcInformer coreinformers.ServiceInformer, name
 	targets := endpoint.Targets{}
 
 	services, err := svcInformer.Lister().Services(namespace).List(labels.Everything())
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to list labels for services in namespace %q: %w", namespace, err)
 	}

--- a/source/endpoints_test.go
+++ b/source/endpoints_test.go
@@ -15,22 +15,14 @@ package source
 
 import (
 	"context"
-	"encoding/binary"
-	"fmt"
-	"math/rand/v2"
-	"net"
-
-	// "net"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeinformers "k8s.io/client-go/informers"
-	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/cache"
+
 	"sigs.k8s.io/external-dns/endpoint"
 )
 
@@ -284,119 +276,4 @@ func TestEndpointTargetsFromServicesWithFixtures(b *testing.T) {
 	targets, err := EndpointTargetsFromServices(svcInformer, "default", sel)
 	assert.NoError(b, err)
 	assert.Equal(b, 2, targets.Len())
-}
-
-func BenchmarkEndpointTargetsFromServicesMedium(b *testing.B) {
-	svcInformer, err := svcInformerWithServices(36, 1000)
-	assert.NoError(b, err)
-
-	sel := map[string]string{"app": "nginx", "env": "prod"}
-
-	for b.Loop() {
-		targets, _ := EndpointTargetsFromServices(svcInformer, "default", sel)
-		assert.Equal(b, 36, targets.Len())
-	}
-}
-
-func BenchmarkEndpointTargetsFromServicesHigh(b *testing.B) {
-	svcInformer, err := svcInformerWithServices(36, 40000)
-	assert.NoError(b, err)
-
-	sel := map[string]string{"app": "nginx", "env": "prod"}
-
-	for b.Loop() {
-		targets, _ := EndpointTargetsFromServices(svcInformer, "default", sel)
-		assert.Equal(b, 36, targets.Len())
-	}
-}
-
-// helperToPopulateFakeClientWithServices populates a fake Kubernetes client with a specified services.
-func svcInformerWithServices(toLookup, underTest int) (coreinformers.ServiceInformer, error) {
-	client := fake.NewClientset()
-	informerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(client, 0, kubeinformers.WithNamespace("default"))
-	svcInformer := informerFactory.Core().V1().Services()
-	ctx := context.Background()
-
-	_, err := svcInformer.Informer().AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-			},
-		},
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to add event handler: %w", err)
-	}
-
-	services := fixturesSvcWithLabels(toLookup, underTest)
-	for _, svc := range services {
-		_, err := client.CoreV1().Services(svc.Namespace).Create(ctx, svc, metav1.CreateOptions{})
-		if err != nil {
-			return nil, fmt.Errorf("failed to create service %s: %w", svc.Name, err)
-		}
-	}
-
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	go informerFactory.Start(stopCh)
-	cache.WaitForCacheSync(stopCh, svcInformer.Informer().HasSynced)
-	return svcInformer, nil
-}
-
-// fixturesSvcWithLabels creates a list of Services for testing purposes.
-// It generates a specified number of services with static labels and random labels.
-// The first `toLookup` services have specific labels, while the next `underTest` services have random labels.
-func fixturesSvcWithLabels(toLookup, underTest int) []*corev1.Service {
-	var services []*corev1.Service
-
-	var randomLabels = func(input int) map[string]string {
-		if input%3 == 0 {
-			// every third service has no labels
-			return map[string]string{}
-		}
-		return map[string]string{
-			"app":                                fmt.Sprintf("service-%d", rand.IntN(100)),
-			fmt.Sprintf("key%d", rand.IntN(100)): fmt.Sprintf("value%d", rand.IntN(100)),
-		}
-	}
-
-	var randomIPs = func() []string {
-		ip := rand.Uint32()
-		buf := make([]byte, 4)
-		binary.LittleEndian.PutUint32(buf, ip)
-		return []string{net.IP(buf).String()}
-	}
-
-	var createService = func(name string, namespace string, selector map[string]string) *corev1.Service {
-		return &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
-			},
-			Spec: corev1.ServiceSpec{
-				Selector:    selector,
-				ExternalIPs: randomIPs(),
-			},
-		}
-	}
-
-	// services with specific labels
-	for i := 0; i < toLookup; i++ {
-		svc := createService("nginx-svc-"+strconv.Itoa(i), "default", map[string]string{"app": "nginx", "env": "prod"})
-		services = append(services, svc)
-	}
-
-	// services with random labels
-	for i := 0; i < underTest; i++ {
-		svc := createService("random-svc-"+strconv.Itoa(i), "default", randomLabels(i))
-		services = append(services, svc)
-	}
-
-	// Shuffle the services to ensure randomness
-	for i := 0; i < 3; i++ {
-		rand.Shuffle(len(services), func(i, j int) {
-			services[i], services[j] = services[j], services[i]
-		})
-	}
-
-	return services
 }

--- a/source/endpoints_test.go
+++ b/source/endpoints_test.go
@@ -267,13 +267,13 @@ func TestEndpointTargetsFromServices(t *testing.T) {
 	}
 }
 
-func TestEndpointTargetsFromServicesWithFixtures(b *testing.T) {
+func TestEndpointTargetsFromServicesWithFixtures(t *testing.T) {
 	svcInformer, err := svcInformerWithServices(2, 9)
-	assert.NoError(b, err)
+	assert.NoError(t, err)
 
 	sel := map[string]string{"app": "nginx", "env": "prod"}
 
 	targets, err := EndpointTargetsFromServices(svcInformer, "default", sel)
-	assert.NoError(b, err)
-	assert.Equal(b, 2, targets.Len())
+	assert.NoError(t, err)
+	assert.Equal(t, 2, targets.Len())
 }

--- a/source/f5_virtualserver_test.go
+++ b/source/f5_virtualserver_test.go
@@ -319,7 +319,7 @@ func TestF5VirtualServerEndpoints(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			fakeKubernetesClient := fakeKube.NewSimpleClientset()
+			fakeKubernetesClient := fakeKube.NewClientset()
 			scheme := runtime.NewScheme()
 			scheme.AddKnownTypes(f5VirtualServerGVR.GroupVersion(), &f5.VirtualServer{}, &f5.VirtualServerList{})
 			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(scheme)

--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -323,12 +323,3 @@ func (sc *gatewaySource) hostNamesFromGateway(gateway *networkingv1alpha3.Gatewa
 
 	return hostnames, nil
 }
-
-func gatewaySelectorMatchesServiceSelector(gwSelector, svcSelector map[string]string) bool {
-	for k, v := range gwSelector {
-		if lbl, ok := svcSelector[k]; !ok || lbl != v {
-			return false
-		}
-	}
-	return true
-}

--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -260,13 +260,7 @@ func (sc *gatewaySource) targetsFromGateway(ctx context.Context, gateway *networ
 		return sc.targetsFromIngress(ctx, ingressStr, gateway)
 	}
 
-	targets, err := EndpointTargetsFromServices(sc.serviceInformer, sc.namespace, gateway.Spec.Selector)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return targets, nil
+	return EndpointTargetsFromServices(sc.serviceInformer, sc.namespace, gateway.Spec.Selector)
 }
 
 // endpointsFromGatewayConfig extracts the endpoints from an Istio Gateway Config object

--- a/source/istio_gateway_test.go
+++ b/source/istio_gateway_test.go
@@ -46,7 +46,7 @@ type GatewaySuite struct {
 }
 
 func (suite *GatewaySuite) SetupTest() {
-	fakeKubernetesClient := fake.NewSimpleClientset()
+	fakeKubernetesClient := fake.NewClientset()
 	fakeIstioClient := istiofake.NewSimpleClientset()
 	var err error
 
@@ -166,7 +166,7 @@ func TestNewIstioGatewaySource(t *testing.T) {
 
 			_, err := NewIstioGatewaySource(
 				context.TODO(),
-				fake.NewSimpleClientset(),
+				fake.NewClientset(),
 				istiofake.NewSimpleClientset(),
 				"",
 				ti.annotationFilter,

--- a/source/istio_virtualservice_test.go
+++ b/source/istio_virtualservice_test.go
@@ -2035,7 +2035,7 @@ func testGatewaySelectorMatchesService(t *testing.T) {
 		},
 	} {
 		t.Run(ti.title, func(t *testing.T) {
-			require.Equal(t, ti.expected, gatewaySelectorMatchesServiceSelector(ti.gwSelector, ti.lbSelector))
+			require.Equal(t, ti.expected, MatchesServiceSelector(ti.gwSelector, ti.lbSelector))
 		})
 	}
 }


### PR DESCRIPTION
## What does it do ?

In this PR, I've added a benchmark tests, to showcase bottlenecks described here https://github.com/kubernetes-sigs/external-dns/pull/5473#issuecomment-2911576025

- benchmark tests
- added more tests
- found duplicate code and replaced with function

## Motivation

When decided to have a look started

- https://github.com/kubernetes-sigs/external-dns/pull/5473
- https://github.com/kubernetes-sigs/external-dns/issues/5016

And this comment https://github.com/kubernetes-sigs/external-dns/pull/5493#discussion_r2143457453

One of the bottlenecks is in this lines https://github.com/kubernetes-sigs/external-dns/blob/051c900d1c6073a2e02c2b55c05ab932af8bcc66/source/endpoints.go#L87-L110

Basically it does
- retrive all services from the cache
- iterate over each service
- iterate over each label

On top of that, the function EndpointTargetsFromServices actually called from within the loop of all virtual services or any other kubernetes entity like [here](https://github.com/kubernetes-sigs/external-dns/blob/051c900d1c6073a2e02c2b55c05ab932af8bcc66/source/istio_gateway.go#L143). This is quite inneficiate....

Benchmark results

```
BenchmarkEndpointTargetsFromServicesMedium-16                       	   11194	    105419 ns/op
BenchmarkEndpointTargetsFromServicesMediumIterateOverGateways
BenchmarkEndpointTargetsFromServicesMediumIterateOverGateways-16    	     290	   4070484 ns/op
BenchmarkEndpointTargetsFromServicesHigh
BenchmarkEndpointTargetsFromServicesHigh-16                         	      88	  12669344 ns/op
BenchmarkEndpointTargetsFromServicesHighIterateOverGateways
BenchmarkEndpointTargetsFromServicesHighIterateOverGateways-16      	       1	13425263466 ns/op
```

Just a hightlight from one of the issues
> We are running on EKS with BatchSizeConfig of 1,000 (default), we have ~3K Isito virtualService objects & 1K Service objects.

So this means that there are 3000 * 1000 * (number of selectors), every time there is a reconcile. 

Follo-up:
- potential improvement from this PR https://github.com/gofogo/k8s-sigs-external-dns-fork/pull/31

## More

- [X] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
