### PR TITLE
refactor(lint): replace with NewSoftErrorf when possible

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -390,7 +390,7 @@ func (p *AWSProvider) zones(ctx context.Context) (map[string]*profiledZone, erro
 					continue
 				}
 				// nothing to do here. Falling through to general error handling
-				return nil, provider.NewSoftError(fmt.Errorf("failed to list hosted zones: %w", err))
+				return nil, provider.NewSoftErrorf("failed to list hosted zones: %w", err)
 			}
 			var zonesToTagFilter []string
 			for _, zone := range resp.HostedZones {

--- a/provider/azure/azure.go
+++ b/provider/azure/azure.go
@@ -119,7 +119,7 @@ func (p *AzureProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, erro
 		for pager.More() {
 			nextResult, err := pager.NextPage(ctx)
 			if err != nil {
-				return nil, provider.NewSoftError(fmt.Errorf("failed to fetch dns records: %w", err))
+				return nil, provider.NewSoftErrorf("failed to fetch dns records: %w", err)
 			}
 			for _, recordSet := range nextResult.Value {
 				if recordSet.Name == nil || recordSet.Type == nil {

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -187,7 +187,7 @@ func (p *GoogleProvider) Zones(ctx context.Context) (map[string]*dns.ManagedZone
 
 	log.Debugf("Matching zones against domain filters: %v", p.domainFilter)
 	if err := p.managedZonesClient.List(p.project).Pages(ctx, f); err != nil {
-		return nil, provider.NewSoftError(fmt.Errorf("failed to list zones: %w", err))
+		return nil, provider.NewSoftErrorf("failed to list zones: %w", err)
 	}
 
 	if len(zones) == 0 {
@@ -297,7 +297,7 @@ func (p *GoogleProvider) submitChange(ctx context.Context, change *dns.Change) e
 			}
 
 			if _, err := p.changesClient.Create(p.project, zone, c).Do(); err != nil {
-				return provider.NewSoftError(fmt.Errorf("failed to create changes: %w", err))
+				return provider.NewSoftErrorf("failed to create changes: %w", err)
 			}
 
 			time.Sleep(p.batchChangeInterval)

--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -613,7 +613,7 @@ func TestGoogleBatchChangeSetExceedingNameChange(t *testing.T) {
 }
 
 func TestSoftErrListZonesConflict(t *testing.T) {
-	p := newGoogleProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), provider.NewZoneIDFilter([]string{}), false, []*endpoint.Endpoint{}, provider.NewSoftError(fmt.Errorf("failed to list zones")), nil)
+	p := newGoogleProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), provider.NewZoneIDFilter([]string{}), false, []*endpoint.Endpoint{}, provider.NewSoftErrorf("failed to list zones"), nil)
 
 	zones, err := p.Zones(context.Background())
 	require.Error(t, err)
@@ -623,7 +623,7 @@ func TestSoftErrListZonesConflict(t *testing.T) {
 }
 
 func TestSoftErrListRecordsConflict(t *testing.T) {
-	p := newGoogleProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), provider.NewZoneIDFilter([]string{}), false, []*endpoint.Endpoint{}, nil, provider.NewSoftError(fmt.Errorf("failed to list records in zone")))
+	p := newGoogleProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), provider.NewZoneIDFilter([]string{}), false, []*endpoint.Endpoint{}, nil, provider.NewSoftErrorf("failed to list records in zone"))
 
 	records, err := p.Records(context.Background())
 	require.Error(t, err)

