### PR TITLE
fix(civo): normalize @ apex record names

### DIFF
--- a/provider/civo/civo.go
+++ b/provider/civo/civo.go
@@ -132,7 +132,8 @@ func (p *CivoProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 
 				// root name is identified by the empty string and should be
 				// translated to zone name for the endpoint entry.
-				if r.Name == "" {
+				// The Civo API may return "@" for apex records instead of "".
+				if r.Name == "" || r.Name == "@" {
 					name = zone.Name
 				}
 
@@ -539,7 +540,12 @@ func getRecordID(records []civogo.DNSRecord, zone civogo.DNSDomain, ep endpoint.
 	for _, record := range records {
 		stripedName := getStrippedRecordName(zone, ep)
 		toUpper := strings.ToUpper(string(record.Type))
-		if record.Name == stripedName && toUpper == ep.RecordType {
+		// The Civo API may return "@" for apex record names instead of "".
+		recordName := record.Name
+		if recordName == "@" {
+			recordName = ""
+		}
+		if recordName == stripedName && toUpper == ep.RecordType {
 			matchedRecords = append(matchedRecords, record)
 		}
 	}


### PR DESCRIPTION
## What does it do ?

Normalizes `"@"` apex record names from the Civo DNS API to empty strings,
matching the provider's existing convention for root domain records.

## Motivation

The Civo API returns `"@"` as the name for apex DNS records. The provider
expected `""`, causing `Records()` to construct names like `@.example.com`
and `getRecordID()` to fail matching existing records. This resulted in
`database_dns_record_already_exist` errors on every sync loop.

Confirmed via live Civo API calls — all apex records return `"name": "@"`.

Related: #6183

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly — not applicable