### PR TITLE
docs: scoping the AWS IAM policy to explicitely defined AWS Route53 zones

### DIFF
--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -9,9 +9,6 @@ Record Sets and Hosted Zones. You'll want to create this Policy in IAM first. In
 our example, we'll call the policy `AllowExternalDNSUpdates` (but you can call
 it whatever you prefer).
 
-If you prefer, you may fine-tune the policy to permit updates only to explicit
-Hosted Zone IDs.
-
 ```json
 {
   "Version": "2012-10-17",
@@ -19,18 +16,18 @@ Hosted Zone IDs.
     {
       "Effect": "Allow",
       "Action": [
-        "route53:ChangeResourceRecordSets"
+        "route53:ChangeResourceRecordSets",
+        "route53:ListResourceRecordSets",
+        "route53:ListTagsForResources"
       ],
       "Resource": [
-        "arn:aws:route53:::hostedzone/*"
+        "arn:aws:route53:::hostedzone/<INSERT YOUR ZONE ID HERE>"
       ]
     },
     {
       "Effect": "Allow",
       "Action": [
-        "route53:ListHostedZones",
-        "route53:ListResourceRecordSets",
-        "route53:ListTagsForResources"
+        "route53:ListHostedZones"
       ],
       "Resource": [
         "*"
@@ -51,10 +48,12 @@ You can use Attribute-based access control(ABAC) for advanced deployments.
     {
       "Effect": "Allow",
       "Action": [
-        "route53:ChangeResourceRecordSets"
+        "route53:ChangeResourceRecordSets",
+        "route53:ListResourceRecordSets",
+        "route53:ListTagsForResources"
       ],
       "Resource": [
-        "arn:aws:route53:::hostedzone/*"
+        "arn:aws:route53:::hostedzone/<INSERT YOUR ZONE ID HERE>"
       ],
       "Condition": {
         "ForAllValues:StringLike": {
@@ -67,9 +66,7 @@ You can use Attribute-based access control(ABAC) for advanced deployments.
     {
       "Effect": "Allow",
       "Action": [
-        "route53:ListHostedZones",
-        "route53:ListResourceRecordSets",
-        "route53:ListTagsForResources"
+        "route53:ListHostedZones"
       ],
       "Resource": [
         "*"


### PR DESCRIPTION
## What does it do ?

It makes end users to pass a zone/zones instead of allowing the policy to edit all zones hosted in an AWS account.

## Motivation

Applying the principle of least privilege is one of the fundamental security best practices. It reduces blast radius and makes permissions more clear and auditable. It's also recommended by AWS https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege

## More

- [x ] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
