### PR TITLE
feat(ingress): add support for default targets in DNS records

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -50,6 +50,15 @@ There are three sources of information for ExternalDNS to decide on DNS name. Ex
 
 3. If `--fqdn-template` flag is specified, e.g. `--fqdn-template={{.Name}}.my-org.com`, ExternalDNS will use service/ingress specifications for the provided template to generate DNS name.
 
+### Default Targets
+
+ExternalDNS allows you to specify a set of default targets that should be used for DNS records if the source doesn't provide any.
+
+*   `--default-targets`: Specifies one or more target IP addresses or hostnames to use as a fallback.
+    *   **New Behavior (>= 0.20)**: This flag acts as a fallback. If a source (like Ingress) provides its own targets (e.g. from the status field or the `external-dns.alpha.kubernetes.io/target` annotation), those targets are used and the default targets are ignored. The default targets are only applied when the source has no valid targets.
+*   `--force-default-targets`: (Deprecated) Forces the application of default targets.
+    *   **Legacy Behavior**: When this flag is used, ExternalDNS will *always* use the targets from `--default-targets`, regardless of whether the source has targets specified or not. This effectively overrides any target information from the source. This flag is deprecated and exists for backward compatibility.
+
 ## Which Service and Ingress controllers are supported?
 
 Regarding Services, we'll support the OSI Layer 4 load balancers that Kubernetes creates on AWS and Google Kubernetes Engine, and possibly other clusters running on Google Compute Engine.

--- a/source/ingress_fqdn_test.go
+++ b/source/ingress_fqdn_test.go
@@ -72,6 +72,7 @@ func TestIngressSourceNewNodeSourceWithFqdn(t *testing.T) {
 				false,
 				labels.Everything(),
 				[]string{},
+				[]string{},
 			)
 
 			if tt.expectError {
@@ -333,6 +334,7 @@ func TestIngressSourceFqdnTemplatingExamples(t *testing.T) {
 				false,
 				false,
 				labels.Everything(),
+				[]string{},
 				[]string{},
 			)
 

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -67,6 +67,7 @@ func (suite *IngressSuite) SetupTest() {
 		false,
 		labels.Everything(),
 		[]string{},
+		[]string{},
 	)
 	suite.NoError(err, "should initialize ingress source")
 }
@@ -131,6 +132,7 @@ func TestNewIngressSource(t *testing.T) {
 				false,
 				labels.Everything(),
 				ti.ingressClassNames,
+				[]string{},
 			)
 			if ti.expectError {
 				assert.Error(t, err)
@@ -150,6 +152,7 @@ func testEndpointsFromIngress(t *testing.T) {
 		ignoreHostnameAnnotation bool
 		ignoreIngressTLSSpec     bool
 		ignoreIngressRulesSpec   bool
+		defaultTargets           []string
 		expected                 []*endpoint.Endpoint
 	}{
 		{
@@ -259,10 +262,24 @@ func testEndpointsFromIngress(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{},
 		},
+		{
+			title: "fallback to default targets",
+			ingress: fakeIngress{
+				dnsnames: []string{"foo.bar"},
+			},
+			defaultTargets: []string{"1.2.3.4"},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"1.2.3.4"},
+				},
+			},
+		},
 	} {
 		t.Run(ti.title, func(t *testing.T) {
 			realIngress := ti.ingress.Ingress()
-			validateEndpoints(t, endpointsFromIngress(realIngress, ti.ignoreHostnameAnnotation, ti.ignoreIngressTLSSpec, ti.ignoreIngressRulesSpec), ti.expected)
+			validateEndpoints(t, endpointsFromIngress(realIngress, ti.ignoreHostnameAnnotation, ti.ignoreIngressTLSSpec, ti.ignoreIngressRulesSpec, ti.defaultTargets), ti.expected)
 		})
 	}
 }
@@ -361,7 +378,7 @@ func testEndpointsFromIngressHostnameSourceAnnotation(t *testing.T) {
 	} {
 		t.Run(ti.title, func(t *testing.T) {
 			realIngress := ti.ingress.Ingress()
-			validateEndpoints(t, endpointsFromIngress(realIngress, false, false, false), ti.expected)
+			validateEndpoints(t, endpointsFromIngress(realIngress, false, false, false, []string{}), ti.expected)
 		})
 	}
 }
@@ -1428,6 +1445,7 @@ func testIngressEndpoints(t *testing.T) {
 				ti.ignoreIngressRulesSpec,
 				ti.ingressLabelSelector,
 				ti.ingressClassNames,
+				[]string{},
 			)
 			// Informer cache has all of the ingresses. Retrieve and validate their endpoints.
 			res, err := source.Endpoints(t.Context())
