### PR TITLE
fix(metrics): Make prometheus metrics labels more type safe.

### DIFF
--- a/pkg/metrics/labels.go
+++ b/pkg/metrics/labels.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+type Labels struct {
+	values map[string]string
+}
+
+func (labels *Labels) GetKeysInOrder() []string {
+	keys := make([]string, 0, len(labels.values))
+	for key := range labels.values {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}
+
+func (labels *Labels) GetValuesOrderedByKey() []string {
+	var orderedValues []string
+	for _, key := range labels.GetKeysInOrder() {
+		orderedValues = append(orderedValues, labels.values[key])
+	}
+
+	return orderedValues
+}
+
+type LabelOption func(*Labels)
+
+func NewLabels(labelNames []string) *Labels {
+	labels := &Labels{
+		values: make(map[string]string),
+	}
+
+	for _, label := range labelNames {
+		labels.values[strings.ToLower(label)] = ""
+	}
+
+	return labels
+}
+
+func (labels *Labels) WithOptions(options ...LabelOption) {
+	for _, option := range options {
+		option(labels)
+	}
+}
+
+func WithLabel(labelName string, labelValue string) LabelOption {
+	return func(labels *Labels) {
+		if _, ok := labels.values[strings.ToLower(labelName)]; !ok {
+			logrus.Errorf("Attempting to set a value for a label that doesn't exist! '%s' does not exist!", labelName)
+		} else {
+			labels.values[strings.ToLower(labelName)] = labelValue
+		}
+	}
+}

--- a/pkg/metrics/labels_test.go
+++ b/pkg/metrics/labels_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/external-dns/internal/testutils"
+)
+
+func TestNewLabels(t *testing.T) {
+	tests := []struct {
+		name               string
+		labelNames         []string
+		expectedLabelNames []string
+	}{
+		{
+			name:               "NewLabels initializes Values with labelNames",
+			labelNames:         []string{"label1", "label2"},
+			expectedLabelNames: []string{"label1", "label2"},
+		},
+		{
+			name:               "NewLabels sets labelNames as lower-case",
+			labelNames:         []string{"LABEL1", "label2"},
+			expectedLabelNames: []string{"label1", "label2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			labels := NewLabels(tt.labelNames)
+			keys := labels.GetKeysInOrder()
+
+			assert.Equal(t, tt.expectedLabelNames, keys)
+		})
+	}
+}
+
+func TestLabelsWithOptions(t *testing.T) {
+	tests := []struct {
+		name              string
+		labelNames        []string
+		options           []LabelOption
+		expectedValuesMap map[string]string
+	}{
+		{
+			name:       "WithOptions sets label values",
+			labelNames: []string{"label1", "label2"},
+			options: []LabelOption{
+				WithLabel("label1", "alpha"),
+				WithLabel("label2", "beta"),
+			},
+			expectedValuesMap: map[string]string{
+				"label1": "alpha",
+				"label2": "beta",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			labels := NewLabels(tt.labelNames)
+			labels.WithOptions(tt.options...)
+
+			assert.Equal(t, tt.expectedValuesMap, labels.values)
+		})
+	}
+}
+
+func TestLabelsWithLabel(t *testing.T) {
+	tests := []struct {
+		name             string
+		labelNames       []string
+		labelName        string
+		labelValue       string
+		expectedLabels   *Labels
+		expectedErrorLog string
+	}{
+		{
+			name:       "WithLabel sets label and value",
+			labelNames: []string{"label1"},
+			labelName:  "label1",
+			labelValue: "alpha",
+			expectedLabels: &Labels{
+				values: map[string]string{
+					"label1": "alpha",
+				}},
+		},
+		{
+			name:       "WithLabel sets labelName to lowercase",
+			labelNames: []string{"label1"},
+			labelName:  "LABEL1",
+			labelValue: "alpha",
+			expectedLabels: &Labels{
+				values: map[string]string{
+					"label1": "alpha",
+				}},
+		},
+		{
+			name:             "WithLabel errors if label doesn't exist",
+			labelNames:       []string{"label1"},
+			labelName:        "notreal",
+			labelValue:       "",
+			expectedErrorLog: "Attempting to set a value for a label that doesn't exist! 'notreal' does not exist!",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hook := testutils.LogsUnderTestWithLogLevel(logrus.WarnLevel, t)
+
+			labels := NewLabels(tt.labelNames)
+			labels.WithOptions(WithLabel(tt.labelName, tt.labelValue))
+
+			if tt.expectedLabels != nil {
+				assert.Equal(t, tt.expectedLabels, labels)
+			}
+
+			if tt.expectedErrorLog != "" {
+				testutils.TestHelperLogContains(tt.expectedErrorLog, hook, t)
+			}
+		})
+	}
+}
+
+func TestLabelsGetKeysInOrder(t *testing.T) {
+	tests := []struct {
+		name                string
+		labels              *Labels
+		expectedKeysInOrder []string
+	}{
+		{
+			"GetKeysInOrder returns keys in alphabetical order",
+			NewLabels([]string{"label2", "label1"}),
+			[]string{"label1", "label2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orderedKeys := tt.labels.GetKeysInOrder()
+
+			assert.Equal(t, tt.expectedKeysInOrder, orderedKeys)
+		})
+	}
+}
+
+func TestLabelsGetValuesOrderedByKey(t *testing.T) {
+	tests := []struct {
+		name                  string
+		labels                *Labels
+		labelOptions          []LabelOption
+		expectedValuesInOrder []string
+	}{
+		{
+			"GetKeysInOrder returns keys in alphabetical order",
+			NewLabels([]string{"label1", "label2"}),
+			[]LabelOption{
+				WithLabel("label2", "beta"),
+				WithLabel("label1", "alpha"),
+			},
+			[]string{"alpha", "beta"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.labels.WithOptions(tt.labelOptions...)
+
+			orderedValues := tt.labels.GetValuesOrderedByKey()
+
+			assert.Equal(t, tt.expectedValuesInOrder, orderedValues)
+		})
+	}
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -33,6 +33,12 @@ func (m *MockMetric) Get() *Metric {
 	return &Metric{FQDN: m.FQDN}
 }
 
+func getTestLabels(t *testing.T, labelNames []string) *Labels {
+	t.Helper()
+
+	return NewLabels(labelNames)
+}
+
 func TestMustRegister(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -61,7 +67,7 @@ func TestMustRegister(t *testing.T) {
 				NewCounterWithOpts(prometheus.CounterOpts{Name: "test_counter_3"}),
 				NewCounterVecWithOpts(prometheus.CounterOpts{Name: "test_counter_vec_3"}, []string{"label"}),
 				NewGaugedVectorOpts(prometheus.GaugeOpts{Name: "test_gauge_v_3"}, []string{"label"}),
-				NewSummaryVecWithOpts(prometheus.SummaryOpts{Name: "test_summary_v_3"}, []string{"label"}),
+				NewSummaryVecWithOpts(prometheus.SummaryOpts{Name: "test_summary_v_3"}, *NewLabels([]string{"label"})),
 			},
 			expected: 5,
 		},

--- a/pkg/metrics/models.go
+++ b/pkg/metrics/models.go
@@ -186,17 +186,11 @@ func (s SummaryVecMetric) Get() *Metric {
 	return &s.Metric
 }
 
-// SetWithLabels sets the value of the SummaryVec metric for the specified label values.
-// All label values are converted to lowercase before being applied.
-func (s SummaryVecMetric) SetWithLabels(value float64, lvs ...string) {
-	for i, v := range lvs {
-		lvs[i] = strings.ToLower(v)
-	}
-
-	s.SummaryVec.WithLabelValues(lvs...).Observe(value)
+func (s SummaryVecMetric) SetWithLabels(value float64, labels *Labels) {
+	s.SummaryVec.WithLabelValues(labels.GetValuesOrderedByKey()...).Observe(value)
 }
 
-func NewSummaryVecWithOpts(opts prometheus.SummaryOpts, labelNames []string) SummaryVecMetric {
+func NewSummaryVecWithOpts(opts prometheus.SummaryOpts, labels Labels) SummaryVecMetric {
 	opts.Namespace = Namespace
 	return SummaryVecMetric{
 		Metric: Metric{
@@ -207,7 +201,7 @@ func NewSummaryVecWithOpts(opts prometheus.SummaryOpts, labelNames []string) Sum
 			Subsystem: opts.Subsystem,
 			Help:      opts.Help,
 		},
-		SummaryVec: *prometheus.NewSummaryVec(opts, labelNames),
+		SummaryVec: *prometheus.NewSummaryVec(opts, labels.GetKeysInOrder()),
 	}
 }
 

--- a/pkg/metrics/models_test.go
+++ b/pkg/metrics/models_test.go
@@ -191,9 +191,16 @@ func TestSummaryV_SetWithLabels(t *testing.T) {
 		Subsystem: "test_sub",
 		Help:      "help text",
 	}
-	sv := NewSummaryVecWithOpts(opts, []string{"label1", "label2"})
 
-	sv.SetWithLabels(5.01, "Alpha", "BETA")
+	labels := NewLabels([]string{"label1", "label2"})
+	sv := NewSummaryVecWithOpts(opts, *labels)
+
+	labels.WithOptions(
+		WithLabel("label1", "alpha"),
+		WithLabel("label2", "beta"),
+	)
+
+	sv.SetWithLabels(5.01, labels)
 
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(sv.SummaryVec)


### PR DESCRIPTION
## What does it do ?

Ensure labels are more type safe and applied in the correct order.

## Motivation

While working on PR #5665 it was determined that we could use more type safety for prometheus labels.

## More

- [ x ] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ x ] Yes, I added unit tests
- [ x ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
