### PR TITLE
fix(alibabacloud): convert domain name format for Chinese IDN support

### DIFF
--- a/internal/idna/idna.go
+++ b/internal/idna/idna.go
@@ -31,6 +31,28 @@ var (
 	)
 )
 
+// ToASCII converts a value to ASCII using the default IDNA profile.
+// It returns the original value on conversion errors.
+func ToASCII(value string) string {
+	ascii, err := Profile.ToASCII(value)
+	if err != nil {
+		log.Debugf("Failed to convert %q to ASCII: %v", value, err)
+		return value
+	}
+	return ascii
+}
+
+// ToUnicode converts a value to Unicode using the default IDNA profile.
+// It returns the original value on conversion errors.
+func ToUnicode(value string) string {
+	unicode, err := Profile.ToUnicode(value)
+	if err != nil {
+		log.Debugf("Failed to convert %q to Unicode: %v", value, err)
+		return value
+	}
+	return unicode
+}
+
 // NormalizeDNSName converts a DNS name to a canonical form, so that we can use string equality
 // it: removes space, get ASCII version of dnsName complient with Section 5 of RFC 5891, ensures there is a trailing dot
 func NormalizeDNSName(dnsName string) string {

--- a/internal/idna/idna_test.go
+++ b/internal/idna/idna_test.go
@@ -155,3 +155,53 @@ func TestNormalizeDNSName(tt *testing.T) {
 		})
 	}
 }
+
+func TestToASCII(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "unicode domain",
+			input: "例子.com",
+			want:  "xn--fsqu00a.com",
+		},
+		{
+			name:  "invalid input returns original",
+			input: "a\x00b.com",
+			want:  "a\x00b.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ToASCII(tt.input))
+		})
+	}
+}
+
+func TestToUnicode(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "punycode domain",
+			input: "xn--fsqu00a.com",
+			want:  "例子.com",
+		},
+		{
+			name:  "invalid input returns original",
+			input: "a\x00b.com",
+			want:  "a\x00b.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ToUnicode(tt.input))
+		})
+	}
+}

--- a/provider/alibabacloud/alibaba_cloud.go
+++ b/provider/alibabacloud/alibaba_cloud.go
@@ -34,6 +34,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/idna"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
 )
