### PR TITLE
chore(e2e): remove call to get latest kubectl

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -5,6 +5,7 @@ set -e
 KO_VERSION="0.18.0"
 KIND_VERSION="0.30.0"
 ALPINE_VERSION="3.22"
+KUBECTL_VERSION="1.35.0"
 
 echo "Starting end-to-end tests for external-dns with local provider..."
 
@@ -20,7 +21,7 @@ kind create cluster
 
 # Install kubectl
 echo "Installing kubectl..."
-curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+curl -LO "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
 chmod +x kubectl
 sudo mv kubectl /usr/local/bin/kubectl
 


### PR DESCRIPTION
## What does it do ?

Fixes #6147 by removing a call that is not needed. 

We will eventually need to get at the bottom of how we want to keep the versions for the script up to date, but for now, there's a human in the loop 🤓  

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
