### PR TITLE
fix(pihole): create record for all targets

### DIFF
--- a/provider/pihole/clientV6.go
+++ b/provider/pihole/clientV6.go
@@ -407,6 +407,14 @@ func (p *piholeClientV6) do(req *http.Request) ([]byte, error) {
 		if err := json.Unmarshal(jRes, &apiError); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal error response: %w", err)
 		}
+		// Ignore if the entry already exists when adding a record
+		if strings.Contains(apiError.Error.Message, "Item already present") {
+			return jRes, nil
+		}
+		// Ignore if the entry does not exist when deleting a record
+		if res.StatusCode == http.StatusNotFound && req.Method == http.MethodDelete {
+			return jRes, nil
+		}
 		if log.IsLevelEnabled(log.DebugLevel) {
 			log.Debugf("Error on request %s", req.URL)
 			if req.Body != nil {

--- a/provider/pihole/clientV6_test.go
+++ b/provider/pihole/clientV6_test.go
@@ -192,10 +192,14 @@ func TestListRecordsV6(t *testing.T) {
 							"192.168.178.33 service1.example.com",
 							"192.168.178.34 service2.example.com",
 							"192.168.178.34 service3.example.com",
+							"192.168.178.35 service8.example.com",
+							"192.168.178.36 service8.example.com",
 							"fc00::1:192:168:1:1 service4.example.com",
 							"fc00::1:192:168:1:2 service5.example.com",
 							"fc00::1:192:168:1:3 service6.example.com",
 							"::ffff:192.168.20.3 service7.example.com",
+							"fc00::1:192:168:1:4 service9.example.com",
+							"fc00::1:192:168:1:5 service9.example.com",
 							"192.168.20.3 service7.example.com"
 						]
 					}
@@ -254,6 +258,10 @@ func TestListRecordsV6(t *testing.T) {
 			DNSName: "service7.example.com",
 			Targets: []string{"192.168.20.3"},
 		},
+		{
+			DNSName: "service8.example.com",
+			Targets: []string{"192.168.178.35", "192.168.178.36"},
+		},
 	}
 	// Test retrieve A records unfiltered
 	arecs, err := cl.listRecords(context.Background(), endpoint.RecordTypeA)
@@ -290,6 +298,10 @@ func TestListRecordsV6(t *testing.T) {
 		{
 			DNSName: "service7.example.com",
 			Targets: []string{"::ffff:192.168.20.3"},
+		},
+		{
+			DNSName: "service9.example.com",
+			Targets: []string{"fc00::1:192:168:1:4", "fc00::1:192:168:1:5"},
 		},
 	}
 