--- a/provider/oci/oci.go
+++ b/provider/oci/oci.go
@@ -215,7 +215,7 @@ func (p *OCIProvider) addPaginatedZones(ctx context.Context, zones map[string]dn
 			Page:          page,
 		})
 		if err != nil {
-			return provider.NewSoftError(fmt.Errorf("listing zones in %s: %w", p.cfg.CompartmentID, err))
+			return provider.NewSoftErrorf("listing zones in %s: %w", p.cfg.CompartmentID, err)
 		}
 		for _, zone := range resp.Items {
 			if p.domainFilter.Match(*zone.Name) && p.zoneIDFilter.Match(*zone.Id) {
@@ -259,7 +259,7 @@ func (p *OCIProvider) newFilteredRecordOperations(endpoints []*endpoint.Endpoint
 func (p *OCIProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
 	zones, err := p.zones(ctx)
 	if err != nil {
-		return nil, provider.NewSoftError(fmt.Errorf("getting zones: %w", err))
+		return nil, provider.NewSoftErrorf("getting zones: %w", err)
 	}
 
 	var endpoints []*endpoint.Endpoint
@@ -272,7 +272,7 @@ func (p *OCIProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error)
 				CompartmentId: &p.cfg.CompartmentID,
 			})
 			if err != nil {
-				return nil, provider.NewSoftError(fmt.Errorf("getting records for zone %q: %w", *zone.Id, err))
+				return nil, provider.NewSoftErrorf("getting records for zone %q: %w", *zone.Id, err)
 			}
 
 			for _, record := range resp.Items {
@@ -319,7 +319,7 @@ func (p *OCIProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) e
 
 	zones, err := p.zones(ctx)
 	if err != nil {
-		return provider.NewSoftError(fmt.Errorf("fetching zones: %w", err))
+		return provider.NewSoftErrorf("fetching zones: %w", err)
 	}
 
 	// Separate into per-zone change sets to be passed to OCI API.

--- a/provider/pdns/pdns.go
+++ b/provider/pdns/pdns.go
@@ -22,7 +22,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"math"
 	"net"
 	"net/http"
@@ -351,7 +350,7 @@ func (p *PDNSProvider) ConvertEndpointsToZones(eps []*endpoint.Endpoint, changet
 				// DELETEs explicitly forbid a TTL, therefore only PATCHes need the TTL
 				if changetype == PdnsReplace {
 					if int64(ep.RecordTTL) > int64(math.MaxInt32) {
-						return nil, provider.NewSoftError(fmt.Errorf("value of record TTL overflows, limited to int32"))
+						return nil, provider.NewSoftErrorf("value of record TTL overflows, limited to int32")
 					}
 					if ep.RecordTTL == 0 {
 						// No TTL was specified for the record, we use the default

--- a/provider/pdns/pdns_test.go
+++ b/provider/pdns/pdns_test.go
@@ -18,7 +18,6 @@ package pdns
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"regexp"
 	"strings"
@@ -725,7 +724,7 @@ type PDNSAPIClientStubPatchZoneFailure struct {
 
 // Just overwrite the PatchZone method to introduce a failure
 func (c *PDNSAPIClientStubPatchZoneFailure) PatchZone(zoneID string, zoneStruct pgo.Zone) (*http.Response, error) {
-	return nil, provider.NewSoftError(fmt.Errorf("Generic PDNS Error"))
+	return nil, provider.NewSoftErrorf("Generic PDNS Error")
 }
 
 /******************************************************************************/
@@ -737,7 +736,7 @@ type PDNSAPIClientStubListZoneFailure struct {
 
 // Just overwrite the ListZone method to introduce a failure
 func (c *PDNSAPIClientStubListZoneFailure) ListZone(zoneID string) (pgo.Zone, *http.Response, error) {
-	return pgo.Zone{}, nil, provider.NewSoftError(fmt.Errorf("Generic PDNS Error"))
+	return pgo.Zone{}, nil, provider.NewSoftErrorf("Generic PDNS Error")
 }
 
 /******************************************************************************/
@@ -749,7 +748,7 @@ type PDNSAPIClientStubListZonesFailure struct {
 
 // Just overwrite the ListZones method to introduce a failure
 func (c *PDNSAPIClientStubListZonesFailure) ListZones() ([]pgo.Zone, *http.Response, error) {
-	return []pgo.Zone{}, nil, provider.NewSoftError(fmt.Errorf("Generic PDNS Error"))
+	return []pgo.Zone{}, nil, provider.NewSoftErrorf("Generic PDNS Error")
 }
 
 /******************************************************************************/


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->
Replace all `provider.NewSoftError(fmt.Errorf())` by `provider.NewSoftErrorf()`

## Motivation

<!-- What inspired you to submit this pull request? -->

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
