### PR TITLE
test(cloudflare): mock provider for cf change tests

### DIFF
--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -1826,20 +1826,24 @@ func TestCloudFlareProvider_Region(t *testing.T) {
 }
 
 func TestCloudFlareProvider_newCloudFlareChange(t *testing.T) {
-	_ = os.Setenv("CF_API_KEY", "xxxxxxxxxxxxxxxxx")
-	_ = os.Setenv("CF_API_EMAIL", "test@test.com")
+	t.Parallel()
 
-	p, err := NewCloudFlareProvider(
-		endpoint.NewDomainFilter([]string{"example.com"}),
-		provider.ZoneIDFilter{},
-		true,
-		false,
-		RegionalServicesConfig{Enabled: true, RegionKey: "us"},
-		CustomHostnamesConfig{Enabled: false},
-		DNSRecordsConfig{PerPage: 50},
-	)
-	if err != nil {
-		t.Fatal(err)
+	comment := string(make([]byte, paidZoneMaxCommentLength+1))
+	freeValidComment := comment[:freeZoneMaxCommentLength]
+	freeInvalidComment := comment[:freeZoneMaxCommentLength+1]
+	paidValidComment := comment[:paidZoneMaxCommentLength]
+	paidInvalidComment := comment[:paidZoneMaxCommentLength+1]
+
+	freeProvider := &CloudFlareProvider{
+		Client:                 NewMockCloudFlareClient(),
+		domainFilter:           endpoint.NewDomainFilter([]string{"example.com"}),
+		RegionalServicesConfig: RegionalServicesConfig{Enabled: true, RegionKey: "us"},
+	}
+	paidProvider := &CloudFlareProvider{
+		Client:                 NewMockCloudFlareClient(),
+		domainFilter:           endpoint.NewDomainFilter([]string{"bar.com"}),
+		RegionalServicesConfig: RegionalServicesConfig{Enabled: true, RegionKey: "us"},
+		DNSRecordsConfig:       DNSRecordsConfig{Comment: paidValidComment},
 	}
 
 	ep := &endpoint.Endpoint{
@@ -1848,44 +1852,11 @@ func TestCloudFlareProvider_newCloudFlareChange(t *testing.T) {
 		Targets:    []string{"192.0.2.1"},
 	}
 
-	change, _ := p.newCloudFlareChange(cloudFlareCreate, ep, ep.Targets[0], nil)
+	change, _ := freeProvider.newCloudFlareChange(cloudFlareCreate, ep, ep.Targets[0], nil)
 	if change.RegionalHostname.regionKey != "us" {
 		t.Errorf("expected region key to be 'us', but got '%s'", change.RegionalHostname.regionKey)
 	}
 
-	var freeValidCommentBuilder strings.Builder
-	for range freeZoneMaxCommentLength {
-		freeValidCommentBuilder.WriteString("x")
-	}
-
-	var freeInvalidCommentBuilder strings.Builder
-	for range freeZoneMaxCommentLength + 1 {
-		freeInvalidCommentBuilder.WriteString("x")
-	}
-
-	var paidValidCommentBuilder strings.Builder
-	for range paidZoneMaxCommentLength {
-		paidValidCommentBuilder.WriteString("x")
-	}
-	var paidInvalidCommentBuilder strings.Builder
-	for range paidZoneMaxCommentLength + 1 {
-		paidInvalidCommentBuilder.WriteString("x")
-	}
-
-	paidProvider, err := NewCloudFlareProvider(
-		endpoint.NewDomainFilter([]string{"bar.com"}),
-		provider.ZoneIDFilter{},
-		true,
-		false,
-		RegionalServicesConfig{Enabled: true, RegionKey: "us"},
-		CustomHostnamesConfig{Enabled: false},
-		DNSRecordsConfig{PerPage: 50, Comment: paidValidCommentBuilder.String()},
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	paidProvider.Client = NewMockCloudFlareClient()
 	commentTestCases := []struct {
 		name     string
 		provider *CloudFlareProvider
@@ -1894,7 +1865,7 @@ func TestCloudFlareProvider_newCloudFlareChange(t *testing.T) {
 	}{
 		{
 			name:     "For free Zone respecting comment length, expect no trimming",
-			provider: p,
+			provider: freeProvider,
 			endpoint: &endpoint.Endpoint{
 				DNSName:    "example.com",
 				RecordType: "A",
@@ -1902,15 +1873,15 @@ func TestCloudFlareProvider_newCloudFlareChange(t *testing.T) {
 				ProviderSpecific: endpoint.ProviderSpecific{
 					{
 						Name:  annotations.CloudflareRecordCommentKey,
-						Value: freeValidCommentBuilder.String(),
+						Value: freeValidComment,
 					},
 				},
 			},
-			expected: len(freeValidCommentBuilder.String()),
+			expected: len(freeValidComment),
 		},
 		{
 			name:     "For free Zones not respecting comment length, expect trimmed comments",
-			provider: p,
+			provider: freeProvider,
 			endpoint: &endpoint.Endpoint{
 				DNSName:    "example.com",
 				RecordType: "A",
@@ -1918,7 +1889,7 @@ func TestCloudFlareProvider_newCloudFlareChange(t *testing.T) {
 				ProviderSpecific: endpoint.ProviderSpecific{
 					{
 						Name:  annotations.CloudflareRecordCommentKey,
-						Value: freeInvalidCommentBuilder.String(),
+						Value: freeInvalidComment,
 					},
 				},
 			},
@@ -1934,11 +1905,11 @@ func TestCloudFlareProvider_newCloudFlareChange(t *testing.T) {
 				ProviderSpecific: endpoint.ProviderSpecific{
 					{
 						Name:  annotations.CloudflareRecordCommentKey,
-						Value: paidValidCommentBuilder.String(),
+						Value: paidValidComment,
 					},
 				},
 			},
-			expected: len(paidValidCommentBuilder.String()),
+			expected: len(paidValidComment),
 		},
 		{
 			name:     "For paid Zones not respecting comment length, expect trimmed comments",
@@ -1950,7 +1921,7 @@ func TestCloudFlareProvider_newCloudFlareChange(t *testing.T) {
 				ProviderSpecific: endpoint.ProviderSpecific{
 					{
 						Name:  annotations.CloudflareRecordCommentKey,
-						Value: paidInvalidCommentBuilder.String(),
+						Value: paidInvalidComment,
 					},
 				},
 			},
@@ -1960,6 +1931,7 @@ func TestCloudFlareProvider_newCloudFlareChange(t *testing.T) {
 
 	for _, test := range commentTestCases {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			change, err := test.provider.newCloudFlareChange(cloudFlareCreate, test.endpoint, test.endpoint.Targets[0], nil)
 			assert.NoError(t, err)
 			if len(change.ResourceRecord.Comment) != test.expected {
@@ -3216,7 +3188,6 @@ func TestConvertCloudflareErrorInContext(t *testing.T) {
 		})
 	}
 }
-
 func TestCloudFlareZonesDomainFilter(t *testing.T) {
 	// Set required environment variables for CloudFlare provider
 	t.Setenv("CF_API_TOKEN", "test-token")


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->
Change `TestCloudFlareProvider_newCloudFlareChange()` to use a mockProdiver instead of a real one with fake credentials.
Also edit the way tests comments are generated.

## Motivation

Current implementation perform a query on cloudflare api as it use a real provider & cloudflare client which is not needed for this test.
This decrease cloudflare package test up to 800ms on my machine. (2,3s->1.5s)
<!-- What inspired you to submit this pull request? -->

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
