### PR TITLE
fix(helm): resolve RBAC permissions for namespaced gateway sources

### DIFF
--- a/charts/external-dns/templates/_helpers.tpl
+++ b/charts/external-dns/templates/_helpers.tpl
@@ -103,3 +103,12 @@ labelSelector:
   matchLabels:
     {{ include "external-dns.selectorLabels" . | nindent 4 }}
 {{- end }}
+
+{{/*
+Check if any Gateway API sources are enabled
+*/}}
+{{- define "external-dns.hasGatewaySources" -}}
+{{- if or (has "gateway-httproute" .Values.sources) (has "gateway-grpcroute" .Values.sources) (has "gateway-tlsroute" .Values.sources) (has "gateway-tcproute" .Values.sources) (has "gateway-udproute" .Values.sources) -}}
+true
+{{- end -}}
+{{- end }}

--- a/charts/external-dns/templates/clusterrole.yaml
+++ b/charts/external-dns/templates/clusterrole.yaml
@@ -58,13 +58,15 @@ rules:
     resources: ["dnsendpoints/status"]
     verbs: ["*"]
 {{- end }}
-{{- if or (has "gateway-httproute" .Values.sources) (has "gateway-grpcroute" .Values.sources) (has "gateway-tlsroute" .Values.sources) (has "gateway-tcproute" .Values.sources) (has "gateway-udproute" .Values.sources) }}
+{{- if include "external-dns.hasGatewaySources" . }}
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["gateways"]
     verbs: ["get","watch","list"]
+{{- if not .Values.namespaced }}
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get","watch","list"]
+{{- end }}
 {{- end }}
 {{- if has "gateway-httproute" .Values.sources }}
   - apiGroups: ["gateway.networking.k8s.io"]
@@ -126,5 +128,18 @@ rules:
 {{- end }}
 {{- with .Values.rbac.additionalPermissions }}
   {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- if and .Values.rbac.create .Values.namespaced (include "external-dns.hasGatewaySources" .) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "external-dns.fullname" . }}-namespaces
