### PR TITLE
fix(aws): use API validation for routing policies

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -955,48 +955,47 @@ func (p *AWSProvider) newChange(action route53types.ChangeAction, ep *endpoint.E
 		change.sizeValues *= 2
 	}
 
-	setIdentifier := ep.SetIdentifier
-	if setIdentifier != "" {
-		change.ResourceRecordSet.SetIdentifier = aws.String(setIdentifier)
-		if prop, ok := ep.GetProviderSpecificProperty(providerSpecificWeight); ok {
-			weight, err := strconv.ParseInt(prop, 10, 64)
-			if err != nil {
-				log.Errorf("Failed parsing value of %s: %s: %v; using weight of 0", providerSpecificWeight, prop, err)
-				weight = 0
-			}
-			change.ResourceRecordSet.Weight = aws.Int64(weight)
-		}
-		if prop, ok := ep.GetProviderSpecificProperty(providerSpecificRegion); ok {
-			change.ResourceRecordSet.Region = route53types.ResourceRecordSetRegion(prop)
-		}
-		if prop, ok := ep.GetProviderSpecificProperty(providerSpecificFailover); ok {
-			change.ResourceRecordSet.Failover = route53types.ResourceRecordSetFailover(prop)
-		}
-		if _, ok := ep.GetProviderSpecificProperty(providerSpecificMultiValueAnswer); ok {
-			change.ResourceRecordSet.MultiValueAnswer = aws.Bool(true)
-		}
-
-		geolocation := &route53types.GeoLocation{}
-		useGeolocation := false
-		if prop, ok := ep.GetProviderSpecificProperty(providerSpecificGeolocationContinentCode); ok {
-			geolocation.ContinentCode = aws.String(prop)
-			useGeolocation = true
-		} else {
-			if prop, ok := ep.GetProviderSpecificProperty(providerSpecificGeolocationCountryCode); ok {
-				geolocation.CountryCode = aws.String(prop)
-				useGeolocation = true
-			}
-			if prop, ok := ep.GetProviderSpecificProperty(providerSpecificGeolocationSubdivisionCode); ok {
-				geolocation.SubdivisionCode = aws.String(prop)
-				useGeolocation = true
-			}
-		}
-		if useGeolocation {
-			change.ResourceRecordSet.GeoLocation = geolocation
-		}
-
-		withChangeForGeoProximityEndpoint(change, ep)
+	if ep.SetIdentifier != "" {
+		change.ResourceRecordSet.SetIdentifier = aws.String(ep.SetIdentifier)
 	}
+	if prop, ok := ep.GetProviderSpecificProperty(providerSpecificWeight); ok {
+		weight, err := strconv.ParseInt(prop, 10, 64)
+		if err != nil {
+			log.Errorf("Failed parsing value of %s: %s: %v; using weight of 0", providerSpecificWeight, prop, err)
+			weight = 0
+		}
+		change.ResourceRecordSet.Weight = aws.Int64(weight)
+	}
+	if prop, ok := ep.GetProviderSpecificProperty(providerSpecificRegion); ok {
+		change.ResourceRecordSet.Region = route53types.ResourceRecordSetRegion(prop)
+	}
+	if prop, ok := ep.GetProviderSpecificProperty(providerSpecificFailover); ok {
+		change.ResourceRecordSet.Failover = route53types.ResourceRecordSetFailover(prop)
+	}
+	if _, ok := ep.GetProviderSpecificProperty(providerSpecificMultiValueAnswer); ok {
+		change.ResourceRecordSet.MultiValueAnswer = aws.Bool(true)
+	}
+
+	geolocation := &route53types.GeoLocation{}
+	useGeolocation := false
+	if prop, ok := ep.GetProviderSpecificProperty(providerSpecificGeolocationContinentCode); ok {
+		geolocation.ContinentCode = aws.String(prop)
+		useGeolocation = true
+	} else {
+		if prop, ok := ep.GetProviderSpecificProperty(providerSpecificGeolocationCountryCode); ok {
+			geolocation.CountryCode = aws.String(prop)
+			useGeolocation = true
+		}
+		if prop, ok := ep.GetProviderSpecificProperty(providerSpecificGeolocationSubdivisionCode); ok {
+			geolocation.SubdivisionCode = aws.String(prop)
+			useGeolocation = true
+		}
+	}
+	if useGeolocation {
+		change.ResourceRecordSet.GeoLocation = geolocation
+	}
+
+	withChangeForGeoProximityEndpoint(change, ep)
 
 	if prop, ok := ep.GetProviderSpecificProperty(providerSpecificHealthCheckID); ok {
 		change.ResourceRecordSet.HealthCheckId = aws.String(prop)


### PR DESCRIPTION
## What does it do?

Let AWS Route53 validate routing policy properties directly, instead of silently
ignoring them when `setIdentifier` is missing. Misconfigurations now surface as
clear AWS API errors.

## Motivation

### Issue #5775   
When routing policies (weight, failover, etc.) are set without
`external-dns.alpha.kubernetes.io/set-identifier`, Route53 ignores them and creates
standard records, causing user confusion.

This behavior was discussed in a previous PR https://github.com/kubernetes-sigs/external-dns/pull/5799

During that discussion, an alternative approach emerged: instead of adding warning
logs or custom validation, delegate validation entirely to the AWS API.  
This PR explores that alternative approach in a separate, focused change.

### Approach  
Remove the conditional logic that gated routing properties on `setIdentifier` and
delegate validation to the AWS API.

### Why this is better
- AWS returns authoritative error messages
- No extra validation or performance overhead
- Simpler, more consistent code

### Example error

```
ERRO[0245] Failure in zone example.com. when submitting change batch: operation error Route 53: ChangeResourceRecordSets, https response error StatusCode: 400, RequestID: xxxxxxxxxx, InvalidInput: Invalid request: Missing field 'SetIdentifier' in Change with [Action=CREATE, Name=a-test5775.example.com, Type=TXT, SetIdentifier=null]  profile=default zoneID=/hostedzone/Z0xxxxxxxxxx zoneName=example.com.
ERRO[0246] Failed to do run once: soft error
failed to submit all changes for the following zones: [/hostedzone/Z0xxxxxxxxxx] (consecutive soft errors: 1)
```

## More
- [x] PR title follows Conventional Commits
- [ ] Unit tests added
- [ ] Documentation updated


