### PR TITLE
chore(codebase): enable linter nonamedreturns

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
     - sloglint # Ensure consistent code style when using log/slog
     - asciicheck  # Checks that all code identifiers does not have non-ASCII symbols in the name
     - nilnil # Checks that there is no simultaneous return of nil error and an nil value. ref: https://golangci-lint.run/usage/linters/#nilnil
+    - nonamedreturns # Checks that functions with named return values do not return named values. https://golangci-lint.run/usage/linters/#nonamedreturns
     - cyclop # Checks function and package cyclomatic complexity. https://golangci-lint.run/usage/linters/#cyclop
 
     # tests

--- a/endpoint/crypto.go
+++ b/endpoint/crypto.go
@@ -68,7 +68,7 @@ func EncryptText(text string, aesKey []byte, nonceEncoded []byte) (string, error
 
 // DecryptText decrypt gziped data using a supplied AES encryption key ang ungzip it
 // in case of decryption failed, will return original input and decryption error
-func DecryptText(text string, aesKey []byte) (decryptResult string, encryptNonce string, err error) {
+func DecryptText(text string, aesKey []byte) (string, string, error) {
 	block, err := aes.NewCipher(aesKey)
 	if err != nil {
 		return "", "", err
@@ -100,7 +100,7 @@ func DecryptText(text string, aesKey []byte) (decryptResult string, encryptNonce
 }
 
 // decompressData gzip compressed data
-func decompressData(data []byte) (resData []byte, err error) {
+func decompressData(data []byte) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
 		return nil, err
@@ -115,7 +115,7 @@ func decompressData(data []byte) (resData []byte, err error) {
 }
 
 // compressData by gzip, for minify data stored in registry
-func compressData(data []byte) (compressedData []byte, err error) {
+func compressData(data []byte) ([]byte, error) {
 	var b bytes.Buffer
 	gz, err := gzip.NewWriterLevel(&b, gzip.BestCompression)
 	if err != nil {

--- a/endpoint/crypto_test.go
+++ b/endpoint/crypto_test.go
@@ -87,6 +87,6 @@ func TestGenerateNonceError(t *testing.T) {
 
 type faultyReader struct{}
 
-func (f *faultyReader) Read(p []byte) (n int, err error) {
+func (f *faultyReader) Read(p []byte) (int, error) {
 	return 0, io.ErrUnexpectedEOF
 }

--- a/pkg/rfc2317/arpa.go
+++ b/pkg/rfc2317/arpa.go
@@ -98,7 +98,7 @@ func CidrToInAddr(cidr string) (string, error) {
 // reverseaddr returns the in-addr.arpa. or ip6.arpa. hostname of the IP
 // address addr suitable for rDNS (PTR) record lookup or an error if it fails
 // to parse the IP address.
-func reverseaddr(addr string) (arpa string, err error) {
+func reverseaddr(addr string) (string, error) {
 	ip := net.ParseIP(addr)
 	if ip == nil {
 		return "", &net.DNSError{Err: "unrecognized address", Name: addr}

--- a/provider/akamai/akamai.go
+++ b/provider/akamai/akamai.go
@@ -40,7 +40,7 @@ const (
 	maxInt     = int(maxUint >> 1)
 )
 
-// edgeDNSClient is a proxy interface of the Akamai edgegrid configdns-v2 package that can be stubbed for testing.
+// AkamaiDNSService is a proxy interface of the Akamai edgegrid configdns-v2 package that can be stubbed for testing.
 type AkamaiDNSService interface {
 	ListZones(queryArgs dns.ZoneListQueryArgs) (*dns.ZoneListResponse, error)
 	GetRecordsets(zone string, queryArgs dns.RecordsetQueryArgs) (*dns.RecordSetResponse, error)
@@ -208,7 +208,8 @@ func (p AkamaiProvider) fetchZones() (akamaiZones, error) {
 }
 
 // Records returns the list of records in a given zone.
-func (p AkamaiProvider) Records(context.Context) (endpoints []*endpoint.Endpoint, err error) {
+func (p AkamaiProvider) Records(context.Context) ([]*endpoint.Endpoint, error) {
+	var endpoints []*endpoint.Endpoint
 	zones, err := p.fetchZones() // returns a filtered set of zones
 	if err != nil {
 		log.Warnf("Failed to identify target zones! Error: %s", err.Error())

--- a/provider/alibabacloud/alibaba_cloud_test.go
+++ b/provider/alibabacloud/alibaba_cloud_test.go
@@ -55,7 +55,7 @@ func NewMockAlibabaCloudDNSAPI() *MockAlibabaCloudDNSAPI {
 	return &api
 }
 
-func (m *MockAlibabaCloudDNSAPI) AddDomainRecord(request *alidns.AddDomainRecordRequest) (response *alidns.AddDomainRecordResponse, err error) {
+func (m *MockAlibabaCloudDNSAPI) AddDomainRecord(request *alidns.AddDomainRecordRequest) (*alidns.AddDomainRecordResponse, error) {
 	ttl, _ := request.TTL.GetValue()
 	m.records = append(m.records, alidns.Record{
 		RecordId:   "3",
@@ -65,11 +65,10 @@ func (m *MockAlibabaCloudDNSAPI) AddDomainRecord(request *alidns.AddDomainRecord
 		RR:         request.RR,
 		Value:      request.Value,
 	})
-	response = alidns.CreateAddDomainRecordResponse()
-	return response, nil
+	return alidns.CreateAddDomainRecordResponse(), nil
 }
 
-func (m *MockAlibabaCloudDNSAPI) DeleteDomainRecord(request *alidns.DeleteDomainRecordRequest) (response *alidns.DeleteDomainRecordResponse, err error) {
+func (m *MockAlibabaCloudDNSAPI) DeleteDomainRecord(request *alidns.DeleteDomainRecordRequest) (*alidns.DeleteDomainRecordResponse, error) {
 	var result []alidns.Record
 	for _, record := range m.records {
 		if record.RecordId != request.RecordId {
@@ -77,24 +76,24 @@ func (m *MockAlibabaCloudDNSAPI) DeleteDomainRecord(request *alidns.DeleteDomain
 		}
 	}
 	m.records = result
-	response = alidns.CreateDeleteDomainRecordResponse()
+	response := alidns.CreateDeleteDomainRecordResponse()
 	response.RecordId = request.RecordId
 	return response, nil
 }
 
-func (m *MockAlibabaCloudDNSAPI) UpdateDomainRecord(request *alidns.UpdateDomainRecordRequest) (response *alidns.UpdateDomainRecordResponse, err error) {
+func (m *MockAlibabaCloudDNSAPI) UpdateDomainRecord(request *alidns.UpdateDomainRecordRequest) (*alidns.UpdateDomainRecordResponse, error) {
 	ttl, _ := request.TTL.GetValue64()
 	for i := range m.records {
 		if m.records[i].RecordId == request.RecordId {
 			m.records[i].TTL = ttl
 		}
 	}
-	response = alidns.CreateUpdateDomainRecordResponse()
+	response := alidns.CreateUpdateDomainRecordResponse()
 	response.RecordId = request.RecordId
 	return response, nil
 }
 
-func (m *MockAlibabaCloudDNSAPI) DescribeDomains(request *alidns.DescribeDomainsRequest) (response *alidns.DescribeDomainsResponse, err error) {
+func (m *MockAlibabaCloudDNSAPI) DescribeDomains(request *alidns.DescribeDomainsRequest) (*alidns.DescribeDomainsResponse, error) {
 	var result alidns.DomainsInDescribeDomains
 	for _, record := range m.records {
 		domain := alidns.Domain{}
@@ -103,19 +102,19 @@ func (m *MockAlibabaCloudDNSAPI) DescribeDomains(request *alidns.DescribeDomains
 			DomainName: domain.DomainName,
 		})
 	}
-	response = alidns.CreateDescribeDomainsResponse()
+	response := alidns.CreateDescribeDomainsResponse()
 	response.Domains = result
 	return response, nil
 }
 
-func (m *MockAlibabaCloudDNSAPI) DescribeDomainRecords(request *alidns.DescribeDomainRecordsRequest) (response *alidns.DescribeDomainRecordsResponse, err error) {
+func (m *MockAlibabaCloudDNSAPI) DescribeDomainRecords(request *alidns.DescribeDomainRecordsRequest) (*alidns.DescribeDomainRecordsResponse, error) {
 	var result []alidns.Record
 	for _, record := range m.records {
 		if record.DomainName == request.DomainName {
 			result = append(result, record)
 		}
 	}
-	response = alidns.CreateDescribeDomainRecordsResponse()
+	response := alidns.CreateDescribeDomainRecordsResponse()
 	response.DomainRecords.Record = result
 	return response, nil
 }
@@ -158,7 +157,7 @@ func NewMockAlibabaCloudPrivateZoneAPI() *MockAlibabaCloudPrivateZoneAPI {
 	return &api
 }
 
-func (m *MockAlibabaCloudPrivateZoneAPI) AddZoneRecord(request *pvtz.AddZoneRecordRequest) (response *pvtz.AddZoneRecordResponse, err error) {
+func (m *MockAlibabaCloudPrivateZoneAPI) AddZoneRecord(request *pvtz.AddZoneRecordRequest) (*pvtz.AddZoneRecordResponse, error) {
 	ttl, _ := request.Ttl.GetValue()
 	m.records = append(m.records, pvtz.Record{
 		RecordId: 3,
@@ -167,11 +166,10 @@ func (m *MockAlibabaCloudPrivateZoneAPI) AddZoneRecord(request *pvtz.AddZoneReco
 		Rr:       request.Rr,
 		Value:    request.Value,
 	})
-	response = pvtz.CreateAddZoneRecordResponse()
-	return response, nil
+	return pvtz.CreateAddZoneRecordResponse(), nil
 }
 
-func (m *MockAlibabaCloudPrivateZoneAPI) DeleteZoneRecord(request *pvtz.DeleteZoneRecordRequest) (response *pvtz.DeleteZoneRecordResponse, err error) {
+func (m *MockAlibabaCloudPrivateZoneAPI) DeleteZoneRecord(request *pvtz.DeleteZoneRecordRequest) (*pvtz.DeleteZoneRecordResponse, error) {
 	recordID, _ := request.RecordId.GetValue64()
 
 	var result []pvtz.Record
@@ -181,11 +179,10 @@ func (m *MockAlibabaCloudPrivateZoneAPI) DeleteZoneRecord(request *pvtz.DeleteZo
 		}
 	}
 	m.records = result
-	response = pvtz.CreateDeleteZoneRecordResponse()
-	return response, nil
+	return pvtz.CreateDeleteZoneRecordResponse(), nil
 }
 
-func (m *MockAlibabaCloudPrivateZoneAPI) UpdateZoneRecord(request *pvtz.UpdateZoneRecordRequest) (response *pvtz.UpdateZoneRecordResponse, err error) {
+func (m *MockAlibabaCloudPrivateZoneAPI) UpdateZoneRecord(request *pvtz.UpdateZoneRecordRequest) (*pvtz.UpdateZoneRecordResponse, error) {
 	recordID, _ := request.RecordId.GetValue64()
 	ttl, _ := request.Ttl.GetValue()
 	for i := range m.records {
@@ -193,24 +190,23 @@ func (m *MockAlibabaCloudPrivateZoneAPI) UpdateZoneRecord(request *pvtz.UpdateZo
 			m.records[i].Ttl = ttl
 		}
 	}
-	response = pvtz.CreateUpdateZoneRecordResponse()
-	return response, nil
+	return pvtz.CreateUpdateZoneRecordResponse(), nil
 }
 
-func (m *MockAlibabaCloudPrivateZoneAPI) DescribeZoneRecords(request *pvtz.DescribeZoneRecordsRequest) (response *pvtz.DescribeZoneRecordsResponse, err error) {
-	response = pvtz.CreateDescribeZoneRecordsResponse()
+func (m *MockAlibabaCloudPrivateZoneAPI) DescribeZoneRecords(request *pvtz.DescribeZoneRecordsRequest) (*pvtz.DescribeZoneRecordsResponse, error) {
+	response := pvtz.CreateDescribeZoneRecordsResponse()
 	response.Records.Record = append(response.Records.Record, m.records...)
 	return response, nil
 }
 
-func (m *MockAlibabaCloudPrivateZoneAPI) DescribeZones(request *pvtz.DescribeZonesRequest) (response *pvtz.DescribeZonesResponse, err error) {
-	response = pvtz.CreateDescribeZonesResponse()
+func (m *MockAlibabaCloudPrivateZoneAPI) DescribeZones(_ *pvtz.DescribeZonesRequest) (*pvtz.DescribeZonesResponse, error) {
+	response := pvtz.CreateDescribeZonesResponse()
 	response.Zones.Zone = append(response.Zones.Zone, m.zone)
 	return response, nil
 }
 
-func (m *MockAlibabaCloudPrivateZoneAPI) DescribeZoneInfo(request *pvtz.DescribeZoneInfoRequest) (response *pvtz.DescribeZoneInfoResponse, err error) {
-	response = pvtz.CreateDescribeZoneInfoResponse()
+func (m *MockAlibabaCloudPrivateZoneAPI) DescribeZoneInfo(_ *pvtz.DescribeZoneInfoRequest) (*pvtz.DescribeZoneInfoResponse, error) {
+	response := pvtz.CreateDescribeZoneInfoResponse()
 	response.ZoneId = m.zone.ZoneId
 	response.ZoneName = m.zone.ZoneName
 	response.BindVpcs = pvtz.BindVpcsInDescribeZoneInfo{Vpc: make([]pvtz.VpcInDescribeZoneInfo, len(m.zone.Vpcs.Vpc))}
@@ -336,7 +332,7 @@ func TestAlibabaCloudProvider_ApplyChanges_HaveNoDefinedZoneDomain(t *testing.T)
 	changes := plan.Changes{
 		Create: []*endpoint.Endpoint{
 			{
-				DNSName:    "www.example.com", //no found this zone by API: DescribeDomains
+				DNSName:    "www.example.com", // no found this zone by API: DescribeDomains
 				RecordType: "A",
 				RecordTTL:  300,
 				Targets:    endpoint.NewTargets("9.9.9.9"),

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -454,10 +454,10 @@ func containsOctalSequence(domain string) bool {
 }
 
 // Records returns the list of records in a given hosted zone.
-func (p *AWSProvider) Records(ctx context.Context) (endpoints []*endpoint.Endpoint, _ error) {
+func (p *AWSProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
 	zones, err := p.zones(ctx)
 	if err != nil {
-		return nil, provider.NewSoftErrorf("records retrieval failed: %w", err)
+		return nil, provider.NewSoftErrorf("records retrieval failed: %v", err)
 	}
 
 	return p.records(ctx, zones)
@@ -940,10 +940,12 @@ func (p *AWSProvider) newChange(action route53types.ChangeAction, ep *endpoint.E
 }
 
 // searches for `changes` that are contained in `queue` and returns the `changes` separated by whether they were found in the queue (`foundChanges`) or not (`notFoundChanges`)
-func findChangesInQueue(changes Route53Changes, queue Route53Changes) (foundChanges, notFoundChanges Route53Changes) {
+func findChangesInQueue(changes Route53Changes, queue Route53Changes) (Route53Changes, Route53Changes) {
 	if queue == nil {
 		return Route53Changes{}, changes
 	}
+
+	var foundChanges, notFoundChanges Route53Changes
 
 	for _, c := range changes {
 		found := false
@@ -959,7 +961,7 @@ func findChangesInQueue(changes Route53Changes, queue Route53Changes) (foundChan
 		}
 	}
 
-	return
+	return foundChanges, notFoundChanges
 }
 
 // group the given changes by name and ownership relation to ensure these are always submitted in the same transaction to Route53;

--- a/provider/azure/azure.go
+++ b/provider/azure/azure.go
@@ -106,11 +106,13 @@ func NewAzureProvider(configFile string, domainFilter *endpoint.DomainFilter, zo
 // Records gets the current records.
 //
 // Returns the current records or an error if the operation failed.
-func (p *AzureProvider) Records(ctx context.Context) (endpoints []*endpoint.Endpoint, _ error) {
+func (p *AzureProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
 	zones, err := p.zones(ctx)
 	if err != nil {
 		return nil, err
 	}
+
+	endpoints := make([]*endpoint.Endpoint, 0)
 
 	for _, zone := range zones {
 		pager := p.recordSetsClient.NewListAllByDNSZonePager(p.resourceGroup, *zone.Name, &dns.RecordSetsClientListAllByDNSZoneOptions{Top: nil})

--- a/provider/civo/civo_test.go
+++ b/provider/civo/civo_test.go
@@ -1169,7 +1169,7 @@ func TestCivoChangesEmpty(t *testing.T) {
 // This function is an adapted copy of the testify package's ElementsMatch function with the
 // call to ObjectsAreEqual replaced with cmp.Equal which better handles struct's with pointers to
 // other structs. It also ignores ordering when comparing unlike cmp.Equal.
-func elementsMatch(t *testing.T, listA, listB interface{}, msgAndArgs ...interface{}) (ok bool) {
+func elementsMatch(t *testing.T, listA, listB interface{}, msgAndArgs ...interface{}) bool {
 	if listA == nil && listB == nil {
 		return true
 	} else if listA == nil {

--- a/provider/digitalocean/digital_ocean_test.go
+++ b/provider/digitalocean/digital_ocean_test.go
@@ -194,7 +194,7 @@ func isEmpty(xs interface{}) bool {
 // This function is an adapted copy of the testify package's ElementsMatch function with the
 // call to ObjectsAreEqual replaced with cmp.Equal which better handles struct's with pointers to
 // other structs. It also ignores ordering when comparing unlike cmp.Equal.
-func elementsMatch(t *testing.T, listA, listB interface{}, msgAndArgs ...interface{}) (ok bool) {
+func elementsMatch(t *testing.T, listA, listB interface{}, msgAndArgs ...interface{}) bool {
 	if listA == nil && listB == nil {
 		return true
 	} else if listA == nil {

--- a/provider/dnsimple/dnsimple.go
+++ b/provider/dnsimple/dnsimple.go
@@ -130,7 +130,7 @@ func NewDnsimpleProvider(domainFilter *endpoint.DomainFilter, zoneIDFilter provi
 }
 
 // GetAccountID returns the account ID given DNSimple credentials.
-func (p *dnsimpleProvider) GetAccountID(ctx context.Context) (accountID string, err error) {
+func (p *dnsimpleProvider) GetAccountID(ctx context.Context) (string, error) {
 	// get DNSimple client accountID
 	whoamiResponse, err := p.identity.Whoami(ctx)
 	if err != nil {
@@ -191,11 +191,12 @@ func (p *dnsimpleProvider) Zones(ctx context.Context) (map[string]dnsimple.Zone,
 }
 
 // Records returns a list of endpoints in a given zone
-func (p *dnsimpleProvider) Records(ctx context.Context) (endpoints []*endpoint.Endpoint, _ error) {
+func (p *dnsimpleProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
 	zones, err := p.Zones(ctx)
 	if err != nil {
 		return nil, err
 	}
+	endpoints := make([]*endpoint.Endpoint, 0)
 	for _, zone := range zones {
 		page := 1
 		listOptions := &dnsimple.ZoneRecordListOptions{}
@@ -318,7 +319,7 @@ func (p *dnsimpleProvider) submitChanges(ctx context.Context, changes []*dnsimpl
 }
 
 // GetRecordID returns the record ID for a given record name and zone.
-func (p *dnsimpleProvider) GetRecordID(ctx context.Context, zone string, recordName string) (recordID int64, err error) {
+func (p *dnsimpleProvider) GetRecordID(ctx context.Context, zone string, recordName string) (int64, error) {
 	page := 1
 	listOptions := &dnsimple.ZoneRecordListOptions{Name: &recordName}
 	for {

--- a/provider/exoscale/exoscale.go
+++ b/provider/exoscale/exoscale.go
@@ -292,9 +292,8 @@ func (f *zoneFilter) Zones(zones map[string]string) map[string]string {
 
 // EndpointZoneID determines zoneID for endpoint from map[zoneID]zoneName by taking longest suffix zoneName match in endpoint DNSName
 // returns empty string if no matches are found
-func (f *zoneFilter) EndpointZoneID(endpoint *endpoint.Endpoint, zones map[string]string) (zoneID string, name string) {
-	var matchZoneID string
-	var matchZoneName string
+func (f *zoneFilter) EndpointZoneID(endpoint *endpoint.Endpoint, zones map[string]string) (string, string) {
+	var matchZoneID, matchZoneName, name string
 	for zoneID, zoneName := range zones {
 		if strings.HasSuffix(endpoint.DNSName, "."+zoneName) && len(zoneName) > len(matchZoneName) {
 			matchZoneName = zoneName

--- a/provider/gandi/client.go
+++ b/provider/gandi/client.go
@@ -19,14 +19,14 @@ import (
 )
 
 type DomainClientAdapter interface {
-	ListDomains() (domains []domain.ListResponse, err error)
+	ListDomains() ([]domain.ListResponse, error)
 }
 
 type domainClient struct {
 	Client *domain.Domain
 }
 
-func (p *domainClient) ListDomains() (domains []domain.ListResponse, err error) {
+func (p *domainClient) ListDomains() ([]domain.ListResponse, error) {
 	return p.Client.ListDomains()
 }
 
@@ -54,9 +54,9 @@ type standardError struct {
 
 type LiveDNSClientAdapter interface {
 	GetDomainRecords(fqdn string) (records []livedns.DomainRecord, err error)
-	CreateDomainRecord(fqdn, name, recordtype string, ttl int, values []string) (response standardResponse, err error)
+	CreateDomainRecord(fqdn, name, recordtype string, ttl int, values []string) (standardResponse, error)
 	DeleteDomainRecord(fqdn, name, recordtype string) (err error)
-	UpdateDomainRecordByNameAndType(fqdn, name, recordtype string, ttl int, values []string) (response standardResponse, err error)
+	UpdateDomainRecordByNameAndType(fqdn, name, recordtype string, ttl int, values []string) (standardResponse, error)
 }
 
 type LiveDNSClient struct {
@@ -67,11 +67,11 @@ func NewLiveDNSClient(client *livedns.LiveDNS) LiveDNSClientAdapter {
 	return &LiveDNSClient{client}
 }
 
-func (p *LiveDNSClient) GetDomainRecords(fqdn string) (records []livedns.DomainRecord, err error) {
+func (p *LiveDNSClient) GetDomainRecords(fqdn string) ([]livedns.DomainRecord, error) {
 	return p.Client.GetDomainRecords(fqdn)
 }
 
-func (p *LiveDNSClient) CreateDomainRecord(fqdn, name, recordtype string, ttl int, values []string) (response standardResponse, err error) {
+func (p *LiveDNSClient) CreateDomainRecord(fqdn, name, recordtype string, ttl int, values []string) (standardResponse, error) {
 	res, err := p.Client.CreateDomainRecord(fqdn, name, recordtype, ttl, values)
 	if err != nil {
 		return standardResponse{}, err
@@ -93,11 +93,11 @@ func (p *LiveDNSClient) CreateDomainRecord(fqdn, name, recordtype string, ttl in
 	}, err
 }
 
-func (p *LiveDNSClient) DeleteDomainRecord(fqdn, name, recordtype string) (err error) {
+func (p *LiveDNSClient) DeleteDomainRecord(fqdn, name, recordtype string) error {
 	return p.Client.DeleteDomainRecord(fqdn, name, recordtype)
 }
 
-func (p *LiveDNSClient) UpdateDomainRecordByNameAndType(fqdn, name, recordtype string, ttl int, values []string) (response standardResponse, err error) {
+func (p *LiveDNSClient) UpdateDomainRecordByNameAndType(fqdn, name, recordtype string, ttl int, values []string) (standardResponse, error) {
 	res, err := p.Client.UpdateDomainRecordByNameAndType(fqdn, name, recordtype, ttl, values)
 	if err != nil {
 		return standardResponse{}, err

--- a/provider/gandi/gandi.go
+++ b/provider/gandi/gandi.go
@@ -83,12 +83,12 @@ func NewGandiProvider(ctx context.Context, domainFilter *endpoint.DomainFilter, 
 	return gandiProvider, nil
 }
 
-func (p *GandiProvider) Zones() (zones []string, err error) {
+func (p *GandiProvider) Zones() ([]string, error) {
 	availableDomains, err := p.DomainClient.ListDomains()
 	if err != nil {
 		return nil, err
 	}
-	zones = []string{}
+	zones := []string{}
 	for _, domain := range availableDomains {
 		if !p.domainFilter.Match(domain.FQDN) {
 			log.Debugf("Excluding domain %s by domain-filter", domain.FQDN)
@@ -156,7 +156,7 @@ func (p *GandiProvider) ApplyChanges(ctx context.Context, changes *plan.Changes)
 	return p.submitChanges(ctx, combinedChanges)
 }
 
-func (p *GandiProvider) submitChanges(ctx context.Context, changes []*GandiChanges) error {
+func (p *GandiProvider) submitChanges(_ context.Context, changes []*GandiChanges) error {
 	if len(changes) == 0 {
 		log.Infof("All records are already up to date")
 		return nil

--- a/provider/gandi/gandi_test.go
+++ b/provider/gandi/gandi_test.go
@@ -49,7 +49,7 @@ const (
 
 // Mock all methods
 
-func (m *mockGandiClient) GetDomainRecords(fqdn string) (records []livedns.DomainRecord, err error) {
+func (m *mockGandiClient) GetDomainRecords(fqdn string) ([]livedns.DomainRecord, error) {
 	m.Actions = append(m.Actions, MockAction{
 		Name: "GetDomainRecords",
 		FQDN: fqdn,
@@ -62,7 +62,7 @@ func (m *mockGandiClient) GetDomainRecords(fqdn string) (records []livedns.Domai
 	return m.RecordsToReturn, nil
 }
 
-func (m *mockGandiClient) CreateDomainRecord(fqdn, name, recordtype string, ttl int, values []string) (response standardResponse, err error) {
+func (m *mockGandiClient) CreateDomainRecord(fqdn, name, recordtype string, ttl int, values []string) (standardResponse, error) {
 	m.Actions = append(m.Actions, MockAction{
 		Name: "CreateDomainRecord",
 		FQDN: fqdn,
@@ -81,7 +81,7 @@ func (m *mockGandiClient) CreateDomainRecord(fqdn, name, recordtype string, ttl 
 	return standardResponse{}, nil
 }
 
-func (m *mockGandiClient) DeleteDomainRecord(fqdn, name, recordtype string) (err error) {
+func (m *mockGandiClient) DeleteDomainRecord(fqdn, name, recordtype string) error {
 	m.Actions = append(m.Actions, MockAction{
 		Name: "DeleteDomainRecord",
 		FQDN: fqdn,
@@ -98,7 +98,7 @@ func (m *mockGandiClient) DeleteDomainRecord(fqdn, name, recordtype string) (err
 	return nil
 }
 
-func (m *mockGandiClient) UpdateDomainRecordByNameAndType(fqdn, name, recordtype string, ttl int, values []string) (response standardResponse, err error) {
+func (m *mockGandiClient) UpdateDomainRecordByNameAndType(fqdn, name, recordtype string, ttl int, values []string) (standardResponse, error) {
 	m.Actions = append(m.Actions, MockAction{
 		Name: "UpdateDomainRecordByNameAndType",
 		FQDN: fqdn,
@@ -117,7 +117,7 @@ func (m *mockGandiClient) UpdateDomainRecordByNameAndType(fqdn, name, recordtype
 	return standardResponse{}, nil
 }
 
-func (m *mockGandiClient) ListDomains() (domains []domain.ListResponse, err error) {
+func (m *mockGandiClient) ListDomains() ([]domain.ListResponse, error) {
 	m.Actions = append(m.Actions, MockAction{
 		Name: "ListDomains",
 	})

--- a/provider/godaddy/godaddy.go
+++ b/provider/godaddy/godaddy.go
@@ -121,7 +121,9 @@ func (z gdZoneIDName) add(zoneID string, zoneRecord *gdRecords) {
 	z[zoneID] = zoneRecord
 }
 
-func (z gdZoneIDName) findZoneRecord(hostname string) (suitableZoneID string, suitableZoneRecord *gdRecords) {
+func (z gdZoneIDName) findZoneRecord(hostname string) (string, *gdRecords) {
+	var suitableZoneID string
+	var suitableZoneRecord *gdRecords
 	for zoneID, zoneRecord := range z {
 		if hostname == zoneRecord.zone || strings.HasSuffix(hostname, "."+zoneRecord.zone) {
 			if suitableZoneRecord == nil || len(zoneRecord.zone) > len(suitableZoneRecord.zone) {
@@ -131,11 +133,11 @@ func (z gdZoneIDName) findZoneRecord(hostname string) (suitableZoneID string, su
 		}
 	}
 
-	return
+	return suitableZoneID, suitableZoneRecord
 }
 
 // NewGoDaddyProvider initializes a new GoDaddy DNS based Provider.
-func NewGoDaddyProvider(ctx context.Context, domainFilter *endpoint.DomainFilter, ttl int64, apiKey, apiSecret string, useOTE, dryRun bool) (*GDProvider, error) {
+func NewGoDaddyProvider(_ context.Context, domainFilter *endpoint.DomainFilter, ttl int64, apiKey, apiSecret string, useOTE, dryRun bool) (*GDProvider, error) {
 	client, err := NewClient(useOTE, apiKey, apiSecret)
 	if err != nil {
 		return nil, err
@@ -218,7 +220,7 @@ func (p *GDProvider) zonesRecords(ctx context.Context, all bool) ([]string, []gd
 	return zones, allRecords, nil
 }
 
-func (p *GDProvider) records(ctx *context.Context, zone string, all bool) (*gdRecords, error) {
+func (p *GDProvider) records(_ *context.Context, zone string, all bool) (*gdRecords, error) {
 	var recordsIds []gdRecordField
 
 	log.Debugf("GoDaddy: Getting records for %s", zone)

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -207,11 +207,13 @@ func (p *GoogleProvider) Zones(ctx context.Context) (map[string]*dns.ManagedZone
 }
 
 // Records returns the list of records in all relevant zones.
-func (p *GoogleProvider) Records(ctx context.Context) (endpoints []*endpoint.Endpoint, _ error) {
+func (p *GoogleProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
 	zones, err := p.Zones(ctx)
 	if err != nil {
 		return nil, err
 	}
+
+	endpoints := make([]*endpoint.Endpoint, 0)
 
 	f := func(resp *dns.ResourceRecordSetsListResponse) error {
 		for _, r := range resp.Rrsets {
@@ -226,7 +228,7 @@ func (p *GoogleProvider) Records(ctx context.Context) (endpoints []*endpoint.End
 
 	for _, z := range zones {
 		if err := p.resourceRecordSetsClient.List(p.project, z.Name).Pages(ctx, f); err != nil {
-			return nil, provider.NewSoftError(fmt.Errorf("failed to list records in zone %s: %w", z.Name, err))
+			return nil, provider.NewSoftErrorf("failed to list records in zone %s: %v", z.Name, err)
 		}
 	}
 

--- a/provider/inmemory/inmemory.go
+++ b/provider/inmemory/inmemory.go
@@ -230,7 +230,7 @@ func (f *filter) Zones(zones map[string]string) map[string]string {
 
 // EndpointZoneID determines zoneID for endpoint from map[zoneID]zoneName by taking longest suffix zoneName match in endpoint DNSName
 // returns empty string if no match found
-func (f *filter) EndpointZoneID(endpoint *endpoint.Endpoint, zones map[string]string) (zoneID string) {
+func (f *filter) EndpointZoneID(endpoint *endpoint.Endpoint, zones map[string]string) string {
 	var matchZoneID, matchZoneName string
 	for zoneID, zoneName := range zones {
 		if strings.HasSuffix(endpoint.DNSName, zoneName) && len(zoneName) > len(matchZoneName) {

--- a/provider/ovh/ovh.go
+++ b/provider/ovh/ovh.go
@@ -242,7 +242,7 @@ func (p *OVHProvider) handleSingleZoneUpdate(ctx context.Context, zoneName strin
 }
 
 // ApplyChanges applies a given set of changes in a given zone.
-func (p *OVHProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) (err error) {
+func (p *OVHProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
 	zones, records := p.lastRunZones, p.lastRunRecords
 	defer func() {
 		p.lastRunRecords = []ovhRecord{}

--- a/provider/plural/plural.go
+++ b/provider/plural/plural.go
@@ -66,17 +66,17 @@ func NewPluralProvider(cluster, provider string) (*PluralProvider, error) {
 	}, nil
 }
 
-func (p *PluralProvider) Records(_ context.Context) (endpoints []*endpoint.Endpoint, err error) {
+func (p *PluralProvider) Records(_ context.Context) ([]*endpoint.Endpoint, error) {
 	records, err := p.Client.DnsRecords()
 	if err != nil {
-		return
+		return nil, err
 	}
 
-	endpoints = make([]*endpoint.Endpoint, len(records))
+	endpoints := make([]*endpoint.Endpoint, len(records))
 	for i, record := range records {
 		endpoints[i] = endpoint.NewEndpoint(record.Name, record.Type, record.Records...)
 	}
-	return
+	return endpoints, nil
 }
 
 func (p *PluralProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {

--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -169,13 +169,13 @@ func NewRfc2136Provider(hosts []string, port int, zoneNames []string, insecure b
 }
 
 // KeyData will return TKEY name and TSIG handle to use for followon actions with a secure connection
-func (r *rfc2136Provider) KeyData(nameserver string) (keyName string, handle *gss.Client, err error) {
-	handle, err = gss.NewClient(new(dns.Client))
+func (r *rfc2136Provider) KeyData(nameserver string) (string, *gss.Client, error) {
+	handle, err := gss.NewClient(new(dns.Client))
 	if err != nil {
-		return keyName, handle, err
+		return "", handle, err
 	}
 
-	keyName, _, err = handle.NegotiateContextWithCredentials(nameserver, r.krb5Realm, r.krb5Username, r.krb5Password)
+	keyName, _, err := handle.NegotiateContextWithCredentials(nameserver, r.krb5Realm, r.krb5Username, r.krb5Password)
 	if err != nil {
 		return keyName, handle, err
 	}
@@ -247,7 +247,7 @@ OuterLoop:
 	return eps, nil
 }
 
-func (r *rfc2136Provider) IncomeTransfer(m *dns.Msg, nameserver string) (env chan *dns.Envelope, err error) {
+func (r *rfc2136Provider) IncomeTransfer(m *dns.Msg, nameserver string) (chan *dns.Envelope, error) {
 	t := new(dns.Transfer)
 	if !r.insecure && !r.gssTsig {
 		t.TsigSecret = map[string]string{r.tsigKeyName: r.tsigSecret}

--- a/provider/rfc2136/rfc2136_test.go
+++ b/provider/rfc2136/rfc2136_test.go
@@ -149,7 +149,7 @@ func (r *rfc2136Stub) setOutput(output []string) error {
 	return nil
 }
 
-func (r *rfc2136Stub) IncomeTransfer(m *dns.Msg, a string) (env chan *dns.Envelope, err error) {
+func (r *rfc2136Stub) IncomeTransfer(m *dns.Msg, a string) (chan *dns.Envelope, error) {
 	outChan := make(chan *dns.Envelope)
 	go func() {
 		for _, e := range r.output {

--- a/provider/zonefinder.go
+++ b/provider/zonefinder.go
@@ -41,7 +41,7 @@ func (z ZoneIDName) Add(zoneID, zoneName string) {
 // SRV records as per RFC 2782, or TXT record for services) that are not
 // IDNA-aware and cannot represent non-ASCII labels. Skipping these labels
 // ensures compatibility with such use cases.
-func (z ZoneIDName) FindZone(hostname string) (suitableZoneID, suitableZoneName string) {
+func (z ZoneIDName) FindZone(hostname string) (string, string) {
 	var name string
 	domainLabels := strings.Split(hostname, ".")
 	for i, label := range domainLabels {
@@ -57,6 +57,8 @@ func (z ZoneIDName) FindZone(hostname string) (suitableZoneID, suitableZoneName 
 	}
 	name = strings.Join(domainLabels, ".")
 
+	var suitableZoneID, suitableZoneName string
+
 	for zoneID, zoneName := range z {
 		if name == zoneName || strings.HasSuffix(name, "."+zoneName) {
 			if suitableZoneName == "" || len(zoneName) > len(suitableZoneName) {
@@ -65,5 +67,5 @@ func (z ZoneIDName) FindZone(hostname string) (suitableZoneID, suitableZoneName 
 			}
 		}
 	}
-	return
+	return suitableZoneID, suitableZoneName
 }

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -338,7 +338,7 @@ func newaffixNameMapper(prefix, suffix, wildcardReplacement string) affixNameMap
 
 // extractRecordTypeDefaultPosition extracts record type from the default position
 // when not using '%{record_type}' in the prefix/suffix
-func extractRecordTypeDefaultPosition(name string) (baseName, recordType string) {
+func extractRecordTypeDefaultPosition(name string) (string, string) {
 	nameS := strings.Split(name, "-")
 	for _, t := range getSupportedTypes() {
 		if nameS[0] == strings.ToLower(t) {
@@ -350,7 +350,7 @@ func extractRecordTypeDefaultPosition(name string) (baseName, recordType string)
 
 // dropAffixExtractType strips TXT record to find an endpoint name it manages
 // it also returns the record type
-func (pr affixNameMapper) dropAffixExtractType(name string) (baseName, recordType string) {
+func (pr affixNameMapper) dropAffixExtractType(name string) (string, string) {
 	prefix := pr.prefix
 	suffix := pr.suffix
 
@@ -397,7 +397,7 @@ func (pr affixNameMapper) isSuffix() bool {
 	return len(pr.prefix) == 0 && len(pr.suffix) > 0
 }
 
-func (pr affixNameMapper) toEndpointName(txtDNSName string) (endpointName string, recordType string) {
+func (pr affixNameMapper) toEndpointName(txtDNSName string) (string, string) {
 	lowerDNSName := strings.ToLower(txtDNSName)
 
 	// drop prefix

--- a/source/ambassador_host.go
+++ b/source/ambassador_host.go
@@ -228,7 +228,7 @@ func (sc *ambassadorHostSource) targetsFromAmbassadorLoadBalancer(ctx context.Co
 //
 // Returns namespace, name, error.
 
-func parseAmbLoadBalancerService(service string) (namespace, name string, err error) {
+func parseAmbLoadBalancerService(service string) (string, string, error) {
 	// Start by assuming that we have namespace/name.
 	parts := strings.Split(service, "/")
 

--- a/source/crd.go
+++ b/source/crd.go
@@ -125,7 +125,7 @@ func NewCRDSource(crdClient rest.Interface, namespace, kind string, annotationFi
 		// missed or dropped events are handled. specify resync period 0 to avoid unnecessary sync handler invocations.
 		informer := cache.NewSharedInformer(
 			&cache.ListWatch{
-				ListWithContextFunc: func(ctx context.Context, lo metav1.ListOptions) (result runtime.Object, err error) {
+				ListWithContextFunc: func(ctx context.Context, lo metav1.ListOptions) (runtime.Object, error) {
 					return sourceCrd.List(ctx, &lo)
 				},
 				WatchFuncWithContext: func(ctx context.Context, lo metav1.ListOptions) (watch.Interface, error) {
@@ -235,20 +235,19 @@ func (cs *crdSource) watch(ctx context.Context, opts *metav1.ListOptions) (watch
 		Watch(ctx)
 }
 
-func (cs *crdSource) List(ctx context.Context, opts *metav1.ListOptions) (result *apiv1alpha1.DNSEndpointList, err error) {
-	result = &apiv1alpha1.DNSEndpointList{}
-	err = cs.crdClient.Get().
+func (cs *crdSource) List(ctx context.Context, opts *metav1.ListOptions) (*apiv1alpha1.DNSEndpointList, error) {
+	result := &apiv1alpha1.DNSEndpointList{}
+	return result, cs.crdClient.Get().
 		Namespace(cs.namespace).
 		Resource(cs.crdResource).
 		VersionedParams(opts, cs.codec).
 		Do(ctx).
 		Into(result)
-	return
 }
 
-func (cs *crdSource) UpdateStatus(ctx context.Context, dnsEndpoint *apiv1alpha1.DNSEndpoint) (result *apiv1alpha1.DNSEndpoint, err error) {
-	result = &apiv1alpha1.DNSEndpoint{}
-	err = cs.crdClient.Put().
+func (cs *crdSource) UpdateStatus(ctx context.Context, dnsEndpoint *apiv1alpha1.DNSEndpoint) (*apiv1alpha1.DNSEndpoint, error) {
+	result := &apiv1alpha1.DNSEndpoint{}
+	return result, cs.crdClient.Put().
 		Namespace(dnsEndpoint.Namespace).
 		Resource(cs.crdResource).
 		Name(dnsEndpoint.Name).
@@ -256,7 +255,6 @@ func (cs *crdSource) UpdateStatus(ctx context.Context, dnsEndpoint *apiv1alpha1.
 		Body(dnsEndpoint).
 		Do(ctx).
 		Into(result)
-	return
 }
 
 // filterByAnnotations filters a list of dnsendpoints by a given annotation selector.

--- a/source/fqdn/fqdn.go
+++ b/source/fqdn/fqdn.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func ParseTemplate(input string) (tmpl *template.Template, err error) {
+func ParseTemplate(input string) (*template.Template, error) {
 	if input == "" {
 		return nil, nil
 	}

--- a/source/service.go
+++ b/source/service.go
@@ -527,7 +527,7 @@ func (sc *serviceSource) filterByServiceType(services []*v1.Service) []*v1.Servi
 	return result
 }
 
-func (sc *serviceSource) generateEndpoints(svc *v1.Service, hostname string, providerSpecific endpoint.ProviderSpecific, setIdentifier string, useClusterIP bool) (endpoints []*endpoint.Endpoint) {
+func (sc *serviceSource) generateEndpoints(svc *v1.Service, hostname string, providerSpecific endpoint.ProviderSpecific, setIdentifier string, useClusterIP bool) []*endpoint.Endpoint {
 	hostname = strings.TrimSuffix(hostname, ".")
 
 	resource := fmt.Sprintf("service/%s/%s", svc.Namespace, svc.Name)
@@ -535,6 +535,8 @@ func (sc *serviceSource) generateEndpoints(svc *v1.Service, hostname string, pro
 	ttl := annotations.TTLFromAnnotations(svc.Annotations, resource)
 
 	targets := annotations.TargetsFromTargetAnnotation(svc.Annotations)
+
+	endpoints := make([]*endpoint.Endpoint, 0)
 
 	if len(targets) == 0 {
 		switch svc.Spec.Type {

--- a/source/utils.go
+++ b/source/utils.go
@@ -42,7 +42,9 @@ func suitableType(target string) string {
 // ParseIngress parses an ingress string in the format "namespace/name" or "name".
 // It returns the namespace and name extracted from the string, or an error if the format is invalid.
 // If the namespace is not provided, it defaults to an empty string.
-func ParseIngress(ingress string) (namespace, name string, err error) {
+func ParseIngress(ingress string) (string, string, error) {
+	var namespace, name string
+	var err error
 	parts := strings.Split(ingress, "/")
 	if len(parts) == 2 {
 		namespace, name = parts[0], parts[1]
@@ -52,7 +54,7 @@ func ParseIngress(ingress string) (namespace, name string, err error) {
 		err = fmt.Errorf("invalid ingress name (name or namespace/name) found %q", ingress)
 	}
 
-	return
+	return namespace, name, err
 }
 
 // MatchesServiceSelector checks if all key-value pairs in the selector map


### PR DESCRIPTION
## What does it do ?

- adds linter `nonamedreturns`

A brief description of the change being made with this pull request](https://medium.com/@yuki.bobier/the-implications-of-named-return-values-in-go-think-twice-before-you-leap-e949e9b0e446)

Fixed failures https://github.com/kubernetes-sigs/external-dns/actions/runs/15996409199/job/45120756190?pr=5594

## Motivation

- Should simplify code reviews
- Code consistency

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
