### PR TITLE
fix(source/service): disable node informer when not required

### DIFF
--- a/source/informers/handlers.go
+++ b/source/informers/handlers.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informers
+
+import (
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/cache"
+)
+
+func DefaultEventHandler(handlers ...func()) cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			if u, ok := obj.(*unstructured.Unstructured); ok {
+				log.WithFields(log.Fields{
+					"apiVersion": u.GetAPIVersion(),
+					"kind":       u.GetKind(),
+					"namespace":  u.GetNamespace(),
+					"name":       u.GetName(),
+				}).Debug("added")
+				for _, handler := range handlers {
+					handler()
+				}
+			}
+		},
+	}
+}

--- a/source/informers/handlers_test.go
+++ b/source/informers/handlers_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informers
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestDefaultEventHandler_AddFunc(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      any
+		expected bool
+	}{
+		{
+			name:     "calls handler for unstructured object",
+			obj:      &unstructured.Unstructured{},
+			expected: true,
+		},
+		{
+			name:     "does not call handler for unknown object",
+			obj:      "not-unstructured",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			handler := DefaultEventHandler(func() { called = true })
+			handler.OnAdd(tt.obj, true)
+			if called != tt.expected {
+				t.Errorf("handler called = %v, want %v", called, tt.expected)
+			}
+		})
+	}
+}

--- a/source/service.go
+++ b/source/service.go
@@ -853,9 +853,6 @@ func (sc *serviceTypes) isNodeInformerRequired() bool {
 	if _, ok := sc.types[v1.ServiceTypeNodePort]; !ok {
 		return true
 	}
-	if _, ok := sc.types[v1.ServiceTypeNodePort]; !ok && sc.enabled {
-		return false
-	}
 	return false
 }
 

--- a/source/service.go
+++ b/source/service.go
@@ -850,10 +850,11 @@ func (sc *serviceTypes) isProcessed(serviceType v1.ServiceType) bool {
 }
 
 func (sc *serviceTypes) isNodeInformerRequired() bool {
-	if _, ok := sc.types[v1.ServiceTypeNodePort]; !ok {
+	if !sc.enabled {
 		return true
 	}
-	return false
+	_, ok := sc.types[v1.ServiceTypeNodePort]
+	return ok
 }
 
 // conditionToBool converts an EndpointConditions condition to a bool value.

--- a/source/service.go
+++ b/source/service.go
@@ -99,33 +99,38 @@ func NewServiceSource(ctx context.Context, kubeClient kubernetes.Interface, name
 	serviceInformer := informerFactory.Core().V1().Services()
 	endpointSlicesInformer := informerFactory.Discovery().V1().EndpointSlices()
 	podInformer := informerFactory.Core().V1().Pods()
-	nodeInformer := informerFactory.Core().V1().Nodes()
 
 	// Add default resource event handlers to properly initialize informer.
-	serviceInformer.Informer().AddEventHandler(
+	_, _ = serviceInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 			},
 		},
 	)
-	endpointSlicesInformer.Informer().AddEventHandler(
+	_, _ = endpointSlicesInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 			},
 		},
 	)
-	podInformer.Informer().AddEventHandler(
+	_, _ = podInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 			},
 		},
 	)
