### PR TITLE
fix(helm): Update helm value schema to allow `create-only` policy type

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Fixed the lack of schema support for `create-only` dns policy in helm values
+
 ### Changed
 
 - Update RBAC for `Service` source to support `EndpointSlices`. ([#5493](https://github.com/kubernetes-sigs/external-dns/pull/5493)) _@vflaux_

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -270,12 +270,13 @@
       }
     },
     "policy": {
-      "description": "How DNS records are synchronized between sources and providers; available values are `sync` \u0026 `upsert-only`.",
+      "description": "How DNS records are synchronized between sources and providers; available values are `create-only`, `sync`, \u0026 `upsert-only`.",
       "default": "upsert-only",
       "type": [
         "string"
       ],
       "enum": [
+        "create-only",
         "sync",
         "upsert-only"
       ]

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -4,24 +4,24 @@
 
 global:
   # -- Global image pull secrets.
-  imagePullSecrets: []  # @schema item: object
+  imagePullSecrets: [] # @schema item: object
 
-image:  # @schema additionalProperties: false
+image: # @schema additionalProperties: false
   # -- Image repository for the `external-dns` container.
   repository: registry.k8s.io/external-dns/external-dns
   # -- Image tag for the `external-dns` container, this will default to `.Chart.AppVersion` if not set.
-  tag:  # @schema type:[string, null]
+  tag: # @schema type:[string, null]
   # -- Image pull policy for the `external-dns` container.
-  pullPolicy: IfNotPresent  # @schema enum:[IfNotPresent, Always];
+  pullPolicy: IfNotPresent # @schema enum:[IfNotPresent, Always];
 
 # -- Image pull secrets.
-imagePullSecrets: []  # @schema item: object
+imagePullSecrets: [] # @schema item: object
 
 # -- (string) Override the name of the chart.
-nameOverride:  # @schema type:[string, null]; default: null
+nameOverride: # @schema type:[string, null]; default: null
 
 # -- (string) Override the full name of the chart.
-fullnameOverride:  # @schema type:[string, null]; default: null
+fullnameOverride: # @schema type:[string, null]; default: null
 
 # -- Labels to add to all chart resources.
 commonLabels: {}
@@ -34,7 +34,7 @@ serviceAccount:
   # -- Annotations to add to the service account. Templates are allowed in both the key and the value. Example: `example.com/annotation/{{ .Values.nameOverride }}: {{ .Values.nameOverride }}`
   annotations: {}
   # -- (string) If this is set and `serviceAccount.create` is `true` this will be used for the created `ServiceAccount` name, if set and `serviceAccount.create` is `false` then this will define an existing `ServiceAccount` to use.
-  name:  # @schema type:[string, null]; default: null
+  name: # @schema type:[string, null]; default: null
   # -- Set this to `false` to [opt out of API credential automounting](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting) for the `ServiceAccount`.
   automountServiceAccountToken: true
 
@@ -42,15 +42,15 @@ service:
   # -- Service annotations.
   annotations: {}
   # -- Service HTTP port.
-  port: 7979  # @schema minimum:0; default:7979
+  port: 7979 # @schema minimum:0; default:7979
   # -- Service IP families (e.g. IPv4 and/or IPv6).
-  ipFamilies: []  # @schema type: [array, null]; item: string; itemEnum: ["IPv4", "IPv6"]; minItems:0; maxItems:2; uniqueItems: true;
+  ipFamilies: [] # @schema type: [array, null]; item: string; itemEnum: ["IPv4", "IPv6"]; minItems:0; maxItems:2; uniqueItems: true;
   #  - IPv4
   #  - IPv6
   # -- Service IP family policy.
-  ipFamilyPolicy:  # @schema type: [string, null];  enum:[SingleStack, PreferDualStack, RequireDualStack, null];
+  ipFamilyPolicy: # @schema type: [string, null];  enum:[SingleStack, PreferDualStack, RequireDualStack, null];
 
-rbac:  # @schema additionalProperties: true
+rbac: # @schema additionalProperties: true
   # -- If `true`, create a `ClusterRole` & `ClusterRoleBinding` with access to the Kubernetes API.
   create: true
   # -- Additional rules to add to the `ClusterRole`.
@@ -63,11 +63,11 @@ deploymentAnnotations: {}
 extraContainers: []
 
 # -- [Deployment Strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy).
-deploymentStrategy:  # @schema additionalProperties: true
-  type: Recreate  # @schema enum:[Recreate, RollingUpdate]; type:string; default: Recreate
+deploymentStrategy: # @schema additionalProperties: true
+  type: Recreate # @schema enum:[Recreate, RollingUpdate]; type:string; default: Recreate
 
 # -- (int) Specify the number of old `ReplicaSets` to retain to allow rollback of the `Deployment``.
-revisionHistoryLimit:  # @schema type:[integer, null];minimum:0
+revisionHistoryLimit: # @schema type:[integer, null];minimum:0
 
 # -- Labels to add to the `Pod`.
 podLabels: {}
@@ -90,16 +90,16 @@ podSecurityContext:
     type: RuntimeDefault
 
 # -- (string) Priority class name for the `Pod`.
-priorityClassName:  # @schema type:[string, null]; default: null
+priorityClassName: # @schema type:[string, null]; default: null
 
 # -- (int) Termination grace period for the `Pod` in seconds.
-terminationGracePeriodSeconds:  # @schema type:[integer, null]
+terminationGracePeriodSeconds: # @schema type:[integer, null]
 
 # -- (string) [DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) for the pod, if not set the default will be used.
-dnsPolicy:  # @schema type:[string, null]; default: null
+dnsPolicy: # @schema type:[string, null]; default: null
 
 # -- (object) [DNS config](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config) for the pod, if not set the default will be used.
-dnsConfig:  # @schema type:[object, null]; default: null
+dnsConfig: # @schema type:[object, null]; default: null
 
 # -- [Init containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) to add to the `Pod` definition.
 initContainers: []
@@ -172,17 +172,17 @@ serviceMonitor:
   # -- Annotations to add to the `ServiceMonitor`.
   annotations: {}
   # -- (string) If set create the `ServiceMonitor` in an alternate namespace.
-  namespace:  # @schema type:[string, null]; default: null
+  namespace: # @schema type:[string, null]; default: null
   # -- (string) If set override the _Prometheus_ default interval.
-  interval:  # @schema type:[string, null]; default: null
+  interval: # @schema type:[string, null]; default: null
   # -- (string) If set override the _Prometheus_ default scrape timeout.
-  scrapeTimeout:  # @schema type:[string, null]; default: null
+  scrapeTimeout: # @schema type:[string, null]; default: null
   # -- (string) If set overrides the _Prometheus_ default scheme.
-  scheme:  # @schema type:[string, null]; default: null
+  scheme: # @schema type:[string, null]; default: null
   # -- Configure the `ServiceMonitor` [TLS config](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig).
   tlsConfig: {}
   # -- (string) Provide a bearer token file for the `ServiceMonitor`.
-  bearerTokenFile:  # @schema type:[string, null]; default: null
+  bearerTokenFile: # @schema type:[string, null]; default: null
   # -- [Relabel configs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) to apply to samples before ingestion.
   relabelings: []
   # -- [Metric relabel configs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs) to apply to samples before ingestion.
@@ -191,10 +191,10 @@ serviceMonitor:
   targetLabels: []
 
 # -- Log level.
-logLevel: info  # @schema enum:[panic, debug, info, warning, error, fatal]; type:string; default: "info"
+logLevel: info # @schema enum:[panic, debug, info, warning, error, fatal]; type:string; default: "info"
 
 # -- Log format.
-logFormat: text  # @schema enum:["text", "json"]; type:string; default: "text"
+logFormat: text # @schema enum:["text", "json"]; type:string; default: "text"
 
 # -- Interval for DNS updates.
 interval: 1m
@@ -211,19 +211,19 @@ sources:
   - ingress
 
 # -- How DNS records are synchronized between sources and providers; available values are `sync` & `upsert-only`.
-policy: upsert-only  # @schema enum:[sync, upsert-only]; type:string; default: "upsert-only"
+policy: upsert-only # @schema enum:[create-only, sync, upsert-only]; type:string; default: "upsert-only"
 
 # -- Specify the registry for storing ownership and labels.
 # Valid values are `txt`, `aws-sd`, `dynamodb` & `noop`.
-registry: txt  # @schema enum:[txt, aws-sd, dynamodb, noop]; default: "txt"
+registry: txt # @schema enum:[txt, aws-sd, dynamodb, noop]; default: "txt"
 # -- (string) Specify an identifier for this instance of _ExternalDNS_ when using a registry other than `noop`.
-txtOwnerId:  # @schema type:[string, null]; default: null
+txtOwnerId: # @schema type:[string, null]; default: null
 # -- (string) Specify a prefix for the domain names of TXT records created for the `txt` registry.
 # Mutually exclusive with `txtSuffix`.
-txtPrefix:  # @schema type:[string, null]; default: null
+txtPrefix: # @schema type:[string, null]; default: null
 # -- (string) Specify a suffix for the domain names of TXT records created for the `txt` registry.
 # Mutually exclusive with `txtPrefix`.
-txtSuffix:  # @schema type:[string, null]; default: null
+txtSuffix: # @schema type:[string, null]; default: null
 
 # -- Limit possible target zones by domain suffixes.
 domainFilters: []
@@ -232,20 +232,20 @@ domainFilters: []
 excludeDomains: []
 
 # -- Filter resources queried for endpoints by label selector
-labelFilter:  # @schema type: [string,null]; default: null
+labelFilter: # @schema type: [string,null]; default: null
 
 # -- Record types to manage (default: A, AAAA, CNAME)
-managedRecordTypes: []  # @schema type: [array, null]; item: string; uniqueItems: true;
+managedRecordTypes: [] # @schema type: [array, null]; item: string; uniqueItems: true;
 
-provider:  # @schema type: [object, string];
+provider: # @schema type: [object, string];
   # -- _ExternalDNS_ provider name; for the available providers and how to configure them see [README](https://github.com/kubernetes-sigs/external-dns/blob/master/charts/external-dns/README.md#providers).
   name: aws
   webhook:
     image:
       # -- (string) Image repository for the `webhook` container.
-      repository:  # @schema type:[string, null]; default: null
+      repository: # @schema type:[string, null]; default: null
       # -- (string) Image tag for the `webhook` container.
-      tag:  # @schema type:[string, null]; default: null
+      tag: # @schema type:[string, null]; default: null
       # -- Image pull policy for the `webhook` container.
       pullPolicy: IfNotPresent
     # -- [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `webhook` container.
@@ -263,24 +263,24 @@ provider:  # @schema type: [object, string];
     # @default -- See _values.yaml_
     livenessProbe:
       httpGet:
-        path: /healthz  # @schema type:[string, null]; default: null
-        port: http-webhook  # @schema type:[integer,string]; default: string
-      initialDelaySeconds: 10  # @schema type:[integer, null]; default: null
-      periodSeconds: 10  # @schema type:[integer, null]; default: null
-      timeoutSeconds: 5  # @schema type:[integer, null]; default: null
-      failureThreshold: 2  # @schema type:[integer, null]; default: null
-      successThreshold: 1  # @schema type:[integer, null]; default: null
+        path: /healthz # @schema type:[string, null]; default: null
+        port: http-webhook # @schema type:[integer,string]; default: string
+      initialDelaySeconds: 10 # @schema type:[integer, null]; default: null
+      periodSeconds: 10 # @schema type:[integer, null]; default: null
+      timeoutSeconds: 5 # @schema type:[integer, null]; default: null
+      failureThreshold: 2 # @schema type:[integer, null]; default: null
+      successThreshold: 1 # @schema type:[integer, null]; default: null
     # -- [Readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `webhook` container.
     # @default -- See _values.yaml_
     readinessProbe:
       httpGet:
-        path: /healthz  # @schema type:[string, null]; default: null
-        port: http-webhook  # @schema type:[integer,string]; default: string
-      initialDelaySeconds: 5  # @schema type:[integer, null]; default: null
-      periodSeconds: 10  # @schema type:[integer, null]; default: null
-      timeoutSeconds: 5  # @schema type:[integer, null]; default: null
-      failureThreshold: 6  # @schema type:[integer, null]; default: null
-      successThreshold: 1  # @schema type:[integer, null]; default: null
+        path: /healthz # @schema type:[string, null]; default: null
+        port: http-webhook # @schema type:[integer,string]; default: string
+      initialDelaySeconds: 5 # @schema type:[integer, null]; default: null
+      periodSeconds: 10 # @schema type:[integer, null]; default: null
+      timeoutSeconds: 5 # @schema type:[integer, null]; default: null
+      failureThreshold: 6 # @schema type:[integer, null]; default: null
+      successThreshold: 1 # @schema type:[integer, null]; default: null
     service:
       # -- Webhook exposed HTTP port for the service.
       port: 8080
@@ -297,17 +297,17 @@ provider:  # @schema type: [object, string];
 
 # -- Extra arguments to provide to _ExternalDNS_.
 # An array or map can be used, with maps allowing for value overrides; maps also support slice values to use the same arg multiple times.
-extraArgs: {}  # @schema type: [array, null, object]; item: string; uniqueItems: true;
+extraArgs: {} # @schema type: [array, null, object]; item: string; uniqueItems: true;
 
 secretConfiguration:
   # -- If `true`, create a `Secret` to store sensitive provider configuration (**DEPRECATED**).
   enabled: false
   # -- Mount path for the `Secret`, this can be templated.
-  mountPath:  # @schema type:[string, null]; default: null
+  mountPath: # @schema type:[string, null]; default: null
   # -- Sub-path for mounting the `Secret`, this can be templated.
-  subPath:  # @schema type:[string, null]; default: null
+  subPath: # @schema type:[string, null]; default: null
   # -- `Secret` data.
   data: {}
 
 # -- (bool) No effect - reserved for use in sub-charting.
-enabled:  # @schema type: [boolean, null]; description: No effect - reserved for use in sub-charting
+enabled: # @schema type: [boolean, null]; description: No effect - reserved for use in sub-charting


### PR DESCRIPTION
## What does it do ?

Introduce schema support for the create-only DNS policy type.
This policy type is supported and works as expected, but fails helm schema validation as it is omitted from the enum.
## Motivation

Allow helm deployments of external-dns to utilize the create-only policy without manual fix(es) occurring post helm deploy.

## More

- [ ] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
