### PR TITLE
chore(endpoint): added empty checks

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -305,6 +305,9 @@ func (e *Endpoint) WithProviderSpecific(key, value string) *Endpoint {
 
 // GetProviderSpecificProperty returns the value of a ProviderSpecificProperty if the property exists.
 func (e *Endpoint) GetProviderSpecificProperty(key string) (string, bool) {
+	if len(e.ProviderSpecific) == 0 {
+		return "", false
+	}
 	for _, providerSpecific := range e.ProviderSpecific {
 		if providerSpecific.Name == key {
 			return providerSpecific.Value, true
@@ -331,6 +334,13 @@ func (e *Endpoint) GetBoolProviderSpecificProperty(key string) (bool, bool) {
 
 // SetProviderSpecificProperty sets the value of a ProviderSpecificProperty.
 func (e *Endpoint) SetProviderSpecificProperty(key string, value string) {
+	if len(e.ProviderSpecific) == 0 {
+		e.ProviderSpecific = append(e.ProviderSpecific, ProviderSpecificProperty{
+			Name:  key,
+			Value: value,
+		})
+		return
+	}
 	for i, providerSpecific := range e.ProviderSpecific {
 		if providerSpecific.Name == key {
 			e.ProviderSpecific[i] = ProviderSpecificProperty{
@@ -346,6 +356,9 @@ func (e *Endpoint) SetProviderSpecificProperty(key string, value string) {
 
 // DeleteProviderSpecificProperty deletes any ProviderSpecificProperty of the specified name.
 func (e *Endpoint) DeleteProviderSpecificProperty(key string) {
+	if len(e.ProviderSpecific) == 0 {
+		return
+	}
 	for i, providerSpecific := range e.ProviderSpecific {
 		if providerSpecific.Name == key {
 			e.ProviderSpecific = append(e.ProviderSpecific[:i], e.ProviderSpecific[i+1:]...)

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -191,26 +191,33 @@ func TestIsLess(t *testing.T) {
 }
 
 func TestGetProviderSpecificProperty(t *testing.T) {
-	e := &Endpoint{
-		ProviderSpecific: []ProviderSpecificProperty{
-			{
-				Name:  "name",
-				Value: "value",
-			},
-		},
-	}
+	t.Run("empty provider specific", func(t *testing.T) {
+		e := &Endpoint{}
+		val, ok := e.GetProviderSpecificProperty("any")
+		assert.False(t, ok)
+		assert.Empty(t, val)
+	})
 
 	t.Run("key is not present in provider specific", func(t *testing.T) {
+		e := &Endpoint{
+			ProviderSpecific: []ProviderSpecificProperty{
+				{Name: "name", Value: "value"},
+			},
+		}
 		val, ok := e.GetProviderSpecificProperty("hello")
 		assert.False(t, ok)
 		assert.Empty(t, val)
 	})
 
 	t.Run("key is present in provider specific", func(t *testing.T) {
+		e := &Endpoint{
+			ProviderSpecific: []ProviderSpecificProperty{
+				{Name: "name", Value: "value"},
+			},
+		}
 		val, ok := e.GetProviderSpecificProperty("name")
 		assert.True(t, ok)
-		assert.NotEmpty(t, val)
-
+		assert.Equal(t, "value", val)
 	})
 }
 
@@ -360,6 +367,12 @@ func TestDeleteProviderSpecificProperty(t *testing.T) {
 		key      string
 		expected []ProviderSpecificProperty
 	}{
+		{
+			name:     "empty provider specific",
+			endpoint: Endpoint{},
+			key:      "any",
+			expected: nil,
+		},
 		{
 			name: "name and key are not matching",
 			endpoint: Endpoint{


### PR DESCRIPTION
## What does it do ?

I captured, that even for 0 properties, there is an improvement if we use Map vs Slice. Reason

- The speedup is consistent (1.38-1.40x) across all endpoint counts, confirming it's a per-lookup constant overhead, not algorithmic complexity.

So I've added empty check to avoid lookups for specific cases.

```go
if len(e.ProviderSpecific) == 0 {
		.......
	}
```

To make sure when ZERO properties, Slice and Map behave same way now

  The final implementation:
  - GetProviderSpecificProperty: len check + slice iteration
  - SetProviderSpecificProperty: slice iteration + append
  - DeleteProviderSpecificProperty: len check + slice iteration + remove

## Motivation

Benchmark results https://github.com/kubernetes-sigs/external-dns/pull/6156
Map or Slice https://github.com/kubernetes-sigs/external-dns/pull/5814 

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
