### PR TITLE
fix(endpoint): deduplicate targets

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -373,11 +373,6 @@ func (e *Endpoint) Describe() string {
 	return fmt.Sprintf("record:%s, owner:%s, type:%s, targets:%s", e.DNSName, e.SetIdentifier, e.RecordType, strings.Join(e.Targets, ", "))
 }
 
-// UniqueOrderedTargets removes duplicate targets from the Endpoint and sorts them in lexicographical order.
-func (e *Endpoint) UniqueOrderedTargets() {
-	e.Targets = NewTargets(e.Targets...)
-}
-
 // FilterEndpointsByOwnerID Apply filter to slice of endpoints and return new filtered slice that includes
 // only endpoints that match.
 func FilterEndpointsByOwnerID(ownerID string, eps []*Endpoint) []*Endpoint {

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -59,7 +59,7 @@ func TestNewTargets(t *testing.T) {
 		{
 			name:     "multiple targets",
 			input:    []string{"example.com", "8.8.8.8", "::0001"},
-			expected: Targets{"example.com", "8.8.8.8", "::0001"},
+			expected: Targets{"8.8.8.8", "::0001", "example.com"},
 		},
 	}
 
@@ -68,7 +68,6 @@ func TestNewTargets(t *testing.T) {
 			Targets := NewTargets(c.input...)
 			changedTarget := Targets.String()
 			assert.Equal(t, c.expected.String(), changedTarget)
-
 		})
 	}
 }
@@ -981,4 +980,50 @@ func TestEndpoint_WithRefObject(t *testing.T) {
 
 	assert.Equal(t, ref, ep.RefObject(), "refObject should be set")
 	assert.Equal(t, ep, result, "should return the same Endpoint pointer")
+}
+
+func TestTargets_UniqueOrdered(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    Targets
+		expected Targets
+	}{
+		{
+			name:     "no duplicates",
+			input:    Targets{"a.example.com", "b.example.com"},
+			expected: Targets{"a.example.com", "b.example.com"},
+		},
+		{
+			name:     "with duplicates",
+			input:    Targets{"a.example.com", "b.example.com", "a.example.com"},
+			expected: Targets{"a.example.com", "b.example.com"},
+		},
+		{
+			name:     "already sorted",
+			input:    Targets{"a.example.com", "c.example.com", "d.example.com"},
+			expected: Targets{"a.example.com", "c.example.com", "d.example.com"},
+		},
+		{
+			name:     "unsorted input",
+			input:    Targets{"z.example.com", "a.example.com", "m.example.com"},
+			expected: Targets{"a.example.com", "m.example.com", "z.example.com"},
+		},
+		{
+			name:     "empty input",
+			input:    Targets{},
+			expected: Targets{},
+		},
+		{
+			name:     "single element",
+			input:    Targets{"only.example.com"},
+			expected: Targets{"only.example.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NewTargets(tt.input...)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -926,49 +926,6 @@ func TestCheckEndpoint(t *testing.T) {
 	}
 }
 
-func TestEndpoint_UniqueOrderedTargets(t *testing.T) {
-	tests := []struct {
-		name     string
-		targets  []string
-		expected Targets
-		want     bool
-	}{
-		{
-			name:     "no duplicates",
-			targets:  []string{"b.example.com", "a.example.com"},
-			expected: Targets{"a.example.com", "b.example.com"},
-		},
-		{
-			name:     "with duplicates",
-			targets:  []string{"a.example.com", "b.example.com", "a.example.com"},
-			expected: Targets{"a.example.com", "b.example.com"},
-		},
-		{
-			name:     "already sorted",
-			targets:  []string{"a.example.com", "b.example.com"},
-			expected: Targets{"a.example.com", "b.example.com"},
-		},
-		{
-			name:     "all duplicates",
-			targets:  []string{"a.example.com", "a.example.com", "a.example.com"},
-			expected: Targets{"a.example.com"},
-		},
-		{
-			name:     "empty",
-			targets:  []string{},
-			expected: Targets{},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ep := &Endpoint{Targets: tt.targets}
-			ep.UniqueOrderedTargets()
-			assert.Equal(t, tt.expected, ep.Targets)
-		})
-	}
-}
-
 func TestEndpoint_WithRefObject(t *testing.T) {
 	ep := &Endpoint{}
 	ref := &events.ObjectReference{
@@ -997,6 +954,11 @@ func TestTargets_UniqueOrdered(t *testing.T) {
 			name:     "with duplicates",
 			input:    Targets{"a.example.com", "b.example.com", "a.example.com"},
 			expected: Targets{"a.example.com", "b.example.com"},
+		},
+		{
+			name:     "all duplicates",
+			input:    []string{"a.example.com", "a.example.com", "a.example.com"},
+			expected: Targets{"a.example.com"},
 		},
 		{
 			name:     "already sorted",

--- a/source/endpoints.go
+++ b/source/endpoints.go
@@ -108,5 +108,5 @@ func EndpointTargetsFromServices(svcInformer coreinformers.ServiceInformer, name
 			}
 		}
 	}
-	return targets, nil
+	return endpoint.NewTargets(targets...), nil
 }

