### PR TITLE
refactor(provider): replace switch with if for record type filtering

### DIFF
--- a/provider/dnsimple/dnsimple.go
+++ b/provider/dnsimple/dnsimple.go
@@ -206,10 +206,7 @@ func (p *dnsimpleProvider) Records(ctx context.Context) (endpoints []*endpoint.E
 				return nil, err
 			}
 			for _, record := range records.Data {
-				switch record.Type {
-				case "A", "CNAME", "TXT":
-					break
-				default:
+				if record.Type != "A" && record.Type != "CNAME" && record.Type != "TXT" {
 					continue
 				}
 				// Apex records have an empty string for their name.

--- a/provider/exoscale/exoscale.go
+++ b/provider/exoscale/exoscale.go
@@ -235,10 +235,7 @@ func (ep *ExoscaleProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, 
 		}
 
 		for _, record := range records {
-			switch *record.Type {
-			case "A", "CNAME", "TXT":
-				break
-			default:
+			if *record.Type != "A" && *record.Type != "CNAME" && *record.Type != "TXT" {
 				continue
 			}
 


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->
Replaces switch statements with simple if conditions in `dnsimple` and `exoscale` providers to improve code clarity and prevent confusion about break statement behavior. 
## Motivation

<!-- What inspired you to submit this pull request? -->

The previous switch statements included meaningless `break` statements at the end of case blocks, which serve no purpose in Go since cases don't fall through by default. 
More importantly, these break statements could be misread as attempting to break out of the containing for loop, when they were actually no-ops. This could lead to confusion for developers reading the code.                                                                   
By replacing the switch with simple if conditions, the intent is clearer: skip unsupported record types and  continue processing supported ones. 

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
