### PR TITLE
docs: remove IBM Cloud DNS from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ ExternalDNS allows you to keep selected zones (via `--domain-filter`) synchroniz
 - [Akamai Edge DNS](https://learn.akamai.com/en-us/products/cloud_security/edge_dns.html)
 - [GoDaddy](https://www.godaddy.com)
 - [Gandi](https://www.gandi.net)
-- [IBM Cloud DNS](https://www.ibm.com/cloud/dns)
 - [Plural](https://www.plural.sh/)
 - [Pi-hole](https://pi-hole.net/)
 - [Alibaba Cloud DNS](https://www.alibabacloud.com/help/en/dns)


### PR DESCRIPTION
Removed IBM Cloud DNS from the list of DNS providers as the code was removed

## What does it do ?

Small doc update

## Motivation

<!-- What inspired you to submit this pull request? -->

## More

- [X] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [X] Yes, I updated end user documentation accordingly
