### PR TITLE
chore(lint): configure goconst linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,39 +1,39 @@
-# https://golangci-lint.run/usage/configuration/
+# https://golangci-lint.run/docs/configuration/
 version: "2"
 linters:
   default: none
   enable: # golangci-lint help linters
-    - copyloopvar # A linter detects places where loop variables are copied. https://golangci-lint.run/usage/linters/#copyloopvar
-    - dogsled # Checks assignments with too many blank identifiers. https://golangci-lint.run/usage/linters/#dogsled
-    - dupword # Duplicate word. https://golangci-lint.run/usage/linters/#dupword
+    - copyloopvar # A linter detects places where loop variables are copied. https://golangci-lint.run/docs/linters/configuration/#copyloopvar
+    - dogsled # Checks assignments with too many blank identifiers. https://golangci-lint.run/docs/linters/configuration/#dogsled
+    - dupword # Duplicate word. https://golangci-lint.run/docs/linters/configuration/#dupword
     - goprintffuncname
     - govet
     - ineffassign
     - misspell
     - revive
-    - recvcheck # Checks for receiver type consistency. https://golangci-lint.run/usage/linters/#recvcheck
+    - recvcheck # Checks for receiver type consistency. https://golangci-lint.run/docs/linters/configuration/#recvcheck
     - rowserrcheck # Checks whether Rows.Err of rows is checked successfully.
-    - errchkjson # Checks types passed to the json encoding functions. ref: https://golangci-lint.run/usage/linters/#errchkjson
-    - errorlint # Checking for unchecked errors in Go code https://golangci-lint.run/usage/linters/#errcheck
+    - errchkjson # Checks types passed to the json encoding functions. ref: https://golangci-lint.run/docs/linters/configuration/#errchkjson
+    - errorlint # Checking for unchecked errors in Go code https://golangci-lint.run/docs/linters/configuration/#errorlint
     - staticcheck
     - unconvert
     - unused
-    - usestdlibvars # A linter that detect the possibility to use variables/constants from the Go standard library. https://golangci-lint.run/usage/linters/#usestdlibvars
+    - usestdlibvars # A linter that detect the possibility to use variables/constants from the Go standard library. https://golangci-lint.run/docs/linters/configuration/#usestdlibvars
     - whitespace
-    - decorder # Check declaration order and count of types, constants, variables and functions. https://golangci-lint.run/usage/linters/#decorder
-    - tagalign # Check that struct tags are well aligned. https://golangci-lint.run/usage/linters/#tagalign
+    - decorder # Check declaration order and count of types, constants, variables and functions. https://golangci-lint.run/docs/linters/configuration/#decorder
+    - tagalign # Check that struct tags are well aligned. https://golangci-lint.run/docs/linters/configuration/#tagalign
     - predeclared # Find code that shadows one of Go's predeclared identifiers
     - sloglint # Ensure consistent code style when using log/slog
     - asciicheck  # Checks that all code identifiers does not have non-ASCII symbols in the name
-    - nilnil # Checks that there is no simultaneous return of nil error and an nil value. ref: https://golangci-lint.run/usage/linters/#nilnil
-    - nonamedreturns # Checks that functions with named return values do not return named values. https://golangci-lint.run/usage/linters/#nonamedreturns
-    - cyclop # Checks function and package cyclomatic complexity. https://golangci-lint.run/usage/linters/#cyclop
+    - nilnil # Checks that there is no simultaneous return of nil error and an nil value. ref: https://golangci-lint.run/docs/linters/configuration/#nilnil
+    - nonamedreturns # Checks that functions with named return values do not return named values. https://golangci-lint.run/docs/linters/configuration/#nonamedreturns
+    - cyclop # Checks function and package cyclomatic complexity. https://golangci-lint.run/docs/linters/configuration/#cyclop
     - gocritic # Analyze source code for various issues, including bugs, performance hiccups, and non-idiomatic coding practices. https://golangci-lint.run/docs/linters/configuration/#gocritic
-    - gochecknoinits # Checks that there are no init() functions in the code. https://golangci-lint.run/usage/linters/#gochecknoinits
-    - goconst # Finds repeated strings that could be replaced by a constant. https://golangci-lint.run/usage/linters/#goconst
+    - gochecknoinits # Checks that there are no init() functions in the code. https://golangci-lint.run/docs/linters/configuration/#gochecknoinits
+    - goconst # Finds repeated strings that could be replaced by a constant. https://golangci-lint.run/docs/linters/configuration/#goconst
 
     # tests
-    - testifylint # Checks usage of github.com/stretchr/testify. https://golangci-lint.run/usage/linters/#testifylint
+    - testifylint # Checks usage of github.com/stretchr/testify. https://golangci-lint.run/docs/linters/configuration/#testifylint
   settings:
     exhaustive:
       default-signifies-exhaustive: false


### PR DESCRIPTION
## What does it do?

Enables and configures the `goconst` linter in golangci-lint to detect repeated string literals that should be constants, while excluding well-known protocol values that don't benefit from being constants.

## Motivation

Following up on the discussion started in #5889, this PR enables the `goconst` linter with appropriate configuration.

The linter is configured to catch genuinely problematic string repetitions (3+ occurrences) while avoiding noise from values that shouldn't become constants:

- **DNS record types** (A, AAAA, CNAME, TXT, etc.) - excluded as these are standard protocol values specific to DNS software and universally recognized
- **Boolean strings** ("true", "false") - actively used in several places throughout the codebase but not critical enough to warrant constants
- **Common indicators** ("none") - similar rationale to boolean strings
- **Registry types** (aws-sd, noop) - ideally these should be constants, but doing so would require rewriting the entire `controller/execute.go` package to use constants consistently for all provider and registry types, which would significantly reduce readability by mixing string literals and constants in switch statements

Setting `min-occurrences: 3` ensures we catch project-specific strings that genuinely need constants while avoiding over-engineering for well-known values.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests *(N/A - configuration change only)*
- [ ] Yes, I updated end user documentation accordingly *(N/A - internal linting configuration)*