### PR TITLE
chore(cloudflare): rename zoneService fields

### DIFF
--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -123,8 +123,8 @@ type cloudFlareDNS interface {
 }
 
 type zoneService struct {
-	service   *cloudflarev0.API
-	serviceV4 *cloudflare.Client
+	serviceV0 *cloudflarev0.API
+	service   *cloudflare.Client
 }
 
 func (z zoneService) ZoneIDByName(zoneName string) (string, error) {
@@ -133,7 +133,7 @@ func (z zoneService) ZoneIDByName(zoneName string) (string, error) {
 		Name: cloudflare.F(zoneName),
 	}
 
-	iter := z.serviceV4.Zones.ListAutoPaging(context.Background(), params)
+	iter := z.service.Zones.ListAutoPaging(context.Background(), params)
 	for zone := range autoPagerIterator(iter) {
 		if zone.Name == zoneName {
 			return zone.ID, nil
@@ -148,40 +148,40 @@ func (z zoneService) ZoneIDByName(zoneName string) (string, error) {
 }
 
 func (z zoneService) CreateDNSRecord(ctx context.Context, rc *cloudflarev0.ResourceContainer, rp cloudflarev0.CreateDNSRecordParams) (cloudflarev0.DNSRecord, error) {
-	return z.service.CreateDNSRecord(ctx, rc, rp)
+	return z.serviceV0.CreateDNSRecord(ctx, rc, rp)
 }
 
 func (z zoneService) ListDNSRecords(ctx context.Context, rc *cloudflarev0.ResourceContainer, rp cloudflarev0.ListDNSRecordsParams) ([]cloudflarev0.DNSRecord, *cloudflarev0.ResultInfo, error) {
-	return z.service.ListDNSRecords(ctx, rc, rp)
+	return z.serviceV0.ListDNSRecords(ctx, rc, rp)
 }
 
 func (z zoneService) UpdateDNSRecord(ctx context.Context, rc *cloudflarev0.ResourceContainer, rp cloudflarev0.UpdateDNSRecordParams) error {
-	_, err := z.service.UpdateDNSRecord(ctx, rc, rp)
+	_, err := z.serviceV0.UpdateDNSRecord(ctx, rc, rp)
 	return err
 }
 
 func (z zoneService) DeleteDNSRecord(ctx context.Context, rc *cloudflarev0.ResourceContainer, recordID string) error {
-	return z.service.DeleteDNSRecord(ctx, rc, recordID)
+	return z.serviceV0.DeleteDNSRecord(ctx, rc, recordID)
 }
 
 func (z zoneService) ListZones(ctx context.Context, params zones.ZoneListParams) autoPager[zones.Zone] {
-	return z.serviceV4.Zones.ListAutoPaging(ctx, params)
+	return z.service.Zones.ListAutoPaging(ctx, params)
 }
 
 func (z zoneService) GetZone(ctx context.Context, zoneID string) (*zones.Zone, error) {
-	return z.serviceV4.Zones.Get(ctx, zones.ZoneGetParams{ZoneID: cloudflare.F(zoneID)})
+	return z.service.Zones.Get(ctx, zones.ZoneGetParams{ZoneID: cloudflare.F(zoneID)})
 }
 
 func (z zoneService) CustomHostnames(ctx context.Context, zoneID string, page int, filter cloudflarev0.CustomHostname) ([]cloudflarev0.CustomHostname, cloudflarev0.ResultInfo, error) {
-	return z.service.CustomHostnames(ctx, zoneID, page, filter)
+	return z.serviceV0.CustomHostnames(ctx, zoneID, page, filter)
 }
 
 func (z zoneService) DeleteCustomHostname(ctx context.Context, zoneID string, customHostnameID string) error {
-	return z.service.DeleteCustomHostname(ctx, zoneID, customHostnameID)
+	return z.serviceV0.DeleteCustomHostname(ctx, zoneID, customHostnameID)
 }
 
 func (z zoneService) CreateCustomHostname(ctx context.Context, zoneID string, ch cloudflarev0.CustomHostname) (*cloudflarev0.CustomHostnameResponse, error) {
-	return z.service.CreateCustomHostname(ctx, zoneID, ch)
+	return z.serviceV0.CreateCustomHostname(ctx, zoneID, ch)
 }
 
 // listZonesV4Params returns the appropriate Zone List Params for v4 API

--- a/provider/cloudflare/cloudflare_regional.go
+++ b/provider/cloudflare/cloudflare_regional.go
@@ -56,21 +56,21 @@ type regionalHostnameChange struct {
 }
 
 func (z zoneService) ListDataLocalizationRegionalHostnames(ctx context.Context, params addressing.RegionalHostnameListParams) autoPager[addressing.RegionalHostnameListResponse] {
-	return z.serviceV4.Addressing.RegionalHostnames.ListAutoPaging(ctx, params)
+	return z.service.Addressing.RegionalHostnames.ListAutoPaging(ctx, params)
 }
 
 func (z zoneService) CreateDataLocalizationRegionalHostname(ctx context.Context, params addressing.RegionalHostnameNewParams) error {
-	_, err := z.serviceV4.Addressing.RegionalHostnames.New(ctx, params)
+	_, err := z.service.Addressing.RegionalHostnames.New(ctx, params)
 	return err
 }
 
 func (z zoneService) UpdateDataLocalizationRegionalHostname(ctx context.Context, hostname string, params addressing.RegionalHostnameEditParams) error {
-	_, err := z.serviceV4.Addressing.RegionalHostnames.Edit(ctx, hostname, params)
+	_, err := z.service.Addressing.RegionalHostnames.Edit(ctx, hostname, params)
 	return err
 }
 
 func (z zoneService) DeleteDataLocalizationRegionalHostname(ctx context.Context, hostname string, params addressing.RegionalHostnameDeleteParams) error {
-	_, err := z.serviceV4.Addressing.RegionalHostnames.Delete(ctx, hostname, params)
+	_, err := z.service.Addressing.RegionalHostnames.Delete(ctx, hostname, params)
 	return err
 }
 


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->
Rename `zoneService` struct fields:
 - service -> serviceV0
 - serviceV4 -> service

## Motivation

https://github.com/kubernetes-sigs/external-dns/pull/5734 renamed imports names to have the legacy api to `cloudflarev0` and the new one as `cloudflare`.
This PR do the same with `zoneService` fields.
<!-- What inspired you to submit this pull request? -->

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
