### PR TITLE
fix(docs): Remove substitution in AES keygen examples

### DIFF
--- a/docs/registry/txt.md
+++ b/docs/registry/txt.md
@@ -118,19 +118,19 @@ Note that the key used for encryption should be a secure key and properly manage
 Python
 
 ```python
-python -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())'
+python -c 'import os,base64; print(base64.standard_b64encode(os.urandom(32)).decode())'
 ```
 
 Bash
 
 ```shell
-dd if=/dev/urandom bs=32 count=1 2>/dev/null | base64 | tr -d -- '\n' | tr -- '+/' '-_'; echo
+dd if=/dev/urandom bs=32 count=1 2>/dev/null | base64; echo
 ```
 
 OpenSSL
 
 ```shell
-openssl rand -base64 32 | tr -- '+/' '-_'
+openssl rand -base64 32
 ```
 
 PowerShell
@@ -138,7 +138,7 @@ PowerShell
 ```powershell
 # Add System.Web assembly to session, just in case
 Add-Type -AssemblyName System.Web
-[Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes([System.Web.Security.Membership]::GeneratePassword(32,4))).Replace("+","-").Replace("/","_")
+[Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes([System.Web.Security.Membership]::GeneratePassword(32,4)))
 ```
 
 Terraform
@@ -146,7 +146,6 @@ Terraform
 ```hcl
 resource "random_password" "txt_key" {
   length           = 32
-  override_special = "-_"
 }
 ```
 


### PR DESCRIPTION
## What does it do ?

This removes the substitution that replaces `+` and `/` to `-` and `_` respectively from the documentation for example to generate AES (base64 encoded) encryption keys.

## Motivation

After testing these commands while wanting to introduce it, there was cases in which the commands effectively used the substitution. Go's `base64.StdEncoding.DecodeString` method does not want these substitutions, hence the keys will not work and ExternalDNS won't start.

As mentioned in #5684; not sure if there was a reasoning behind this substitution.

Considering not every generation of a key with those commands result in the substitution being triggered, some generated keys effectively worked hence it may have been overlooked.

## More

- [X] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] ~~Yes, I added unit tests~~
- [X] Yes, I updated end user documentation accordingly