### PR TITLE
chore(template): enchance issue-template for bug-report

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -7,8 +7,10 @@ assignees: ''
 
 ---
 
-<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
+<!--
+Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
 
+Make sure to validate the behavior against latest release https://github.com/kubernetes-sigs/external-dns/releases as we don't support past versions.
 -->
 
 **What happened**:
@@ -16,6 +18,10 @@ assignees: ''
 **What you expected to happen**:
 
 **How to reproduce it (as minimally and precisely as possible)**:
+
+<!--
+Please provide as much detail as possible, including Kubernetes manifests with spec.status, ExternalDNS arguments, and logs. Reproducing bugs without sufficient information is time-consuming and often impossible.
+-->
 
 **Anything else we need to know?**:
 


### PR DESCRIPTION
## What does it do ?

Just adds extra msg to `How to reproduce it` and ask to validate behavior with latest release. Many bugs are reported against older versions like 0.15 or 0.13, which are years out of date.

## Motivation

Too many bugs without minimal reproducible configs.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
