### PR TITLE
deps(go): bump go from 1.25.5 -> 1.25.7. CVE fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/external-dns
 
-go 1.25.5
+go 1.25.7
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0


### PR DESCRIPTION
## What does it do ?

Announcment https://groups.google.com/g/golang-nuts/c/05wEerWuZVU

I'm not sure where or not we are vulnerabile, same time HIGH CVE fixed in 1.27. https://cyberpress.org/go-1-25-7-and-1-24-13-released/

Based on recent Bitnami/VMware security releases,
version 1.25.7 fixes high-severity vulnerabilities in specific container components. 
Specifically, the 1.25.7 update addresses:

    CVE-2025-68121 (High Severity): A vulnerability in stdlib was resolved in this version. 

Additionally, Snyk vulnerability scanning shows that for certain Linux distributions (e.g., Oracle 7), versions prior to 1.25.7-2.el7 were vulnerable to several issues, including: 

    CVE-2023-27487 & CVE-2023-27488: Related to HTTP Request Smuggling and Resource Allocation. 

It is highly recommended to update to this version or higher to mitigate these security risks. 

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
