### PR TITLE
fix(charts): add schema for provider.webhook.serviceMonitor

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Grant `networking.k8s.io/ingresses` and `gateway.solo.io/gateways` permissions when using `gloo-proxy` source. ([#5909](https://github.com/kubernetes-sigs/external-dns/pull/5909)) _@cucxabong_
 
+### Fixed
+
+- Fixed the missing schema for `.provider.webhook.serviceMonitor` configs ([#5932](https://github.com/kubernetes-sigs/external-dns/pull/5932)) _@chrisbsmith_
+
 ## [v1.19.0] - 2025-09-08
 
 ### Added

--- a/charts/external-dns/tests/json-schema_test.yaml
+++ b/charts/external-dns/tests/json-schema_test.yaml
@@ -62,3 +62,12 @@ tests:
       readinessProbe: null
     asserts:
       - notFailedTemplate: {}
+
+  - it: should not fail when provider webhook serviceMonitor interval is not null
+    set:
+      provider:
+        webhook:
+          serviceMonitor:
+            interval: 30s
+    asserts:
+      - notFailedTemplate: {}

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -502,10 +502,16 @@
               "type": "object",
               "properties": {
                 "bearerTokenFile": {
-                  "type": "null"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "interval": {
-                  "type": "null"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "metricRelabelings": {
                   "type": "array"
@@ -514,10 +520,16 @@
                   "type": "array"
                 },
                 "scheme": {
-                  "type": "null"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "scrapeTimeout": {
-                  "type": "null"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "tlsConfig": {
                   "type": "object"

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -296,11 +296,11 @@ provider:  # @schema type: [object, string]
     # -- Optional [Service Monitor](https://prometheus-operator.dev/docs/operator/design/#servicemonitor) configuration for the `webhook` container.
     # @default -- See _values.yaml_
     serviceMonitor:
-      interval:
-      scheme:
+      interval:  # @schema type:[string, null]; default: null
+      scheme:  # @schema type:[string, null]; default: null
       tlsConfig: {}
-      bearerTokenFile:
-      scrapeTimeout:
+      bearerTokenFile:  # @schema type:[string, null]; default: null
+      scrapeTimeout:  # @schema type:[string, null]; default: null
       metricRelabelings: []
       relabelings: []
 


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->

Updates the json schema for the `provider.webhook.serviceMontior` object to allow non null values.

## Motivation

<!-- What inspired you to submit this pull request? -->

helm template and deploy failed when I attempted to add a serviceMonitor for my webhook.

Fixes #5931 

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x]  Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
