### PR TITLE
chore(node): remove warning msg

### DIFF
--- a/source/node.go
+++ b/source/node.go
@@ -34,8 +34,6 @@ import (
 	"sigs.k8s.io/external-dns/source/informers"
 )
 
-const warningMsg = "The default behavior of exposing internal IPv6 addresses will change in the next minor version. Use --no-expose-internal-ipv6 flag to opt-in to the new behavior."
-
 type nodeSource struct {
 	client                kubernetes.Interface
 	annotationFilter      string
@@ -189,7 +187,6 @@ func (ns *nodeSource) nodeAddresses(node *v1.Node) ([]string, error) {
 
 	if len(addresses[v1.NodeExternalIP]) > 0 {
 		if ns.exposeInternalIPv6 {
-			log.Warn(warningMsg)
 			return append(addresses[v1.NodeExternalIP], internalIpv6Addresses...), nil
 		}
 		return addresses[v1.NodeExternalIP], nil

--- a/source/node_test.go
+++ b/source/node_test.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/mock"
 	"k8s.io/client-go/kubernetes"
 	corev1lister "k8s.io/client-go/listers/core/v1"
@@ -549,11 +548,6 @@ func testNodeEndpointsWithIPv6(t *testing.T) {
 		_, err := kubeClient.CoreV1().Nodes().Create(t.Context(), node, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		var hook *test.Hook
-		if tc.exposeInternalIPv6 {
-			hook = testutils.LogsUnderTestWithLogLevel(log.WarnLevel, t)
-		}
-
 		// Create our object under test and get the endpoints.
 		client, err := NewNodeSource(
 			t.Context(),
@@ -572,10 +566,6 @@ func testNodeEndpointsWithIPv6(t *testing.T) {
 			require.Error(t, err)
 		} else {
 			require.NoError(t, err)
-
-			if tc.exposeInternalIPv6 && hook != nil {
-				testutils.TestHelperLogContainsWithLogLevel(warningMsg, log.WarnLevel, hook, t)
-			}
 		}
 
 		// Validate returned endpoints against desired endpoints.


### PR DESCRIPTION
## What does it do ?

Removes warning message. As it's confusing, I can still see it, since the proposal was implemented https://github.com/kubernetes-sigs/external-dns/blob/master/docs/proposal/002-internal-ipv6-handling-rollback.md

## Motivation

My understanding this change was released https://github.com/kubernetes-sigs/external-dns/pull/5575. So the msg is no longer relevant

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
