### PR TITLE
docs(traefik): public and private routing

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -38,7 +38,7 @@
 | `--[no-]ignore-ingress-rules-spec` | Ignore the spec.rules section in Ingress resources (default: false) |
 | `--[no-]ignore-ingress-tls-spec` | Ignore the spec.tls section in Ingress resources (default: false) |
 | `--[no-]ignore-non-host-network-pods` | Ignore pods not running on host network when using pod source (default: false) |
-| `--ingress-class=INGRESS-CLASS` | Require on source ingress to have this class name; specify multiple times for more then one class (optional; defaults to any class) |
+| `--ingress-class=INGRESS-CLASS` | Require an Ingress to have this class name; specify multiple times to allow more than one class (optional; defaults to any class) |
 | `--label-filter=""` | Filter resources queried for endpoints by label selector; currently supported by source types crd, gateway-httproute, gateway-grpcroute, gateway-tlsroute, gateway-tcproute, gateway-udproute, ingress, node, openshift-route, service and ambassador-host |
 | `--managed-record-types=A...` | Record types to manage; specify multiple times to include many; (default: A,AAAA,CNAME) (supported records: A, AAAA, CNAME, NS, SRV, TXT) |
 | `--namespace=""` | Limit resources queried for endpoints to a specific namespace (default: all namespaces) |

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -38,7 +38,7 @@
 | `--[no-]ignore-ingress-rules-spec` | Ignore the spec.rules section in Ingress resources (default: false) |
 | `--[no-]ignore-ingress-tls-spec` | Ignore the spec.tls section in Ingress resources (default: false) |
 | `--[no-]ignore-non-host-network-pods` | Ignore pods not running on host network when using pod source (default: false) |
-| `--ingress-class=INGRESS-CLASS` | Require an Ingress to have this class name (defaults to any class; specify multiple times to allow more than one class) |
+| `--ingress-class=INGRESS-CLASS` | Require on source ingress to have this class name; specify multiple times for more then one class (optional; defaults to any class) |
 | `--label-filter=""` | Filter resources queried for endpoints by label selector; currently supported by source types crd, gateway-httproute, gateway-grpcroute, gateway-tlsroute, gateway-tcproute, gateway-udproute, ingress, node, openshift-route, service and ambassador-host |
 | `--managed-record-types=A...` | Record types to manage; specify multiple times to include many; (default: A,AAAA,CNAME) (supported records: A, AAAA, CNAME, NS, SRV, TXT) |
 | `--namespace=""` | Limit resources queried for endpoints to a specific namespace (default: all namespaces) |

--- a/docs/snippets/traefik-proxy/ingress-route-default.yaml
+++ b/docs/snippets/traefik-proxy/ingress-route-default.yaml
@@ -1,0 +1,18 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: traefik-ingress
+  annotations:
+    external-dns.alpha.kubernetes.io/target: traefik.example.com
+    kubernetes.io/ingress.class: traefik
+spec:
+  entryPoints:
+    - web
+    - websecure
+  routes:
+    - match: Host(`application.example.com`)
+      kind: Rule
+      services:
+        - name: service
+          namespace: namespace
+          port: port

--- a/docs/snippets/traefik-proxy/ingress-route-public-private.yaml
+++ b/docs/snippets/traefik-proxy/ingress-route-public-private.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: traefik.io/v1
+kind: IngressRoute
+metadata:
+  name: traefik-public-abc
+  annotations:
+    kubernetes.io/ingress.class: traefik-public
+  labels:
+    # required for traefik
+    traffic-type: private
+spec:
+  entryPoints:
+    - web
+    - websecure
+  routes:
+    - match: Host(`application.public.example.com`)
+      kind: Rule
+      services:
+        - name: service
+          namespace: namespace
+          port: port
+  tls:
+    secretName: traefik-tls-cert-public
+---
+apiVersion: traefik.io/v1
+kind: IngressRoute
+metadata:
+  name: traefik-private-abc
+  annotations:
+    kubernetes.io/ingress.class: traefik-private
+  labels:
+    # required for traefik
+    traffic-type: private
+spec:
+  entryPoints:
+    - web
+    - websecure
+  routes:
+    - match: Host(`application.private.tlc`)
+      kind: Rule
+      services:
+        - name: service
+          namespace: namespace
+          port: port
+  tls:
+    secretName: traefik-tls-cert-private

--- a/docs/snippets/traefik-proxy/ingress-route-public-private.yaml
+++ b/docs/snippets/traefik-proxy/ingress-route-public-private.yaml
@@ -5,9 +5,6 @@ metadata:
   name: traefik-public-abc
   annotations:
     kubernetes.io/ingress.class: traefik-public
-  labels:
-    # required for traefik
-    traffic-type: private
 spec:
   entryPoints:
     - web
@@ -28,9 +25,6 @@ metadata:
   name: traefik-private-abc
   annotations:
     kubernetes.io/ingress.class: traefik-private
-  labels:
-    # required for traefik
-    traffic-type: private
 spec:
   entryPoints:
     - web

--- a/docs/snippets/traefik-proxy/traefik-public-private-config.yaml
+++ b/docs/snippets/traefik-proxy/traefik-public-private-config.yaml
@@ -1,0 +1,16 @@
+---
+type: public
+providers:
+  kubernetesCRD:
+    labelSelector: traffic-type in (public, middleware-public, ...other selectors..)
+
+  kubernetesIngress:
+    labelSelector: traffic-type in (public, middleware-public, ...other selectors..)
+---
+type: private
+providers:
+  kubernetesCRD:
+    labelSelector: traffic-type in (private, middleware-private, ...other selectors..)
+
+  kubernetesIngress:
+    labelSelector: traffic-type in (private, middleware-private, ...other selectors..)

--- a/docs/snippets/traefik-proxy/traefik-public-private-config.yaml
+++ b/docs/snippets/traefik-proxy/traefik-public-private-config.yaml
@@ -2,15 +2,15 @@
 type: public
 providers:
   kubernetesCRD:
-    labelSelector: traffic-type in (public, middleware-public, ...other selectors..)
+    ingressClass: traefik-public
 
   kubernetesIngress:
-    labelSelector: traffic-type in (public, middleware-public, ...other selectors..)
+    ingressClass: traefik-public
 ---
 type: private
 providers:
   kubernetesCRD:
-    labelSelector: traffic-type in (private, middleware-private, ...other selectors..)
+    ingressClass: traefik-private
 
   kubernetesIngress:
-    labelSelector: traffic-type in (private, middleware-private, ...other selectors..)
+    ingressClass: traefik-private

