### PR TITLE
feat(chart): add support for envFrom clause for `external-dns` container.

### DIFF
--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -105,6 +105,7 @@ If `namespaced` is set to `true`, please ensure that `sources` my only contains 
 | domainFilters | list | `[]` | Limit possible target zones by domain suffixes. |
 | enabled | bool | `nil` | No effect - reserved for use in sub-charting. |
 | env | list | `[]` | [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `external-dns` container. |
+| envFrom | list | `[]` | [Environment variables from Secrets and ConfigMaps](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#define-a-container-environment-variable-with-data-from-a-single-secret) for the `external-dns` container. |
 | excludeDomains | list | `[]` | Intentionally exclude domains from being managed. |
 | extraArgs | object | `{}` | Extra arguments to provide to _ExternalDNS_. An array or map can be used, with maps allowing for value overrides; maps also support slice values to use the same arg multiple times. |
 | extraContainers | list | `[]` | Extra containers to add to the `Deployment`. |

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -85,6 +85,10 @@ spec:
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          { { - with .Values.envFrom } }
+          envFrom:
+            { { - toYaml . | nindent 12 } }
+          { { - end } }
           args:
             - --log-level={{ .Values.logLevel }}
             - --log-format={{ .Values.logFormat }}

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -76,6 +76,10 @@
       "description": "[Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `external-dns` container.",
       "type": "array"
     },
+    "envFrom": {
+      "description": "[Environment variables from Secrets and ConfigMaps](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#define-a-container-environment-variable-with-data-from-a-single-secret) for the `external-dns` container.",
+      "type": "array"
+    },
     "excludeDomains": {
       "description": "Intentionally exclude domains from being managed.",
       "type": "array"

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -119,6 +119,9 @@ securityContext:
 # -- [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `external-dns` container.
 env: []
 
+# -- [Environment variables from Secrets and ConfigMaps](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#define-a-container-environment-variable-with-data-from-a-single-secret) for the `external-dns` container.
+envFrom: []
+
 # -- [Liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `external-dns` container.
 # @default -- See _values.yaml_
 livenessProbe:


### PR DESCRIPTION
## What does it do ?

This feat adds support for `envFrom:` clause for `external-dns` container.

## Motivation

There is a need to mount a Secret for Cloudflare token and pass other ENV values.
The clause supports ConfigMap as well.
```
            envFrom:
            - secretRef:
                name: external-dns-cf
```

Existing way to pass ENV var complicates chart configuration by adding 5 extra lines per 1 env variable from Secret/ConfigMap:
```
            env:
            - name: CF_API_TOKEN
              valueFrom:
                secretKeyRef:
                  name: external-dns-cf
                  key: apiToken
```

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
