### PR TITLE
fix(endpoint): domains handling with idna

### DIFF
--- a/endpoint/domain_filter.go
+++ b/endpoint/domain_filter.go
@@ -25,7 +25,8 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/idna"
+
+	"sigs.k8s.io/external-dns/internal/idna"
 )
 
 type MatchAllDomainFilters []DomainFilterInterface
@@ -247,9 +248,9 @@ func (df *DomainFilter) MatchParent(domain string) bool {
 }
 
 // normalizeDomain converts a domain to a canonical form, so that we can filter on it
-// it: trim "." suffix, get Unicode version of domain complient with Section 5 of RFC 5891
+// it: trim "." suffix, get Unicode version of domain compliant with Section 5 of RFC 5891
 func normalizeDomain(domain string) string {
-	s, err := idna.Lookup.ToUnicode(strings.TrimSuffix(domain, "."))
+	s, err := idna.Profile.ToUnicode(strings.TrimSuffix(domain, "."))
 	if err != nil {
 		log.Warnf(`Got error while parsing domain %s: %v`, domain, err)
 	}

--- a/internal/idna/idna.go
+++ b/internal/idna/idna.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package idna
+
+import (
+	"golang.org/x/net/idna"
+)
+
+var (
+	Profile = idna.New(
+		idna.MapForLookup(),
+		idna.Transitional(true),
+		idna.StrictDomainName(false),
+	)
+)

--- a/internal/idna/idna_test.go
+++ b/internal/idna/idna_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package idna
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProfileWithDefault(t *testing.T) {
+	tets := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "*.GÖPHER.com",
+			expected: "*.göpher.com",
+		},
+		{
+			input:    "*._abrakadabra.com",
+			expected: "*._abrakadabra.com",
+		},
+		{
+			input:    "_abrakadabra.com",
+			expected: "_abrakadabra.com",
+		},
+		{
+			input:    "*.foo.kube.example.com",
+			expected: "*.foo.kube.example.com",
+		},
+		{
+			input:    "xn--bcher-kva.example.com",
+			expected: "bücher.example.com",
+		},
+	}
+	for _, tt := range tets {
+		t.Run(strings.ToLower(tt.input), func(t *testing.T) {
+			result, err := Profile.ToUnicode(tt.input)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -23,9 +23,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/idna"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/idna"
 )
 
 // PropertyComparator is used in Plan for comparing the previous and current custom annotations.
@@ -340,16 +340,10 @@ func filterRecordsForPlan(records []*endpoint.Endpoint, domainFilter endpoint.Ma
 	return filtered
 }
 
-var idnaProfile = idna.New(
-	idna.MapForLookup(),
-	idna.Transitional(true),
-	idna.StrictDomainName(false),
-)
-
 // normalizeDNSName converts a DNS name to a canonical form, so that we can use string equality
 // it: removes space, get ASCII version of dnsName complient with Section 5 of RFC 5891, ensures there is a trailing dot
 func normalizeDNSName(dnsName string) string {
-	s, err := idnaProfile.ToASCII(strings.TrimSpace(dnsName))
+	s, err := idna.Profile.ToASCII(strings.TrimSpace(dnsName))
 	if err != nil {
 		log.Warnf(`Got error while parsing DNSName %s: %v`, dnsName, err)
 	}

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -735,7 +735,6 @@ func (p *AWSProvider) submitChanges(ctx context.Context, changes Route53Changes,
 			}
 
 			if !p.dryRun {
-
 				params := &route53.ChangeResourceRecordSetsInput{
 					HostedZoneId: aws.String(z),
 					ChangeBatch: &route53types.ChangeBatch{

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -734,56 +734,58 @@ func (p *AWSProvider) submitChanges(ctx context.Context, changes Route53Changes,
 				log.Infof("Desired change: %s %s %s", c.Action, *c.ResourceRecordSet.Name, c.ResourceRecordSet.Type)
 			}
 
-			if !p.dryRun {
-				params := &route53.ChangeResourceRecordSetsInput{
-					HostedZoneId: aws.String(z),
-					ChangeBatch: &route53types.ChangeBatch{
-						Changes: b.Route53Changes(),
-					},
-				}
+			if p.dryRun {
+				continue
+			}
 
-				successfulChanges := 0
+			params := &route53.ChangeResourceRecordSetsInput{
+				HostedZoneId: aws.String(z),
+				ChangeBatch: &route53types.ChangeBatch{
+					Changes: b.Route53Changes(),
+				},
+			}
 
-				client := p.clients[zones[z].profile]
-				if _, err := client.ChangeResourceRecordSets(ctx, params); err != nil {
-					log.Errorf("Failure in zone %s when submitting change batch: %v", *zones[z].zone.Name, err)
+			successfulChanges := 0
 
-					changesByOwnership := groupChangesByNameAndOwnershipRelation(b)
+			client := p.clients[zones[z].profile]
+			if _, err := client.ChangeResourceRecordSets(ctx, params); err != nil {
+				log.Errorf("Failure in zone %s when submitting change batch: %v", *zones[z].zone.Name, err)
 
-					if len(changesByOwnership) > 1 {
-						log.Debug("Trying to submit change sets one-by-one instead")
-						for _, changes := range changesByOwnership {
-							if log.Logger.IsLevelEnabled(debugLevel) {
-								for _, c := range changes {
-									log.Debugf("Desired change: %s %s %s", c.Action, *c.ResourceRecordSet.Name, c.ResourceRecordSet.Type)
-								}
-							}
-							params.ChangeBatch = &route53types.ChangeBatch{
-								Changes: changes.Route53Changes(),
-							}
-							if _, err := client.ChangeResourceRecordSets(ctx, params); err != nil {
-								failedUpdate = true
-								log.Errorf("Failed submitting change (error: %v), it will be retried in a separate change batch in the next iteration", err)
-								p.failedChangesQueue[z] = append(p.failedChangesQueue[z], changes...)
-							} else {
-								successfulChanges = successfulChanges + len(changes)
+				changesByOwnership := groupChangesByNameAndOwnershipRelation(b)
+
+				if len(changesByOwnership) > 1 {
+					log.Debug("Trying to submit change sets one-by-one instead")
+					for _, changes := range changesByOwnership {
+						if log.Logger.IsLevelEnabled(debugLevel) {
+							for _, c := range changes {
+								log.Debugf("Desired change: %s %s %s", c.Action, *c.ResourceRecordSet.Name, c.ResourceRecordSet.Type)
 							}
 						}
-					} else {
-						failedUpdate = true
+						params.ChangeBatch = &route53types.ChangeBatch{
+							Changes: changes.Route53Changes(),
+						}
+						if _, err := client.ChangeResourceRecordSets(ctx, params); err != nil {
+							failedUpdate = true
+							log.Errorf("Failed submitting change (error: %v), it will be retried in a separate change batch in the next iteration", err)
+							p.failedChangesQueue[z] = append(p.failedChangesQueue[z], changes...)
+						} else {
+							successfulChanges = successfulChanges + len(changes)
+						}
 					}
 				} else {
-					successfulChanges = len(b)
+					failedUpdate = true
 				}
+			} else {
+				successfulChanges = len(b)
+			}
 
-				if successfulChanges > 0 {
-					// z is the R53 Hosted Zone ID already as aws.StringValue
-					log.Infof("%d record(s) were successfully updated", successfulChanges)
-				}
+			if successfulChanges > 0 {
+				// z is the R53 Hosted Zone ID already as aws.StringValue
+				log.Infof("%d record(s) were successfully updated", successfulChanges)
+			}
 
-				if i != len(batchCs)-1 {
-					time.Sleep(p.batchChangeInterval)
-				}
+			if i != len(batchCs)-1 {
+				time.Sleep(p.batchChangeInterval)
 			}
 		}
 

--- a/provider/zonefinder_test.go
+++ b/provider/zonefinder_test.go
@@ -32,14 +32,16 @@ func TestZoneIDName(t *testing.T) {
 	z.Add("654321", "foo.qux.baz")
 	z.Add("987654", "エイミー.みんな")
 	z.Add("123123", "_metadata.example.com")
+	z.Add("1231231", "_foo._metadata.example.com")
 	z.Add("456456", "_metadata.エイミー.みんな")
 
 	assert.Equal(t, ZoneIDName{
-		"123456": "qux.baz",
-		"654321": "foo.qux.baz",
-		"987654": "エイミー.みんな",
-		"123123": "_metadata.example.com",
-		"456456": "_metadata.エイミー.みんな",
+		"123456":  "qux.baz",
+		"654321":  "foo.qux.baz",
+		"987654":  "エイミー.みんな",
+		"123123":  "_metadata.example.com",
+		"1231231": "_foo._metadata.example.com",
+		"456456":  "_metadata.エイミー.みんな",
 	}, z)
 
 	// simple entry in a domain
@@ -76,6 +78,10 @@ func TestZoneIDName(t *testing.T) {
 	zoneID, zoneName = z.FindZone("xn--eckh0ome.xn--q9jyb4c")
 	assert.Equal(t, "エイミー.みんな", zoneName)
 	assert.Equal(t, "987654", zoneID)
+
+	zoneID, zoneName = z.FindZone("_foo._metadata.example.com")
+	assert.Equal(t, "_foo._metadata.example.com", zoneName)
+	assert.Equal(t, "1231231", zoneID)
 
 	hook := testutils.LogsUnderTestWithLogLevel(log.WarnLevel, t)
 	_, _ = z.FindZone("???")


### PR DESCRIPTION
## What does it do ?

- We need custom idna profile in multiple locations
- TXT records not deleted for idna affected records
- records with `*` not handled correctly 
- for aws provider on DryRun added early return to reduce nesting


Follow-up most likely
- AWS provider HostedZoneId should be just an ID, without `prefix`. Example terraform https://github.com/hashicorp/terraform-provider-aws/blob/47afa5c147c6c5efede000e47d5d42483a0da928/internal/service/route53/record.go#L980 and API https://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets.html

## Motivation

Fixes #5649
Fixes #5602

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

Current
<img width="1704" height="640" alt="Screenshot 2025-07-25 at 12 07 00" src="https://github.com/user-attachments/assets/c87dd9b4-1321-4574-b5fd-90b9a656557d" />

<img width="1919" height="527" alt="Screenshot 2025-07-25 at 12 42 31" src="https://github.com/user-attachments/assets/4376023a-5f92-43fd-a267-439fdaad526d" />

With the fix

records added
<img width="1523" height="874" alt="Screenshot 2025-07-25 at 14 59 52" src="https://github.com/user-attachments/assets/486265a0-52eb-419a-80c8-a8ad09a8fd11" />

records deleted
<img width="1523" height="874" alt="Screenshot 2025-07-25 at 15 01 25" src="https://github.com/user-attachments/assets/c33c04b3-1692-4f25-a52b-b703e6a9b2d1" />

same for records with `*` and `_`
<img width="1788" height="528" alt="Screenshot 2025-07-25 at 12 44 02" src="https://github.com/user-attachments/assets/2f2d554b-82f8-4188-a0d8-d0de83a5dd92" />




