### PR TITLE
fix(cloudflare): unnecessary record updates

### DIFF
--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -744,12 +744,7 @@ func (p *CloudFlareProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]
 			e.DeleteProviderSpecificProperty(annotations.CloudflareCustomHostnameKey)
 		}
 
-		if p.RegionalServicesConfig.Enabled {
-			// Add default region key if not set
-			if _, ok := e.GetProviderSpecificProperty(annotations.CloudflareRegionKey); !ok {
-				e.SetProviderSpecificProperty(annotations.CloudflareRegionKey, p.RegionalServicesConfig.RegionKey)
-			}
-		}
+		p.adjustEndpointProviderSpecificRegionKeyProperty(e)
 
 		adjustedEndpoints = append(adjustedEndpoints, e)
 	}

--- a/provider/cloudflare/cloudflare_regional.go
+++ b/provider/cloudflare/cloudflare_regional.go
@@ -222,11 +222,32 @@ func (p *CloudFlareProvider) addEnpointsProviderSpecificRegionKeyProperty(ctx co
 	}
 
 	for _, ep := range supportedEndpoints {
+		var regionKey string
 		if rh, found := regionalHostnames[ep.DNSName]; found {
-			ep.SetProviderSpecificProperty(annotations.CloudflareRegionKey, rh.regionKey)
+			regionKey = rh.regionKey
 		}
+		ep.SetProviderSpecificProperty(annotations.CloudflareRegionKey, regionKey)
 	}
 	return nil
+}
+
+// adjustEnpointProviderSpecificRegionKeyProperty updates the given endpoint's provider-specific
+// Cloudflare region key based on the provider's RegionalServicesConfig.
+//   - If regional services are disabled or the endpoint's record type does not
+//     support regional hostnames, the Cloudflare region key is removed.
+//   - If enabled and supported, and the key is not already set, it is initialized
+//     to the provider's default RegionKey.
+//
+// The endpoint is modified in place and any explicitly set region key is left unchanged.
+func (p *CloudFlareProvider) adjustEndpointProviderSpecificRegionKeyProperty(ep *endpoint.Endpoint) {
+	if !p.RegionalServicesConfig.Enabled || !recordTypeRegionalHostnameSupported[ep.RecordType] {
+		ep.DeleteProviderSpecificProperty(annotations.CloudflareRegionKey)
+		return
+	}
+	// Add default region key if not set
+	if _, ok := ep.GetProviderSpecificProperty(annotations.CloudflareRegionKey); !ok {
+		ep.SetProviderSpecificProperty(annotations.CloudflareRegionKey, p.RegionalServicesConfig.RegionKey)
+	}
 }
 
 // desiredRegionalHostnames builds a list of desired regional hostnames from changes.


### PR DESCRIPTION
## What does it do ?

In the cloudflare provider:
- Move the code in `AdjustEndpoints()` to add the provider specific regional key in a new func in `cloudflare_regional.go`.
- This new func set the endpoint's regional key when regional support is enabled and the record type is supported. If not it remove the key (if a user defined it in `DNSRecord` crd for example).
- always add the provider specific regional key in `addEnpointsProviderSpecificRegionKeyProperty()` when regional support is enabled (empty string if there is no corresponding regional hostname on cloudflare).



## Motivation

Improve consistency between the endpoints from sources and endpoints from the cloudflare provider in order to prevent false diff detection.
There is currently unneeded updates due to a missing provider specific regional key in `AdjustEndpoints()`.

<!-- What inspired you to submit this pull request? -->

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
