### PR TITLE
feat(provider/cloudflare): add support for tags

### DIFF
--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -397,6 +397,7 @@ metadata:
   annotations:
     # Assigns three tags to the DNS record created from this resource
     external-dns.alpha.kubernetes.io/cloudflare-tags: "owner:frontend-team, env:dev, component:api"
+```
 
 ## Using CRD source to manage DNS records in Cloudflare
 

--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -388,7 +388,8 @@ Requires [Cloudflare for SaaS](https://developers.cloudflare.com/cloudflare-for-
 
 ## Setting Cloudflare DNS Record Tags
 
-Cloudflare allows you to add descriptive tags to DNS records. This can be useful for organizing your records, for example, by environment (`production`, `staging`) or by the team that owns them (`frontend-team`). ExternalDNS can manage these tags for you.
+Cloudflare allows you to add descriptive tags to DNS records. This can be useful for organizing your records.
+For example one can apply tags by environment (`production`, `staging`) or by the team that owns them (`frontend-team`, `backend-team`). ExternalDNS can manage these tags for you.
 
 To assign tags to a DNS record, add the `external-dns.alpha.kubernetes.io/cloudflare-tags` annotation to your Kubernetes resource (like a Service or Ingress). The value should be a comma-separated list of your desired tags.
 

--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -386,6 +386,18 @@ Requires [Cloudflare for SaaS](https://developers.cloudflare.com/cloudflare-for-
 
 **Note:** Due to using the legacy cloudflare-go v0 API for custom hostname management, the custom hostname page size is fixed at 50. This limitation will be addressed in a future migration to the v4 SDK.
 
+## Setting Cloudflare DNS Record Tags
+
+Cloudflare allows you to add descriptive tags to DNS records. This can be useful for organizing your records, for example, by environment (`production`, `staging`) or by the team that owns them (`frontend-team`). ExternalDNS can manage these tags for you.
+
+To assign tags to a DNS record, add the `external-dns.alpha.kubernetes.io/cloudflare-tags` annotation to your Kubernetes resource (like a Service or Ingress). The value should be a comma-separated list of your desired tags.
+
+```yaml
+metadata:
+  annotations:
+    # Assigns three tags to the DNS record created from this resource
+    external-dns.alpha.kubernetes.io/cloudflare-tags: "owner:frontend-team, env:dev, component:api"
+
 ## Using CRD source to manage DNS records in Cloudflare
 
 Please refer to the [CRD source documentation](../sources/crd.md#example) for more information.

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -751,7 +751,7 @@ func (p *CloudFlareProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]
 				if trimmed != "" {
 					cleanedTags = append(cleanedTags, trimmed)
 				}
-			} 
+			}
 			sort.Strings(cleanedTags)
 			e.SetProviderSpecificProperty(annotations.CloudflareTagsKey, strings.Join(cleanedTags, ","))
 		}

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -751,7 +751,7 @@ func (p *CloudFlareProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]
 				if trimmed != "" {
 					cleanedTags = append(cleanedTags, trimmed)
 				}
-			}
+			} 
 			sort.Strings(cleanedTags)
 			e.SetProviderSpecificProperty(annotations.CloudflareTagsKey, strings.Join(cleanedTags, ","))
 		}

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -279,6 +279,7 @@ func getUpdateDNSRecordParam(zoneID string, cfc cloudFlareChange) dns.RecordUpda
 			Content:  cloudflare.F(cfc.ResourceRecord.Content),
 			Priority: cloudflare.F(cfc.ResourceRecord.Priority),
 			Comment:  cloudflare.F(cfc.ResourceRecord.Comment),
+			Tags:     cloudflare.F(cfc.ResourceRecord.Tags),
 		},
 	}
 }
@@ -295,6 +296,7 @@ func getCreateDNSRecordParam(zoneID string, cfc *cloudFlareChange) dns.RecordNew
 			Content:  cloudflare.F(cfc.ResourceRecord.Content),
 			Priority: cloudflare.F(cfc.ResourceRecord.Priority),
 			Comment:  cloudflare.F(cfc.ResourceRecord.Comment),
