### PR TITLE
fix(source/service): make sure only unique targets available for futher processing

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -19,6 +19,7 @@ package endpoint
 import (
 	"fmt"
 	"net/netip"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -353,7 +354,21 @@ func (e *Endpoint) String() string {
 	return fmt.Sprintf("%s %d IN %s %s %s %s", e.DNSName, e.RecordTTL, e.RecordType, e.SetIdentifier, e.Targets, e.ProviderSpecific)
 }
 
-// Apply filter to slice of endpoints and return new filtered slice that includes
+// UniqueOrderedTargets removes duplicate targets from the Endpoint and sorts them in lexicographical order.
+func (e *Endpoint) UniqueOrderedTargets() {
+	result := make([]string, 0, len(e.Targets))
+	existing := make(map[string]bool)
+	for _, target := range e.Targets {
+		if _, ok := existing[target]; !ok {
+			result = append(result, target)
+			existing[target] = true
+		}
+	}
+	slices.Sort(result)
+	e.Targets = result
+}
+
+// FilterEndpointsByOwnerID Apply filter to slice of endpoints and return new filtered slice that includes
 // only endpoints that match.
 func FilterEndpointsByOwnerID(ownerID string, eps []*Endpoint) []*Endpoint {
 	filtered := []*Endpoint{}

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -925,3 +925,46 @@ func TestCheckEndpoint(t *testing.T) {
 		})
 	}
 }
+
+func TestEndpoint_UniqueOrderedTargets(t *testing.T) {
+	tests := []struct {
+		name     string
+		targets  []string
+		expected Targets
+		want     bool
+	}{
+		{
+			name:     "no duplicates",
+			targets:  []string{"b.example.com", "a.example.com"},
+			expected: Targets{"a.example.com", "b.example.com"},
+		},
+		{
+			name:     "with duplicates",
+			targets:  []string{"a.example.com", "b.example.com", "a.example.com"},
+			expected: Targets{"a.example.com", "b.example.com"},
+		},
+		{
+			name:     "already sorted",
+			targets:  []string{"a.example.com", "b.example.com"},
+			expected: Targets{"a.example.com", "b.example.com"},
+		},
+		{
+			name:     "all duplicates",
+			targets:  []string{"a.example.com", "a.example.com", "a.example.com"},
+			expected: Targets{"a.example.com"},
+		},
+		{
+			name:     "empty",
+			targets:  []string{},
+			expected: Targets{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := &Endpoint{Targets: tt.targets}
+			ep.UniqueOrderedTargets()
+			assert.Equal(t, tt.expected, ep.Targets)
+		})
+	}
+}

