### PR TITLE
test(awssd): fix a flaky test

### DIFF
--- a/provider/awssd/fixtures_test.go
+++ b/provider/awssd/fixtures_test.go
@@ -19,9 +19,7 @@ package awssd
 import (
 	"context"
 	"errors"
-	"math/rand"
 	"reflect"
-	"strconv"
 	"testing"
 	"time"
 
@@ -58,7 +56,7 @@ type AWSSDClientStub struct {
 
 func (s *AWSSDClientStub) CreateService(_ context.Context, input *servicediscovery.CreateServiceInput, _ ...func(*servicediscovery.Options)) (*servicediscovery.CreateServiceOutput, error) {
 	srv := &types.Service{
-		Id:               aws.String(strconv.Itoa(rand.Intn(10000))),
+		Id:               input.Name,
 		DnsConfig:        input.DnsConfig,
 		Name:             input.Name,
 		Description:      input.Description,


### PR DESCRIPTION
## What does it do ?

Fix the flaky test `TestAWSSDProvider_CreateService()`.

Use a deterministic ID when creating a service in the stub client to avoid random collision in `s.service` map (indexed by service ID). 
https://github.com/kubernetes-sigs/external-dns/blob/a4522f0b7616ef97c7deb9bec6959611bc4d92cd/provider/awssd/fixtures_test.go#L74
## Motivation

```
 --- FAIL: TestAWSSDProvider_CreateService (0.00s)
    fixtures_test.go:264: 
        	Error Trace:	/home/prow/go/src/github.com/kubernetes-sigs/external-dns/provider/awssd/fixtures_test.go:264
        	            				/home/prow/go/src/github.com/kubernetes-sigs/external-dns/provider/awssd/aws_sd_test.go:497
        	Error:      	"map[1307:0xc0000f7340 7804:0xc0000f7180 9424:0xc0000f6fc0]" should have 4 item(s), but has 3
        	Test:       	TestAWSSDProvider_CreateService
FAIL
```
https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_external-dns/5550/pull-external-dns-unit-test/1936508282768199680

Can be reproduce with (if you have luck):
`go test --run 'TestAWSSDProvider_CreateService$' ./provider/awssd/ -count=10000; echo $?`



## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
