### PR TITLE
fix(zonefinder): transform zone name to unicode as well

### DIFF
--- a/provider/ovh/ovh.go
+++ b/provider/ovh/ovh.go
@@ -33,6 +33,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/idna"
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
@@ -156,7 +157,7 @@ func (p *OVHProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error)
 	return endpoints, nil
 }
 
-func planChangesByZoneName(zones []string, changes *plan.Changes) map[string]*plan.Changes {
+func planChangesByZoneName(zones []string, changes *plan.Changes) (map[string]*plan.Changes, error) {
 	zoneNameIDMapper := provider.ZoneIDName{}
 	for _, zone := range zones {
 		zoneNameIDMapper.Add(zone, zone)
@@ -164,35 +165,47 @@ func planChangesByZoneName(zones []string, changes *plan.Changes) map[string]*pl
 
 	output := map[string]*plan.Changes{}
 	for _, endpt := range changes.Delete {
-		_, zoneName := zoneNameIDMapper.FindZone(endpt.DNSName)
+		zoneName, _ := zoneNameIDMapper.FindZone(endpt.DNSName)
+		if zoneName == "" {
+			return nil, provider.NewSoftErrorf("record %q have not found matching DNS zone in OVH provider", endpt.DNSName)
+		}
 		if _, ok := output[zoneName]; !ok {
 			output[zoneName] = &plan.Changes{}
 		}
 		output[zoneName].Delete = append(output[zoneName].Delete, endpt)
 	}
 	for _, endpt := range changes.Create {
-		_, zoneName := zoneNameIDMapper.FindZone(endpt.DNSName)
+		zoneName, _ := zoneNameIDMapper.FindZone(endpt.DNSName)
+		if zoneName == "" {
+			return nil, provider.NewSoftErrorf("record %q have not found matching DNS zone in OVH provider", endpt.DNSName)
+		}
 		if _, ok := output[zoneName]; !ok {
 			output[zoneName] = &plan.Changes{}
 		}
 		output[zoneName].Create = append(output[zoneName].Create, endpt)
 	}
 	for _, endpt := range changes.UpdateOld {
-		_, zoneName := zoneNameIDMapper.FindZone(endpt.DNSName)
+		zoneName, _ := zoneNameIDMapper.FindZone(endpt.DNSName)
+		if zoneName == "" {
+			return nil, provider.NewSoftErrorf("record %q have not found matching DNS zone in OVH provider", endpt.DNSName)
+		}
 		if _, ok := output[zoneName]; !ok {
 			output[zoneName] = &plan.Changes{}
 		}
 		output[zoneName].UpdateOld = append(output[zoneName].UpdateOld, endpt)
 	}
 	for _, endpt := range changes.UpdateNew {
-		_, zoneName := zoneNameIDMapper.FindZone(endpt.DNSName)
+		zoneName, _ := zoneNameIDMapper.FindZone(endpt.DNSName)
+		if zoneName == "" {
+			return nil, provider.NewSoftErrorf("record %q have not found matching DNS zone in OVH provider", endpt.DNSName)
+		}
 		if _, ok := output[zoneName]; !ok {
 			output[zoneName] = &plan.Changes{}
 		}
 		output[zoneName].UpdateNew = append(output[zoneName].UpdateNew, endpt)
 	}
 
-	return output
+	return output, nil
 }
 
 func (p *OVHProvider) computeSingleZoneChanges(_ context.Context, zoneName string, existingRecords []ovhRecord, changes *plan.Changes) ([]ovhChange, error) {
@@ -264,7 +277,10 @@ func (p *OVHProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) e
 		}
 	}
 
-	changesByZoneName := planChangesByZoneName(zones, changes)
+	changesByZoneName, err := planChangesByZoneName(zones, changes)
+	if err != nil {
+		return err
+	}
 	eg, ctx := errgroup.WithContext(ctx)
 
 	for zoneName, changes := range changesByZoneName {
@@ -555,6 +571,13 @@ func (p *OVHProvider) newOvhChangeCreateDelete(action int, endpoints []*endpoint
 func convertDNSNameIntoSubDomain(DNSName string, zoneName string) string { // nolint: gocritic // captLocal
 	if DNSName == zoneName {
 		return ""
+	}
+
+	if name, err := idna.Profile.ToUnicode(DNSName); err == nil {
+		DNSName = name
+	}
+	if name, err := idna.Profile.ToUnicode(zoneName); err == nil {
+		zoneName = name
 	}
 
 	return strings.TrimSuffix(DNSName, "."+zoneName)

--- a/provider/zonefinder.go
+++ b/provider/zonefinder.go
@@ -27,7 +27,12 @@ import (
 type ZoneIDName map[string]string
 
 func (z ZoneIDName) Add(zoneID, zoneName string) {
-	z[zoneID] = zoneName
+	var err error
+	z[zoneID], err = idna.Profile.ToUnicode(zoneName)
+	if err != nil {
+		log.Warnf("failed to convert zonename %q to its Unicode form: %v", zoneName, err)
+		z[zoneID] = zoneName
+	}
 }
 
 // FindZone identifies the most suitable DNS zone for a given hostname.

--- a/provider/zonefinder_test.go
+++ b/provider/zonefinder_test.go
@@ -35,6 +35,8 @@ func TestZoneIDName(t *testing.T) {
 	z.Add("1231231", "_foo._metadata.example.com")
 	z.Add("456456", "_metadata.エイミー.みんな")
 	z.Add("123412", "*.example.com")
+	// adding a zone as punycode, see that it is injected as unicode/international format
+	z.Add("234567", "xn--testcass-e1ae.fr")
 
 	assert.Equal(t, ZoneIDName{
 		"123456":  "qux.baz",
@@ -44,6 +46,7 @@ func TestZoneIDName(t *testing.T) {
 		"1231231": "_foo._metadata.example.com",
 		"456456":  "_metadata.エイミー.みんな",
 		"123412":  "*.example.com",
+		"234567":  "testécassé.fr",
 	}, z)
 
 	// simple entry in a domain
@@ -88,6 +91,15 @@ func TestZoneIDName(t *testing.T) {
 	zoneID, zoneName = z.FindZone("*.example.com")
 	assert.Equal(t, "*.example.com", zoneName)
 	assert.Equal(t, "123412", zoneID)
+
+	// looking for a zone that has been inserted as punycode
+	zoneID, zoneName = z.FindZone("example.testécassé.fr")
+	assert.Equal(t, "testécassé.fr", zoneName)
+	assert.Equal(t, "234567", zoneID)
+
+	zoneID, zoneName = z.FindZone("example.xn--testcass-e1ae.fr")
+	assert.Equal(t, "testécassé.fr", zoneName)
+	assert.Equal(t, "234567", zoneID)
 
 	hook := testutils.LogsUnderTestWithLogLevel(log.WarnLevel, t)
 	_, _ = z.FindZone("xn--not-a-valid-punycode")


### PR DESCRIPTION
## What does it do ?

This change fix a different of behaviour inside provider/zone_finder.
Record name are converted to unicode, while zone name were not converted as unicode when inserted, leading to inconsistencies.

<!-- A brief description of the change being made with this pull request. -->

## Motivation


Fixes #5914

With #5147, external-dns now handle IDNA zone name, and zone_finder is handling them as unicode.
But, if a provider pushes a zone name punnyencoded, and not using unicode, the find function is not handing it correctly.

<!-- What inspired you to submit this pull request? -->

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
