### PR TITLE
endpoints benchmarking

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -312,6 +312,11 @@ func (e *Endpoint) GetProviderSpecificProperty(key string) (string, bool) {
 	return "", false
 }
 
+func (e *Endpoint) GetProviderSpecificPropertyHashMap(key string) (string, bool) {
+	value, ok := e.providerSpecificHashMap[key]
+	return value, ok
+}
+
 // SetProviderSpecificProperty sets the value of a ProviderSpecificProperty.
 func (e *Endpoint) SetProviderSpecificProperty(key string, value string) {
 	for i, providerSpecific := range e.ProviderSpecific {

--- a/endpoint/endpoint_bechmark_get_test.go
+++ b/endpoint/endpoint_bechmark_get_test.go
@@ -1,0 +1,197 @@
+package endpoint
+
+import (
+	"fmt"
+	"testing"
+)
+
+func BenchmarkEndpointGet100With3Properties(b *testing.B) {
+	endpoints := buildEndpointsWithProperties(100, 3)
+
+	for b.Loop() {
+		for _, e := range endpoints {
+			e.GetProviderSpecificProperty("prop1")
+			e.GetProviderSpecificProperty("prop2")
+			e.GetProviderSpecificProperty("prop3")
+		}
+	}
+}
+
+func BenchmarkEndpointGet100With3PropertiesHashMap(b *testing.B) {
+	endpoints := buildEndpointsWithProperties(100, 3)
+
+	for b.Loop() {
+		for _, e := range endpoints {
+			e.GetProviderSpecificPropertyHashMap("prop1")
+			e.GetProviderSpecificPropertyHashMap("prop2")
+			e.GetProviderSpecificPropertyHashMap("prop3")
+		}
+	}
+}
+
+func BenchmarkEndpointGet1000With3Properties(b *testing.B) {
+	endpoints := buildEndpointsWithProperties(1000, 3)
+
+	for b.Loop() {
+		for _, e := range endpoints {
+			e.GetProviderSpecificProperty("prop1")
+			e.GetProviderSpecificProperty("prop2")
+			e.GetProviderSpecificProperty("prop3")
+		}
+	}
+}
+
+func BenchmarkEndpointGet1000With3PropertiesHashMap(b *testing.B) {
+	endpoints := buildEndpointsWithProperties(1000, 3)
+
+	for b.Loop() {
+		for _, e := range endpoints {
+			e.GetProviderSpecificPropertyHashMap("prop1")
+			e.GetProviderSpecificPropertyHashMap("prop2")
+			e.GetProviderSpecificPropertyHashMap("prop3")
+		}
+	}
+}
+
+func BenchmarkEndpointGet100With5Properties(b *testing.B) {
+	endpoints := buildEndpointsWithProperties(100, 5)
+
+	for b.Loop() {
+		for _, e := range endpoints {
+			e.GetProviderSpecificProperty("prop1")
+			e.GetProviderSpecificProperty("prop2")
+			e.GetProviderSpecificProperty("prop3")
+			e.GetProviderSpecificProperty("prop4")
+			e.GetProviderSpecificProperty("prop5")
+		}
+	}
+}
+
+func BenchmarkEndpointGet100With5PropertiesHashMap(b *testing.B) {
+	endpoints := buildEndpointsWithProperties(100, 5)
+
+	for b.Loop() {
+		for _, e := range endpoints {
+			e.GetProviderSpecificPropertyHashMap("prop1")
+			e.GetProviderSpecificPropertyHashMap("prop2")
+			e.GetProviderSpecificPropertyHashMap("prop3")
+			e.GetProviderSpecificPropertyHashMap("prop4")
+			e.GetProviderSpecificPropertyHashMap("prop5")
+		}
+	}
+}
+
+func BenchmarkEndpointGet1000With5Properties(b *testing.B) {
+	endpoints := buildEndpointsWithProperties(1000, 5)
+
+	for b.Loop() {
+		for _, e := range endpoints {
+			e.GetProviderSpecificProperty("prop1")
+			e.GetProviderSpecificProperty("prop2")
+			e.GetProviderSpecificProperty("prop3")
+			e.GetProviderSpecificProperty("prop4")
+			e.GetProviderSpecificProperty("prop5")
+		}
+	}
+}
+
+func BenchmarkEndpointGet1000With5PropertiesHashMap(b *testing.B) {
+	endpoints := buildEndpointsWithProperties(1000, 5)
+
+	for b.Loop() {
+		for _, e := range endpoints {
+			e.GetProviderSpecificPropertyHashMap("prop1")
+			e.GetProviderSpecificPropertyHashMap("prop2")
+			e.GetProviderSpecificPropertyHashMap("prop3")
+			e.GetProviderSpecificPropertyHashMap("prop4")
+			e.GetProviderSpecificPropertyHashMap("prop5")
+		}
+	}
+}
+
+func BenchmarkEndpointGet100With10Properties(b *testing.B) {
+	endpoints := buildEndpointsWithProperties(100, 10)
+
+	for b.Loop() {
+		for _, e := range endpoints {
+			e.GetProviderSpecificProperty("prop1")
+			e.GetProviderSpecificProperty("prop2")
+			e.GetProviderSpecificProperty("prop3")
+			e.GetProviderSpecificProperty("prop4")
+			e.GetProviderSpecificProperty("prop5")
+			e.GetProviderSpecificProperty("prop6")
+			e.GetProviderSpecificProperty("prop7")
+			e.GetProviderSpecificProperty("prop8")
+			e.GetProviderSpecificProperty("prop9")
+			e.GetProviderSpecificProperty("prop10")
+		}
+	}
+}
+
+func BenchmarkEndpointGet100With10PropertiesHashMap(b *testing.B) {
+	endpoints := buildEndpointsWithProperties(100, 10)
+
+	for b.Loop() {
+		for _, e := range endpoints {
+			e.GetProviderSpecificPropertyHashMap("prop1")
+			e.GetProviderSpecificPropertyHashMap("prop2")
+			e.GetProviderSpecificPropertyHashMap("prop3")
+			e.GetProviderSpecificPropertyHashMap("prop4")
+			e.GetProviderSpecificPropertyHashMap("prop5")
+			e.GetProviderSpecificPropertyHashMap("prop6")
+			e.GetProviderSpecificPropertyHashMap("prop7")
+			e.GetProviderSpecificPropertyHashMap("prop8")
+			e.GetProviderSpecificPropertyHashMap("prop9")
+			e.GetProviderSpecificPropertyHashMap("prop10")
+		}
+	}
+}
+
+func BenchmarkEndpointGet1000With10Properties(b *testing.B) {
+	endpoints := buildEndpointsWithProperties(1000, 10)
+
+	for b.Loop() {
+		for _, e := range endpoints {
+			e.GetProviderSpecificProperty("prop1")
+			e.GetProviderSpecificProperty("prop2")
+			e.GetProviderSpecificProperty("prop3")
+			e.GetProviderSpecificProperty("prop4")
+			e.GetProviderSpecificProperty("prop5")
+			e.GetProviderSpecificProperty("prop6")
+			e.GetProviderSpecificProperty("prop7")
+			e.GetProviderSpecificProperty("prop8")
+			e.GetProviderSpecificProperty("prop9")
+			e.GetProviderSpecificProperty("prop10")
+		}
+	}
+}
+
+func BenchmarkEndpointGet1000With10PropertiesHashMap(b *testing.B) {
+	endpoints := buildEndpointsWithProperties(1000, 10)
+
+	for b.Loop() {
+		for _, e := range endpoints {
+			e.GetProviderSpecificPropertyHashMap("prop1")
+			e.GetProviderSpecificPropertyHashMap("prop2")
+			e.GetProviderSpecificPropertyHashMap("prop3")
+			e.GetProviderSpecificPropertyHashMap("prop4")
+			e.GetProviderSpecificPropertyHashMap("prop5")
+			e.GetProviderSpecificPropertyHashMap("prop6")
+			e.GetProviderSpecificPropertyHashMap("prop7")
+			e.GetProviderSpecificPropertyHashMap("prop8")
+			e.GetProviderSpecificPropertyHashMap("prop9")
+			e.GetProviderSpecificPropertyHashMap("prop10")
+		}
+	}
+}
+
+func buildEndpointsWithProperties(nEndpoints int, properties int) []Endpoint {
+	endpoints := make([]Endpoint, nEndpoints)
+	for i := 0; i < nEndpoints; i++ {
+		endpoints[i] = *NewEndpoint(fmt.Sprintf("index-%d.example.com", i), RecordTypeA)
+		for n := 0; n < properties; n++ {
+			endpoints[i].SetProviderSpecificProperty(fmt.Sprintf("prop%d", n+1), fmt.Sprintf("value%d", n+1))
+		}
+	}
+	return endpoints
+}

--- a/endpoint/endpoint_bechmark_test.go
+++ b/endpoint/endpoint_bechmark_test.go
@@ -192,14 +192,3 @@ func buildEndpointsWithoutProperties(nEndpoints int) []Endpoint {
 	}
 	return endpoints
 }
-
-func buildEndpointsWithProperties(nEndpoints int, properties map[string]string) []Endpoint {
-	endpoints := make([]Endpoint, nEndpoints)
-	for i := 0; i < nEndpoints; i++ {
-		endpoints[i] = *NewEndpoint(fmt.Sprintf("index-%d.example.com", i), RecordTypeA)
-		for k, v := range properties {
-			endpoints[i].SetProviderSpecificProperty(k, v)
-		}
-	}
-	return endpoints
-}


### PR DESCRIPTION
## What does it do ?

based on changes https://github.com/kubernetes-sigs/external-dns/pulls

Test for 100 and 1000 endpoints. 3-5-10 provider specific properties. AWS Provider has 15+ provider specific properties. For 0 or 1 provider specific property results a very similar, so no difference

Benchmark results for SET

```
BenchmarkEndpoint100With3Properties-14             	  107157	     10382 ns/op
BenchmarkEndpoint100With3PropertiesHashMap-14      	  441897	      2697 ns/op

BenchmarkEndpoint1000With3Properties-14            	   10000	    101178 ns/op
BenchmarkEndpoint1000With3PropertiesHashMap-14     	   40654	     29626 ns/op

BenchmarkEndpoint100With5Properties-14             	   62971	     19200 ns/op
BenchmarkEndpoint100With5PropertiesHashMap-14      	  273492	      4360 ns/op

BenchmarkEndpoint1000With5Properties-14            	    6369	    188473 ns/op
BenchmarkEndpoint1000With5PropertiesHashMap-14     	   26612	     45139 ns/op

BenchmarkEndpoint100With10Properties-14            	   31771	     37703 ns/op
BenchmarkEndpoint100With10PropertiesHashMap-14    	  114465	      8924 ns/op

BenchmarkEndpoint1000With10Properties-14           	    3216	    368685 ns/op
BenchmarkEndpoint1000With10PropertiesHashMap-14    	   13005	     92032 ns/op
```

For GET

```
BenchmarkEndpointGet100With3Properties-14             	  711708	      1682 ns/op
BenchmarkEndpointGet100With3PropertiesHashMap-14      	 1603716	       751.4 ns/op
BenchmarkEndpointGet1000With3Properties-14            	   69355	     17505 ns/op
BenchmarkEndpointGet1000With3PropertiesHashMap-14     	  146449	      8172 ns/op
BenchmarkEndpointGet100With5Properties-14             	  338419	      3617 ns/op
BenchmarkEndpointGet100With5PropertiesHashMap-14      	 1204328	       996.6 ns/op
BenchmarkEndpointGet1000With5Properties-14            	   32306	     37875 ns/op
BenchmarkEndpointGet1000With5PropertiesHashMap-14     	  110757	     10682 ns/op
BenchmarkEndpointGet100With10Properties-14            	  113233	     10765 ns/op
BenchmarkEndpointGet100With10PropertiesHashMap-14     	  745789	      1659 ns/op
BenchmarkEndpointGet1000With10Properties-14           	   10000	    106341 ns/op
BenchmarkEndpointGet1000With10PropertiesHashMap-14    	   73141	     16503 ns/op
```