### PR TITLE
fix(provider): IDNA awareness in the zone finder

### DIFF
--- a/provider/zonefinder.go
+++ b/provider/zonefinder.go
@@ -20,7 +20,8 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/idna"
+
+	"sigs.k8s.io/external-dns/internal/idna"
 )
 
 type ZoneIDName map[string]string
@@ -48,7 +49,7 @@ func (z ZoneIDName) FindZone(hostname string) (string, string) {
 		if strings.Contains(label, "_") {
 			continue
 		}
-		convertedLabel, err := idna.Lookup.ToUnicode(label)
+		convertedLabel, err := idna.Profile.ToUnicode(label)
 		if err != nil {
 			log.Warnf("Failed to convert label %q of hostname %q to its Unicode form: %v", label, hostname, err)
 			convertedLabel = label

--- a/provider/zonefinder_test.go
+++ b/provider/zonefinder_test.go
@@ -34,6 +34,7 @@ func TestZoneIDName(t *testing.T) {
 	z.Add("123123", "_metadata.example.com")
 	z.Add("1231231", "_foo._metadata.example.com")
 	z.Add("456456", "_metadata.エイミー.みんな")
+	z.Add("123412", "*.example.com")
 
 	assert.Equal(t, ZoneIDName{
 		"123456":  "qux.baz",
@@ -42,6 +43,7 @@ func TestZoneIDName(t *testing.T) {
 		"123123":  "_metadata.example.com",
 		"1231231": "_foo._metadata.example.com",
 		"456456":  "_metadata.エイミー.みんな",
+		"123412":  "*.example.com",
 	}, z)
 
 	// simple entry in a domain
@@ -83,8 +85,12 @@ func TestZoneIDName(t *testing.T) {
 	assert.Equal(t, "_foo._metadata.example.com", zoneName)
 	assert.Equal(t, "1231231", zoneID)
 
-	hook := testutils.LogsUnderTestWithLogLevel(log.WarnLevel, t)
-	_, _ = z.FindZone("???")
+	zoneID, zoneName = z.FindZone("*.example.com")
+	assert.Equal(t, "*.example.com", zoneName)
+	assert.Equal(t, "123412", zoneID)
 
-	testutils.TestHelperLogContains("Failed to convert label \"???\" of hostname \"???\" to its Unicode form: idna: disallowed rune U+003F", hook, t)
+	hook := testutils.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+	_, _ = z.FindZone("xn--not-a-valid-punycode")
+
+	testutils.TestHelperLogContains("Failed to convert label \"xn--not-a-valid-punycode\" of hostname \"xn--not-a-valid-punycode\" to its Unicode form: idna: invalid label", hook, t)
 }


### PR DESCRIPTION
## What does it do ?
This PR fixes an overlooked usage of the old IDNA logic in `FindZone()` that still emits warning logs when parsing hostnames containing the `*` character. Although PR #5685 addressed this issue in some parts of the code by using a new IDNA profile that allows characters like `*`, one remaining path still uses the old profile, resulting in warning logs like:
`Failed to convert label “*” of hostname “*.example.com” to its Unicode form: idna: disallowed rune U+002A`
This PR updates the logic to consistently use the intended IDNA profile and avoid logging spurious warnings for wildcard hostnames.

<!-- A brief description of the change being made with this pull request. -->

## Motivation
This PR follows up on the changes in #5685 , which partially addressed unnecessary warning logs for hostnames with characters like `*`. However, the `FindZone()` function still uses the outdated IDNA conversion logic, causing the warning to appear even after #5685 was merged.

Suppressing these unnecessary warnings improves log clarity and avoids confusion for users working with wildcard DNS entries.

<!-- What inspired you to submit this pull request? -->

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
