### PR TITLE
fix: reduce warning by using idna profile

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -339,10 +339,16 @@ func filterRecordsForPlan(records []*endpoint.Endpoint, domainFilter endpoint.Ma
 	return filtered
 }
 
+var idnaProfile = idna.New(
+	idna.MapForLookup(),
+	idna.Transitional(true),
+	idna.StrictDomainName(false),
+)
+
 // normalizeDNSName converts a DNS name to a canonical form, so that we can use string equality
 // it: removes space, get ASCII version of dnsName complient with Section 5 of RFC 5891, ensures there is a trailing dot
 func normalizeDNSName(dnsName string) string {
-	s, err := idna.Lookup.ToASCII(strings.TrimSpace(dnsName))
+	s, err := idnaProfile.ToASCII(strings.TrimSpace(dnsName))
 	if err != nil {
 		log.Warnf(`Got error while parsing DNSName %s: %v`, dnsName, err)
 	}

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -1028,7 +1028,7 @@ func validateEntries(t *testing.T, entries, expected []*endpoint.Endpoint) {
 	}
 }
 
-func TestNormalizeDNSName(t *testing.T) {
+func TestNormalizeDNSName(tt *testing.T) {
 	records := []struct {
 		dnsName string
 		expect  string
@@ -1060,6 +1060,18 @@ func TestNormalizeDNSName(t *testing.T) {
 		{
 			"foo.com.",
 			"foo.com.",
+		},
+		{
+			"_foo.com.",
+			"_foo.com.",
+		},
+		{
+			"\u005Ffoo.com.",
+			"_foo.com.",
+		},
+		{
+			".foo.com.",
+			".foo.com.",
 		},
 		{
 			"foo123.COM",
@@ -1099,8 +1111,10 @@ func TestNormalizeDNSName(t *testing.T) {
 		},
 	}
 	for _, r := range records {
-		gotName := normalizeDNSName(r.dnsName)
-		assert.Equal(t, r.expect, gotName)
+		tt.Run(r.dnsName, func(t *testing.T) {
+			gotName := normalizeDNSName(r.dnsName)
+			assert.Equal(t, r.expect, gotName)
+		})
 	}
 }
 


### PR DESCRIPTION
fixes #5581, tested by running test with -v and added println("warn") to the log warning path
