### PR TITLE
feat(source/istio): support version 1.25+

### DIFF
--- a/docs/sources/istio.md
+++ b/docs/sources/istio.md
@@ -7,11 +7,11 @@ It is meant to supplement the other provider-specific setup tutorials.
 
 **Note:** Currently supported version is `1.22` with `v1beta1` stored version.
 
-- [Support status of Istio releases ](https://istio.io/latest/docs/releases/supported-releases/)
+- [Support status of Istio releases](https://istio.io/latest/docs/releases/supported-releases/)
 
-* Manifest (for clusters without RBAC enabled)
-* Manifest (for clusters with RBAC enabled)
-* Update existing ExternalDNS Deployment
+- Manifest (for clusters without RBAC enabled)
+- Manifest (for clusters with RBAC enabled)
+- Update existing ExternalDNS Deployment
 
 ## Manifest (for clusters without RBAC enabled)
 
@@ -123,9 +123,9 @@ spec:
 
 ## Update existing ExternalDNS Deployment
 
-* For clusters with running `external-dns`, you can just update the deployment.
-* With access to the `kube-system` namespace, update the existing `external-dns` deployment.
-  * Add a parameter to the arguments of the container to create dns entries with `--source=istio-gateway`.
+- For clusters with running `external-dns`, you can just update the deployment.
+- With access to the `kube-system` namespace, update the existing `external-dns` deployment.
+  - Add a parameter to the arguments of the container to create dns entries with `--source=istio-gateway`.
 
 Execute the following command or update the argument.
 
@@ -324,13 +324,13 @@ EOF
 
 ## Debug ExternalDNS
 
-* Look for the deployment pod to see the status
+- Look for the deployment pod to see the status
 
 ```console$ kubectl get pods | grep external-dns
 external-dns-6b84999479-4knv9     1/1     Running   0   3h29m
 ```
 
-* Watch for the logs as follows
+- Watch for the logs as follows
 
 ```console
 kubectl logs -f external-dns-6b84999479-4knv9
@@ -340,7 +340,7 @@ At this point, you can `create` or `update` any `Istio Gateway` object with `hos
 
 > **ATTENTION**: Make sure to specify those whose account is related to the DNS record.
 
-* Successful executions will print the following
+- Successful executions will print the following
 
 ```console
 time="2020-01-17T06:08:08Z" level=info msg="Desired change: CREATE httpbin.example.com A"
@@ -349,7 +349,7 @@ time="2020-01-17T06:08:08Z" level=info msg="2 record(s) in zone example.com. wer
 time="2020-01-17T06:09:08Z" level=info msg="All records are already up to date, there are no changes for the matching hosted zones"
 ```
 
-* If there's any problem around `clusterrole`, you would see the errors showing wrong permissions:
+- If there's any problem around `clusterrole`, you would see the errors showing wrong permissions:
 
 ```console
 source \"gateways\" in API group \"networking.istio.io\" at the cluster scope"

--- a/docs/sources/istio.md
+++ b/docs/sources/istio.md
@@ -148,13 +148,13 @@ The following are relevant snippets from that tutorial.
 With automatic sidecar injection:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.6/samples/httpbin/httpbin.yaml
+kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.22/samples/httpbin/httpbin.yaml
 ```
 
 Otherwise:
 
 ```bash
-kubectl apply -f <(istioctl kube-inject -f https://raw.githubusercontent.com/istio/istio/release-1.6/samples/httpbin/httpbin.yaml)
+kubectl apply -f <(istioctl kube-inject -f https://raw.githubusercontent.com/istio/istio/release-1.22/samples/httpbin/httpbin.yaml)
 ```
 
 ### Using a Gateway as a source

--- a/docs/sources/istio.md
+++ b/docs/sources/istio.md
@@ -5,6 +5,10 @@ It is meant to supplement the other provider-specific setup tutorials.
 
 **Note:** Using the Istio Gateway source requires Istio >=1.0.0.
 
+**Note:** Currently supported version is `1.22` with `v1beta1` stored version.
+
+- [Support status of Istio releases ](https://istio.io/latest/docs/releases/supported-releases/)
+
 * Manifest (for clusters without RBAC enabled)
 * Manifest (for clusters with RBAC enabled)
 * Update existing ExternalDNS Deployment

--- a/docs/sources/istio.md
+++ b/docs/sources/istio.md
@@ -5,7 +5,7 @@ It is meant to supplement the other provider-specific setup tutorials.
 
 **Note:** Using the Istio Gateway source requires Istio >=1.0.0.
 
-**Note:** Currently supported version is `1.22` with `v1beta1` stored version.
+**Note:** Currently supported versions are `1.25` and `1.26` with `v1beta1` stored version.
 
 - [Support status of Istio releases](https://istio.io/latest/docs/releases/supported-releases/)
 
@@ -152,13 +152,13 @@ The following are relevant snippets from that tutorial.
 With automatic sidecar injection:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.22/samples/httpbin/httpbin.yaml
+kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.25/samples/httpbin/httpbin.yaml
 ```
 
 Otherwise:
 
 ```bash
-kubectl apply -f <(istioctl kube-inject -f https://raw.githubusercontent.com/istio/istio/release-1.22/samples/httpbin/httpbin.yaml)
+kubectl apply -f <(istioctl kube-inject -f https://raw.githubusercontent.com/istio/istio/release-1.25/samples/httpbin/httpbin.yaml)
 ```
 
 ### Using a Gateway as a source

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -1511,7 +1511,6 @@ func TestNewTXTScheme(t *testing.T) {
 		assert.Nil(t, ctx.Value(provider.RecordsContextKey))
 	}
 	err := r.ApplyChanges(ctx, changes)
-	fmt.Println(err)
 	require.NoError(t, err)
 }
 

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -18,7 +18,6 @@ package registry
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"strings"
 	"testing"

--- a/source/istio_gateway_test.go
+++ b/source/istio_gateway_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	networkingv1alpha3api "istio.io/api/networking/v1alpha3"
-	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	networkingv1alpha3api "istio.io/api/networking/v1beta1"
+	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
 	v1 "k8s.io/api/core/v1"
 	networkv1 "k8s.io/api/networking/v1"
@@ -1494,7 +1494,7 @@ func testGatewayEndpoints(t *testing.T) {
 			fakeIstioClient := istiofake.NewSimpleClientset()
 			for _, config := range ti.configItems {
 				gatewayCfg := config.Config()
-				_, err := fakeIstioClient.NetworkingV1alpha3().Gateways(ti.targetNamespace).Create(context.Background(), gatewayCfg, metav1.CreateOptions{})
+				_, err := fakeIstioClient.NetworkingV1beta1().Gateways(ti.targetNamespace).Create(context.Background(), gatewayCfg, metav1.CreateOptions{})
 				require.NoError(t, err)
 			}
 

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -416,24 +416,8 @@ func virtualServiceBindsToGateway(virtualService *v1beta1.VirtualService, gatewa
 	return false
 }
 
-// TODO: similar to ParseIngress
-func parseGateway(gateway string) (string, string, error) {
-	var namespace, name string
-	var err error
-	parts := strings.Split(gateway, "/")
-	if len(parts) == 2 {
-		namespace, name = parts[0], parts[1]
-	} else if len(parts) == 1 {
-		name = parts[0]
-	} else {
-		err = fmt.Errorf("invalid gateway name (name or namespace/name) found '%v'", gateway)
-	}
-
-	return namespace, name, err
-}
-
 func (sc *virtualServiceSource) targetsFromIngress(ctx context.Context, ingressStr string, gateway *v1beta1.Gateway) (endpoint.Targets, error) {
-	namespace, name, err := parseGateway(ingressStr)
+	namespace, name, err := ParseIngress(ingressStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse Ingress annotation on Gateway (%s/%s): %w", gateway.Namespace, gateway.Name, err)
 	}

--- a/source/istio_virtualservice_test.go
+++ b/source/istio_virtualservice_test.go
@@ -24,9 +24,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"istio.io/api/meta/v1alpha1"
-	istionetworking "istio.io/api/networking/v1alpha3"
-	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	v1alpha1 "istio.io/api/meta/v1alpha1"
+	istionetworking "istio.io/api/networking/v1beta1"
+	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
 	v1 "k8s.io/api/core/v1"
 	networkv1 "k8s.io/api/networking/v1"
@@ -98,7 +98,7 @@ func (suite *VirtualServiceSuite) SetupTest() {
 		namespace: "istio-system",
 		dnsnames:  [][]string{{"*"}},
 	}).Config()
-	_, err = fakeIstioClient.NetworkingV1alpha3().Gateways(suite.gwconfig.Namespace).Create(context.Background(), suite.gwconfig, metav1.CreateOptions{})
+	_, err = fakeIstioClient.NetworkingV1beta1().Gateways(suite.gwconfig.Namespace).Create(context.Background(), suite.gwconfig, metav1.CreateOptions{})
 	suite.NoError(err, "should succeed")
 
 	suite.vsconfig = (fakeVirtualServiceConfig{
@@ -107,7 +107,7 @@ func (suite *VirtualServiceSuite) SetupTest() {
 		gateways:  []string{"istio-system/foo-gateway-with-targets"},
 		dnsnames:  []string{"foo"},
 	}).Config()
-	_, err = fakeIstioClient.NetworkingV1alpha3().VirtualServices(suite.vsconfig.Namespace).Create(context.Background(), suite.vsconfig, metav1.CreateOptions{})
+	_, err = fakeIstioClient.NetworkingV1beta1().VirtualServices(suite.vsconfig.Namespace).Create(context.Background(), suite.vsconfig, metav1.CreateOptions{})
 	suite.NoError(err, "should succeed")
 
 	suite.source, err = NewIstioVirtualServiceSource(
@@ -1975,12 +1975,12 @@ func testVirtualServiceEndpoints(t *testing.T) {
 			fakeIstioClient := istiofake.NewSimpleClientset()
 
 			for _, gateway := range gateways {
-				_, err := fakeIstioClient.NetworkingV1alpha3().Gateways(gateway.Namespace).Create(context.Background(), gateway, metav1.CreateOptions{})
+				_, err := fakeIstioClient.NetworkingV1beta1().Gateways(gateway.Namespace).Create(context.Background(), gateway, metav1.CreateOptions{})
 				require.NoError(t, err)
 			}
 
 			for _, virtualservice := range virtualservices {
-				_, err := fakeIstioClient.NetworkingV1alpha3().VirtualServices(virtualservice.Namespace).Create(context.Background(), virtualservice, metav1.CreateOptions{})
+				_, err := fakeIstioClient.NetworkingV1beta1().VirtualServices(virtualservice.Namespace).Create(context.Background(), virtualservice, metav1.CreateOptions{})
 				require.NoError(t, err)
 			}
 
@@ -2041,7 +2041,7 @@ func testGatewaySelectorMatchesService(t *testing.T) {
 }
 
 func newTestVirtualServiceSource(loadBalancerList []fakeIngressGatewayService, ingressList []fakeIngress, gwList []fakeGatewayConfig) (*virtualServiceSource, error) {
-	fakeKubernetesClient := fake.NewSimpleClientset()
+	fakeKubernetesClient := fake.NewClientset()
 	fakeIstioClient := istiofake.NewSimpleClientset()
 
 	for _, lb := range loadBalancerList {
@@ -2064,7 +2064,7 @@ func newTestVirtualServiceSource(loadBalancerList []fakeIngressGatewayService, i
 		gwObj := gw.Config()
 		// use create instead of add
 		// https://github.com/kubernetes/client-go/blob/92512ee2b8cf6696e9909245624175b7f0c971d9/testing/fixture.go#LL336C3-L336C52
-		_, err := fakeIstioClient.NetworkingV1alpha3().Gateways(gw.namespace).Create(context.Background(), gwObj, metav1.CreateOptions{})
+		_, err := fakeIstioClient.NetworkingV1beta1().Gateways(gw.namespace).Create(context.Background(), gwObj, metav1.CreateOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/source/istio_virtualservice_test.go
+++ b/source/istio_virtualservice_test.go
@@ -2168,7 +2168,7 @@ func TestVirtualServiceSourceGetGateway(t *testing.T) {
 			ctx:            context.TODO(),
 			gatewayStr:     "1/2/3/",
 			virtualService: &networkingv1beta1.VirtualService{},
-		}, want: nil, expectedErrStr: "invalid gateway name (name or namespace/name) found '1/2/3/'"},
+		}, want: nil, expectedErrStr: "invalid ingress name (name or namespace/name) found \"1/2/3/\""},
 		{name: "ExistingGateway", fields: fields{
 			virtualServiceSource: func() *virtualServiceSource {
 				vs, _ := newTestVirtualServiceSource(nil, nil, []fakeGatewayConfig{{

--- a/source/istio_virtualservice_test.go
+++ b/source/istio_virtualservice_test.go
@@ -24,9 +24,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	v1alpha1 "istio.io/api/meta/v1alpha1"
+	"istio.io/api/meta/v1alpha1"
 	istionetworking "istio.io/api/networking/v1beta1"
-	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
 	v1 "k8s.io/api/core/v1"
 	networkv1 "k8s.io/api/networking/v1"
@@ -44,8 +44,8 @@ type VirtualServiceSuite struct {
 	source     Source
 	lbServices []*v1.Service
 	ingresses  []*networkv1.Ingress
-	gwconfig   *networkingv1alpha3.Gateway
-	vsconfig   *networkingv1alpha3.VirtualService
+	gwconfig   *networkingv1beta1.Gateway
+	vsconfig   *networkingv1beta1.VirtualService
 }
 
 func (suite *VirtualServiceSuite) SetupTest() {
@@ -1948,8 +1948,8 @@ func testVirtualServiceEndpoints(t *testing.T) {
 		t.Run(ti.title, func(t *testing.T) {
 			t.Parallel()
 
-			var gateways []*networkingv1alpha3.Gateway
-			var virtualservices []*networkingv1alpha3.VirtualService
+			var gateways []*networkingv1beta1.Gateway
+			var virtualservices []*networkingv1beta1.VirtualService
 
 			for _, gwItem := range ti.gwConfigs {
 				gateways = append(gateways, gwItem.Config())
@@ -1958,7 +1958,7 @@ func testVirtualServiceEndpoints(t *testing.T) {
 				virtualservices = append(virtualservices, vsItem.Config())
 			}
 
-			fakeKubernetesClient := fake.NewSimpleClientset()
+			fakeKubernetesClient := fake.NewClientset()
 
 			for _, lb := range ti.lbServices {
 				service := lb.Service()
@@ -1979,8 +1979,8 @@ func testVirtualServiceEndpoints(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			for _, virtualservice := range virtualservices {
-				_, err := fakeIstioClient.NetworkingV1beta1().VirtualServices(virtualservice.Namespace).Create(context.Background(), virtualservice, metav1.CreateOptions{})
+			for _, vService := range virtualservices {
+				_, err := fakeIstioClient.NetworkingV1beta1().VirtualServices(vService.Namespace).Create(context.Background(), vService, metav1.CreateOptions{})
 				require.NoError(t, err)
 			}
 
@@ -2101,7 +2101,7 @@ type fakeVirtualServiceConfig struct {
 	exportTo    string
 }
 
-func (c fakeVirtualServiceConfig) Config() *networkingv1alpha3.VirtualService {
+func (c fakeVirtualServiceConfig) Config() *networkingv1beta1.VirtualService {
 	vs := istionetworking.VirtualService{
 		Gateways: c.gateways,
 		Hosts:    c.dnsnames,
@@ -2110,7 +2110,7 @@ func (c fakeVirtualServiceConfig) Config() *networkingv1alpha3.VirtualService {
 		vs.ExportTo = []string{c.exportTo}
 	}
 
-	return &networkingv1alpha3.VirtualService{
+	return &networkingv1beta1.VirtualService{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        c.name,
 			Namespace:   c.namespace,
@@ -2127,13 +2127,13 @@ func TestVirtualServiceSourceGetGateway(t *testing.T) {
 	type args struct {
 		ctx            context.Context
 		gatewayStr     string
-		virtualService *networkingv1alpha3.VirtualService
+		virtualService *networkingv1beta1.VirtualService
 	}
 	tests := []struct {
 		name           string
 		fields         fields
 		args           args
-		want           *networkingv1alpha3.Gateway
+		want           *networkingv1beta1.Gateway
 		expectedErrStr string
 	}{
 		{name: "EmptyGateway", fields: fields{
@@ -2155,7 +2155,7 @@ func TestVirtualServiceSourceGetGateway(t *testing.T) {
 		}, args: args{
 			ctx:        context.TODO(),
 			gatewayStr: "doesnt/exist",
-			virtualService: &networkingv1alpha3.VirtualService{
+			virtualService: &networkingv1beta1.VirtualService{
 				TypeMeta:   metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{Name: "exist", Namespace: "doesnt"},
 				Spec:       istionetworking.VirtualService{},
@@ -2167,7 +2167,7 @@ func TestVirtualServiceSourceGetGateway(t *testing.T) {
 		}, args: args{
 			ctx:            context.TODO(),
 			gatewayStr:     "1/2/3/",
-			virtualService: &networkingv1alpha3.VirtualService{},
+			virtualService: &networkingv1beta1.VirtualService{},
 		}, want: nil, expectedErrStr: "invalid gateway name (name or namespace/name) found '1/2/3/'"},
 		{name: "ExistingGateway", fields: fields{
 			virtualServiceSource: func() *virtualServiceSource {
@@ -2180,13 +2180,13 @@ func TestVirtualServiceSourceGetGateway(t *testing.T) {
 		}, args: args{
 			ctx:        context.TODO(),
 			gatewayStr: "bar/foo",
-			virtualService: &networkingv1alpha3.VirtualService{
+			virtualService: &networkingv1beta1.VirtualService{
 				TypeMeta:   metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
 				Spec:       istionetworking.VirtualService{},
 				Status:     v1alpha1.IstioStatus{},
 			},
-		}, want: &networkingv1alpha3.Gateway{
+		}, want: &networkingv1beta1.Gateway{
 			TypeMeta:   metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
 			Spec:       istionetworking.Gateway{},


### PR DESCRIPTION
## What does it do ?

- Added support for currently supported version 1.22 - 1.25, 1.26 https://istio.io/latest/docs/releases/supported-releases/
- fixed `istio.md` with pre-commit-hook

> Note; tested with 1.22 and 1.25 versions. Works without issues

Currently supported version is 1.25, as 1.22 end of life is Jan 22, 2025 

Stored versions
```sh
# istio 1.22
❯❯ kubectl get crd virtualservices.networking.istio.io -ojsonpath='{.status.storedVersions}'
["v1beta1"]%

❯❯ kubectl get crd gateways.networking.istio.io -ojsonpath='{.status.storedVersions}'
["v1beta1"]%

# istio 1.26
❯❯ kubectl get crd virtualservices.networking.istio.io -ojsonpath='{.status.storedVersions}'
["v1beta1"]%

❯❯ kubectl get crd gateways.networking.istio.io -ojsonpath='{.status.storedVersions}'
["v1beta1"]%
```

It is safe to use`v1`, but I think we should support `v1beta` while `v1beta` is current storage version

![Screenshot 2025-07-04 at 12 14 23](https://github.com/user-attachments/assets/086ccb44-0b2d-43d0-805f-4b57928e89bd)

## Motivation

Fixes: #4473, #2798

Follow-up:
- `istio-virtualservice` in some occasions incorrectly identify RecordType `cname` instead of `a` record
- improve performance https://github.com/kubernetes-sigs/external-dns/pull/5547

## More

- [X] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Yes, I added unit tests
- [X] Yes, I updated end user documentation accordingly

## Smoke test for `kind: Gateway`

Arguments

```sh
go run main.go \
    --provider=aws \
    --registry=txt \
    --source=service \
    --log-level=info \
    --source=istio-gateway \
    --policy=sync \
    --fqdn-template="{{ .Kind | toLower }}-{{ .APIVersion | replace \"networking.istio.io/\" \"\"}}-{{.Name}}.local.tld" \
    --combine-fqdn-annotation \
    --domain-filter=local.tld
```

```yml
# https://istio.io/latest/docs/reference/config/networking/gateway/
apiVersion: networking.istio.io/v1alpha3
kind: Gateway
metadata:
  name: httpbin-gateway
  namespace: extdns-istio
  annotations:
    external-dns.alpha.kubernetes.io/target : 10.172.1.12
spec:
  selector:
    istio: ingressgateway
  servers:
  - port:
      number: 80
      name: http
      protocol: HTTP
    hosts:
    - "httpbin.local.ltd"
```

Create
![Screenshot 2025-07-04 at 10 49 43](https://github.com/user-attachments/assets/3641d9c6-5367-4549-bccb-b5560ba565b6)

![Screenshot 2025-07-04 at 10 39 18](https://github.com/user-attachments/assets/4e2d7871-112d-47aa-b681-e32bfbace2b2)

Delete

![Screenshot 2025-07-04 at 10 43 03](https://github.com/user-attachments/assets/4a9e47f7-fc15-42f4-9af6-6ce46c509517)

### Virtual Service

```sh
go run main.go \
    --provider=aws \
    --interval=30s \
    --registry=txt \
    --log-level=info \
    --source=istio-virtualservice \
    --policy=sync
```

Manifest files

```yml
---
# https://istio.io/latest/docs/reference/config/networking/gateway/
apiVersion: networking.istio.io/v1alpha3
kind: Gateway
metadata:
  name: httpbin-gateway
  namespace: extdns-istio
  annotations:
    external-dns.alpha.kubernetes.io/target : 10.172.1.256
spec:
  selector:
    istio: ingressgateway
  servers:
  - port:
      number: 80
      name: http
      protocol: HTTP
    hosts:
    - "httpbin-test.local.tld"
---
# https://istio.io/latest/docs/reference/config/networking/virtual-service/
# Configure routes for traffic entering via the Gateway
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: httpbin-vservice
  namespace: extdns-istio
spec:
  hosts:
  - "httpbin-test.local.tld"
  gateways:
  - extdns-istio/httpbin-gateway
  http:
  - match:
    - uri:
        prefix: /status
    - uri:
        prefix: /delay
    route:
    - destination:
        port:
          number: 8000
        host: httpbin
```

Create
![Screenshot 2025-07-04 at 12 03 08](https://github.com/user-attachments/assets/9197213d-919d-4906-8357-5db60b672717)

![Screenshot 2025-07-04 at 12 03 43](https://github.com/user-attachments/assets/75037b31-f5ac-405e-841c-e721e124850a)

Delete

![Screenshot 2025-07-04 at 12 07 18](https://github.com/user-attachments/assets/8bd94a94-8574-4f54-af55-d262f4132947)

![Screenshot 2025-07-04 at 12 07 29](https://github.com/user-attachments/assets/4ec17fe4-bef3-4c4b-8362-0f487b367289)
