### PR TITLE
refactor(source): use less memory on deduplication

### DIFF
--- a/source/wrappers/dedupsource.go
+++ b/source/wrappers/dedupsource.go
@@ -40,7 +40,7 @@ func NewDedupSource(source source.Source) source.Source {
 func (ms *dedupSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error) {
 	log.Debug("dedupSource: collecting endpoints and removing duplicates")
 	result := make([]*endpoint.Endpoint, 0)
-	collected := map[string]bool{}
+	collected := make(map[string]struct{})
 
 	endpoints, err := ms.source.Endpoints(ctx)
 	if err != nil {
@@ -63,7 +63,7 @@ func (ms *dedupSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, err
 			continue
 		}
 
-		collected[identifier] = true
+		collected[identifier] = struct{}{}
 		result = append(result, ep)
 	}
 


### PR DESCRIPTION
## What does it do ?

Replace `bool` by `struct{}` for tracking already seen items.

## Motivation

An empty `struct{}` in Go is zero sized (0 bytes).
https://udaykishoreresu.medium.com/gos-zero-byte-secret-why-struct-outperforms-bool-for-scalable-deduplication-4de84cc8c712

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
