### PR TITLE
test(cloudflare): clear environment variables before setting test values

### DIFF
--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -332,10 +332,10 @@ func NewCloudFlareProvider(
 		configV4 *cloudflare.Client
 		err      error
 	)
-	if os.Getenv(cfAPITokenEnvKey) != "" {
-		token := os.Getenv(cfAPITokenEnvKey)
-		if strings.HasPrefix(token, "file:") {
-			tokenBytes, err := os.ReadFile(strings.TrimPrefix(token, "file:"))
+	token := os.Getenv(cfAPITokenEnvKey)
+	if token != "" {
+		if trimed, ok := strings.CutPrefix(token, "file:"); ok {
+			tokenBytes, err := os.ReadFile(trimed)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read %s from file: %w", cfAPITokenEnvKey, err)
 			}

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -1816,8 +1816,10 @@ func TestCustomTTLWithEnabledProxyNotChanged(t *testing.T) {
 }
 
 func TestCloudFlareProvider_Region(t *testing.T) {
-	t.Setenv(cfAPITokenEnvKey, "abc123def")
-	t.Setenv(cfAPIEmailEnvKey, "test@test.com")
+	testutils.TestHelperEnvSetter(t, map[string]string{
+		cfAPITokenEnvKey: "abc123def",
+		cfAPIEmailEnvKey: "test@test.com",
+	})
 	provider, err := NewCloudFlareProvider(
 		endpoint.NewDomainFilter([]string{"example.com"}),
 		provider.ZoneIDFilter{},


### PR DESCRIPTION
## What does it do ?

Cleans environment variables before each CloudFlare provider test and refactors environment variable handling by extracting variable names to constants.

## Motivation

Tests were potentially unstable due to interference from previously set environment variables. 
This change ensures each test starts with a clean environment state and improves code maintainability by using constants for environment variable names.


## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
