### PR TITLE
chore(helm): add rbac unit-tests for istio sources

### DIFF
--- a/charts/external-dns/tests/rbac_test.yaml
+++ b/charts/external-dns/tests/rbac_test.yaml
@@ -391,3 +391,97 @@ tests:
       - isKind:
           of: RoleBinding
         template: clusterrolebinding.yaml
+
+  - it: should create only Role when namespaced=true for istio sources
+    set:
+      namespaced: true
+      sources:
+        - istio-virtualservice
+        - istio-gateway
+    asserts:
+      - isKind:
+          of: Role
+        template: clusterrole.yaml
+      - isKind:
+          of: RoleBinding
+        template: clusterrolebinding.yaml
+      - equal:
+          path: rules
+          value:
+          - apiGroups: [""]
+            resources: ["services"]
+            verbs: ["get","watch","list"]
+          - apiGroups: ["discovery.k8s.io"]
+            resources: ["endpointslices"]
+            verbs: ["get","watch","list"]
+          - apiGroups: ["extensions","networking.k8s.io"]
+            resources: ["ingresses"]
+            verbs: ["get","watch","list"]
+          - apiGroups: ["networking.istio.io"]
+            resources: ["gateways"]
+            verbs: ["get","watch","list"]
+          - apiGroups: ["networking.istio.io"]
+            resources: ["virtualservices"]
+            verbs: ["get","watch","list"]
+        template: clusterrole.yaml
+
+  - it: should create only ClusterRole for istio-gateway with ingress permissions
+    set:
+      namespaced: false
+      sources:
+        - istio-gateway
+    asserts:
+      - isKind:
+          of: ClusterRole
+        template: clusterrole.yaml
+      - isKind:
+          of: ClusterRoleBinding
+        template: clusterrolebinding.yaml
+      - equal:
+          path: rules
+          value:
+            - apiGroups: [""]
+              resources: ["services"]
+              verbs: ["get","watch","list"]
+            - apiGroups: ["discovery.k8s.io"]
+              resources: ["endpointslices"]
+              verbs: ["get","watch","list"]
+            - apiGroups: ["extensions","networking.k8s.io"]
+              resources: ["ingresses"]
+              verbs: ["get","watch","list"]
+            - apiGroups: ["networking.istio.io"]
+              resources: ["gateways"]
+              verbs: ["get","watch","list"]
+        template: clusterrole.yaml
+
+  - it: should create only ClusterRole for istio-virtualservice with ingress permissions required
+    set:
+      namespaced: false
+      sources:
+        - istio-virtualservice
+    asserts:
+      - isKind:
+          of: ClusterRole
+        template: clusterrole.yaml
+      - isKind:
+          of: ClusterRoleBinding
+        template: clusterrolebinding.yaml
+      - equal:
+          path: rules
+          value:
+            - apiGroups: [""]
+              resources: ["services"]
+              verbs: ["get","watch","list"]
+            - apiGroups: ["discovery.k8s.io"]
+              resources: ["endpointslices"]
+              verbs: ["get","watch","list"]
+            - apiGroups: ["extensions","networking.k8s.io"]
+              resources: ["ingresses"]
+              verbs: ["get","watch","list"]
+            - apiGroups: ["networking.istio.io"]
+              resources: ["gateways"]
+              verbs: ["get","watch","list"]
+            - apiGroups: ["networking.istio.io"]
+              resources: ["virtualservices"]
+              verbs: ["get","watch","list"]
+        template: clusterrole.yaml


### PR DESCRIPTION
## What does it do ?

Adds RBAC tests for istio sources.

> RE the duplicate calls were you thinking of adding something like a singleflight wrapper?

I think the code already have `singleflight` https://github.com/kubernetes-sigs/external-dns/blob/master/source/wrappers/dedupsource.go. Unless I misunderstood the idea.

The problem I see at the moment, `istio-virtualservice` actually fully duplicates some of the `istio-gateway` logic with `ingresses`. So we may need to consider cleanup in the future `istio-virtualservice`

## Motivation

https://github.com/kubernetes-sigs/external-dns/pull/5743#issuecomment-3195820713

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
