### PR TITLE
docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Breaking changes were introduced in external-dns in the following versions:
 
 ## Running ExternalDNS
 
-The are two ways of running ExternalDNS:
+There are two ways of running ExternalDNS:
 
 - Deploying to a Cluster
 - Running Locally


### PR DESCRIPTION
## What does it do?

Fixes a typo in the README.md file: "The are" → "There are" in the "Running ExternalDNS" section.

## Motivation

Improves documentation clarity and correctness.

## More

- [x] Yes, this PR title follows Conventional Commits
- [x] Yes, I updated end user documentation accordingly