-	nodeInformer.Informer().AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-			},
-		},
-	)
+
+	// Transform the slice into a map so it will be way much easier and fast to filter later
+	sTypesFilter, err := newServiceTypesFilter(serviceTypeFilter)
+	if err != nil {
+		return nil, err
+	}
+
+	var nodeInformer coreinformers.NodeInformer
+	if sTypesFilter.isNodeInformerRequired() {
+		nodeInformer = informerFactory.Core().V1().Nodes()
+		_, _ = nodeInformer.Informer().AddEventHandler(informers.DefaultEventHandler())
+	}
 
 	// Add an indexer to the EndpointSlice informer to index by the service name label
 	err = endpointSlicesInformer.Informer().AddIndexers(cache.Indexers{
@@ -151,12 +156,6 @@ func NewServiceSource(ctx context.Context, kubeClient kubernetes.Interface, name
 
 	// wait for the local cache to be populated.
 	if err := informers.WaitForCacheSync(context.Background(), informerFactory); err != nil {
-		return nil, err
-	}
-
-	// Transform the slice into a map so it will be way much easier and fast to filter later
-	sTypesFilter, err := newServiceTypesFilter(serviceTypeFilter)
-	if err != nil {
 		return nil, err
 	}
 
@@ -198,7 +197,7 @@ func (sc *serviceSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, err
 		return nil, err
 	}
 
-	endpoints := []*endpoint.Endpoint{}
+	endpoints := make([]*endpoint.Endpoint, 0)
 
 	for _, svc := range services {
 		// Check controller annotation to see if we are responsible.
@@ -293,11 +292,7 @@ func (sc *serviceSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, err
 func (sc *serviceSource) extractHeadlessEndpoints(svc *v1.Service, hostname string, ttl endpoint.TTL) []*endpoint.Endpoint {
 	var endpoints []*endpoint.Endpoint
 
-	labelSelector, err := metav1.ParseToLabelSelector(labels.Set(svc.Spec.Selector).AsSelectorPreValidated().String())
-	if err != nil {
-		return nil
-	}
-	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	selector, err := annotations.ParseFilter(labels.Set(svc.Spec.Selector).AsSelectorPreValidated().String())
 	if err != nil {
 		return nil
 	}
@@ -371,6 +366,10 @@ func (sc *serviceSource) extractHeadlessEndpoints(svc *v1.Service, hostname stri
 				targets := annotations.TargetsFromTargetAnnotation(pod.Annotations)
 				if len(targets) == 0 {
 					if endpointsType == EndpointsTypeNodeExternalIP {
+						if sc.nodeInformer == nil {
+							log.Warnf("Skipping EndpointSlice %s/%s as --service-type-filter disable node informer", endpointSlice.Namespace, endpointSlice.Name)
+							continue
+						}
 						node, err := sc.nodeInformer.Lister().Get(pod.Spec.NodeName)
 						if err != nil {
 							log.Errorf("Get node[%s] of pod[%s] error: %v; not adding any NodeExternalIP endpoints", pod.Spec.NodeName, pod.GetName(), err)
@@ -466,7 +465,8 @@ func (sc *serviceSource) endpointsFromTemplate(svc *v1.Service) ([]*endpoint.End
 // endpointsFromService extracts the endpoints from a service object
 func (sc *serviceSource) endpoints(svc *v1.Service) []*endpoint.Endpoint {
 	var endpoints []*endpoint.Endpoint
-	// Skip endpoints if we do not want entries from annotations
+
+	// Skip endpoints if we do not want entries from annotations or service is excluded
 	if sc.ignoreHostnameAnnotation {
 		return endpoints
 	}
@@ -519,7 +519,7 @@ func (sc *serviceSource) filterByServiceType(services []*v1.Service) []*v1.Servi
 	}
 	var result []*v1.Service
 	for _, service := range services {
-		if _, ok := sc.serviceTypeFilter.types[service.Spec.Type]; ok {
+		if sc.serviceTypeFilter.isProcessed(service.Spec.Type) {
 			result = append(result, service)
 		}
 	}
@@ -808,9 +808,12 @@ func (sc *serviceSource) AddEventHandler(_ context.Context, handler func()) {
 
 	// Right now there is no way to remove event handler from informer, see:
 	// https://github.com/kubernetes/kubernetes/issues/79610
-	sc.serviceInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
+	_, _ = sc.serviceInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
 	if sc.listenEndpointEvents {
-		sc.endpointSlicesInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
+		_, _ = sc.endpointSlicesInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
+	}
+	if sc.serviceTypeFilter.isNodeInformerRequired() {
+		_, _ = sc.nodeInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
 	}
 }
 
@@ -828,18 +831,32 @@ func newServiceTypesFilter(filter []string) (*serviceTypes, error) {
 			enabled: false,
 		}, nil
 	}
-	types := make(map[v1.ServiceType]bool)
+	result := make(map[v1.ServiceType]bool)
 	for _, serviceType := range filter {
 		if _, ok := knownServiceTypes[v1.ServiceType(serviceType)]; !ok {
 			return nil, fmt.Errorf("unsupported service type filter: %q. Supported types are: %q", serviceType, slices.Collect(maps.Keys(knownServiceTypes)))
 		}
-		types[v1.ServiceType(serviceType)] = true
+		result[v1.ServiceType(serviceType)] = true
 	}
 
 	return &serviceTypes{
 		enabled: true,
-		types:   types,
+		types:   result,
 	}, nil
+}
+
+func (sc *serviceTypes) isProcessed(serviceType v1.ServiceType) bool {
+	return !sc.enabled || sc.types[serviceType]
+}
+
+func (sc *serviceTypes) isNodeInformerRequired() bool {
+	if _, ok := sc.types[v1.ServiceTypeNodePort]; !ok {
+		return true
+	}
+	if _, ok := sc.types[v1.ServiceTypeNodePort]; !ok && sc.enabled {
+		return false
+	}
+	return false
 }
 
 // conditionToBool converts an EndpointConditions condition to a bool value.

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -301,6 +301,18 @@ func testServiceSourceEndpoints(t *testing.T) {
 			},
 		},
 		{
+			title:              "with excluded service type should not generate endpoints",
+			svcNamespace:       "testing",
+			svcName:            "foo",
+			svcType:            v1.ServiceTypeLoadBalancer,
+			fqdnTemplate:       "{{.Name}}.fqdn.org,{{.Name}}.fqdn.com",
+			labels:             map[string]string{},
+			annotations:        map[string]string{},
+			lbs:                []string{"1.2.3.4"},
+			serviceTypesFilter: []string{string(v1.ServiceTypeNodePort)},
+			expected:           []*endpoint.Endpoint{},
+		},
+		{
 			title:                    "FQDN template with multiple hostnames return an endpoint with target IP when ignoring annotations",
 			svcNamespace:             "testing",
 			svcName:                  "foo",
@@ -455,7 +467,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			},
 			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
-			serviceTypesFilter: []string{},
+			serviceTypesFilter: []string{string(v1.ServiceTypeLoadBalancer), string(v1.ServiceTypeNodePort)},
 			expected: []*endpoint.Endpoint{
 				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
 			},
@@ -920,7 +932,6 @@ func testServiceSourceEndpoints(t *testing.T) {
 			annotations: map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
-			externalIPs:        []string{},
 			lbs:                []string{"1.2.3.4"},
 			serviceTypesFilter: []string{string(v1.ServiceTypeLoadBalancer)},
 			expected:           []*endpoint.Endpoint{},
@@ -3675,6 +3686,7 @@ func TestExternalServices(t *testing.T) {
 		annotations              map[string]string
 		externalName             string
 		externalIPs              []string
+		serviceTypeFilter        []string
 		expected                 []*endpoint.Endpoint
 		expectError              bool
 	}{
@@ -3692,6 +3704,7 @@ func TestExternalServices(t *testing.T) {
 				hostnameAnnotationKey: "service.example.org",
 			},
 			"111.111.111.111",
+			[]string{},
 			[]string{},
 			[]*endpoint.Endpoint{
 				{DNSName: "service.example.org", Targets: endpoint.Targets{"111.111.111.111"}, RecordType: endpoint.RecordTypeA},
@@ -3713,6 +3726,7 @@ func TestExternalServices(t *testing.T) {
 			},
 			"2001:db8::111",
 			[]string{},
+			[]string{},
 			[]*endpoint.Endpoint{
 				{DNSName: "service.example.org", Targets: endpoint.Targets{"2001:db8::111"}, RecordType: endpoint.RecordTypeAAAA},
 			},
@@ -3732,6 +3746,7 @@ func TestExternalServices(t *testing.T) {
 				hostnameAnnotationKey: "service.example.org",
 			},
 			"remote.example.com",
+			[]string{},
 			[]string{},
 			[]*endpoint.Endpoint{
 				{DNSName: "service.example.org", Targets: endpoint.Targets{"remote.example.com"}, RecordType: endpoint.RecordTypeCNAME},
@@ -3753,6 +3768,7 @@ func TestExternalServices(t *testing.T) {
 			},
 			"service.example.org",
 			[]string{"10.2.3.4", "11.2.3.4"},
+			[]string{},
 			[]*endpoint.Endpoint{
 				{DNSName: "service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"10.2.3.4", "11.2.3.4"}},
 			},
@@ -3773,10 +3789,30 @@ func TestExternalServices(t *testing.T) {
 			},
 			"service.example.org",
 			[]string{"10.2.3.4", "11.2.3.4", "2001:db8::1", "2001:db8::2"},
+			[]string{string(v1.ServiceTypeNodePort), string(v1.ServiceTypeExternalName)},
 			[]*endpoint.Endpoint{
 				{DNSName: "service.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"10.2.3.4", "11.2.3.4"}},
 				{DNSName: "service.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:db8::1", "2001:db8::2"}},
 			},
+			false,
+		},
+		{
+			"annotated ExternalName service with externalIPs of dualstack and excluded in serviceTypeFilter",
+			"",
+			"testing",
+			"foo",
+			v1.ServiceTypeExternalName,
+			"",
+			"",
+			false,
+			map[string]string{"component": "foo"},
+			map[string]string{
+				hostnameAnnotationKey: "service.example.org",
+			},
+			"service.example.org",
+			[]string{"10.2.3.4", "11.2.3.4", "2001:db8::1", "2001:db8::2"},
+			[]string{string(v1.ServiceTypeNodePort), string(v1.ServiceTypeClusterIP)},
+			[]*endpoint.Endpoint{},
 			false,
 		},
 	} {
@@ -3816,7 +3852,7 @@ func TestExternalServices(t *testing.T) {
 				true,
 				false,
 				false,
-				[]string{},
+				tc.serviceTypeFilter,
 				tc.ignoreHostnameAnnotation,
 				labels.Everything(),
 				false,
@@ -3890,6 +3926,63 @@ func BenchmarkServiceEndpoints(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, err := client.Endpoints(context.Background())
 		require.NoError(b, err)
+	}
+}
+
+func TestNewServiceSourceInformersEnabled(t *testing.T) {
+	tests := []struct {
+		name      string
+		asserts   func(svc *serviceSource)
+		svcFilter []string
+	}{
+		{
+			name: "serviceTypeFilter is set to empty",
+			asserts: func(svc *serviceSource) {
+				assert.NotNil(t, svc)
+				assert.NotNil(t, svc.serviceTypeFilter)
+				assert.False(t, svc.serviceTypeFilter.enabled)
+				assert.NotNil(t, svc.nodeInformer)
+			},
+		},
+		{
+			name:      "serviceTypeFilter contains NodePort",
+			svcFilter: []string{string(v1.ServiceTypeNodePort)},
+			asserts: func(svc *serviceSource) {
+				assert.NotNil(t, svc)
+				assert.NotNil(t, svc.serviceTypeFilter)
+				assert.True(t, svc.serviceTypeFilter.enabled)
+				assert.Nil(t, svc.nodeInformer)
+			},
+		},
+	}
+
+	for _, ts := range tests {
+		t.Run(ts.name, func(t *testing.T) {
+			svc, err := NewServiceSource(
+				t.Context(),
+				fake.NewClientset(),
+				"default",
+				"",
+				"",
+				false,
+				"",
+				true,
+				false,
+				false,
+				ts.svcFilter,
+				false,
+				labels.Everything(),
+				false,
+				false,
+				false,
+			)
+			require.NoError(t, err)
+			svcSrc, ok := svc.(*serviceSource)
+			if !ok {
+				require.Fail(t, "expected serviceSource")
+			}
+			ts.asserts(svcSrc)
+		})
 	}
 }
 
@@ -4145,4 +4238,50 @@ func createTestServicesByType(namespace string, typeCounts map[v1.ServiceType]in
 		services[i], services[j] = services[j], services[i]
 	})
 	return services
+}
+
+func TestServiceTypes_isNodeInformerRequired(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter *serviceTypes
+		want   bool
+	}{
+		{
+			name: "NodePort type present",
+			filter: &serviceTypes{
+				enabled: true,
+				types: map[v1.ServiceType]bool{
+					v1.ServiceTypeNodePort: true,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "NodePort type absent, filter enabled",
+			filter: &serviceTypes{
+				enabled: true,
+				types: map[v1.ServiceType]bool{
+					v1.ServiceTypeClusterIP: true,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "NodePort type absent, filter disabled",
+			filter: &serviceTypes{
+				enabled: false,
+				types:   map[v1.ServiceType]bool{},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.filter.isNodeInformerRequired()
+			if got != tt.want {
+				t.Errorf("isNodeInformerRequired() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## What does it do ?

- when `--service-type-filter` is configured, disable node informer when not required

`nodeInformer` used in 2 places

- `v1.ServiceTypeNodePort` (could be safely disabled)
   - extractNodePortTargets
    - nodesExternalTrafficPolicyTypeLocal
- `V1. ServiceTypeClusterIP`  -> added null check, and warning message, so that if informer is disabled but should be enabled
   - extractHeadlessEndpoints

## Motivation

Fixes #3169

Follow-up:
- we could exclude certain services from caching/indexing when `--service-type-filter` is specified. This should increase performance and reduce number of API calls and etc.
- disable pod informer when LoadBalancer is set https://github.com/kubernetes-sigs/external-dns/issues/4955 and https://github.com/kubernetes-sigs/external-dns/issues/3173 and https://github.com/kubernetes-sigs/external-dns/issues/3169#issuecomment-2545205472
- add Node Transformer as in this PR https://github.com/kubernetes-sigs/external-dns/pull/5596

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
