### PR TITLE
feat(chart): Add support for extra objects

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Added
+
+- Support for extra objects
+
 ## [v1.18.0] - 2025-07-14
 
 ### Changed

--- a/charts/external-dns/templates/extra-objects.yaml
+++ b/charts/external-dns/templates/extra-objects.yaml
@@ -1,0 +1,22 @@
+{{- range .Values.extraObjects }}
+---
+{{- $rendered := "" }}
+{{- if typeIs "string" . }}
+  {{- $rendered = tpl . $ }}
+{{- else }}
+  {{- $rendered = tpl (. | toYaml) $ }}
+{{- end }}
+
+{{- $obj := $rendered | fromYaml }}
+{{- $commonLabels := include "external-dns.labels" $ | fromYaml }}
+
+{{- if not $obj.metadata }}
+  {{- $_ := set $obj "metadata" dict }}
+{{- end }}
+
+{{- $existingLabels := $obj.metadata.labels | default dict }}
+{{- $mergedLabels := merge $existingLabels $commonLabels }}
+{{- $_ := set $obj.metadata "labels" $mergedLabels }}
+
+{{- $obj | toYaml }}
+{{- end }}

--- a/charts/external-dns/tests/common-metadata_test.yaml
+++ b/charts/external-dns/tests/common-metadata_test.yaml
@@ -14,6 +14,12 @@ tests:
         mountPath: "/etc/kubernetes/"
       serviceMonitor:
         enabled: true
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: "my-extra-cm"
+          data: {}
     asserts:
       - exists:
           path: metadata.labels

--- a/charts/external-dns/tests/extra-objects_test.yaml
+++ b/charts/external-dns/tests/extra-objects_test.yaml
@@ -1,0 +1,40 @@
+suite: Extra objects rendering
+templates:
+  - "extra-objects.yaml"
+release:
+  name: external-dns
+chart:
+  version: "1.15.0"
+  appVersion: "0.15.0"
+tests:
+  - it: "should render correctly the objects"
+    set:
+      extraObjects:
+        - |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: string-cm-{{ .Release.Name }}
+          data:
+            foo: {{ .Release.Name }}
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: "obj-cm-{{ .Release.Name }}"
+          data:
+          foo: "{{ .Release.Namespace }}"
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentSelector:
+          path: metadata.name
+          value: string-cm-external-dns
+        equal:
+          path: data.foo
+          value: external-dns
+      - documentSelector:
+          path: metadata.name
+          value: obj-cm-external-dns
+        equal:
+          path: data.foo
+          value: NAMESPACE

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -83,6 +83,10 @@
       "description": "Extra containers to add to the `Deployment`.",
       "type": "array"
     },
+    "extraObjects": {
+      "description": "Extra Kubernetes objects to deploy with the helm chart.",
+      "type": "array"
+    },
     "extraVolumeMounts": {
       "description": "Extra [volume mounts](https://kubernetes.io/docs/concepts/storage/volumes/) for the `external-dns` container.",
       "type": "array"

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -312,5 +312,8 @@ secretConfiguration:
   # -- `Secret` data.
   data: {}
 
+# -- Extra Kubernetes objects to deploy with the helm chart
+extraObjects: []
+
 # -- (bool) No effect - reserved for use in sub-charting.
 enabled:  # @schema type: [boolean, null]; description: No effect - reserved for use in sub-charting


### PR DESCRIPTION
## What does it do ?

Add support for extra objects on helm chart.

## Motivation
Helps to deploy resources related to the chart without creating an other chart (eg: an external secret for provider credentials).

## More

- [X] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly
