### PR TITLE
refactor(annotations): use common prefix to simplify filtering in informer transformers

### DIFF
--- a/source/annotations/annotations.go
+++ b/source/annotations/annotations.go
@@ -18,37 +18,41 @@ import (
 )
 
 const (
+	// AnnotationKeyPrefix is set on all annotations consumed by external-dns (outside of user templates)
+	// to provide easy filtering.
+	AnnotationKeyPrefix = "external-dns.alpha.kubernetes.io/"
+
 	// CloudflareProxiedKey The annotation used for determining if traffic will go through Cloudflare
-	CloudflareProxiedKey        = "external-dns.alpha.kubernetes.io/cloudflare-proxied"
-	CloudflareCustomHostnameKey = "external-dns.alpha.kubernetes.io/cloudflare-custom-hostname"
-	CloudflareRegionKey         = "external-dns.alpha.kubernetes.io/cloudflare-region-key"
-	CloudflareRecordCommentKey  = "external-dns.alpha.kubernetes.io/cloudflare-record-comment"
+	CloudflareProxiedKey        = AnnotationKeyPrefix + "cloudflare-proxied"
+	CloudflareCustomHostnameKey = AnnotationKeyPrefix + "cloudflare-custom-hostname"
+	CloudflareRegionKey         = AnnotationKeyPrefix + "cloudflare-region-key"
+	CloudflareRecordCommentKey  = AnnotationKeyPrefix + "cloudflare-record-comment"
 
-	AWSPrefix        = "external-dns.alpha.kubernetes.io/aws-"
-	SCWPrefix        = "external-dns.alpha.kubernetes.io/scw-"
-	WebhookPrefix    = "external-dns.alpha.kubernetes.io/webhook-"
-	CloudflarePrefix = "external-dns.alpha.kubernetes.io/cloudflare-"
+	AWSPrefix        = AnnotationKeyPrefix + "aws-"
+	SCWPrefix        = AnnotationKeyPrefix + "scw-"
+	WebhookPrefix    = AnnotationKeyPrefix + "webhook-"
+	CloudflarePrefix = AnnotationKeyPrefix + "cloudflare-"
 
-	TtlKey     = "external-dns.alpha.kubernetes.io/ttl"
+	TtlKey     = AnnotationKeyPrefix + "ttl"
 	ttlMinimum = 1
 	ttlMaximum = math.MaxInt32
 
-	SetIdentifierKey = "external-dns.alpha.kubernetes.io/set-identifier"
-	AliasKey         = "external-dns.alpha.kubernetes.io/alias"
-	TargetKey        = "external-dns.alpha.kubernetes.io/target"
+	SetIdentifierKey = AnnotationKeyPrefix + "set-identifier"
+	AliasKey         = AnnotationKeyPrefix + "alias"
+	TargetKey        = AnnotationKeyPrefix + "target"
 	// The annotation used for figuring out which controller is responsible
-	ControllerKey = "external-dns.alpha.kubernetes.io/controller"
+	ControllerKey = AnnotationKeyPrefix + "controller"
 	// The annotation used for defining the desired hostname
-	HostnameKey = "external-dns.alpha.kubernetes.io/hostname"
+	HostnameKey = AnnotationKeyPrefix + "hostname"
 	// The annotation used for specifying whether the public or private interface address is used
-	AccessKey = "external-dns.alpha.kubernetes.io/access"
+	AccessKey = AnnotationKeyPrefix + "access"
 	// The annotation used for specifying the type of endpoints to use for headless services
-	EndpointsTypeKey = "external-dns.alpha.kubernetes.io/endpoints-type"
+	EndpointsTypeKey = AnnotationKeyPrefix + "endpoints-type"
 	// The annotation used to determine the source of hostnames for ingresses.  This is an optional field - all
 	// available hostname sources are used if not specified.
-	IngressHostnameSourceKey = "external-dns.alpha.kubernetes.io/ingress-hostname-source"
+	IngressHostnameSourceKey = AnnotationKeyPrefix + "ingress-hostname-source"
 	// The value of the controller annotation so that we feel responsible
 	ControllerValue = "dns-controller"
 	// The annotation used for defining the desired hostname
-	InternalHostnameKey = "external-dns.alpha.kubernetes.io/internal-hostname"
+	InternalHostnameKey = AnnotationKeyPrefix + "internal-hostname"
 )


### PR DESCRIPTION
This PR is extracted from #5595.

## What does it do ?

In order to filter annotations in informer transformers, this PR makes it more explicit that a common prefix is used. New prefixes can be added later-on if need be, but all annotations should be anchored in a known prefix.

## Motivation

This change should avoid addition of annotations mistakenly not matching expected patterns in informers.
There is no change otherwise

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] ~~Yes, I added unit tests~~
- [ ] ~~Yes, I updated end user documentation accordingly~~

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
