### PR TITLE
chore(source/net-filter): improve flow logic and add more tests

### DIFF
--- a/endpoint/domain_filter_test.go
+++ b/endpoint/domain_filter_test.go
@@ -949,3 +949,9 @@ func TestDomainFilterNormalizeDomain(t *testing.T) {
 		assert.Equal(t, r.expect, gotName)
 	}
 }
+
+func TestMatchTargetFilterReturnsProperEmptyVal(t *testing.T) {
+	var emptyFilters []string
+	assert.True(t, matchFilter(emptyFilters, "sometarget.com", true))
+	assert.False(t, matchFilter(emptyFilters, "sometarget.com", false))
+}

--- a/endpoint/target_filter_test.go
+++ b/endpoint/target_filter_test.go
@@ -66,6 +66,18 @@ var targetFilterTests = []targetFilterTest{
 		[]string{"10.1.2.3"},
 		false,
 	},
+	{
+		[]string{},
+		[]string{"10.0.0.0/8"},
+		[]string{"49.13.41.161"},
+		true,
+	},
+	{
+		[]string{},
+		[]string{"10.0.0.0/8"},
+		[]string{"10.0.1.101"},
+		false,
+	},
 }
 
 func TestTargetFilterWithExclusions(t *testing.T) {
@@ -89,8 +101,21 @@ func TestTargetFilterMatchWithEmptyFilter(t *testing.T) {
 	}
 }
 
-func TestMatchTargetFilterReturnsProperEmptyVal(t *testing.T) {
-	emptyFilters := []string{}
-	assert.True(t, matchFilter(emptyFilters, "sometarget.com", true))
-	assert.False(t, matchFilter(emptyFilters, "sometarget.com", false))
+func TestTargetNetFilter_IsEnabled(t *testing.T) {
+	tests := []struct {
+		name        string
+		filterNets  []string
+		excludeNets []string
+		want        bool
+	}{
+		{"both empty", []string{}, []string{}, false},
+		{"filterNets non-empty", []string{"10.0.0.0/8"}, []string{}, true},
+		{"excludeNets non-empty", []string{}, []string{"10.0.0.0/8"}, true},
+		{"both non-empty", []string{"10.0.0.0/8"}, []string{"192.168.0.0/16"}, true},
+	}
+
+	for _, tt := range tests {
+		tf := NewTargetNetFilterWithExclusions(tt.filterNets, tt.excludeNets)
+		assert.Equal(t, tt.want, tf.IsEnabled())
+	}
 }

--- a/source/wrappers/targetfiltersource.go
+++ b/source/wrappers/targetfiltersource.go
@@ -21,34 +21,38 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	source2 "sigs.k8s.io/external-dns/source"
+	"sigs.k8s.io/external-dns/source"
 
 	"sigs.k8s.io/external-dns/endpoint"
 )
 
 // targetFilterSource is a Source that removes endpoints matching the target filter from its wrapped source.
 type targetFilterSource struct {
-	source       source2.Source
+	source       source.Source
 	targetFilter endpoint.TargetFilterInterface
 }
 
 // NewTargetFilterSource creates a new targetFilterSource wrapping the provided Source.
