### PR TITLE
docs: Consistency review on namespaced configs in chart readme

### DIFF
--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -64,13 +64,11 @@ If `namespaced=true` is defined, the Helm chart will setup `Roles` and `RoleBind
 Note: When using Gateway API sources in namespaced mode, a cluster-scoped permission to list namespaces is required, unless you also set `gatewayNamespace`. If you set `gatewayNamespace`, all RBAC remains namespaced and no `ClusterRole`/`ClusterRoleBinding` is created.
 
 ### Namespace-only limitations
-=======
 
 Not all sources are supported in namespace-only scope, since some sources depend on cluster-wide resources.
 For example: Source `node` isn't supported, since `kind: Node` has scope `Cluster`.
 Sources like `istio-virtualservice` only work if all resources like `Gateway` and `VirtualService` are present in the same
 namespace as `external-dns`.
-
 The annotation `external-dns.alpha.kubernetes.io/endpoints-type: NodeExternalIP` is not supported.
 
 If `namespaced` is set to `true`, please ensure that `sources` only contains supported sources (Default: `service,ingress`).

--- a/charts/external-dns/README.md.gotmpl
+++ b/charts/external-dns/README.md.gotmpl
@@ -59,13 +59,11 @@ If `namespaced=true` is defined, the Helm chart will setup `Roles` and `RoleBind
 Note: When using Gateway API sources in namespaced mode, a cluster-scoped permission to list namespaces is required, unless you also set `gatewayNamespace`. If you set `gatewayNamespace`, all RBAC remains namespaced and no `ClusterRole`/`ClusterRoleBinding` is created.
 
 ### Namespace-only limitations
-=======
 
 Not all sources are supported in namespace-only scope, since some sources depend on cluster-wide resources.
 For example: Source `node` isn't supported, since `kind: Node` has scope `Cluster`.
 Sources like `istio-virtualservice` only work if all resources like `Gateway` and `VirtualService` are present in the same
 namespace as `external-dns`.
-
 The annotation `external-dns.alpha.kubernetes.io/endpoints-type: NodeExternalIP` is not supported.
 
 If `namespaced` is set to `true`, please ensure that `sources` only contains supported sources (Default: `service,ingress`).


### PR DESCRIPTION
## What does it do ?

Review the "namespace-only" docs in the Helm chart for consistency.

## Motivation

Saw a typo when installing the chart.

## More

- [X] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [X] Yes, I updated end user documentation accordingly