### PR TITLE
chore(ci): speed-up & coveralls

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
       env:
         GOMAXPROCS: 4
         GOMEMLIMIT: 8192MiB
-      run: make test
+      run: make go-test
 
     - name: Send coverage
       uses: coverallsapp/github-action@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,8 +51,9 @@ jobs:
       run: make test
 
     - name: Send coverage
-      uses: shogo82148/actions-goveralls@v1
+      uses: coverallsapp/github-action@v2
       with:
-        path-to-profile: profile.cov
+        file: profile.cov
+        format: golang
       if: github.actor != 'nektos/act' && matrix.os == 'ubuntu-latest'
       continue-on-error: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,12 +11,12 @@ permissions:
 
 jobs:
 
-  build:
+  test:
     permissions:
       contents: read  #  to fetch code (actions/checkout)
       checks: write  #  to create a new check based on the results (shogo82148/actions-goveralls)
 
-    name: Build
+    name: Test
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -55,5 +55,18 @@ jobs:
       with:
         file: profile.cov
         format: golang
+        flag-name: run-${{ join(matrix.*, '-') }}
+        parallel: true
       if: github.actor != 'nektos/act' && matrix.os == 'ubuntu-latest'
       continue-on-error: true
+
+  finish:
+    needs: test
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@v2
+      with:
+        parallel-finished: true
+        carryforward: "run-ubuntu-latest,run-macos-latest"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,16 +38,10 @@ jobs:
       run: |
         go get -v -t -d ./...
 
-    - name: Install additional CI for nektos/act
-      run: |
-            apt update
-            apt install -y make gcc libc-dev git
-      if: github.actor == 'nektos/act' && matrix.os == 'ubuntu-latest'
-
     - name: Test
       env:
-        GOMAXPROCS: 1
-        GOMEMLIMIT: 2048MiB
+        GOMAXPROCS: 4
+        GOMEMLIMIT: 8192MiB
       run: make test
 
     - name: Send coverage
@@ -57,7 +51,6 @@ jobs:
         format: golang
         flag-name: run-${{ join(matrix.*, '-') }}
         parallel: true
-      if: github.actor != 'nektos/act' && matrix.os == 'ubuntu-latest'
       continue-on-error: true
 
   finish:

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,14 @@ crd: controller-gen-install
 #? test: The verify target runs tasks similar to the CI tasks, but without code coverage
 .PHONY: test
 test:
+	go test -race ./...
+
+
+.PHONY: test
+go-test:
 	go test -race -coverprofile=profile.cov ./...
+	go tool cover -func=profile.cov > coverage.summary
+	@tail -n 1 coverage.summary
 
 #? build: The build targets allow to build the binary and container image
 .PHONY: build


### PR DESCRIPTION
## What does it do ?

1. Switch CI to use [coveralls](https://coveralls.io/)
2. Rename job name from "Build" to "Test", since it calls `make test`
3. Upgrade resources, following https://github.com/kubernetes/test-infra/pull/35591

## Motivation

1. Fixes #5854
2. Speed-up CI

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
