### PR TITLE
fix(helm): update helm schema to support `create-only` DNS policy

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Fixed the lack of schema support for `create-only` dns policy in helm values.
+
 ### Changed
 
 - Update RBAC for `Service` source to support `EndpointSlices`. ([#5493](https://github.com/kubernetes-sigs/external-dns/pull/5493)) _@vflaux_

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -270,12 +270,13 @@
       }
     },
     "policy": {
-      "description": "How DNS records are synchronized between sources and providers; available values are `sync` \u0026 `upsert-only`.",
+      "description": "How DNS records are synchronized between sources and providers; available values are `create-only`, `sync`, \u0026 `upsert-only`.",
       "default": "upsert-only",
       "type": [
         "string"
       ],
       "enum": [
+        "create-only",
         "sync",
         "upsert-only"
       ]

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -211,7 +211,7 @@ sources:
   - ingress
 
 # -- How DNS records are synchronized between sources and providers; available values are `sync` & `upsert-only`.
-policy: upsert-only  # @schema enum:[sync, upsert-only]; type:string; default: "upsert-only"
+policy: upsert-only  # @schema enum:[create-only, sync, upsert-only]; type:string; default: "upsert-only"
 
 # -- Specify the registry for storing ownership and labels.
 # Valid values are `txt`, `aws-sd`, `dynamodb` & `noop`.


### PR DESCRIPTION
## What does it do ?

Introduce schema support for the `create-only` DNS policy type.
This policy type is supported and works as expected, but fails helm schema validation as it is omitted from the enum.
## Motivation

Allow helm deployments of external-dns to utilize the `create-only` policy without manual fix(es) occurring post helm deploy.
## More

Are unit tests needed for this since the schema is already validating?
If so they can be added, but would be redundant no?

- [X] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [X] Yes, I updated end user documentation accordingly
