### PR TITLE
refactor: explicitly return at most one endpoint in `generateTXTRecord`

### DIFF
--- a/registry/txt_encryption_test.go
+++ b/registry/txt_encryption_test.go
@@ -109,28 +109,26 @@ func TestGenerateTXTGenerateTextRecordEncryptionWihDecryption(t *testing.T) {
 				key := []byte(k)
 				r, err := NewTXTRegistry(p, "", "", "owner", time.Minute, "", []string{}, []string{}, true, key, "")
 				assert.NoError(t, err, "Error creating TXT registry")
-				txtRecords := r.generateTXTRecord(test.record)
-				assert.Len(t, txtRecords, len(test.record.Targets))
+				txt := r.generateTXTRecord(test.record)
+				assert.NotNil(t, txt)
 
-				for _, txt := range txtRecords {
-					// should return a TXT record with the encryption nonce label. At the moment nonce is not set as label.
-					assert.NotContains(t, txt.Labels, "txt-encryption-nonce")
+				// should return a TXT record with the encryption nonce label. At the moment nonce is not set as label.
+				assert.NotContains(t, txt.Labels, "txt-encryption-nonce")
 
-					assert.Len(t, txt.Targets, 1)
-					assert.LessOrEqual(t, len(txt.Targets), 1)
+				assert.Len(t, txt.Targets, 1)
+				assert.LessOrEqual(t, len(txt.Targets), 1)
 
-					// decrypt targets
-					for _, target := range txtRecords[0].Targets {
-						encryptedText, errUnquote := strconv.Unquote(target)
-						assert.NoError(t, errUnquote, "Error unquoting the encrypted text")
+				// decrypt targets
+				for _, target := range txt.Targets {
+					encryptedText, errUnquote := strconv.Unquote(target)
+					assert.NoError(t, errUnquote, "Error unquoting the encrypted text")
 
-						actual, nonce, errDecrypt := endpoint.DecryptText(encryptedText, r.txtEncryptAESKey)
-						assert.NoError(t, errDecrypt, "Error decrypting the encrypted text")
+					actual, nonce, errDecrypt := endpoint.DecryptText(encryptedText, r.txtEncryptAESKey)
+					assert.NoError(t, errDecrypt, "Error decrypting the encrypted text")
 
-						assert.True(t, strings.HasPrefix(encryptedText, nonce),
-							"Nonce '%s' should be a prefix of the encrypted text: '%s'", nonce, encryptedText)
-						assert.Equal(t, test.decrypted, actual)
-					}
+					assert.True(t, strings.HasPrefix(encryptedText, nonce),
+						"Nonce '%s' should be a prefix of the encrypted text: '%s'", nonce, encryptedText)
+					assert.Equal(t, test.decrypted, actual)
 				}
 			})
 		}

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -1516,14 +1516,12 @@ func TestNewTXTScheme(t *testing.T) {
 
 func TestGenerateTXT(t *testing.T) {
 	record := newEndpointWithOwner("foo.test-zone.example.org", "new-foo.loadbalancer.com", endpoint.RecordTypeCNAME, "owner")
-	expectedTXT := []*endpoint.Endpoint{
-		{
-			DNSName:    "cname-foo.test-zone.example.org",
-			Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=owner\""},
-			RecordType: endpoint.RecordTypeTXT,
-			Labels: map[string]string{
-				endpoint.OwnedRecordLabelKey: "foo.test-zone.example.org",
-			},
+	expectedTXT := &endpoint.Endpoint{
+		DNSName:    "cname-foo.test-zone.example.org",
+		Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=owner\""},
+		RecordType: endpoint.RecordTypeTXT,
+		Labels: map[string]string{
+			endpoint.OwnedRecordLabelKey: "foo.test-zone.example.org",
 		},
 	}
 	p := inmemory.NewInMemoryProvider()
@@ -1535,14 +1533,12 @@ func TestGenerateTXT(t *testing.T) {
 
 func TestGenerateTXTWithMigration(t *testing.T) {
 	record := newEndpointWithOwner("foo.test-zone.example.org", "1.2.3.4", endpoint.RecordTypeA, "owner")
-	expectedTXTBeforeMigration := []*endpoint.Endpoint{
-		{
-			DNSName:    "a-foo.test-zone.example.org",
-			Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=owner\""},
-			RecordType: endpoint.RecordTypeTXT,
-			Labels: map[string]string{
-				endpoint.OwnedRecordLabelKey: "foo.test-zone.example.org",
-			},
+	expectedTXTBeforeMigration := &endpoint.Endpoint{
+		DNSName:    "a-foo.test-zone.example.org",
+		Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=owner\""},
+		RecordType: endpoint.RecordTypeTXT,
+		Labels: map[string]string{
+			endpoint.OwnedRecordLabelKey: "foo.test-zone.example.org",
 		},
 	}
 	p := inmemory.NewInMemoryProvider()
@@ -1551,14 +1547,12 @@ func TestGenerateTXTWithMigration(t *testing.T) {
 	gotTXTBeforeMigration := r.generateTXTRecord(record)
 	assert.Equal(t, expectedTXTBeforeMigration, gotTXTBeforeMigration)
 
-	expectedTXTAfterMigration := []*endpoint.Endpoint{
-		{
-			DNSName:    "a-foo.test-zone.example.org",
-			Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=foobar\""},
-			RecordType: endpoint.RecordTypeTXT,
-			Labels: map[string]string{
-				endpoint.OwnedRecordLabelKey: "foo.test-zone.example.org",
-			},
+	expectedTXTAfterMigration := &endpoint.Endpoint{
+		DNSName:    "a-foo.test-zone.example.org",
+		Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=foobar\""},
+		RecordType: endpoint.RecordTypeTXT,
+		Labels: map[string]string{
+			endpoint.OwnedRecordLabelKey: "foo.test-zone.example.org",
 		},
 	}
 
@@ -1570,14 +1564,12 @@ func TestGenerateTXTWithMigration(t *testing.T) {
 
 func TestGenerateTXTForAAAA(t *testing.T) {
 	record := newEndpointWithOwner("foo.test-zone.example.org", "2001:DB8::1", endpoint.RecordTypeAAAA, "owner")
-	expectedTXT := []*endpoint.Endpoint{
-		{
-			DNSName:    "aaaa-foo.test-zone.example.org",
-			Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=owner\""},
-			RecordType: endpoint.RecordTypeTXT,
-			Labels: map[string]string{
-				endpoint.OwnedRecordLabelKey: "foo.test-zone.example.org",
-			},
+	expectedTXT := &endpoint.Endpoint{
+		DNSName:    "aaaa-foo.test-zone.example.org",
+		Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=owner\""},
+		RecordType: endpoint.RecordTypeTXT,
+		Labels: map[string]string{
+			endpoint.OwnedRecordLabelKey: "foo.test-zone.example.org",
 		},
 	}
 	p := inmemory.NewInMemoryProvider()
@@ -1595,8 +1587,8 @@ func TestFailGenerateTXT(t *testing.T) {
 		RecordType: endpoint.RecordTypeCNAME,
 		Labels:     map[string]string{},
 	}
-	// A bad DNS name returns empty expected TXT
-	expectedTXT := []*endpoint.Endpoint{}
+	// A bad DNS name returns nil
+	var expectedTXT *endpoint.Endpoint
 	p := inmemory.NewInMemoryProvider()
 	p.CreateZone(testZone)
 	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour, "", []string{}, []string{}, false, nil, "")
@@ -1749,23 +1741,14 @@ func TestGenerateTXTRecordWithNewFormatOnly(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour, "", []string{}, []string{}, false, nil, "")
-			records := r.generateTXTRecord(tc.endpoint)
+			txt := r.generateTXTRecord(tc.endpoint)
 
-			assert.Len(t, records, tc.expectedRecords, tc.description)
+			assert.NotNil(t, txt, tc.description)
 
-			for _, record := range records {
-				assert.Equal(t, endpoint.RecordTypeTXT, record.RecordType)
-			}
+			assert.Equal(t, endpoint.RecordTypeTXT, txt.RecordType)
 
 			if tc.endpoint.RecordType == endpoint.RecordTypeAAAA {
-				hasNewFormat := false
-				for _, record := range records {
-					if strings.HasPrefix(record.DNSName, tc.expectedPrefix) {
-						hasNewFormat = true
-						break
-					}
-				}
-				assert.True(t, hasNewFormat,
+				assert.True(t, strings.HasPrefix(txt.DNSName, tc.expectedPrefix),
 					"Should have at least one record with prefix %s when using new format", tc.expectedPrefix)
 			}
 		})
@@ -2082,15 +2065,13 @@ func TestTXTRecordMigration(t *testing.T) {
 
 	newTXTRecord := r.generateTXTRecord(createdRecords[0])
 
-	expectedTXTRecords := []*endpoint.Endpoint{
-		{
-			DNSName:    "a-bar.test-zone.example.org",
-			Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=foo\""},
-			RecordType: endpoint.RecordTypeTXT,
-		},
+	expectedTXTRecord := endpoint.Endpoint{
+		DNSName:    "a-bar.test-zone.example.org",
+		Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=foo\""},
+		RecordType: endpoint.RecordTypeTXT,
 	}
 
-	assert.Equal(t, expectedTXTRecords[0].Targets, newTXTRecord[0].Targets)
+	assert.Equal(t, expectedTXTRecord.Targets, newTXTRecord.Targets)
 
 	r, _ = NewTXTRegistry(p, "%{record_type}-", "", "foobar", time.Hour, "", []string{}, []string{}, false, nil, "foo")
 
@@ -2098,14 +2079,12 @@ func TestTXTRecordMigration(t *testing.T) {
 
 	updatedTXTRecord := r.generateTXTRecord(updatedRecords[0])
 
-	expectedFinalTXT := []*endpoint.Endpoint{
-		{
-			DNSName:    "a-bar.test-zone.example.org",
-			Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=foobar\""},
-			RecordType: endpoint.RecordTypeTXT,
-		},
+	expectedFinalTXT := endpoint.Endpoint{
+		DNSName:    "a-bar.test-zone.example.org",
+		Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=foobar\""},
+		RecordType: endpoint.RecordTypeTXT,
 	}
 
-	assert.Equal(t, updatedTXTRecord[0].Targets, expectedFinalTXT[0].Targets)
+	assert.Equal(t, updatedTXTRecord.Targets, expectedFinalTXT.Targets)
 
 }


### PR DESCRIPTION
## What does it do ?

Changes `generateTXTRecord` to return exactly one endpoint or `nil` (in case of error) instead of a list of endpoints.

## Motivation

This change will allow to keep TXT records generated for `updateOld` and `updateNew` aligned by construction. (_Aligned_ meaning that `updateOld[i]` corresponds to `updateNew[i]`.) Such alignment is not possible if `generateTXTRecord` returns an opaque list. See also https://github.com/kubernetes-sigs/external-dns/pull/5681.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
