### PR TITLE
fix(provider/aws): null pointer when records mailformed

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -637,6 +637,10 @@ func (p *AWSProvider) createUpdateChanges(newEndpoints, oldEndpoints []*endpoint
 	var updates []*endpoint.Endpoint
 
 	for i, newE := range newEndpoints {
+		if i >= len(oldEndpoints) || oldEndpoints[i] == nil {
+			log.Debugf("skip %s as endpoint not found in current endpoints", newE.DNSName)
+			continue
+		}
 		oldE := oldEndpoints[i]
 		if p.requiresDeleteCreate(oldE, newE) {
 			deletes = append(deletes, oldE)

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -637,11 +637,11 @@ func (p *AWSProvider) createUpdateChanges(newEndpoints, oldEndpoints []*endpoint
 	var updates []*endpoint.Endpoint
 
 	for i, newE := range newEndpoints {
-		oldE := oldEndpoints[i]
-		if i >= len(oldEndpoints) || oldE == nil {
+		if i >= len(oldEndpoints) || oldEndpoints[i] == nil {
 			log.Debugf("skip %s as endpoint not found in current endpoints", newE.DNSName)
 			continue
 		}
+		oldE := oldEndpoints[i]
 		if p.requiresDeleteCreate(oldE, newE) {
 			deletes = append(deletes, oldE)
 			creates = append(creates, newE)

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -637,11 +637,11 @@ func (p *AWSProvider) createUpdateChanges(newEndpoints, oldEndpoints []*endpoint
 	var updates []*endpoint.Endpoint
 
 	for i, newE := range newEndpoints {
-		if i >= len(oldEndpoints) || oldEndpoints[i] == nil {
+		oldE := oldEndpoints[i]
+		if i >= len(oldEndpoints) || oldE == nil {
 			log.Debugf("skip %s as endpoint not found in current endpoints", newE.DNSName)
 			continue
 		}
-		oldE := oldEndpoints[i]
 		if p.requiresDeleteCreate(oldE, newE) {
 			deletes = append(deletes, oldE)
 			creates = append(creates, newE)

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -2817,3 +2817,35 @@ func TestGeoProximityWithBias(t *testing.T) {
 		})
 	}
 }
+
+func TestAWSProvider_createUpdateChanges_NewMoreThanOld(t *testing.T) {
+	provider, _ := newAWSProvider(t, endpoint.NewDomainFilter([]string{"foo.bar."}), provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), true, false, nil)
+
+	oldEndpoints := []*endpoint.Endpoint{
+		endpoint.NewEndpointWithTTL("record1.foo.bar.", endpoint.RecordTypeA, endpoint.TTL(300), "1.1.1.1"),
+		nil,
+	}
+	newEndpoints := []*endpoint.Endpoint{
+		endpoint.NewEndpointWithTTL("record1.foo.bar.", endpoint.RecordTypeA, endpoint.TTL(300), "1.1.1.1"),
+		endpoint.NewEndpointWithTTL("record2.foo.bar.", endpoint.RecordTypeA, endpoint.TTL(300), "2.2.2.2"),
+	}
+
+	changes := provider.createUpdateChanges(newEndpoints, oldEndpoints)
+
+	// record2 should be created, record1 should be upserted
+	var creates, upserts, deletes int
+	for _, c := range changes {
+		switch c.Action {
+		case route53types.ChangeActionCreate:
+			creates++
+		case route53types.ChangeActionUpsert:
+			upserts++
+		case route53types.ChangeActionDelete:
+			deletes++
+		}
+	}
+
+	require.Equal(t, 0, creates, "should create the extra new endpoint")
+	require.Equal(t, 1, upserts, "should upsert the matching endpoint")
+	require.Equal(t, 0, deletes, "should not delete anything")
+}

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -2828,6 +2828,7 @@ func TestAWSProvider_createUpdateChanges_NewMoreThanOld(t *testing.T) {
 	newEndpoints := []*endpoint.Endpoint{
 		endpoint.NewEndpointWithTTL("record1.foo.bar.", endpoint.RecordTypeA, endpoint.TTL(300), "1.1.1.1"),
 		endpoint.NewEndpointWithTTL("record2.foo.bar.", endpoint.RecordTypeA, endpoint.TTL(300), "2.2.2.2"),
+		endpoint.NewEndpointWithTTL("record3.foo.bar.", endpoint.RecordTypeA, endpoint.TTL(300), "3.3.3.3"),
 	}
 
 	changes := provider.createUpdateChanges(newEndpoints, oldEndpoints)


### PR DESCRIPTION
## What does it do ?

- added null pointer check when endpoints sizes do not match

This fix will help as well https://github.com/kubernetes-sigs/external-dns/pull/5459

Managed to capture null pointer with tests, but not in real cluster. 

<img width="1378" height="698" alt="Screenshot 2025-07-10 at 19 04 40" src="https://github.com/user-attachments/assets/a8951bbe-b9ef-45d4-a89b-282b2d4c0fb6" />

## Motivation

Fixes #5634

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