--- a/provider/pihole/clientV6_test.go
+++ b/provider/pihole/clientV6_test.go
@@ -717,6 +717,10 @@ func TestCreateRecordV6(t *testing.T) {
 		if r.Method == http.MethodPut && (r.URL.Path == "/api/config/dns/hosts/192.168.1.1 test.example.com" ||
 			r.URL.Path == "/api/config/dns/hosts/fc00::1:192:168:1:1 test.example.com" ||
 			r.URL.Path == "/api/config/dns/cnameRecords/source1.example.com,target1.domain.com" ||
+			r.URL.Path == "/api/config/dns/hosts/192.168.1.2 test.example.com" ||
+			r.URL.Path == "/api/config/dns/hosts/192.168.1.3 test.example.com" ||
+			r.URL.Path == "/api/config/dns/hosts/fc00::1:192:168:1:2 test.example.com" ||
+			r.URL.Path == "/api/config/dns/hosts/fc00::1:192:168:1:3 test.example.com" ||
 			r.URL.Path == "/api/config/dns/cnameRecords/source2.example.com,target2.domain.com,500") {
 
 			// Return A records
@@ -748,10 +752,30 @@ func TestCreateRecordV6(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Test create multiple A records
+	ep = &endpoint.Endpoint{
+		DNSName:    "test.example.com",
+		Targets:    []string{"192.168.1.2", "192.168.1.3"},
+		RecordType: endpoint.RecordTypeA,
+	}
+	if err := cl.createRecord(context.Background(), ep); err != nil {
+		t.Fatal(err)
+	}
+
 	// Test create AAAA record
 	ep = &endpoint.Endpoint{
 		DNSName:    "test.example.com",
 		Targets:    []string{"fc00::1:192:168:1:1"},
+		RecordType: endpoint.RecordTypeAAAA,
+	}
+	if err := cl.createRecord(context.Background(), ep); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test create multiple AAAA records
+	ep = &endpoint.Endpoint{
+		DNSName:    "test.example.com",
+		Targets:    []string{"fc00::1:192:168:1:2", "fc00::1:192:168:1:3"},
 		RecordType: endpoint.RecordTypeAAAA,
 	}
 	if err := cl.createRecord(context.Background(), ep); err != nil {
@@ -776,6 +800,16 @@ func TestCreateRecordV6(t *testing.T) {
 		RecordType: endpoint.RecordTypeCNAME,
 	}
 	if err := cl.createRecord(context.Background(), ep); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test create CNAME record with multiple targets and ensure it fails
+	ep = &endpoint.Endpoint{
+		DNSName:    "source3.example.com",
+		Targets:    []string{"target3.domain.com", "target4.domain.com"},
+		RecordType: endpoint.RecordTypeCNAME,
+	}
+	if err := cl.createRecord(context.Background(), ep); err == nil {
 		t.Fatal(err)
 	}
 

--- a/provider/pihole/clientV6_test.go
+++ b/provider/pihole/clientV6_test.go
@@ -468,8 +468,34 @@ func TestErrorsV6(t *testing.T) {
 	if len(resp) != 2 {
 		t.Fatal("Expected one records returned, got:", len(resp))
 	}
-	if resp[1].RecordTTL != 0 {
-		t.Fatal("Expected no TTL returned, got:", resp[0].RecordTTL)
+
+	expected := []*endpoint.Endpoint{
+		{
+			DNSName:   "source1.example.com",
+			Targets:   []string{"target1.domain.com"},
+			RecordTTL: 100,
+		},
+		{
+			DNSName: "source2.example.com",
+			Targets: []string{"target2.domain.com"},
+		},
+	}
+
+	expectedMap := make(map[string]*endpoint.Endpoint)
+	for _, ep := range expected {
+		expectedMap[ep.DNSName] = ep
+	}
+	for _, rec := range resp {
+		if ep, ok := expectedMap[rec.DNSName]; ok {
+			if cmp.Diff(ep.Targets, rec.Targets) != "" {
+				t.Errorf("Got invalid targets for %s: %v, expected: %v", rec.DNSName, rec.Targets, ep.Targets)
+			}
+			if ep.RecordTTL != rec.RecordTTL {
+				t.Errorf("Got invalid TTL for %s: %d, expected: %d", rec.DNSName, rec.RecordTTL, ep.RecordTTL)
+			}
+		} else {
+			t.Errorf("Unexpected record found: %s", rec.DNSName)
+		}
 	}
 
 }

--- a/provider/pihole/clientV6_test.go
+++ b/provider/pihole/clientV6_test.go
@@ -239,19 +239,19 @@ func TestListRecordsV6(t *testing.T) {
 	// Ensure A records were parsed correctly
 	expected := []*endpoint.Endpoint{
 		{
-			DNSName:    "service1.example.com",
+			DNSName: "service1.example.com",
 			Targets: []string{"192.168.178.33"},
 		},
 		{
-			DNSName:    "service2.example.com",
+			DNSName: "service2.example.com",
 			Targets: []string{"192.168.178.34"},
 		},
 		{
-			DNSName:    "service3.example.com",
+			DNSName: "service3.example.com",
 			Targets: []string{"192.168.178.34"},
 		},
 		{
-			DNSName:    "service7.example.com",
+			DNSName: "service7.example.com",
 			Targets: []string{"192.168.20.3"},
 		},
 	}
@@ -276,19 +276,19 @@ func TestListRecordsV6(t *testing.T) {
 	// Ensure AAAA records were parsed correctly
 	expected = []*endpoint.Endpoint{
 		{
-			DNSName:    "service4.example.com",
+			DNSName: "service4.example.com",
 			Targets: []string{"fc00::1:192:168:1:1"},
 		},
 		{
-			DNSName:    "service5.example.com",
+			DNSName: "service5.example.com",
 			Targets: []string{"fc00::1:192:168:1:2"},
 		},
 		{
-			DNSName:    "service6.example.com",
+			DNSName: "service6.example.com",
 			Targets: []string{"fc00::1:192:168:1:3"},
 		},
 		{
-			DNSName:    "service7.example.com",
+			DNSName: "service7.example.com",
 			Targets: []string{"::ffff:192.168.20.3"},
 		},
 	}
@@ -318,18 +318,18 @@ func TestListRecordsV6(t *testing.T) {
 	// Ensure CNAME records were parsed correctly
 	expected = []*endpoint.Endpoint{
 		{
-			DNSName:    "source1.example.com",
-			Targets:    []string{"target1.domain.com"},
-			RecordTTL:  1000,
+			DNSName:   "source1.example.com",
+			Targets:   []string{"target1.domain.com"},
+			RecordTTL: 1000,
 		},
 		{
-			DNSName:    "source2.example.com",
-			Targets:    []string{"target2.domain.com"},
-			RecordTTL:  50,
+			DNSName:   "source2.example.com",
+			Targets:   []string{"target2.domain.com"},
+			RecordTTL: 50,
 		},
 		{
-			DNSName:    "source3.example.com",
-			Targets:    []string{"target3.domain.com"},
+			DNSName: "source3.example.com",
+			Targets: []string{"target3.domain.com"},
 		},
 	}
 

--- a/provider/pihole/pihole.go
+++ b/provider/pihole/pihole.go
@@ -22,6 +22,7 @@ import (
 	"slices"
 
 	"github.com/google/go-cmp/cmp"
+
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
@@ -134,7 +135,6 @@ func (p *PiholeProvider) ApplyChanges(ctx context.Context, changes *plan.Changes
 					delete(updateNew, key)
 					continue
 				}
-
 			} else {
 				// For API version <= 5, we only check the first target.
 				if newRecord.Targets[0] == ep.Targets[0] {

--- a/provider/pihole/pihole.go
+++ b/provider/pihole/pihole.go
@@ -19,7 +19,9 @@ package pihole
 import (
 	"context"
 	"errors"
+	"slices"
 
+	"github.com/google/go-cmp/cmp"
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
@@ -32,7 +34,8 @@ var ErrNoPiholeServer = errors.New("no pihole server found in the environment or
 // PiholeProvider is an implementation of Provider for Pi-hole Local DNS.
 type PiholeProvider struct {
 	provider.BaseProvider
-	api piholeAPI
+	api        piholeAPI
+	apiVersion string
 }
 
 // PiholeConfig is used for configuring a PiholeProvider.
@@ -70,7 +73,7 @@ func NewPiholeProvider(cfg PiholeConfig) (*PiholeProvider, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &PiholeProvider{api: api}, nil
+	return &PiholeProvider{api: api, apiVersion: cfg.APIVersion}, nil
 }
 
 // Records implements Provider, populating a slice of endpoints from
@@ -105,6 +108,19 @@ func (p *PiholeProvider) ApplyChanges(ctx context.Context, changes *plan.Changes
 	updateNew := make(map[piholeEntryKey]*endpoint.Endpoint)
 	for _, ep := range changes.UpdateNew {
 		key := piholeEntryKey{ep.DNSName, ep.RecordType}
+
+		// If the API version is 6, we need to handle multiple targets for the same DNS name.
+		if p.apiVersion == "6" {
+			if existing, ok := updateNew[key]; ok {
+				existing.Targets = append(existing.Targets, ep.Targets...)
+
+				// Deduplicate targets
+				slices.Sort(existing.Targets)
+				existing.Targets = slices.Compact(existing.Targets)
+
+				ep = existing
+			}
+		}
 		updateNew[key] = ep
 	}
 
@@ -112,14 +128,24 @@ func (p *PiholeProvider) ApplyChanges(ctx context.Context, changes *plan.Changes
 		// Check if this existing entry has an exact match for an updated entry and skip it if so.
 		key := piholeEntryKey{ep.DNSName, ep.RecordType}
 		if newRecord := updateNew[key]; newRecord != nil {
-			// PiHole only has a single target; no need to compare other fields.
-			if newRecord.Targets[0] == ep.Targets[0] {
-				delete(updateNew, key)
-				continue
+			// If the API version is 6, we need to handle multiple targets for the same DNS name.
+			if p.apiVersion == "6" {
+				if cmp.Diff(ep.Targets, newRecord.Targets) == "" {
+					delete(updateNew, key)
+					continue
+				}
+
+			} else {
+				// For API version <= 5, we only check the first target.
+				if newRecord.Targets[0] == ep.Targets[0] {
+					delete(updateNew, key)
+					continue
+				}
 			}
-		}
-		if err := p.api.deleteRecord(ctx, ep); err != nil {
-			return err
+
+			if err := p.api.deleteRecord(ctx, ep); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/provider/pihole/piholeV6_test.go
+++ b/provider/pihole/piholeV6_test.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 )
@@ -60,7 +61,7 @@ func (t *testPiholeClientV6) createRecord(_ context.Context, ep *endpoint.Endpoi
 func (t *testPiholeClientV6) deleteRecord(_ context.Context, ep *endpoint.Endpoint) error {
 	newEPs := make([]*endpoint.Endpoint, 0)
 	for _, existing := range t.endpoints {
-		if existing.DNSName != ep.DNSName && existing.Targets[0] != ep.Targets[0] {
+		if existing.DNSName != ep.DNSName || cmp.Diff(existing.Targets, ep.Targets) != "" || existing.RecordType != ep.RecordType {
 			newEPs = append(newEPs, existing)
 		}
 	}
@@ -83,6 +84,7 @@ func TestErrorHandling(t *testing.T) {
 	requests := requestTrackerV6{}
 	p := &PiholeProvider{
 		api: &testPiholeClientV6{endpoints: make([]*endpoint.Endpoint, 0), requests: &requests},
+		apiVersion: "6",
 	}
 
 	p.api.(*testPiholeClientV6).trigger = "AERROR"
@@ -122,6 +124,7 @@ func TestProviderV6(t *testing.T) {
 	requests := requestTrackerV6{}
 	p := &PiholeProvider{
 		api: &testPiholeClientV6{endpoints: make([]*endpoint.Endpoint, 0), requests: &requests},
+		apiVersion: "6",
 	}
 
 	records, err := p.Records(context.Background())
@@ -343,6 +346,11 @@ func TestProviderV6(t *testing.T) {
 				RecordType: endpoint.RecordTypeA,
 			},
 			{
+				DNSName:    "test2.example.com",
+				Targets:    []string{"10.0.0.2"},
+				RecordType: endpoint.RecordTypeA,
+			},
+			{
 				DNSName:    "test1.example.com",
 				Targets:    []string{"fc00::1:192:168:1:1"},
 				RecordType: endpoint.RecordTypeAAAA,
@@ -383,7 +391,7 @@ func TestProviderV6(t *testing.T) {
 
 	expectedCreateA := endpoint.Endpoint{
 		DNSName:    "test2.example.com",
-		Targets:    []string{"10.0.0.1"},
+		Targets:    []string{"10.0.0.1", "10.0.0.2"},
 		RecordType: endpoint.RecordTypeA,
 	}
 	expectedDeleteA := endpoint.Endpoint{

--- a/provider/pihole/piholeV6_test.go
+++ b/provider/pihole/piholeV6_test.go
@@ -83,7 +83,7 @@ func (r *requestTrackerV6) clear() {
 func TestErrorHandling(t *testing.T) {
 	requests := requestTrackerV6{}
 	p := &PiholeProvider{
-		api: &testPiholeClientV6{endpoints: make([]*endpoint.Endpoint, 0), requests: &requests},
+		api:        &testPiholeClientV6{endpoints: make([]*endpoint.Endpoint, 0), requests: &requests},
 		apiVersion: "6",
 	}
 
@@ -123,7 +123,7 @@ func TestNewPiholeProviderV6(t *testing.T) {
 func TestProviderV6(t *testing.T) {
 	requests := requestTrackerV6{}
 	p := &PiholeProvider{
-		api: &testPiholeClientV6{endpoints: make([]*endpoint.Endpoint, 0), requests: &requests},
+		api:        &testPiholeClientV6{endpoints: make([]*endpoint.Endpoint, 0), requests: &requests},
 		apiVersion: "6",
 	}
 


### PR DESCRIPTION
## What does it do ?

- create multiple targets for A and AAAA records for the pihole provider

## Motivation

#5423  

Since a month already passed from the original PR without any updates, I created this PR with some improvements.
It's also fine by me if the original PR gets merged after appropriate changes, I don't want to take any credits or anything, just want to get this fix in place :).

## Open questions

Should we do anything if any of the individual requests fail, e.g.
1. I want to create a DNS entry with multiple targets: example.com, [192.168.1.2, 192.168.1.3]
2. The first entry gets created: `example.com 192.168.1.2`
3. The second entry fails for some reason

The same would probably happen with updates.

As it currently stands (if I read it correctly), updates and failures wouldn't get noticed ever:
https://github.com/kubernetes-sigs/external-dns/blob/2d898cd88d6cef94edf65c715f44594d0c6f2a00/provider/pihole/pihole.go#L111-L120

Should we also update the old pihole client to work with multiple targets or create different logic in the Pihole Provider depending on the pihole version?

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly