### PR TITLE
docs(readme): replace incorrect breaking change version v0.20.0 -> v0.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Breaking changes were introduced in external-dns in the following versions:
 
 - [`v0.10.0`](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.10.0): use of `networking.k8s.io/ingresses` instead of `extensions/ingresses` (see [#2281](https://github.com/kubernetes-sigs/external-dns/pull/2281))
 - [`v0.18.0`](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.18.0): use of `discovery.k8s.io/endpointslices` instead of `endpoints` (see [#5493](https://github.com/kubernetes-sigs/external-dns/pull/5493))
-- [`v0.19.0`](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.19.0): expose internal ipv6 by default (see [#5575](https://github.com/kubernetes-sigs/external-dns/pull/5575)) and disable legacy listeners on `traefik.containo.us` API Group (see [#5565](https://github.com/kubernetes-sigs/external-dns/pull/5565))
+- [`v0.19.0`](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.19.0): don't expose internal ipv6 by default (see [#5575](https://github.com/kubernetes-sigs/external-dns/pull/5575)) and disable legacy listeners on `traefik.containo.us` API Group (see [#5565](https://github.com/kubernetes-sigs/external-dns/pull/5565))
 
 | ExternalDNS                  |      ≤ 0.9.x       | ≥ 0.10.x and ≤ 0.17.x |      ≥ 0.18.x      |
 | ---------------------------- | :----------------: | :-------------------: | :----------------: |


### PR DESCRIPTION
## What does it do ?

- Replace mentioned version "v0.20.0" -> "v0.19.0" as both breaking changes that are mentioned in version v0.20.0 actually first appeared in v0.19.0
- Replace terms "expose external ipv6" -> "expose internal ipv6" based on the terms used in the code

## Motivation

When I checked the changelog of version [v0.19.0](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.19.0), I noticed the breaking change/PR https://github.com/kubernetes-sigs/external-dns/pull/5575. But then when I read the README, I noticed in section [Kubernetes version compatibility](https://github.com/kubernetes-sigs/external-dns/blob/bb67452f3853170ae26d8a5b9fac0e96fb8e614c/README.md#kubernetes-version-compatibility), there is no mention of v0.19.0 but instead it mentions v0.20.0. Based on https://github.com/kubernetes-sigs/external-dns/pull/5575 merge [commit](https://github.com/kubernetes-sigs/external-dns/commit/2d898cd88d6cef94edf65c715f44594d0c6f2a00), it seems it's first appeared in v0.19.0 so [v0.19.0](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.19.0) changelog is correct.

Additionally, PR https://github.com/kubernetes-sigs/external-dns/pull/5575 is titled `feat(nodes)!: expose external ipv6 by default`. However it seems it's a typo as the actual terms used in the code is [internal ipv6](https://github.com/kubernetes-sigs/external-dns/blob/bb67452f3853170ae26d8a5b9fac0e96fb8e614c/docs/flags.md?plain=1#L30).

This PR will correct the readme and should reduce confusion. PR https://github.com/kubernetes-sigs/external-dns/pull/5575 title should also be updated with the correction to reduce confusion.

Please CMIIW.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
