### PR TITLE
feat(source): use transformers in pod informers to reduce memory footprint

### DIFF
--- a/source/pod.go
+++ b/source/pod.go
@@ -24,6 +24,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	kubeinformers "k8s.io/client-go/informers"
@@ -76,6 +77,36 @@ func NewPodSource(
 	}
 
 	_, _ = podInformer.Informer().AddEventHandler(informers.DefaultEventHandler())
+
+	// Transformer is used to reduce the memory usage of the informer.
+	// The pod informer will otherwise store a full in-memory, go-typed copy of all pod schemas in the cluster.
+	// If watchList is not used it will not prevent memory bursts on the initial informer sync.
+	podInformer.Informer().SetTransform(func(i interface{}) (interface{}, error) {
+		pod, ok := i.(*corev1.Pod)
+		if !ok {
+			return nil, fmt.Errorf("object is not a pod")
+		}
+		if pod.UID == "" {
+			// Pod was already transformed and we must be idempotent.
+			return pod, nil
+		}
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				// Name/namespace must always be kept for the informer to work.
+				Name:      pod.Name,
+				Namespace: pod.Namespace,
+				// Used by the controller. This includes non-external-dns prefixed annotations.
+				Annotations: pod.Annotations,
+			},
+			Spec: corev1.PodSpec{
+				HostNetwork: pod.Spec.HostNetwork,
+				NodeName:    pod.Spec.NodeName,
+			},
+			Status: corev1.PodStatus{
+				PodIP: pod.Status.PodIP,
+			},
+		}, nil
+	})
 	_, _ = nodeInformer.Informer().AddEventHandler(informers.DefaultEventHandler())
 
 	informerFactory.Start(ctx.Done())

--- a/source/pod_test.go
+++ b/source/pod_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1lister "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -996,4 +997,85 @@ func nodesFixturesIPv4() []*corev1.Node {
 			},
 		},
 	}
+}
+
+func TestPodTransformerInPodSource(t *testing.T) {
+	ctx := t.Context()
+	fakeClient := fake.NewClientset()
+
+	pod := &v1.Pod{
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Name: "test",
+			}},
+			Hostname:    "test-hostname",
+			NodeName:    "test-node",
+			HostNetwork: true,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-ns",
+			Name:      "test-name",
+			Labels: map[string]string{
+				"label1": "value1",
+				"label2": "value2",
+				"label3": "value3",
+			},
+			Annotations: map[string]string{
+				"user-annotation": "value",
+				"external-dns.alpha.kubernetes.io/hostname": "test-hostname",
+				"external-dns.alpha.kubernetes.io/random":   "value",
+				"other/annotation":                          "value",
+			},
+			UID: "someuid",
+		},
+		Status: v1.PodStatus{
+			PodIP:  "127.0.0.1",
+			HostIP: "127.0.0.2",
+			Conditions: []v1.PodCondition{{
+				Type:   v1.PodReady,
+				Status: v1.ConditionTrue,
+			}, {
+				Type:   v1.ContainersReady,
+				Status: v1.ConditionFalse,
+			}},
+		},
+	}
+
+	_, err := fakeClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Should not error when creating the source
+	src, err := NewPodSource(ctx, fakeClient, "", "", false, "", "", false, "", nil)
+	require.NoError(t, err)
+	ps, ok := src.(*podSource)
+	require.True(t, ok)
+
+	retrieved, err := ps.podInformer.Lister().Pods("test-ns").Get("test-name")
+	require.NoError(t, err)
+
+	// Metadata
+	assert.Equal(t, "test-name", retrieved.Name)
+	assert.Equal(t, "test-ns", retrieved.Namespace)
+	assert.Empty(t, retrieved.UID)
+	assert.Empty(t, retrieved.Labels)
+	// Filtered
+	assert.Equal(t, map[string]string{
+		"user-annotation": "value",
+		"external-dns.alpha.kubernetes.io/hostname": "test-hostname",
+		"external-dns.alpha.kubernetes.io/random":   "value",
+		"other/annotation":                          "value",
+	}, retrieved.Annotations)
+
+	// Spec
+	assert.Empty(t, retrieved.Spec.Containers)
+	assert.Empty(t, retrieved.Spec.Hostname)
+	assert.Equal(t, "test-node", retrieved.Spec.NodeName)
+	assert.True(t, retrieved.Spec.HostNetwork)
+
+	// Status
+	assert.Empty(t, retrieved.Status.ContainerStatuses)
+	assert.Empty(t, retrieved.Status.InitContainerStatuses)
+	assert.Empty(t, retrieved.Status.HostIP)
+	assert.Equal(t, "127.0.0.1", retrieved.Status.PodIP)
+	assert.Empty(t, retrieved.Status.Conditions)
 }

--- a/source/pod_test.go
+++ b/source/pod_test.go
@@ -1081,7 +1081,7 @@ func TestPodTransformerInPodSource(t *testing.T) {
 		assert.Empty(t, retrieved.Status.Conditions)
 	})
 
-	t.Run("transormer is not used when fqdnTemplate is set", func(t *testing.T) {
+	t.Run("transformer is not used when fqdnTemplate is set", func(t *testing.T) {
 		ctx := t.Context()
 		fakeClient := fake.NewClientset()
 


### PR DESCRIPTION
## What does it do ?

This PR adds transformers to the pod informers in the `pod` and `service` sources to reduce the resulting memory footprint.

## Motivation

As described in the issue, the pod informers currently lead to a large memory usage of the external-dns pods. As the controller only requires a few specific fields we can leverage transformers in the informers to greatly reduce the footprint.
In our environment this reduces the _average_ memory usage by ~10 times, and once using watch list (disabled by default) and the next client-go release, we now have a _peak_ memory usage 10 times smaller, greatly reducing our controller footprint.

This PR does not enable watchlist (but I'll raise a PR to optionally do so) as it is currently not really valuable without a fix in the next release of client-go.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] ~~Yes, I updated end user documentation accordingly~~ Not applicable, this change is purely technical within the informer

Refs: #5595 

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
