### PR TITLE
feat(chart): add a PodDisruptionBudget and a NetworkPolicy to the Helm chart

### DIFF
--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -126,7 +126,15 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | managedRecordTypes | list | `[]` | Record types to manage (default: A, AAAA, CNAME) |
 | nameOverride | string | `nil` | Override the name of the chart. |
 | namespaced | bool | `false` | if `true`, _ExternalDNS_ will run in a namespaced scope (`Role`` and `Rolebinding`` will be namespaced too). |
+| networkPolicy.allowExternalEgress | bool | `true` | Allow the pod to access any range of port and all destinations. |
+| networkPolicy.enabled | bool | `true` | If `true`, create a [`NetworkPolicy`](https://kubernetes.io/docs/concepts/services-networking/network-policies/) resource. |
+| networkPolicy.extraEgress | list | `[]` | Extra egress rules. |
+| networkPolicy.extraIngress | list | `[]` | Extra ingress rules. |
+| networkPolicy.kubeAPIServerPorts | list | `[443,6443,8443]` | List of possible kube-apiserver endpoints to allow egress to when `allowExternalEgress` is set to `false`. |
 | nodeSelector | object | `{}` | Node labels to match for `Pod` [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). |
+| pdb.create | bool | `false` | If `true`, create a [`PodDisruptionBudget`](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) resource. |
+| pdb.maxUnavailable | string | `nil` | Maximum number or percentage of pods that may be made unavailable, defaults to `1` if both `pdb.minAvailable` and `pdb.maxUnavailable` are empty. |
+| pdb.minAvailable | string | `nil` | Minimum number or percentage of pods that should remain scheduled. |
 | podAnnotations | object | `{}` | Annotations to add to the `Pod`. |
 | podLabels | object | `{}` | Labels to add to the `Pod`. |
 | podSecurityContext | object | See _values.yaml_ | [Pod security context](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podsecuritycontext-v1-core), this supports full customisation. |

--- a/charts/external-dns/templates/networkpolicy.yaml
+++ b/charts/external-dns/templates/networkpolicy.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ include "external-dns.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "external-dns.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "external-dns.selectorLabels" . | nindent 6 }}
+      {{- with dig "external-dns" "podLabels" nil .Values.AsMap }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- if .Values.networkPolicy.allowExternalEgress }}
+  egress:
+    - {}
+  {{- else }}
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+        {{- range $port := .Values.networkPolicy.kubeAPIServerPorts }}
+        - port: {{ $port }}
+        {{- end }}
+    {{- if .Values.networkPolicy.extraEgress }}
+    {{- toYaml .Values.networkPolicy.extraEgress | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  ingress:
+    - ports:
+        - port: 7979
+    {{- if .Values.networkPolicy.extraIngress }}
+    {{- toYaml .Values.networkPolicy.extraIngress | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/external-dns/templates/pdb.yaml
+++ b/charts/external-dns/templates/pdb.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.pdb.create }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "external-dns.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "external-dns.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if or .Values.pdb.maxUnavailable (not .Values.pdb.minAvailable) }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "external-dns.selectorLabels" . | nindent 6 }}
+      {{- with dig "external-dns" "podLabels" nil .Values.AsMap }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+{{- end -}}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -164,6 +164,26 @@ topologySpreadConstraints: []
 # -- Node taints which will be tolerated for `Pod` [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
 tolerations: []
 
+pdb:
+  # -- If `true`, create a [`PodDisruptionBudget`](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) resource.
+  create: false
+  # -- Minimum number or percentage of pods that should remain scheduled.
+  minAvailable:  # @schema type:[integer, null]; minimum:0; default: null
+  # -- Maximum number or percentage of pods that may be made unavailable, defaults to `1` if both `pdb.minAvailable` and `pdb.maxUnavailable` are empty.
+  maxUnavailable:  # @schema type:[integer, null]; minimum:0; default: null
+
+networkPolicy:
+  # -- If `true`, create a [`NetworkPolicy`](https://kubernetes.io/docs/concepts/services-networking/network-policies/) resource.
+  enabled: true
+  # -- Allow the pod to access any range of port and all destinations.
+  allowExternalEgress: true
+  # -- List of possible kube-apiserver endpoints to allow egress to when `allowExternalEgress` is set to `false`.
+  kubeAPIServerPorts: [443, 6443, 8443]
+  # -- Extra ingress rules.
+  extraIngress: []
+  # -- Extra egress rules.
+  extraEgress: []
+
 serviceMonitor:
   # -- If `true`, create a `ServiceMonitor` resource to support the _Prometheus Operator_.
   enabled: false


### PR DESCRIPTION
## What does it do ?

Add a PodDisruptionBudget and a NetworkPolicy to the Helm chart, both enabled by default.

## Motivation

To have feature parity with the [Bitnami external-dns chart](https://github.com/bitnami/charts/tree/main/bitnami/external-dns) and ease the migration from it.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
