### PR TITLE
docs(rfc2136): hard learned lesson about AXFR

### DIFF
--- a/docs/tutorials/rfc2136.md
+++ b/docs/tutorials/rfc2136.md
@@ -40,6 +40,8 @@ following.
   faces the internet.
   - Add the key that you generated/was given to you above. Copy paste the four
   lines that you got (not the same as the example key) into your file.
+  - Make sure zone transfer is enabled for the key, this enables listing all
+  records
   - Create a zone for kubernetes. If you already have a zone, skip to the next
   step. (I put the zone in it's own subdirectory because named,
   which shouldn't be running as root, needs to create a journal file and the
@@ -84,6 +86,16 @@ following.
   ```
 
   - Reload (or restart) named
+
+### AXFR and the sync policy
+
+When using the `sync` policy, ExternalDNS requires AXFR (zone transfer) to be
+explicitly enabled via the `--rfc2136-tsig-axfr` flag. This is necessary for
+ExternalDNS to list all existing DNS records and determine which ones should be
+lifecycled.
+
+Without `--rfc2136-tsig-axfr`, ExternalDNS cannot list records and will act as
+if the policy was set to `upsert-only`. No warning will be provided.
 
 ### Using external-dns
 


### PR DESCRIPTION
## What does it do ?

A minor documentation change to make the expected policy behaviour a bit more obvious when using rfc2136.

## Motivation

After much ~~raging~~ unplanned enlightenment I figured out that the axfr flag is required for the sync policy to behave as expected. Just jotting it down for the next guy / gal / cyborg.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] ~~Yes, I added unit tests~~ (N/A)
- [x] Yes, I updated end user documentation accordingly
