### PR TITLE
fix(controller): panic in OCI provider build

### DIFF
--- a/controller/execute.go
+++ b/controller/execute.go
@@ -278,17 +278,17 @@ func buildProvider(
 		if cfg.OCIAuthInstancePrincipal {
 			if len(cfg.OCICompartmentOCID) == 0 {
 				err = fmt.Errorf("instance principal authentication requested, but no compartment OCID provided")
-			} else {
-				authConfig := oci.OCIAuthConfig{UseInstancePrincipal: true}
-				config = &oci.OCIConfig{Auth: authConfig, CompartmentID: cfg.OCICompartmentOCID}
+				break
 			}
+			authConfig := oci.OCIAuthConfig{UseInstancePrincipal: true}
+			config = &oci.OCIConfig{Auth: authConfig, CompartmentID: cfg.OCICompartmentOCID}
 		} else {
-			config, err = oci.LoadOCIConfig(cfg.OCIConfigFile)
+			if config, err = oci.LoadOCIConfig(cfg.OCIConfigFile); err != nil {
+				break
+			}
 		}
 		config.ZoneCacheDuration = cfg.OCIZoneCacheDuration
-		if err == nil {
-			p, err = oci.NewOCIProvider(*config, domainFilter, zoneIDFilter, cfg.OCIZoneScope, cfg.DryRun)
-		}
+		p, err = oci.NewOCIProvider(*config, domainFilter, zoneIDFilter, cfg.OCIZoneScope, cfg.DryRun)
 	case "rfc2136":
 		tlsConfig := rfc2136.TLSConfig{
 			UseTLS:                cfg.RFC2136UseTLS,

--- a/controller/execute_test.go
+++ b/controller/execute_test.go
@@ -265,6 +265,23 @@ func TestBuildProvider(t *testing.T) {
 			expectedType: "*provider.CachedProvider",
 		},
 		{
+			name: "oci provider instance principal without compartment OCID",
+			cfg: &externaldns.Config{
+				Provider:                 "oci",
+				OCIAuthInstancePrincipal: true,
+				OCICompartmentOCID:       "",
+			},
+			expectedError: "instance principal authentication requested, but no compartment OCID provided",
+		},
+		{
+			name: "oci provider without config file",
+			cfg: &externaldns.Config{
+				Provider:      "oci",
+				OCIConfigFile: "",
+			},
+			expectedError: "reading OCI config file",
+		},
+		{
 			name: "coredns provider",
 			cfg: &externaldns.Config{
 				Provider: "coredns",


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->
Fix a panic when building the OCI provider with missing config fields.

I would have liked to add tests for successful OCI provider builds, but this query the instance metadata API or require a config file, so it's not easy to test as is.

## Motivation

fix #5849


## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
