### PR TITLE
fix(service): rollback nodeinformer for addevent handler

### DIFF
--- a/source/service.go
+++ b/source/service.go
@@ -896,9 +896,6 @@ func (sc *serviceSource) AddEventHandler(_ context.Context, handler func()) {
 	if sc.listenEndpointEvents && sc.serviceTypeFilter.isRequired(v1.ServiceTypeNodePort, v1.ServiceTypeClusterIP) {
 		_, _ = sc.endpointSlicesInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
 	}
-	if sc.serviceTypeFilter.isRequired(v1.ServiceTypeNodePort) {
-		_, _ = sc.nodeInformer.Informer().AddEventHandler(eventHandlerFunc(handler))
-	}
 }
 
 type serviceTypes struct {

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -5119,11 +5119,11 @@ func TestServiceSource_AddEventHandler(t *testing.T) {
 		{
 			name:   "AddEventHandler should trigger all event handlers when empty filter is provided",
 			filter: []string{},
-			times:  3,
+			times:  2,
 			asserts: func(t *testing.T, s *serviceSource) {
 				fakeServiceInformer.AssertNumberOfCalls(t, "Informer", 1)
 				fakeEdpInformer.AssertNumberOfCalls(t, "Informer", 1)
-				fakeNodeInformer.AssertNumberOfCalls(t, "Informer", 1)
+				fakeNodeInformer.AssertNumberOfCalls(t, "Informer", 0)
 			},
 		},
 		{
@@ -5149,11 +5149,11 @@ func TestServiceSource_AddEventHandler(t *testing.T) {
 		{
 			name:   "AddEventHandler should configure all service event handlers",
 			filter: []string{string(v1.ServiceTypeNodePort)},
-			times:  3,
+			times:  2,
 			asserts: func(t *testing.T, s *serviceSource) {
 				fakeServiceInformer.AssertNumberOfCalls(t, "Informer", 1)
 				fakeEdpInformer.AssertNumberOfCalls(t, "Informer", 1)
-				fakeNodeInformer.AssertNumberOfCalls(t, "Informer", 1)
+				fakeNodeInformer.AssertNumberOfCalls(t, "Informer", 0)
 			},
 		},
 	}


### PR DESCRIPTION
## What does it do ?

- rollback adding nodeinformer to service.addeventhandler

## Motivation

- The change was added here https://github.com/kubernetes-sigs/external-dns/pull/5613/files#diff-cf68f602fa7c20e5341f3b83054df68ade1586a144b1eae5347e0ac47096d3aa. Seems like the behavior changed slightly, worth to rollback, if nodeinformer is required there, we could add it in the future
- Fixes #5796 
- This PR superseeds https://github.com/kubernetes-sigs/external-dns/pull/5848/files#diff-cf68f602fa7c20e5341f3b83054df68ade1586a144b1eae5347e0ac47096d3aa. Reasons
  1. No requirement at the moment for this behaviour in event handler
  2. Worth to keep simple event handler logic for now. We could re-open the pr if/when there are valid use-cases

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
