### PR TITLE
feat(chart): add option to configure annotationFilter via dedicated helm value

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,7 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
-- Added option to configure `annotationFilter` via dedicated helm value. ([#5737](https://github.com/kubernetes-sigs/external-dns/pull/5737)) _@dshatokhin_
+### Added
+
+- Add option to configure `annotationFilter` via dedicated chart value. ([#5737](https://github.com/kubernetes-sigs/external-dns/pull/5737)) _@dshatokhin_
 
 ## [v1.18.0] - 2025-07-14
 

--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+- Added option to configure `annotationFilter` via dedicated helm value. ([#5737](https://github.com/kubernetes-sigs/external-dns/pull/5737)) _@dshatokhin_
+
 ## [v1.18.0] - 2025-07-14
 
 ### Changed

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -94,6 +94,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity settings for `Pod` [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels. |
+| annotationFilter | string | `nil` | Filter resources queried for endpoints by annotation selector |
 | automountServiceAccountToken | bool | `true` | Set this to `false` to [opt out of API credential automounting](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting) for the `Pod`. |
 | commonLabels | object | `{}` | Labels to add to all chart resources. |
 | deploymentAnnotations | object | `{}` | Annotations to add to the `Deployment`. |

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -94,7 +94,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity settings for `Pod` [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels. |
-| annotationFilter | string | `nil` | Filter resources queried for endpoints by annotation selector |
+| annotationFilter | string | `nil` | Filter resources queried for endpoints by annotation selector. |
 | automountServiceAccountToken | bool | `true` | Set this to `false` to [opt out of API credential automounting](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting) for the `Pod`. |
 | commonLabels | object | `{}` | Labels to add to all chart resources. |
 | deploymentAnnotations | object | `{}` | Annotations to add to the `Deployment`. |
@@ -118,7 +118,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | imagePullSecrets | list | `[]` | Image pull secrets. |
 | initContainers | list | `[]` | [Init containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) to add to the `Pod` definition. |
 | interval | string | `"1m"` | Interval for DNS updates. |
-| labelFilter | string | `nil` | Filter resources queried for endpoints by label selector |
+| labelFilter | string | `nil` | Filter resources queried for endpoints by label selector. |
 | livenessProbe | object | See _values.yaml_ | [Liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `external-dns` container. |
 | logFormat | string | `"text"` | Log format. |
 | logLevel | string | `"info"` | Log level. |

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -123,6 +123,9 @@ spec:
             {{- if .Values.labelFilter }}
             - --label-filter={{ .Values.labelFilter }}
             {{- end }}
+            {{- if .Values.annotationFilter }}
+            - --annotation-filter={{ .Values.annotationFilter }}
+            {{- end }}
             {{- range .Values.managedRecordTypes }}
             - --managed-record-types={{ . }}
             {{- end }}

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -6,6 +6,13 @@
       "description": "Affinity settings for `Pod` [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels.",
       "type": "object"
     },
+    "annotationFilter": {
+      "description": "Filter resources queried for endpoints by annotation selector",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "automountServiceAccountToken": {
       "description": "Set this to `false` to [opt out of API credential automounting](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting) for the `Pod`.",
       "type": "boolean"
@@ -23,9 +30,8 @@
       "type": "object",
       "properties": {
         "type": {
-          "type": [
-            "string"
-          ],
+          "default": "Recreate",
+          "type": "string",
           "enum": [
             "Recreate",
             "RollingUpdate"
@@ -93,6 +99,13 @@
     },
     "fullnameOverride": {
       "description": "Override the full name of the chart.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "gatewayNamespace": {
+      "description": "_Gateway API_ gateway namespace to watch.",
       "type": [
         "string",
         "null"
@@ -192,9 +205,7 @@
     "logFormat": {
       "description": "Log format.",
       "default": "text",
-      "type": [
-        "string"
-      ],
+      "type": "string",
       "enum": [
         "text",
         "json"
@@ -203,9 +214,7 @@
     "logLevel": {
       "description": "Log level.",
       "default": "info",
-      "type": [
-        "string"
-      ],
+      "type": "string",
       "enum": [
         "panic",
         "debug",
@@ -272,9 +281,7 @@
     "policy": {
       "description": "How DNS records are synchronized between sources and providers; available values are `create-only`, `sync`, \u0026 `upsert-only`.",
       "default": "upsert-only",
-      "type": [
-        "string"
-      ],
+      "type": "string",
       "enum": [
         "create-only",
         "sync",
@@ -367,6 +374,7 @@
                       ]
                     },
                     "port": {
+                      "default": "string",
                       "type": [
                         "integer",
                         "string"
@@ -420,6 +428,7 @@
                       ]
                     },
                     "port": {
+                      "default": "string",
                       "type": [
                         "integer",
                         "string"

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -7,7 +7,7 @@
       "type": "object"
     },
     "annotationFilter": {
-      "description": "Filter resources queried for endpoints by annotation selector",
+      "description": "Filter resources queried for endpoints by annotation selector.",
       "type": [
         "string",
         "null"
@@ -164,7 +164,7 @@
       "type": "string"
     },
     "labelFilter": {
-      "description": "Filter resources queried for endpoints by label selector",
+      "description": "Filter resources queried for endpoints by label selector.",
       "type": [
         "string",
         "null"

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -12,7 +12,7 @@ image:  # @schema additionalProperties: false
   # -- Image tag for the `external-dns` container, this will default to `.Chart.AppVersion` if not set.
   tag:  # @schema type:[string, null]
   # -- Image pull policy for the `external-dns` container.
-  pullPolicy: IfNotPresent  # @schema enum:[IfNotPresent, Always];
+  pullPolicy: IfNotPresent  # @schema enum:[IfNotPresent, Always]
 
 # -- Image pull secrets.
 imagePullSecrets: []  # @schema item: object
@@ -44,11 +44,11 @@ service:
   # -- Service HTTP port.
   port: 7979  # @schema minimum:0; default:7979
   # -- Service IP families (e.g. IPv4 and/or IPv6).
-  ipFamilies: []  # @schema type: [array, null]; item: string; itemEnum: ["IPv4", "IPv6"]; minItems:0; maxItems:2; uniqueItems: true;
+  ipFamilies: []  # @schema type: [array, null]; item: string; itemEnum: ["IPv4", "IPv6"]; minItems:0; maxItems:2; uniqueItems: true
   #  - IPv4
   #  - IPv6
   # -- Service IP family policy.
-  ipFamilyPolicy:  # @schema type: [string, null];  enum:[SingleStack, PreferDualStack, RequireDualStack, null];
+  ipFamilyPolicy:  # @schema type: [string, null];  enum:[SingleStack, PreferDualStack, RequireDualStack, null]
 
 rbac:  # @schema additionalProperties: true
   # -- If `true`, create a `ClusterRole` & `ClusterRoleBinding` with access to the Kubernetes API.
@@ -237,10 +237,13 @@ excludeDomains: []
 # -- Filter resources queried for endpoints by label selector
 labelFilter:  # @schema type: [string,null]; default: null
 
-# -- Record types to manage (default: A, AAAA, CNAME)
-managedRecordTypes: []  # @schema type: [array, null]; item: string; uniqueItems: true;
+# -- Filter resources queried for endpoints by annotation selector
+annotationFilter:  # @schema type: [string,null]; default: null
 
-provider:  # @schema type: [object, string];
+# -- Record types to manage (default: A, AAAA, CNAME)
+managedRecordTypes: []  # @schema type: [array, null]; item: string; uniqueItems: true
+
+provider:  # @schema type: [object, string]
   # -- _ExternalDNS_ provider name; for the available providers and how to configure them see [README](https://github.com/kubernetes-sigs/external-dns/blob/master/charts/external-dns/README.md#providers).
   name: aws
   webhook:
@@ -300,7 +303,7 @@ provider:  # @schema type: [object, string];
 
 # -- Extra arguments to provide to _ExternalDNS_.
 # An array or map can be used, with maps allowing for value overrides; maps also support slice values to use the same arg multiple times.
-extraArgs: {}  # @schema type: [array, null, object]; item: string; uniqueItems: true;
+extraArgs: {}  # @schema type: [array, null, object]; item: string; uniqueItems: true
 
 secretConfiguration:
   # -- If `true`, create a `Secret` to store sensitive provider configuration (**DEPRECATED**).

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -234,10 +234,10 @@ domainFilters: []
 # -- Intentionally exclude domains from being managed.
 excludeDomains: []
 
-# -- Filter resources queried for endpoints by label selector
+# -- Filter resources queried for endpoints by label selector.
 labelFilter:  # @schema type: [string,null]; default: null
 
-# -- Filter resources queried for endpoints by annotation selector
+# -- Filter resources queried for endpoints by annotation selector.
 annotationFilter:  # @schema type: [string,null]; default: null
 
 # -- Record types to manage (default: A, AAAA, CNAME)

--- a/scripts/helm-tools.sh
+++ b/scripts/helm-tools.sh
@@ -67,8 +67,8 @@ update_schema() {
 
 diff_schema() {
   cd charts/external-dns
-  helm schema  \
-    -output diff-schema.schema.json
+  helm schema \
+    --output diff-schema.schema.json
   trap 'rm -rf -- "diff-schema.schema.json"' EXIT
   CURRENT_SCHEMA=$(cat values.schema.json)
   GENERATED_SCHEMA=$(cat diff-schema.schema.json)


### PR DESCRIPTION
## What does it do ?

This PR introduces ability to configure `--annotation-filter` flag with `annotationFilter` helm value.

## Motivation

Both `labelFilter` and `annotationFilter` should be supported and be easily configurable with helm chart.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

Our team is moving from bitnami chart to this one and this change would be useful for other teams who probably doing the same. This will help us to ensure smooth transition without breaking expectations.