@@ -1507,6 +1525,108 @@ func TestIngressWithConfiguration(t *testing.T) {
 		cfg       *Config
 		expected  []*endpoint.Endpoint
 	}{
+		{
+			title: "Ingress with fallback to default ip target",
+			cfg: &Config{
+				DefaultTargets: []string{"8.8.8.8"},
+			},
+			ingresses: []*networkv1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-ingress",
+						Namespace: "default",
+					},
+					Spec: networkv1.IngressSpec{
+						Rules: []networkv1.IngressRule{
+							{Host: "abc.example.com"},
+						},
+					},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{DNSName: "abc.example.com", Targets: endpoint.Targets{"8.8.8.8"}, RecordType: endpoint.RecordTypeA},
+			},
+		},
+		{
+			title: "Ingress with default ip target and valid status ip",
+			cfg: &Config{
+				DefaultTargets: []string{"8.8.8.8"},
+			},
+			ingresses: []*networkv1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-ingress",
+						Namespace: "default",
+					},
+					Spec: networkv1.IngressSpec{
+						Rules: []networkv1.IngressRule{
+							{Host: "abc.example.com"},
+						},
+					},
+					Status: networkv1.IngressStatus{
+						LoadBalancer: networkv1.IngressLoadBalancerStatus{
+							Ingress: []networkv1.IngressLoadBalancerIngress{
+								{IP: "1.2.3.4"},
+							},
+						},
+					},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{DNSName: "abc.example.com", Targets: endpoint.Targets{"1.2.3.4"}, RecordType: endpoint.RecordTypeA},
+			},
+		},
+		{
+			title: "Ingress with fallback to default cname target",
+			cfg: &Config{
+				DefaultTargets: []string{"example.com"},
+			},
+			ingresses: []*networkv1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-ingress",
+						Namespace: "default",
+					},
+					Spec: networkv1.IngressSpec{
+						Rules: []networkv1.IngressRule{
+							{Host: "abc.example.com"},
+						},
+					},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{DNSName: "abc.example.com", Targets: endpoint.Targets{"example.com"}, RecordType: endpoint.RecordTypeCNAME},
+			},
+		},
+		{
+			title: "Ingress with default cname target and valid status ip",
+			cfg: &Config{
+				DefaultTargets: []string{"google.com"},
+			},
+			ingresses: []*networkv1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-ingress",
+						Namespace: "default",
+					},
+					Spec: networkv1.IngressSpec{
+						Rules: []networkv1.IngressRule{
+							{Host: "abc.example.com"},
+						},
+					},
+					Status: networkv1.IngressStatus{
+						LoadBalancer: networkv1.IngressLoadBalancerStatus{
+							Ingress: []networkv1.IngressLoadBalancerIngress{
+								{IP: "1.2.3.4"},
+							},
+						},
+					},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{DNSName: "abc.example.com", Targets: endpoint.Targets{"1.2.3.4"}, RecordType: endpoint.RecordTypeA},
+			},
+		},
 		{
 			title: "hostname and targets configured as annotations",
 			ingresses: []*networkv1.Ingress{
@@ -1712,6 +1832,7 @@ func TestIngressWithConfiguration(t *testing.T) {
 				tt.cfg.IgnoreIngressRulesSpec,
 				labels.Everything(),
 				tt.cfg.IngressClassNames,
+				tt.cfg.DefaultTargets,
 			)
 			require.NoError(t, err)
 			endpoints, err := src.Endpoints(t.Context())

--- a/source/store.go
+++ b/source/store.go
@@ -443,7 +443,7 @@ func buildIngressSource(ctx context.Context, p ClientGenerator, cfg *Config) (So
 	if err != nil {
 		return nil, err
 	}
-	return NewIngressSource(ctx, client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.IgnoreHostnameAnnotation, cfg.IgnoreIngressTLSSpec, cfg.IgnoreIngressRulesSpec, cfg.LabelFilter, cfg.IngressClassNames)
+	return NewIngressSource(ctx, client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.IgnoreHostnameAnnotation, cfg.IgnoreIngressTLSSpec, cfg.IgnoreIngressRulesSpec, cfg.LabelFilter, cfg.IngressClassNames, cfg.DefaultTargets)
 }
 
 // buildPodSource creates a Pod source for exposing Kubernetes pods as DNS records.


### PR DESCRIPTION
## What does it do ?

As per discussion in https://github.com/kubernetes-sigs/external-dns/issues/6134 this PR covers situation where external-dns is configured to use `--default-targets` and the ingress object doesn't have any targets. In this situation, the ingress will be silently dropped and no records will be created. 

## Motivation

Provide support for (mainly onprem) clusters where connectivity is not provided via load balancer. Also, provides documentation/spec around usage of `default-targets` and `--force-default-targets`.

## Additional notes
There is an area for improvement imho but it requires input from maintainers (if it is a correct behaviour)

* `--force-default-targets` is marked as **deprecated**.  I think we should remove such deprecation given the fact that it is a perfectly valid use case for wanting to override all entrypoints in the clusters for one reason or another. 
* At the moment `--force-default-targets` ignores completely annotation "external-dns.alpha.kubernetes.io/target" and will happily override whatever is stored there. I think this is wrong since the more specific override should have priority over generic override (frankly I do not see a situation where user does set override annotation for a specific object but then wants it to be overwritten by a global value, but I can see a valid use case for inverse)

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly


