### PR TITLE
refactor(provider/cloudflare): use local regionalHostname struct

### DIFF
--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -220,7 +220,7 @@ type CloudFlareProvider struct {
 type cloudFlareChange struct {
 	Action              changeAction
 	ResourceRecord      cloudflare.DNSRecord
-	RegionalHostname    cloudflare.RegionalHostname
+	RegionalHostname    regionalHostname
 	CustomHostnames     map[string]cloudflare.CustomHostname
 	CustomHostnamesPrev []string
 }

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -48,7 +48,7 @@ type MockAction struct {
 	ZoneId           string
 	RecordId         string
 	RecordData       cloudflare.DNSRecord
-	RegionalHostname cloudflare.RegionalHostname
+	RegionalHostname regionalHostname
 }
 
 type mockCloudFlareClient struct {
@@ -60,7 +60,7 @@ type mockCloudFlareClient struct {
 	listZonesContextError error
 	dnsRecordsError       error
 	customHostnames       map[string][]cloudflare.CustomHostname
-	regionalHostnames     map[string][]cloudflare.RegionalHostname
+	regionalHostnames     map[string][]regionalHostname
 }
 
 var ExampleDomain = []cloudflare.DNSRecord{
@@ -102,7 +102,7 @@ func NewMockCloudFlareClient() *mockCloudFlareClient {
 			"002": {},
 		},
 		customHostnames:   map[string][]cloudflare.CustomHostname{},
-		regionalHostnames: map[string][]cloudflare.RegionalHostname{},
+		regionalHostnames: map[string][]regionalHostname{},
 	}
 }
 
@@ -1795,8 +1795,8 @@ func TestCloudFlareProvider_newCloudFlareChange(t *testing.T) {
 	}
 
 	change, _ := p.newCloudFlareChange(cloudFlareCreate, ep, ep.Targets[0], nil)
-	if change.RegionalHostname.RegionKey != "us" {
-		t.Errorf("expected region key to be 'us', but got '%s'", change.RegionalHostname.RegionKey)
+	if change.RegionalHostname.regionKey != "us" {
+		t.Errorf("expected region key to be 'us', but got '%s'", change.RegionalHostname.regionKey)
 	}
 
 	var freeValidCommentBuilder strings.Builder
@@ -1949,8 +1949,8 @@ func TestCloudFlareProvider_submitChangesCNAME(t *testing.T) {
 				ID:      "1234567890",
 				Content: "my-tunnel-guid-here.cfargotunnel.com",
 			},
-			RegionalHostname: cloudflare.RegionalHostname{
-				Hostname: "my-domain-here.app",
+			RegionalHostname: regionalHostname{
+				hostname: "my-domain-here.app",
 			},
 		},
 		{
@@ -1961,9 +1961,9 @@ func TestCloudFlareProvider_submitChangesCNAME(t *testing.T) {
 				ID:      "9876543210",
 				Content: "heritage=external-dns,external-dns/owner=default,external-dns/resource=service/external-dns/my-domain-here-app",
 			},
-			RegionalHostname: cloudflare.RegionalHostname{
-				Hostname:  "my-domain-here.app",
-				RegionKey: "",
+			RegionalHostname: regionalHostname{
+				hostname:  "my-domain-here.app",
+				regionKey: "",
 			},
 		},
 	}
@@ -2012,8 +2012,8 @@ func TestCloudFlareProvider_submitChangesApex(t *testing.T) {
 				ID:      "1234567890",
 				Content: "my-tunnel-guid-here.cfargotunnel.com",
 			},
-			RegionalHostname: cloudflare.RegionalHostname{
-				Hostname: "@", // APEX record
+			RegionalHostname: regionalHostname{
+				hostname: "@", // APEX record
 			},
 		},
 		{
@@ -2024,9 +2024,9 @@ func TestCloudFlareProvider_submitChangesApex(t *testing.T) {
 				ID:      "9876543210",
 				Content: "heritage=external-dns,external-dns/owner=default,external-dns/resource=service/external-dns/my-domain-here-app",
 			},
-			RegionalHostname: cloudflare.RegionalHostname{
-				Hostname:  "@", // APEX record
-				RegionKey: "",
+			RegionalHostname: regionalHostname{
+				hostname:  "@", // APEX record
+				regionKey: "",
 			},
 		},
 	}


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->
Use a local regionalHostname stuct instead of the cloudflare.RegionalHostname from the deperecated cloudflare client.

## Motivation

<!-- What inspired you to submit this pull request? -->
This is to prepare for https://github.com/kubernetes-sigs/external-dns/pull/5609 and reduce PR size/complexity.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
