### PR TITLE
feat(pihole)!: deprecate v5 API support

### DIFF
--- a/provider/pihole/pihole.go
+++ b/provider/pihole/pihole.go
@@ -22,6 +22,7 @@ import (
 	"slices"
 
 	"github.com/google/go-cmp/cmp"
+	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
@@ -31,6 +32,10 @@ import (
 // ErrNoPiholeServer is returned when there is no Pihole server configured
 // in the environment.
 var ErrNoPiholeServer = errors.New("no pihole server found in the environment or flags")
+
+const (
+	warningMsg = "Pi-hole v5 API support is deprecated. Set --pihole-api-version=\"6\" to use the Pi-hole v6 API. The v5 API will be removed in a future release."
+)
 
 // PiholeProvider is an implementation of Provider for Pi-hole Local DNS.
 type PiholeProvider struct {
@@ -69,6 +74,7 @@ func NewPiholeProvider(cfg PiholeConfig) (*PiholeProvider, error) {
 	case "6":
 		api, err = newPiholeClientV6(cfg)
 	default:
+		log.Warn(warningMsg)
 		api, err = newPiholeClient(cfg)
 	}
 	if err != nil {


### PR DESCRIPTION
## What does it do ?

- Add deprecation warning when using Pi-hole v5 API (the default)
- Guide users to migrate by setting --pihole-api-version="6"

Pihole v5 was last released with hot fix in `Dec 29, 2024` aka 2+ years ago. Those who want to stay on software that is working but not patched and no longer supported, they should pin current version of external-dns. There is no point to support both versions. Release page https://github.com/pi-hole/pi-hole/releases?page=2

After the next release, we will:
- Remove the `--pihole-api-version` flag
- Remove support for `v5` API

## Motivation

Pi-hole v5 is end-of-life. Dropping v5 support simplifies maintenance and lets us focus on the current Pi-hole v6 API.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
