### PR TITLE
chore: add Simply webhook provider to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ from the usage of any externally developed webhook.
 | OpenWRT               | https://github.com/renanqts/external-dns-openwrt-webhook             |
 | RouterOS              | https://github.com/benfiola/external-dns-routeros-provider           |
 | SAKURA Cloud          | https://github.com/sacloud/external-dns-sacloud-webhook              |
+| Simply                | https://github.com/uozalp/external-dns-simply-webhook                |
 | STACKIT               | https://github.com/stackitcloud/external-dns-stackit-webhook         |
 | Unbound               | https://github.com/guillomep/external-dns-unbound-webhook            |
 | Unifi                 | https://github.com/kashalls/external-dns-unifi-webhook               |


### PR DESCRIPTION
## What does it do ?

Adds the Simply.com DNS webhook provider to the list of available webhook providers in the README.

## Motivation

Adding it to the README makes it discoverable for other users who might want to use Simply.com as their DNS provider with external-dns.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly