### PR TITLE
chore(doc): Adding EKS Pod Identity Associations section for AWS

### DIFF
--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -412,7 +412,7 @@ Follow the steps under [When using clusters with RBAC enabled](#when-using-clust
 If you deployed ExternalDNS before adding the service account annotation and the corresponding role, you will likely see error with `failed to list hosted zones: AccessDenied: User`.
 You can delete the current running ExternalDNS pod(s) after updating the annotation, so that new pods scheduled will have appropriate configuration to access Route53.
 
-### EKS Pod Identity
+### EKS Pod Identity Associations
 
 Alternatively to [IRSA](#iam-roles-for-service-accounts) on AWS EKS it is possible to use the new native method `EKS Pod Identity`, which associates IAM roles with Kubernetes service accounts, simplifying the process of granting AWS permissions to any Pod.
 
@@ -491,6 +491,20 @@ aws eks create-pod-identity-association \
 The same behaviour above can be achieved using Terraform. Here is a minimal placeholder snippet:
 
 ```hcl
+data "aws_iam_policy_document" "eks_assume_role" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession"
+    ]
+  }
+}
+
 resource "aws_iam_role" "external_dns_pod_identity" {
   name               = "external-dns-pod-identity"
   assume_role_policy = data.aws_iam_policy_document.eks_assume_role.json


### PR DESCRIPTION
## What does it do ?

This add a section for EKS Pod Identity Associations as alternative and newer method of permission model compared to IRSA, though this only works in pure EKS clusters.

## Motivation

I tried and deployed the external-dns operator using EKS Pod Identity Associations rather then IRSA to grant it with the permissions required in AWS for accessing Route53.
It worked seamlessly, so I decided to document it as an alternative and more modern method for granting AWS permissions to the operator in EKS clusters.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
