### PR TITLE
feat(helm): add envfrom properties

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Added
+
+- Added `envFrom` property for all pods. ([#5630](https://github.com/kubernetes-sigs/external-dns/pull/5630)) _@oliverbaehler_
+
 ### Changed
 
 - Update RBAC for `Service` source to support `EndpointSlices`. ([#5493](https://github.com/kubernetes-sigs/external-dns/pull/5493)) _@vflaux_

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -103,6 +103,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | domainFilters | list | `[]` | Limit possible target zones by domain suffixes. |
 | enabled | bool | `nil` | No effect - reserved for use in sub-charting. |
 | env | list | `[]` | [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `external-dns` container. |
+| envFrom | list | `[]` | [Environment from Configmaps/Secrets](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `external-dns` container. |
 | excludeDomains | list | `[]` | Intentionally exclude domains from being managed. |
 | extraArgs | object | `{}` | Extra arguments to provide to _ExternalDNS_. An array or map can be used, with maps allowing for value overrides; maps also support slice values to use the same arg multiple times. |
 | extraContainers | list | `[]` | Extra containers to add to the `Deployment`. |
@@ -132,6 +133,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | provider.name | string | `"aws"` | _ExternalDNS_ provider name; for the available providers and how to configure them see [README](https://github.com/kubernetes-sigs/external-dns/blob/master/charts/external-dns/README.md#providers). |
 | provider.webhook.args | list | `[]` | Extra arguments to provide for the `webhook` container. |
 | provider.webhook.env | list | `[]` | [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `webhook` container. |
+| provider.webhook.envFrom | list | `[]` | [Environment from Configmaps/Secrets](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `webhook` container. |
 | provider.webhook.extraVolumeMounts | list | `[]` | Extra [volume mounts](https://kubernetes.io/docs/concepts/storage/volumes/) for the `webhook` container. |
 | provider.webhook.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the `webhook` container. |
 | provider.webhook.image.repository | string | `nil` | Image repository for the `webhook` container. |

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -85,6 +85,10 @@ spec:
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args:
             - --log-level={{ .Values.logLevel }}
             - --log-format={{ .Values.logFormat }}
@@ -176,6 +180,10 @@ spec:
           imagePullPolicy: {{ .image.pullPolicy }}
           {{- with .env }}
           env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .envFrom }}
+          envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .args }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -119,6 +119,9 @@ securityContext:
 # -- [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `external-dns` container.
 env: []
 
+# -- [Environment from Configmaps/Secrets](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `external-dns` container.
+envFrom: []
+
 # -- [Liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `external-dns` container.
 # @default -- See _values.yaml_
 livenessProbe:
@@ -250,6 +253,8 @@ provider:  # @schema type: [object, string];
       pullPolicy: IfNotPresent
     # -- [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `webhook` container.
     env: []
+    # -- [Environment from Configmaps/Secrets](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `webhook` container.
+    envFrom: []
     # -- Extra arguments to provide for the `webhook` container.
     args: []
     # -- Extra [volume mounts](https://kubernetes.io/docs/concepts/storage/volumes/) for the `webhook` container.


### PR DESCRIPTION
## What does it do ?

It allows to define `envFrom` properties for the containers. The only clean way to inject secrets into the containers.

## Motivation

Currently a have secrets in a dedicated Kubernetes Secret, i would like to mount the values from said secret to the external-dns environment.

## More

> i did not get the schema get to work, i would appriciate your help here.

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
