### PR TITLE
resolve `LC_DYSYMTAB` warning in unit test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ update-tools-deps:
 #? test: The verify target runs tasks similar to the CI tasks, but without code coverage
 .PHONY: test
 test:
-	go test -race ./...
+	CGO_ENABLED=0 go test -race ./...
 
 
 .PHONY: test


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

Fix `ld` warning in macos
```
$ make test
...
# sigs.k8s.io/external-dns/provider/ns1.test
ld: warning: '/private/var/folders/wb/t6q4mr6d5bj96h5clzfc6xzc0000gn/T/go-link-2160407824/000013.o' has malformed LC_DYSYMTAB, expected 98 undefined symbols to start at index 1626, found 95 undefined symbols starting at index 1626
ok  	sigs.k8s.io/external-dns/provider/linode	1.630s
# sigs.k8s.io/external-dns/provider/oci.test
ld: warning: '/private/var/folders/wb/t6q4mr6d5bj96h5clzfc6xzc0000gn/T/go-link-2561427685/000013.o' has malformed LC_DYSYMTAB, expected 98 undefined symbols to start at index 1626, found 95 undefined symbols starting at index 1626
...
```