### PR TITLE
refactor(annotations): modernize ProviderSpecificAnnotation

### DIFF
--- a/source/annotations/provider_specific.go
+++ b/source/annotations/provider_specific.go
@@ -33,21 +33,18 @@ func ProviderSpecificAnnotations(annotations map[string]string) (endpoint.Provid
 	for k, v := range annotations {
 		if k == SetIdentifierKey {
 			setIdentifier = v
-		} else if strings.HasPrefix(k, AWSPrefix) {
-			attr := strings.TrimPrefix(k, AWSPrefix)
+		} else if attr, ok := strings.CutPrefix(k, AWSPrefix); ok {
 			providerSpecificAnnotations = append(providerSpecificAnnotations, endpoint.ProviderSpecificProperty{
 				Name:  fmt.Sprintf("aws/%s", attr),
 				Value: v,
 			})
-		} else if strings.HasPrefix(k, SCWPrefix) {
-			attr := strings.TrimPrefix(k, SCWPrefix)
+		} else if attr, ok := strings.CutPrefix(k, SCWPrefix); ok {
 			providerSpecificAnnotations = append(providerSpecificAnnotations, endpoint.ProviderSpecificProperty{
 				Name:  fmt.Sprintf("scw/%s", attr),
 				Value: v,
 			})
-		} else if strings.HasPrefix(k, WebhookPrefix) {
+		} else if attr, ok := strings.CutPrefix(k, WebhookPrefix); ok {
 			// Support for wildcard annotations for webhook providers
-			attr := strings.TrimPrefix(k, WebhookPrefix)
 			providerSpecificAnnotations = append(providerSpecificAnnotations, endpoint.ProviderSpecificProperty{
 				Name:  fmt.Sprintf("webhook/%s", attr),
 				Value: v,


### PR DESCRIPTION
## What does it do ?

<img width="940" height="378" alt="Screenshot 2025-09-06 at 15 46 43" src="https://github.com/user-attachments/assets/27bb25dd-0d3a-4bda-b59e-4fa7a089fd2f" />

The method has 100% coverage, so if we covering edge cases, should be a safe refactore

<img width="1418" height="923" alt="Screenshot 2025-09-06 at 15 49 50" src="https://github.com/user-attachments/assets/e2e723b7-1941-4d22-b341-0393f7e5b458" />

## Motivation

Modernize for method ProviderSpecificAnnotations

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
