### PR TITLE
test: update goversion label to 1.25 in metrics test

### DIFF
--- a/pkg/metrics/models_test.go
+++ b/pkg/metrics/models_test.go
@@ -129,7 +129,7 @@ func TestNewGaugeFuncMetric(t *testing.T) {
 			subSystem:  "",
 			constLabels: prometheus.Labels{
 				"version":   "0.0.1",
-				"goversion": "1.24",
+				"goversion": "1.25",
 				"arch":      "arm64",
 			},
 			expectedFqName:          "external_dns_build_info",

--- a/pkg/metrics/models_test.go
+++ b/pkg/metrics/models_test.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -129,7 +130,7 @@ func TestNewGaugeFuncMetric(t *testing.T) {
 			subSystem:  "",
 			constLabels: prometheus.Labels{
 				"version":   "0.0.1",
-				"goversion": "1.25",
+				"goversion": runtime.Version(),
 				"arch":      "arm64",
 			},
 			expectedFqName:          "external_dns_build_info",


### PR DESCRIPTION
Update test label to Go 1.25 in metrics and ensure workflow uses correct Go version. References kubernetes-sigs/external-dns#5869.