### PR TITLE
feat: add --include-domains flag for exact FQDN whitelist matching

### DIFF
--- a/controller/execute.go
+++ b/controller/execute.go
@@ -117,6 +117,7 @@ func Execute() {
 	domainFilter := endpoint.NewDomainFilterWithOptions(
 		endpoint.WithDomainFilter(cfg.DomainFilter),
 		endpoint.WithDomainExclude(cfg.DomainExclude),
+		endpoint.WithIncludeDomains(cfg.IncludeDomains),
 		endpoint.WithRegexDomainFilter(cfg.RegexDomainFilter),
 		endpoint.WithRegexDomainExclude(cfg.RegexDomainExclude),
 	)

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -77,6 +77,7 @@ type Config struct {
 	GoogleZoneVisibility                          string
 	DomainFilter                                  []string
 	DomainExclude                                 []string
+	IncludeDomains                                []string
 	RegexDomainFilter                             *regexp.Regexp
 	RegexDomainExclude                            *regexp.Regexp
 	ZoneNameFilter                                []string
@@ -273,6 +274,7 @@ var defaultConfig = &Config{
 	DryRun:                       false,
 	ExcludeDNSRecordTypes:        []string{},
 	DomainExclude:                []string{},
+	IncludeDomains:               []string{},
 	ExcludeTargetNets:            []string{},
 	EmitEvents:                   []string{},
 	ExcludeUnschedulable:         true,
@@ -546,6 +548,7 @@ func bindFlags(b flags.FlagBinder, cfg *Config) {
 	b.DurationVar("provider-cache-time", "The time to cache the DNS provider record list requests.", defaultConfig.ProviderCacheTime, &cfg.ProviderCacheTime)
 	b.StringsVar("domain-filter", "Limit possible target zones by a domain suffix; specify multiple times for multiple domains (optional)", []string{""}, &cfg.DomainFilter)
 	b.StringsVar("exclude-domains", "Exclude subdomains (optional)", []string{""}, &cfg.DomainExclude)
+	b.StringsVar("include-domains", "Limit to exact FQDNs; only domains that exactly match one of these will be managed; specify multiple times for multiple domains (optional)", []string{""}, &cfg.IncludeDomains)
 	b.RegexpVar("regex-domain-filter", "Limit possible domains and target zones by a Regex filter; Overrides domain-filter (optional)", defaultConfig.RegexDomainFilter, &cfg.RegexDomainFilter)
 	b.RegexpVar("regex-domain-exclusion", "Regex filter that excludes domains and target zones matched by regex-domain-filter (optional)", defaultConfig.RegexDomainExclude, &cfg.RegexDomainExclude)
 	b.StringsVar("zone-name-filter", "Filter target zones by zone domain (For now, only AzureDNS provider is using this flag); specify multiple times for multiple zones (optional)", []string{""}, &cfg.ZoneNameFilter)


### PR DESCRIPTION
## Summary

This PR adds a new `--include-domains` flag that allows users to specify an explicit whitelist of fully qualified domain names (FQDNs) that external-dns is allowed to manage.

Unlike the existing `--domain-filter` flag which uses suffix matching (e.g., `example.com` matches `api.example.com`), `--include-domains` requires **exact matches**. This provides stricter control and is simpler to audit than regex-based filtering.

## Motivation

When operating external-dns in production environments with multiple services, operators often need to ensure that external-dns can only manage specific DNS records. The current options are:
- `--domain-filter`: suffix-based, too permissive for strict use cases
- `--regex-domain-filter`: powerful but regex escaping errors are easy to make and create silent security issues

For example, forgetting to escape dots in regex:
```
--regex-domain-filter=^api.example.com$   # forgot to escape dots

api.example.com  -> true  (correct)
apiaexample.com  -> true  (unintended match - security issue)
api-example.com  -> true  (unintended match - security issue)
```

The new `--include-domains` flag eliminates this class of errors entirely by using simple string comparison.

## Usage

```bash
external-dns --include-domains=api.example.com --include-domains=app.example.com
```

This will only allow external-dns to manage DNS records for `api.example.com` and `app.example.com`, rejecting any other domains including their subdomains.

## Changes

- Add `IncludeDomains` field to Config struct
- Add `--include-domains` flag binding
- Add `includeDomains` field to DomainFilter struct
- Implement `matchExactDomain()` for exact FQDN matching
- Add `NewIncludeDomainsFilter()` constructor
- Add `WithIncludeDomains()` option function
- Update `NewDomainFilterWithOptions()` to prioritize includeDomains
- Add mutual exclusivity validation (thanks @ivankatliarchuk for the feedback)
- Add comprehensive tests

## Mutual Exclusivity

Based on feedback from @ivankatliarchuk, `--include-domains` is now mutually exclusive with other domain filter flags. If combined, external-dns will return a clear error:

```
--include-domains and --domain-filter/--exclude-domains are mutually exclusive
--include-domains and --regex-domain-filter/--regex-domain-exclusion are mutually exclusive
```

This ensures it's a separate mode of operation rather than another layer of options.