### PR TITLE
fix(endpoint): correct function name in comment

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -313,7 +313,7 @@ func (e *Endpoint) GetProviderSpecificProperty(key string) (string, bool) {
 	return "", false
 }
 
-// GetBoolProperty returns a boolean provider-specific property value.
+// GetBoolProviderSpecificProperty returns a boolean provider-specific property value.
 func (e *Endpoint) GetBoolProviderSpecificProperty(key string) (bool, bool) {
 	prop, ok := e.GetProviderSpecificProperty(key)
 	if !ok {


### PR DESCRIPTION
## What does it do ?

Fix incorrect function name in godoc comment for `GetBoolProviderSpecificProperty`.

## Motivation

The comment said `GetBoolProperty` but the actual function name is `GetBoolProviderSpecificProperty`. This fixes the mismatch to follow Go documentation conventions.


## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