--- a/source/service.go
+++ b/source/service.go
@@ -252,6 +252,29 @@ func (sc *serviceSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, err
 		sort.Slice(endpoints, func(i, j int) bool {
 			return endpoints[i].Labels[endpoint.ResourceLabelKey] < endpoints[j].Labels[endpoint.ResourceLabelKey]
 		})
+		mergedEndpoints := make(map[endpoint.EndpointKey][]*endpoint.Endpoint)
+		for _, ep := range endpoints {
+			key := ep.Key()
+			if existing, ok := mergedEndpoints[key]; ok {
+				if existing[0].RecordType == endpoint.RecordTypeCNAME {
+					log.Debugf("CNAME %s with multiple targets found", ep.DNSName)
+					mergedEndpoints[key] = append(existing, ep)
+					continue
+				}
+				existing[0].Targets = append(existing[0].Targets, ep.Targets...)
+				existing[0].UniqueOrderedTargets()
+				mergedEndpoints[key] = existing
+			} else {
+				ep.UniqueOrderedTargets()
+				mergedEndpoints[key] = []*endpoint.Endpoint{ep}
+			}
+		}
+		processed := make([]*endpoint.Endpoint, 0, len(mergedEndpoints))
+		for _, ep := range mergedEndpoints {
+			processed = append(processed, ep...)
+		}
+		endpoints = processed
+
 		// Use stable sort to not disrupt the order of services
 		sort.SliceStable(endpoints, func(i, j int) bool {
 			if endpoints[i].DNSName != endpoints[j].DNSName {
@@ -259,31 +282,6 @@ func (sc *serviceSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, err
 			}
 			return endpoints[i].RecordType < endpoints[j].RecordType
 		})
-		mergedEndpoints := []*endpoint.Endpoint{}
-		mergedEndpoints = append(mergedEndpoints, endpoints[0])
-		for i := 1; i < len(endpoints); i++ {
-			lastMergedEndpoint := len(mergedEndpoints) - 1
-			if mergedEndpoints[lastMergedEndpoint].DNSName == endpoints[i].DNSName &&
-				mergedEndpoints[lastMergedEndpoint].RecordType == endpoints[i].RecordType &&
-				mergedEndpoints[lastMergedEndpoint].RecordType != endpoint.RecordTypeCNAME && // It is against RFC-1034 for CNAME records to have multiple targets, so skip merging
-				mergedEndpoints[lastMergedEndpoint].SetIdentifier == endpoints[i].SetIdentifier &&
-				mergedEndpoints[lastMergedEndpoint].RecordTTL == endpoints[i].RecordTTL {
-				mergedEndpoints[lastMergedEndpoint].Targets = append(mergedEndpoints[lastMergedEndpoint].Targets, endpoints[i].Targets[0])
-			} else {
-				mergedEndpoints = append(mergedEndpoints, endpoints[i])
-			}
-
-			if mergedEndpoints[lastMergedEndpoint].DNSName == endpoints[i].DNSName &&
-				mergedEndpoints[lastMergedEndpoint].RecordType == endpoints[i].RecordType &&
-				mergedEndpoints[lastMergedEndpoint].RecordType == endpoint.RecordTypeCNAME {
-				log.Debugf("CNAME %s with multiple targets found", endpoints[i].DNSName)
-			}
-		}
-		endpoints = mergedEndpoints
-	}
-
-	for _, ep := range endpoints {
-		sort.Sort(ep.Targets)
 	}
 
 	return endpoints, nil


### PR DESCRIPTION
## What does it do ?

- Only unique targets pushed to registry for headless services 

## Motivation

Partially address #4282

follow-up:
- review FQDN behaviour https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/hostport.md#headless-service, as docs do not looks right to me
- resolve `root domain records` processing. Find an initial PR, address it or document the behavior

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

fixtures used in testing
```yml
---
apiVersion: v1
kind: Service
metadata:
  name: kafka
  namespace: default
  labels:
    app: kafka
  annotations:
    external-dns.alpha.kubernetes.io/hostname:  example.org
spec:
  ports:
  - port: 80
    name: web
  clusterIP: None
  selector:
    app: kafka
---
apiVersion: v1
kind: Service
metadata:
  name: kafka-2
  namespace: default
  labels:
    app: kafka
  annotations:
    external-dns.alpha.kubernetes.io/hostname:  example.org
spec:
  ports:
  - port: 80
    name: web
  clusterIP: None
  selector:
    app: kafka
---
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: kafka
  namespace: default
spec:
  serviceName: "kafka"
  replicas: 3
  selector:
    matchLabels:
      app: kafka
  template:
    metadata:
      labels:
        app: kafka
    spec:
      containers:
      - name: nginx
        image: registry.k8s.io/nginx-slim:0.27
        ports:
        - containerPort: 80
          name: web
```

smoke test before


![Screenshot 2025-07-05 at 00 28 48](https://github.com/user-attachments/assets/08569710-1f9f-4f39-acd5-a5dab09e0e70)


```json
{
  "ResourceRecordSets": [
    {
      "Name": "example.org.",
      "Type": "A",
      "TTL": 300,
      "ResourceRecords": [
        {
          "Value": "10.244.1.3"
        },
        {
          "Value": "10.244.1.4"
        },
        {
          "Value": "10.244.1.5"
        }
      ]
    },
    {
      "Name": "example.org.",
      "Type": "NS",
      "TTL": 172800,
      "ResourceRecords": [
        {
          "Value": "ns-2048.awsdns-64.com"
        },
        {
          "Value": "ns-2049.awsdns-65.net"
        },
        {
          "Value": "ns-2050.awsdns-66.org"
        },
        {
          "Value": "ns-2051.awsdns-67.co.uk"
        }
      ]
    },
    {
      "Name": "example.org.",
      "Type": "SOA",
      "TTL": 900,
      "ResourceRecords": [
        {
          "Value": "{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"
        }
      ]
    },
    {
      "Name": "a-kafka-0.example.org.",
      "Type": "TXT",
      "TTL": 300,
      "ResourceRecords": [
        {
          "Value": "\"heritage=external-dns,external-dns/owner=default,external-dns/resource=service/default/kafka\""
        }
      ]
    },
    {
      "Name": "a-kafka-1.example.org.",
      "Type": "TXT",
      "TTL": 300,
      "ResourceRecords": [
        {
          "Value": "\"heritage=external-dns,external-dns/owner=default,external-dns/resource=service/default/kafka\""
        }
      ]
    },
    {
      "Name": "a-kafka-2.example.org.",
      "Type": "TXT",
      "TTL": 300,
      "ResourceRecords": [
        {
          "Value": "\"heritage=external-dns,external-dns/owner=default,external-dns/resource=service/default/kafka\""
        }
      ]
    },
    {
      "Name": "kafka-0.example.org.",
      "Type": "A",
      "TTL": 300,
      "ResourceRecords": [
        {
          "Value": "10.244.1.3"
        },
        {
          "Value": "10.244.1.3"
        }
      ]
    },
    {
      "Name": "kafka-1.example.org.",
      "Type": "A",
      "TTL": 300,
      "ResourceRecords": [
        {
          "Value": "10.244.1.4"
        },
        {
          "Value": "10.244.1.4"
        }
      ]
    },
    {
      "Name": "kafka-2.example.org.",
      "Type": "A",
      "TTL": 300,
      "ResourceRecords": [
        {
          "Value": "10.244.1.5"
        },
        {
          "Value": "10.244.1.5"
        }
      ]
    }
  ]
}
```


smoke test after

```json
{
  "ResourceRecordSets": [
    {
      "Name": "example.org.",
      "Type": "A",
      "TTL": 300,
      "ResourceRecords": [
        {
          "Value": "10.244.1.3"
        },
        {
          "Value": "10.244.1.4"
        },
        {
          "Value": "10.244.1.5"
        }
      ]
    },
    {
      "Name": "example.org.",
      "Type": "NS",
      "TTL": 172800,
      "ResourceRecords": [
        {
          "Value": "ns-2048.awsdns-64.com"
        },
        {
          "Value": "ns-2049.awsdns-65.net"
        },
        {
          "Value": "ns-2050.awsdns-66.org"
        },
        {
          "Value": "ns-2051.awsdns-67.co.uk"
        }
      ]
    },
    {
      "Name": "example.org.",
      "Type": "SOA",
      "TTL": 900,
      "ResourceRecords": [
        {
          "Value": "{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"
        }
      ]
    },
    {
      "Name": "a-kafka-0.example.org.",
      "Type": "TXT",
      "TTL": 300,
      "ResourceRecords": [
        {
          "Value": "\"heritage=external-dns,external-dns/owner=default,external-dns/resource=service/default/kafka\""
        }
      ]
    },
    {
      "Name": "a-kafka-1.example.org.",
      "Type": "TXT",
      "TTL": 300,
      "ResourceRecords": [
        {
          "Value": "\"heritage=external-dns,external-dns/owner=default,external-dns/resource=service/default/kafka\""
        }
      ]
    },
    {
      "Name": "a-kafka-2.example.org.",
      "Type": "TXT",
      "TTL": 300,
      "ResourceRecords": [
        {
          "Value": "\"heritage=external-dns,external-dns/owner=default,external-dns/resource=service/default/kafka\""
        }
      ]
    },
    {
      "Name": "kafka-0.example.org.",
      "Type": "A",
      "TTL": 300,
      "ResourceRecords": [
        {
          "Value": "10.244.1.3"
        }
      ]
    },
    {
      "Name": "kafka-1.example.org.",
      "Type": "A",
      "TTL": 300,
      "ResourceRecords": [
        {
          "Value": "10.244.1.4"
        }
      ]
    },
    {
      "Name": "kafka-2.example.org.",
      "Type": "A",
      "TTL": 300,
      "ResourceRecords": [
        {
          "Value": "10.244.1.5"
        }
      ]
    }
  ]
}
```

The idea is to address root domain record in follow-up

![Screenshot 2025-07-05 at 00 39 28](https://github.com/user-attachments/assets/e7c3dc11-2c45-4af4-9633-30f119cad783)

