### PR TITLE
WIP chore(source): istio informers index service objects

### DIFF
--- a/source/informers/service_indexers.go
+++ b/source/informers/service_indexers.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informers
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	SvcSpecSelectorIndex          = "spec.selector"
+	SvcNamespaceSpecSelectorIndex = "namespace/spec.selector"
+)
+
+var (
+	// ServiceIndexers of indexers to allow fast lookups of services by their spec.selector.
+	// This indexer is used to find services that match a specific label selector.
+	// Usage:
+	//   serviceInformer.Informer().AddIndexers(ServiceIndexers)
+	//   serviceInformer.Lister().ByIndex(SvcSpecSelectorIndex, ToSHA(labels.Set(selector).String()))
+	ServiceIndexers = cache.Indexers{
+		SvcSpecSelectorIndex: func(obj any) ([]string, error) {
+			svc, ok := obj.(*corev1.Service)
+			if !ok {
+				return nil, nil
+			}
+			return []string{ToSHA(labels.Set(svc.Spec.Selector).String())}, nil
+		},
+	}
+	// ServiceNsSelectorIndexers for namespace/spec.selector to allow fast lookups of services by their spec.selector and namespace.
+	// Usage:
+	//      serviceInformer.Informer().AddIndexers(ServiceNsSelectorIndexers)
+	//      serviceInformer.Lister().ByIndex(SvcNamespaceSpecSelectorIndex, ToSHA(svc.Namespace + "/" + labels.Set(svc.Spec.Selector).String()))
+	ServiceNsSelectorIndexers = cache.Indexers{
+		SvcNamespaceSpecSelectorIndex: func(obj any) ([]string, error) {
+			svc, ok := obj.(*corev1.Service)
+			if !ok {
+				return nil, nil
+			}
+			return []string{ToSHA(svc.Namespace + "/" + labels.Set(svc.Spec.Selector).String())}, nil
+		},
+	}
+)
+
+func ServiceWithDefaultOptions(serviceInformer corev1informers.ServiceInformer, namespace string) error {
+	_, _ = serviceInformer.Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj any) {
+				if !log.IsLevelEnabled(log.DebugLevel) {
+					return
+				}
+				u, ok := obj.(*unstructured.Unstructured)
+				if !ok {
+					log.Debugf("%s added", u.GetKind())
+				} else {
+					log.WithFields(log.Fields{
+						"apiVersion": u.GetAPIVersion(),
+						"kind":       u.GetKind(),
+						"name":       u.GetName(),
+						"namespace":  u.GetNamespace(),
+					}).Info("added")
+				}
+			},
+		},
+	)
+
+	if namespace == "" {
+		return serviceInformer.Informer().AddIndexers(ServiceIndexers)
+	}
+	return serviceInformer.Informer().AddIndexers(ServiceNsSelectorIndexers)
+}
+
+// ToSHA returns the SHA1 hash of the input string as a hex string.
+// Using a SHA1 hash of the label selector string (as in ToSHA(labels.Set(selector).String())) is useful:
+// - It provides a consistent and compact representation of the selector.
+// - It allows for efficient indexing and lookup in Kubernetes informers.
+// - It avoids issues with long label selector strings that could exceed index length limits.
+func ToSHA(s string) string {
+	h := sha1.New()
+	h.Write([]byte(s))
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/source/informers/service_indexers_test.go
+++ b/source/informers/service_indexers_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestServiceIndexers_SpecSelectorIndex(t *testing.T) {
+	svc := &corev1.Service{}
+	svc.Spec.Selector = map[string]string{"app": "nginx", "env": "prod"}
+
+	indexFunc := ServiceIndexers[SvcSpecSelectorIndex]
+	indexKeys, err := indexFunc(svc)
+	expectedKey := ToSHA(labels.Set(svc.Spec.Selector).String())
+
+	assert.NoError(t, err)
+	assert.Len(t, indexKeys, 1)
+	assert.Equal(t, expectedKey, indexKeys[0])
+}
+
+func TestServiceNsSelectorIndexers_NamespaceSpecSelectorIndex(t *testing.T) {
+	svc := &corev1.Service{}
+	svc.Namespace = "test-ns"
+	svc.Spec.Selector = map[string]string{"app": "nginx", "env": "prod"}
+
+	indexFunc := ServiceNsSelectorIndexers[SvcNamespaceSpecSelectorIndex]
+	indexKeys, err := indexFunc(svc)
+
+	expectedKey := ToSHA(svc.Namespace + "/" + labels.Set(svc.Spec.Selector).String())
+
+	assert.NoError(t, err)
+	assert.Len(t, indexKeys, 1)
+	assert.Equal(t, expectedKey, indexKeys[0])
+}
+
+func TestServiceWithDefaultOptions_AddsCorrectIndexers(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		want      cache.Indexers
+	}{
+		{"empty namespace", "", ServiceIndexers},
+		{"non-empty namespace", "ns", ServiceNsSelectorIndexers},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockInf := &mockInformer{}
+
+			si := &fakeSvcInformer{
+				informer: mockInf,
+			}
+			err := ServiceWithDefaultOptions(si, tt.namespace)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, mockInf.addedIndexersTimes, "AddIndexers should be called once")
+			assert.Equal(t, 1, mockInf.addedHandlerTimes, "AddEventHandler should be called once")
+			assert.Equal(t, tt.want, mockInf.addedIndexers)
+		})
+	}
+}
+
+// mocks
+type fakeSvcInformer struct {
+	mock.Mock
+	informer *mockInformer
+}
+
+func (f *fakeSvcInformer) Informer() cache.SharedIndexInformer {
+	return f.informer
+}
+
+func (f *fakeSvcInformer) Lister() corev1listers.ServiceLister {
+	return nil
+}
+
+// mockInformer implements the minimal methods needed for testing.
+type mockInformer struct {
+	cache.SharedIndexInformer
+	addedIndexers      cache.Indexers
+	addedIndexersTimes int
+	addedHandlerTimes  int
+}
+
+func (m *mockInformer) AddEventHandler(_ cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	m.addedHandlerTimes++
+	return nil, nil
+}
+
+func (m *mockInformer) AddIndexers(indexers cache.Indexers) error {
+	m.addedIndexers = indexers
+	m.addedIndexersTimes++
+	return nil
+}


### PR DESCRIPTION
## What does it do ?
> note; to review after release

Indexers are way waster then listers, the difference could be 10x times with a cost of  +~10% memory usage(for indexes)

## Motivation

- previous PR https://github.com/kubernetes-sigs/external-dns/pull/5536
- previous PR https://github.com/kubernetes-sigs/external-dns/pull/5466
- opened PR https://github.com/kubernetes-sigs/external-dns/pull/5473#issuecomment-2911576025

TODO:
- share syntetic results
- share results for real cluster

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