+  labels:
+    {{- include "external-dns.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get","watch","list"]
 {{- end }}
 {{- end }}

--- a/charts/external-dns/templates/clusterrole.yaml
+++ b/charts/external-dns/templates/clusterrole.yaml
@@ -59,9 +59,11 @@ rules:
     verbs: ["*"]
 {{- end }}
 {{- if include "external-dns.hasGatewaySources" . }}
+{{- if or (not .Values.namespaced) (and .Values.namespaced (not .Values.gatewayNamespace)) }}
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["gateways"]
     verbs: ["get","watch","list"]
+{{- end }}
 {{- if not .Values.namespaced }}
   - apiGroups: [""]
     resources: ["namespaces"]
@@ -141,5 +143,19 @@ rules:
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get","watch","list"]
+{{- if .Values.gatewayNamespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "external-dns.fullname" . }}-gateway
+  namespace: {{ .Values.gatewayNamespace }}
+  labels:
+    {{- include "external-dns.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gateways"]
+    verbs: ["get","watch","list"]
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/external-dns/templates/clusterrolebinding.yaml
+++ b/charts/external-dns/templates/clusterrolebinding.yaml
@@ -13,4 +13,21 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "external-dns.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- if and .Values.rbac.create .Values.namespaced (include "external-dns.hasGatewaySources" .) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "external-dns.fullname" . }}-namespaces
+  labels:
+    {{- include "external-dns.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "external-dns.fullname" . }}-namespaces
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "external-dns.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/external-dns/templates/clusterrolebinding.yaml
+++ b/charts/external-dns/templates/clusterrolebinding.yaml
@@ -29,5 +29,23 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "external-dns.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- if .Values.gatewayNamespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "external-dns.fullname" . }}-gateway
+  namespace: {{ .Values.gatewayNamespace }}
+  labels:
+    {{- include "external-dns.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "external-dns.fullname" . }}-gateway
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "external-dns.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -111,6 +111,9 @@ spec:
             {{- if .Values.namespaced }}
             - --namespace={{ .Release.Namespace }}
             {{- end }}
+            {{- if .Values.gatewayNamespace }}
+            - --gateway-namespace={{ .Values.gatewayNamespace }}
+            {{- end }}
             {{- range .Values.domainFilters }}
             - --domain-filter={{ . }}
             {{- end }}

--- a/charts/external-dns/tests/rbac_test.yaml
+++ b/charts/external-dns/tests/rbac_test.yaml
@@ -156,3 +156,103 @@ tests:
             - apiGroups: ["gateway.networking.k8s.io"]
               resources: ["udproutes"]
               verbs: ["get","watch","list"]
+
+  - it: should create Role instead of ClusterRole when namespaced is true
+    set:
+      namespaced: true
+      sources:
+        - service
+    asserts:
+      - isKind:
+          of: Role
+        template: clusterrole.yaml
+      - equal:
+          path: metadata.name
+          value: rbac-external-dns
+        template: clusterrole.yaml
+
+  - it: should create RoleBinding instead of ClusterRoleBinding when namespaced is true
+    set:
+      namespaced: true
+      sources:
+        - service
+    asserts:
+      - isKind:
+          of: RoleBinding
+        template: clusterrolebinding.yaml
+      - equal:
+          path: metadata.name
+          value: rbac-external-dns-viewer
+        template: clusterrolebinding.yaml
+
+  - it: should exclude namespaces permissions from Role when namespaced is true with gateway sources
+    set:
+      namespaced: true
+      sources:
+        - gateway-httproute
+    asserts:
+      - template: clusterrole.yaml
+        documentIndex: 0
+        equal:
+          path: rules
+          value:
+            - apiGroups: ["gateway.networking.k8s.io"]
+              resources: ["gateways"]
+              verbs: ["get","watch","list"]
+            - apiGroups: ["gateway.networking.k8s.io"]
+              resources: ["httproutes"]
+              verbs: ["get","watch","list"]
+
+  - it: should create additional ClusterRole for namespaces when namespaced is true with gateway sources
+    set:
+      namespaced: true
+      sources:
+        - gateway-httproute
+    asserts:
+      - hasDocuments:
+          count: 2
+        template: clusterrole.yaml
+      - isKind:
+          of: Role
+        documentIndex: 0
+        template: clusterrole.yaml
+      - isKind:
+          of: ClusterRole
+        documentIndex: 1
+        template: clusterrole.yaml
+      - equal:
+          path: metadata.name
+          value: rbac-external-dns-namespaces
+        documentIndex: 1
+        template: clusterrole.yaml
+      - equal:
+          path: rules
+          value:
+            - apiGroups: [""]
+              resources: ["namespaces"]
+              verbs: ["get","watch","list"]
+        documentIndex: 1
+        template: clusterrole.yaml
+
+  - it: should create additional ClusterRoleBinding for namespaces when namespaced is true with gateway sources
+    set:
+      namespaced: true
+      sources:
+        - gateway-httproute
+    asserts:
+      - hasDocuments:
+          count: 2
+        template: clusterrolebinding.yaml
+      - isKind:
+          of: RoleBinding
+        documentIndex: 0
+        template: clusterrolebinding.yaml
+      - isKind:
+          of: ClusterRoleBinding
+        documentIndex: 1
+        template: clusterrolebinding.yaml
+      - equal:
+          path: metadata.name
+          value: rbac-external-dns-namespaces
+        documentIndex: 1
+        template: clusterrolebinding.yaml

--- a/charts/external-dns/tests/rbac_test.yaml
+++ b/charts/external-dns/tests/rbac_test.yaml
@@ -185,74 +185,209 @@ tests:
           value: rbac-external-dns-viewer
         template: clusterrolebinding.yaml
 
-  - it: should exclude namespaces permissions from Role when namespaced is true with gateway sources
+  - it: should create all required resources when namespaced=true and gatewayNamespace is specified
     set:
       namespaced: true
+      gatewayNamespace: gateway-ns
       sources:
         - gateway-httproute
     asserts:
-      - template: clusterrole.yaml
-        documentIndex: 0
-        equal:
-          path: rules
-          value:
-            - apiGroups: ["gateway.networking.k8s.io"]
-              resources: ["gateways"]
-              verbs: ["get","watch","list"]
-            - apiGroups: ["gateway.networking.k8s.io"]
-              resources: ["httproutes"]
-              verbs: ["get","watch","list"]
-
-  - it: should create additional ClusterRole for namespaces when namespaced is true with gateway sources
-    set:
-      namespaced: true
-      sources:
-        - gateway-httproute
-    asserts:
+      # Should have: main Role + ClusterRole for namespaces + Gateway Role
       - hasDocuments:
-          count: 2
+          count: 3
         template: clusterrole.yaml
+      - hasDocuments:
+          count: 3
+        template: clusterrolebinding.yaml
+      
+      # Main role should exist and contain route permissions but NOT gateway permissions
       - isKind:
           of: Role
-        documentIndex: 0
+        documentSelector:
+          path: metadata.name
+          value: rbac-external-dns
         template: clusterrole.yaml
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["gateway.networking.k8s.io"]
+            resources: ["httproutes"]
+            verbs: ["get","watch","list"]
+        documentSelector:
+          path: metadata.name
+          value: rbac-external-dns
+        template: clusterrole.yaml
+      - notContains:
+          path: rules
+          content:
+            apiGroups: ["gateway.networking.k8s.io"]
+            resources: ["gateways"]
+            verbs: ["get","watch","list"]
+        documentSelector:
+          path: metadata.name
+          value: rbac-external-dns
+        template: clusterrole.yaml
+      
+      # ClusterRole for namespaces should exist
       - isKind:
           of: ClusterRole
-        documentIndex: 1
-        template: clusterrole.yaml
-      - equal:
+        documentSelector:
           path: metadata.name
           value: rbac-external-dns-namespaces
-        documentIndex: 1
+        template: clusterrole.yaml
+      
+      # Gateway role should exist and have gateway permissions only
+      - isKind:
+          of: Role
+        documentSelector:
+          path: metadata.name
+          value: rbac-external-dns-gateway
         template: clusterrole.yaml
       - equal:
+          path: metadata.namespace
+          value: gateway-ns
+        documentSelector:
+          path: metadata.name
+          value: rbac-external-dns-gateway
+        template: clusterrole.yaml
+      - contains:
           path: rules
-          value:
-            - apiGroups: [""]
-              resources: ["namespaces"]
-              verbs: ["get","watch","list"]
-        documentIndex: 1
+          content:
+            apiGroups: ["gateway.networking.k8s.io"]
+            resources: ["gateways"]
+            verbs: ["get","watch","list"]
+        documentSelector:
+          path: metadata.name
+          value: rbac-external-dns-gateway
         template: clusterrole.yaml
 
-  - it: should create additional ClusterRoleBinding for namespaces when namespaced is true with gateway sources
+
+  - it: should create main Role with gateway permissions and ClusterRole for namespaces when namespaced=true and gatewayNamespace is not set
     set:
       namespaced: true
       sources:
         - gateway-httproute
     asserts:
+      # Should have: main Role + ClusterRole for namespaces  
+      - hasDocuments:
+          count: 2
+        template: clusterrole.yaml
       - hasDocuments:
           count: 2
         template: clusterrolebinding.yaml
+      # Main Role should exist and contain gateway permissions
       - isKind:
-          of: RoleBinding
-        documentIndex: 0
-        template: clusterrolebinding.yaml
+          of: Role
+        documentSelector:
+          path: metadata.name
+          value: rbac-external-dns
+        template: clusterrole.yaml
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["gateway.networking.k8s.io"]
+            resources: ["gateways"]
+            verbs: ["get","watch","list"]
+        documentSelector:
+          path: metadata.name
+          value: rbac-external-dns
+        template: clusterrole.yaml
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["gateway.networking.k8s.io"]
+            resources: ["httproutes"]
+            verbs: ["get","watch","list"]
+        documentSelector:
+          path: metadata.name
+          value: rbac-external-dns
+        template: clusterrole.yaml
+      # ClusterRole for namespaces should exist
       - isKind:
-          of: ClusterRoleBinding
-        documentIndex: 1
-        template: clusterrolebinding.yaml
-      - equal:
+          of: ClusterRole
+        documentSelector:
           path: metadata.name
           value: rbac-external-dns-namespaces
-        documentIndex: 1
+        template: clusterrole.yaml
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["namespaces"]
+            verbs: ["get","watch","list"]
+        documentSelector:
+          path: metadata.name
+          value: rbac-external-dns-namespaces
+        template: clusterrole.yaml
+
+  - it: should create ClusterRole with all permissions when namespaced=false and gateway sources exist
+    set:
+      namespaced: false
+      sources:
+        - gateway-httproute
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: clusterrole.yaml
+      - hasDocuments:
+          count: 1
+        template: clusterrolebinding.yaml
+      - isKind:
+          of: ClusterRole
+        template: clusterrole.yaml
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["gateway.networking.k8s.io"]
+            resources: ["gateways"]
+            verbs: ["get","watch","list"]
+        template: clusterrole.yaml
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["namespaces"]
+            verbs: ["get","watch","list"]
+        template: clusterrole.yaml
+
+  - it: should create only ClusterRole when namespaced=false and no gateway sources
+    set:
+      namespaced: false
+      sources:
+        - service
+        - ingress
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: clusterrole.yaml
+      - hasDocuments:
+          count: 1
+        template: clusterrolebinding.yaml
+      - isKind:
+          of: ClusterRole
+        template: clusterrole.yaml
+      - notContains:
+          path: rules
+          content:
+            apiGroups: ["gateway.networking.k8s.io"]
+        template: clusterrole.yaml
+
+  - it: should create only Role when namespaced=true and no gateway sources
+    set:
+      namespaced: true
+      sources:
+        - service
+        - ingress
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: clusterrole.yaml
+      - hasDocuments:
+          count: 1
+        template: clusterrolebinding.yaml
+      - isKind:
+          of: Role
+        template: clusterrole.yaml
+      - isKind:
+          of: RoleBinding
         template: clusterrolebinding.yaml

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -205,6 +205,9 @@ triggerLoopOnEvent: false
 # -- if `true`, _ExternalDNS_ will run in a namespaced scope (`Role`` and `Rolebinding`` will be namespaced too).
 namespaced: false
 
+# -- _Gateway API_ gateway namespace to watch.
+gatewayNamespace: # @schema type:[string, null]; default: null
+
 # -- _Kubernetes_ resources to monitor for DNS entries.
 sources:
   - service


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->
This PR resolves RBAC permission issues when using Gateway API sources with `namespaced: true` configuration in the Helm chart.
It implements proper conditional RBAC creation that supports both same-namespace and cross-namespace gateway access scenarios while maintaining backward compatibility.
## Motivation

Fixes #5300 - Gateway API sources require ClusterRole permissions when using `namespaced: true`, but the current implementation creates insufficient Role permissions, causing external-dns to fail with RBAC errors.

**Problem**: When `namespaced: true` is set with gateway sources, external-dns needs:

- Namespace informer access (ClusterRole for `namespaces` resource)
- Gateway resource access (varies based on `gatewayNamespace` configuration)

**Root Cause**: The namespace informer uses `NamespacesFromSelector` functionality which requires cluster-wide namespace access, but `namespaced: true` only creates Role permissions.

## Solution

Implements **Split RBAC** approach with conditional logic:

### Scenarios Supported:
1. **`namespaced=false` + gateway sources** → ClusterRole with all permissions
2. **`namespaced=true` + gateway sources + no `gatewayNamespace`** → Main Role (with gateway permissions) + ClusterRole for namespaces
3. **`namespaced=true` + gateway sources + `gatewayNamespace` specified** → Main Role + ClusterRole for namespaces + Cross-namespace Gateway Role
4. **`namespaced=false/true` + no gateway sources** → Standard behavior (unchanged)

<!-- What inspired you to submit this pull request? -->

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
