### PR TITLE
refactor(cloudflare): use lib v4 for zone services

### DIFF
--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -12,7 +12,7 @@ ExternalDNS is currently migrating from the legacy CloudFlare Go SDK v0 to the m
 
 - Zone management (listing, filtering, pagination)
 - Zone details retrieval (`GetZone`)
-- Zone ID lookup by name (`ZoneIDByName`)  
+- Zone ID lookup by name (`ZoneIDByName`)
 - Zone plan detection (fully v4 implementation)
 - Regional services (data localization)
 

--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -4,6 +4,34 @@ This tutorial describes how to setup ExternalDNS for usage within a Kubernetes c
 
 Make sure to use **>=0.4.2** version of ExternalDNS for this tutorial.
 
+## CloudFlare SDK Migration Status
+
+ExternalDNS is currently migrating from the legacy CloudFlare Go SDK v0 to the modern v4 SDK to improve performance, reliability, and access to newer CloudFlare features. The migration status is:
+
+**✅ Fully migrated to v4 SDK:**
+- Zone management (listing, filtering, pagination)
+- Zone details retrieval (`GetZone`)
+- Zone ID lookup by name (`ZoneIDByName`)  
+- Zone plan detection (fully v4 implementation)
+- Regional services (data localization)
+
+**🔄 Still using legacy v0 SDK:**
+- DNS record management (create, update, delete records)
+- Custom hostnames
+- Proxied records
+
+This mixed approach ensures continued functionality while gradually modernizing the codebase. Users should not experience any breaking changes during this transition.
+
+### SDK Dependencies
+
+ExternalDNS currently uses:
+- **cloudflare-go v0.115.0+**: Legacy SDK for DNS records, custom hostnames, and proxied record features
+- **cloudflare-go/v4 v4.6.0+**: Modern SDK for all zone management and regional services operations
+
+Zone management has been fully migrated to the v4 SDK, providing improved performance and reliability.
+
+Both SDKs are automatically managed as Go module dependencies and require no special configuration from users.
+
 ## Creating a Cloudflare DNS zone
 
 We highly recommend to read this tutorial if you haven't used Cloudflare before:
@@ -353,7 +381,7 @@ The custom hostname DNS must resolve to the Cloudflare DNS record (`external-dns
 
 Requires [Cloudflare for SaaS](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/) product and "SSL and Certificates" API permission.
 
-Due to a limitation within the cloudflare-go v0 API, the custom hostname page size is fixed at 50.
+**Note:** Due to using the legacy cloudflare-go v0 API for custom hostname management, the custom hostname page size is fixed at 50. This limitation will be addressed in a future migration to the v4 SDK.
 
 ## Using CRD source to manage DNS records in Cloudflare
 

--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -9,6 +9,7 @@ Make sure to use **>=0.4.2** version of ExternalDNS for this tutorial.
 ExternalDNS is currently migrating from the legacy CloudFlare Go SDK v0 to the modern v4 SDK to improve performance, reliability, and access to newer CloudFlare features. The migration status is:
 
 **✅ Fully migrated to v4 SDK:**
+
 - Zone management (listing, filtering, pagination)
 - Zone details retrieval (`GetZone`)
 - Zone ID lookup by name (`ZoneIDByName`)  
@@ -16,6 +17,7 @@ ExternalDNS is currently migrating from the legacy CloudFlare Go SDK v0 to the m
 - Regional services (data localization)
 
 **🔄 Still using legacy v0 SDK:**
+
 - DNS record management (create, update, delete records)
 - Custom hostnames
 - Proxied records
@@ -25,6 +27,7 @@ This mixed approach ensures continued functionality while gradually modernizing 
 ### SDK Dependencies
 
 ExternalDNS currently uses:
+
 - **cloudflare-go v0.115.0+**: Legacy SDK for DNS records, custom hostnames, and proxied record features
 - **cloudflare-go/v4 v4.6.0+**: Modern SDK for all zone management and regional services operations
 

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -56,7 +56,7 @@ const (
 
 	// Cloudflare tier limitations https://developers.cloudflare.com/dns/manage-dns-records/reference/record-attributes/#availability
 	freeZoneMaxCommentLength = 100
-	paidZoneMaxCommentLength  = 500
+	paidZoneMaxCommentLength = 500
 )
 
 var changeActionNames = map[changeAction]string{

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -56,7 +56,7 @@ const (
 
 	// Cloudflare tier limitations https://developers.cloudflare.com/dns/manage-dns-records/reference/record-attributes/#availability
 	freeZoneMaxCommentLength = 100
-	paidZoneMaxCommentLength = 500
+	paidZoneMaxCommentLength  = 500
 )
 
 var changeActionNames = map[changeAction]string{


### PR DESCRIPTION
## What does it do ?

This pull request migrates the regional services logic to the Cloudflare library v4 while retaining the old version for other functionalities like zones, custom hostnames, and DNS records. It introduces a redefined RegionalHostname struct (as done in #5615) and a new autoPagerIterator() function to convert the v4 library's "AutoPager" into a Go iterator, intended for broader use in list calls. The logic remains unchanged, with adjustments only to the API and associated structs.

Similar to #5609 

## Motivation

Iterative approach to #5540 

## More

- [X] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Yes, I added unit tests
- [X] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
