### PR TITLE
chore: upgrade ExternalDNS to go v1.25 and golangci-lint v2.5

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -48,7 +48,7 @@ jobs:
       with:
         verify: true
         args: --timeout=30m
-        version: v2.2
+        version: v2.5
 
       # https://github.com/daveshanley/vacuum
     - name: Lint OpenAPI spec

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'docker.io/library/golang:1.24-bookworm'
+  - name: 'docker.io/library/golang:1.25-bookworm'
     entrypoint: make
     env:
       - VERSION=$_GIT_TAG

--- a/docs/contributing/dev-guide.md
+++ b/docs/contributing/dev-guide.md
@@ -7,7 +7,7 @@ The `external-dns` is the work of thousands of contributors, and is maintained b
 Building and/or testing `external-dns` requires additional tooling.
 
 - [Git](https://git-scm.com/downloads)
-- [Go 1.24+](https://golang.org/dl/)
+- [Go 1.25+](https://golang.org/dl/)
 - [Go modules](https://github.com/golang/go/wiki/Modules)
 - [golangci-lint](https://github.com/golangci/golangci-lint)
 - [ko](https://ko.build/)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/external-dns
 
-go 1.24.2
+go 1.25
 
 require (
 	cloud.google.com/go/compute/metadata v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -913,7 +913,7 @@ github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxS
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
-github.com/oracle/oci-go-sdk/v65 v65.99.0 h1:M/a+N0IFk+TUCqyuf0kbqp4RyAIF+H7FmOe+CEiVbhs=
+github.com/oracle/oci-go-sdk/v65 v65.99.0 h1:JWVKFPDhab4UmecMxkkpYlJZXk5QcB+RYU1BSEYV8lE=
 github.com/oracle/oci-go-sdk/v65 v65.99.0/go.mod h1:RGiXfpDDmRRlLtqlStTzeBjjdUNXyqm3KXKyLCm3A/Q=
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=
 github.com/ovh/go-ovh v1.9.0/go.mod h1:cTVDnl94z4tl8pP1uZ/8jlVxntjSIf09bNcQ5TJSC7c=

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -17,7 +17,7 @@
 # renovate: datasource=github-releases depName=kubernetes-sigs/controller-tools
 CONTROLLER_TOOLS_GENERATOR_VERSION=v0.17.2
 # renovate: datasource=github-releases depName=golangci/golangci-lint
-GOLANG_CI_LINTER_VERSION=v2.2.2
+GOLANG_CI_LINTER_VERSION=v2.5.0
 
 # Execute
 # scripts/install-tools.sh


### PR DESCRIPTION
## What does it do ?

This update external dns to go 1.25 and golangci-lint to v2.5
Inspired by #5106

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
