### PR TITLE
refactor(pihole): reduce cyclomatic complexity of TestProvider

### DIFF
--- a/provider/pihole/pihole_test.go
+++ b/provider/pihole/pihole_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package pihole
 
 import (
@@ -23,6 +22,7 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
+	_ "sigs.k8s.io/external-dns/provider"
 )
 
 type testPiholeClient struct {
@@ -68,106 +68,13 @@ func (r *requestTracker) clear() {
 	r.deleteRequests = nil
 }
 
-func TestNewPiholeProvider(t *testing.T) {
-	// Test invalid configuration
-	_, err := NewPiholeProvider(PiholeConfig{})
-	if err == nil {
-		t.Error("Expected error from invalid configuration")
-	}
-	// Test valid configuration
-	_, err = NewPiholeProvider(PiholeConfig{Server: "test.example.com"})
-	if err != nil {
-		t.Error("Expected no error from valid configuration, got:", err)
-	}
-}
-
-func TestProvider(t *testing.T) {
+func TestProvider_UpdateRecords(t *testing.T) {
 	requests := requestTracker{}
 	p := &PiholeProvider{
 		api: &testPiholeClient{endpoints: make([]*endpoint.Endpoint, 0), requests: &requests},
 	}
-
-	records, err := p.Records(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(records) != 0 {
-		t.Fatal("Expected empty list of records, got:", records)
-	}
-
-	// Populate the provider with records
-	records = []*endpoint.Endpoint{
-		{
-			DNSName:    "test1.example.com",
-			Targets:    []string{"192.168.1.1"},
-			RecordType: endpoint.RecordTypeA,
-		},
-		{
-			DNSName:    "test2.example.com",
-			Targets:    []string{"192.168.1.2"},
-			RecordType: endpoint.RecordTypeA,
-		},
-		{
-			DNSName:    "test3.example.com",
-			Targets:    []string{"192.168.1.3"},
-			RecordType: endpoint.RecordTypeA,
-		},
-		{
-			DNSName:    "test1.example.com",
-			Targets:    []string{"fc00::1:192:168:1:1"},
-			RecordType: endpoint.RecordTypeAAAA,
-		},
-		{
-			DNSName:    "test2.example.com",
-			Targets:    []string{"fc00::1:192:168:1:2"},
-			RecordType: endpoint.RecordTypeAAAA,
-		},
-		{
-			DNSName:    "test3.example.com",
-			Targets:    []string{"fc00::1:192:168:1:3"},
-			RecordType: endpoint.RecordTypeAAAA,
-		},
-	}
-	if err := p.ApplyChanges(context.Background(), &plan.Changes{
-		Create: records,
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	// Test records are correct on retrieval
-
-	newRecords, err := p.Records(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(newRecords) != 6 {
-		t.Fatal("Expected list of 6 records, got:", records)
-	}
-	if len(requests.createRequests) != 6 {
-		t.Fatal("Expected 6 create requests, got:", requests.createRequests)
-	}
-	if len(requests.deleteRequests) != 0 {
-		t.Fatal("Expected no delete requests, got:", requests.deleteRequests)
-	}
-
-	for idx, record := range records {
-		if newRecords[idx].DNSName != record.DNSName {
-			t.Error("DNS Name malformed on retrieval, got:", newRecords[idx].DNSName, "expected:", record.DNSName)
-		}
-		if newRecords[idx].Targets[0] != record.Targets[0] {
-			t.Error("Targets malformed on retrieval, got:", newRecords[idx].Targets, "expected:", record.Targets)
-		}
-
-		if !reflect.DeepEqual(requests.createRequests[idx], record) {
-			t.Error("Unexpected create request, got:", newRecords[idx].DNSName, "expected:", record.DNSName)
-		}
-	}
-
-	requests.clear()
-
-	// Test delete a record
-
-	records = []*endpoint.Endpoint{
+	// Create initial records
+	initialRecords := []*endpoint.Endpoint{
 		{
 			DNSName:    "test1.example.com",
 			Targets:    []string{"192.168.1.1"},
@@ -189,67 +96,36 @@ func TestProvider(t *testing.T) {
 			RecordType: endpoint.RecordTypeAAAA,
 		},
 	}
-	recordToDeleteA := endpoint.Endpoint{
-		DNSName:    "test3.example.com",
-		Targets:    []string{"192.168.1.3"},
-		RecordType: endpoint.RecordTypeA,
-	}
 	if err := p.ApplyChanges(context.Background(), &plan.Changes{
-		Delete: []*endpoint.Endpoint{
-			&recordToDeleteA,
-		},
+		Create: initialRecords,
 	}); err != nil {
 		t.Fatal(err)
 	}
-	recordToDeleteAAAA := endpoint.Endpoint{
-		DNSName:    "test3.example.com",
-		Targets:    []string{"fc00::1:192:168:1:3"},
-		RecordType: endpoint.RecordTypeAAAA,
-	}
-	if err := p.ApplyChanges(context.Background(), &plan.Changes{
-		Delete: []*endpoint.Endpoint{
-			&recordToDeleteAAAA,
-		},
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	// Test records are updated
-	newRecords, err = p.Records(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(newRecords) != 4 {
-		t.Fatal("Expected list of 4 records, got:", records)
-	}
-	if len(requests.createRequests) != 0 {
-		t.Fatal("Expected no create requests, got:", requests.createRequests)
-	}
-	if len(requests.deleteRequests) != 2 {
-		t.Fatal("Expected 2 delete request, got:", requests.deleteRequests)
-	}
-
-	for idx, record := range records {
-		if newRecords[idx].DNSName != record.DNSName {
-			t.Error("DNS Name malformed on retrieval, got:", newRecords[idx].DNSName, "expected:", record.DNSName)
-		}
-		if newRecords[idx].Targets[0] != record.Targets[0] {
-			t.Error("Targets malformed on retrieval, got:", newRecords[idx].Targets, "expected:", record.Targets)
-		}
-	}
-
-	if !reflect.DeepEqual(requests.deleteRequests[0], &recordToDeleteA) {
-		t.Error("Unexpected delete request, got:", requests.deleteRequests[0], "expected:", recordToDeleteA)
-	}
-	if !reflect.DeepEqual(requests.deleteRequests[1], &recordToDeleteAAAA) {
-		t.Error("Unexpected delete request, got:", requests.deleteRequests[1], "expected:", recordToDeleteAAAA)
-	}
-
 	requests.clear()
-
-	// Test update a record
-
-	records = []*endpoint.Endpoint{
+	// Update records
+	updateOld := []*endpoint.Endpoint{
+		{
+			DNSName:    "test1.example.com",
+			Targets:    []string{"192.168.1.1"},
+			RecordType: endpoint.RecordTypeA,
+		},
+		{
+			DNSName:    "test2.example.com",
+			Targets:    []string{"192.168.1.2"},
+			RecordType: endpoint.RecordTypeA,
+		},
+		{
+			DNSName:    "test1.example.com",
+			Targets:    []string{"fc00::1:192:168:1:1"},
+			RecordType: endpoint.RecordTypeAAAA,
+		},
+		{
+			DNSName:    "test2.example.com",
+			Targets:    []string{"fc00::1:192:168:1:2"},
+			RecordType: endpoint.RecordTypeAAAA,
+		},
+	}
+	updateNew := []*endpoint.Endpoint{
 		{
 			DNSName:    "test1.example.com",
 			Targets:    []string{"192.168.1.1"},
@@ -272,56 +148,12 @@ func TestProvider(t *testing.T) {
 		},
 	}
 	if err := p.ApplyChanges(context.Background(), &plan.Changes{
-		UpdateOld: []*endpoint.Endpoint{
-			{
-				DNSName:    "test1.example.com",
-				Targets:    []string{"192.168.1.1"},
-				RecordType: endpoint.RecordTypeA,
-			},
-			{
-				DNSName:    "test2.example.com",
-				Targets:    []string{"192.168.1.2"},
-				RecordType: endpoint.RecordTypeA,
-			},
-			{
-				DNSName:    "test1.example.com",
-				Targets:    []string{"fc00::1:192:168:1:1"},
-				RecordType: endpoint.RecordTypeAAAA,
-			},
-			{
-				DNSName:    "test2.example.com",
-				Targets:    []string{"fc00::1:192:168:1:2"},
-				RecordType: endpoint.RecordTypeAAAA,
-			},
-		},
-		UpdateNew: []*endpoint.Endpoint{
-			{
-				DNSName:    "test1.example.com",
-				Targets:    []string{"192.168.1.1"},
-				RecordType: endpoint.RecordTypeA,
-			},
-			{
-				DNSName:    "test2.example.com",
-				Targets:    []string{"10.0.0.1"},
-				RecordType: endpoint.RecordTypeA,
-			},
-			{
-				DNSName:    "test1.example.com",
-				Targets:    []string{"fc00::1:192:168:1:1"},
-				RecordType: endpoint.RecordTypeAAAA,
-			},
-			{
-				DNSName:    "test2.example.com",
-				Targets:    []string{"fc00::1:10:0:0:1"},
-				RecordType: endpoint.RecordTypeAAAA,
-			},
-		},
+		UpdateOld: updateOld,
+		UpdateNew: updateNew,
 	}); err != nil {
 		t.Fatal(err)
 	}
-
-	// Test records are updated
-	newRecords, err = p.Records(context.Background())
+	newRecords, err := p.Records(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -334,8 +166,7 @@ func TestProvider(t *testing.T) {
 	if len(requests.deleteRequests) != 2 {
 		t.Fatal("Expected 2 delete request, got:", requests.deleteRequests)
 	}
-
-	for idx, record := range records {
+	for idx, record := range updateNew {
 		if newRecords[idx].DNSName != record.DNSName {
 			t.Error("DNS Name malformed on retrieval, got:", newRecords[idx].DNSName, "expected:", record.DNSName)
 		}
@@ -343,7 +174,6 @@ func TestProvider(t *testing.T) {
 			t.Error("Targets malformed on retrieval, got:", newRecords[idx].Targets, "expected:", record.Targets)
 		}
 	}
-
 	expectedCreateA := endpoint.Endpoint{
 		DNSName:    "test2.example.com",
 		Targets:    []string{"10.0.0.1"},
@@ -364,7 +194,6 @@ func TestProvider(t *testing.T) {
 		Targets:    []string{"fc00::1:192:168:1:2"},
 		RecordType: endpoint.RecordTypeAAAA,
 	}
-
 	for _, request := range requests.createRequests {
 		switch request.RecordType {
 		case endpoint.RecordTypeA:
@@ -375,7 +204,6 @@ func TestProvider(t *testing.T) {
 			if !reflect.DeepEqual(request, &expectedCreateAAAA) {
 				t.Error("Unexpected create request, got:", request, "expected:", &expectedCreateAAAA)
 			}
-		default:
 		}
 	}
 
@@ -389,9 +217,6 @@ func TestProvider(t *testing.T) {
 			if !reflect.DeepEqual(request, &expectedDeleteAAAA) {
 				t.Error("Unexpected delete request, got:", request, "expected:", &expectedDeleteAAAA)
 			}
-		default:
 		}
 	}
-
-	requests.clear()
 }

--- a/provider/pihole/pihole_test.go
+++ b/provider/pihole/pihole_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package pihole
 
 import (
@@ -22,7 +23,6 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
-	_ "sigs.k8s.io/external-dns/provider"
 )
 
 type testPiholeClient struct {
@@ -66,6 +66,189 @@ type requestTracker struct {
 func (r *requestTracker) clear() {
 	r.createRequests = nil
 	r.deleteRequests = nil
+}
+
+func TestNewPiholeProvider(t *testing.T) {
+	// Test invalid configuration
+	_, err := NewPiholeProvider(PiholeConfig{})
+	if err == nil {
+		t.Error("Expected error from invalid configuration")
+	}
+	// Test valid configuration
+	_, err = NewPiholeProvider(PiholeConfig{Server: "test.example.com"})
+	if err != nil {
+		t.Error("Expected no error from valid configuration, got:", err)
+	}
+}
+
+func TestProvider_InitialState(t *testing.T) {
+	requests := requestTracker{}
+	p := &PiholeProvider{
+		api: &testPiholeClient{endpoints: make([]*endpoint.Endpoint, 0), requests: &requests},
+	}
+	records, err := p.Records(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 0 {
+		t.Fatal("Expected empty list of records, got:", records)
+	}
+}
+
+func TestProvider_CreateRecords(t *testing.T) {
+	requests := requestTracker{}
+	p := &PiholeProvider{
+		api: &testPiholeClient{endpoints: make([]*endpoint.Endpoint, 0), requests: &requests},
+	}
+	records := []*endpoint.Endpoint{
+		{
+			DNSName:    "test1.example.com",
+			Targets:    []string{"192.168.1.1"},
+			RecordType: endpoint.RecordTypeA,
+		},
+		{
+			DNSName:    "test2.example.com",
+			Targets:    []string{"192.168.1.2"},
+			RecordType: endpoint.RecordTypeA,
+		},
+		{
+			DNSName:    "test3.example.com",
+			Targets:    []string{"192.168.1.3"},
+			RecordType: endpoint.RecordTypeA,
+		},
+		{
+			DNSName:    "test1.example.com",
+			Targets:    []string{"fc00::1:192:168:1:1"},
+			RecordType: endpoint.RecordTypeAAAA,
+		},
+		{
+			DNSName:    "test2.example.com",
+			Targets:    []string{"fc00::1:192:168:1:2"},
+			RecordType: endpoint.RecordTypeAAAA,
+		},
+		{
+			DNSName:    "test3.example.com",
+			Targets:    []string{"fc00::1:192:168:1:3"},
+			RecordType: endpoint.RecordTypeAAAA,
+		},
+	}
+	if err := p.ApplyChanges(context.Background(), &plan.Changes{
+		Create: records,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	newRecords, err := p.Records(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(newRecords) != 6 {
+		t.Fatal("Expected list of 6 records, got:", records)
+	}
+	if len(requests.createRequests) != 6 {
+		t.Fatal("Expected 6 create requests, got:", requests.createRequests)
+	}
+	if len(requests.deleteRequests) != 0 {
+		t.Fatal("Expected no delete requests, got:", requests.deleteRequests)
+	}
+	for idx, record := range records {
+		if newRecords[idx].DNSName != record.DNSName {
+			t.Error("DNS Name malformed on retrieval, got:", newRecords[idx].DNSName, "expected:", record.DNSName)
+		}
+		if newRecords[idx].Targets[0] != record.Targets[0] {
+			t.Error("Targets malformed on retrieval, got:", newRecords[idx].Targets, "expected:", record.Targets)
+		}
+		if !reflect.DeepEqual(requests.createRequests[idx], record) {
+			t.Error("Unexpected create request, got:", newRecords[idx].DNSName, "expected:", record.DNSName)
+		}
+	}
+	requests.clear()
+}
+
+func TestProvider_DeleteRecords(t *testing.T) {
+	requests := requestTracker{}
+	p := &PiholeProvider{
+		api: &testPiholeClient{endpoints: make([]*endpoint.Endpoint, 0), requests: &requests},
+	}
+	records := []*endpoint.Endpoint{
+		{
+			DNSName:    "test1.example.com",
+			Targets:    []string{"192.168.1.1"},
+			RecordType: endpoint.RecordTypeA,
+		},
+		{
+			DNSName:    "test2.example.com",
+			Targets:    []string{"192.168.1.2"},
+			RecordType: endpoint.RecordTypeA,
+		},
+		{
+			DNSName:    "test1.example.com",
+			Targets:    []string{"fc00::1:192:168:1:1"},
+			RecordType: endpoint.RecordTypeAAAA,
+		},
+		{
+			DNSName:    "test2.example.com",
+			Targets:    []string{"fc00::1:192:168:1:2"},
+			RecordType: endpoint.RecordTypeAAAA,
+		},
+	}
+	// Create initial records
+	if err := p.ApplyChanges(context.Background(), &plan.Changes{
+		Create: records,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	recordToDeleteA := endpoint.Endpoint{
+		DNSName:    "test3.example.com",
+		Targets:    []string{"192.168.1.3"},
+		RecordType: endpoint.RecordTypeA,
+	}
+	if err := p.ApplyChanges(context.Background(), &plan.Changes{
+		Delete: []*endpoint.Endpoint{
+			&recordToDeleteA,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	recordToDeleteAAAA := endpoint.Endpoint{
+		DNSName:    "test3.example.com",
+		Targets:    []string{"fc00::1:192:168:1:3"},
+		RecordType: endpoint.RecordTypeAAAA,
+	}
+	if err := p.ApplyChanges(context.Background(), &plan.Changes{
+		Delete: []*endpoint.Endpoint{
+			&recordToDeleteAAAA,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	newRecords, err := p.Records(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(newRecords) != 4 {
+		t.Fatal("Expected list of 4 records, got:", records)
+	}
+	if len(requests.createRequests) != 4 {
+		t.Fatal("Expected 4 create requests, got:", requests.createRequests)
+	}
+	if len(requests.deleteRequests) != 2 {
+		t.Fatal("Expected 2 delete request, got:", requests.deleteRequests)
+	}
+	for idx, record := range records {
+		if newRecords[idx].DNSName != record.DNSName {
+			t.Error("DNS Name malformed on retrieval, got:", newRecords[idx].DNSName, "expected:", record.DNSName)
+		}
+		if newRecords[idx].Targets[0] != record.Targets[0] {
+			t.Error("Targets malformed on retrieval, got:", newRecords[idx].Targets, "expected:", record.Targets)
+		}
+	}
+	if !reflect.DeepEqual(requests.deleteRequests[0], &recordToDeleteA) {
+		t.Error("Unexpected delete request, got:", requests.deleteRequests[0], "expected:", recordToDeleteA)
+	}
+	if !reflect.DeepEqual(requests.deleteRequests[1], &recordToDeleteAAAA) {
+		t.Error("Unexpected delete request, got:", requests.deleteRequests[1], "expected:", recordToDeleteAAAA)
+	}
+	requests.clear()
 }
 
 func TestProvider_UpdateRecords(t *testing.T) {
@@ -206,7 +389,6 @@ func TestProvider_UpdateRecords(t *testing.T) {
 			}
 		}
 	}
-
 	for _, request := range requests.deleteRequests {
 		switch request.RecordType {
 		case endpoint.RecordTypeA:
@@ -219,4 +401,5 @@ func TestProvider_UpdateRecords(t *testing.T) {
 			}
 		}
 	}
+	requests.clear()
 }


### PR DESCRIPTION
## What does it do?

Reduces the cyclomatic complexity of TestProvider from 43. The next highest is TestProviderV6 with a complexity of 43

## Motivation

Addresses #5419 

## More

- [X] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
