### PR TITLE
fix(rbac): conditional endpointslices perms

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add option to configure `annotationFilter` via dedicated chart value. ([#5737](https://github.com/kubernetes-sigs/external-dns/pull/5737)) _@dshatokhin_
 
+### Changed
+
+- Grant `discovery.k8s.io/endpointslices` permission only when using `service` source. ([#5746](https://github.com/kubernetes-sigs/external-dns/pull/5746)) _@vflaux_
+
 ## [v1.18.0] - 2025-07-14
 
 ### Changed

--- a/charts/external-dns/templates/clusterrole.yaml
+++ b/charts/external-dns/templates/clusterrole.yaml
@@ -20,6 +20,8 @@ rules:
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["get","watch","list"]
+{{- end }}
+{{- if has "service" .Values.sources }}
   - apiGroups: ["discovery.k8s.io"]
     resources: ["endpointslices"]
     verbs: ["get","watch","list"]

--- a/charts/external-dns/tests/rbac_test.yaml
+++ b/charts/external-dns/tests/rbac_test.yaml
@@ -52,6 +52,50 @@ tests:
               resources: ["ingresses"]
               verbs: ["get","watch","list"]
 
+  - it: should create no RBAC rules when no sources are set
+    set:
+      sources: []
+    asserts:
+      - template: clusterrole.yaml
+        equal:
+          path: rules
+          value: null
+
+  - it: should create default RBAC rules for 'ingresses' with source 'ingress'
+    set:
+      sources:
+        - ingress
+    asserts:
+      - template: clusterrole.yaml
+        equal:
+          path: rules
+          value:
+            - apiGroups: ["extensions","networking.k8s.io"]
+              resources: ["ingresses"]
+              verbs: ["get","watch","list"]
+
+  - it: should create default RBAC rules for 'nodes', 'pods', 'services' and 'endpointslices' with source 'service'
+    set:
+      sources:
+        - service
+    asserts:
+      - template: clusterrole.yaml
+        equal:
+          path: rules
+          value:
+            - apiGroups: [""]
+              resources: ["nodes"]
+              verbs: ["list", "watch"]
+            - apiGroups: [""]
+              resources: ["pods"]
+              verbs: ["get", "watch", "list"]
+            - apiGroups: [""]
+              resources: ["services"]
+              verbs: ["get","watch","list"]
+            - apiGroups: ["discovery.k8s.io"]
+              resources: ["endpointslices"]
+              verbs: ["get","watch","list"]
+
   - it: should create default RBAC rules for 'ambassador-host'
     set:
       sources:
@@ -411,9 +455,6 @@ tests:
           - apiGroups: [""]
             resources: ["services"]
             verbs: ["get","watch","list"]
-          - apiGroups: ["discovery.k8s.io"]
-            resources: ["endpointslices"]
-            verbs: ["get","watch","list"]
           - apiGroups: ["extensions","networking.k8s.io"]
             resources: ["ingresses"]
             verbs: ["get","watch","list"]
@@ -443,9 +484,6 @@ tests:
             - apiGroups: [""]
               resources: ["services"]
               verbs: ["get","watch","list"]
-            - apiGroups: ["discovery.k8s.io"]
-              resources: ["endpointslices"]
-              verbs: ["get","watch","list"]
             - apiGroups: ["extensions","networking.k8s.io"]
               resources: ["ingresses"]
               verbs: ["get","watch","list"]
@@ -471,9 +509,6 @@ tests:
           value:
             - apiGroups: [""]
               resources: ["services"]
-              verbs: ["get","watch","list"]
-            - apiGroups: ["discovery.k8s.io"]
-              resources: ["endpointslices"]
               verbs: ["get","watch","list"]
             - apiGroups: ["extensions","networking.k8s.io"]
               resources: ["ingresses"]

--- a/docs/tutorials/godaddy.md
+++ b/docs/tutorials/godaddy.md
@@ -103,9 +103,6 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["list","watch"]
-- apiGroups: [""]
-  resources: ["endpoints"]
-  verbs: ["get","watch","list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/docs/tutorials/ovh.md
+++ b/docs/tutorials/ovh.md
@@ -139,9 +139,6 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["list"]
-- apiGroups: [""]
-  resources: ["endpoints"]
-  verbs: ["get","watch","list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## What does it do ?

- Only grant `endpointslices` RBAC when `service` source is used in chart.
- Removes unneeded `v1/endpoints`  permissions in *godaddy* & *ovh* tutorials.

## Motivation

<!-- What inspired you to submit this pull request? -->

We grant `endpointslices` permissions when not needed in the helm chart. If I'm not mistaken, only the `service` source use `endpointslices`.


## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
