### PR TITLE
tests(source/crd): increase timeouts when it can randomly fails

### DIFF
--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -548,7 +548,7 @@ func TestCRDSource_AddEventHandler_Add(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return counter.Load() == 1
-	}, time.Second, 10*time.Millisecond)
+	}, 2*time.Second, 10*time.Millisecond)
 }
 
 func TestCRDSource_AddEventHandler_Update(t *testing.T) {
@@ -569,7 +569,7 @@ func TestCRDSource_AddEventHandler_Update(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return len(watcher.Items) == 1
-	}, time.Second, 10*time.Millisecond)
+	}, 2*time.Second, 10*time.Millisecond)
 
 	modified := obj.DeepCopy()
 	modified.SetLabels(map[string]string{"new-label": "this"})
@@ -577,11 +577,11 @@ func TestCRDSource_AddEventHandler_Update(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return len(watcher.Items) == 1
-	}, time.Second, 10*time.Millisecond)
+	}, 2*time.Second, 10*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		return counter.Load() == 2
-	}, time.Second, 10*time.Millisecond)
+	}, 2*time.Second, 10*time.Millisecond)
 }
 
 func TestCRDSource_AddEventHandler_Delete(t *testing.T) {
@@ -600,7 +600,7 @@ func TestCRDSource_AddEventHandler_Delete(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return counter.Load() == 1
-	}, time.Second, 10*time.Millisecond)
+	}, 2*time.Second, 10*time.Millisecond)
 }
 
 func TestCRDSource_Watch(t *testing.T) {
@@ -733,7 +733,7 @@ func helperCreateWatcherWithInformer(t *testing.T) (*cachetesting.FakeController
 
 	require.Eventually(t, func() bool {
 		return cache.WaitForCacheSync(ctx.Done(), informer.HasSynced)
-	}, time.Second, 10*time.Millisecond)
+	}, 2*time.Second, 10*time.Millisecond)
 
 	cs := &crdSource{
 		informer: informer,


### PR DESCRIPTION
## What does it do ?

Increase some timeout in CRD source unit tests.

## Motivation

<!-- What inspired you to submit this pull request? -->
Some tests randomly fails: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_external-dns/5781/pull-external-dns-unit-test/1962451651566505984

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
