### PR TITLE
fix: zonefinder used wrong quotation style

### DIFF
--- a/provider/zonefinder.go
+++ b/provider/zonefinder.go
@@ -43,19 +43,19 @@ func (z ZoneIDName) Add(zoneID, zoneName string) {
 // ensures compatibility with such use cases.
 func (z ZoneIDName) FindZone(hostname string) (suitableZoneID, suitableZoneName string) {
 	var name string
-	domain_labels := strings.Split(hostname, ".")
-	for i, label := range domain_labels {
+	domainLabels := strings.Split(hostname, ".")
+	for i, label := range domainLabels {
 		if strings.Contains(label, "_") {
 			continue
 		}
 		convertedLabel, err := idna.Lookup.ToUnicode(label)
 		if err != nil {
-			log.Warnf("Failed to convert label '%s' of hostname '%s' to its Unicode form: %v", label, hostname, err)
+			log.Warnf("Failed to convert label %q of hostname %q to its Unicode form: %v", label, hostname, err)
 			convertedLabel = label
 		}
-		domain_labels[i] = convertedLabel
+		domainLabels[i] = convertedLabel
 	}
-	name = strings.Join(domain_labels, ".")
+	name = strings.Join(domainLabels, ".")
 
 	for zoneID, zoneName := range z {
 		if name == zoneName || strings.HasSuffix(name, "."+zoneName) {

--- a/provider/zonefinder_test.go
+++ b/provider/zonefinder_test.go
@@ -80,5 +80,5 @@ func TestZoneIDName(t *testing.T) {
 	hook := testutils.LogsUnderTestWithLogLevel(log.WarnLevel, t)
 	_, _ = z.FindZone("???")
 
-	testutils.TestHelperLogContains("Failed to convert label '???' of hostname '???' to its Unicode form: idna: disallowed rune U+003F", hook, t)
+	testutils.TestHelperLogContains("Failed to convert label \"???\" of hostname \"???\" to its Unicode form: idna: disallowed rune U+003F", hook, t)
 }


### PR DESCRIPTION
fix: zonefinder used a quoted version of %s, but we should use %q instead

https://github.com/kubernetes-sigs/external-dns/pull/5281 introduced a bad format string