### PR TITLE
provider/akamai: return early when there are no relevant changes

### DIFF
--- a/provider/akamai/akamai.go
+++ b/provider/akamai/akamai.go
@@ -256,6 +256,12 @@ func (p AkamaiProvider) Records(context.Context) ([]*endpoint.Endpoint, error) {
 
 // ApplyChanges applies a given set of changes in a given zone.
 func (p AkamaiProvider) ApplyChanges(_ context.Context, changes *plan.Changes) error {
+	// return early if there is nothing to change
+	if len(changes.Create) == 0 && len(changes.Delete) == 0 && len(changes.UpdateNew) == 0 {
+		log.Info("All records are already up to date")
+		return nil
+	}
+
 	zoneNameIDMapper := provider.ZoneIDName{}
 	zones, err := p.fetchZones()
 	if err != nil {

--- a/provider/akamai/akamai_test.go
+++ b/provider/akamai/akamai_test.go
@@ -369,3 +369,23 @@ func TestAkamaiApplyChanges(t *testing.T) {
 	apply := c.ApplyChanges(context.Background(), changes)
 	assert.NoError(t, apply)
 }
+
+func TestAkamaiApplyChangesEmpty(t *testing.T) {
+	stub := newStub()
+	domfilter := endpoint.NewDomainFilter([]string{"example.com"})
+	idfilter := provider.ZoneIDFilter{}
+	c, err := createAkamaiStubProvider(stub, domfilter, idfilter)
+	require.NoError(t, err)
+
+	// Don't set up any zone output - if fetchZones is called, it would return empty
+	// but we're testing that it's not called at all
+	changes := &plan.Changes{
+		Create:    []*endpoint.Endpoint{},
+		Delete:    []*endpoint.Endpoint{},
+		UpdateOld: []*endpoint.Endpoint{},
+		UpdateNew: []*endpoint.Endpoint{},
+	}
+
+	err = c.ApplyChanges(context.Background(), changes)
+	assert.NoError(t, err)
+}

--- a/provider/akamai/akamai_test.go
+++ b/provider/akamai/akamai_test.go
@@ -389,3 +389,34 @@ func TestAkamaiApplyChangesEmpty(t *testing.T) {
 	err = c.ApplyChanges(context.Background(), changes)
 	assert.NoError(t, err)
 }
+
+func TestAkamaiApplyChangesFilteredByDomain(t *testing.T) {
+	stub := newStub()
+	domfilter := endpoint.NewDomainFilter([]string{"example.com"})
+	idfilter := provider.ZoneIDFilter{}
+	c, err := createAkamaiStubProvider(stub, domfilter, idfilter)
+	require.NoError(t, err)
+
+	// Set up zones for example.com only
+	stub.setOutput("zone", []any{"example.com"})
+
+	// All changes are for other.com which doesn't match the domain filter
+	// These should be filtered out and no API calls should be made
+	changes := &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			{DNSName: "www.other.com", RecordType: "A", Targets: endpoint.Targets{"10.0.0.1"}, RecordTTL: 300},
+		},
+		Delete: []*endpoint.Endpoint{
+			{DNSName: "delete.other.com", RecordType: "A", Targets: endpoint.Targets{"10.0.0.2"}, RecordTTL: 300},
+		},
+		UpdateOld: []*endpoint.Endpoint{
+			{DNSName: "update.other.com", RecordType: "A", Targets: endpoint.Targets{"10.0.0.3"}, RecordTTL: 300},
+		},
+		UpdateNew: []*endpoint.Endpoint{
+			{DNSName: "update.other.com", RecordType: "A", Targets: endpoint.Targets{"10.0.0.4"}, RecordTTL: 300},
+		},
+	}
+
+	err = c.ApplyChanges(context.Background(), changes)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## What does it do ?

Currently, if a cluster has multiple instances of external-dns, with
different domain filters (e.g across multiple providers), the Akamai
provider will repeatedly re-create all of its zones records, even when
there are no changes relevant to its filtered set.

While this isn't inherently a problem for a single cluster controlling
an entire zone, if you have many clusters updating records in a single
zone, the chances of these no-op operations conflicting, failing, and
resulting in the exit of external-dns is quite high. This can prevent
real changes from being applied.

This PR adds defensive filtering and exiting when no relevant
changes are detected, based pretty heavily on the implementations of
other, more active providers.

## Motivation

Production issues with external-dns regularly crashing when it conflicts with other instances for no-op change applications.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly (There isn't really documentation for this behavior)