### PR TITLE
fix(chart): Change .extraContainers type to array

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update RBAC for `Service` source to support `EndpointSlices`. ([#5493](https://github.com/kubernetes-sigs/external-dns/pull/5493)) _@vflaux_
 
+### Fixed
+
+- Fixed the type of `.extraContainers` from `object` to `list` (array). ([#5564](https://github.com/kubernetes-sigs/external-dns/pull/5564)) _@svengreb_
+
 ## [v1.17.0] - 2025-06-04
 
 ### Changed

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -105,7 +105,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | env | list | `[]` | [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `external-dns` container. |
 | excludeDomains | list | `[]` | Intentionally exclude domains from being managed. |
 | extraArgs | object | `{}` | Extra arguments to provide to _ExternalDNS_. An array or map can be used, with maps allowing for value overrides; maps also support slice values to use the same arg multiple times. |
-| extraContainers | object | `{}` | Extra containers to add to the `Deployment`. |
+| extraContainers | list | `[]` | Extra containers to add to the `Deployment`. |
 | extraVolumeMounts | list | `[]` | Extra [volume mounts](https://kubernetes.io/docs/concepts/storage/volumes/) for the `external-dns` container. |
 | extraVolumes | list | `[]` | Extra [volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the `Pod`. |
 | fullnameOverride | string | `nil` | Override the full name of the chart. |

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -81,7 +81,7 @@
     },
     "extraContainers": {
       "description": "Extra containers to add to the `Deployment`.",
-      "type": "object"
+      "type": "array"
     },
     "extraVolumeMounts": {
       "description": "Extra [volume mounts](https://kubernetes.io/docs/concepts/storage/volumes/) for the `external-dns` container.",

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -60,7 +60,7 @@ rbac:  # @schema additionalProperties: true
 deploymentAnnotations: {}
 
 # -- Extra containers to add to the `Deployment`.
-extraContainers: {}
+extraContainers: []
 
 # -- [Deployment Strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy).
 deploymentStrategy:  # @schema additionalProperties: true


### PR DESCRIPTION
## What does it do ?

Adding additional containers is currently impossible because the `.extraContainers` attribute is defined as object while the templating expects an array. This blocks the addition of other containers to the deployment using the Helm chart.

This PR changes the type of the `.extraContainers` attribute to an array to match [the template logic](https://github.com/kubernetes-sigs/external-dns/blob/57abe1d2/charts/external-dns/templates/deployment.yaml#L74-L76).

## Motivation

Adding additional containers to the `Deployment` using the Helm chart.
I also came across this problem while trying to add a webhook provider container as a workaround for https://github.com/kubernetes-sigs/external-dns/issues/5071, but this was also impossible due to this type mismatch.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Possible Impacts

I suspect that this attribute has never been usable since its introduction in https://github.com/kubernetes-sigs/external-dns/pull/4432 so users should not be affected when they did not use a modified chart or patched the values using e.g. FluxCD.
