### PR TITLE
chore(domainfilter): use pointer receivers for DomainFilter

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -45,7 +45,7 @@ type mockProvider struct {
 
 type filteredMockProvider struct {
 	provider.BaseProvider
-	domainFilter      endpoint.DomainFilter
+	domainFilter      *endpoint.DomainFilter
 	RecordsStore      []*endpoint.Endpoint
 	RecordsCallCount  int
 	ApplyChangesCalls []*plan.Changes
@@ -328,7 +328,7 @@ func TestShouldRunOnce(t *testing.T) {
 	assert.True(t, ctrl.ShouldRunOnce(now))
 }
 
-func testControllerFiltersDomains(t *testing.T, configuredEndpoints []*endpoint.Endpoint, domainFilter endpoint.DomainFilter, providerEndpoints []*endpoint.Endpoint, expectedChanges []*plan.Changes) {
+func testControllerFiltersDomains(t *testing.T, configuredEndpoints []*endpoint.Endpoint, domainFilter *endpoint.DomainFilter, providerEndpoints []*endpoint.Endpoint, expectedChanges []*plan.Changes) {
 	t.Helper()
 	cfg := externaldns.NewConfig()
 	cfg.ManagedDNSRecordTypes = []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME}
@@ -402,7 +402,7 @@ func TestWhenNoFilterControllerConsidersAllComain(t *testing.T) {
 				Targets:    endpoint.Targets{"8.8.8.8"},
 			},
 		},
-		endpoint.DomainFilter{},
+		&endpoint.DomainFilter{},
 		[]*endpoint.Endpoint{
 			{
 				DNSName:    "some-record.used.tld",

--- a/controller/execute.go
+++ b/controller/execute.go
@@ -145,7 +145,7 @@ func Execute() {
 func buildProvider(
 	ctx context.Context,
 	cfg *externaldns.Config,
-	domainFilter endpoint.DomainFilter,
+	domainFilter *endpoint.DomainFilter,
 ) (provider.Provider, error) {
 	var p provider.Provider
 	var err error
@@ -339,7 +339,7 @@ func buildProvider(
 	return p, err
 }
 
-func buildController(cfg *externaldns.Config, src source.Source, p provider.Provider, filter endpoint.DomainFilter) (*Controller, error) {
+func buildController(cfg *externaldns.Config, src source.Source, p provider.Provider, filter *endpoint.DomainFilter) (*Controller, error) {
 	policy, ok := plan.Policies[cfg.Policy]
 	if !ok {
 		return nil, fmt.Errorf("unknown policy: %s", cfg.Policy)
@@ -429,7 +429,7 @@ func buildSource(ctx context.Context, cfg *externaldns.Config) (source.Source, e
 }
 
 // RegexDomainFilter overrides DomainFilter
-func createDomainFilter(cfg *externaldns.Config) endpoint.DomainFilter {
+func createDomainFilter(cfg *externaldns.Config) *endpoint.DomainFilter {
 	if cfg.RegexDomainFilter != nil && cfg.RegexDomainFilter.String() != "" {
 		return endpoint.NewRegexDomainFilter(cfg.RegexDomainFilter, cfg.RegexDomainExclusion)
 	} else {

--- a/controller/execute_test.go
+++ b/controller/execute_test.go
@@ -134,7 +134,7 @@ func TestCreateDomainFilter(t *testing.T) {
 	tests := []struct {
 		name                 string
 		cfg                  *externaldns.Config
-		expectedDomainFilter endpoint.DomainFilter
+		expectedDomainFilter *endpoint.DomainFilter
 		isConfigured         bool
 	}{
 		{

--- a/endpoint/domain_filter.go
+++ b/endpoint/domain_filter.go
@@ -80,23 +80,26 @@ func prepareFilters(filters []string) []string {
 }
 
 // NewDomainFilterWithExclusions returns a new DomainFilter, given a list of matches and exclusions
-func NewDomainFilterWithExclusions(domainFilters []string, excludeDomains []string) DomainFilter {
-	return DomainFilter{Filters: prepareFilters(domainFilters), exclude: prepareFilters(excludeDomains)}
+func NewDomainFilterWithExclusions(domainFilters []string, excludeDomains []string) *DomainFilter {
+	return &DomainFilter{Filters: prepareFilters(domainFilters), exclude: prepareFilters(excludeDomains)}
 }
 
 // NewDomainFilter returns a new DomainFilter given a comma separated list of domains
-func NewDomainFilter(domainFilters []string) DomainFilter {
-	return DomainFilter{Filters: prepareFilters(domainFilters)}
+func NewDomainFilter(domainFilters []string) *DomainFilter {
+	return &DomainFilter{Filters: prepareFilters(domainFilters)}
 }
 
 // NewRegexDomainFilter returns a new DomainFilter given a regular expression
-func NewRegexDomainFilter(regexDomainFilter *regexp.Regexp, regexDomainExclusion *regexp.Regexp) DomainFilter {
-	return DomainFilter{regex: regexDomainFilter, regexExclusion: regexDomainExclusion}
+func NewRegexDomainFilter(regexDomainFilter *regexp.Regexp, regexDomainExclusion *regexp.Regexp) *DomainFilter {
+	return &DomainFilter{regex: regexDomainFilter, regexExclusion: regexDomainExclusion}
 }
 
 // Match checks whether a domain can be found in the DomainFilter.
 // RegexFilter takes precedence over Filters
 func (df *DomainFilter) Match(domain string) bool {
+	if df == nil {
+		return true // nil filter matches everything
+	}
 	if df.regex != nil && df.regex.String() != "" || df.regexExclusion != nil && df.regexExclusion.String() != "" {
 		return matchRegex(df.regex, df.regexExclusion, domain)
 	}
@@ -146,6 +149,9 @@ func matchRegex(regex *regexp.Regexp, negativeRegex *regexp.Regexp, domain strin
 
 // IsConfigured returns true if any inclusion or exclusion rules have been specified.
 func (df *DomainFilter) IsConfigured() bool {
+	if df == nil {
+		return false // nil filter is not configured
+	}
 	if df.regex != nil && df.regex.String() != "" {
 		return true
 	} else if df.regexExclusion != nil && df.regexExclusion.String() != "" {
@@ -155,6 +161,13 @@ func (df *DomainFilter) IsConfigured() bool {
 }
 
 func (df *DomainFilter) MarshalJSON() ([]byte, error) {
+	if df == nil {
+		// compatibility with nil DomainFilter
+		return json.Marshal(domainFilterSerde{
+			Include: nil,
+			Exclude: nil,
+		})
+	}
 	if df.regex != nil || df.regexExclusion != nil {
 		var include, exclude string
 		if df.regex != nil {
@@ -184,7 +197,7 @@ func (df *DomainFilter) UnmarshalJSON(b []byte) error {
 	}
 
 	if deserialized.RegexInclude == "" && deserialized.RegexExclude == "" {
-		*df = NewDomainFilterWithExclusions(deserialized.Include, deserialized.Exclude)
+		*df = *NewDomainFilterWithExclusions(deserialized.Include, deserialized.Exclude)
 		return nil
 	}
 
@@ -205,11 +218,14 @@ func (df *DomainFilter) UnmarshalJSON(b []byte) error {
 			return fmt.Errorf("invalid regexExclude: %w", err)
 		}
 	}
-	*df = NewRegexDomainFilter(include, exclude)
+	*df = *NewRegexDomainFilter(include, exclude)
 	return nil
 }
 
 func (df *DomainFilter) MatchParent(domain string) bool {
+	if df == nil {
+		return true // nil filter matches everything
+	}
 	if matchFilter(df.exclude, domain, false) {
 		return false
 	}

--- a/endpoint/domain_filter.go
+++ b/endpoint/domain_filter.go
@@ -96,7 +96,7 @@ func NewRegexDomainFilter(regexDomainFilter *regexp.Regexp, regexDomainExclusion
 
 // Match checks whether a domain can be found in the DomainFilter.
 // RegexFilter takes precedence over Filters
-func (df DomainFilter) Match(domain string) bool {
+func (df *DomainFilter) Match(domain string) bool {
 	if df.regex != nil && df.regex.String() != "" || df.regexExclusion != nil && df.regexExclusion.String() != "" {
 		return matchRegex(df.regex, df.regexExclusion, domain)
 	}
@@ -145,7 +145,7 @@ func matchRegex(regex *regexp.Regexp, negativeRegex *regexp.Regexp, domain strin
 }
 
 // IsConfigured returns true if any inclusion or exclusion rules have been specified.
-func (df DomainFilter) IsConfigured() bool {
+func (df *DomainFilter) IsConfigured() bool {
 	if df.regex != nil && df.regex.String() != "" {
 		return true
 	} else if df.regexExclusion != nil && df.regexExclusion.String() != "" {
@@ -154,7 +154,7 @@ func (df DomainFilter) IsConfigured() bool {
 	return len(df.Filters) > 0 || len(df.exclude) > 0
 }
 
-func (df DomainFilter) MarshalJSON() ([]byte, error) {
+func (df *DomainFilter) MarshalJSON() ([]byte, error) {
 	if df.regex != nil || df.regexExclusion != nil {
 		var include, exclude string
 		if df.regex != nil {
@@ -209,7 +209,7 @@ func (df *DomainFilter) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (df DomainFilter) MatchParent(domain string) bool {
+func (df *DomainFilter) MatchParent(domain string) bool {
 	if matchFilter(df.exclude, domain, false) {
 		return false
 	}

--- a/endpoint/domain_filter_test.go
+++ b/endpoint/domain_filter_test.go
@@ -701,22 +701,22 @@ func TestDomainFilterDeserializeError(t *testing.T) {
 	}
 }
 
-func assertSerializes[T any](t *testing.T, domainFilter DomainFilter, expectedSerialization map[string]T) {
-	serialized, err := json.Marshal(&domainFilter)
+func assertSerializes[T any](t *testing.T, domainFilter *DomainFilter, expectedSerialization map[string]T) {
+	serialized, err := json.Marshal(domainFilter)
 	assert.NoError(t, err, "serializing")
 	expected, err := json.Marshal(expectedSerialization)
 	require.NoError(t, err)
 	assert.JSONEq(t, string(expected), string(serialized), "json serialization")
 }
 
-func deserialize[T any](t *testing.T, serialized map[string]T) DomainFilter {
+func deserialize[T any](t *testing.T, serialized map[string]T) *DomainFilter {
 	inJson, err := json.Marshal(serialized)
 	require.NoError(t, err)
 	var deserialized DomainFilter
 	err = json.Unmarshal(inJson, &deserialized)
 	assert.NoError(t, err, "deserializing")
 
-	return deserialized
+	return &deserialized
 }
 
 func TestDomainFilterMatchParent(t *testing.T) {

--- a/endpoint/domain_filter_test.go
+++ b/endpoint/domain_filter_test.go
@@ -702,7 +702,7 @@ func TestDomainFilterDeserializeError(t *testing.T) {
 }
 
 func assertSerializes[T any](t *testing.T, domainFilter DomainFilter, expectedSerialization map[string]T) {
-	serialized, err := json.Marshal(domainFilter)
+	serialized, err := json.Marshal(&domainFilter)
 	assert.NoError(t, err, "serializing")
 	expected, err := json.Marshal(expectedSerialization)
 	require.NoError(t, err)

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -902,7 +902,7 @@ func (suite *PlanTestSuite) TestDomainFiltersInitial() {
 		Policies:       []Policy{&SyncPolicy{}},
 		Current:        current,
 		Desired:        desired,
-		DomainFilter:   endpoint.MatchAllDomainFilters{&domainFilter},
+		DomainFilter:   endpoint.MatchAllDomainFilters{domainFilter},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
@@ -926,7 +926,7 @@ func (suite *PlanTestSuite) TestDomainFiltersUpdate() {
 		Policies:       []Policy{&SyncPolicy{}},
 		Current:        current,
 		Desired:        desired,
-		DomainFilter:   endpoint.MatchAllDomainFilters{&domainFilter},
+		DomainFilter:   endpoint.MatchAllDomainFilters{domainFilter},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 

--- a/provider/akamai/akamai.go
+++ b/provider/akamai/akamai.go
@@ -51,7 +51,7 @@ type AkamaiDNSService interface {
 }
 
 type AkamaiConfig struct {
-	DomainFilter          endpoint.DomainFilter
+	DomainFilter          *endpoint.DomainFilter
 	ZoneIDFilter          provider.ZoneIDFilter
 	ServiceConsumerDomain string
 	ClientToken           string
@@ -68,7 +68,7 @@ type AkamaiConfig struct {
 type AkamaiProvider struct {
 	provider.BaseProvider
 	// Edgedns zones to filter on
-	domainFilter endpoint.DomainFilter
+	domainFilter *endpoint.DomainFilter
 	// Contract Ids to filter on
 	zoneIDFilter provider.ZoneIDFilter
 	// Edgegrid library configuration

--- a/provider/akamai/akamai_test.go
+++ b/provider/akamai/akamai_test.go
@@ -49,7 +49,7 @@ func newStub() *edgednsStub {
 	}
 }
 
-func createAkamaiStubProvider(stub *edgednsStub, domfilter endpoint.DomainFilter, idfilter provider.ZoneIDFilter) (*AkamaiProvider, error) {
+func createAkamaiStubProvider(stub *edgednsStub, domfilter *endpoint.DomainFilter, idfilter provider.ZoneIDFilter) (*AkamaiProvider, error) {
 	akamaiConfig := AkamaiConfig{
 		DomainFilter:          domfilter,
 		ZoneIDFilter:          idfilter,
@@ -153,7 +153,7 @@ func (r *edgednsStub) UpdateRecord(record *dns.RecordBody, zone string, recLock 
 // Test FetchZones
 func TestFetchZonesZoneIDFilter(t *testing.T) {
 	stub := newStub()
-	domfilter := endpoint.DomainFilter{}
+	domfilter := &endpoint.DomainFilter{}
 	idfilter := provider.NewZoneIDFilter([]string{"Test"})
 	c, err := createAkamaiStubProvider(stub, domfilter, idfilter)
 	assert.NoError(t, err)
@@ -186,7 +186,7 @@ func TestFetchZonesEmpty(t *testing.T) {
 // TestAkamaiRecords tests record endpoint
 func TestAkamaiRecords(t *testing.T) {
 	stub := newStub()
-	domfilter := endpoint.DomainFilter{}
+	domfilter := &endpoint.DomainFilter{}
 	idfilter := provider.ZoneIDFilter{}
 	c, err := createAkamaiStubProvider(stub, domfilter, idfilter)
 	require.NoError(t, err)
@@ -221,7 +221,7 @@ func TestAkamaiRecords(t *testing.T) {
 
 func TestAkamaiRecordsEmpty(t *testing.T) {
 	stub := newStub()
-	domfilter := endpoint.DomainFilter{}
+	domfilter := &endpoint.DomainFilter{}
 	idfilter := provider.NewZoneIDFilter([]string{"Nonexistent"})
 	c, err := createAkamaiStubProvider(stub, domfilter, idfilter)
 	require.NoError(t, err)
@@ -265,7 +265,7 @@ func TestAkamaiRecordsFilters(t *testing.T) {
 // (p AkamaiProvider) createRecordsets(zoneNameIDMapper provider.ZoneIDName, endpoints []*endpoint.Endpoint) error
 func TestCreateRecords(t *testing.T) {
 	stub := newStub()
-	domfilter := endpoint.DomainFilter{}
+	domfilter := &endpoint.DomainFilter{}
 	idfilter := provider.ZoneIDFilter{}
 	c, err := createAkamaiStubProvider(stub, domfilter, idfilter)
 	assert.NoError(t, err)
@@ -281,7 +281,7 @@ func TestCreateRecords(t *testing.T) {
 
 func TestCreateRecordsDomainFilter(t *testing.T) {
 	stub := newStub()
-	domfilter := endpoint.DomainFilter{}
+	domfilter := &endpoint.DomainFilter{}
 	idfilter := provider.ZoneIDFilter{}
 	c, err := createAkamaiStubProvider(stub, domfilter, idfilter)
 	assert.NoError(t, err)
@@ -299,7 +299,7 @@ func TestCreateRecordsDomainFilter(t *testing.T) {
 // TestDeleteRecords validate delete
 func TestDeleteRecords(t *testing.T) {
 	stub := newStub()
-	domfilter := endpoint.DomainFilter{}
+	domfilter := &endpoint.DomainFilter{}
 	idfilter := provider.ZoneIDFilter{}
 	c, err := createAkamaiStubProvider(stub, domfilter, idfilter)
 	assert.NoError(t, err)
@@ -333,7 +333,7 @@ func TestDeleteRecordsDomainFilter(t *testing.T) {
 // Test record update func
 func TestUpdateRecords(t *testing.T) {
 	stub := newStub()
-	domfilter := endpoint.DomainFilter{}
+	domfilter := &endpoint.DomainFilter{}
 	idfilter := provider.ZoneIDFilter{}
 	c, err := createAkamaiStubProvider(stub, domfilter, idfilter)
 	require.NoError(t, err)

--- a/provider/alibabacloud/alibaba_cloud.go
+++ b/provider/alibabacloud/alibaba_cloud.go
@@ -70,7 +70,7 @@ type AlibabaCloudPrivateZoneAPI interface {
 // AlibabaCloudProvider implements the DNS provider for Alibaba Cloud.
 type AlibabaCloudProvider struct {
 	provider.BaseProvider
-	domainFilter         endpoint.DomainFilter
+	domainFilter         *endpoint.DomainFilter
 	zoneIDFilter         provider.ZoneIDFilter // Private Zone only
 	MaxChangeCount       int
 	EvaluateTargetHealth bool
@@ -97,7 +97,7 @@ type alibabaCloudConfig struct {
 // NewAlibabaCloudProvider creates a new Alibaba Cloud provider.
 //
 // Returns the provider or an error if a provider could not be created.
-func NewAlibabaCloudProvider(configFile string, domainFilter endpoint.DomainFilter, zoneIDFileter provider.ZoneIDFilter, zoneType string, dryRun bool) (*AlibabaCloudProvider, error) {
+func NewAlibabaCloudProvider(configFile string, domainFilter *endpoint.DomainFilter, zoneIDFileter provider.ZoneIDFilter, zoneType string, dryRun bool) (*AlibabaCloudProvider, error) {
 	cfg := alibabaCloudConfig{}
 	if configFile != "" {
 		contents, err := os.ReadFile(configFile)

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -279,7 +279,7 @@ type AWSProvider struct {
 	batchChangeInterval   time.Duration
 	evaluateTargetHealth  bool
 	// only consider hosted zones managing domains ending in this suffix
-	domainFilter endpoint.DomainFilter
+	domainFilter *endpoint.DomainFilter
 	// filter hosted zones by id
 	zoneIDFilter provider.ZoneIDFilter
 	// filter hosted zones by type (e.g. private or public)
@@ -296,7 +296,7 @@ type AWSProvider struct {
 
 // AWSConfig contains configuration to create a new AWS provider.
 type AWSConfig struct {
-	DomainFilter          endpoint.DomainFilter
+	DomainFilter          *endpoint.DomainFilter
 	ZoneIDFilter          provider.ZoneIDFilter
 	ZoneTypeFilter        provider.ZoneTypeFilter
 	ZoneTagFilter         provider.ZoneTagFilter
@@ -624,7 +624,7 @@ func (p *AWSProvider) GetDomainFilter() endpoint.DomainFilterInterface {
 	zones, err := p.Zones(context.Background())
 	if err != nil {
 		log.Errorf("failed to list zones: %v", err)
-		return endpoint.DomainFilter{}
+		return &endpoint.DomainFilter{}
 	}
 	zoneNames := []string(nil)
 	for _, z := range zones {

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -373,12 +373,12 @@ func TestAWSZonesWithTagFilterError(t *testing.T) {
 }
 
 func TestAWSRecordsFilter(t *testing.T) {
-	provider, _ := newAWSProvider(t, endpoint.DomainFilter{}, provider.ZoneIDFilter{}, provider.ZoneTypeFilter{}, false, false, nil)
+	provider, _ := newAWSProvider(t, &endpoint.DomainFilter{}, provider.ZoneIDFilter{}, provider.ZoneTypeFilter{}, false, false, nil)
 	domainFilter := provider.GetDomainFilter()
 	require.NotNil(t, domainFilter)
-	require.IsType(t, endpoint.DomainFilter{}, domainFilter)
+	require.IsType(t, &endpoint.DomainFilter{}, domainFilter)
 	count := 0
-	filters := domainFilter.(endpoint.DomainFilter).Filters
+	filters := domainFilter.(*endpoint.DomainFilter).Filters
 	for _, tld := range []string{
 		"zone-4.ext-dns-test-3.teapot.zalan.do",
 		".zone-4.ext-dns-test-3.teapot.zalan.do",
@@ -2208,11 +2208,11 @@ func listAWSRecords(t *testing.T, client Route53API, zone string) []route53types
 	return resp.ResourceRecordSets
 }
 
-func newAWSProvider(t *testing.T, domainFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, zoneTypeFilter provider.ZoneTypeFilter, evaluateTargetHealth, dryRun bool, records []route53types.ResourceRecordSet) (*AWSProvider, *Route53APIStub) {
+func newAWSProvider(t *testing.T, domainFilter *endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, zoneTypeFilter provider.ZoneTypeFilter, evaluateTargetHealth, dryRun bool, records []route53types.ResourceRecordSet) (*AWSProvider, *Route53APIStub) {
 	return newAWSProviderWithTagFilter(t, domainFilter, zoneIDFilter, zoneTypeFilter, provider.NewZoneTagFilter([]string{}), evaluateTargetHealth, dryRun, records)
 }
 
-func newAWSProviderWithTagFilter(t *testing.T, domainFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, zoneTypeFilter provider.ZoneTypeFilter, zoneTagFilter provider.ZoneTagFilter, evaluateTargetHealth, dryRun bool, records []route53types.ResourceRecordSet) (*AWSProvider, *Route53APIStub) {
+func newAWSProviderWithTagFilter(t *testing.T, domainFilter *endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, zoneTypeFilter provider.ZoneTypeFilter, zoneTagFilter provider.ZoneTagFilter, evaluateTargetHealth, dryRun bool, records []route53types.ResourceRecordSet) (*AWSProvider, *Route53APIStub) {
 	client := NewRoute53APIStub(t)
 
 	provider := &AWSProvider{

--- a/provider/aws/aws_utils_test.go
+++ b/provider/aws/aws_utils_test.go
@@ -53,7 +53,7 @@ func providerFilters(client *Route53APIFixtureStub, options ...func(awsProvider 
 		clients:              map[string]Route53API{defaultAWSProfile: client},
 		evaluateTargetHealth: false,
 		dryRun:               false,
-		domainFilter:         endpoint.NewDomainFilter([]string{}),
+		domainFilter:         &endpoint.DomainFilter{},
 		zoneIDFilter:         provider.NewZoneIDFilter([]string{}),
 		zoneTypeFilter:       provider.NewZoneTypeFilter(""),
 		zoneTagFilter:        provider.NewZoneTagFilter([]string{}),

--- a/provider/awssd/aws_sd.go
+++ b/provider/awssd/aws_sd.go
@@ -76,7 +76,7 @@ type AWSSDProvider struct {
 	client AWSSDClient
 	dryRun bool
 	// only consider namespaces ending in this suffix
-	namespaceFilter endpoint.DomainFilter
+	namespaceFilter *endpoint.DomainFilter
 	// filter namespace by type (private or public)
 	namespaceTypeFilter sdtypes.NamespaceFilter
 	// enables service without instances cleanup
@@ -88,7 +88,7 @@ type AWSSDProvider struct {
 }
 
 // NewAWSSDProvider initializes a new AWS Cloud Map based Provider.
-func NewAWSSDProvider(domainFilter endpoint.DomainFilter, namespaceType string, dryRun, cleanEmptyService bool, ownerID string, tags map[string]string, client AWSSDClient) (*AWSSDProvider, error) {
+func NewAWSSDProvider(domainFilter *endpoint.DomainFilter, namespaceType string, dryRun, cleanEmptyService bool, ownerID string, tags map[string]string, client AWSSDClient) (*AWSSDProvider, error) {
 	p := &AWSSDProvider{
 		client:              client,
 		dryRun:              dryRun,

--- a/provider/awssd/aws_sd_test.go
+++ b/provider/awssd/aws_sd_test.go
@@ -300,7 +300,7 @@ func TestAWSSDProvider_ListNamespaces(t *testing.T) {
 
 	for _, tc := range []struct {
 		msg                 string
-		domainFilter        endpoint.DomainFilter
+		domainFilter        *endpoint.DomainFilter
 		namespaceTypeFilter string
 		expectedNamespaces  []*sdtypes.NamespaceSummary
 	}{

--- a/provider/awssd/fixtures_test.go
+++ b/provider/awssd/fixtures_test.go
@@ -206,7 +206,7 @@ func (s *AWSSDClientStub) DeleteService(ctx context.Context, input *sd.DeleteSer
 	return &sd.DeleteServiceOutput{}, nil
 }
 
-func newTestAWSSDProvider(api AWSSDClient, domainFilter endpoint.DomainFilter, namespaceTypeFilter, ownerID string) *AWSSDProvider {
+func newTestAWSSDProvider(api AWSSDClient, domainFilter *endpoint.DomainFilter, namespaceTypeFilter, ownerID string) *AWSSDProvider {
 	return &AWSSDProvider{
 		client:              api,
 		dryRun:              false,

--- a/provider/azure/azure.go
+++ b/provider/azure/azure.go
@@ -53,8 +53,8 @@ type RecordSetsClient interface {
 // AzureProvider implements the DNS provider for Microsoft's Azure cloud platform.
 type AzureProvider struct {
 	provider.BaseProvider
-	domainFilter                 endpoint.DomainFilter
-	zoneNameFilter               endpoint.DomainFilter
+	domainFilter                 *endpoint.DomainFilter
+	zoneNameFilter               *endpoint.DomainFilter
 	zoneIDFilter                 provider.ZoneIDFilter
 	dryRun                       bool
 	resourceGroup                string
@@ -69,7 +69,7 @@ type AzureProvider struct {
 // NewAzureProvider creates a new Azure provider.
 //
 // Returns the provider or an error if a provider could not be created.
-func NewAzureProvider(configFile string, domainFilter endpoint.DomainFilter, zoneNameFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, subscriptionID string, resourceGroup string, userAssignedIdentityClientID string, activeDirectoryAuthorityHost string, zonesCacheDuration time.Duration, maxRetriesCount int, dryRun bool) (*AzureProvider, error) {
+func NewAzureProvider(configFile string, domainFilter *endpoint.DomainFilter, zoneNameFilter *endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, subscriptionID string, resourceGroup string, userAssignedIdentityClientID string, activeDirectoryAuthorityHost string, zonesCacheDuration time.Duration, maxRetriesCount int, dryRun bool) (*AzureProvider, error) {
 	cfg, err := getConfig(configFile, subscriptionID, resourceGroup, userAssignedIdentityClientID, activeDirectoryAuthorityHost)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read Azure config file '%s': %w", configFile, err)

--- a/provider/azure/azure_private_dns.go
+++ b/provider/azure/azure_private_dns.go
@@ -48,8 +48,8 @@ type PrivateRecordSetsClient interface {
 // AzurePrivateDNSProvider implements the DNS provider for Microsoft's Azure Private DNS service
 type AzurePrivateDNSProvider struct {
 	provider.BaseProvider
-	domainFilter                 endpoint.DomainFilter
-	zoneNameFilter               endpoint.DomainFilter
+	domainFilter                 *endpoint.DomainFilter
+	zoneNameFilter               *endpoint.DomainFilter
 	zoneIDFilter                 provider.ZoneIDFilter
 	dryRun                       bool
 	resourceGroup                string
@@ -64,7 +64,7 @@ type AzurePrivateDNSProvider struct {
 // NewAzurePrivateDNSProvider creates a new Azure Private DNS provider.
 //
 // Returns the provider or an error if a provider could not be created.
-func NewAzurePrivateDNSProvider(configFile string, domainFilter endpoint.DomainFilter, zoneNameFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, subscriptionID string, resourceGroup string, userAssignedIdentityClientID string, activeDirectoryAuthorityHost string, zonesCacheDuration time.Duration, maxRetriesCount int, dryRun bool) (*AzurePrivateDNSProvider, error) {
+func NewAzurePrivateDNSProvider(configFile string, domainFilter *endpoint.DomainFilter, zoneNameFilter *endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, subscriptionID string, resourceGroup string, userAssignedIdentityClientID string, activeDirectoryAuthorityHost string, zonesCacheDuration time.Duration, maxRetriesCount int, dryRun bool) (*AzurePrivateDNSProvider, error) {
 	cfg, err := getConfig(configFile, subscriptionID, resourceGroup, userAssignedIdentityClientID, activeDirectoryAuthorityHost)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read Azure config file '%s': %w", configFile, err)

--- a/provider/azure/azure_privatedns_test.go
+++ b/provider/azure/azure_privatedns_test.go
@@ -224,13 +224,13 @@ func createPrivateMockRecordSetMultiWithTTL(name, recordType string, ttl int64, 
 }
 
 // newMockedAzurePrivateDNSProvider creates an AzureProvider comprising the mocked clients for zones and recordsets
-func newMockedAzurePrivateDNSProvider(domainFilter endpoint.DomainFilter, zoneNameFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, dryRun bool, resourceGroup string, zones []*privatedns.PrivateZone, recordSets []*privatedns.RecordSet, maxRetriesCount int) (*AzurePrivateDNSProvider, error) {
+func newMockedAzurePrivateDNSProvider(domainFilter *endpoint.DomainFilter, zoneNameFilter *endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, dryRun bool, resourceGroup string, zones []*privatedns.PrivateZone, recordSets []*privatedns.RecordSet, maxRetriesCount int) (*AzurePrivateDNSProvider, error) {
 	zonesClient := newMockPrivateZonesClient(zones)
 	recordSetsClient := newMockPrivateRecordSectsClient(recordSets)
 	return newAzurePrivateDNSProvider(domainFilter, zoneNameFilter, zoneIDFilter, dryRun, resourceGroup, &zonesClient, &recordSetsClient, maxRetriesCount), nil
 }
 
-func newAzurePrivateDNSProvider(domainFilter endpoint.DomainFilter, zoneNameFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, dryRun bool, resourceGroup string, privateZonesClient PrivateZonesClient, privateRecordsClient PrivateRecordSetsClient, maxRetriesCount int) *AzurePrivateDNSProvider {
+func newAzurePrivateDNSProvider(domainFilter *endpoint.DomainFilter, zoneNameFilter *endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, dryRun bool, resourceGroup string, privateZonesClient PrivateZonesClient, privateRecordsClient PrivateRecordSetsClient, maxRetriesCount int) *AzurePrivateDNSProvider {
 	return &AzurePrivateDNSProvider{
 		domainFilter:     domainFilter,
 		zoneNameFilter:   zoneNameFilter,

--- a/provider/azure/azure_test.go
+++ b/provider/azure/azure_test.go
@@ -237,13 +237,13 @@ func createMockRecordSetMultiWithTTL(name, recordType string, ttl int64, values 
 }
 
 // newMockedAzureProvider creates an AzureProvider comprising the mocked clients for zones and recordsets
-func newMockedAzureProvider(domainFilter endpoint.DomainFilter, zoneNameFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, dryRun bool, resourceGroup string, userAssignedIdentityClientID string, activeDirectoryAuthorityHost string, zones []*dns.Zone, recordSets []*dns.RecordSet, maxRetriesCount int) (*AzureProvider, error) {
+func newMockedAzureProvider(domainFilter *endpoint.DomainFilter, zoneNameFilter *endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, dryRun bool, resourceGroup string, userAssignedIdentityClientID string, activeDirectoryAuthorityHost string, zones []*dns.Zone, recordSets []*dns.RecordSet, maxRetriesCount int) (*AzureProvider, error) {
 	zonesClient := newMockZonesClient(zones)
 	recordSetsClient := newMockRecordSetsClient(recordSets)
 	return newAzureProvider(domainFilter, zoneNameFilter, zoneIDFilter, dryRun, resourceGroup, userAssignedIdentityClientID, activeDirectoryAuthorityHost, &zonesClient, &recordSetsClient, maxRetriesCount), nil
 }
 
-func newAzureProvider(domainFilter endpoint.DomainFilter, zoneNameFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, dryRun bool, resourceGroup string, userAssignedIdentityClientID string, activeDirectoryAuthorityHost string, zonesClient ZonesClient, recordsClient RecordSetsClient, maxRetriesCount int) *AzureProvider {
+func newAzureProvider(domainFilter *endpoint.DomainFilter, zoneNameFilter *endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, dryRun bool, resourceGroup string, userAssignedIdentityClientID string, activeDirectoryAuthorityHost string, zonesClient ZonesClient, recordsClient RecordSetsClient, maxRetriesCount int) *AzureProvider {
 	return &AzureProvider{
 		domainFilter:                 domainFilter,
 		zoneNameFilter:               zoneNameFilter,

--- a/provider/civo/civo.go
+++ b/provider/civo/civo.go
@@ -35,7 +35,7 @@ import (
 type CivoProvider struct {
 	provider.BaseProvider
 	Client       civogo.Client
-	domainFilter endpoint.DomainFilter
+	domainFilter *endpoint.DomainFilter
 	DryRun       bool
 }
 
@@ -71,7 +71,7 @@ type CivoChangeDelete struct {
 }
 
 // NewCivoProvider initializes a new Civo DNS based Provider.
-func NewCivoProvider(domainFilter endpoint.DomainFilter, dryRun bool) (*CivoProvider, error) {
+func NewCivoProvider(domainFilter *endpoint.DomainFilter, dryRun bool) (*CivoProvider, error) {
 	token, ok := os.LookupEnv("CIVO_TOKEN")
 	if !ok {
 		return nil, fmt.Errorf("no token found")

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -226,7 +226,7 @@ type CloudFlareProvider struct {
 	provider.BaseProvider
 	Client cloudFlareDNS
 	// only consider hosted zones managing domains ending in this suffix
-	domainFilter          endpoint.DomainFilter
+	domainFilter          *endpoint.DomainFilter
 	zoneIDFilter          provider.ZoneIDFilter
 	proxiedByDefault      bool
 	DryRun                bool
@@ -289,7 +289,7 @@ func convertCloudflareError(err error) error {
 }
 
 // NewCloudFlareProvider initializes a new CloudFlare DNS based Provider.
-func NewCloudFlareProvider(domainFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, proxiedByDefault bool, dryRun bool, regionKey string, customHostnamesConfig CustomHostnamesConfig, dnsRecordsConfig DNSRecordsConfig) (*CloudFlareProvider, error) {
+func NewCloudFlareProvider(domainFilter *endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, proxiedByDefault bool, dryRun bool, regionKey string, customHostnamesConfig CustomHostnamesConfig, dnsRecordsConfig DNSRecordsConfig) (*CloudFlareProvider, error) {
 	// initialize via chosen auth method and returns new API object
 	var (
 		config *cloudflare.API

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -464,7 +464,7 @@ func AssertActions(t *testing.T, provider *CloudFlareProvider, endpoints []*endp
 	plan := &plan.Plan{
 		Current:        records,
 		Desired:        endpoints,
-		DomainFilter:   endpoint.MatchAllDomainFilters{&domainFilter},
+		DomainFilter:   endpoint.MatchAllDomainFilters{domainFilter},
 		ManagedRecords: managedRecords,
 	}
 
@@ -1670,7 +1670,7 @@ func TestCloudflareComplexUpdate(t *testing.T) {
 	plan := &plan.Plan{
 		Current:        records,
 		Desired:        endpoints,
-		DomainFilter:   endpoint.MatchAllDomainFilters{&domainFilter},
+		DomainFilter:   endpoint.MatchAllDomainFilters{domainFilter},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1761,7 +1761,7 @@ func TestCustomTTLWithEnabledProxyNotChanged(t *testing.T) {
 	plan := &plan.Plan{
 		Current:        records,
 		Desired:        endpoints,
-		DomainFilter:   endpoint.MatchAllDomainFilters{&domainFilter},
+		DomainFilter:   endpoint.MatchAllDomainFilters{domainFilter},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
@@ -2222,7 +2222,7 @@ func TestCloudflareDNSRecordsOperationsFail(t *testing.T) {
 			plan := &plan.Plan{
 				Current:        records,
 				Desired:        endpoints,
-				DomainFilter:   endpoint.MatchAllDomainFilters{&domainFilter},
+				DomainFilter:   endpoint.MatchAllDomainFilters{domainFilter},
 				ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 			}
 			planned := plan.Calculate()
@@ -2645,7 +2645,7 @@ func TestCloudflareCustomHostnameOperations(t *testing.T) {
 			plan := &plan.Plan{
 				Current:        records,
 				Desired:        endpoints,
-				DomainFilter:   endpoint.MatchAllDomainFilters{&domainFilter},
+				DomainFilter:   endpoint.MatchAllDomainFilters{domainFilter},
 				ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME, endpoint.RecordTypeTXT},
 			}
 			planned := plan.Calculate()
@@ -2669,7 +2669,7 @@ func TestCloudflareCustomHostnameOperations(t *testing.T) {
 		plan := &plan.Plan{
 			Current:        records,
 			Desired:        endpoints,
-			DomainFilter:   endpoint.MatchAllDomainFilters{&domainFilter},
+			DomainFilter:   endpoint.MatchAllDomainFilters{domainFilter},
 			ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 		}
 
@@ -2799,7 +2799,7 @@ func TestCloudflareDisabledCustomHostnameOperations(t *testing.T) {
 		plan := &plan.Plan{
 			Current:        records,
 			Desired:        endpoints,
-			DomainFilter:   endpoint.MatchAllDomainFilters{&domainFilter},
+			DomainFilter:   endpoint.MatchAllDomainFilters{domainFilter},
 			ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 		}
 		planned := plan.Calculate()
@@ -2898,7 +2898,7 @@ func TestCloudflareCustomHostnameNotFoundOnRecordDeletion(t *testing.T) {
 		plan := &plan.Plan{
 			Current:        records,
 			Desired:        endpoints,
-			DomainFilter:   endpoint.MatchAllDomainFilters{&domainFilter},
+			DomainFilter:   endpoint.MatchAllDomainFilters{domainFilter},
 			ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 		}
 
@@ -2981,7 +2981,7 @@ func TestCloudflareListCustomHostnamesWithPagionation(t *testing.T) {
 	plan := &plan.Plan{
 		Current:        records,
 		Desired:        endpoints,
-		DomainFilter:   endpoint.MatchAllDomainFilters{&domainFilter},
+		DomainFilter:   endpoint.MatchAllDomainFilters{domainFilter},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 

--- a/provider/coredns/coredns.go
+++ b/provider/coredns/coredns.go
@@ -55,7 +55,7 @@ type coreDNSProvider struct {
 	provider.BaseProvider
 	dryRun        bool
 	coreDNSPrefix string
-	domainFilter  endpoint.DomainFilter
+	domainFilter  *endpoint.DomainFilter
 	client        coreDNSClient
 }
 
@@ -195,7 +195,7 @@ func newETCDClient() (coreDNSClient, error) {
 }
 
 // NewCoreDNSProvider is a CoreDNS provider constructor
-func NewCoreDNSProvider(domainFilter endpoint.DomainFilter, prefix string, dryRun bool) (provider.Provider, error) {
+func NewCoreDNSProvider(domainFilter *endpoint.DomainFilter, prefix string, dryRun bool) (provider.Provider, error) {
 	client, err := newETCDClient()
 	if err != nil {
 		return nil, err

--- a/provider/coredns/coredns_test.go
+++ b/provider/coredns/coredns_test.go
@@ -415,9 +415,7 @@ func TestCoreDNSApplyChanges_DomainDoNotMatch(t *testing.T) {
 	coredns := coreDNSProvider{
 		client:        client,
 		coreDNSPrefix: defaultCoreDNSPrefix,
-		domainFilter: endpoint.DomainFilter{
-			Filters: []string{"example.local"},
-		},
+		domainFilter:  endpoint.NewDomainFilter([]string{"example.local"}),
 	}
 
 	changes1 := &plan.Changes{
@@ -755,7 +753,7 @@ func TestNewCoreDNSProvider(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			testutils.TestHelperEnvSetter(t, tt.envs)
 
-			provider, err := NewCoreDNSProvider(endpoint.DomainFilter{}, "/prefix/", false)
+			provider, err := NewCoreDNSProvider(&endpoint.DomainFilter{}, "/prefix/", false)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.EqualError(t, err, tt.errMsg)

--- a/provider/digitalocean/digital_ocean.go
+++ b/provider/digitalocean/digital_ocean.go
@@ -43,7 +43,7 @@ type DigitalOceanProvider struct {
 	provider.BaseProvider
 	Client godo.DomainsService
 	// only consider hosted zones managing domains ending in this suffix
-	domainFilter endpoint.DomainFilter
+	domainFilter *endpoint.DomainFilter
 	// page size when querying paginated APIs
 	apiPageSize int
 	DryRun      bool
@@ -77,7 +77,7 @@ func (c *digitalOceanChanges) Empty() bool {
 }
 
 // NewDigitalOceanProvider initializes a new DigitalOcean DNS based Provider.
-func NewDigitalOceanProvider(ctx context.Context, domainFilter endpoint.DomainFilter, dryRun bool, apiPageSize int) (*DigitalOceanProvider, error) {
+func NewDigitalOceanProvider(ctx context.Context, domainFilter *endpoint.DomainFilter, dryRun bool, apiPageSize int) (*DigitalOceanProvider, error) {
 	token, ok := os.LookupEnv("DO_TOKEN")
 	if !ok {
 		return nil, fmt.Errorf("no token found")

--- a/provider/dnsimple/dnsimple.go
+++ b/provider/dnsimple/dnsimple.go
@@ -87,7 +87,7 @@ type dnsimpleProvider struct {
 	client       dnsimpleZoneServiceInterface
 	identity     dnsimpleIdentityService
 	accountID    string
-	domainFilter endpoint.DomainFilter
+	domainFilter *endpoint.DomainFilter
 	zoneIDFilter provider.ZoneIDFilter
 	dryRun       bool
 }
@@ -98,7 +98,7 @@ type dnsimpleChange struct {
 }
 
 // NewDnsimpleProvider initializes a new Dnsimple based provider
-func NewDnsimpleProvider(domainFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, dryRun bool) (provider.Provider, error) {
+func NewDnsimpleProvider(domainFilter *endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, dryRun bool) (provider.Provider, error) {
 	oauthToken := os.Getenv("DNSIMPLE_OAUTH")
 	if len(oauthToken) == 0 {
 		return nil, fmt.Errorf("no dnsimple oauth token provided")

--- a/provider/exoscale/exoscale.go
+++ b/provider/exoscale/exoscale.go
@@ -41,7 +41,7 @@ type EgoscaleClientI interface {
 // ExoscaleProvider initialized as dns provider with no records
 type ExoscaleProvider struct {
 	provider.BaseProvider
-	domain         endpoint.DomainFilter
+	domain         *endpoint.DomainFilter
 	client         EgoscaleClientI
 	apiEnv         string
 	apiZone        string
@@ -252,7 +252,7 @@ func (ep *ExoscaleProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, 
 }
 
 // ExoscaleWithDomain modifies the domain on which dns zones are filtered
-func ExoscaleWithDomain(domainFilter endpoint.DomainFilter) ExoscaleOption {
+func ExoscaleWithDomain(domainFilter *endpoint.DomainFilter) ExoscaleOption {
 	return func(p *ExoscaleProvider) {
 		p.domain = domainFilter
 	}

--- a/provider/gandi/gandi.go
+++ b/provider/gandi/gandi.go
@@ -47,11 +47,11 @@ type GandiProvider struct {
 	provider.BaseProvider
 	LiveDNSClient LiveDNSClientAdapter
 	DomainClient  DomainClientAdapter
-	domainFilter  endpoint.DomainFilter
+	domainFilter  *endpoint.DomainFilter
 	DryRun        bool
 }
 
-func NewGandiProvider(ctx context.Context, domainFilter endpoint.DomainFilter, dryRun bool) (*GandiProvider, error) {
+func NewGandiProvider(ctx context.Context, domainFilter *endpoint.DomainFilter, dryRun bool) (*GandiProvider, error) {
 	key, ok_key := os.LookupEnv("GANDI_KEY")
 	pat, ok_pat := os.LookupEnv("GANDI_PAT")
 	if !ok_key && !ok_pat {

--- a/provider/godaddy/godaddy.go
+++ b/provider/godaddy/godaddy.go
@@ -58,7 +58,7 @@ type gdClient interface {
 type GDProvider struct {
 	provider.BaseProvider
 
-	domainFilter endpoint.DomainFilter
+	domainFilter *endpoint.DomainFilter
 	client       gdClient
 	ttl          int64
 	DryRun       bool
@@ -135,7 +135,7 @@ func (z gdZoneIDName) findZoneRecord(hostname string) (suitableZoneID string, su
 }
 
 // NewGoDaddyProvider initializes a new GoDaddy DNS based Provider.
-func NewGoDaddyProvider(ctx context.Context, domainFilter endpoint.DomainFilter, ttl int64, apiKey, apiSecret string, useOTE, dryRun bool) (*GDProvider, error) {
+func NewGoDaddyProvider(ctx context.Context, domainFilter *endpoint.DomainFilter, ttl int64, apiKey, apiSecret string, useOTE, dryRun bool) (*GDProvider, error) {
 	client, err := NewClient(useOTE, apiKey, apiSecret)
 	if err != nil {
 		return nil, err

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -109,7 +109,7 @@ type GoogleProvider struct {
 	// Interval between batch updates.
 	batchChangeInterval time.Duration
 	// only consider hosted zones managing domains ending in this suffix
-	domainFilter endpoint.DomainFilter
+	domainFilter *endpoint.DomainFilter
 	// filter for zones based on visibility
 	zoneTypeFilter provider.ZoneTypeFilter
 	// only consider hosted zones ending with this zone id
@@ -125,7 +125,7 @@ type GoogleProvider struct {
 }
 
 // NewGoogleProvider initializes a new Google CloudDNS based Provider.
-func NewGoogleProvider(ctx context.Context, project string, domainFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, batchChangeSize int, batchChangeInterval time.Duration, zoneVisibility string, dryRun bool) (*GoogleProvider, error) {
+func NewGoogleProvider(ctx context.Context, project string, domainFilter *endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, batchChangeSize int, batchChangeInterval time.Duration, zoneVisibility string, dryRun bool) (*GoogleProvider, error) {
 	gcloud, err := google.DefaultClient(ctx, dns.NdevClouddnsReadwriteScope)
 	if err != nil {
 		return nil, err

--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -677,7 +677,7 @@ func validateChangeRecord(t *testing.T, record *dns.ResourceRecordSet, expected 
 	assert.Equal(t, expected.Type, record.Type)
 }
 
-func newGoogleProviderZoneOverlap(t *testing.T, domainFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, zoneTypeFilter provider.ZoneTypeFilter, dryRun bool, _ []*endpoint.Endpoint) *GoogleProvider {
+func newGoogleProviderZoneOverlap(t *testing.T, domainFilter *endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, zoneTypeFilter provider.ZoneTypeFilter, dryRun bool, _ []*endpoint.Endpoint) *GoogleProvider {
 	provider := &GoogleProvider{
 		project:                  "zalando-external-dns-test",
 		dryRun:                   false,
@@ -744,7 +744,7 @@ func newGoogleProviderZoneOverlap(t *testing.T, domainFilter endpoint.DomainFilt
 	return provider
 }
 
-func newGoogleProvider(t *testing.T, domainFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, dryRun bool, records []*endpoint.Endpoint, zonesErr, recordsErr error) *GoogleProvider {
+func newGoogleProvider(t *testing.T, domainFilter *endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, dryRun bool, records []*endpoint.Endpoint, zonesErr, recordsErr error) *GoogleProvider {
 	provider := &GoogleProvider{
 		project:      "zalando-external-dns-test",
 		dryRun:       false,

--- a/provider/inmemory/inmemory.go
+++ b/provider/inmemory/inmemory.go
@@ -77,7 +77,7 @@ func InMemoryWithLogging() InMemoryOption {
 }
 
 // InMemoryWithDomain modifies the domain on which dns zones are filtered
-func InMemoryWithDomain(domainFilter endpoint.DomainFilter) InMemoryOption {
+func InMemoryWithDomain(domainFilter *endpoint.DomainFilter) InMemoryOption {
 	return func(p *InMemoryProvider) {
 		p.domain = domainFilter
 	}

--- a/provider/linode/linode.go
+++ b/provider/linode/linode.go
@@ -48,7 +48,7 @@ type LinodeDomainClient interface {
 type LinodeProvider struct {
 	provider.BaseProvider
 	Client       LinodeDomainClient
-	domainFilter endpoint.DomainFilter
+	domainFilter *endpoint.DomainFilter
 	DryRun       bool
 }
 
@@ -79,7 +79,7 @@ type LinodeChangeDelete struct {
 }
 
 // NewLinodeProvider initializes a new Linode DNS based Provider.
-func NewLinodeProvider(domainFilter endpoint.DomainFilter, dryRun bool) (*LinodeProvider, error) {
+func NewLinodeProvider(domainFilter *endpoint.DomainFilter, dryRun bool) (*LinodeProvider, error) {
 	token, ok := os.LookupEnv("LINODE_TOKEN")
 	if !ok {
 		return nil, fmt.Errorf("no token found")

--- a/provider/ns1/ns1.go
+++ b/provider/ns1/ns1.go
@@ -85,7 +85,7 @@ func (n NS1DomainService) ListZones() ([]*dns.Zone, *http.Response, error) {
 
 // NS1Config passes cli args to the NS1Provider
 type NS1Config struct {
-	DomainFilter  endpoint.DomainFilter
+	DomainFilter  *endpoint.DomainFilter
 	ZoneIDFilter  provider.ZoneIDFilter
 	NS1Endpoint   string
 	NS1IgnoreSSL  bool
@@ -97,7 +97,7 @@ type NS1Config struct {
 type NS1Provider struct {
 	provider.BaseProvider
 	client        NS1DomainClient
-	domainFilter  endpoint.DomainFilter
+	domainFilter  *endpoint.DomainFilter
 	zoneIDFilter  provider.ZoneIDFilter
 	dryRun        bool
 	minTTLSeconds int

--- a/provider/oci/oci.go
+++ b/provider/oci/oci.go
@@ -63,7 +63,7 @@ type OCIProvider struct {
 	client ociDNSClient
 	cfg    OCIConfig
 
-	domainFilter endpoint.DomainFilter
+	domainFilter *endpoint.DomainFilter
 	zoneIDFilter provider.ZoneIDFilter
 	zoneScope    string
 	zoneCache    *zoneCache
@@ -93,7 +93,7 @@ func LoadOCIConfig(path string) (*OCIConfig, error) {
 }
 
 // NewOCIProvider initializes a new OCI DNS based Provider.
-func NewOCIProvider(cfg OCIConfig, domainFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, zoneScope string, dryRun bool) (*OCIProvider, error) {
+func NewOCIProvider(cfg OCIConfig, domainFilter *endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, zoneScope string, dryRun bool) (*OCIProvider, error) {
 	var client ociDNSClient
 	var err error
 	var configProvider common.ConfigurationProvider

--- a/provider/oci/oci_test.go
+++ b/provider/oci/oci_test.go
@@ -129,7 +129,7 @@ func (c *mockOCIDNSClient) PatchZoneRecords(ctx context.Context, request dns.Pat
 }
 
 // newOCIProvider creates an OCI provider with API calls mocked out.
-func newOCIProvider(client ociDNSClient, domainFilter endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, zoneScope string, dryRun bool) *OCIProvider {
+func newOCIProvider(client ociDNSClient, domainFilter *endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, zoneScope string, dryRun bool) *OCIProvider {
 	return &OCIProvider{
 		client: client,
 		cfg: OCIConfig{
@@ -246,7 +246,7 @@ func TestOCIZones(t *testing.T) {
 	barZoneId := "ocid1.dns-zone.oc1..502aeddba262b92fd13ed7874f6f1404"
 	testCases := []struct {
 		name         string
-		domainFilter endpoint.DomainFilter
+		domainFilter *endpoint.DomainFilter
 		zoneIDFilter provider.ZoneIDFilter
 		zoneScope    string
 		expected     map[string]dns.ZoneSummary
@@ -321,7 +321,7 @@ func TestOCIZones(t *testing.T) {
 func TestOCIRecords(t *testing.T) {
 	testCases := []struct {
 		name         string
-		domainFilter endpoint.DomainFilter
+		domainFilter *endpoint.DomainFilter
 		zoneIDFilter provider.ZoneIDFilter
 		expected     []*endpoint.Endpoint
 	}{

--- a/provider/ovh/ovh.go
+++ b/provider/ovh/ovh.go
@@ -60,7 +60,7 @@ type OVHProvider struct {
 
 	apiRateLimiter ratelimit.Limiter
 
-	domainFilter endpoint.DomainFilter
+	domainFilter *endpoint.DomainFilter
 
 	// DryRun enables dry-run mode
 	DryRun bool
@@ -123,7 +123,7 @@ type ovhChange struct {
 }
 
 // NewOVHProvider initializes a new OVH DNS based Provider.
-func NewOVHProvider(ctx context.Context, domainFilter endpoint.DomainFilter, endpoint string, apiRateLimit int, enableCNAMERelative, dryRun bool) (*OVHProvider, error) {
+func NewOVHProvider(ctx context.Context, domainFilter *endpoint.DomainFilter, endpoint string, apiRateLimit int, enableCNAMERelative, dryRun bool) (*OVHProvider, error) {
 	client, err := ovh.NewEndpointClient(endpoint)
 	if err != nil {
 		return nil, err
@@ -371,7 +371,7 @@ func (p *OVHProvider) zones(ctx context.Context) ([]string, error) {
 	}
 
 	for _, zoneName := range zones {
-		if p.domainFilter.Match(zoneName) {
+		if p.domainFilter == nil || p.domainFilter.Match(zoneName) {
 			filteredZones = append(filteredZones, zoneName)
 		}
 	}

--- a/provider/ovh/ovh_test.go
+++ b/provider/ovh/ovh_test.go
@@ -621,7 +621,7 @@ func TestOvhRecordString(t *testing.T) {
 }
 
 func TestNewOvhProvider(t *testing.T) {
-	var domainFilter endpoint.DomainFilter
+	domainFilter := &endpoint.DomainFilter{}
 	_, err := NewOVHProvider(t.Context(), domainFilter, "ovh-eu", 20, false, true)
 	td.CmpError(t, err)
 

--- a/provider/pdns/pdns.go
+++ b/provider/pdns/pdns.go
@@ -62,7 +62,7 @@ const (
 
 // PDNSConfig is comprised of the fields necessary to create a new PDNSProvider
 type PDNSConfig struct {
-	DomainFilter endpoint.DomainFilter
+	DomainFilter *endpoint.DomainFilter
 	DryRun       bool
 	Server       string
 	ServerID     string
@@ -140,7 +140,7 @@ type PDNSAPIClient struct {
 	serverID     string
 	authCtx      context.Context
 	client       *pgo.APIClient
-	domainFilter endpoint.DomainFilter
+	domainFilter *endpoint.DomainFilter
 }
 
 // ListZones : Method returns all enabled zones from PowerDNS

--- a/provider/pdns/pdns_test.go
+++ b/provider/pdns/pdns_test.go
@@ -597,35 +597,15 @@ var (
 		},
 	}
 
-	DomainFilterListSingle = endpoint.DomainFilter{
-		Filters: []string{
-			"example.com",
-		},
-	}
+	DomainFilterListSingle = endpoint.NewDomainFilter([]string{"example.com"})
 
-	DomainFilterChildListSingle = endpoint.DomainFilter{
-		Filters: []string{
-			"a.example.com",
-		},
-	}
+	DomainFilterChildListSingle = endpoint.NewDomainFilter([]string{"a.example.com"})
 
-	DomainFilterListMultiple = endpoint.DomainFilter{
-		Filters: []string{
-			"example.com",
-			"mock.com",
-		},
-	}
+	DomainFilterListMultiple = endpoint.NewDomainFilter([]string{"example.com", "mock.com"})
 
-	DomainFilterChildListMultiple = endpoint.DomainFilter{
-		Filters: []string{
-			"a.example.com",
-			"c.example.com",
-		},
-	}
+	DomainFilterChildListMultiple = endpoint.NewDomainFilter([]string{"a.example.com", "c.example.com"})
 
-	DomainFilterListEmpty = endpoint.DomainFilter{
-		Filters: []string{},
-	}
+	DomainFilterListEmpty = endpoint.NewDomainFilter([]string{})
 
 	RegexDomainFilter = endpoint.NewRegexDomainFilter(regexp.MustCompile("example.com"), nil)
 

--- a/provider/pihole/pihole.go
+++ b/provider/pihole/pihole.go
@@ -44,7 +44,7 @@ type PiholeConfig struct {
 	// Disable verification of TLS certificates.
 	TLSInsecureSkipVerify bool
 	// A filter to apply when looking up and applying records.
-	DomainFilter endpoint.DomainFilter
+	DomainFilter *endpoint.DomainFilter
 	// Do nothing and log what would have changed to stdout.
 	DryRun bool
 	// PiHole API version =<5 or >=6, default is 5

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -64,7 +64,7 @@ func (b BaseProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoi
 }
 
 func (b BaseProvider) GetDomainFilter() endpoint.DomainFilterInterface {
-	return endpoint.DomainFilter{}
+	return &endpoint.DomainFilter{}
 }
 
 type contextKey struct {

--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -68,7 +68,7 @@ type rfc2136Provider struct {
 	krb5Realm    string
 
 	// only consider hosted zones managing domains ending in this suffix
-	domainFilter endpoint.DomainFilter
+	domainFilter *endpoint.DomainFilter
 	dryRun       bool
 	actions      rfc2136Actions
 
@@ -110,7 +110,7 @@ type rfc2136Actions interface {
 }
 
 // NewRfc2136Provider is a factory function for OpenStack rfc2136 providers
-func NewRfc2136Provider(hosts []string, port int, zoneNames []string, insecure bool, keyName string, secret string, secretAlg string, axfr bool, domainFilter endpoint.DomainFilter, dryRun bool, minTTL time.Duration, createPTR bool, gssTsig bool, krb5Username string, krb5Password string, krb5Realm string, batchChangeSize int, tlsConfig TLSConfig, loadBalancingStrategy string, actions rfc2136Actions) (provider.Provider, error) {
+func NewRfc2136Provider(hosts []string, port int, zoneNames []string, insecure bool, keyName string, secret string, secretAlg string, axfr bool, domainFilter *endpoint.DomainFilter, dryRun bool, minTTL time.Duration, createPTR bool, gssTsig bool, krb5Username string, krb5Password string, krb5Realm string, batchChangeSize int, tlsConfig TLSConfig, loadBalancingStrategy string, actions rfc2136Actions) (provider.Provider, error) {
 	secretAlgChecked, ok := tsigAlgs[secretAlg]
 	if !ok && !insecure && !gssTsig {
 		return nil, fmt.Errorf("%s is not supported TSIG algorithm", secretAlg)

--- a/provider/rfc2136/rfc2136_test.go
+++ b/provider/rfc2136/rfc2136_test.go
@@ -186,7 +186,7 @@ func createRfc2136StubProvider(stub *rfc2136Stub, zoneNames ...string) (provider
 		ClientCertFilePath:    "",
 		ClientCertKeyFilePath: "",
 	}
-	return NewRfc2136Provider([]string{""}, 0, zoneNames, false, "key", "secret", "hmac-sha512", true, endpoint.DomainFilter{}, false, 300*time.Second, false, false, "", "", "", 50, tlsConfig, "", stub)
+	return NewRfc2136Provider([]string{""}, 0, zoneNames, false, "key", "secret", "hmac-sha512", true, &endpoint.DomainFilter{}, false, 300*time.Second, false, false, "", "", "", 50, tlsConfig, "", stub)
 }
 
 func createRfc2136StubProviderWithHosts(stub *rfc2136Stub) (provider.Provider, error) {
@@ -197,15 +197,15 @@ func createRfc2136StubProviderWithHosts(stub *rfc2136Stub) (provider.Provider, e
 		ClientCertFilePath:    "",
 		ClientCertKeyFilePath: "",
 	}
-	return NewRfc2136Provider([]string{"rfc2136-host1", "rfc2136-host2", "rfc2136-host3"}, 0, nil, false, "key", "secret", "hmac-sha512", true, endpoint.DomainFilter{}, false, 300*time.Second, false, false, "", "", "", 50, tlsConfig, "", stub)
+	return NewRfc2136Provider([]string{"rfc2136-host1", "rfc2136-host2", "rfc2136-host3"}, 0, nil, false, "key", "secret", "hmac-sha512", true, &endpoint.DomainFilter{}, false, 300*time.Second, false, false, "", "", "", 50, tlsConfig, "", stub)
 }
 
 func createRfc2136TLSStubProvider(stub *rfc2136Stub, tlsConfig TLSConfig) (provider.Provider, error) {
-	return NewRfc2136Provider([]string{"rfc2136-host"}, 0, nil, false, "key", "secret", "hmac-sha512", true, endpoint.DomainFilter{}, false, 300*time.Second, false, false, "", "", "", 50, tlsConfig, "", stub)
+	return NewRfc2136Provider([]string{"rfc2136-host"}, 0, nil, false, "key", "secret", "hmac-sha512", true, &endpoint.DomainFilter{}, false, 300*time.Second, false, false, "", "", "", 50, tlsConfig, "", stub)
 }
 
 func createRfc2136TLSStubProviderWithHosts(stub *rfc2136Stub, tlsConfig TLSConfig) (provider.Provider, error) {
-	return NewRfc2136Provider([]string{"rfc2136-host1", "rfc2136-host2"}, 0, nil, false, "key", "secret", "hmac-sha512", true, endpoint.DomainFilter{}, false, 300*time.Second, false, false, "", "", "", 50, tlsConfig, "", stub)
+	return NewRfc2136Provider([]string{"rfc2136-host1", "rfc2136-host2"}, 0, nil, false, "key", "secret", "hmac-sha512", true, &endpoint.DomainFilter{}, false, 300*time.Second, false, false, "", "", "", 50, tlsConfig, "", stub)
 }
 
 func createRfc2136StubProviderWithReverse(stub *rfc2136Stub) (provider.Provider, error) {
@@ -218,7 +218,7 @@ func createRfc2136StubProviderWithReverse(stub *rfc2136Stub) (provider.Provider,
 	}
 
 	zones := []string{"foo.com", "3.2.1.in-addr.arpa"}
-	return NewRfc2136Provider([]string{""}, 0, zones, false, "key", "secret", "hmac-sha512", true, endpoint.DomainFilter{Filters: zones}, false, 300*time.Second, true, false, "", "", "", 50, tlsConfig, "", stub)
+	return NewRfc2136Provider([]string{""}, 0, zones, false, "key", "secret", "hmac-sha512", true, endpoint.NewDomainFilter(zones), false, 300*time.Second, true, false, "", "", "", 50, tlsConfig, "", stub)
 }
 
 func createRfc2136StubProviderWithZones(stub *rfc2136Stub) (provider.Provider, error) {
@@ -230,7 +230,7 @@ func createRfc2136StubProviderWithZones(stub *rfc2136Stub) (provider.Provider, e
 		ClientCertKeyFilePath: "",
 	}
 	zones := []string{"foo.com", "foobar.com"}
-	return NewRfc2136Provider([]string{""}, 0, zones, false, "key", "secret", "hmac-sha512", true, endpoint.DomainFilter{}, false, 300*time.Second, false, false, "", "", "", 50, tlsConfig, "", stub)
+	return NewRfc2136Provider([]string{""}, 0, zones, false, "key", "secret", "hmac-sha512", true, &endpoint.DomainFilter{}, false, 300*time.Second, false, false, "", "", "", 50, tlsConfig, "", stub)
 }
 
 func createRfc2136StubProviderWithZonesFilters(stub *rfc2136Stub) (provider.Provider, error) {
@@ -242,7 +242,7 @@ func createRfc2136StubProviderWithZonesFilters(stub *rfc2136Stub) (provider.Prov
 		ClientCertKeyFilePath: "",
 	}
 	zones := []string{"foo.com", "foobar.com"}
-	return NewRfc2136Provider([]string{""}, 0, zones, false, "key", "secret", "hmac-sha512", true, endpoint.DomainFilter{Filters: zones}, false, 300*time.Second, false, false, "", "", "", 50, tlsConfig, "", stub)
+	return NewRfc2136Provider([]string{""}, 0, zones, false, "key", "secret", "hmac-sha512", true, endpoint.NewDomainFilter(zones), false, 300*time.Second, false, false, "", "", "", 50, tlsConfig, "", stub)
 }
 
 func createRfc2136StubProviderWithStrategy(stub *rfc2136Stub, strategy string) (provider.Provider, error) {
@@ -253,7 +253,7 @@ func createRfc2136StubProviderWithStrategy(stub *rfc2136Stub, strategy string) (
 		ClientCertFilePath:    "",
 		ClientCertKeyFilePath: "",
 	}
-	return NewRfc2136Provider([]string{"rfc2136-host1", "rfc2136-host2", "rfc2136-host3"}, 0, nil, false, "key", "secret", "hmac-sha512", true, endpoint.DomainFilter{}, false, 300*time.Second, false, false, "", "", "", 50, tlsConfig, strategy, stub)
+	return NewRfc2136Provider([]string{"rfc2136-host1", "rfc2136-host2", "rfc2136-host3"}, 0, nil, false, "key", "secret", "hmac-sha512", true, &endpoint.DomainFilter{}, false, 300*time.Second, false, false, "", "", "", 50, tlsConfig, strategy, stub)
 }
 
 func extractUpdateSectionFromMessage(msg fmt.Stringer) []string {

--- a/provider/scaleway/scaleway.go
+++ b/provider/scaleway/scaleway.go
@@ -45,7 +45,7 @@ type ScalewayProvider struct {
 	domainAPI DomainAPI
 	dryRun    bool
 	// only consider hosted zones managing domains ending in this suffix
-	domainFilter endpoint.DomainFilter
+	domainFilter *endpoint.DomainFilter
 }
 
 // ScalewayChange differentiates between ChangActions
@@ -55,7 +55,7 @@ type ScalewayChange struct {
 }
 
 // NewScalewayProvider initializes a new Scaleway DNS provider
-func NewScalewayProvider(ctx context.Context, domainFilter endpoint.DomainFilter, dryRun bool) (*ScalewayProvider, error) {
+func NewScalewayProvider(ctx context.Context, domainFilter *endpoint.DomainFilter, dryRun bool) (*ScalewayProvider, error) {
 	var err error
 	defaultPageSize := uint64(1000)
 	if envPageSize, ok := os.LookupEnv("SCW_DEFAULT_PAGE_SIZE"); ok {

--- a/provider/transip/transip.go
+++ b/provider/transip/transip.go
@@ -41,14 +41,14 @@ const (
 type TransIPProvider struct {
 	provider.BaseProvider
 	domainRepo   domain.Repository
-	domainFilter endpoint.DomainFilter
+	domainFilter *endpoint.DomainFilter
 	dryRun       bool
 
 	zoneMap provider.ZoneIDName
 }
 
 // NewTransIPProvider initializes a new TransIP Provider.
-func NewTransIPProvider(accountName, privateKeyFile string, domainFilter endpoint.DomainFilter, dryRun bool) (*TransIPProvider, error) {
+func NewTransIPProvider(accountName, privateKeyFile string, domainFilter *endpoint.DomainFilter, dryRun bool) (*TransIPProvider, error) {
 	// check given arguments
 	if accountName == "" {
 		return nil, errors.New("required --transip-account not set")

--- a/provider/webhook/api/httpapi_test.go
+++ b/provider/webhook/api/httpapi_test.go
@@ -39,7 +39,7 @@ var records []*endpoint.Endpoint
 
 type FakeWebhookProvider struct {
 	err           error
-	domainFilter  endpoint.DomainFilter
+	domainFilter  *endpoint.DomainFilter
 	assertChanges func(*plan.Changes)
 }
 
@@ -334,7 +334,7 @@ func TestNegotiateHandler_Success(t *testing.T) {
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	require.Equal(t, MediaTypeFormatAndVersion, res.Header.Get(ContentTypeHeader))
 
-	var df endpoint.DomainFilter
+	df := &endpoint.DomainFilter{}
 	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 	require.NoError(t, df.UnmarshalJSON(body))

--- a/provider/webhook/webhook.go
+++ b/provider/webhook/webhook.go
@@ -94,7 +94,7 @@ var (
 type WebhookProvider struct {
 	client          *http.Client
 	remoteServerURL *url.URL
-	DomainFilter    endpoint.DomainFilter
+	DomainFilter    *endpoint.DomainFilter
 }
 
 func init() {
@@ -132,8 +132,8 @@ func NewWebhookProvider(u string) (*WebhookProvider, error) {
 		return nil, fmt.Errorf("wrong content type returned from server: %s", ct)
 	}
 
-	df := endpoint.DomainFilter{}
-	if err := json.NewDecoder(resp.Body).Decode(&df); err != nil {
+	df := &endpoint.DomainFilter{}
+	if err := json.NewDecoder(resp.Body).Decode(df); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response body of DomainFilter: %w", err)
 	}
 


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->
Standardizes `DomainFilter` method receivers to use pointer receivers consistently.
Changes `DomainFilter` methods (`Match`, `IsConfigured`, `MarshalJSON`, `MatchParent`) from value receivers to pointer receivers, and fixes the corresponding `json.Marshal` call to use &`domainFilter`.

## Motivation
This addresses the discussion in #5522 where inconsistent receiver types were identified in the `DomainFilter` struct. Since `UnmarshalJSON` requires a pointer receiver, all other methods should use pointer receivers for consistency. This change prepares the codebase for enabling the `recvcheck` linter and improves overall code consistency.

<!-- What inspired you to submit this pull request? -->

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
