### PR TITLE
chore(codebase): remove pointer to an interface

### DIFF
--- a/source/crd.go
+++ b/source/crd.go
@@ -188,11 +188,9 @@ func (cs *crdSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 
 			illegalTarget := false
 			for _, target := range ep.Targets {
-				if ep.RecordType != endpoint.RecordTypeNAPTR && strings.HasSuffix(target, ".") {
-					illegalTarget = true
-					break
-				}
-				if ep.RecordType == endpoint.RecordTypeNAPTR && !strings.HasSuffix(target, ".") {
+				isNAPTR := ep.RecordType == endpoint.RecordTypeNAPTR
+				hasDot := strings.HasSuffix(target, ".")
+				if (isNAPTR && !hasDot) || (!isNAPTR && hasDot) {
 					illegalTarget = true
 					break
 				}

--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -736,7 +736,7 @@ func helperCreateWatcherWithInformer(t *testing.T) (*cachetesting.FakeController
 	}, time.Second, 10*time.Millisecond)
 
 	cs := &crdSource{
-		informer: &informer,
+		informer: informer,
 	}
 
 	return watcher, *cs


### PR DESCRIPTION
## What does it do ?

- The `*` is not required when `cache.SharedInformer` is an interface. In Go, interfaces are reference types, so we should use `cache.SharedInformer` (not `*cache.SharedInformer`). Using a pointer to an interface is almost always unnecessary and can lead to confusion.
- slightly simplify decision logic

## Motivation

- Relates https://github.com/kubernetes-sigs/external-dns/issues/5243

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
