### PR TITLE
chore(deps): configure dependabot for mkdocs deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,18 @@ updates:
       dev-dependencies:
         patterns:
           - "*"
+
+  # Dependencies listed in requirements.txt
+  - package-ecosystem: "pip"
+    directory: "docs/scripts"
+    schedule:
+      interval: "monthly"
+    groups:
+      mkdocs-deps:
+        patterns:
+          - "*"
+    labels:
+      - python
+      - dependencies
+      - ok-to-test
+      - release-note-none


### PR DESCRIPTION
## What does it do ?

API GW Example
- dependabot config https://github.com/kubernetes-sigs/gateway-api/blob/8ed1be6633ecfbc63f554d2531b7a9519928af76/.github/dependabot.yml#L50
- PR opened https://github.com/kubernetes-sigs/gateway-api/pull/4367/changes

follow-up
- automated test to validate mkdocs build success

## Motivation

Manual dep bump is not great https://github.com/kubernetes-sigs/external-dns/pull/6058

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

[2]: https://github.com/kubernetes-sigs/gateway-api/pull/4367/changes