### PR TITLE
feat(helm): Add support for extraObjects in the helm chart

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Added
+
+- Add `extraObjects` feature to Helm chart. ([#5719](https://github.com/kubernetes-sigs/external-dns/pull/5719)) _@cest-pas-faux_
+
 ## [v1.18.0] - 2025-07-14
 
 ### Changed

--- a/charts/external-dns/templates/extraobjects.yaml
+++ b/charts/external-dns/templates/extraobjects.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ toYaml . }}
+{{ end }}

--- a/charts/external-dns/tests/extraobjects_test.yaml
+++ b/charts/external-dns/tests/extraobjects_test.yaml
@@ -1,0 +1,71 @@
+suite: ExtraObjects functionality
+templates:
+  - extraobjects.yaml
+chart:
+  appVersion: 0.15.0
+  version: 1.15.0
+tests:
+  - it: should render empty when no extraObjects are provided
+    set:
+      extraObjects: []
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render extraObjects when provided
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: external-dns-config
+            namespace: default
+          data:
+            KEY: VALUE
+        - apiVersion: policy/v1
+          kind: PodDisruptionBudget
+          metadata:
+            name: external-dns-pdb
+          spec:
+            minAvailable: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: external-dns
+    asserts:
+      - hasDocuments:
+          count: 2
+      - contains:
+          kind: ConfigMap
+      - contains:
+          kind: PodDisruptionBudget
+      - equal:
+          path: [0].metadata.name
+          value: external-dns-config
+      - equal:
+          path: [1].metadata.name
+          value: external-dns-pdb
+      - equal:
+          path: [1].spec.minAvailable
+          value: 1
+
+  - it: should render single extraObject correctly
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: external-dns-secret
+          type: Opaque
+          stringData:
+            MYKEY: MYVALUE
+    asserts:
+      - hasDocuments:
+          count: 1
+      - contains:
+          kind: Secret
+      - equal:
+          path: [0].metadata.name
+          value: external-dns-secret
+      - equal:
+          path: [0].type
+          value: Opaque

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -314,3 +314,15 @@ secretConfiguration:
 
 # -- (bool) No effect - reserved for use in sub-charting.
 enabled:  # @schema type: [boolean, null]; description: No effect - reserved for use in sub-charting
+
+# -- Extra objects to add to the Helm Release.
+extraObjects: []
+  # - apiVersion: policy/v1
+  #   kind: PodDisruptionBudget
+  #   metadata:
+  #     name: external-dns
+  #   spec:
+  #     minAvailable: 1
+  #     selector:
+  #       matchLabels:
+  #         app.kubernetes.io/name: external-dns


### PR DESCRIPTION

## What does it do ?

This feature adds and extraObjects array to the values file to be rendered as plain kubernetes manifests.
I added an example with a PDB, we could change it with something else.

## Motivation

Most charts implements this feature to allow users to manage more objects/features related to the release without having to rely on a template being made for it.
This feature lacked in the bitnami/external-dns for us to add a PDB, it would be great to have it in this chart.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

