### PR TITLE
docs(aws): add helm repo command to the tutorial

### DIFF
--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -473,7 +473,7 @@ env:
 Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
 
 ```shell
-helm repo add external-dns https://kubernetes-sigs.github.io/external-dns/
+helm repo add --force-update external-dns https://kubernetes-sigs.github.io/external-dns/
 
 helm upgrade --install external-dns external-dns/external-dns --values values.yaml
 ```

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -473,6 +473,8 @@ env:
 Finally, install the ExternalDNS chart with Helm using the configuration specified in your values.yaml file:
 
 ```shell
+helm repo add external-dns https://kubernetes-sigs.github.io/external-dns/
+
 helm upgrade --install external-dns external-dns/external-dns --values values.yaml
 ```
 


### PR DESCRIPTION
## What does it do ?

Added the missing Helm command under the AWS Installation tutorial.

Although the command is mentioned under the "[Chart](https://kubernetes-sigs.github.io/external-dns/latest/charts/external-dns/#installing-the-chart)" section, users who land directly on the AWS Installation page may find it difficult to locate.


## More

- [ ] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly