### PR TITLE
fix(pihole): support special characters in pihole password

### DIFF
--- a/provider/pihole/clientV6.go
+++ b/provider/pihole/clientV6.go
@@ -337,7 +337,15 @@ func (p *piholeClientV6) retrieveNewToken(ctx context.Context) error {
 	log.Debugf("Fetching new token from %s", apiUrl)
 
 	// Define the JSON payload
-	jsonData := []byte(`{"password":"` + p.cfg.Password + `"}`)
+	body := struct {
+		Password string `json:"password"`
+	}{
+		Password: p.cfg.Password,
+	}
+	jsonData, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiUrl, bytes.NewBuffer(jsonData))
 	if err != nil {

--- a/provider/pihole/clientV6_test.go
+++ b/provider/pihole/clientV6_test.go
@@ -132,7 +132,7 @@ func TestNewPiholeClientV6(t *testing.T) {
 
 			w.Header().Set("Content-Type", "application/json")
 
-			if requestData["password"] != "correct" {
+			if requestData["password"] != `correct\"²` {
 				// Return unsuccessful authentication response
 				w.WriteHeader(http.StatusUnauthorized)
 				_, err = w.Write([]byte(`{
@@ -179,13 +179,13 @@ func TestNewPiholeClientV6(t *testing.T) {
 
 	// Test correct password
 	cl, err = newPiholeClientV6(
-		PiholeConfig{Server: srvr.URL, APIVersion: "6", Password: "correct"},
+		PiholeConfig{Server: srvr.URL, APIVersion: "6", Password: `correct\"²`},
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if cl.(*piholeClientV6).token != "supersecret" {
-		t.Error("Parsed invalid token from login response:", cl.(*piholeClient).token)
+		t.Error("Parsed invalid token from login response:", cl.(*piholeClientV6).token)
 	}
 }
 


### PR DESCRIPTION
## What does it do ?

Current implementation does not handle special characters in pihole password correctly. It skips proper JSON marshalling of the request & sends invalid json to pihole API. This change fixes it by introducing proper JSON marshalling.

## Motivation

I've hit this problem myself on my homelab setup, here's a log:

```
time="2025-12-02T13:20:36Z" level=debug msg="Fetching new token from http://http.pi-hole.svc.cluster.local/api/auth"
time="2025-12-02T13:20:36Z" level=debug msg="Error on request http://http.pi-hole.svc.cluster.local/api/auth"
time="2025-12-02T13:20:36Z" level=debug msg="Body of the request {}"
time="2025-12-02T13:20:36Z" level=fatal msg="received 400 status code from request: [bad_request] Invalid request body data (no valid JSON), error at hint (\\hei0MachahmaeThoo7u\"}) - 0.000226s"
```

Hint in the log is part of the request json starting with invalid escape sequence `\h` which happened because my password contains backslash.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
