### PR TITLE
fix(scripts): helm plugins install disable verify

### DIFF
--- a/scripts/helm-tools.sh
+++ b/scripts/helm-tools.sh
@@ -37,11 +37,11 @@ EOF
 install() {
   if [[ -x $(which helm) ]]; then
       echo "installing https://github.com/losisin/helm-values-schema-json.git plugin"
-      helm plugin install https://github.com/losisin/helm-values-schema-json.git | true
+      helm plugin install https://github.com/losisin/helm-values-schema-json.git --verify=false | true
       helm plugin update schema
       helm plugin list | grep "schema"
 
-      helm plugin install https://github.com/helm-unittest/helm-unittest.git | true
+      helm plugin install https://github.com/helm-unittest/helm-unittest.git --verify=false | true
       helm plugin update unittest
       helm plugin list | grep "unittest"
 


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->
Disable helm 4 plugins install verification in `scripts/helm-tools.sh`.

## Motivation

Plugins install fails with helm 4.

Note: this breaks install with helm 3 as `--verify` flag does not exists.

## More

- [c] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
