### PR TITLE
Allow the webhook sidecar to be optional in case the webhook is outside the cluster

### DIFF
--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -142,6 +142,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | provider.webhook.securityContext | object | See _values.yaml_ | [Pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) for the `webhook` container. |
 | provider.webhook.service.port | int | `8080` | Webhook exposed HTTP port for the service. |
 | provider.webhook.serviceMonitor | object | See _values.yaml_ | Optional [Service Monitor](https://prometheus-operator.dev/docs/operator/design/#servicemonitor) configuration for the `webhook` container. |
+| provider.webhook.sidecar | bool | `true` | If false, then do not add a webhook sidecar to the `external-dns` deployment. |
 | rbac.additionalPermissions | list | `[]` | Additional rules to add to the `ClusterRole`. |
 | rbac.create | bool | `true` | If `true`, create a `ClusterRole` & `ClusterRoleBinding` with access to the Kubernetes API. |
 | readinessProbe | object | See _values.yaml_ | [Readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `external-dns` container. |

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -170,6 +170,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- if eq $providerName "webhook" }}
+        {{- if .Values.provider.webhook.sidecar }}
         {{- with .Values.provider.webhook }}
         - name: webhook
           image: {{ include "external-dns.webhookImage" . }}
@@ -204,6 +205,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- end }}
         {{- end }}
         {{- end }}
       {{- if or .Values.secretConfiguration.enabled .Values.extraVolumes }}

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -506,6 +506,10 @@
                   "type": "object"
                 }
               }
+            },
+            "sidecar": {
+              "description": "If false, then do not add a webhook sidecar to the external-dns deployment.",
+              "type": "boolean"
             }
           }
         }

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -241,6 +241,8 @@ provider:  # @schema type: [object, string];
   # -- _ExternalDNS_ provider name; for the available providers and how to configure them see [README](https://github.com/kubernetes-sigs/external-dns/blob/master/charts/external-dns/README.md#providers).
   name: aws
   webhook:
+    # -- (bool) If false, then do not add a webhook sidecar to the `external-dns` deployment.
+    sidecar: true
     image:
       # -- (string) Image repository for the `webhook` container.
       repository:  # @schema type:[string, null]; default: null


### PR DESCRIPTION
## What does it do ?

It's possible to run the webhook outside the cluster. See https://github.com/kubernetes-sigs/external-dns/issues/5585.

## Motivation

In my particular environment, I run the webhook outside the cluster and so the webhook sidecar is un-needed.

## More

- [ ] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [X] Yes, I updated end user documentation accordingly