@@ -415,7 +416,8 @@ func (p *AlibabaCloudProvider) getDomainList() ([]string, error) {
 			return nil, err
 		}
 		for _, tmpDomain := range resp.Domains.Domain {
-			domainNames = append(domainNames, tmpDomain.DomainName)
+			punycode := idna.ToASCII(tmpDomain.DomainName)
+			domainNames = append(domainNames, punycode)
 		}
 		nextPage := getNextPageNumber(resp.PageNumber, defaultAlibabaCloudPageSize, resp.TotalCount)
 		if nextPage == 0 {
@@ -429,8 +431,9 @@ func (p *AlibabaCloudProvider) getDomainList() ([]string, error) {
 
 func (p *AlibabaCloudProvider) getDomainRecords(domainName string) ([]alidns.Record, error) {
 	var results []alidns.Record
+	apiDomainName := idna.ToUnicode(domainName)
 	request := alidns.CreateDescribeDomainRecordsRequest()
-	request.DomainName = domainName
+	request.DomainName = apiDomainName
 	request.PageSize = requests.NewInteger(defaultAlibabaCloudPageSize)
 	request.PageNumber = "1"
 	request.Scheme = defaultAlibabaCloudRequestScheme
@@ -442,6 +445,12 @@ func (p *AlibabaCloudProvider) getDomainRecords(domainName string) ([]alidns.Rec
 		}
 
 		for _, record := range response.DomainRecords.Record {
+			punycode := idna.ToASCII(record.DomainName)
+			record.DomainName = punycode
+			if !isASCII(record.RR) {
+				record.RR = idna.ToASCII(record.RR)
+			}
+
 			domainName := record.RR + "." + record.DomainName
 			recordType := record.Type
 
@@ -513,8 +522,10 @@ func (p *AlibabaCloudProvider) createRecord(endpoint *endpoint.Endpoint, target 
 		return fmt.Errorf("no corresponding DNS zone found for this domain")
 	}
 
+	apiDomainName := idna.ToUnicode(domain)
+
 	request := alidns.CreateAddDomainRecordRequest()
-	request.DomainName = domain
+	request.DomainName = apiDomainName
 	request.Type = endpoint.RecordType
 	request.RR = rr
 	request.Scheme = defaultAlibabaCloudRequestScheme
@@ -697,6 +708,15 @@ func (p *AlibabaCloudProvider) splitDNSName(dnsName string, hostedZoneDomains []
 		rr = nullHostAlibabaCloud
 	}
 	return rr, domain
+}
+
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
 }
 
 func (p *AlibabaCloudProvider) matchVPC(zoneID string) bool {

--- a/provider/alibabacloud/alibaba_cloud_test.go
+++ b/provider/alibabacloud/alibaba_cloud_test.go
@@ -29,7 +29,9 @@ import (
 )
 
 type MockAlibabaCloudDNSAPI struct {
-	records []alidns.Record
+	records                []alidns.Record
+	LastAddDomainName      string
+	LastDescribeDomainName string
 }
 
 func NewMockAlibabaCloudDNSAPI() *MockAlibabaCloudDNSAPI {
@@ -56,6 +58,7 @@ func NewMockAlibabaCloudDNSAPI() *MockAlibabaCloudDNSAPI {
 }
 
 func (m *MockAlibabaCloudDNSAPI) AddDomainRecord(request *alidns.AddDomainRecordRequest) (*alidns.AddDomainRecordResponse, error) {
+	m.LastAddDomainName = request.DomainName
 	ttl, _ := request.TTL.GetValue()
 	m.records = append(m.records, alidns.Record{
 		RecordId:   "3",
@@ -108,6 +111,7 @@ func (m *MockAlibabaCloudDNSAPI) DescribeDomains(request *alidns.DescribeDomains
 }
 
 func (m *MockAlibabaCloudDNSAPI) DescribeDomainRecords(request *alidns.DescribeDomainRecordsRequest) (*alidns.DescribeDomainRecordsResponse, error) {
+	m.LastDescribeDomainName = request.DomainName
 	var result []alidns.Record
 	for _, record := range m.records {
 		if record.DomainName == request.DomainName {
@@ -504,6 +508,12 @@ func TestAlibabaCloudProvider_splitDNSName(t *testing.T) {
 	if rr != "@" || domain != "" {
 		t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
 	}
+
+	endpoint.DNSName = "externaldns.example.com"
+	rr, domain = p.splitDNSName(endpoint.DNSName, []string{"example.com"})
+	if rr != "externaldns" || domain != "example.com" {
+		t.Errorf("Failed to splitDNSName for %s: rr=%s, domain=%s", endpoint.DNSName, rr, domain)
+	}
 }
 
 func TestAlibabaCloudProvider_TXTEndpoint(t *testing.T) {
@@ -530,5 +540,115 @@ func TestAlibabaCloudProvider_TXTEndpoint_PrivateZone(t *testing.T) {
 	}
 	if p.unescapeTXTRecordValue(recordValue) != endpointTarget {
 		t.Errorf("Failed to unescapeTXTRecordValue: %s", p.unescapeTXTRecordValue(recordValue))
+	}
+}
+
+func TestAlibabaCloudProvider_CreateRecord_IDN(t *testing.T) {
+	tests := []struct {
+		name              string
+		dnsName           string
+		hostedZoneDomains []string
+		expectedRR        string
+		expectedAPIDomain string
+	}{
+		{
+			name:              "Chinese domain with subdomain",
+			dnsName:           "www.例子.com",
+			hostedZoneDomains: []string{"例子.com"},
+			expectedRR:        "www",
+			expectedAPIDomain: "例子.com",
+		},
+		{
+			name:              "Punycode input should be converted to Unicode for API",
+			dnsName:           "api.xn--fsqu00a.com",
+			hostedZoneDomains: []string{"xn--fsqu00a.com"},
+			expectedRR:        "api",
+			expectedAPIDomain: "例子.com",
+		},
+		{
+			name:              "ASCII domain unchanged",
+			dnsName:           "www.example.com",
+			hostedZoneDomains: []string{"example.com"},
+			expectedRR:        "www",
+			expectedAPIDomain: "example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockAPI := NewMockAlibabaCloudDNSAPI()
+			p := &AlibabaCloudProvider{
+				domainFilter: endpoint.NewDomainFilter(tt.hostedZoneDomains),
+				dryRun:       false,
+				dnsClient:    mockAPI,
+			}
+
+			ep := endpoint.NewEndpoint(tt.dnsName, "A", "1.2.3.4")
+			err := p.createRecord(ep, "1.2.3.4", tt.hostedZoneDomains)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedAPIDomain, mockAPI.LastAddDomainName,
+				"API should receive Unicode format domain name, not punycode")
+		})
+	}
+}
+
+func TestAlibabaCloudProvider_GetDomainRecords_IDN(t *testing.T) {
+	tests := []struct {
+		name              string
+		domainName        string
+		expectedAPIDomain string
+	}{
+		{
+			name:              "Punycode domain should be converted to Unicode for API",
+			domainName:        "xn--fsqu00a.com",
+			expectedAPIDomain: "例子.com",
+		},
+		{
+			name:              "ASCII domain unchanged",
+			domainName:        "example.com",
+			expectedAPIDomain: "example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockAPI := NewMockAlibabaCloudDNSAPI()
+			p := &AlibabaCloudProvider{
+				domainFilter: endpoint.NewDomainFilter([]string{tt.domainName}),
+				dryRun:       false,
+				dnsClient:    mockAPI,
+			}
+
+			_, _ = p.getDomainRecords(tt.domainName)
+
+			assert.Equal(t, tt.expectedAPIDomain, mockAPI.LastDescribeDomainName,
+				"API should receive Unicode format domain name, not punycode")
+		})
+	}
+}
+
+func TestAlibabaCloudProvider_GetDomainRecords_RRUnicodeToPunycode(t *testing.T) {
+	mockAPI := NewMockAlibabaCloudDNSAPI()
+	mockAPI.records = []alidns.Record{
+		{
+			DomainName: "例子.com",
+			RR:         "测试",
+			Type:       "A",
+		},
+	}
+
+	p := &AlibabaCloudProvider{
+		domainFilter: endpoint.NewDomainFilter([]string{"xn--fsqu00a.com"}),
+		dryRun:       false,
+		dnsClient:    mockAPI,
+	}
+
+	records, err := p.getDomainRecords("xn--fsqu00a.com")
+
+	assert.NoError(t, err)
+	if assert.Len(t, records, 1) {
+		assert.Equal(t, "xn--0zwm56d", records[0].RR)
+		assert.Equal(t, "xn--fsqu00a.com", records[0].DomainName)
 	}
 }


### PR DESCRIPTION
  Alibaba Cloud DNS API expects Unicode for IDN domains; convert Punycode to Unicode before API calls and back to Punycode after responses to keep internal consistency.

  Also normalize non-ASCII RR labels to Punycode when reading records.

  ## What does it do ?

  - Converts IDN DomainName to Unicode for Alibaba Cloud API calls (create/describe).
  - Converts returned DomainName and non‑ASCII RR labels back to Punycode for internal matching.
  - Adds unit tests for IDN conversions in create/get record paths.

  ## Motivation

  Alibaba Cloud DNS API returns InvalidDomainName.NoExist when DomainName is Punycode.
  This change ensures API calls use Unicode while keeping internal behavior consistent.

  ## More

  - [x] Yes, this PR title follows Conventional Commits (https://www.conventionalcommits.org/en/v1.0.0/)
  - [x] Yes, I added unit tests
  - [x] Yes, I updated end user documentation accordingly (Documentation not needed for this change)