### PR TITLE
fix(tests): ensure tests using `testutils.LogsUnderTestWithLogLevel()` are not run in parallel

### DIFF
--- a/internal/testutils/helpers.go
+++ b/internal/testutils/helpers.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package testutils
 
+import (
+	"strings"
+	"testing"
+)
+
 // ToPtr returns a pointer to the given value of any type.
 // Example usage:
 //
@@ -24,4 +29,22 @@ package testutils
 //	fmt.Println(*fooPtr) // Output: 42
 func ToPtr[T any](v T) *T {
 	return &v
+}
+
+// IsParallel checks if the current test has been marked to run in parallel (i.e. t.Parallel was called).
+// It returns true if the test is marked as parallel, false otherwise.
+//
+// Note: This function uses a deliberate call to t.Setenv that will panic if t.Parallel was previously used;
+// the panic is recovered and inspected to determine if parallel execution was attempted.
+func IsParallel(t *testing.T) (paralell bool) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			if msg, ok := r.(string); ok && strings.HasPrefix(msg, "testing:") {
+				paralell = true
+			}
+		}
+	}()
+	t.Setenv(" ", "") // panic if t.Parallel was called
+	return
 }

--- a/internal/testutils/helpers_test.go
+++ b/internal/testutils/helpers_test.go
@@ -45,3 +45,20 @@ func TestIsPointer(t *testing.T) {
 
 	assert.IsType(t, *ptr, value)
 }
+
+func TestIsParallel(t *testing.T) {
+	t.Run("not-parallel", func(t *testing.T) {
+		assert.False(t, IsParallel(t), "IsParallel returned true for a non-parallel test")
+		t.Run("not-parallel subtest", func(t *testing.T) {
+			assert.False(t, IsParallel(t), "IsParallel returned true for a non-parallel subtest")
+		})
+	})
+
+	t.Run("parallel", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, IsParallel(t), "IsParallel returned false for a parallel test")
+		t.Run("parallel subtest", func(t *testing.T) {
+			assert.True(t, IsParallel(t), "IsParallel returned false for a parallel subtest")
+		})
+	})
+}

