### PR TITLE
chore(deps): bump json-yaml-validate to v3.3.1

### DIFF
--- a/.github/workflows/json-yaml-validate.yml
+++ b/.github/workflows/json-yaml-validate.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: json-yaml-validate
-        uses: GrantBirki/json-yaml-validate@v3.2.1 # pin @v3.2.1 bug in 3.3.0: https://github.com/GrantBirki/json-yaml-validate/issues/86
+        uses: GrantBirki/json-yaml-validate@v3.3.1
         with:
           # ref: https://github.com/GrantBirki/json-yaml-validate?tab=readme-ov-file#inputs-
           comment: "true" # enable comment mode


### PR DESCRIPTION
## What does it do ?

Update the dependency

## Motivation

Blocking [issue](https://github.com/GrantBirki/json-yaml-validate/issues/86) has been fixed

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
