### PR TITLE
fix(cloudflare): fix action display in logs

### DIFF
--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -544,7 +544,7 @@ func (p *CloudFlareProvider) submitChanges(ctx context.Context, changes []*cloud
 				"record": change.ResourceRecord.Name,
 				"type":   change.ResourceRecord.Type,
 				"ttl":    change.ResourceRecord.TTL,
-				"action": change.Action,
+				"action": change.Action.String(),
 				"zone":   zoneID,
 			}
 

--- a/provider/cloudflare/cloudflare_regional.go
+++ b/provider/cloudflare/cloudflare_regional.go
@@ -80,7 +80,7 @@ func (p *CloudFlareProvider) submitDataLocalizationRegionalHostnameChanges(ctx c
 		logFields := log.Fields{
 			"hostname":   rhChange.Hostname,
 			"region_key": rhChange.RegionKey,
-			"action":     rhChange.action,
+			"action":     rhChange.action.String(),
 			"zone":       resourceContainer.Identifier,
 		}
 		log.WithFields(logFields).Info("Changing regional hostname")


### PR DESCRIPTION
## What does it do ?

Fix the display of action in cloudflare provider logs.
<!-- A brief description of the change being made with this pull request. -->

Regressed by: https://github.com/kubernetes-sigs/external-dns/pull/5329

## Motivation

Action is displayed as an int instead of using its `String()` func.
```
{"action":"1","level":"info","msg":"Changing record.","record":"external-dns-test.xxx.xx","time":"2025-06-21T21:24:31","ttl":1,"type":"CNAME","zone":"xxx"}
```
After:
```
{"action":"DELETE","level":"info","msg":"Changing record.","record":"external-dns-test.xxx.xx","time":"2025-06-21T21:24:31","ttl":1,"type":"CNAME","zone":"xxx"}
```
<!-- What inspired you to submit this pull request? -->

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