--- a/internal/testutils/log.go
+++ b/internal/testutils/log.go
@@ -37,6 +37,9 @@ import (
 // testutils.TestHelperLogContains("expected debug log message", hook, t)
 func LogsUnderTestWithLogLevel(level log.Level, t *testing.T) *test.Hook {
 	t.Helper()
+	if IsParallel(t) {
+		t.Fatal("LogsUnderTestWithLogLevel can not be used in parallel tests")
+	}
 	logger, hook := test.NewNullLogger()
 
 	log.AddHook(hook)

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package aws
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -2200,11 +2199,10 @@ func TestAWSCanonicalHostedZone(t *testing.T) {
 }
 
 func TestAWSCanonicalHostedZoneNotExist(t *testing.T) {
-	var buf bytes.Buffer
-	log.SetOutput(&buf)
+	hook := testutils.LogsUnderTestWithLogLevel(log.WarnLevel, t)
 	host := "foo.elb.eastwest-1.amazonaws.com"
 	_ = canonicalHostedZone(host)
-	assert.Containsf(t, buf.String(), "Could not find canonical hosted zone for domain", host)
+	testutils.TestHelperLogContainsWithLogLevel(fmt.Sprintf("Could not find canonical hosted zone for domain %s.", host), log.WarnLevel, hook, t)
 }
 
 func BenchmarkTestAWSCanonicalHostedZone(b *testing.B) {

--- a/provider/cloudflare/cloudflare_regional_test.go
+++ b/provider/cloudflare/cloudflare_regional_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cloudflare/cloudflare-go/v5/addressing"
 	"github.com/cloudflare/cloudflare-go/v5/dns"
 	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 
 	"github.com/stretchr/testify/assert"
 
@@ -843,7 +844,6 @@ func TestRecordsWithListRegionalHostnameFaillure(t *testing.T) {
 }
 
 func TestApplyChangesWithRegionalHostnamesFaillures(t *testing.T) {
-	t.Parallel()
 	type fields struct {
 		Records           map[string]dns.RecordResponse
 		RegionalHostnames []regionalHostname
@@ -1006,7 +1006,10 @@ func TestApplyChangesWithRegionalHostnamesFaillures(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+
+			if tt.expectDebug == "" {
+				t.Parallel()
+			}
 			records := tt.fields.Records
 			if records == nil {
 				records = map[string]dns.RecordResponse{}
@@ -1029,7 +1032,10 @@ func TestApplyChangesWithRegionalHostnamesFaillures(t *testing.T) {
 					RegionKey: tt.fields.RegionKey,
 				},
 			}
-			hook := testutils.LogsUnderTestWithLogLevel(log.DebugLevel, t)
+			var hook *test.Hook
+			if tt.expectDebug != "" {
+				hook = testutils.LogsUnderTestWithLogLevel(log.DebugLevel, t)
+			}
 			err := p.ApplyChanges(t.Context(), tt.args.changes)
 			assert.Error(t, err, "ApplyChanges should return an error")
 			if tt.errMsg != "" && err != nil {
@@ -1043,7 +1049,6 @@ func TestApplyChangesWithRegionalHostnamesFaillures(t *testing.T) {
 }
 
 func TestApplyChangesWithRegionalHostnamesDryRun(t *testing.T) {
-	t.Parallel()
 	type fields struct {
 		Records           map[string]dns.RecordResponse
 		RegionalHostnames []regionalHostname
@@ -1155,7 +1160,6 @@ func TestApplyChangesWithRegionalHostnamesDryRun(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			records := tt.fields.Records
 			if records == nil {
 				records = map[string]dns.RecordResponse{}

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1571,7 +1572,10 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			src, err := NewGatewayHTTPRouteSource(clients, &tt.config)
 			require.NoError(t, err, "failed to create Gateway HTTPRoute Source")
 
-			hook := testutils.LogsUnderTestWithLogLevel(log.DebugLevel, t)
+			var hook *test.Hook
+			if len(tt.logExpectations) > 0 {
+				hook = testutils.LogsUnderTestWithLogLevel(log.DebugLevel, t)
+			}
 
 			endpoints, err := src.Endpoints(ctx)
 			require.NoError(t, err, "failed to get Endpoints")

--- a/source/node_test.go
+++ b/source/node_test.go
@@ -44,8 +44,6 @@ import (
 )
 
 func TestNodeSource(t *testing.T) {
-	t.Parallel()
-
 	t.Run("NewNodeSource", testNodeSourceNewNodeSource)
 	t.Run("Endpoints", testNodeSourceEndpoints)
 	t.Run("EndpointsIPv6", testNodeEndpointsWithIPv6)

--- a/source/pod_test.go
+++ b/source/pod_test.go
@@ -685,7 +685,6 @@ func TestPodSource(t *testing.T) {
 }
 
 func TestPodSourceLogs(t *testing.T) {
-	t.Parallel()
 	// Generate unique pod names to avoid log conflicts across parallel tests.
 	// Since logs are globally shared, using the same pod names could cause
 	// false positives in unexpectedDebugLogs assertions.


### PR DESCRIPTION


## What does it do ?

<!-- A brief description of the change being made with this pull request. -->
Ensure tests using log capture with `testutils.LogsUnderTestWithLogLevel()` are not run in parallel.
Also changes some test to use the `testutils` package for log capture.

This introduce a helper function `testutils.IsParallel()`.
A parallel test panic when `t.SetEnv()` is called. This is used to determine if the test is marked to run in parallel or not.
This is clearly a hack as the testing package do not expose this info.

## Motivation

<!-- What inspired you to submit this pull request? -->
Some tests that capture logs run in parallel which may cause tests to fails randomly. 

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
