### PR TITLE
docs: remove link to external-dns-routeros-provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ from the usage of any externally developed webhook.
 | Netic                 | https://github.com/neticdk/external-dns-tidydns-webhook              |
 | OpenStack Designate   | https://github.com/inovex/external-dns-designate-webhook             |
 | OpenWRT               | https://github.com/renanqts/external-dns-openwrt-webhook             |
-| RouterOS              | https://github.com/benfiola/external-dns-routeros-provider           |
 | SAKURA Cloud          | https://github.com/sacloud/external-dns-sacloud-webhook              |
 | Simply                | https://github.com/uozalp/external-dns-simply-webhook                |
 | STACKIT               | https://github.com/stackitcloud/external-dns-stackit-webhook         |


### PR DESCRIPTION
## What does it do ?

Removes the link to the `external-dns-routeros-provider` webhook provider.

## Motivation

It looks like there's a similar effort called [external-dns-mikrotik-provider](https://github.com/mirceanton/external-dns-provider-mikrotik) that's listed in the README, appear to be more widely adopted, and is intended to accomplish the same goals. I'd rather align behind a common solution, rather than present competing implementations of the same thing.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [n/a ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
