### PR TITLE
test: improve code coverage on aws, cloudfoundry & nat64 source

### DIFF
--- a/internal/testutils/log.go
+++ b/internal/testutils/log.go
@@ -114,3 +114,14 @@ func TestHelperLogContainsWithLogLevel(msg string, level log.Level, hook *test.H
 	}
 	assert.True(t, isContains, "Expected log message not found: %s with level %s", msg, level)
 }
+
+// TestHelperWithLogExitFunc overrides the logrus ExitFunc for the duration of a test.
+// It returns a restore function that resets the ExitFunc back to the previous value.
+func TestHelperWithLogExitFunc(exitFunc func(int)) func() {
+	logger := log.StandardLogger()
+	previousExitFunc := logger.ExitFunc
+	logger.ExitFunc = exitFunc
+	return func() {
+		logger.ExitFunc = previousExitFunc
+	}
+}

--- a/provider/aws/config_test.go
+++ b/provider/aws/config_test.go
@@ -18,21 +18,32 @@ package aws
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/external-dns/internal/testutils"
+	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 )
 
 func Test_newV2Config(t *testing.T) {
+	testutils.TestHelperEnvSetter(t, map[string]string{
+		"AWS_REGION":                "us-east-1",
+		"AWS_EC2_METADATA_DISABLED": "true",
+	})
+
 	t.Run("should use profile from credentials file", func(t *testing.T) {
 		// setup
 		credsFile, err := prepareCredentialsFile(t)
 		defer os.Remove(credsFile.Name())
 		require.NoError(t, err)
-		os.Setenv("AWS_SHARED_CREDENTIALS_FILE", credsFile.Name())
-		defer os.Unsetenv("AWS_SHARED_CREDENTIALS_FILE")
+		testutils.TestHelperEnvSetter(t, map[string]string{
+			"AWS_SHARED_CREDENTIALS_FILE": credsFile.Name(),
+		})
 
 		// when
 		cfg, err := newV2Config(AWSSessionConfig{Profile: "profile2"})
@@ -47,10 +58,10 @@ func Test_newV2Config(t *testing.T) {
 
 	t.Run("should respect env variables without profile", func(t *testing.T) {
 		// setup
-		os.Setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
-		os.Setenv("AWS_SECRET_ACCESS_KEY", "topsecret")
-		defer os.Unsetenv("AWS_ACCESS_KEY_ID")
-		defer os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+		testutils.TestHelperEnvSetter(t, map[string]string{
+			"AWS_ACCESS_KEY_ID":     "AKIAIOSFODNN7EXAMPLE",
+			"AWS_SECRET_ACCESS_KEY": "topsecret",
+		})
 
 		// when
 		cfg, err := newV2Config(AWSSessionConfig{})
@@ -65,8 +76,9 @@ func Test_newV2Config(t *testing.T) {
 
 	t.Run("should not error when AWS_CA_BUNDLE set", func(t *testing.T) {
 		// setup
-		os.Setenv("AWS_CA_BUNDLE", "../../internal/testresources/ca.pem")
-		defer os.Unsetenv("AWS_CA_BUNDLE")
+		testutils.TestHelperEnvSetter(t, map[string]string{
+			"AWS_CA_BUNDLE": "../../internal/testresources/ca.pem",
+		})
 
 		// when
 		_, err := newV2Config(AWSSessionConfig{})
@@ -74,6 +86,64 @@ func Test_newV2Config(t *testing.T) {
 
 		// then
 		assert.NoError(t, err)
+	})
+
+	t.Run("should configure assume role credentials", func(t *testing.T) {
+		// setup
+		testutils.TestHelperEnvSetter(t, map[string]string{
+			"AWS_ACCESS_KEY_ID":     "AKIAIOSFODNN7EXAMPLE",
+			"AWS_SECRET_ACCESS_KEY": "topsecret",
+		})
+
+		// when
+		cfg, err := newV2Config(AWSSessionConfig{
+			AssumeRole:           "arn:aws:iam::123456789012:role/example",
+			AssumeRoleExternalID: "external-id",
+		})
+
+		// then
+		require.NoError(t, err)
+		require.NotNil(t, cfg.Credentials)
+		assert.Contains(t, fmt.Sprintf("%T", cfg.Credentials), "CredentialsCache")
+	})
+
+	t.Run("should log assume role without external ID", func(t *testing.T) {
+		// setup
+		testutils.TestHelperEnvSetter(t, map[string]string{
+			"AWS_ACCESS_KEY_ID":     "AKIAIOSFODNN7EXAMPLE",
+			"AWS_SECRET_ACCESS_KEY": "topsecret",
+		})
+
+		hook := testutils.LogsUnderTestWithLogLevel(logrus.InfoLevel, t)
+		defer hook.Reset()
+
+		// when
+		_, err := newV2Config(AWSSessionConfig{
+			AssumeRole: "arn:aws:iam::123456789012:role/example",
+		})
+
+		// then
+		require.NoError(t, err)
+		testutils.TestHelperLogContainsWithLogLevel(
+			"Assuming role: arn:aws:iam::123456789012:role/example",
+			logrus.InfoLevel,
+			hook,
+			t,
+		)
+	})
+
+	t.Run("returns error when config cannot be loaded", func(t *testing.T) {
+		// setup
+		testutils.TestHelperEnvSetter(t, map[string]string{
+			"AWS_SHARED_CREDENTIALS_FILE": "missing-ca.pem",
+		})
+
+		// when
+		_, err := newV2Config(AWSSessionConfig{Profile: "profile1"})
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "instantiating AWS config")
 	})
 }
 
@@ -85,4 +155,103 @@ func prepareCredentialsFile(t *testing.T) (*os.File, error) {
 	err = credsFile.Close()
 	require.NoError(t, err)
 	return credsFile, err
+}
+
+func TestCreateV2Configs(t *testing.T) {
+	testutils.TestHelperEnvSetter(t, map[string]string{
+		"AWS_REGION":                "us-east-1",
+		"AWS_EC2_METADATA_DISABLED": "true",
+	})
+
+	t.Run("returns default profile when none configured", func(t *testing.T) {
+		// setup
+		testutils.TestHelperEnvSetter(t, map[string]string{
+			"AWS_ACCESS_KEY_ID":     "AKIAIOSFODNN7EXAMPLE",
+			"AWS_SECRET_ACCESS_KEY": "topsecret",
+		})
+
+		cfg := &externaldns.Config{
+			AWSAPIRetries: 3,
+		}
+
+		// when
+		configs := CreateV2Configs(cfg)
+
+		// then
+		require.Len(t, configs, 1)
+		_, ok := configs[defaultAWSProfile]
+		assert.True(t, ok)
+	})
+
+	t.Run("returns profile configs when configured", func(t *testing.T) {
+		// setup
+		credsFile, err := prepareCredentialsFile(t)
+		defer os.Remove(credsFile.Name())
+		require.NoError(t, err)
+		testutils.TestHelperEnvSetter(t, map[string]string{
+			"AWS_SHARED_CREDENTIALS_FILE": credsFile.Name(),
+		})
+
+		cfg := &externaldns.Config{
+			AWSProfiles:   []string{"profile1", "profile2"},
+			AWSAPIRetries: 2,
+		}
+
+		// when
+		configs := CreateV2Configs(cfg)
+
+		// then
+		require.Len(t, configs, 2)
+		creds, err := configs["profile1"].Credentials.Retrieve(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "AKID1234", creds.AccessKeyID)
+		assert.Equal(t, "SECRET1", creds.SecretAccessKey)
+
+		creds, err = configs["profile2"].Credentials.Retrieve(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "AKID2345", creds.AccessKeyID)
+		assert.Equal(t, "SECRET2", creds.SecretAccessKey)
+	})
+}
+
+func TestCreateConfigFatalOnError(t *testing.T) {
+	testutils.TestHelperEnvSetter(t, map[string]string{
+		"AWS_REGION":                "us-east-1",
+		"AWS_EC2_METADATA_DISABLED": "true",
+	})
+
+	t.Run("CreateDefaultV2Config exits on load error", func(t *testing.T) {
+		testutils.TestHelperEnvSetter(t, map[string]string{
+			"AWS_PROFILE":                 "profile1",
+			"AWS_SHARED_CREDENTIALS_FILE": "missing-ca.pem",
+		})
+
+		exitCode := 0
+		_ = testutils.TestHelperWithLogExitFunc(func(code int) {
+			exitCode = code
+			panic("exit")
+		})
+
+		assert.Panics(t, func() {
+			CreateDefaultV2Config(&externaldns.Config{})
+		})
+		assert.Equal(t, 1, exitCode)
+	})
+
+	t.Run("CreateV2Configs exits on load error", func(t *testing.T) {
+		testutils.TestHelperEnvSetter(t, map[string]string{
+			"AWS_SHARED_CREDENTIALS_FILE": "missing-ca.pem",
+		})
+
+		exitCode := 0
+		_ = testutils.TestHelperWithLogExitFunc(func(code int) {
+			exitCode = code
+			panic("exit")
+		})
+
+		assert.Panics(t, func() {
+			CreateV2Configs(&externaldns.Config{AWSProfiles: []string{"profile1"}})
+		})
+		assert.Equal(t, 1, exitCode)
+	})
 }

--- a/source/cloudfoundry_test.go
+++ b/source/cloudfoundry_test.go
@@ -17,10 +17,17 @@ limitations under the License.
 package source
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/cloudfoundry-community/go-cfclient"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 type RouteSuite struct {
@@ -35,4 +42,112 @@ func TestRouteSource(t *testing.T) {
 // testRouteSourceImplementsSource tests that cloudfoundrySource is a valid Source.
 func testRouteSourceImplementsSource(t *testing.T) {
 	require.Implements(t, (*Source)(nil), new(cloudfoundrySource))
+}
+
+func TestCloudFoundrySourceEndpoints(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/private_domains":
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(map[string]interface{}{
+				"total_results": 1,
+				"total_pages":   1,
+				"next_url":      "",
+				"resources": []map[string]interface{}{
+					{
+						"metadata": map[string]interface{}{
+							"guid":       "domain-guid",
+							"created_at": "now",
+							"updated_at": "now",
+						},
+						"entity": map[string]interface{}{
+							"name": "example.com",
+						},
+					},
+				},
+			}); err != nil {
+				t.Errorf("encode domains response: %v", err)
+			}
+		case "/v2/routes":
+			if got := r.URL.Query().Get("q"); got != "domain_guid:domain-guid" {
+				t.Errorf("expected domain query to be %q, got %q", "domain_guid:domain-guid", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(map[string]interface{}{
+				"total_results": 2,
+				"total_pages":   1,
+				"next_url":      "",
+				"resources": []map[string]interface{}{
+					{
+						"metadata": map[string]interface{}{
+							"guid":       "route-guid",
+							"created_at": "now",
+							"updated_at": "now",
+						},
+						"entity": map[string]interface{}{
+							"host":        "app",
+							"domain_guid": "domain-guid",
+						},
+					},
+					{
+						"metadata": map[string]interface{}{
+							"guid":       "route-guid-2",
+							"created_at": "now",
+							"updated_at": "now",
+						},
+						"entity": map[string]interface{}{
+							"host":        "api",
+							"domain_guid": "domain-guid",
+						},
+					},
+				},
+			}); err != nil {
+				t.Errorf("encode routes response: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := &cfclient.Client{
+		Config: cfclient.Config{
+			ApiAddress: server.URL,
+			HttpClient: server.Client(),
+			UserAgent:  "cloudfoundry-test",
+		},
+	}
+
+	source, err := NewCloudFoundrySource(client)
+	require.NoError(t, err)
+
+	source.AddEventHandler(context.Background(), func() {})
+	endpoints, err := source.Endpoints(context.Background())
+	require.NoError(t, err)
+
+	expected := []*endpoint.Endpoint{
+		endpoint.NewEndpointWithTTL("app.example.com", endpoint.RecordTypeCNAME, 300, "example.com"),
+		endpoint.NewEndpointWithTTL("api.example.com", endpoint.RecordTypeCNAME, 300, "example.com"),
+	}
+	for _, ep := range expected {
+		ep.Targets[0] = server.Listener.Addr().String()
+	}
+	require.ElementsMatch(t, expected, endpoints)
+}
+
+func TestCloudFoundrySourceEndpointsPanicsOnBadURL(t *testing.T) {
+	client := &cfclient.Client{
+		Config: cfclient.Config{
+			ApiAddress: "http://[::1]:namedport",
+			HttpClient: http.DefaultClient,
+			UserAgent:  "cloudfoundry-test",
+		},
+	}
+
+	source, err := NewCloudFoundrySource(client)
+	require.NoError(t, err)
+
+	require.Panics(t, func() {
+		_, _ = source.Endpoints(context.Background())
+	})
 }

--- a/source/fqdn/fqdn_test.go
+++ b/source/fqdn/fqdn_test.go
@@ -392,3 +392,22 @@ func (t *testObject) DeepCopyObject() runtime.Object {
 		ObjectMeta: *t.ObjectMeta.DeepCopy(),
 	}
 }
+
+func TestExecTemplateExecutionError(t *testing.T) {
+	tmpl, err := ParseTemplate("{{ call .Name }}")
+	require.NoError(t, err)
+
+	obj := &metav1.PartialObjectMetadata{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "TestKind",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-name",
+			Namespace: "default",
+		},
+	}
+
+	_, err = ExecTemplate(tmpl, obj)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to apply template on TestKind default/test-name")
+}

--- a/source/service_fqdn_test.go
+++ b/source/service_fqdn_test.go
@@ -820,7 +820,6 @@ func TestServiceSourceFqdnTemplatingExamples(t *testing.T) {
 
 			// TODO; when all resources have the resource label, we could add this check to the validateEndpoints function.
 			for _, ep := range endpoints {
-				fmt.Println(ep)
 				require.Contains(t, ep.Labels, endpoint.ResourceLabelKey)
 			}
 		})

--- a/source/wrappers/nat64source.go
+++ b/source/wrappers/nat64source.go
@@ -27,6 +27,10 @@ import (
 	"sigs.k8s.io/external-dns/source"
 )
 
+var (
+	addrFromSlice = netip.AddrFromSlice
+)
+
 // nat64Source is a Source that adds A endpoints for AAAA records including an NAT64 address.
 type nat64Source struct {
 	source        source.Source
@@ -90,8 +94,8 @@ func (s *nat64Source) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, erro
 			ipBytes := ip.As16()
 			v4AddrBytes := ipBytes[12:16]
 
-			v4Addr, isOk := netip.AddrFromSlice(v4AddrBytes)
-			if !isOk {
+			v4Addr, ok := addrFromSlice(v4AddrBytes)
+			if !ok {
 				return nil, fmt.Errorf("could not parse %v to IPv4 address", v4AddrBytes)
 			}
 


### PR DESCRIPTION
## What does it do ?
-  Increase unit test coverage for AWS config helper logic in provider/aws/config.go to cover assume-role and profile handling.
- Validate CreateV2Configs behavior for default single-profile and multiple-profile configurations.
-  Ensure test stability in CI by setting AWS_REGION and disabling IMDS via AWS_EC2_METADATA_DISABLED within tests.
-  Ensure ExecTemplate error handling is covered when template execution fails.
 - Verify the returned error includes resource Kind, Namespace, and Name context for easier debugging.
 - Improve unit test coverage for the NAT64 source by adding tests for error paths in endpoint parsing.
 - Allow simulating IPv4 parsing failures in tests by making the address construction function overridable.
 - cover cloudfoundry with tests

<img width="1690" height="824" alt="Screenshot 2025-12-20 at 17 43 52" src="https://github.com/user-attachments/assets/db69e816-6b09-467d-88f2-3bb3b5d4f7e1" />
<img width="1690" height="824" alt="Screenshot 2025-12-20 at 17 33 52" src="https://github.com/user-attachments/assets/138912d9-02aa-4bd9-bce3-5df70b00d4dd" />

<img width="1690" height="824" alt="Screenshot 2025-12-20 at 17 26 55" src="https://github.com/user-attachments/assets/7204a48e-db44-45d7-be94-3f7429191d1f" />
<img width="1602" height="695" alt="Screenshot 2025-12-20 at 16 22 50" src="https://github.com/user-attachments/assets/144e60c9-9eec-4901-9b56-bef14b7f4ce4" />


## Motivation

Relates https://github.com/kubernetes-sigs/external-dns/issues/5150

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
