### PR TITLE
refactor(source/nat64): optional source & early prefixes parsing

### DIFF
--- a/controller/execute.go
+++ b/controller/execute.go
@@ -448,8 +448,13 @@ func buildSource(ctx context.Context, cfg *externaldns.Config) (source.Source, e
 	// Combine multiple sources into a single, deduplicated source.
 	combinedSource := wrappers.NewDedupSource(wrappers.NewMultiSource(sources, sourceCfg.DefaultTargets, sourceCfg.ForceDefaultTargets))
 	cfg.AddSourceWrapper("dedup")
-	combinedSource = wrappers.NewNAT64Source(combinedSource, cfg.NAT64Networks)
-	cfg.AddSourceWrapper("nat64")
+	if len(cfg.NAT64Networks) > 0 {
+		combinedSource, err = wrappers.NewNAT64Source(combinedSource, cfg.NAT64Networks)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create NAT64 source wrapper: %w", err)
+		}
+		cfg.AddSourceWrapper("nat64")
+	}
 	// Filter targets
 	targetFilter := endpoint.NewTargetNetFilterWithExclusions(cfg.TargetNetFilter, cfg.ExcludeTargetNets)
 	if targetFilter.IsEnabled() {

--- a/controller/execute_test.go
+++ b/controller/execute_test.go
@@ -454,14 +454,25 @@ func TestBuildSourceWithWrappers(t *testing.T) {
 			},
 		},
 		{
-			name: "configuration without target filter wrapper",
+			name: "configuration with nat64 networks",
+			cfg: &externaldns.Config{
+				APIServerURL:  svr.URL,
+				Sources:       []string{"fake"},
+				NAT64Networks: []string{"2001:db8::/96"},
+			},
+			asserts: func(t *testing.T, cfg *externaldns.Config) {
+				assert.True(t, cfg.IsSourceWrapperInstrumented("nat64"))
+			},
+		},
+		{
+			name: "default configuration",
 			cfg: &externaldns.Config{
 				APIServerURL: svr.URL,
 				Sources:      []string{"fake"},
 			},
 			asserts: func(t *testing.T, cfg *externaldns.Config) {
 				assert.True(t, cfg.IsSourceWrapperInstrumented("dedup"))
-				assert.True(t, cfg.IsSourceWrapperInstrumented("nat64"))
+				assert.False(t, cfg.IsSourceWrapperInstrumented("nat64"))
 				assert.False(t, cfg.IsSourceWrapperInstrumented("target-filter"))
 			},
 		},

--- a/source/wrappers/nat64source.go
+++ b/source/wrappers/nat64source.go
@@ -30,19 +30,13 @@ import (
 // nat64Source is a Source that adds A endpoints for AAAA records including an NAT64 address.
 type nat64Source struct {
 	source        source.Source
-	nat64Prefixes []string
+	nat64Prefixes []netip.Prefix
 }
 
 // NewNAT64Source creates a new nat64Source wrapping the provided Source.
-func NewNAT64Source(source source.Source, nat64Prefixes []string) source.Source {
-	return &nat64Source{source: source, nat64Prefixes: nat64Prefixes}
-}
-
-// Endpoints collects endpoints from its wrapped source and returns them without duplicates.
-func (s *nat64Source) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error) {
-	log.Debug("nat64Source: collecting endpoints and processing NAT64 translation")
+func NewNAT64Source(source source.Source, nat64Prefixes []string) (source.Source, error) {
 	parsedNAT64Prefixes := make([]netip.Prefix, 0)
-	for _, prefix := range s.nat64Prefixes {
+	for _, prefix := range nat64Prefixes {
 		pPrefix, err := netip.ParsePrefix(prefix)
 		if err != nil {
 			return nil, err
@@ -53,6 +47,12 @@ func (s *nat64Source) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, erro
 		}
 		parsedNAT64Prefixes = append(parsedNAT64Prefixes, pPrefix)
 	}
+	return &nat64Source{source: source, nat64Prefixes: parsedNAT64Prefixes}, nil
+}
+
+// Endpoints collects endpoints from its wrapped source and returns them without duplicates.
+func (s *nat64Source) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	log.Debug("nat64Source: collecting endpoints and processing NAT64 translation")
 
 	additionalEndpoints := []*endpoint.Endpoint{}
 
@@ -76,7 +76,7 @@ func (s *nat64Source) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, erro
 
 			var sPrefix *netip.Prefix
 
-			for _, cPrefix := range parsedNAT64Prefixes {
+			for _, cPrefix := range s.nat64Prefixes {
 				if cPrefix.Contains(ip) {
 					sPrefix = &cPrefix
 				}


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->
- add the nat64 source only when nat64 networks are defined (--nat64-networks)
- parse nat64 networks when creating the source, not on every `Endpoints()` call

## Motivation

The NAT64 source do nothing when no nat64 networks are defined.
<!-- What inspired you to submit this pull request? -->

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
