### PR TITLE
chore(metrics): refactor metrics to use common registry

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -26,6 +26,7 @@ curl https://localhost:7979/metrics
 | last_sync_timestamp_seconds | Gauge | controller | Timestamp of last successful sync with the DNS provider |
 | no_op_runs_total | Counter | controller | Number of reconcile loops ending up with no changes on the DNS provider side. |
 | verified_records | Gauge | controller | Number of DNS records that exists both in source and registry (vector). |
+| request_duration_seconds | Summaryvec | http | The HTTP request latencies in seconds. |
 | cache_apply_changes_calls | Counter | provider | Number of calls to the provider cache ApplyChanges. |
 | cache_records_calls | Counter | provider | Number of calls to the provider cache Records list. |
 | endpoints_total | Gauge | registry | Number of Endpoints in the registry |
@@ -76,7 +77,6 @@ curl https://localhost:7979/metrics
 | go_memstats_sys_bytes |
 | go_sched_gomaxprocs_threads |
 | go_threads |
-| http_request_duration_seconds |
 | process_cpu_seconds_total |
 | process_max_fds |
 | process_network_receive_bytes_total |

--- a/internal/gen/docs/metrics/main_test.go
+++ b/internal/gen/docs/metrics/main_test.go
@@ -37,7 +37,7 @@ func TestComputeMetrics(t *testing.T) {
 		t.Errorf("Expected not empty metrics registry, got %d", len(reg.Metrics))
 	}
 
-	assert.Len(t, reg.Metrics, 20)
+	assert.Len(t, reg.Metrics, 21)
 }
 
 func TestGenerateMarkdownTableRenderer(t *testing.T) {

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -57,25 +57,3 @@ func TestNewInstrumentedClient(t *testing.T) {
 	_, ok = result2.Transport.(*CustomRoundTripper)
 	require.True(t, ok)
 }
-
-func TestPathProcessor(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"/foo/bar", "bar"},
-		{"/foo/", ""},
-		{"/", ""},
-		{"", ""},
-		{"/foo/bar/baz", "baz"},
-		{"foo/bar", "bar"},
-		{"foo", "foo"},
-		{"foo/", ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			require.Equal(t, tt.expected, pathProcessor(tt.input))
-		})
-	}
-}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -73,7 +73,7 @@ func NewMetricsRegister() *MetricRegistry {
 //	}
 func (m *MetricRegistry) MustRegister(cs IMetric) {
 	switch v := cs.(type) {
-	case CounterMetric, GaugeMetric, CounterVecMetric, GaugeVecMetric, GaugeFuncMetric:
+	case CounterMetric, GaugeMetric, SummaryVecMetric, CounterVecMetric, GaugeVecMetric, GaugeFuncMetric:
 		if _, exists := m.mName[cs.Get().FQDN]; exists {
 			return
 		} else {
@@ -85,6 +85,8 @@ func (m *MetricRegistry) MustRegister(cs IMetric) {
 			m.Registerer.MustRegister(metric.Counter)
 		case GaugeMetric:
 			m.Registerer.MustRegister(metric.Gauge)
+		case SummaryVecMetric:
+			m.Registerer.MustRegister(metric.SummaryVec)
 		case GaugeVecMetric:
 			m.Registerer.MustRegister(metric.Gauge)
 		case CounterVecMetric:

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -61,8 +61,9 @@ func TestMustRegister(t *testing.T) {
 				NewCounterWithOpts(prometheus.CounterOpts{Name: "test_counter_3"}),
 				NewCounterVecWithOpts(prometheus.CounterOpts{Name: "test_counter_vec_3"}, []string{"label"}),
 				NewGaugedVectorOpts(prometheus.GaugeOpts{Name: "test_gauge_v_3"}, []string{"label"}),
+				NewSummaryVecWithOpts(prometheus.SummaryOpts{Name: "test_summary_v_3"}, []string{"label"}),
 			},
-			expected: 4,
+			expected: 5,
 		},
 		{
 			name: "unsupported metric",

--- a/pkg/metrics/models.go
+++ b/pkg/metrics/models.go
@@ -176,3 +176,42 @@ func NewGaugeFuncMetric(opts prometheus.GaugeOpts) GaugeFuncMetric {
 		GaugeFunc: prometheus.NewGaugeFunc(opts, func() float64 { return 1 }),
 	}
 }
+
+type SummaryVecMetric struct {
+	Metric
+	SummaryVec prometheus.SummaryVec
+}
+
+func (s SummaryVecMetric) Get() *Metric {
+	return &s.Metric
+}
+
+// SetWithLabels sets the value of the SummaryVec metric for the specified label values.
+// All label values are converted to lowercase before being applied.
+func (s SummaryVecMetric) SetWithLabels(value float64, lvs ...string) {
+	for i, v := range lvs {
+		lvs[i] = strings.ToLower(v)
+	}
+
+	s.SummaryVec.WithLabelValues(lvs...).Observe(value)
+}
+
+func NewSummaryVecWithOpts(opts prometheus.SummaryOpts, labelNames []string) SummaryVecMetric {
+	opts.Namespace = Namespace
+	return SummaryVecMetric{
+		Metric: Metric{
+			Type:      "summaryVec",
+			Name:      opts.Name,
+			FQDN:      fmt.Sprintf("%s_%s", opts.Subsystem, opts.Name),
+			Namespace: opts.Namespace,
+			Subsystem: opts.Subsystem,
+			Help:      opts.Help,
+		},
+		SummaryVec: *prometheus.NewSummaryVec(opts, labelNames),
+	}
+}
+
+func PathProcessor(path string) string {
+	parts := strings.Split(path, "/")
+	return parts[len(parts)-1]
+}


### PR DESCRIPTION
## What does it do ?

This PR refactors the metrics so that the request_duration_metric is configured in the same way as the other metrics.

## Motivation

While working on solving the AWS_CA_BUNDLE issue we had to refactor the request_duration_metric and it was decided to split the refactor off into it's own PR.

## More

- [ x ] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ x ] Yes, I added unit tests
- [ x ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
