### PR TITLE
fix(core): fix events mode

### DIFF
--- a/source/wrappers/targetfiltersource.go
+++ b/source/wrappers/targetfiltersource.go
@@ -75,7 +75,5 @@ func (ms *targetFilterSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoi
 }
 
 func (ms *targetFilterSource) AddEventHandler(ctx context.Context, handler func()) {
-	if ms.targetFilter.IsEnabled() {
-		ms.source.AddEventHandler(ctx, handler)
-	}
+	ms.source.AddEventHandler(ctx, handler)
 }


### PR DESCRIPTION
## What does it do ?

Restores `--events` mode

## Motivation

`--events` mode was broken for a `service` source for me after https://github.com/kubernetes-sigs/external-dns/pull/5629#discussion_r2222595165

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

This is just to scratch my itch, feel free to take over this PR if necessary.