### PR TITLE
chore(endpoint): harden AES-GCM encryption and remove sensitive data from logs

### DIFF
--- a/endpoint/crypto_test.go
+++ b/endpoint/crypto_test.go
@@ -27,10 +27,16 @@ import (
 )
 
 func TestEncrypt(t *testing.T) {
-	// Verify that text encryption and decryption works
+	// Verify that nil nonce is rejected
 	aesKey := []byte("s%zF`.*'5`9.AhI2!B,.~hmbs^.*TL?;")
 	plaintext := "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
-	encryptedtext, err := EncryptText(plaintext, aesKey, nil)
+	_, err := EncryptText(plaintext, aesKey, "")
+	require.EqualError(t, err, "nonce must be provided")
+
+	// Verify that text encryption and decryption works with a generated nonce
+	nonce, err := GenerateNonce()
+	require.NoError(t, err)
+	encryptedtext, err := EncryptText(plaintext, aesKey, nonce)
 	require.NoError(t, err)
 	decryptedtext, _, err := DecryptText(encryptedtext, aesKey)
 	require.NoError(t, err)
@@ -67,7 +73,7 @@ func TestGenerateNonceSuccess(t *testing.T) {
 	require.NotEmpty(t, nonce)
 
 	// Test nonce length
-	decodedNonce, err := base64.StdEncoding.DecodeString(string(nonce))
+	decodedNonce, err := base64.StdEncoding.DecodeString(nonce)
 	require.NoError(t, err)
 	require.Len(t, decodedNonce, standardGcmNonceSize)
 }
@@ -82,7 +88,7 @@ func TestGenerateNonceError(t *testing.T) {
 
 	nonce, err := GenerateNonce()
 	require.Error(t, err)
-	require.Nil(t, nonce)
+	require.Empty(t, nonce)
 }
 
 type faultyReader struct{}

--- a/endpoint/labels_test.go
+++ b/endpoint/labels_test.go
@@ -105,7 +105,7 @@ func (suite *LabelsSuite) TestEncryptionFailed() {
 	_ = foo.Serialize(false, true, []byte("wrong-key"))
 
 	suite.True(fatalCrash, "should fail if encryption key is wrong")
-	suite.Contains(b.String(), "Failed to encrypt the text")
+	suite.Contains(b.String(), "Failed to encrypt the text:")
 }
 
 func (suite *LabelsSuite) TestEncryptionFailedFaultyReader() {


### PR DESCRIPTION
## What does it do ?

  - Reject empty nonce in EncryptText with explicit error instead of silently using all-zero nonce
  - Fail fast — validate nonce before allocating cipher/GCM
  - Use consistent NewGCMWithNonceSize in both encrypt and decrypt paths
  - Change GenerateNonce return type from []byte to string to eliminate redundant type conversions
  - Stop logging AES key and plaintext in Serialize error path
  - Stop logging ciphertext in DecryptText debug path
  - Remove logrus dependency from crypto.go
  - labels.go -> Simplify with direct map lookup — no need for var declaration + extractedNonce temporary
  - Simplify error messages to include data sizes instead of dumping full ciphertext

follow-up:
- more tests for this package

## Motivation

  - An empty nonce produces an all-zero GCM nonce which breaks AES-GCM's security guarantees if reused with the same key
  - The log.Fatalf message in Serialize included the AES encryption key in plaintext, which would leak to any log aggregator
  - Encrypt/decrypt used different GCM constructors (NewGCMWithNonceSize vs NewGCM) — functionally equivalent for 12-byte nonce today, but fragile if the constant ever
  changes
  - Error messages dumped full ciphertext which is noisy and unhelpful for debugging
## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
