### PR TITLE
fix: add required properties to api components

### DIFF
--- a/api/webhook.yaml
+++ b/api/webhook.yaml
@@ -147,6 +147,8 @@ components:
       description: |
         external-dns will only create DNS records for host names (specified in ingress objects and services with the external-dns annotation) related to zones that match filters. They can set in external-dns deployment manifest.
       type: object
+      required:
+        - filters
       properties:
         filters:
           type: array
@@ -175,6 +177,12 @@ components:
       description: |
         This is a DNS record.
       type: object
+      required:
+        - dnsName
+        - targets
+        - recordType
+        - setIdentifier
+        - recordTTL
       properties:
         dnsName:
           type: string
@@ -226,6 +234,9 @@ components:
       description: |
         Allows provider to pass property specific to their implementation.
       type: object
+      required:
+        - name
+        - value
       properties:
         name:
           type: string


### PR DESCRIPTION
## What does it do ?

Updates the OpenAPI schema to indicate required properties in the components

## Motivation

Using the schema with a code generation tool, such as [datamodel-codegen](https://koxudaxi.github.io/datamodel-code-generator/) for Python Pydantic currently outputs models with all properties marked as optional. This does not match the types in the code.

## More

- [ x ] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

No tests or documentation required

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
