### PR TITLE
refactor(controller): replace custom SIGTERM handler with NotifyContext

### DIFF
--- a/controller/execute.go
+++ b/controller/execute.go
@@ -47,6 +47,12 @@ import (
 )
 
 func Execute() {
+	ctx, finalize := contextWithSigtermHandler(context.Background())
+	defer finalize()
+	execute(ctx)
+}
+
+func execute(ctx context.Context) {
 	cfg := externaldns.NewConfig()
 	if err := cfg.ParseFlags(os.Args[1:]); err != nil {
 		log.Fatalf("flag parsing error: %v", err)
@@ -83,10 +89,7 @@ func Execute() {
 
 	log.Info(externaldns.Banner())
 
-	ctx, cancel := context.WithCancel(context.Background())
-
 	go serveMetrics(cfg.MetricsAddress)
-	go handleSigterm(cancel)
 
 	sCfg, err := source.NewSourceConfig(cfg)
 	if err != nil {
@@ -201,14 +204,23 @@ func configureLogger(cfg *externaldns.Config) error {
 	return nil
 }
 
-// handleSigterm listens for a SIGTERM signal and triggers the provided cancel function
-// to gracefully terminate the application. It logs a message when the signal is received.
-func handleSigterm(cancel func()) {
-	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, syscall.SIGTERM)
-	<-signals
-	log.Info("Received SIGTERM. Terminating...")
-	cancel()
+// contextWithSigtermHandler returns a context that is canceled when a SIGTERM signal is received and
+// a function to wait for the signal handler to finish processing.
+func contextWithSigtermHandler(ctx context.Context) (context.Context, func()) {
+	endCh := make(chan struct{})
+	ctx, stop := signal.NotifyContext(ctx, syscall.SIGTERM)
+	context.AfterFunc(ctx, func() {
+		log.Info("Received SIGTERM. Terminating...")
+		close(endCh)
+	})
+	return ctx, func() {
+		stop()
+		select {
+		case <-ctx.Done():
+			<-endCh
+		default:
+		}
+	}
 }
 
 // serveMetrics starts an HTTP server that serves health and metrics endpoints.

--- a/controller/execute_test.go
+++ b/controller/execute_test.go
@@ -17,11 +17,15 @@ limitations under the License.
 package controller
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"os"
 	"os/exec"
+	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -106,9 +110,9 @@ func TestConfigureLogger(t *testing.T) {
 }
 
 // Helper used by runExecuteSubprocess.
-func TestHelperProcess(_ *testing.T) {
+func TestHelperProcess(t *testing.T) {
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
-		return
+		t.SkipNow()
 	}
 	// Parse args after the "--" sentinel.
 	idx := -1
@@ -133,7 +137,6 @@ func runExecuteSubprocess(t *testing.T, args []string) (int, error) {
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
-	// TODO: investigate why -test.run=TestHelperProcess
 	cmdArgs := append([]string{"-test.run=TestHelperProcess", "--"}, args...)
 	cmd := exec.CommandContext(ctx, os.Args[0], cmdArgs...)
 	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
@@ -305,4 +308,55 @@ func TestControllerRunCancelContextStopsLoop(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("controller did not stop after context cancellation")
 	}
+}
+
+// TestContextWithSigtermHandlerHelper is a helper process that sets up the SIGTERM handler
+// and waits for it to be triggered.
+func TestContextWithSigtermHandlerHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		t.SkipNow()
+	}
+	log.SetOutput(os.Stdout)
+	ctx, finalize := contextWithSigtermHandler(t.Context())
+	t.Log("helper started")
+	<-ctx.Done()
+	defer finalize()
+}
+
+// TestContextWithSigtermHandler verifies that the contextWithSigtermHandler function correctly handles SIGTERM signals.
+func TestContextWithSigtermHandler(t *testing.T) {
+	// Start the helper process that sets up the signal handler and waits for SIGTERM.
+	cmd := exec.CommandContext(t.Context(),
+		os.Args[0],
+		"-test.run=TestContextWithSigtermHandlerHelper",
+		"-test.v",
+	)
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+	out, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	err = cmd.Start()
+	require.NoError(t, err)
+	require.NotNil(t, cmd.Process)
+
+	// Wait for the helper to start before sending SIGTERM.
+	scanner := bufio.NewScanner(out)
+	for scanner.Scan() {
+		if strings.Contains(scanner.Text(), "helper started") {
+			break
+		}
+	}
+	require.NoError(t, scanner.Err())
+
+	err = cmd.Process.Signal(syscall.SIGTERM)
+	require.NoError(t, err)
+
+	// Read the remaining output.
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, out)
+	require.NoError(t, err)
+
+	err = cmd.Wait()
+	require.NoError(t, err)
+
+	assert.Contains(t, buf.String(), "Received SIGTERM. Terminating...")
 }


### PR DESCRIPTION

## What does it do ?

- Replaces the custom SIGTERM signal handler with Go’s standard signal.NotifyContext in the controller.
- Removes the manual goroutine and channel-based signal handling logic.
- Introduces a new helper (contextWithSigtermHandler) to create a context that is canceled on SIGTERM and logs the event.
- Refactors tests to use a subprocess and verify that the context is canceled and the log message is printed when SIGTERM is received.

## Motivation

- Simplifies and modernizes signal handling by using Go’s idiomatic context cancellation.
- Eliminates race conditions and potential goroutine leaks present in the old manual signal handler.
- Improves test reliability and coverage for SIGTERM handling by using a robust subprocess-based approach.

<details>

# Previous description

## What does it do ?

Fix a race condition between the signal handler setup and the signal send in the test for `handleSigterm()`.

In the test, in rare case the SIGTERM signal could be send before the `handleSigterm()` calls `signal.Notify()`.

In this case, the cancel function is never called.

The test always pass because it silently ignore this with the select case `sig := <-sigChan`.

I think we need to test that the signal received is a SIGTERM  and that the cancel func has been called. Not one of the two conditions.


<!-- A brief description of the change being made with this pull request. -->

## Motivation

This primarily concerns testing and ensuring correctness. There is most likely no issue when the controller run.

I could reproduce this with `go test -timeout 30s -count 1000 -run ^TestHandleSigterm$ sigs.k8s.io/external-dns/controller` after removing the `sig := <-sigChan` select case in the current code.
(edit: test was removed in https://github.com/kubernetes-sigs/external-dns/pull/5816)
<details>

```golang
func TestHandleSigterm(t *testing.T) {
	cancelCalled := make(chan bool, 1)
	cancel := func() {
		cancelCalled <- true
	}

	var logOutput bytes.Buffer
	log.SetOutput(&logOutput)
	defer log.SetOutput(os.Stderr)

	go handleSigterm(cancel)

	// Simulate sending a SIGTERM signal
	sigChan := make(chan os.Signal, 1)
	signal.Notify(sigChan, syscall.SIGTERM)
	err := syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
	assert.NoError(t, err)

	// Wait for the cancel function to be called
	select {
	case <-cancelCalled:
		assert.Contains(t, logOutput.String(), "Received SIGTERM. Terminating...")
	// case sig := <-sigChan:
	// 	assert.Equal(t, syscall.SIGTERM, sig)
	case <-time.After(1 * time.Second):
		t.Fatal("cancel function was not called")
	}
}
```
</details>

```
$ go test -timeout 30s -count 1000 -run ^TestHandleSigterm$ sigs.k8s.io/external-dns/controller
--- FAIL: TestHandleSigterm (1.00s)
    execute_test.go:350: cancel function was not called
--- FAIL: TestHandleSigterm (1.00s)
    execute_test.go:350: cancel function was not called
--- FAIL: TestHandleSigterm (1.00s)
    execute_test.go:350: cancel function was not called
--- FAIL: TestHandleSigterm (1.00s)
    execute_test.go:350: cancel function was not called
time="2026-03-28T04:55:43+01:00" level=info msg="Received SIGTERM. Terminating..."
--- FAIL: TestHandleSigterm (1.00s)
    execute_test.go:350: cancel function was not called
--- FAIL: TestHandleSigterm (1.00s)
    execute_test.go:350: cancel function was not called
time="2026-03-28T04:55:45+01:00" level=info msg="Received SIGTERM. Terminating..."
FAIL
FAIL    sigs.k8s.io/external-dns/controller     6.352s
FAIL
```

After this patch:
```
$ go test -timeout 30s -count 1000 -run ^TestHandleSigterm$ sigs.k8s.io/external-dns/controller
ok      sigs.k8s.io/external-dns/controller     0.032s [no tests to run]
```

</details>

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
