### PR TITLE
feat(external-dns): add extraDeploy option for additional K8s manifests

### DIFF
--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -107,6 +107,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | excludeDomains | list | `[]` | Intentionally exclude domains from being managed. |
 | extraArgs | object | `{}` | Extra arguments to provide to _ExternalDNS_. An array or map can be used, with maps allowing for value overrides; maps also support slice values to use the same arg multiple times. |
 | extraContainers | list | `[]` | Extra containers to add to the `Deployment`. |
+| extraDeploy | list | `[]` | Array of extra K8s manifests to deploy alongside the chart. Supports templating via `tpl` function. |
 | extraVolumeMounts | list | `[]` | Extra [volume mounts](https://kubernetes.io/docs/concepts/storage/volumes/) for the `external-dns` container. |
 | extraVolumes | list | `[]` | Extra [volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the `Pod`. |
 | fullnameOverride | string | `nil` | Override the full name of the chart. |

--- a/charts/external-dns/templates/extra-deploy.yaml
+++ b/charts/external-dns/templates/extra-deploy.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ tpl . $ }}
+{{- end }}

--- a/charts/external-dns/tests/common-metadata_test.yaml
+++ b/charts/external-dns/tests/common-metadata_test.yaml
@@ -1,6 +1,8 @@
 suite: All resources contains metadata
 templates:
   - "*.yaml"
+excludeTemplates:
+  - "extra-deploy.yaml"
 release:
   name: external-dns
 chart:

--- a/charts/external-dns/tests/extra-deploy_test.yaml
+++ b/charts/external-dns/tests/extra-deploy_test.yaml
@@ -1,0 +1,174 @@
+suite: ExtraDeploy configuration
+templates:
+  - extra-deploy.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+tests:
+  - it: should not create any documents when extraDeploy is empty
+    set:
+      extraDeploy: []
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create any documents when extraDeploy is not set
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should deploy a single manifest
+    set:
+      extraDeploy:
+        - |-
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: test-config
+          data:
+            key: value
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: test-config
+      - equal:
+          path: data.key
+          value: value
+
+  - it: should deploy multiple manifests
+    set:
+      extraDeploy:
+        - |-
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: test-config-1
+          data:
+            key1: value1
+        - |-
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: test-secret-1
+          data:
+            secretKey: secretValue
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: ConfigMap
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: test-config-1
+        documentIndex: 0
+      - isKind:
+          of: Secret
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: test-secret-1
+        documentIndex: 1
+
+  - it: should support templating with release values
+    set:
+      extraDeploy:
+        - |-
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: {{ .Release.Name }}-config
+            namespace: {{ .Release.Namespace }}
+          data:
+            releaseName: {{ .Release.Name }}
+            namespace: {{ .Release.Namespace }}
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: test-release-config
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - equal:
+          path: data.releaseName
+          value: test-release
+      - equal:
+          path: data.namespace
+          value: test-namespace
+
+  - it: should support templating with chart values
+    set:
+      customValue: my-custom-value
+      extraDeploy:
+        - |-
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: templated-config
+          data:
+            customValue: {{ .Values.customValue }}
+            provider: {{ .Values.provider.name }}
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: data.customValue
+          value: my-custom-value
+      - equal:
+          path: data.provider
+          value: aws
+
+  - it: should support complex manifest with ExternalSecret
+    set:
+      extraDeploy:
+        - |-
+          apiVersion: external-secrets.io/v1
+          kind: ExternalSecret
+          metadata:
+            name: {{ .Release.Name }}-tsig-secret
+            namespace: {{ .Release.Namespace }}
+          spec:
+            secretStoreRef:
+              kind: ClusterSecretStore
+              name: secretstore
+            target:
+              creationPolicy: Owner
+            dataFrom:
+              - extract:
+                  conversionStrategy: Default
+                  decodingStrategy: None
+                  key: cluster-tsig-secret
+                  metadataPolicy: None
+                  property: rfc2136_tsig_secret
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: apiVersion
+          value: external-secrets.io/v1
+      - equal:
+          path: metadata.name
+          value: test-release-tsig-secret
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - equal:
+          path: spec.secretStoreRef.kind
+          value: ClusterSecretStore
+      - equal:
+          path: spec.secretStoreRef.name
+          value: secretstore
+      - equal:
+          path: spec.target.creationPolicy
+          value: Owner
+      - equal:
+          path: spec.dataFrom[0].extract.key
+          value: cluster-tsig-secret

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -89,6 +89,13 @@
       "description": "Extra containers to add to the `Deployment`.",
       "type": "array"
     },
