### PR TITLE
test(source/wrappers): fix race condition

### DIFF
--- a/source/wrappers/multisource_test.go
+++ b/source/wrappers/multisource_test.go
@@ -65,13 +65,13 @@ func testMultiSourceEndpoints(t *testing.T) {
 		},
 		{
 			"single non-empty child source returns child's endpoints",
-			[][]*endpoint.Endpoint{{foo}},
-			[]*endpoint.Endpoint{foo},
+			[][]*endpoint.Endpoint{{foo.DeepCopy()}},
+			[]*endpoint.Endpoint{foo.DeepCopy()},
 		},
 		{
 			"multiple non-empty child sources returns merged children's endpoints",
-			[][]*endpoint.Endpoint{{foo}, {bar}},
-			[]*endpoint.Endpoint{foo, bar},
+			[][]*endpoint.Endpoint{{foo.DeepCopy()}, {bar.DeepCopy()}},
+			[]*endpoint.Endpoint{foo.DeepCopy(), bar.DeepCopy()},
 		},
 	} {
 


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->
Deep copy endpoint in test cases in `testMultiSourceEndpoints()` before testing.

## Motivation

Fix a race condition in source/wrappers tests.
<!-- What inspired you to submit this pull request? -->

Before:

<details>

```
$ CGO_ENABLED=1 go test -race -count=100 ./source/wrappers/...
==================
WARNING: DATA RACE
Read at 0x00c000608c10 by goroutine 195:
  sigs.k8s.io/external-dns/source/wrappers.sortEndpoints()
      /external-dns/source/wrappers/source_test.go:30 +0x8e
  sigs.k8s.io/external-dns/source/wrappers.validateEndpoints()
      /external-dns/source/wrappers/source_test.go:67 +0x144
  sigs.k8s.io/external-dns/source/wrappers.testMultiSourceEndpoints.func1()
      /external-dns/source/wrappers/multisource_test.go:100 +0x444
  testing.tRunner()
      /go/1.25.1/libexec/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x44

Previous write at 0x00c000608c10 by goroutine 194:
  sigs.k8s.io/external-dns/source/wrappers.sortEndpoints()
      /external-dns/source/wrappers/source_test.go:30 +0xbd
  sigs.k8s.io/external-dns/source/wrappers.validateEndpoints()
      /external-dns/source/wrappers/source_test.go:67 +0x144
  sigs.k8s.io/external-dns/source/wrappers.testMultiSourceEndpoints.func1()
      /external-dns/source/wrappers/multisource_test.go:100 +0x444
  testing.tRunner()
      /go/1.25.1/libexec/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x44

Goroutine 195 (running) created at:
  testing.(*T).Run()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x9d2
  sigs.k8s.io/external-dns/source/wrappers.testMultiSourceEndpoints()
      /external-dns/source/wrappers/multisource_test.go:78 +0x95b
  testing.tRunner()
      /go/1.25.1/libexec/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x44

Goroutine 194 (finished) created at:
  testing.(*T).Run()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x9d2
  sigs.k8s.io/external-dns/source/wrappers.testMultiSourceEndpoints()
      /external-dns/source/wrappers/multisource_test.go:78 +0x95b
  testing.tRunner()
      /go/1.25.1/libexec/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x44
==================
==================
WARNING: DATA RACE
Read at 0x00c0004f4550 by goroutine 195:
  k8s.io/utils/set.Set[go.shape.string].Insert()
      /go/pkg/mod/k8s.io/utils@v0.0.0-20241210054802-24370beab758/set/set.go:48 +0x11e
  k8s.io/utils/set.New[go.shape.string]()
      /go/pkg/mod/k8s.io/utils@v0.0.0-20241210054802-24370beab758/set/set.go:33 +0xca
  sigs.k8s.io/external-dns/endpoint.NewTargets()
      /external-dns/endpoint/endpoint.go:86 +0x189
  sigs.k8s.io/external-dns/source/wrappers.sortEndpoints()
      /external-dns/source/wrappers/source_test.go:30 +0xa4
  sigs.k8s.io/external-dns/source/wrappers.validateEndpoints()
      /external-dns/source/wrappers/source_test.go:67 +0x144
  sigs.k8s.io/external-dns/source/wrappers.testMultiSourceEndpoints.func1()
      /external-dns/source/wrappers/multisource_test.go:100 +0x444
  testing.tRunner()
      /go/1.25.1/libexec/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x44

Previous write at 0x00c0004f4550 by goroutine 194:
  k8s.io/utils/set.Set[go.shape.string].SortedList()
      /go/pkg/mod/k8s.io/utils@v0.0.0-20241210054802-24370beab758/set/set.go:173 +0x1e4
  sigs.k8s.io/external-dns/endpoint.NewTargets()
      /external-dns/endpoint/endpoint.go:86 +0x19c
  sigs.k8s.io/external-dns/source/wrappers.sortEndpoints()
      /external-dns/source/wrappers/source_test.go:30 +0xa4
  sigs.k8s.io/external-dns/source/wrappers.validateEndpoints()
      /external-dns/source/wrappers/source_test.go:67 +0x144
  sigs.k8s.io/external-dns/source/wrappers.testMultiSourceEndpoints.func1()
      /external-dns/source/wrappers/multisource_test.go:100 +0x444
  testing.tRunner()
      /go/1.25.1/libexec/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x44

Goroutine 195 (running) created at:
  testing.(*T).Run()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x9d2
  sigs.k8s.io/external-dns/source/wrappers.testMultiSourceEndpoints()
      /external-dns/source/wrappers/multisource_test.go:78 +0x95b
  testing.tRunner()
      /go/1.25.1/libexec/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x44

Goroutine 194 (finished) created at:
  testing.(*T).Run()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x9d2
  sigs.k8s.io/external-dns/source/wrappers.testMultiSourceEndpoints()
      /external-dns/source/wrappers/multisource_test.go:78 +0x95b
  testing.tRunner()
      /go/1.25.1/libexec/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x44
==================
--- FAIL: TestMultiSource (0.00s)
    --- FAIL: TestMultiSource/Endpoints (0.00s)
        --- FAIL: TestMultiSource/Endpoints/multiple_non-empty_child_sources_returns_merged_children's_endpoints (0.00s)
            testing.go:1617: race detected during execution of test
==================
WARNING: DATA RACE
Write at 0x00c00051a410 by goroutine 3274:
  sigs.k8s.io/external-dns/source/wrappers.sortEndpoints()
      /external-dns/source/wrappers/source_test.go:30 +0xbd
  sigs.k8s.io/external-dns/source/wrappers.validateEndpoints()
      /external-dns/source/wrappers/source_test.go:67 +0x144
  sigs.k8s.io/external-dns/source/wrappers.testMultiSourceEndpoints.func1()
      /external-dns/source/wrappers/multisource_test.go:100 +0x444
  testing.tRunner()
      /go/1.25.1/libexec/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x44

Previous read at 0x00c00051a410 by goroutine 3271:
  sigs.k8s.io/external-dns/source/wrappers.validateEndpoint()
      /external-dns/source/wrappers/source_test.go:85 +0x1e4
  sigs.k8s.io/external-dns/source/wrappers.validateEndpoints()
      /external-dns/source/wrappers/source_test.go:70 +0x17e
  sigs.k8s.io/external-dns/source/wrappers.testMultiSourceEndpoints.func1()
      /external-dns/source/wrappers/multisource_test.go:100 +0x444
  testing.tRunner()
      /go/1.25.1/libexec/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x44

Goroutine 3274 (running) created at:
  testing.(*T).Run()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x9d2
  sigs.k8s.io/external-dns/source/wrappers.testMultiSourceEndpoints()
      /external-dns/source/wrappers/multisource_test.go:78 +0x95b
  testing.tRunner()
      /go/1.25.1/libexec/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x44

Goroutine 3271 (running) created at:
  testing.(*T).Run()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x9d2
  sigs.k8s.io/external-dns/source/wrappers.testMultiSourceEndpoints()
      /external-dns/source/wrappers/multisource_test.go:78 +0x95b
  testing.tRunner()
      /go/1.25.1/libexec/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x44
==================
--- FAIL: TestTargetFilterSourceEndpoints (0.00s)
    testing.go:1617: race detected during execution of test
--- FAIL: TestTargetFilterSource (0.00s)
    --- FAIL: TestTargetFilterSource/Endpoints (0.00s)
        --- FAIL: TestTargetFilterSource/Endpoints/filter_exclude_internal_net (0.00s)
            testing.go:1617: race detected during execution of test
        --- FAIL: TestTargetFilterSource/Endpoints/filter_exclusion_all (0.00s)
            testing.go:1617: race detected during execution of test
--- FAIL: TestMultiSource (0.00s)
    --- FAIL: TestMultiSource/Endpoints (0.00s)
        --- FAIL: TestMultiSource/Endpoints/single_non-empty_child_source_returns_child's_endpoints (0.00s)
            testing.go:1617: race detected during execution of test
        --- FAIL: TestMultiSource/Endpoints/multiple_non-empty_child_sources_returns_merged_children's_endpoints (0.00s)
            testing.go:1617: race detected during execution of test
==================
WARNING: DATA RACE
Read at 0x00c00006f3b0 by goroutine 8466:
  sigs.k8s.io/external-dns/endpoint.Targets.Same()
      /external-dns/endpoint/endpoint.go:124 +0x184
  sigs.k8s.io/external-dns/source/wrappers.validateEndpoint()
      /external-dns/source/wrappers/source_test.go:85 +0x20c
  sigs.k8s.io/external-dns/source/wrappers.validateEndpoints()
      /external-dns/source/wrappers/source_test.go:70 +0x17e
  sigs.k8s.io/external-dns/source/wrappers.testMultiSourceEndpoints.func1()
      /external-dns/source/wrappers/multisource_test.go:100 +0x444
  testing.tRunner()
      /go/1.25.1/libexec/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x44

Previous write at 0x00c00006f3b0 by goroutine 8467:
  k8s.io/utils/set.Set[go.shape.string].SortedList()
      /go/pkg/mod/k8s.io/utils@v0.0.0-20241210054802-24370beab758/set/set.go:173 +0x1e4
  sigs.k8s.io/external-dns/endpoint.NewTargets()
      /external-dns/endpoint/endpoint.go:86 +0x19c
  sigs.k8s.io/external-dns/source/wrappers.sortEndpoints()
      /external-dns/source/wrappers/source_test.go:30 +0xa4
  sigs.k8s.io/external-dns/source/wrappers.validateEndpoints()
      /external-dns/source/wrappers/source_test.go:67 +0x144
  sigs.k8s.io/external-dns/source/wrappers.testMultiSourceEndpoints.func1()
      /external-dns/source/wrappers/multisource_test.go:100 +0x444
  testing.tRunner()
      /go/1.25.1/libexec/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x44

Goroutine 8466 (running) created at:
  testing.(*T).Run()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x9d2
  sigs.k8s.io/external-dns/source/wrappers.testMultiSourceEndpoints()
      /external-dns/source/wrappers/multisource_test.go:78 +0x95b
  testing.tRunner()
      /go/1.25.1/libexec/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x44

Goroutine 8467 (running) created at:
  testing.(*T).Run()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x9d2
  sigs.k8s.io/external-dns/source/wrappers.testMultiSourceEndpoints()
      /external-dns/source/wrappers/multisource_test.go:78 +0x95b
  testing.tRunner()
      /go/1.25.1/libexec/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /go/1.25.1/libexec/src/testing/testing.go:1997 +0x44
==================
--- FAIL: TestMultiSource (0.00s)
    --- FAIL: TestMultiSource/Endpoints (0.00s)
        --- FAIL: TestMultiSource/Endpoints/single_non-empty_child_source_returns_child's_endpoints (0.00s)
            testing.go:1617: race detected during execution of test
        --- FAIL: TestMultiSource/Endpoints/multiple_non-empty_child_sources_returns_merged_children's_endpoints (0.00s)
            testing.go:1617: race detected during execution of test
FAIL
FAIL    sigs.k8s.io/external-dns/source/wrappers        0.715s
FAIL
```

</details>

After:

<details>

```
$ CGO_ENABLED=1 go test -race -count=100 ./source/wrappers/...
ok      sigs.k8s.io/external-dns/source/wrappers        1.731s
```

</details>

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
