### PR TITLE
docs(readme): update k8s compatiblity table

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,13 +162,18 @@ The following table clarifies the current status of the providers according to t
 
 ## Kubernetes version compatibility
 
-A [breaking change](https://github.com/kubernetes-sigs/external-dns/pull/2281) was added in external-dns v0.10.0.
+Breaking changes were introduced in external-dns in the following versions:
 
-| ExternalDNS                    |      <= 0.9.x      |     >= 0.10.0      |
-| ------------------------------ | :----------------: | :----------------: |
-| Kubernetes <= 1.18             | :white_check_mark: |        :x:         |
-| Kubernetes >= 1.19 and <= 1.21 | :white_check_mark: | :white_check_mark: |
-| Kubernetes >= 1.22             |        :x:         | :white_check_mark: |
+- [`v0.10.0`](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.10.0): use of `networking.k8s.io/ingresses` instead of `extensions/ingresses` (see [#2281](https://github.com/kubernetes-sigs/external-dns/pull/2281))
+- [`v0.18.0`](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.18.0): use of `discovery.k8s.io/endpointslices` instead of `endpoints` (see [#5493](https://github.com/kubernetes-sigs/external-dns/pull/5493))
+
+| ExternalDNS                  |      ≤ 0.9.x       | ≤ 0.10.x and ≥ 0.17.x |      ≥ 0.18.x      |
+| ---------------------------- | :----------------: | :-------------------: | :----------------: |
+| Kubernetes ≤ 1.18            | :white_check_mark: |          :x:          |        :x:         |
+| Kubernetes 1.19 and 1.20     | :white_check_mark: |  :white_check_mark:   |        :x:         |
+| Kubernetes 1.21              | :white_check_mark: |  :white_check_mark:   | :white_check_mark: |
+| Kubernetes ≥ 1.22 and ≤ 1.32 |        :x:         |  :white_check_mark:   | :white_check_mark: |
+| Kubernetes ≥ 1.33            |        :x:         |          :x:          | :white_check_mark: |
 
 ## Running ExternalDNS
 


### PR DESCRIPTION
## What does it do ?

Update the Kubernetes compatibility table in `README.md`.
<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->

There is a breaking change since `v0.18.0` with the switch to `endpointslices` (https://github.com/kubernetes-sigs/external-dns/pull/5493). See https://github.com/kubernetes-sigs/external-dns/pull/5493#issuecomment-3160760711.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
