### PR TITLE
fix(api): rollback changes for omitempty

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -98,6 +98,9 @@ linters:
       - linters:
           - gochecknoinits
         path: ^(.*/controller\.go|internal/.*/init\.go|pkg/.*/metrics\.go|.*/webhook\.go|.*/http\.go|apis/.*\.go|.*/cached_provider\.go)$
+      - linters:
+          - modernize
+        path: ^(apis/.*\.go)$
     paths:
       - endpoint/zz_generated.deepcopy.go
       - third_party$

--- a/apis/v1alpha1/dnsendpoint.go
+++ b/apis/v1alpha1/dnsendpoint.go
@@ -35,17 +35,17 @@ import (
 // +versionName=v1alpha1
 type DNSEndpoint struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   DNSEndpointSpec   `json:"spec"`
-	Status DNSEndpointStatus `json:"status"`
+	Spec   DNSEndpointSpec   `json:"spec,omitempty"`
+	Status DNSEndpointStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // DNSEndpointList is a list of DNSEndpoint objects
 type DNSEndpointList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
+	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []DNSEndpoint `json:"items"`
 }
 


### PR DESCRIPTION
## What does it do ?

Rollback changes introduced with this PR https://github.com/kubernetes-sigs/external-dns/pull/6035/changes#diff-2547039d7c613fb593d80e03e99bccdb82626acbe9c52acdd4f2c0314bfd25a5

When is techically correct that `omitempty` has no effect on nested struct fields, the CRD generation logic takes to account presence of this annotation.

<img width="1558" height="728" alt="Screenshot 2026-01-08 at 08 09 12" src="https://github.com/user-attachments/assets/f18f2208-cca7-46b2-a92d-1d869b602e04" />

We have not had CI validation, hence easy to miss changes or breaking chaning. This should be resolved in follow-up PR

## Motivation

Unblock PR https://github.com/kubernetes-sigs/external-dns/pull/6079/changes#diff-77d7944d6730d9054d0aee66a4b5a67e1248fcead4681e2ebf2e63d35ae137ef

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
