### PR TITLE
test(source/istio): add missing test cases

### DIFF
--- a/source/endpoints_test.go
+++ b/source/endpoints_test.go
@@ -239,6 +239,55 @@ func TestEndpointTargetsFromServices(t *testing.T) {
 			selector:  map[string]string{"app": "nginx"},
 			expected:  endpoint.Targets{},
 		},
+		{
+			name: "multiple selectors",
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "fake",
+						Namespace: "default",
+					},
+					Spec: corev1.ServiceSpec{
+						Selector:    map[string]string{"app": "apache", "version": "v1"},
+						ExternalIPs: []string{"158.123.32.23"},
+					},
+				},
+			},
+			namespace: "default",
+			selector:  map[string]string{"version": "v1"},
+			expected:  endpoint.Targets{"158.123.32.23"},
+		},
+		{
+			name: "complex selectors",
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "fake",
+						Namespace: "default",
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							"app":     "demo",
+							"env":     "prod",
+							"team":    "devops",
+							"version": "v1",
+							"release": "stable",
+							"track":   "daily",
+							"tier":    "backend",
+						},
+						ExternalIPs: []string{"158.123.32.23"},
+					},
+				},
+			},
+			namespace: "default",
+			selector: map[string]string{
+				"version": "v1",
+				"release": "stable",
+				"tier":    "backend",
+				"app":     "demo",
+			},
+			expected: endpoint.Targets{"158.123.32.23"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What does it do ?

In this PR https://github.com/kubernetes-sigs/external-dns/pull/5708, while was doing smoke testing on real clusters, found, that some of the cases with selectors where not covered, as a results all tests where green, but on real cluster the change could lead to a bug. 

follow-up:
- slice PR https://github.com/kubernetes-sigs/external-dns/pull/5708

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
