### PR TITLE
docs(tutorials): import existing DNS records into ExternalDNS

### DIFF
--- a/docs/advanced/import-records.md
+++ b/docs/advanced/import-records.md
@@ -1,4 +1,4 @@
-# Managing and Importing Existing DNS Records with ExternalDNS
+# Import Existing DNS Records
 
 Sometimes DNS records are created manually (e.g., through Route53, CloudDNS, or AzureDNS), but you still want ExternalDNS to take ownership of them for ongoing management. This tutorial shows how to “import” such records into ExternalDNS by creating the appropriate TXT records.
 

--- a/docs/tutorials/externaldns-import-tutorial.md
+++ b/docs/tutorials/externaldns-import-tutorial.md
@@ -6,9 +6,9 @@ Sometimes DNS records are created manually (e.g., through Route53, CloudDNS, or 
 
 ## Prerequisites
 
-- A working Kubernetes cluster
-- ExternalDNS installed and configured with your DNS provider
-- Manually created DNS records that you want to manage
+* A working Kubernetes cluster
+* ExternalDNS installed and configured with your DNS provider
+* Manually created DNS records that you want to manage
 
 ---
 
@@ -42,7 +42,7 @@ spec:
       protocol: HTTP
 ```
 
-ExternalDNS deployment file example:
+External-dns deployment file:
 
 ```yaml
 apiVersion: apps/v1
@@ -101,15 +101,15 @@ To let ExternalDNS take ownership of the existing A record, you must add TXT rec
 
 ```text
 aaaa-grafana.dev.example.com  → TXT → "heritage=external-dns,external-dns/owner=dev.example.com,external-dns/resource=gateway/istio/gateway"
-cname-grafana.dev.example.com → TXT → "heritage=external-dns,external-dns/owner=dev.example.com,external-dns/resource=gateway/istio/gateway"
+cname-grafana.dev.example.com → TXT → "heritage=external-dns,external-dns/owner=dev.example.com,external-dns/resource/gateway/istio/gateway"
 ```
 
 Note: The easiest way to determine the correct TXT value is to create a dummy record with ExternalDNS. This will generate the required TXT entries, which you can then copy and apply to your manually created records.
 
 These TXT records tell ExternalDNS:
 
-- Which resource owns the record (`external-dns/resource=...`) (in this case, it's istio)
-- Which owner identifier is managing it (`external-dns/owner=...`)
+* Which resource owns the record (`external-dns/resource=...`) (in this case, it's istio)
+* Which owner identifier is managing it (`external-dns/owner=...`)
 
 ---
 
@@ -117,17 +117,16 @@ These TXT records tell ExternalDNS:
 
 After creating the TXT records, wait for the next reconciliation loop. You should now see ExternalDNS managing the record without errors.
 
-- With `policy=sync`: if you remove the entry from the Kubernetes resource (e.g., Istio Gateway), ExternalDNS will also remove the corresponding DNS record from your provider.
-- With `policy=upsert-only`: ExternalDNS will not delete existing records, even if you remove them from Kubernetes resources.
+* With `policy=sync`: if you remove the entry from the Kubernetes resource (e.g., Istio Gateway), ExternalDNS will also remove the corresponding DNS record from your provider.
+* With `policy=upsert-only`: ExternalDNS will not delete existing records, even if you remove them from Kubernetes resources.
 
 ---
 
 ## Notes
 
-- TXT records are required because they serve as ownership markers, preventing conflicts between multiple ExternalDNS controllers.
-- This approach is especially useful during migrations, where DNS records pre-exist but you want to avoid downtime or duplication.
+* TXT records are required because they serve as ownership markers, preventing conflicts between multiple ExternalDNS controllers.
+* This approach is especially useful during migrations, where DNS records pre-exist but you want to avoid downtime or duplication.
 
 ---
 
 With this setup, ExternalDNS will manage both newly created and previously existing records in a consistent way.
-

--- a/docs/tutorials/externaldns-import-tutorial.md
+++ b/docs/tutorials/externaldns-import-tutorial.md
@@ -101,7 +101,7 @@ To let ExternalDNS take ownership of the existing A record, you must add TXT rec
 
 ```text
 aaaa-grafana.dev.example.com  → TXT → "heritage=external-dns,external-dns/owner=dev.example.com,external-dns/resource=gateway/istio/gateway"
-cname-grafana.dev.example.com → TXT → "heritage=external-dns,external-dns/owner=dev.example.com,external-dns/resource/gateway/istio/gateway"
+cname-grafana.dev.example.com → TXT → "heritage=external-dns,external-dns/owner=dev.example.com,external-dns/resource=gateway/istio/gateway"
 ```
 
 Note: The easiest way to determine the correct TXT value is to create a dummy record with ExternalDNS. This will generate the required TXT entries, which you can then copy and apply to your manually created records.

--- a/docs/tutorials/externaldns-import-tutorial.md
+++ b/docs/tutorials/externaldns-import-tutorial.md
@@ -5,6 +5,7 @@ Sometimes DNS records are created manually (e.g., through Route53, CloudDNS, or 
 ---
 
 ## Prerequisites
+
 - A working Kubernetes cluster
 - ExternalDNS installed and configured with your DNS provider
 - Manually created DNS records that you want to manage
@@ -15,14 +16,15 @@ Sometimes DNS records are created manually (e.g., through Route53, CloudDNS, or 
 
 Let’s assume you already have the following A record created manually in Route53:
 
-```
+```text
 grafana.dev.example.com  → A record → pointing to NLB
 ```
 
 This entry is referenced in an Istio Gateway resource but was not created by ExternalDNS.
 
 This is how a gateway.yaml file looks like:
-```
+
+```yaml
 apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
@@ -40,8 +42,9 @@ spec:
       protocol: HTTP
 ```
 
-External-dns deployment file:
-```
+ExternalDNS deployment file example:
+
+```yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -96,13 +99,15 @@ spec:
 
 To let ExternalDNS take ownership of the existing A record, you must add TXT records that follow the ExternalDNS format. For example:
 
-```
+```text
 aaaa-grafana.dev.example.com  → TXT → "heritage=external-dns,external-dns/owner=dev.example.com,external-dns/resource=gateway/istio/gateway"
-cname-grafana.dev.example.com → TXT → "heritage=external-dns,external-dns/owner=dev.example.com,external-dns/resource=gateway/istio/gateway"
+cname-grafana.dev.example.com → TXT → "heritage=external-dns,external-dns/owner=dev.example.com,external-dns/resource/gateway/istio/gateway"
 ```
+
 Note: The easiest way to determine the correct TXT value is to create a dummy record with ExternalDNS. This will generate the required TXT entries, which you can then copy and apply to your manually created records.
 
 These TXT records tell ExternalDNS:
+
 - Which resource owns the record (`external-dns/resource=...`) (in this case, it's istio)
 - Which owner identifier is managing it (`external-dns/owner=...`)
 
@@ -112,15 +117,17 @@ These TXT records tell ExternalDNS:
 
 After creating the TXT records, wait for the next reconciliation loop. You should now see ExternalDNS managing the record without errors.
 
-- With `policy=sync`: if you remove the entry from the Kubernetes resource (e.g., Istio Gateway), ExternalDNS will also remove the corresponding DNS record from your provider.  
-- With `policy=upsert-only`: ExternalDNS will not delete existing records, even if you remove them from Kubernetes resources.  
+- With `policy=sync`: if you remove the entry from the Kubernetes resource (e.g., Istio Gateway), ExternalDNS will also remove the corresponding DNS record from your provider.
+- With `policy=upsert-only`: ExternalDNS will not delete existing records, even if you remove them from Kubernetes resources.
 
 ---
 
 ## Notes
+
 - TXT records are required because they serve as ownership markers, preventing conflicts between multiple ExternalDNS controllers.
 - This approach is especially useful during migrations, where DNS records pre-exist but you want to avoid downtime or duplication.
 
 ---
 
 With this setup, ExternalDNS will manage both newly created and previously existing records in a consistent way.
+

--- a/docs/tutorials/externaldns-import-tutorial.md
+++ b/docs/tutorials/externaldns-import-tutorial.md
@@ -1,0 +1,126 @@
+# Managing and Importing Existing DNS Records with ExternalDNS
+
+Sometimes DNS records are created manually (e.g., through Route53, CloudDNS, or AzureDNS), but you still want ExternalDNS to take ownership of them for ongoing management. This tutorial shows how to “import” such records into ExternalDNS by creating the appropriate TXT records.
+
+---
+
+## Prerequisites
+- A working Kubernetes cluster
+- ExternalDNS installed and configured with your DNS provider
+- Manually created DNS records that you want to manage
+
+---
+
+## Example: Importing a Manually Created A Record
+
+Let’s assume you already have the following A record created manually in Route53:
+
+```
+grafana.dev.example.com  → A record → pointing to NLB
+```
+
+This entry is referenced in an Istio Gateway resource but was not created by ExternalDNS.
+
+This is how a gateway.yaml file looks like:
+```
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: gateway
+  namespace: istio-system
+spec:
+  selector:
+    istio: gateway
+  servers:
+  - hosts:
+    - grafana.dev.example.com
+    port:
+      name: http
+      number: 80
+      protocol: HTTP
+```
+
+External-dns deployment file:
+```
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+  namespace: kube-system
+spec:
+  minReadySeconds: 15
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: external-dns
+  strategy:
+    rollingUpdate:
+      maxSurge: 50%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - --source=service
+        - --source=ingress
+        - --source=istio-gateway
+        - --domain-filter=dev.example.com.
+        - --provider=aws
+        - --policy=sync
+        - --aws-zone-type=private
+        - --registry=txt
+        - --events
+        - --txt-owner-id=dev.example.com
+        - --log-level=info
+        env:
+        - name: AWS_DEFAULT_REGION
+          value: us-west-2
+        image: registry.k8s.io/external-dns/external-dns:v0.19.0
+        imagePullPolicy: IfNotPresent
+        name: external-dns
+      securityContext:
+        fsGroup: 65534
+        runAsNonRoot: false
+      serviceAccount: external-dns
+```
+
+---
+
+## Step 1: Create Corresponding TXT Records
+
+To let ExternalDNS take ownership of the existing A record, you must add TXT records that follow the ExternalDNS format. For example:
+
+```
+aaaa-grafana.dev.example.com  → TXT → "heritage=external-dns,external-dns/owner=dev.example.com,external-dns/resource=gateway/istio/gateway"
+cname-grafana.dev.example.com → TXT → "heritage=external-dns,external-dns/owner=dev.example.com,external-dns/resource=gateway/istio/gateway"
+```
+Note: The easiest way to determine the correct TXT value is to create a dummy record with ExternalDNS. This will generate the required TXT entries, which you can then copy and apply to your manually created records.
+
+These TXT records tell ExternalDNS:
+- Which resource owns the record (`external-dns/resource=...`) (in this case, it's istio)
+- Which owner identifier is managing it (`external-dns/owner=...`)
+
+---
+
+## Step 2: Verify ExternalDNS Behavior
+
+After creating the TXT records, wait for the next reconciliation loop. You should now see ExternalDNS managing the record without errors.
+
+- With `policy=sync`: if you remove the entry from the Kubernetes resource (e.g., Istio Gateway), ExternalDNS will also remove the corresponding DNS record from your provider.  
+- With `policy=upsert-only`: ExternalDNS will not delete existing records, even if you remove them from Kubernetes resources.  
+
+---
+
+## Notes
+- TXT records are required because they serve as ownership markers, preventing conflicts between multiple ExternalDNS controllers.
+- This approach is especially useful during migrations, where DNS records pre-exist but you want to avoid downtime or duplication.
+
+---
+
+With this setup, ExternalDNS will manage both newly created and previously existing records in a consistent way.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,23 +19,24 @@ nav:
       - Providers: docs/providers.md
   - Tutorials: docs/tutorials/*
   - Annotations:
-    - About: docs/annotations/annotations.md
+      - About: docs/annotations/annotations.md
   - Sources: docs/sources/*
   - Registries:
-    - About: docs/registry/registry.md
-    - TXT: docs/registry/txt.md
-    - DynamoDB: docs/registry/dynamodb.md
+      - About: docs/registry/registry.md
+      - TXT: docs/registry/txt.md
+      - DynamoDB: docs/registry/dynamodb.md
   - Advanced Topics:
-    - Initial Design: docs/initial-design.md
-    - Kubernetes Events: docs/advanced/events.md
-    - Leader Election: docs/proposal/001-leader-election.md
-    - Monitoring: docs/monitoring/*
-    - MultiTarget: docs/proposal/multi-target.md
-    - NAT64: docs/advanced/nat64.md
-    - Rate Limits: docs/advanced/rate-limits.md
-    - TTL: docs/advanced/ttl.md
-    - FQDN Templating: docs/advanced/fqdn-templating.md
-    - Decisions: docs/proposal/0*.md
+      - FQDN Templating: docs/advanced/fqdn-templating.md
+      - Import Records: docs/advanced/import-records.md
+      - Initial Design: docs/initial-design.md
+      - Kubernetes Events: docs/advanced/events.md
+      - Leader Election: docs/proposal/001-leader-election.md
+      - Monitoring: docs/monitoring/*
+      - MultiTarget: docs/proposal/multi-target.md
+      - NAT64: docs/advanced/nat64.md
+      - Rate Limits: docs/advanced/rate-limits.md
+      - TTL: docs/advanced/ttl.md
+      - Decisions: docs/proposal/0*.md
   - Contributing:
       - Kubernetes Contributions: CONTRIBUTING.md
       - Release: docs/release.md


### PR DESCRIPTION
## What does it do ?

This PR adds a new tutorial document (externaldns-import-tutorial.md) that explains how to manage and import manually created DNS records into ExternalDNS using TXT records. It provides a step-by-step guide with examples for scenarios where records were created outside ExternalDNS but still need to be managed going forward.

## Motivation
Many users run into issues when they already have manually created DNS records (for example, for Istio Gateways or pre-existing A records) and want ExternalDNS to take ownership. Without proper TXT records, reconciliation can fail with errors like `response error StatusCode: 400`. This tutorial helps users understand how to safely import and manage such records, reducing confusion and avoiding misconfigurations.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
