### PR TITLE
feat(crd): Support MX record with trailing dot

### DIFF
--- a/docs/sources/mx-record.md
+++ b/docs/sources/mx-record.md
@@ -1,7 +1,7 @@
 # MX record with CRD source
 
 You can create and manage MX records with the help of [CRD source](../sources/crd.md)
-and `DNSEndpoint` CRD. Currently, this feature is only supported by `aws`, `azure`, `cloudflare`, `digitalocean` and `google` providers.
+and `DNSEndpoint` CRD. Currently, this feature is only supported by `aws`, `azure`, `cloudflare`, `digitalocean`, `google` and `webhook` providers.
 
 In order to start managing MX records you need to set the `--managed-record-types=MX` flag.
 

--- a/source/crd.go
+++ b/source/crd.go
@@ -195,25 +195,21 @@ func (cs *crdSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 			if (ep.RecordType == endpoint.RecordTypeCNAME || ep.RecordType == endpoint.RecordTypeA || ep.RecordType == endpoint.RecordTypeAAAA) && len(ep.Targets) < 1 {
 				log.Debugf("Endpoint %s with DNSName %s has an empty list of targets, allowing it to pass through for default-targets processing", dnsEndpoint.Name, ep.DNSName)
 			}
-			isNAPTR := ep.RecordType == endpoint.RecordTypeNAPTR
-			isTXT := ep.RecordType == endpoint.RecordTypeTXT
-			isMx := ep.RecordType == endpoint.RecordTypeMX
 			illegalTarget := false
 			for _, target := range ep.Targets {
 				hasDot := strings.HasSuffix(target, ".")
-				// Skip dot validation for TXT records as they can contain arbitrary text
-				if !isTXT {
-					// Allow trailing dots if record is NAPTR OR MX.
-					// Otherwise, if it's NOT NAPTR and NOT MX, a dot is illegal.
-					if isNAPTR || isMx {
-						if !hasDot {
-							illegalTarget = true
-							break
-						}
-					} else if hasDot {
-						illegalTarget = true
-						break
-					}
+
+				switch ep.RecordType {
+				case endpoint.RecordTypeTXT, endpoint.RecordTypeMX:
+					continue // TXT records allow arbitrary text, skip validation; MX records can have trailing dot but it's not required, skip validation
+				case endpoint.RecordTypeNAPTR:
+					illegalTarget = !hasDot // Must have trailing dot
+				default:
+					illegalTarget = hasDot // Must NOT have trailing dot
+				}
+
+				if illegalTarget {
+					break
 				}
 			}
 			if illegalTarget {

--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -539,6 +539,27 @@ func testCRDSourceEndpoints(t *testing.T) {
 			expectEndpoints: true,
 			expectError:     false,
 		},
+		{
+			title:                "MX Record without trailing dot in target",
+			registeredAPIVersion: apiv1alpha1.GroupVersion.String(),
+			apiVersion:           apiv1alpha1.GroupVersion.String(),
+			registeredKind:       apiv1alpha1.DNSEndpointKind,
+			kind:                 apiv1alpha1.DNSEndpointKind,
+			namespace:            "foo",
+			registeredNamespace:  "foo",
+			labels:               map[string]string{"test": "that"},
+			labelFilter:          "test=that",
+			endpoints: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					Targets:    endpoint.Targets{"example.com"},
+					RecordType: endpoint.RecordTypeMX,
+					RecordTTL:  180,
+				},
+			},
+			expectEndpoints: true,
+			expectError:     false,
+		},
 	} {
 		t.Run(ti.title, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
## What does it do ?

This PR allows trailing dots in MX Record targets, allowing to use a different FQDN for your Mail server

## Motivation

Currently trailing dots are not supported in MX records that are created using the DNSEndpoint CRD. But an MX record with a trailing dot signifies a FQDN, instructing the DNS server not to append the root domain to the entry, which is important in case your Mail server is not running under the same domain.

Currently external DNS throughs a warning like this if the target has a trailing dot:
```
Endpoint <endpoint name> with DNSName fqdn.example.com. has an illegal target format.
```

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