+			Tags:     cloudflare.F(cfc.ResourceRecord.Tags),
 		},
 	}
 }
@@ -827,6 +829,17 @@ func (p *CloudFlareProvider) newCloudFlareChange(action changeAction, ep *endpoi
 		comment = val
 	}
 
+	var tags []string
+    if val, ok := ep.GetProviderSpecificProperty(annotations.CloudflareTagsKey); ok {
+        // Split the comma-separated string of tags
+        for _, tag := range strings.Split(val, ",") {
+            trimmedTag := strings.TrimSpace(tag)
+            if trimmedTag != "" {
+                tags = append(tags, trimmedTag)
+            }
+        }
+    }
+
 	if len(comment) > freeZoneMaxCommentLength {
 		comment = p.DNSRecordsConfig.trimAndValidateComment(ep.DNSName, comment, p.ZoneHasPaidPlan)
 	}
@@ -851,6 +864,7 @@ func (p *CloudFlareProvider) newCloudFlareChange(action changeAction, ep *endpoi
 			Type:     dns.RecordResponseType(ep.RecordType),
 			Content:  target,
 			Comment:  comment,
+			Tags:     tags,
 			Priority: priority,
 		},
 		RegionalHostname:    p.regionalHostname(ep),

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -101,15 +101,15 @@ func TestCloudflareProviderTags(t *testing.T) {
 			{
 				name: "Correctly sorts and cleans tags from annotation",
 				inputEndpoint: endpoint.NewEndpoint("test.example.com", endpoint.RecordTypeA, "1.2.3.4").
-					WithProviderSpecific(annotations.CloudflareTagsKey, "owner:nikhil, env:dev, app:test "),
-				expectedTags:   "app:test,env:dev,owner:nikhil",
+					WithProviderSpecific(annotations.CloudflareTagsKey, "owner:owner_name, env:dev, app:test "),
+				expectedTags:   "app:test,env:dev,owner:owner_name",
 				expectProperty: true,
 			},
 			{
 				name: "Handles a single tag",
 				inputEndpoint: endpoint.NewEndpoint("single.example.com", endpoint.RecordTypeA, "1.2.3.4").
-					WithProviderSpecific(annotations.CloudflareTagsKey, "owner:nikhil"),
-				expectedTags:   "owner:nikhil",
+					WithProviderSpecific(annotations.CloudflareTagsKey, "owner:owner_name"),
+				expectedTags:   "owner:owner_name",
 				expectProperty: true,
 			},
 			{
@@ -154,7 +154,7 @@ func TestCloudflareProviderTags(t *testing.T) {
 				Name:    "test.example.com",
 				Type:    "A",
 				Content: "1.2.3.4",
-				Tags:    []string{"owner:nikhil", "env:dev", "app:test"},
+				Tags:    []string{"owner:owner_name", "env:dev", "app:test"},
 			},
 		}
 
@@ -163,7 +163,7 @@ func TestCloudflareProviderTags(t *testing.T) {
 
 		val, ok := endpoints[0].GetProviderSpecificProperty(annotations.CloudflareTagsKey)
 		assert.True(t, ok)
-		assert.Equal(t, "app:test,env:dev,owner:nikhil", val, "Tags from API should be sorted")
+		assert.Equal(t, "app:test,env:dev,owner:owner_name", val, "Tags from API should be sorted")
 	})
 }
 

--- a/source/annotations/annotations.go
+++ b/source/annotations/annotations.go
@@ -27,6 +27,7 @@ const (
 	CloudflareCustomHostnameKey = AnnotationKeyPrefix + "cloudflare-custom-hostname"
 	CloudflareRegionKey         = AnnotationKeyPrefix + "cloudflare-region-key"
 	CloudflareRecordCommentKey  = AnnotationKeyPrefix + "cloudflare-record-comment"
+	CloudflareTagsKey           = AnnotationKeyPrefix + "cloudflare-tags"
 
 	AWSPrefix        = AnnotationKeyPrefix + "aws-"
 	CoreDNSPrefix    = AnnotationKeyPrefix + "coredns-"

--- a/source/annotations/provider_specific.go
+++ b/source/annotations/provider_specific.go
@@ -75,7 +75,12 @@ func ProviderSpecificAnnotations(annotations map[string]string) (endpoint.Provid
 					Name:  CloudflareRecordCommentKey,
 					Value: v,
 				})
