### PR TITLE
feat(coredns): rename ownerId and ownedBy to owner

### DIFF
--- a/docs/tutorials/coredns.md
+++ b/docs/tutorials/coredns.md
@@ -33,14 +33,14 @@ This features works directly without any change to CoreDNS. CoreDNS will ignore 
 
 ### Other entries inside etcd
 
-Service entries in etcd without an `ownedby` field will be filtered out by the provider if `strictly-owned` is activated.
-Warning: If you activate `strictly-owned` afterwards, these entries will be ignored as the `ownedby` field is empty.
+Service entries in etcd without an `owner` field will be filtered out by the provider if `strictly-owned` is activated.
+Warning: If you activate `strictly-owned` afterwards, these entries will be ignored as the `owner` field is empty.
 
 ### Ways to migrate to a multi cluster setup
 
 Ways:
 
-1. Add the correct owner to all services inside etcd by adding the field `ownedby` to the JSON.
+1. Add the correct owner to all services inside etcd by adding the field `owner` to the JSON.
 2. Remove all services and allow them to be required again after restarting the provider. (Possible downtime.)
 
 ## Specific service annotation options


### PR DESCRIPTION
## What does it do ?

* Rename all usage of any owner variant to owner
* Set the label to owner from the field (reduce confuse)

## Motivation

We looked again into the code were a bit confused about naming as we had ownerID, ownedBy, and owner. 

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
