### PR TITLE
fix(metrics): add CNAME to known record types

### DIFF
--- a/controller/metrics_test.go
+++ b/controller/metrics_test.go
@@ -367,7 +367,7 @@ func TestGaugeMetricsWithMixedRecords(t *testing.T) {
 
 	testutils.TestHelperVerifyMetricsGaugeVectorWithLabels(t, 534, sourceRecords.Gauge, map[string]string{"record_type": "a"})
 	testutils.TestHelperVerifyMetricsGaugeVectorWithLabels(t, 324, sourceRecords.Gauge, map[string]string{"record_type": "aaaa"})
-	testutils.TestHelperVerifyMetricsGaugeVectorWithLabels(t, 0, sourceRecords.Gauge, map[string]string{"record_type": "cname"})
+	testutils.TestHelperVerifyMetricsGaugeVectorWithLabels(t, 2, sourceRecords.Gauge, map[string]string{"record_type": "cname"})
 	testutils.TestHelperVerifyMetricsGaugeVectorWithLabels(t, 11, sourceRecords.Gauge, map[string]string{"record_type": "srv"})
 
 	testutils.TestHelperVerifyMetricsGaugeVectorWithLabels(t, 5334, registryRecords.Gauge, map[string]string{"record_type": "a"})

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -54,6 +54,7 @@ var (
 	KnownRecordTypes = []string{
 		RecordTypeA,
 		RecordTypeAAAA,
+		RecordTypeCNAME,
 		RecordTypeTXT,
 		RecordTypeSRV,
 		RecordTypeNS,


### PR DESCRIPTION
## What does it do ?

Add metrics for CNAME records

## Motivation

Currently all records types metrics are added except this one

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