-			}
+			} else if strings.Contains(k, CloudflareTagsKey) {
+                providerSpecificAnnotations = append(providerSpecificAnnotations, endpoint.ProviderSpecificProperty{
+                    Name:  CloudflareTagsKey,
+                    Value: v,
+                })
+            }
 		}
 	}
 	return providerSpecificAnnotations, setIdentifier

--- a/source/annotations/provider_specific.go
+++ b/source/annotations/provider_specific.go
@@ -76,11 +76,11 @@ func ProviderSpecificAnnotations(annotations map[string]string) (endpoint.Provid
 					Value: v,
 				})
 			} else if strings.Contains(k, CloudflareTagsKey) {
-                providerSpecificAnnotations = append(providerSpecificAnnotations, endpoint.ProviderSpecificProperty{
-                    Name:  CloudflareTagsKey,
-                    Value: v,
-                })
-            }
+				providerSpecificAnnotations = append(providerSpecificAnnotations, endpoint.ProviderSpecificProperty{
+					Name:  CloudflareTagsKey,
+					Value: v,
+				})
+			}
 		}
 	}
 	return providerSpecificAnnotations, setIdentifier

--- a/source/annotations/provider_specific_test.go
+++ b/source/annotations/provider_specific_test.go
@@ -94,6 +94,41 @@ func TestProviderSpecificAnnotations(t *testing.T) {
 }
 
 func TestGetProviderSpecificCloudflareAnnotations(t *testing.T) {
+
+	for _, tc := range []struct {
+		title         string
+		annotations   map[string]string
+		expectedKey   string
+		expectedValue string
+	}{
+		{
+			title:         "Cloudflare tags annotation is set correctly",
+			annotations:   map[string]string{CloudflareTagsKey: "env:test,owner:team-a"},
+			expectedKey:   CloudflareTagsKey,
+			expectedValue: "env:test,owner:team-a",
+		},
+		{
+			title: "Cloudflare tags annotation among another annotations is set correctly",
+			annotations: map[string]string{
+				"random annotation 1": "random value 1",
+				CloudflareTagsKey:     "env:test,owner:team-b",
+				"random annotation 2": "random value 2"},
+			expectedKey:   CloudflareTagsKey,
+			expectedValue: "env:test,owner:team-b",
+		},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			providerSpecificAnnotations, _ := ProviderSpecificAnnotations(tc.annotations)
+			for _, providerSpecificAnnotation := range providerSpecificAnnotations {
+				if providerSpecificAnnotation.Name == tc.expectedKey {
+					assert.Equal(t, tc.expectedValue, providerSpecificAnnotation.Value)
+					return
+				}
+			}
+			t.Errorf("Cloudflare provider specific annotation %s is not set correctly to %s", tc.expectedKey, tc.expectedValue)
+		})
+	}
+
 	for _, tc := range []struct {
 		title         string
 		annotations   map[string]string


### PR DESCRIPTION
## What does it do ?

This pull request adds support for Cloudflare's native Tags feature.

It introduces a new annotation, external-dns.alpha.kubernetes.io/cloudflare-tags, which allows users to specify a comma-separated list of key:value tags on a source resource.

The provider code has been updated to:

1. Parse this new annotation.
2. Include the tags in the payload for both CREATE and UPDATE API calls to Cloudflare.
3. Read existing tags from Cloudflare records to ensure the correct plan is calculated.

## Motivation

Currently, external-dns supports provider-specific metadata like comments for Cloudflare, but it lacks support for Tags. Cloudflare Tags are a powerful feature for resource management, allowing users to:

- Filter DNS records in the dashboard and via the API.
- Automate actions based on specific tags.
- Track costs and ownership for DNS resources.

Without this feature, we have to manage tags manually after external-dns creates a record, which is not scalable and goes against GitOps principles. This change brings external-dns closer to feature parity with the Cloudflare provider's capabilities and enables better infrastructure-as-code practices.

## More

- [x]  Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
