### PR TITLE
fix(controller): panic in events.Controller.Add()

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -174,8 +174,8 @@ type Controller struct {
 	// The runAtMutex is for atomic updating of nextRunAt and lastRunAt
 	runAtMutex sync.Mutex
 	// The lastRunAt used for throttling and batching reconciliation
-	lastRunAt       time.Time
-	EventController events.EventEmitter
+	lastRunAt    time.Time
+	EventEmitter events.EventEmitter
 	// MangedRecordTypes are DNS record types that will be considered for management.
 	ManagedRecordTypes []string
 	// ExcludeRecordTypes are DNS record types that will be excluded from management.
@@ -247,7 +247,7 @@ func (c *Controller) RunOnce(ctx context.Context) error {
 			deprecatedRegistryErrors.Counter.Inc()
 			return err
 		} else {
-			emitChangeEvent(c.EventController, *plan.Changes, events.RecordReady)
+			emitChangeEvent(c.EventEmitter, *plan.Changes, events.RecordReady)
 		}
 	} else {
 		controllerNoChangesTotal.Counter.Inc()

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -228,7 +228,7 @@ func TestRunOnce(t *testing.T) {
 		Registry:           r,
 		Policy:             &plan.SyncPolicy{},
 		ManagedRecordTypes: cfg.ManagedDNSRecordTypes,
-		EventController:    emitter,
+		EventEmitter:       emitter,
 	}
 
 	assert.NoError(t, ctrl.RunOnce(context.Background()))

--- a/controller/execute.go
+++ b/controller/execute.go
@@ -363,13 +363,14 @@ func buildController(
 		events.WithKubeConfig(cfg.KubeConfig, cfg.APIServerURL, cfg.RequestTimeout),
 		events.WithEmitEvents(cfg.EmitEvents),
 		events.WithDryRun(cfg.DryRun))
-	var eventsCtrl *events.Controller
+	var eventEmitter events.EventEmitter
 	if eventsCfg.IsEnabled() {
-		eventsCtrl, err = events.NewEventController(eventsCfg)
+		eventCtrl, err := events.NewEventController(eventsCfg)
 		if err != nil {
 			log.Fatal(err)
 		}
-		eventsCtrl.Run(ctx)
+		eventCtrl.Run(ctx)
+		eventEmitter = eventCtrl
 	}
 
 	return &Controller{
@@ -381,7 +382,7 @@ func buildController(
 		ManagedRecordTypes:   cfg.ManagedDNSRecordTypes,
 		ExcludeRecordTypes:   cfg.ExcludeDNSRecordTypes,
 		MinEventSyncInterval: cfg.MinEventSyncInterval,
-		EventController:      eventsCtrl,
+		EventEmitter:         eventEmitter,
 	}, nil
 }
 


### PR DESCRIPTION
## What does it do ?

Fix a panic in `sigs.k8s.io/external-dns/pkg/events.(*Controller).Add()`.

## Motivation

See https://github.com/kubernetes-sigs/external-dns/pull/5659#issuecomment-3218267613

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
