### PR TITLE
feat(nodes)!: expose external ipv6 by default

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -29,7 +29,7 @@
 | `--exclude-record-types=EXCLUDE-RECORD-TYPES` | Record types to exclude from management; specify multiple times to exclude many; (optional) |
 | `--exclude-target-net=EXCLUDE-TARGET-NET` | Exclude target nets (optional) |
 | `--[no-]exclude-unschedulable` | Exclude nodes that are considered unschedulable (default: true) |
-| `--[no-]expose-internal-ipv6` | When using the node source, expose internal IPv6 addresses (optional). Default is true. |
+| `--[no-]expose-internal-ipv6` | When using the node source, expose internal IPv6 addresses (optional, default: false) |
 | `--fqdn-template=""` | A templated string that's used to generate DNS names from sources that don't define a hostname themselves, or to add a hostname suffix when paired with the fake source (optional). Accepts comma separated list for multiple global FQDN. |
 | `--gateway-label-filter=GATEWAY-LABEL-FILTER` | Filter Gateways of Route endpoints via label selector (default: all gateways) |
 | `--gateway-name=GATEWAY-NAME` | Limit Gateways of Route endpoints to a specific name (default: all names) |

--- a/docs/proposal/002-internal-ipv6-handling-rollback.md
+++ b/docs/proposal/002-internal-ipv6-handling-rollback.md
@@ -1,11 +1,12 @@
 <!-- clone me -->
+
 ```yaml
 ---
 title: "Proposal: Rollback IPv6 internal Node IP exposure"
 version: if applicable
 authors: @ivankatliarchuk, @szuecs, @mloiseleur
 creation-date: 2025-01-01
-status: approved
+status: implemented
 ---
 ```
 
@@ -47,7 +48,7 @@ Proposed Changes in `source/node.go` file.
 ```go
 // IPv6 addresses are labeled as NodeInternalIP despite being usable externally as well.
 if addr.Type == v1.NodeInternalIP && ns.exposeInternalIP && ... {
-	pv6Addresses = append(ipv6Addresses, addr.Address)
+    ipv6Addresses = append(ipv6Addresses, addr.Address)
 }
 ```
 

--- a/docs/sources/nodes.md
+++ b/docs/sources/nodes.md
@@ -13,11 +13,10 @@ In case you want to override the default, for example if you manage per-host DNS
 
 ## IPv6 Behavior
 
-By default, ExternalDNS exposes the IPv6 `InternalIP` of the nodes. To prevent this, you can use the `--no-expose-internal-ipv6` flag.
-**The default behavior will change in the next minor release.** ExternalDNS will no longer expose the IPv6 `InternalIP` addresses by default.
-You can still explicitly expose the internal ipv6 addresses by using the `--expose-internal-ipv6` flag, if needed.
+By default, ExternalDNS exposes the IPv6 `ExternalIP` of the nodes.
+If needed, one can still explicitly expose the internal ipv6 addresses by using the `--expose-internal-ipv6` flag.
 
-### Example spec (without exposing IPv6 `InternalIP` addresses)
+### Example spec
 
 ```yaml
 spec:
@@ -36,7 +35,6 @@ spec:
     - --txt-owner-id=my-identifier
     - --policy=sync
     - --log-level=debug
-    - --no-expose-internal-ipv6
 ```
 
 ## Manifest (for cluster without RBAC enabled)

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -277,7 +277,7 @@ var defaultConfig = &Config{
 	ExoscaleAPIKey:               "",
 	ExoscaleAPISecret:            "",
 	ExoscaleAPIZone:              "ch-gva-2",
-	ExposeInternalIPV6:           true,
+	ExposeInternalIPV6:           false,
 	FQDNTemplate:                 "",
 	GatewayLabelFilter:           "",
 	GatewayName:                  "",
@@ -464,7 +464,7 @@ func App(cfg *Config) *kingpin.Application {
 	app.Flag("exclude-record-types", "Record types to exclude from management; specify multiple times to exclude many; (optional)").Default().StringsVar(&cfg.ExcludeDNSRecordTypes)
 	app.Flag("exclude-target-net", "Exclude target nets (optional)").StringsVar(&cfg.ExcludeTargetNets)
 	app.Flag("exclude-unschedulable", "Exclude nodes that are considered unschedulable (default: true)").Default(strconv.FormatBool(defaultConfig.ExcludeUnschedulable)).BoolVar(&cfg.ExcludeUnschedulable)
-	app.Flag("expose-internal-ipv6", "When using the node source, expose internal IPv6 addresses (optional). Default is true.").BoolVar(&cfg.ExposeInternalIPV6)
+	app.Flag("expose-internal-ipv6", "When using the node source, expose internal IPv6 addresses (optional, default: false)").BoolVar(&cfg.ExposeInternalIPV6)
 	app.Flag("fqdn-template", "A templated string that's used to generate DNS names from sources that don't define a hostname themselves, or to add a hostname suffix when paired with the fake source (optional). Accepts comma separated list for multiple global FQDN.").Default(defaultConfig.FQDNTemplate).StringVar(&cfg.FQDNTemplate)
 	app.Flag("gateway-label-filter", "Filter Gateways of Route endpoints via label selector (default: all gateways)").StringVar(&cfg.GatewayLabelFilter)
 	app.Flag("gateway-name", "Limit Gateways of Route endpoints to a specific name (default: all names)").StringVar(&cfg.GatewayName)


### PR DESCRIPTION
## What does it do ?

Change default of expose-internal-ipv6

## Motivation

Follow-up of #5192

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I updated unit tests accordingly
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
