### PR TITLE
test(wrappers): fix data races in target filter and multi-source

### DIFF
--- a/source/wrappers/multisource_test.go
+++ b/source/wrappers/multisource_test.go
@@ -45,9 +45,6 @@ func testMultiSourceImplementsSource(t *testing.T) {
 
 // testMultiSourceEndpoints tests merged endpoints from children are returned.
 func testMultiSourceEndpoints(t *testing.T) {
-	foo := &endpoint.Endpoint{DNSName: "foo", Targets: endpoint.Targets{"8.8.8.8"}}
-	bar := &endpoint.Endpoint{DNSName: "bar", Targets: endpoint.Targets{"8.8.4.4"}}
-
 	for _, tc := range []struct {
 		title           string
 		nestedEndpoints [][]*endpoint.Endpoint
@@ -65,19 +62,26 @@ func testMultiSourceEndpoints(t *testing.T) {
 		},
 		{
 			"single non-empty child source returns child's endpoints",
-			[][]*endpoint.Endpoint{{foo}},
-			[]*endpoint.Endpoint{foo},
+			[][]*endpoint.Endpoint{
+				{&endpoint.Endpoint{DNSName: "foo", Targets: endpoint.Targets{"8.8.8.8"}}},
+			},
+			[]*endpoint.Endpoint{
+				{DNSName: "foo", Targets: endpoint.Targets{"8.8.8.8"}},
+			},
 		},
 		{
 			"multiple non-empty child sources returns merged children's endpoints",
-			[][]*endpoint.Endpoint{{foo}, {bar}},
-			[]*endpoint.Endpoint{foo, bar},
+			[][]*endpoint.Endpoint{{
+				&endpoint.Endpoint{DNSName: "foo", Targets: endpoint.Targets{"8.8.8.8"}},
+			}, {
+				&endpoint.Endpoint{DNSName: "bar", Targets: endpoint.Targets{"8.8.4.4"}}}},
+			[]*endpoint.Endpoint{
+				{DNSName: "foo", Targets: endpoint.Targets{"8.8.8.8"}},
+				{DNSName: "bar", Targets: endpoint.Targets{"8.8.4.4"}}},
 		},
 	} {
 
 		t.Run(tc.title, func(t *testing.T) {
-			t.Parallel()
-
 			// Prepare the nested mock sources.
 			sources := make([]source.Source, 0, len(tc.nestedEndpoints))
 

--- a/source/wrappers/source_test.go
+++ b/source/wrappers/source_test.go
@@ -31,7 +31,7 @@ func sortEndpoints(endpoints []*endpoint.Endpoint) {
 		}
 	}
 
-	sort.SliceStable(endpoints, func(i, k int) bool {
+	sort.Slice(endpoints, func(i, k int) bool {
 		// Sort by DNSName, RecordType, and Targets
 		ei, ek := endpoints[i], endpoints[k]
 		if ei == nil || ek == nil {

--- a/source/wrappers/source_test.go
+++ b/source/wrappers/source_test.go
@@ -30,7 +30,8 @@ func sortEndpoints(endpoints []*endpoint.Endpoint) {
 			ep.Targets = endpoint.NewTargets(ep.Targets...)
 		}
 	}
-	sort.Slice(endpoints, func(i, k int) bool {
+
+	sort.SliceStable(endpoints, func(i, k int) bool {
 		// Sort by DNSName, RecordType, and Targets
 		ei, ek := endpoints[i], endpoints[k]
 		if ei == nil || ek == nil {

--- a/source/wrappers/source_test.go
+++ b/source/wrappers/source_test.go
@@ -30,7 +30,6 @@ func sortEndpoints(endpoints []*endpoint.Endpoint) {
 			ep.Targets = endpoint.NewTargets(ep.Targets...)
 		}
 	}
-
 	sort.Slice(endpoints, func(i, k int) bool {
 		// Sort by DNSName, RecordType, and Targets
 		ei, ek := endpoints[i], endpoints[k]

--- a/source/wrappers/targetfiltersource_test.go
+++ b/source/wrappers/targetfiltersource_test.go
@@ -70,13 +70,6 @@ func TestEchoSourceReturnGivenSources(t *testing.T) {
 	}
 }
 
-func TestTargetFilterSource(t *testing.T) {
-	t.Parallel()
-
-	t.Run("Interface", TestTargetFilterSourceImplementsSource)
-	t.Run("Endpoints", TestTargetFilterSourceEndpoints)
-}
-
 // TestTargetFilterSourceImplementsSource tests that targetFilterSource is a valid Source.
 func TestTargetFilterSourceImplementsSource(t *testing.T) {
 	var _ source.Source = &targetFilterSource{}
@@ -120,10 +113,7 @@ func TestTargetFilterSourceEndpoints(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-
 		t.Run(tt.title, func(t *testing.T) {
-			t.Parallel()
-
 			echo := testutils.NewMockSource(tt.endpoints...)
 			src := NewTargetFilterSource(echo, tt.filters)
 


### PR DESCRIPTION
## What does it do ?

This PR addresses test flakiness caused by data races in TestTargetFilterSource, TestTargetFilterSourceEndpoints, and TestMultiSource.
- Removed duplicate execution of TestTargetFilterSourceEndpoints (was being run both as a standalone test and as a subtest).
- Eliminated unsafe concurrent access by avoiding t.Parallel() in cases where tests mutate data.

Relevant issue https://github.com/stretchr/testify/issues/187

## Motivation

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-external-dns-push-images/1965760676924231680

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