-func NewTargetFilterSource(source source2.Source, targetFilter endpoint.TargetFilterInterface) source2.Source {
+func NewTargetFilterSource(source source.Source, targetFilter endpoint.TargetFilterInterface) source.Source {
 	return &targetFilterSource{source: source, targetFilter: targetFilter}
 }
 
 // Endpoints collects endpoints from its wrapped source and returns
 // them without targets matching the target filter.
 func (ms *targetFilterSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error) {
-	result := []*endpoint.Endpoint{}
-
 	endpoints, err := ms.source.Endpoints(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	if !ms.targetFilter.IsEnabled() {
+		return endpoints, nil
+	}
+
+	result := make([]*endpoint.Endpoint, 0, len(endpoints))
+
 	for _, ep := range endpoints {
-		filteredTargets := []string{}
+		filteredTargets := make([]string, 0, len(ep.Targets))
 
 		for _, t := range ep.Targets {
 			if ms.targetFilter.Match(t) {
@@ -71,5 +75,7 @@ func (ms *targetFilterSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoi
 }
 
 func (ms *targetFilterSource) AddEventHandler(ctx context.Context, handler func()) {
-	ms.source.AddEventHandler(ctx, handler)
+	if ms.targetFilter.IsEnabled() {
+		ms.source.AddEventHandler(ctx, handler)
+	}
 }

--- a/source/wrappers/targetfiltersource_test.go
+++ b/source/wrappers/targetfiltersource_test.go
@@ -19,6 +19,7 @@ package wrappers
 import (
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 	"sigs.k8s.io/external-dns/source"
@@ -42,15 +43,21 @@ func (m *mockTargetNetFilter) Match(target string) bool {
 	return m.targets[target]
 }
 
+func (m *mockTargetNetFilter) IsEnabled() bool {
+	return true
+}
+
 // echoSource is a Source that returns the endpoints passed in on creation.
 type echoSource struct {
+	mock.Mock
 	endpoints []*endpoint.Endpoint
 }
 
 func (e *echoSource) AddEventHandler(ctx context.Context, handler func()) {
+	e.Called(ctx)
 }
 
-// Endpoints returns all of the endpoints passed in on creation
+// Endpoints returns all the endpoints passed in on creation
 func (e *echoSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error) {
 	return e.endpoints, nil
 }
@@ -63,7 +70,7 @@ func NewEchoSource(endpoints []*endpoint.Endpoint) source.Source {
 func TestEchoSourceReturnGivenSources(t *testing.T) {
 	startEndpoints := []*endpoint.Endpoint{{
 		DNSName:    "foo.bar.com",
-		RecordType: "A",
+		RecordType: endpoint.RecordTypeA,
 		Targets:    endpoint.Targets{"1.2.3.4"},
 		RecordTTL:  endpoint.TTL(300),
 		Labels:     endpoint.Labels{},
@@ -75,9 +82,9 @@ func TestEchoSourceReturnGivenSources(t *testing.T) {
 		t.Errorf("Expected no error but got %s", err.Error())
 	}
 
-	for i, endpoint := range endpoints {
-		if endpoint != startEndpoints[i] {
-			t.Errorf("Expected %s but got %s", startEndpoints[i], endpoint)
+	for i, ep := range endpoints {
+		if ep != startEndpoints[i] {
+			t.Errorf("Expected %s but got %s", startEndpoints[i], ep)
 		}
 	}
 }
@@ -107,28 +114,28 @@ func TestTargetFilterSourceEndpoints(t *testing.T) {
 			title:   "filter exclusion all",
 			filters: NewMockTargetNetFilter([]string{}),
 			endpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo", "A", "1.2.3.4"),
-				endpoint.NewEndpoint("foo", "A", "1.2.3.5"),
-				endpoint.NewEndpoint("foo", "A", "1.2.3.6"),
-				endpoint.NewEndpoint("foo", "A", "1.3.4.5"),
-				endpoint.NewEndpoint("foo", "A", "1.4.4.5")},
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.5"),
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.6"),
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "1.3.4.5"),
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "1.4.4.5")},
 			expected: []*endpoint.Endpoint{},
 		},
 		{
 			title:   "filter exclude internal net",
 			filters: NewMockTargetNetFilter([]string{"8.8.8.8"}),
 			endpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo", "A", "10.0.0.1"),
-				endpoint.NewEndpoint("foo", "A", "8.8.8.8")},
-			expected: []*endpoint.Endpoint{endpoint.NewEndpoint("foo", "A", "8.8.8.8")},
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.0.1"),
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "8.8.8.8")},
+			expected: []*endpoint.Endpoint{endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "8.8.8.8")},
 		},
 		{
 			title:   "filter only internal",
 			filters: NewMockTargetNetFilter([]string{"10.0.0.1"}),
 			endpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo", "A", "10.0.0.1"),
-				endpoint.NewEndpoint("foo", "A", "8.8.8.8")},
-			expected: []*endpoint.Endpoint{endpoint.NewEndpoint("foo", "A", "10.0.0.1")},
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.0.1"),
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "8.8.8.8")},
+			expected: []*endpoint.Endpoint{endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.0.1")},
 		},
 	}
 	for _, tt := range tests {
@@ -142,6 +149,122 @@ func TestTargetFilterSourceEndpoints(t *testing.T) {
 			endpoints, err := src.Endpoints(context.Background())
 			require.NoError(t, err, "failed to get Endpoints")
 			validateEndpoints(t, endpoints, tt.expected)
+		})
+	}
+}
+
+func TestTargetFilterConcreteTargetFilter(t *testing.T) {
+	tests := []struct {
+		title     string
+		filters   endpoint.TargetFilterInterface
+		endpoints []*endpoint.Endpoint
+		expected  []*endpoint.Endpoint
+	}{
+		{
+			title:   "should skip filtering if no filters are set",
+			filters: endpoint.NewTargetNetFilterWithExclusions([]string{}, []string{}),
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.5"),
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.6"),
+			},
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.5"),
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.6"),
+			},
+		},
+		{
+			title:   "should include all targets when filters are not correctly set",
+			filters: endpoint.NewTargetNetFilterWithExclusions([]string{"8.8.8.8"}, []string{}),
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.0.1"),
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "8.8.8.8")},
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.0.1"),
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "8.8.8.8"),
+			},
+		},
+		{
+			title:   "should include internal when include filter is set",
+			filters: endpoint.NewTargetNetFilterWithExclusions([]string{"10.0.0.0/8"}, []string{}),
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.0.1"),
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "49.13.41.161")},
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.0.1"),
+			},
+		},
+		{
+			title:   "exclude internal keep public ips",
+			filters: endpoint.NewTargetNetFilterWithExclusions([]string{}, []string{"10.0.0.0/8"}),
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.178.43"),
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.1.101"),
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "49.13.41.161")},
+			expected: []*endpoint.Endpoint{endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "49.13.41.161")},
+		},
+		{
+			title:   "should not exclude ipv6 when excluding ipv4",
+			filters: endpoint.NewTargetNetFilterWithExclusions([]string{}, []string{"10.0.0.0/8"}),
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.178.43"),
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeAAAA, "2a01:asdf:asdf:asdf::1"),
+			},
+			expected: []*endpoint.Endpoint{endpoint.NewEndpoint("foo", endpoint.RecordTypeAAAA, "2a01:asdf:asdf:asdf::1")},
+		},
+		{
+			title:   "should not include ipv6 when including ipv4",
+			filters: endpoint.NewTargetNetFilterWithExclusions([]string{"10.0.0.0/8"}, []string{}),
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.178.43"),
+				endpoint.NewEndpoint("foo", endpoint.RecordTypeAAAA, "2a01:asdf:asdf:asdf::1"),
+			},
+			expected: []*endpoint.Endpoint{endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.178.43")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			echo := NewEchoSource(tt.endpoints)
+			src := NewTargetFilterSource(echo, tt.filters)
+
+			endpoints, err := src.Endpoints(context.Background())
+			require.NoError(t, err, "failed to get Endpoints")
+
+			validateEndpoints(t, endpoints, tt.expected)
+		})
+	}
+}
+
+func TestTargetFilterSource_AddEventHandler(t *testing.T) {
+	tests := []struct {
+		title   string
+		filters endpoint.TargetFilterInterface
+		times   int
+	}{
+		{
+			title:   "should add event handler if target filter is enabled",
+			filters: endpoint.NewTargetNetFilterWithExclusions([]string{"10.0.0.0/8"}, []string{}),
+			times:   1,
+		},
+		{
+			title:   "should not add event handler if target filter is disabled",
+			filters: endpoint.NewTargetNetFilterWithExclusions([]string{}, []string{}),
+			times:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			echo := NewEchoSource([]*endpoint.Endpoint{})
+
+			m := echo.(*echoSource)
+			m.On("AddEventHandler", t.Context()).Return()
+
+			src := NewTargetFilterSource(echo, tt.filters)
+			src.AddEventHandler(t.Context(), func() {})
+
+			m.AssertNumberOfCalls(t, "AddEventHandler", tt.times)
 		})
 	}
 }


### PR DESCRIPTION
## What does it do ?

- added more unit tests
- targetfiltersource.go was tested with fully mocked filter, so it was pretty much dummy. Added  concrete filter to make sure the real behaviour is test
- added function `IsEnabled()`, this to make sure, that we do not do any filtering, not waisting CPU cycles when filter is not enabled. Initial PR https://github.com/kubernetes-sigs/external-dns/pull/2693, no mentioning why it was done a way that even with empty filters is trying to cycle over every single endpoint
- no point to `ip := net.ParseIP(target)` on every filter, make sense to parse IP just once

## Motivation

The PR does not sole the issue, not yet found the root cause
Relates https://github.com/kubernetes-sigs/external-dns/issues/5608

## More

- [X] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