+    "extraDeploy": {
+      "description": "Array of extra K8s manifests to deploy alongside the chart. Supports templating via `tpl` function.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "extraVolumeMounts": {
       "description": "Extra [volume mounts](https://kubernetes.io/docs/concepts/storage/volumes/) for the `external-dns` container.",
       "type": "array"

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -149,6 +149,9 @@ extraVolumes: []
 # -- Extra [volume mounts](https://kubernetes.io/docs/concepts/storage/volumes/) for the `external-dns` container.
 extraVolumeMounts: []
 
+# -- Array of extra K8s manifests to deploy alongside the chart. Supports templating via `tpl` function.
+extraDeploy: []
+
 # -- [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the `external-dns` container.
 resources: {}
 


### PR DESCRIPTION
# feat: add extraDeploy field to deploy arbitrary manifests alongside chart

Introduced the `extraDeploy` field in the README, values schema, and values.yaml to allow users to specify extra Kubernetes manifests to deploy alongside the chart, supporting templating via the `tpl` function.

## What does it do?

This PR adds an `extraDeploy` configuration option that allows users to deploy arbitrary Kubernetes manifests alongside the external-dns chart. Users can provide an array of YAML manifest strings that will be rendered as additional resources during chart installation.

Key features:
- Supports Helm templating via the `tpl` function (e.g., `{{ .Release.Namespace }}`, `{{ .Values.customValue }}`)
- Allows multiple manifests to be deployed
- Integrates seamlessly with existing chart values and templating context
- Useful for deploying related resources like Secrets, ConfigMaps, or CRDs that external-dns depends on

## Motivation

Many users need to deploy additional Kubernetes resources alongside external-dns, such as:
- External Secrets for provider credentials (as shown in the RFC2136 TSIG secret example)
- Custom RBAC resources for specific use cases
- ConfigMaps with provider-specific configurations
- Network policies or security contexts

Previously, users had to manage these resources separately or create wrapper charts. This feature enables a cleaner, single-chart deployment approach while maintaining the flexibility to template these additional resources with chart values.

## Example Usage

```yaml
extraDeploy:
  - |-
    apiVersion: external-secrets.io/v1
    kind: ExternalSecret
    metadata:
      name: {{ .Release.Name }}-tsig-secret
      namespace: {{ .Release.Namespace }}
    spec:
      secretStoreRef:
        kind: ClusterSecretStore
        name: secretstore
      target:
        creationPolicy: Owner
      dataFrom:
        - extract:
            key: cluster-tsig-secret
            property: rfc2136_tsig_secret
```

## Changes Made

- Added `extraDeploy: []` field to `values.yaml` with documentation
- Created `templates/extra-deploy.yaml` template file with conditional rendering
- Updated `values.schema.json` to include schema validation
- Updated `README.md` documentation table
- Added comprehensive unit tests with 7 test cases covering all scenarios
- Updated `common-metadata_test.yaml` to use `excludeTemplates` for the new template

## Implementation Notes

### Test Exclusion
The `extra-deploy.yaml` template is excluded from the common metadata test because:
- It renders user-provided manifests that may not follow chart labeling conventions
- The template conditionally renders only when `extraDeploy` values are provided
- User-provided manifests should not be forced to include standard Helm labels

The exclusion is implemented using the `excludeTemplates` field in `common-metadata_test.yaml`:
```yaml
templates:
  - "*.yaml"
excludeTemplates:
  - "extra-deploy.yaml"
```

This approach maintains the wildcard pattern for future-proofing while cleanly excluding the user-manifest template.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->