--- a/docs/snippets/traefik-proxy/with-cluster-rbac.yaml
+++ b/docs/snippets/traefik-proxy/with-cluster-rbac.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups: [""]
+  resources: ["services","endpoints","pods"]
+  verbs: ["get","watch","list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["list","watch"]
+- apiGroups: ["traefik.containo.us","traefik.io"]
+  resources: ["ingressroutes", "ingressroutetcps", "ingressrouteudps"]
+  verbs: ["get","watch","list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+  namespace: default
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      serviceAccountName: external-dns
+      containers:
+      - name: external-dns
+        # update this to the desired external-dns version
+        image: registry.k8s.io/external-dns/external-dns:v0.17.0
+        args:
+        - --source=traefik-proxy
+        - --provider=aws
+        - --registry=txt
+        - --txt-owner-id=my-identifier

--- a/docs/snippets/traefik-proxy/without-rbac.yaml
+++ b/docs/snippets/traefik-proxy/without-rbac.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      containers:
+      - name: external-dns
+        # update this to the desired external-dns version
+        image: registry.k8s.io/external-dns/external-dns:v0.17.0
+        args:
+        - --source=traefik-proxy
+        - --provider=aws
+        - --registry=txt
+        - --txt-owner-id=my-identifier

--- a/docs/sources/traefik-proxy.md
+++ b/docs/sources/traefik-proxy.md
@@ -66,7 +66,7 @@ args:
 ---
 args:
   - --source=traefik-proxy
-  - --annotation-filter="kubernetes.io/ingress.class=traefik-public"
+  - --annotation-filter="kubernetes.io/ingress.class=traefik-private"
 ```
 
 ## Cleanup

--- a/docs/sources/traefik-proxy.md
+++ b/docs/sources/traefik-proxy.md
@@ -40,7 +40,7 @@ Depending where you run your IngressRoute it can take a little while for Externa
 
 ## Support private and public routing
 
-To create a more robust and manageable Kubernetes environment, leverage separate Ingress classes to finely control public and private routing's security, performance, and operational policies.
+To create a more robust and manageable Kubernetes environment, leverage separate Ingress classes to finely control public and private routing's security, performance, and operational policies. Similar approach could work in multi-tenant environments.
 
 For this we are going to need two instances of `traefik` (public and private) as well as two instances of `external-dns`.
 

--- a/docs/sources/traefik-proxy.md
+++ b/docs/sources/traefik-proxy.md
@@ -1,123 +1,29 @@
 # Traefik Proxy Source
 
+- [Traefik Documentation](https://doc.traefik.io/traefik/)
+- [Traefik Helm Chart](https://github.com/traefik/traefik-helm-chart)
+
 This tutorial describes how to configure ExternalDNS to use the Traefik Proxy source.
 It is meant to supplement the other provider-specific setup tutorials.
 
 ## Manifest (for clusters without RBAC enabled)
 
 ```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: external-dns
-spec:
-  strategy:
-    type: Recreate
-  selector:
-    matchLabels:
-      app: external-dns
-  template:
-    metadata:
-      labels:
-        app: external-dns
-    spec:
-      containers:
-      - name: external-dns
-        # update this to the desired external-dns version
-        image: registry.k8s.io/external-dns/external-dns:v0.17.0
-        args:
-        - --source=traefik-proxy
-        - --provider=aws
-        - --registry=txt
-        - --txt-owner-id=my-identifier
+[[% include 'traefik-proxy/without-rbac.yaml' %]]
 ```
 
 ## Manifest (for clusters with RBAC enabled)
 
 ```yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: external-dns
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: external-dns
-rules:
-- apiGroups: [""]
-  resources: ["services","endpoints","pods"]
-  verbs: ["get","watch","list"]
-- apiGroups: [""]
-  resources: ["nodes"]
-  verbs: ["list","watch"]
-- apiGroups: ["traefik.containo.us","traefik.io"]
-  resources: ["ingressroutes", "ingressroutetcps", "ingressrouteudps"]
-  verbs: ["get","watch","list"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: external-dns-viewer
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: external-dns
-subjects:
-- kind: ServiceAccount
-  name: external-dns
-  namespace: default
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: external-dns
-spec:
-  strategy:
-    type: Recreate
-  selector:
-    matchLabels:
-      app: external-dns
-  template:
-    metadata:
-      labels:
-        app: external-dns
-    spec:
-      serviceAccountName: external-dns
-      containers:
-      - name: external-dns
-        # update this to the desired external-dns version
-        image: registry.k8s.io/external-dns/external-dns:v0.17.0
-        args:
-        - --source=traefik-proxy
-        - --provider=aws
-        - --registry=txt
-        - --txt-owner-id=my-identifier
+[[% include 'traefik-proxy/with-cluster-rbac.yaml' %]]
 ```
 
 ## Deploying a Traefik IngressRoute
 
-Create a IngressRoute file called 'traefik-ingress.yaml' with the following contents:
+Create an IngressRoute file called 'ingress-route-default' with the following contents:
 
 ```yaml
-apiVersion: traefik.io/v1alpha1
-kind: IngressRoute
-metadata:
-  name: traefik-ingress
-  annotations:
-    external-dns.alpha.kubernetes.io/target: traefik.example.com
-    kubernetes.io/ingress.class: traefik
-spec:
-  entryPoints:
-    - web
-    - websecure
-  routes:
-    - match: Host(`application.example.com`)
-      kind: Rule
-      services:
-        - name: service
-          namespace: namespace
-          port: port
+[[% include 'traefik-proxy/ingress-route-default.yaml' %]]
 ```
 
 Note the annotation on the IngressRoute (`external-dns.alpha.kubernetes.io/target`); use the same hostname as the traefik DNS.
@@ -127,30 +33,61 @@ ExternalDNS uses this annotation to determine what services should be registered
 Create the IngressRoute:
 
 ```sh
-kubectl create -f traefik-ingress.yaml
+kubectl create -f docs/snippets/traefik-proxy/ingress-route-default.yaml
 ```
 
 Depending where you run your IngressRoute it can take a little while for ExternalDNS synchronize the DNS record.
+
+## Support private and public routing
+
+To create a more robust and manageable Kubernetes environment, leverage separate Ingress classes to finely control public and private routing's security, performance, and operational policies.
+
+For this we are going to need two instances of `traefik` (public and private) as well as two instances of `external-dns`.
+
+The `traefik` configuration should contain (for more detailed configured validate with the vendor)
+
+```yaml
+[[% include 'traefik-proxy/traefik-public-private-config.yaml' %]]
+```
+
+Create a IngressRoutes files with the following contents:
+
+```yaml
+[[% include 'traefik-proxy/ingress-route-public-private.yaml' %]]
+```
+
+And the arguments for `external-dns` instances should looks like
+
+```yaml
+---
+args:
+  - --source=traefik-proxy
+  - --annotation-filter="kubernetes.io/ingress.class=traefik-public"
+---
+args:
+  - --source=traefik-proxy
+  - --annotation-filter="kubernetes.io/ingress.class=traefik-public"
+```
 
 ## Cleanup
 
 Now that we have verified that ExternalDNS will automatically manage Traefik DNS records, we can delete the tutorial's example:
 
 ```sh
-kubectl delete -f traefik-ingress.yaml
+kubectl delete -f docs/snippets/traefik-proxy/ingress-route-default.yaml
 kubectl delete -f externaldns.yaml
 ```
 
 ## Additional Flags
 
-| Flag | Description |
-| --- | --- |
+| Flag                     | Description                                              |
+|--------------------------|----------------------------------------------------------|
 | --traefik-disable-legacy | Disable listeners on Resources under traefik.containo.us |
-| --traefik-disable-new | Disable listeners on Resources under traefik.io |
+| --traefik-disable-new    | Disable listeners on Resources under traefik.io          |
 
 ### Disabling Resource Listeners
 
-Traefik has deprecated the legacy API group, traefik.containo.us, in favor of traefik.io. By default the traefik-proxy source will listen for resources under both API groups; however, this may cause timeouts with the following message
+Traefik has deprecated the legacy API group, `traefik.containo.us`, in favor of `traefik.io`. By default the `traefik-proxy` source will listen for resources under both API groups; however, this may cause timeouts with the following message
 
 ```sh
 FATA[0060] failed to sync traefik.io/v1alpha1, Resource=ingressroutes: context deadline exceeded

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -475,7 +475,7 @@ func App(cfg *Config) *kingpin.Application {
 	app.Flag("ignore-ingress-rules-spec", "Ignore the spec.rules section in Ingress resources (default: false)").BoolVar(&cfg.IgnoreIngressRulesSpec)
 	app.Flag("ignore-ingress-tls-spec", "Ignore the spec.tls section in Ingress resources (default: false)").BoolVar(&cfg.IgnoreIngressTLSSpec)
 	app.Flag("ignore-non-host-network-pods", "Ignore pods not running on host network when using pod source (default: false)").BoolVar(&cfg.IgnoreNonHostNetworkPods)
-	app.Flag("ingress-class", "Require on source ingress to have this class name; specify multiple times for more then one class (optional; defaults to any class)").StringsVar(&cfg.IngressClassNames)
+	app.Flag("ingress-class", "Require an Ingress to have this class name; specify multiple times to allow more than one class (optional; defaults to any class)").StringsVar(&cfg.IngressClassNames)
 	app.Flag("label-filter", "Filter resources queried for endpoints by label selector; currently supported by source types crd, gateway-httproute, gateway-grpcroute, gateway-tlsroute, gateway-tcproute, gateway-udproute, ingress, node, openshift-route, service and ambassador-host").Default(defaultConfig.LabelFilter).StringVar(&cfg.LabelFilter)
 	managedRecordTypesHelp := fmt.Sprintf("Record types to manage; specify multiple times to include many; (default: %s) (supported records: A, AAAA, CNAME, NS, SRV, TXT)", strings.Join(defaultConfig.ManagedDNSRecordTypes, ","))
 	app.Flag("managed-record-types", managedRecordTypesHelp).Default(defaultConfig.ManagedDNSRecordTypes...).StringsVar(&cfg.ManagedDNSRecordTypes)

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -475,7 +475,7 @@ func App(cfg *Config) *kingpin.Application {
 	app.Flag("ignore-ingress-rules-spec", "Ignore the spec.rules section in Ingress resources (default: false)").BoolVar(&cfg.IgnoreIngressRulesSpec)
 	app.Flag("ignore-ingress-tls-spec", "Ignore the spec.tls section in Ingress resources (default: false)").BoolVar(&cfg.IgnoreIngressTLSSpec)
 	app.Flag("ignore-non-host-network-pods", "Ignore pods not running on host network when using pod source (default: false)").BoolVar(&cfg.IgnoreNonHostNetworkPods)
-	app.Flag("ingress-class", "Require an Ingress to have this class name (defaults to any class; specify multiple times to allow more than one class)").StringsVar(&cfg.IngressClassNames)
+	app.Flag("ingress-class", "Require on source ingress to have this class name; specify multiple times for more then one class (optional; defaults to any class)").StringsVar(&cfg.IngressClassNames)
 	app.Flag("label-filter", "Filter resources queried for endpoints by label selector; currently supported by source types crd, gateway-httproute, gateway-grpcroute, gateway-tlsroute, gateway-tcproute, gateway-udproute, ingress, node, openshift-route, service and ambassador-host").Default(defaultConfig.LabelFilter).StringVar(&cfg.LabelFilter)
 	managedRecordTypesHelp := fmt.Sprintf("Record types to manage; specify multiple times to include many; (default: %s) (supported records: A, AAAA, CNAME, NS, SRV, TXT)", strings.Join(defaultConfig.ManagedDNSRecordTypes, ","))
 	app.Flag("managed-record-types", managedRecordTypesHelp).Default(defaultConfig.ManagedDNSRecordTypes...).StringsVar(&cfg.ManagedDNSRecordTypes)

--- a/source/traefik_proxy.go
+++ b/source/traefik_proxy.go
@@ -43,32 +43,32 @@ import (
 )
 
 var (
-	ingressrouteGVR = schema.GroupVersionResource{
+	ingressRouteGVR = schema.GroupVersionResource{
 		Group:    "traefik.io",
 		Version:  "v1alpha1",
 		Resource: "ingressroutes",
 	}
-	ingressrouteTCPGVR = schema.GroupVersionResource{
+	ingressRouteTCPGVR = schema.GroupVersionResource{
 		Group:    "traefik.io",
 		Version:  "v1alpha1",
 		Resource: "ingressroutetcps",
 	}
-	ingressrouteUDPGVR = schema.GroupVersionResource{
+	ingressRouteUDPGVR = schema.GroupVersionResource{
 		Group:    "traefik.io",
 		Version:  "v1alpha1",
 		Resource: "ingressrouteudps",
 	}
-	oldIngressrouteGVR = schema.GroupVersionResource{
+	oldIngressRouteGVR = schema.GroupVersionResource{
 		Group:    "traefik.containo.us",
 		Version:  "v1alpha1",
 		Resource: "ingressroutes",
 	}
-	oldIngressrouteTCPGVR = schema.GroupVersionResource{
+	oldIngressRouteTCPGVR = schema.GroupVersionResource{
 		Group:    "traefik.containo.us",
 		Version:  "v1alpha1",
 		Resource: "ingressroutetcps",
 	}
-	oldIngressrouteUDPGVR = schema.GroupVersionResource{
+	oldIngressRouteUDPGVR = schema.GroupVersionResource{
 		Group:    "traefik.containo.us",
 		Version:  "v1alpha1",
 		Resource: "ingressrouteudps",
@@ -81,21 +81,26 @@ var (
 )
 
 type traefikSource struct {
-	annotationFilter           string
-	ignoreHostnameAnnotation   bool
 	dynamicKubeClient          dynamic.Interface
+	kubeClient                 kubernetes.Interface
+	annotationFilter           string
+	namespace                  string
+	ignoreHostnameAnnotation   bool
 	ingressRouteInformer       kubeinformers.GenericInformer
 	ingressRouteTcpInformer    kubeinformers.GenericInformer
 	ingressRouteUdpInformer    kubeinformers.GenericInformer
 	oldIngressRouteInformer    kubeinformers.GenericInformer
 	oldIngressRouteTcpInformer kubeinformers.GenericInformer
 	oldIngressRouteUdpInformer kubeinformers.GenericInformer
-	kubeClient                 kubernetes.Interface
-	namespace                  string
 	unstructuredConverter      *unstructuredConverter
 }
 
-func NewTraefikSource(ctx context.Context, dynamicKubeClient dynamic.Interface, kubeClient kubernetes.Interface, namespace string, annotationFilter string, ignoreHostnameAnnotation bool, disableLegacy bool, disableNew bool) (Source, error) {
+func NewTraefikSource(
+	ctx context.Context,
+	dynamicKubeClient dynamic.Interface,
+	kubeClient kubernetes.Interface,
+	namespace, annotationFilter string,
+	ignoreHostnameAnnotation, disableLegacy, disableNew bool) (Source, error) {
 	// Use shared informer to listen for add/update/delete of Host in the specified namespace.
 	// Set resync period to 0, to prevent processing when nothing has changed.
 	informerFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicKubeClient, 0, namespace, nil)
@@ -104,40 +109,40 @@ func NewTraefikSource(ctx context.Context, dynamicKubeClient dynamic.Interface, 
 
 	// Add default resource event handlers to properly initialize informers.
 	if !disableNew {
-		ingressRouteInformer = informerFactory.ForResource(ingressrouteGVR)
-		ingressRouteTcpInformer = informerFactory.ForResource(ingressrouteTCPGVR)
-		ingressRouteUdpInformer = informerFactory.ForResource(ingressrouteUDPGVR)
-		ingressRouteInformer.Informer().AddEventHandler(
+		ingressRouteInformer = informerFactory.ForResource(ingressRouteGVR)
+		ingressRouteTcpInformer = informerFactory.ForResource(ingressRouteTCPGVR)
+		ingressRouteUdpInformer = informerFactory.ForResource(ingressRouteUDPGVR)
+		_, _ = ingressRouteInformer.Informer().AddEventHandler(
 			cache.ResourceEventHandlerFuncs{
 				AddFunc: func(obj interface{}) {},
 			},
 		)
-		ingressRouteTcpInformer.Informer().AddEventHandler(
+		_, _ = ingressRouteTcpInformer.Informer().AddEventHandler(
 			cache.ResourceEventHandlerFuncs{
 				AddFunc: func(obj interface{}) {},
 			},
 		)
-		ingressRouteUdpInformer.Informer().AddEventHandler(
+		_, _ = ingressRouteUdpInformer.Informer().AddEventHandler(
 			cache.ResourceEventHandlerFuncs{
 				AddFunc: func(obj interface{}) {},
 			},
 		)
 	}
 	if !disableLegacy {
-		oldIngressRouteInformer = informerFactory.ForResource(oldIngressrouteGVR)
-		oldIngressRouteTcpInformer = informerFactory.ForResource(oldIngressrouteTCPGVR)
-		oldIngressRouteUdpInformer = informerFactory.ForResource(oldIngressrouteUDPGVR)
-		oldIngressRouteInformer.Informer().AddEventHandler(
+		oldIngressRouteInformer = informerFactory.ForResource(oldIngressRouteGVR)
+		oldIngressRouteTcpInformer = informerFactory.ForResource(oldIngressRouteTCPGVR)
+		oldIngressRouteUdpInformer = informerFactory.ForResource(oldIngressRouteUDPGVR)
+		_, _ = oldIngressRouteInformer.Informer().AddEventHandler(
 			cache.ResourceEventHandlerFuncs{
 				AddFunc: func(obj interface{}) {},
 			},
 		)
-		oldIngressRouteTcpInformer.Informer().AddEventHandler(
+		_, _ = oldIngressRouteTcpInformer.Informer().AddEventHandler(
 			cache.ResourceEventHandlerFuncs{
 				AddFunc: func(obj interface{}) {},
 			},
 		)
-		oldIngressRouteUdpInformer.Informer().AddEventHandler(
+		_, _ = oldIngressRouteUdpInformer.Informer().AddEventHandler(
 			cache.ResourceEventHandlerFuncs{
 				AddFunc: func(obj interface{}) {},
 			},
@@ -460,24 +465,24 @@ func (ts *traefikSource) AddEventHandler(ctx context.Context, handler func()) {
 	// https://github.com/kubernetes/kubernetes/issues/79610
 	log.Debug("Adding event handler for IngressRoute")
 	if ts.ingressRouteInformer != nil {
-		ts.ingressRouteInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
+		_, _ = ts.ingressRouteInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
 	}
 	if ts.oldIngressRouteInformer != nil {
-		ts.oldIngressRouteInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
+		_, _ = ts.oldIngressRouteInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
 	}
 	log.Debug("Adding event handler for IngressRouteTCP")
 	if ts.ingressRouteTcpInformer != nil {
-		ts.ingressRouteTcpInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
+		_, _ = ts.ingressRouteTcpInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
 	}
 	if ts.oldIngressRouteTcpInformer != nil {
-		ts.oldIngressRouteTcpInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
+		_, _ = ts.oldIngressRouteTcpInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
 	}
 	log.Debug("Adding event handler for IngressRouteUDP")
 	if ts.ingressRouteUdpInformer != nil {
-		ts.ingressRouteUdpInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
+		_, _ = ts.ingressRouteUdpInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
 	}
 	if ts.oldIngressRouteUdpInformer != nil {
-		ts.oldIngressRouteUdpInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
+		_, _ = ts.oldIngressRouteUdpInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
 	}
 }
 
@@ -488,12 +493,12 @@ func newTraefikUnstructuredConverter() (*unstructuredConverter, error) {
 	}
 
 	// Add the core types we need
-	uc.scheme.AddKnownTypes(ingressrouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
-	uc.scheme.AddKnownTypes(oldIngressrouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
-	uc.scheme.AddKnownTypes(ingressrouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
-	uc.scheme.AddKnownTypes(oldIngressrouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
-	uc.scheme.AddKnownTypes(ingressrouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
-	uc.scheme.AddKnownTypes(oldIngressrouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
+	uc.scheme.AddKnownTypes(ingressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
+	uc.scheme.AddKnownTypes(oldIngressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
+	uc.scheme.AddKnownTypes(ingressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
+	uc.scheme.AddKnownTypes(oldIngressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
+	uc.scheme.AddKnownTypes(ingressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
+	uc.scheme.AddKnownTypes(oldIngressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
 	if err := scheme.AddToScheme(uc.scheme); err != nil {
 		return nil, err
 	}
@@ -917,8 +922,7 @@ func filterResourcesByAnnotations[T any](resources []*T, annotationFilter string
 
 	var filteredList []*T
 	for _, resource := range resources {
-		annotations := getAnnotations(resource)
-		if selector.Matches(labels.Set(annotations)) {
+		if selector.Matches(labels.Set(getAnnotations(resource))) {
 			filteredList = append(filteredList, resource)
 		}
 	}

--- a/source/traefik_proxy_test.go
+++ b/source/traefik_proxy_test.go
@@ -55,7 +55,7 @@ func TestTraefikProxyIngressRouteEndpoints(t *testing.T) {
 			title: "IngressRoute with hostname annotation",
 			ingressRoute: IngressRoute{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: ingressrouteGVR.GroupVersion().String(),
+					APIVersion: ingressRouteGVR.GroupVersion().String(),
 					Kind:       "IngressRoute",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -85,7 +85,7 @@ func TestTraefikProxyIngressRouteEndpoints(t *testing.T) {
 			title: "IngressRoute with host rule",
 			ingressRoute: IngressRoute{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: ingressrouteGVR.GroupVersion().String(),
+					APIVersion: ingressRouteGVR.GroupVersion().String(),
 					Kind:       "IngressRoute",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -121,7 +121,7 @@ func TestTraefikProxyIngressRouteEndpoints(t *testing.T) {
 			title: "IngressRoute with hostheader rule",
 			ingressRoute: IngressRoute{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: ingressrouteGVR.GroupVersion().String(),
+					APIVersion: ingressRouteGVR.GroupVersion().String(),
 					Kind:       "IngressRoute",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -157,7 +157,7 @@ func TestTraefikProxyIngressRouteEndpoints(t *testing.T) {
 			title: "IngressRoute with multiple host rules",
 			ingressRoute: IngressRoute{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: ingressrouteGVR.GroupVersion().String(),
+					APIVersion: ingressRouteGVR.GroupVersion().String(),
 					Kind:       "IngressRoute",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -203,7 +203,7 @@ func TestTraefikProxyIngressRouteEndpoints(t *testing.T) {
 			title: "IngressRoute with multiple host rules and annotation",
 			ingressRoute: IngressRoute{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: ingressrouteGVR.GroupVersion().String(),
+					APIVersion: ingressRouteGVR.GroupVersion().String(),
 					Kind:       "IngressRoute",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -260,7 +260,7 @@ func TestTraefikProxyIngressRouteEndpoints(t *testing.T) {
 			title: "IngressRoute ignoring annotation",
 			ingressRoute: IngressRoute{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: ingressrouteGVR.GroupVersion().String(),
+					APIVersion: ingressRouteGVR.GroupVersion().String(),
 					Kind:       "IngressRoute",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -308,7 +308,7 @@ func TestTraefikProxyIngressRouteEndpoints(t *testing.T) {
 			title: "IngressRoute omit wildcard",
 			ingressRoute: IngressRoute{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: ingressrouteGVR.GroupVersion().String(),
+					APIVersion: ingressRouteGVR.GroupVersion().String(),
 					Kind:       "IngressRoute",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -336,12 +336,12 @@ func TestTraefikProxyIngressRouteEndpoints(t *testing.T) {
 
 			fakeKubernetesClient := fakeKube.NewSimpleClientset()
 			scheme := runtime.NewScheme()
-			scheme.AddKnownTypes(ingressrouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
-			scheme.AddKnownTypes(ingressrouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
-			scheme.AddKnownTypes(ingressrouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
-			scheme.AddKnownTypes(oldIngressrouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
-			scheme.AddKnownTypes(oldIngressrouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
-			scheme.AddKnownTypes(oldIngressrouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
+			scheme.AddKnownTypes(ingressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
+			scheme.AddKnownTypes(ingressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
+			scheme.AddKnownTypes(ingressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
+			scheme.AddKnownTypes(oldIngressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
+			scheme.AddKnownTypes(oldIngressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
+			scheme.AddKnownTypes(oldIngressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
 			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(scheme)
 
 			ir := unstructured.Unstructured{}
@@ -352,7 +352,7 @@ func TestTraefikProxyIngressRouteEndpoints(t *testing.T) {
 			assert.NoError(t, ir.UnmarshalJSON(ingressRouteAsJSON))
 
 			// Create proxy resources
-			_, err = fakeDynamicClient.Resource(ingressrouteGVR).Namespace(defaultTraefikNamespace).Create(context.Background(), &ir, metav1.CreateOptions{})
+			_, err = fakeDynamicClient.Resource(ingressRouteGVR).Namespace(defaultTraefikNamespace).Create(context.Background(), &ir, metav1.CreateOptions{})
 			assert.NoError(t, err)
 
 			source, err := NewTraefikSource(context.TODO(), fakeDynamicClient, fakeKubernetesClient, defaultTraefikNamespace, "kubernetes.io/ingress.class=traefik", ti.ignoreHostnameAnnotation, false, false)
@@ -361,7 +361,7 @@ func TestTraefikProxyIngressRouteEndpoints(t *testing.T) {
 
 			count := &unstructured.UnstructuredList{}
 			for len(count.Items) < 1 {
-				count, _ = fakeDynamicClient.Resource(ingressrouteGVR).Namespace(defaultTraefikNamespace).List(context.Background(), metav1.ListOptions{})
+				count, _ = fakeDynamicClient.Resource(ingressRouteGVR).Namespace(defaultTraefikNamespace).List(context.Background(), metav1.ListOptions{})
 			}
 
 			endpoints, err := source.Endpoints(context.Background())
@@ -385,7 +385,7 @@ func TestTraefikProxyIngressRouteTCPEndpoints(t *testing.T) {
 			title: "IngressRouteTCP with hostname annotation",
 			ingressRouteTCP: IngressRouteTCP{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: ingressrouteTCPGVR.GroupVersion().String(),
+					APIVersion: ingressRouteTCPGVR.GroupVersion().String(),
 					Kind:       "IngressRouteTCP",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -415,7 +415,7 @@ func TestTraefikProxyIngressRouteTCPEndpoints(t *testing.T) {
 			title: "IngressRouteTCP with host sni rule",
 			ingressRouteTCP: IngressRouteTCP{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: ingressrouteTCPGVR.GroupVersion().String(),
+					APIVersion: ingressRouteTCPGVR.GroupVersion().String(),
 					Kind:       "IngressRouteTCP",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -451,7 +451,7 @@ func TestTraefikProxyIngressRouteTCPEndpoints(t *testing.T) {
 			title: "IngressRouteTCP with multiple host sni rules",
 			ingressRouteTCP: IngressRouteTCP{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: ingressrouteTCPGVR.GroupVersion().String(),
+					APIVersion: ingressRouteTCPGVR.GroupVersion().String(),
 					Kind:       "IngressRouteTCP",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -497,7 +497,7 @@ func TestTraefikProxyIngressRouteTCPEndpoints(t *testing.T) {
 			title: "IngressRouteTCP with multiple host sni rules and annotation",
 			ingressRouteTCP: IngressRouteTCP{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: ingressrouteTCPGVR.GroupVersion().String(),
+					APIVersion: ingressRouteTCPGVR.GroupVersion().String(),
 					Kind:       "IngressRouteTCP",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -554,7 +554,7 @@ func TestTraefikProxyIngressRouteTCPEndpoints(t *testing.T) {
 			title: "IngressRouteTCP ignoring annotation",
 			ingressRouteTCP: IngressRouteTCP{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: ingressrouteTCPGVR.GroupVersion().String(),
+					APIVersion: ingressRouteTCPGVR.GroupVersion().String(),
 					Kind:       "IngressRouteTCP",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -602,7 +602,7 @@ func TestTraefikProxyIngressRouteTCPEndpoints(t *testing.T) {
 			title: "IngressRouteTCP omit wildcard host sni",
 			ingressRouteTCP: IngressRouteTCP{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: ingressrouteTCPGVR.GroupVersion().String(),
+					APIVersion: ingressRouteTCPGVR.GroupVersion().String(),
 					Kind:       "IngressRouteTCP",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -630,12 +630,12 @@ func TestTraefikProxyIngressRouteTCPEndpoints(t *testing.T) {
 
 			fakeKubernetesClient := fakeKube.NewSimpleClientset()
 			scheme := runtime.NewScheme()
-			scheme.AddKnownTypes(ingressrouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
-			scheme.AddKnownTypes(ingressrouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
-			scheme.AddKnownTypes(ingressrouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
-			scheme.AddKnownTypes(oldIngressrouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
-			scheme.AddKnownTypes(oldIngressrouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
-			scheme.AddKnownTypes(oldIngressrouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
+			scheme.AddKnownTypes(ingressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
+			scheme.AddKnownTypes(ingressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
+			scheme.AddKnownTypes(ingressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
+			scheme.AddKnownTypes(oldIngressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
+			scheme.AddKnownTypes(oldIngressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
+			scheme.AddKnownTypes(oldIngressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
 			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(scheme)
 
 			ir := unstructured.Unstructured{}
@@ -646,7 +646,7 @@ func TestTraefikProxyIngressRouteTCPEndpoints(t *testing.T) {
 			require.NoError(t, ir.UnmarshalJSON(ingressRouteAsJSON))
 
 			// Create proxy resources
-			_, err = fakeDynamicClient.Resource(ingressrouteTCPGVR).Namespace(defaultTraefikNamespace).Create(context.Background(), &ir, metav1.CreateOptions{})
+			_, err = fakeDynamicClient.Resource(ingressRouteTCPGVR).Namespace(defaultTraefikNamespace).Create(context.Background(), &ir, metav1.CreateOptions{})
 			require.NoError(t, err)
 
 			source, err := NewTraefikSource(context.TODO(), fakeDynamicClient, fakeKubernetesClient, defaultTraefikNamespace, "kubernetes.io/ingress.class=traefik", ti.ignoreHostnameAnnotation, false, false)
@@ -655,7 +655,7 @@ func TestTraefikProxyIngressRouteTCPEndpoints(t *testing.T) {
 
 			count := &unstructured.UnstructuredList{}
 			for len(count.Items) < 1 {
-				count, _ = fakeDynamicClient.Resource(ingressrouteTCPGVR).Namespace(defaultTraefikNamespace).List(context.Background(), metav1.ListOptions{})
+				count, _ = fakeDynamicClient.Resource(ingressRouteTCPGVR).Namespace(defaultTraefikNamespace).List(context.Background(), metav1.ListOptions{})
 			}
 
 			endpoints, err := source.Endpoints(context.Background())
@@ -679,7 +679,7 @@ func TestTraefikProxyIngressRouteUDPEndpoints(t *testing.T) {
 			title: "IngressRouteTCP with hostname annotation",
 			ingressRouteUDP: IngressRouteUDP{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: ingressrouteUDPGVR.GroupVersion().String(),
+					APIVersion: ingressRouteUDPGVR.GroupVersion().String(),
 					Kind:       "IngressRouteUDP",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -709,7 +709,7 @@ func TestTraefikProxyIngressRouteUDPEndpoints(t *testing.T) {
 			title: "IngressRouteTCP with multiple hostname annotation",
 			ingressRouteUDP: IngressRouteUDP{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: ingressrouteUDPGVR.GroupVersion().String(),
+					APIVersion: ingressRouteUDPGVR.GroupVersion().String(),
 					Kind:       "IngressRouteUDP",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -749,7 +749,7 @@ func TestTraefikProxyIngressRouteUDPEndpoints(t *testing.T) {
 			title: "IngressRouteTCP ignoring hostname annotation",
 			ingressRouteUDP: IngressRouteUDP{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: ingressrouteUDPGVR.GroupVersion().String(),
+					APIVersion: ingressRouteUDPGVR.GroupVersion().String(),
 					Kind:       "IngressRouteUDP",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -772,12 +772,12 @@ func TestTraefikProxyIngressRouteUDPEndpoints(t *testing.T) {
 
 			fakeKubernetesClient := fakeKube.NewSimpleClientset()
 			scheme := runtime.NewScheme()
-			scheme.AddKnownTypes(ingressrouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
-			scheme.AddKnownTypes(ingressrouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
-			scheme.AddKnownTypes(ingressrouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
-			scheme.AddKnownTypes(oldIngressrouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
-			scheme.AddKnownTypes(oldIngressrouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
-			scheme.AddKnownTypes(oldIngressrouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
+			scheme.AddKnownTypes(ingressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
+			scheme.AddKnownTypes(ingressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
+			scheme.AddKnownTypes(ingressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
+			scheme.AddKnownTypes(oldIngressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
+			scheme.AddKnownTypes(oldIngressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
+			scheme.AddKnownTypes(oldIngressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
 			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(scheme)
 
 			ir := unstructured.Unstructured{}
@@ -788,7 +788,7 @@ func TestTraefikProxyIngressRouteUDPEndpoints(t *testing.T) {
 			assert.NoError(t, ir.UnmarshalJSON(ingressRouteAsJSON))
 
 			// Create proxy resources
-			_, err = fakeDynamicClient.Resource(ingressrouteUDPGVR).Namespace(defaultTraefikNamespace).Create(context.Background(), &ir, metav1.CreateOptions{})
+			_, err = fakeDynamicClient.Resource(ingressRouteUDPGVR).Namespace(defaultTraefikNamespace).Create(context.Background(), &ir, metav1.CreateOptions{})
 			assert.NoError(t, err)
 
 			source, err := NewTraefikSource(context.TODO(), fakeDynamicClient, fakeKubernetesClient, defaultTraefikNamespace, "kubernetes.io/ingress.class=traefik", ti.ignoreHostnameAnnotation, false, false)
@@ -797,7 +797,7 @@ func TestTraefikProxyIngressRouteUDPEndpoints(t *testing.T) {
 
 			count := &unstructured.UnstructuredList{}
 			for len(count.Items) < 1 {
-				count, _ = fakeDynamicClient.Resource(ingressrouteUDPGVR).Namespace(defaultTraefikNamespace).List(context.Background(), metav1.ListOptions{})
+				count, _ = fakeDynamicClient.Resource(ingressRouteUDPGVR).Namespace(defaultTraefikNamespace).List(context.Background(), metav1.ListOptions{})
 			}
 
 			endpoints, err := source.Endpoints(context.Background())
@@ -821,7 +821,7 @@ func TestTraefikProxyOldIngressRouteEndpoints(t *testing.T) {
 			title: "IngressRoute with hostname annotation",
 			ingressRoute: IngressRoute{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: oldIngressrouteGVR.GroupVersion().String(),
+					APIVersion: oldIngressRouteGVR.GroupVersion().String(),
 					Kind:       "IngressRoute",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -851,7 +851,7 @@ func TestTraefikProxyOldIngressRouteEndpoints(t *testing.T) {
 			title: "IngressRoute with host rule",
 			ingressRoute: IngressRoute{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: oldIngressrouteGVR.GroupVersion().String(),
+					APIVersion: oldIngressRouteGVR.GroupVersion().String(),
 					Kind:       "IngressRoute",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -887,7 +887,7 @@ func TestTraefikProxyOldIngressRouteEndpoints(t *testing.T) {
 			title: "IngressRoute with hostheader rule",
 			ingressRoute: IngressRoute{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: oldIngressrouteGVR.GroupVersion().String(),
+					APIVersion: oldIngressRouteGVR.GroupVersion().String(),
 					Kind:       "IngressRoute",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -923,7 +923,7 @@ func TestTraefikProxyOldIngressRouteEndpoints(t *testing.T) {
 			title: "IngressRoute with multiple host rules",
 			ingressRoute: IngressRoute{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: oldIngressrouteGVR.GroupVersion().String(),
+					APIVersion: oldIngressRouteGVR.GroupVersion().String(),
 					Kind:       "IngressRoute",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -969,7 +969,7 @@ func TestTraefikProxyOldIngressRouteEndpoints(t *testing.T) {
 			title: "IngressRoute with multiple host rules and annotation",
 			ingressRoute: IngressRoute{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: oldIngressrouteGVR.GroupVersion().String(),
+					APIVersion: oldIngressRouteGVR.GroupVersion().String(),
 					Kind:       "IngressRoute",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -1026,7 +1026,7 @@ func TestTraefikProxyOldIngressRouteEndpoints(t *testing.T) {
 			title: "IngressRoute ignoring annotation",
 			ingressRoute: IngressRoute{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: oldIngressrouteGVR.GroupVersion().String(),
+					APIVersion: oldIngressRouteGVR.GroupVersion().String(),
 					Kind:       "IngressRoute",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -1074,7 +1074,7 @@ func TestTraefikProxyOldIngressRouteEndpoints(t *testing.T) {
 			title: "IngressRoute omit wildcard",
 			ingressRoute: IngressRoute{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: oldIngressrouteGVR.GroupVersion().String(),
+					APIVersion: oldIngressRouteGVR.GroupVersion().String(),
 					Kind:       "IngressRoute",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -1102,12 +1102,12 @@ func TestTraefikProxyOldIngressRouteEndpoints(t *testing.T) {
 
 			fakeKubernetesClient := fakeKube.NewSimpleClientset()
 			scheme := runtime.NewScheme()
-			scheme.AddKnownTypes(ingressrouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
-			scheme.AddKnownTypes(ingressrouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
-			scheme.AddKnownTypes(ingressrouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
-			scheme.AddKnownTypes(oldIngressrouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
-			scheme.AddKnownTypes(oldIngressrouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
-			scheme.AddKnownTypes(oldIngressrouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
+			scheme.AddKnownTypes(ingressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
+			scheme.AddKnownTypes(ingressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
+			scheme.AddKnownTypes(ingressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
+			scheme.AddKnownTypes(oldIngressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
+			scheme.AddKnownTypes(oldIngressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
+			scheme.AddKnownTypes(oldIngressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
 			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(scheme)
 
 			ir := unstructured.Unstructured{}
@@ -1118,7 +1118,7 @@ func TestTraefikProxyOldIngressRouteEndpoints(t *testing.T) {
 			assert.NoError(t, ir.UnmarshalJSON(ingressRouteAsJSON))
 
 			// Create proxy resources
-			_, err = fakeDynamicClient.Resource(oldIngressrouteGVR).Namespace(defaultTraefikNamespace).Create(context.Background(), &ir, metav1.CreateOptions{})
+			_, err = fakeDynamicClient.Resource(oldIngressRouteGVR).Namespace(defaultTraefikNamespace).Create(context.Background(), &ir, metav1.CreateOptions{})
 			assert.NoError(t, err)
 
 			source, err := NewTraefikSource(context.TODO(), fakeDynamicClient, fakeKubernetesClient, defaultTraefikNamespace, "kubernetes.io/ingress.class=traefik", ti.ignoreHostnameAnnotation, false, false)
@@ -1127,7 +1127,7 @@ func TestTraefikProxyOldIngressRouteEndpoints(t *testing.T) {
 
 			count := &unstructured.UnstructuredList{}
 			for len(count.Items) < 1 {
-				count, _ = fakeDynamicClient.Resource(oldIngressrouteGVR).Namespace(defaultTraefikNamespace).List(context.Background(), metav1.ListOptions{})
+				count, _ = fakeDynamicClient.Resource(oldIngressRouteGVR).Namespace(defaultTraefikNamespace).List(context.Background(), metav1.ListOptions{})
 			}
 
 			endpoints, err := source.Endpoints(context.Background())
@@ -1151,7 +1151,7 @@ func TestTraefikProxyOldIngressRouteTCPEndpoints(t *testing.T) {
 			title: "IngressRouteTCP with hostname annotation",
 			ingressRouteTCP: IngressRouteTCP{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: oldIngressrouteTCPGVR.GroupVersion().String(),
+					APIVersion: oldIngressRouteTCPGVR.GroupVersion().String(),
 					Kind:       "IngressRouteTCP",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -1181,7 +1181,7 @@ func TestTraefikProxyOldIngressRouteTCPEndpoints(t *testing.T) {
 			title: "IngressRouteTCP with host sni rule",
 			ingressRouteTCP: IngressRouteTCP{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: oldIngressrouteTCPGVR.GroupVersion().String(),
+					APIVersion: oldIngressRouteTCPGVR.GroupVersion().String(),
 					Kind:       "IngressRouteTCP",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -1217,7 +1217,7 @@ func TestTraefikProxyOldIngressRouteTCPEndpoints(t *testing.T) {
 			title: "IngressRouteTCP with multiple host sni rules",
 			ingressRouteTCP: IngressRouteTCP{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: oldIngressrouteTCPGVR.GroupVersion().String(),
+					APIVersion: oldIngressRouteTCPGVR.GroupVersion().String(),
 					Kind:       "IngressRouteTCP",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -1263,7 +1263,7 @@ func TestTraefikProxyOldIngressRouteTCPEndpoints(t *testing.T) {
 			title: "IngressRouteTCP with multiple host sni rules and annotation",
 			ingressRouteTCP: IngressRouteTCP{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: oldIngressrouteTCPGVR.GroupVersion().String(),
+					APIVersion: oldIngressRouteTCPGVR.GroupVersion().String(),
 					Kind:       "IngressRouteTCP",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -1320,7 +1320,7 @@ func TestTraefikProxyOldIngressRouteTCPEndpoints(t *testing.T) {
 			title: "IngressRouteTCP ignoring annotation",
 			ingressRouteTCP: IngressRouteTCP{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: oldIngressrouteTCPGVR.GroupVersion().String(),
+					APIVersion: oldIngressRouteTCPGVR.GroupVersion().String(),
 					Kind:       "IngressRouteTCP",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -1368,7 +1368,7 @@ func TestTraefikProxyOldIngressRouteTCPEndpoints(t *testing.T) {
 			title: "IngressRouteTCP omit wildcard host sni",
 			ingressRouteTCP: IngressRouteTCP{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: oldIngressrouteTCPGVR.GroupVersion().String(),
+					APIVersion: oldIngressRouteTCPGVR.GroupVersion().String(),
 					Kind:       "IngressRouteTCP",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -1396,12 +1396,12 @@ func TestTraefikProxyOldIngressRouteTCPEndpoints(t *testing.T) {
 
 			fakeKubernetesClient := fakeKube.NewSimpleClientset()
 			scheme := runtime.NewScheme()
-			scheme.AddKnownTypes(ingressrouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
-			scheme.AddKnownTypes(ingressrouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
-			scheme.AddKnownTypes(ingressrouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
-			scheme.AddKnownTypes(oldIngressrouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
-			scheme.AddKnownTypes(oldIngressrouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
-			scheme.AddKnownTypes(oldIngressrouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
+			scheme.AddKnownTypes(ingressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
+			scheme.AddKnownTypes(ingressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
+			scheme.AddKnownTypes(ingressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
+			scheme.AddKnownTypes(oldIngressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
+			scheme.AddKnownTypes(oldIngressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
+			scheme.AddKnownTypes(oldIngressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
 			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(scheme)
 
 			ir := unstructured.Unstructured{}
@@ -1412,7 +1412,7 @@ func TestTraefikProxyOldIngressRouteTCPEndpoints(t *testing.T) {
 			assert.NoError(t, ir.UnmarshalJSON(ingressRouteAsJSON))
 
 			// Create proxy resources
-			_, err = fakeDynamicClient.Resource(oldIngressrouteTCPGVR).Namespace(defaultTraefikNamespace).Create(context.Background(), &ir, metav1.CreateOptions{})
+			_, err = fakeDynamicClient.Resource(oldIngressRouteTCPGVR).Namespace(defaultTraefikNamespace).Create(context.Background(), &ir, metav1.CreateOptions{})
 			assert.NoError(t, err)
 
 			source, err := NewTraefikSource(context.TODO(), fakeDynamicClient, fakeKubernetesClient, defaultTraefikNamespace, "kubernetes.io/ingress.class=traefik", ti.ignoreHostnameAnnotation, false, false)
@@ -1421,7 +1421,7 @@ func TestTraefikProxyOldIngressRouteTCPEndpoints(t *testing.T) {
 
 			count := &unstructured.UnstructuredList{}
 			for len(count.Items) < 1 {
-				count, _ = fakeDynamicClient.Resource(oldIngressrouteTCPGVR).Namespace(defaultTraefikNamespace).List(context.Background(), metav1.ListOptions{})
+				count, _ = fakeDynamicClient.Resource(oldIngressRouteTCPGVR).Namespace(defaultTraefikNamespace).List(context.Background(), metav1.ListOptions{})
 			}
 
 			endpoints, err := source.Endpoints(context.Background())
@@ -1445,7 +1445,7 @@ func TestTraefikProxyOldIngressRouteUDPEndpoints(t *testing.T) {
 			title: "IngressRouteTCP with hostname annotation",
 			ingressRouteUDP: IngressRouteUDP{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: oldIngressrouteUDPGVR.GroupVersion().String(),
+					APIVersion: oldIngressRouteUDPGVR.GroupVersion().String(),
 					Kind:       "IngressRouteUDP",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -1475,7 +1475,7 @@ func TestTraefikProxyOldIngressRouteUDPEndpoints(t *testing.T) {
 			title: "IngressRouteTCP with multiple hostname annotation",
 			ingressRouteUDP: IngressRouteUDP{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: oldIngressrouteUDPGVR.GroupVersion().String(),
+					APIVersion: oldIngressRouteUDPGVR.GroupVersion().String(),
 					Kind:       "IngressRouteUDP",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -1515,7 +1515,7 @@ func TestTraefikProxyOldIngressRouteUDPEndpoints(t *testing.T) {
 			title: "IngressRouteTCP ignoring hostname annotation",
 			ingressRouteUDP: IngressRouteUDP{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: oldIngressrouteUDPGVR.GroupVersion().String(),
+					APIVersion: oldIngressRouteUDPGVR.GroupVersion().String(),
 					Kind:       "IngressRouteUDP",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -1538,12 +1538,12 @@ func TestTraefikProxyOldIngressRouteUDPEndpoints(t *testing.T) {
 
 			fakeKubernetesClient := fakeKube.NewSimpleClientset()
 			scheme := runtime.NewScheme()
-			scheme.AddKnownTypes(ingressrouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
-			scheme.AddKnownTypes(ingressrouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
-			scheme.AddKnownTypes(ingressrouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
-			scheme.AddKnownTypes(oldIngressrouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
-			scheme.AddKnownTypes(oldIngressrouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
-			scheme.AddKnownTypes(oldIngressrouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
+			scheme.AddKnownTypes(ingressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
+			scheme.AddKnownTypes(ingressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
+			scheme.AddKnownTypes(ingressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
+			scheme.AddKnownTypes(oldIngressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
+			scheme.AddKnownTypes(oldIngressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
+			scheme.AddKnownTypes(oldIngressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
 			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(scheme)
 
 			ir := unstructured.Unstructured{}
@@ -1554,7 +1554,7 @@ func TestTraefikProxyOldIngressRouteUDPEndpoints(t *testing.T) {
 			assert.NoError(t, ir.UnmarshalJSON(ingressRouteAsJSON))
 
 			// Create proxy resources
-			_, err = fakeDynamicClient.Resource(oldIngressrouteUDPGVR).Namespace(defaultTraefikNamespace).Create(context.Background(), &ir, metav1.CreateOptions{})
+			_, err = fakeDynamicClient.Resource(oldIngressRouteUDPGVR).Namespace(defaultTraefikNamespace).Create(context.Background(), &ir, metav1.CreateOptions{})
 			assert.NoError(t, err)
 
 			source, err := NewTraefikSource(context.TODO(), fakeDynamicClient, fakeKubernetesClient, defaultTraefikNamespace, "kubernetes.io/ingress.class=traefik", ti.ignoreHostnameAnnotation, false, false)
@@ -1563,7 +1563,7 @@ func TestTraefikProxyOldIngressRouteUDPEndpoints(t *testing.T) {
 
 			count := &unstructured.UnstructuredList{}
 			for len(count.Items) < 1 {
-				count, _ = fakeDynamicClient.Resource(oldIngressrouteUDPGVR).Namespace(defaultTraefikNamespace).List(context.Background(), metav1.ListOptions{})
+				count, _ = fakeDynamicClient.Resource(oldIngressRouteUDPGVR).Namespace(defaultTraefikNamespace).List(context.Background(), metav1.ListOptions{})
 			}
 
 			endpoints, err := source.Endpoints(context.Background())
@@ -1590,7 +1590,7 @@ func TestTraefikAPIGroupDisableFlags(t *testing.T) {
 			title: "IngressRoute.traefik.containo.us with the legacy API group enabled",
 			ingressRoute: IngressRoute{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: oldIngressrouteGVR.GroupVersion().String(),
+					APIVersion: oldIngressRouteGVR.GroupVersion().String(),
 					Kind:       "IngressRoute",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -1603,7 +1603,7 @@ func TestTraefikAPIGroupDisableFlags(t *testing.T) {
 					},
 				},
 			},
-			gvr:           oldIngressrouteGVR,
+			gvr:           oldIngressRouteGVR,
 			disableLegacy: false,
 			disableNew:    false,
 			expected: []*endpoint.Endpoint{
@@ -1623,7 +1623,7 @@ func TestTraefikAPIGroupDisableFlags(t *testing.T) {
 			title: "IngressRoute.traefik.containo.us with the legacy API group disabled",
 			ingressRoute: IngressRoute{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: oldIngressrouteGVR.GroupVersion().String(),
+					APIVersion: oldIngressRouteGVR.GroupVersion().String(),
 					Kind:       "IngressRoute",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -1636,7 +1636,7 @@ func TestTraefikAPIGroupDisableFlags(t *testing.T) {
 					},
 				},
 			},
-			gvr:           oldIngressrouteGVR,
+			gvr:           oldIngressRouteGVR,
 			disableLegacy: true,
 			disableNew:    false,
 		},
@@ -1644,7 +1644,7 @@ func TestTraefikAPIGroupDisableFlags(t *testing.T) {
 			title: "IngressRoute.traefik.io with the new API group enabled",
 			ingressRoute: IngressRoute{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: ingressrouteGVR.GroupVersion().String(),
+					APIVersion: ingressRouteGVR.GroupVersion().String(),
 					Kind:       "IngressRoute",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -1657,7 +1657,7 @@ func TestTraefikAPIGroupDisableFlags(t *testing.T) {
 					},
 				},
 			},
-			gvr:           ingressrouteGVR,
+			gvr:           ingressRouteGVR,
 			disableLegacy: false,
 			disableNew:    false,
 			expected: []*endpoint.Endpoint{
@@ -1677,7 +1677,7 @@ func TestTraefikAPIGroupDisableFlags(t *testing.T) {
 			title: "IngressRoute.traefik.io with the new API group disabled",
 			ingressRoute: IngressRoute{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: ingressrouteGVR.GroupVersion().String(),
+					APIVersion: ingressRouteGVR.GroupVersion().String(),
 					Kind:       "IngressRoute",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -1690,7 +1690,7 @@ func TestTraefikAPIGroupDisableFlags(t *testing.T) {
 					},
 				},
 			},
-			gvr:           ingressrouteGVR,
+			gvr:           ingressRouteGVR,
 			disableLegacy: false,
 			disableNew:    true,
 		},
@@ -1701,12 +1701,12 @@ func TestTraefikAPIGroupDisableFlags(t *testing.T) {
 
 			fakeKubernetesClient := fakeKube.NewSimpleClientset()
 			scheme := runtime.NewScheme()
-			scheme.AddKnownTypes(ingressrouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
-			scheme.AddKnownTypes(ingressrouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
-			scheme.AddKnownTypes(ingressrouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
-			scheme.AddKnownTypes(oldIngressrouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
-			scheme.AddKnownTypes(oldIngressrouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
-			scheme.AddKnownTypes(oldIngressrouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
+			scheme.AddKnownTypes(ingressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
+			scheme.AddKnownTypes(ingressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
+			scheme.AddKnownTypes(ingressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
+			scheme.AddKnownTypes(oldIngressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
+			scheme.AddKnownTypes(oldIngressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
+			scheme.AddKnownTypes(oldIngressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
 			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(scheme)
 
 			ir := unstructured.Unstructured{}


### PR DESCRIPTION
## What does it do ?

- Added docs how to traefik proxy with public/private routing
- treafik-proxy.go IDE linting
- linked https://github.com/kubernetes-sigs/external-dns/pull/5380

## Motivation

Issue https://github.com/kubernetes-sigs/external-dns/issues/5474

follow-up for traefik-proxy source (just too keep a todo list for future):
- support label selectors
- support FQDN
- add support for native traefik informers (currently not exist)
- remove legacy/old Treafik apis

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

 
![Screenshot 2025-06-24 at 08 52 22](https://github.com/user-attachments/assets/e04cd104-7278-41a5-a235-88bcfa67505b)
![Screenshot 2025-06-24 at 08 53 15](https://github.com/user-attachments/assets/5ae0426f-a335-457a-b31f-be7fe049fdf1)
![Screenshot 2025-06-24 at 08 54 30](https://github.com/user-attachments/assets/82fc9aba-55ce-4b99-a051-d01110ae375d)


how it looks like
![Screenshot 2025-06-24 at 08 57 54](https://github.com/user-attachments/assets/5a4b35c0-1b1d-456e-afc1-e9da4f0b0558)