--- a/source/endpoints_test.go
+++ b/source/endpoints_test.go
@@ -155,7 +155,25 @@ func TestEndpointTargetsFromServices(t *testing.T) {
 			},
 			namespace: "default",
 			selector:  map[string]string{"app": "nginx"},
-			expected:  endpoint.Targets{"192.0.2.1", "158.123.32.23"},
+			expected:  endpoint.Targets{"158.123.32.23", "192.0.2.1"},
+		},
+		{
+			name: "matching service with duplicate external IPs",
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+					},
+					Spec: corev1.ServiceSpec{
+						Selector:    map[string]string{"app": "nginx"},
+						ExternalIPs: []string{"192.0.2.1", "192.0.2.1", "158.123.32.23"},
+					},
+				},
+			},
+			namespace: "default",
+			selector:  map[string]string{"app": "nginx"},
+			expected:  endpoint.Targets{"158.123.32.23", "192.0.2.1"},
 		},
 		{
 			name: "no matching service as service without selector",

--- a/source/istio_gateway_test.go
+++ b/source/istio_gateway_test.go
@@ -1874,12 +1874,12 @@ func TestSingleGatewayMultipleServicesPointingToSameLoadBalancer(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, src)
 
-	res, err := src.Endpoints(t.Context())
+	got, err := src.Endpoints(t.Context())
 	require.NoError(t, err)
 
-	validateEndpoints(t, res, []*endpoint.Endpoint{
-		endpoint.NewEndpoint("example.org", endpoint.RecordTypeA, "34.66.66.77").WithLabel("resource", "gateway/argocd/argocd"),
-		endpoint.NewEndpoint("example.org", endpoint.RecordTypeA, "34.66.66.77").WithLabel("resource", "gateway/argocd/argocd"),
+	validateEndpoints(t, got, []*endpoint.Endpoint{
+		endpoint.NewEndpoint("example.org", endpoint.RecordTypeA, "34.66.66.77").WithLabel(endpoint.ResourceLabelKey, "gateway/argocd/argocd"),
+		endpoint.NewEndpoint("example.org", endpoint.RecordTypeA, "34.66.66.77").WithLabel(endpoint.ResourceLabelKey, "gateway/argocd/argocd"),
 	})
 }
 

--- a/source/istio_gateway_test.go
+++ b/source/istio_gateway_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/external-dns/internal/testutils"
 
 	"sigs.k8s.io/external-dns/endpoint"
 )
@@ -1730,6 +1731,156 @@ func TestTransformerInIstioGatewaySource(t *testing.T) {
 		"selector2": "two",
 		"selector3": "three",
 	}, rService.Spec.Selector)
