### PR TITLE
refactor(informers): unify cache sync functions using generics

### DIFF
--- a/source/gateway.go
+++ b/source/gateway.go
@@ -29,7 +29,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	kubeinformers "k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -194,10 +193,10 @@ func newGatewayRouteSource(
 	nsInformer := kubeInformerFactory.Core().V1().Namespaces() // TODO: Namespace informer should be shared across gateway sources.
 	nsInformer.Informer()                                      // Register with factory before starting.
 
-	informerFactory.Start(wait.NeverStop)
-	kubeInformerFactory.Start(wait.NeverStop)
+	informerFactory.Start(ctx.Done())
+	kubeInformerFactory.Start(ctx.Done())
 	if rtInformerFactory != informerFactory {
-		rtInformerFactory.Start(wait.NeverStop)
+		rtInformerFactory.Start(ctx.Done())
 
 		if err := informers.WaitForCacheSync(ctx, rtInformerFactory); err != nil {
 			return nil, err


### PR DESCRIPTION
## What does it do ?

- `WaitForCacheSync` and `WaitForDynamicCacheSync` unified into a single generic `waitForCacheSync[K comparable]` function.
- Changed from awkward "failed to sync %v: %w with timeout %s" to "failed to sync %v after %s: %w" - putting the timeout context before the wrapped error.
- Replaced wait.NeverStop with ctx.Done() for informer factories, allowing proper context-based cancellation
- line `timeout := defaultRequestTimeout * time.Second` noted the current timeout behavior for future consideration.

Something to consider for future. 
Found this PR https://github.com/kubernetes-sigs/external-dns/commit/60c649bf5c4069e2f307d9c342e0e4bc114618d8#diff-cf68f602fa7c20e5341f3b83054df68ade1586a144b1eae5347e0ac47096d3aa

So in past it was something like
```go
	// wait for the local cache to be populated.
	err = poll(time.Second, 60*time.Second, func() (bool, error) {
		return serviceInformer.Informer().HasSynced() &&
			endpointsInformer.Informer().HasSynced() &&
			podInformer.Informer().HasSynced() &&
			nodeInformer.Informer().HasSynced(), nil
	})
	if err != nil {
		return nil, fmt.Errorf("failed to sync cache: %v", err)

	}
```

It's basically very historycall.

What is wrong with current `timeout := defaultRequestTimeout * time.Second` Ignores the caller's context deadline: The function receives a ctx but then creates a new timeout, effectively overriding whatever deadline the caller may have set. If  the caller passed a context with a 30s timeout, this function ignores it and waits 60s anyway. 

As we supporint context correctly now https://github.com/kubernetes-sigs/external-dns/pull/6049

We could remove internal timeout entirely - let caller control it. This needs testing

```go
 func waitForCacheSync[K comparable](ctx context.Context, waitFunc func(<-chan struct{}) map[K]bool) error {
      for typ, done := range waitFunc(ctx.Done()) {
          if !done {
              return fmt.Errorf("failed to sync %v: %w", typ, ctx.Err())
          }
      }
      return nil
  }
```

## Motivation

Close https://github.com/kubernetes-sigs/external-dns/issues/6038

No more work is required for #6038, my understanind when this changes released https://github.com/kubernetes-sigs/gateway-api/pull/4376 we should have al ready and fixed.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
