### PR TITLE
fix: cloudflare softError failedZones

### DIFF
--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -721,7 +721,7 @@ func (p *CloudFlareProvider) submitChanges(ctx context.Context, changes []*cloud
 	}
 
 	if len(failedZones) > 0 {
-		return fmt.Errorf("failed to submit all changes for the following zones: %q", failedZones)
+		return provider.NewSoftErrorf("failed to submit all changes for the following zones: %q", failedZones)
 	}
 
 	return nil


### PR DESCRIPTION
## What does it do ?

Does a softError when external-dns is unable to update the Zone. This can be triggered due to dual DNS records.

## Motivation

There is no reason to fatal just because we can't write to a zone https://github.com/kubernetes-sigs/external-dns/issues/5898
Rather, do a soft crash and give it a try in a new reconcile.

<!-- What inspired you to submit this pull request? -->

## More

- [X] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
