### PR TITLE
docs(source/service): headless records and root/base domain

### DIFF
--- a/docs/tutorials/hostport.md
+++ b/docs/tutorials/hostport.md
@@ -169,7 +169,7 @@ Very important here, is to set the `hostPort`(only works if the PodSecurityPolic
 
 Now we need to define a headless service to use to expose the Kafka pods. There are generally two approaches to use expose the nodeport of a Headless service:
 
-1. Add `--fqdn-template={{name}}.example.org`
+1. Add `--fqdn-template={{ .Name }}.example.org`
 2. Use a full annotation
 
 If you go with #1, you just need to define the headless service, here is an example of the case #2:
@@ -190,22 +190,24 @@ spec:
     component: kafka
 ```
 
-This will create 3 dns records:
+This will create 4 dns records:
 
 ```sh
-kafka-0.example.org
-kafka-1.example.org
-kafka-2.example.org
+kafka-0.example.org IP-0
+kafka-1.example.org IP-1
+kafka-2.example.org IP-2
+example.org IP-0,IP-1,IP-2
 ```
 
-If you set `--fqdn-template={{name}}.example.org` you can omit the annotation.
-Generally it is a better approach to use  `--fqdn-template={{name}}.example.org`, because then
-you would get the service name inside the generated A records:
+> !Notice rood domain with records `example.org`
+
+If you set `--fqdn-template={{ .Name }}.example.org` you can omit the annotation.
 
 ```sh
-kafka-0.ksvc.example.org
-kafka-1.ksvc.example.org
-kafka-2.ksvc.example.org
+kafka-0.ksvc.example.org IP-0
+kafka-1.ksvc.example.org IP-1
+kafka-2.ksvc.example.org IP-2
+ksvc.example.org IP-0,IP-1,IP-2
 ```
 
 #### Using pods' HostIPs as targets


### PR DESCRIPTION
## What does it do ?

- Updated documentation for kafka and headless records handling
- Added use cases for `external-dns.alpha.kubernetes.io/hostname` annotations

## Motivation

- Follow-up for PR https://github.com/kubernetes-sigs/external-dns/pull/5614
- Discussion https://github.com/kubernetes-sigs/external-dns/pull/5614#issuecomment-3042800664

Fixes #4282, #2832

I'm unsure if there is a solution. At the moment we could use annotation or FQDN templating. When `host` annotation is used, my understanding the host is set as is, which make sense. It's more a misconfiguration to me on client side. We ofcourse could do a validation, something like `publicsuffix.EffectiveTLDPlusOne(hostname)` or similar, but not clear what the value is.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