+}
+
+func TestSingleGatewayMultipleServicesPointingToSameLoadBalancer(t *testing.T) {
+	fakeKubeClient := fake.NewClientset()
+	fakeIstioClient := istiofake.NewSimpleClientset()
+
+	gw := &networkingv1beta1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "argocd",
+			Namespace: "argocd",
+		},
+		Spec: istionetworking.Gateway{
+			Servers: []*istionetworking.Server{
+				{
+					Hosts: []string{"example.org"},
+					Tls: &istionetworking.ServerTLSSettings{
+						HttpsRedirect: true,
+					},
+				},
+				{
+					Hosts: []string{"example.org"},
+					Tls: &istionetworking.ServerTLSSettings{
+						ServerCertificate: IstioGatewayIngressSource,
+						Mode:              istionetworking.ServerTLSSettings_SIMPLE,
+					},
+				},
+			},
+			Selector: map[string]string{
+				"istio": "ingressgateway",
+			},
+		},
+	}
+
+	services := []*v1.Service{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "istio-ingressgateway",
+				Namespace: "default",
+				Labels: map[string]string{
+					"app":   "istio-ingressgateway",
+					"istio": "ingressgateway",
+				},
+			},
+			Spec: v1.ServiceSpec{
+				Type:                  v1.ServiceTypeLoadBalancer,
+				ClusterIP:             "10.118.223.3",
+				ClusterIPs:            []string{"10.118.223.3"},
+				ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyCluster,
+				IPFamilies:            []v1.IPFamily{v1.IPv4Protocol},
+				IPFamilyPolicy:        testutils.ToPtr(v1.IPFamilyPolicySingleStack),
+				Ports: []v1.ServicePort{
+					{
+						Name:       "http2",
+						Port:       80,
+						Protocol:   v1.ProtocolTCP,
+						TargetPort: intstr.FromInt32(8080),
+						NodePort:   30127,
+					},
+				},
+				Selector: map[string]string{
+					"app":   "istio-ingressgateway",
+					"istio": "ingressgateway",
+				},
+				SessionAffinity: v1.ServiceAffinityNone,
+			},
+			Status: v1.ServiceStatus{
+				LoadBalancer: v1.LoadBalancerStatus{
+					Ingress: []v1.LoadBalancerIngress{
+						{
+							IP:     "34.66.66.77",
+							IPMode: testutils.ToPtr(v1.LoadBalancerIPModeVIP),
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "istio-ingressgatewayudp",
+				Namespace: "default",
+				Labels: map[string]string{
+					"app":   "istio-ingressgatewayudp",
+					"istio": "ingressgateway",
+				},
+			},
+			Spec: v1.ServiceSpec{
+				Type:                  v1.ServiceTypeLoadBalancer,
+				ClusterIP:             "10.118.220.130",
+				ClusterIPs:            []string{"10.118.220.130"},
+				ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyCluster,
+				IPFamilies:            []v1.IPFamily{v1.IPv4Protocol},
+				IPFamilyPolicy:        testutils.ToPtr(v1.IPFamilyPolicySingleStack),
+				Ports: []v1.ServicePort{
+					{
+						Name:       "upd-dns",
+						Port:       53,
+						Protocol:   v1.ProtocolUDP,
+						TargetPort: intstr.FromInt32(5353),
+						NodePort:   30873,
+					},
+				},
+				Selector: map[string]string{
+					"app":   "istio-ingressgatewayudp",
+					"istio": "ingressgateway",
+				},
+				SessionAffinity: v1.ServiceAffinityNone,
+			},
+			Status: v1.ServiceStatus{
+				LoadBalancer: v1.LoadBalancerStatus{
+					Ingress: []v1.LoadBalancerIngress{
+						{
+							IP:     "34.66.66.77",
+							IPMode: testutils.ToPtr(v1.LoadBalancerIPModeVIP),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	assert.NotNil(t, services)
+
+	for _, svc := range services {
+		_, err := fakeKubeClient.CoreV1().Services(svc.Namespace).Create(t.Context(), svc, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	_, err := fakeIstioClient.NetworkingV1beta1().Gateways(gw.Namespace).Create(t.Context(), gw, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	src, err := NewIstioGatewaySource(
+		t.Context(),
+		fakeKubeClient,
+		fakeIstioClient,
+		"",
+		"",
+		"",
+		false,
+		false,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, src)
+
+	res, err := src.Endpoints(t.Context())
+	require.NoError(t, err)
+
+	validateEndpoints(t, res, []*endpoint.Endpoint{
+		endpoint.NewEndpoint("example.org", endpoint.RecordTypeA, "34.66.66.77").WithLabel("resource", "gateway/argocd/argocd"),
+		endpoint.NewEndpoint("example.org", endpoint.RecordTypeA, "34.66.66.77").WithLabel("resource", "gateway/argocd/argocd"),
+	})
 }
 
 // gateway specific helper functions

--- a/source/service.go
+++ b/source/service.go
@@ -294,10 +294,10 @@ func (sc *serviceSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, err
 					continue
 				}
 				existing[0].Targets = append(existing[0].Targets, ep.Targets...)
-				existing[0].UniqueOrderedTargets()
+				existing[0].Targets = endpoint.NewTargets(existing[0].Targets...)
 				mergedEndpoints[key] = existing
 			} else {
-				ep.UniqueOrderedTargets()
+				ep.Targets = endpoint.NewTargets(ep.Targets...)
 				mergedEndpoints[key] = []*endpoint.Endpoint{ep}
 			}
 		}

--- a/source/wrappers/dedupsource.go
+++ b/source/wrappers/dedupsource.go
@@ -55,7 +55,7 @@ func (ms *dedupSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, err
 		}
 
 		if len(ep.Targets) > 1 {
-			ep.Targets = removeDuplicates(ep.Targets)
+			ep.Targets = endpoint.NewTargets(ep.Targets...)
 		}
 
 		identifier := strings.Join([]string{ep.RecordType, ep.DNSName, ep.SetIdentifier, ep.Targets.String()}, "/")

--- a/source/wrappers/dedupsource.go
+++ b/source/wrappers/dedupsource.go
@@ -54,13 +54,11 @@ func (ms *dedupSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, err
 			continue
 		}
 
-		targets := ep.Targets
-		if len(targets) > 1 {
-			targets = removeDuplicates(targets)
-			ep.Targets = targets
+		if len(ep.Targets) > 1 {
+			ep.Targets = removeDuplicates(ep.Targets)
 		}
 
-		identifier := strings.Join([]string{ep.RecordType, ep.DNSName, ep.SetIdentifier, targets.String()}, "/")
+		identifier := strings.Join([]string{ep.RecordType, ep.DNSName, ep.SetIdentifier, ep.Targets.String()}, "/")
 
 		if _, ok := collected[identifier]; ok {
 			log.Debugf("Removing duplicate endpoint %s", ep)
@@ -75,8 +73,7 @@ func (ms *dedupSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, err
 }
 
 func removeDuplicates(targets []string) []string {
-	s := set.New(targets...)
-	return s.SortedList()
+	return set.New(targets...).SortedList()
 }
 
 func (ms *dedupSource) AddEventHandler(ctx context.Context, handler func()) {

--- a/source/wrappers/dedupsource.go
+++ b/source/wrappers/dedupsource.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"strings"
 
-	"k8s.io/utils/set"
-
 	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/external-dns/endpoint"
@@ -70,10 +68,6 @@ func (ms *dedupSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, err
 	}
 
 	return result, nil
-}
-
-func removeDuplicates(targets []string) []string {
-	return set.New(targets...).SortedList()
 }
 
 func (ms *dedupSource) AddEventHandler(ctx context.Context, handler func()) {

--- a/source/wrappers/dedupsource_test.go
+++ b/source/wrappers/dedupsource_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/internal/testutils"
 	"sigs.k8s.io/external-dns/source"
@@ -180,37 +179,6 @@ func TestDedupSource_AddEventHandler(t *testing.T) {
 			src.AddEventHandler(t.Context(), func() {})
 
 			mockSource.AssertNumberOfCalls(t, "AddEventHandler", tt.times)
-		})
-	}
-}
-
-func TestRemoveDuplicates(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    []string
-		expected []string
-	}{
-		{
-			name:     "removes duplicates and sorts",
-			input:    []string{"b", "a", "a", "c"},
-			expected: []string{"a", "b", "c"},
-		},
-		{
-			name:     "no duplicates",
-			input:    []string{"x", "y", "z"},
-			expected: []string{"x", "y", "z"},
-		},
-		{
-			name:     "empty slice",
-			input:    []string{},
-			expected: []string{},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := removeDuplicates(tt.input)
-			assert.Equal(t, tt.expected, got)
 		})
 	}
 }


### PR DESCRIPTION
## What does it do ?

Deduplicate not just DNS names but targets as well

- deduplicate targets
- added tests
- added targets sorting, this will reduce a number of issues with DIFF related to target sorted/not-sorted
- follow-up https://github.com/kubernetes-sigs/external-dns/blob/master/source/istio_gateway.go#L197-L200

## Motivation

Fixes #5664

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
