### PR TITLE
docs(contributing): add reference to developer documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,16 @@ We have full documentation on how to get started contributing here:
 - [Kubernetes Contributor Guide](https://git.k8s.io/community/contributors/guide) - Main contributor documentation, or you can just jump directly to the [contributing section](https://git.k8s.io/community/contributors/guide#contributing)
 - [Contributor Cheat Sheet](https://git.k8s.io/community/contributors/guide/contributor-cheatsheet) - Common resources for existing developers
 
+## Developer Documentation
+
+For more detailed contribution guides, see [Developer Documentation](docs/contributing) which includes:
+
+- [Development Guide](docs/contributing/dev-guide.md) - Setting up development environment, building, and testing
+- [Chart Development](docs/contributing/chart.md) - Working with Helm charts
+- [Design Documentation](docs/contributing/design.md) - Architecture and design decisions
+- [Sources and Providers](docs/contributing/sources-and-providers.md) - Adding new sources and providers
+- [Source Wrappers](docs/contributing/source-wrappers.md) - Source wrapper implementation details
+
 This project follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification on PR title. The explicit commit history is used, among other things, to provide a readable changelog in release notes.
 
 ## How to test a PR


### PR DESCRIPTION
## Summary

Follow-up to #5889 - adds reference to detailed developer documentation in `docs/contributing/` from root `CONTRIBUTING.md`.

## Motivation

To simplify development and avoid split-brain when looking for contribution guidance - all important information for contributors is now easily discoverable from a single entry point.

## Changes

- Added "Developer Documentation" section after "Getting Started"
- Includes links to all major developer guides:
  - dev-guide.md (development environment setup)
  - chart.md (Helm chart development)
  - design.md (architecture documentation)
  - sources-and-providers.md (adding new integrations)
  - source-wrappers.md (source wrapper details)

## Testing

- ✅ Verified all links are valid
- ✅ Markdown linting passes