### PR TITLE
docs: clarify hostname annotation behavior

### DIFF
--- a/docs/annotations/annotations.md
+++ b/docs/annotations/annotations.md
@@ -73,8 +73,8 @@ For `Pods`, uses the `Pod`'s `Status.PodIP`, unless they are `hostNetwork: true`
 
 Notes:
 
-- This annotation adds extra hostnames alongside any automatically derived hostnames (e.g., from Ingress.spec.rules[].host).
-- The [`ingress-hostname-source`](#external-dnsalphakubernetesioingress-hostname-source) annotation may be used to control the behavior of the `hostname` annotation.
+- This annotation can override or add extra hostnames alongside any automatically derived hostnames (e.g., from Ingress.spec.rules[].host).
+- The [`ingress-hostname-source`](#external-dnsalphakubernetesioingress-hostname-source) annotation may be used to specify where to get the domain for an `Ingress` resource.
 - Hostnames must match the domain filter set in ExternalDNS (e.g., --domain-filter=example.com).
 - This is an alpha annotation — subject to change; newer versions may support alternatives or deprecate it.
 - This annotation is helpful for:


### PR DESCRIPTION
## What does it do ?

Explicitly states that by default, the `hostname` annotation will NOT override the automatically detected hostnames. Instead, the two lists are merged together, unless the `ingress-hostname-source` annotation is used to adjust this behavior.

## Motivation

I spent some time messing around before realizing that `ingress-hostname-source` existed as I thought `hostname` would override.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
