### PR TITLE
fix(coredns): unexpected delete when owner is activated

### DIFF
--- a/provider/coredns/coredns.go
+++ b/provider/coredns/coredns.go
@@ -447,12 +447,8 @@ func (p coreDNSProvider) createServicesForEndpoint(ctx context.Context, dnsName 
 			continue
 		}
 		if !slices.Contains(ep.Targets, label) {
-			key := p.etcdKeyFor(labelPrefix + "." + dnsName)
-			log.Infof("Delete key %s", key)
-			if p.dryRun {
-				continue
-			}
-			if err := p.client.DeleteService(ctx, key); err != nil {
+			err := p.deleteByDnsName(ctx, labelPrefix+"."+dnsName)
+			if err != nil {
 				return nil, err
 			}
 		}
@@ -494,14 +490,22 @@ func (p coreDNSProvider) deleteEndpoints(ctx context.Context, endpoints []*endpo
 		if ep.Labels[randomPrefixLabel] != "" {
 			dnsName = ep.Labels[randomPrefixLabel] + "." + dnsName
 		}
-		key := p.etcdKeyFor(dnsName)
-		log.Infof("Delete key %s", key)
-		if p.dryRun {
-			continue
-		}
-		if err := p.client.DeleteService(ctx, key); err != nil {
+		err := p.deleteByDnsName(ctx, dnsName)
+		if err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func (p coreDNSProvider) deleteByDnsName(ctx context.Context, dnsName string) error {
+	key := p.etcdKeyFor(dnsName)
+	log.Infof("Delete key %s", key)
+	if p.dryRun {
+		return nil
+	}
+	if err := p.client.DeleteService(ctx, key); err != nil {
+		return err
 	}
 	return nil
 }

--- a/provider/coredns/coredns.go
+++ b/provider/coredns/coredns.go
@@ -51,7 +51,8 @@ const (
 
 var (
 	// avoids allocating a new slice on every call
-	skipLabels = []string{"originalText", "prefix", "resource"}
+	// prevents unwanted deletion of etcd keys based on labels
+	skipLabels = []string{"originalText", "prefix", "resource", endpoint.OwnerLabelKey}
 )
 
 // coreDNSClient is an interface to work with CoreDNS service records in etcd

--- a/provider/coredns/coredns_test.go
+++ b/provider/coredns/coredns_test.go
@@ -1326,6 +1326,66 @@ func TestApplyChangesAWithGroupServiceTranslation(t *testing.T) {
 	validateServices(client.services, expectedServices1, t, 1)
 }
 
+// Prevents unwanted deletion of etcd keys https://github.com/kubernetes-sigs/external-dns/commit/83ea480c57fcc6beeaf8a6a3e8446cb87e07415d
+func TestApplyChangesPreventCleanupForKnownLabels(t *testing.T) {
+	client := fakeETCDClient{
+		map[string]Service{
+			"/skydns/local/domain1/test":         {Host: "10.0.0.0"},
+			"/skydns/local/domain1/originalText": {Host: "10.0.0.0"},
+			"/skydns/local/domain1/prefix":       {Host: "10.0.0.0"},
+			"/skydns/local/domain1/resource":     {Host: "10.0.0.0"},
+			"/skydns/local/domain1/owner":        {Host: "10.0.0.0"},
+		},
+	}
+	coredns := coreDNSProvider{
+		client:        client,
+		coreDNSPrefix: defaultCoreDNSPrefix,
+	}
+
+	changes1 := &plan.Changes{
+		UpdateOld: []*endpoint.Endpoint{
+			{
+				DNSName:    "domain1.local",
+				RecordType: endpoint.RecordTypeA,
+				Targets:    endpoint.Targets{"5.5.5.5"},
+				Labels: map[string]string{
+					"5.5.5.5":              "random",
+					"10.0.0.0":             "test",
+					"originalText":         "originalText",
+					"prefix":               "prefix",
+					"resource":             "resource",
+					endpoint.OwnerLabelKey: endpoint.OwnerLabelKey,
+				},
+			},
+		},
+		UpdateNew: []*endpoint.Endpoint{
+			{
+				DNSName:    "domain1.local",
+				RecordType: endpoint.RecordTypeA,
+				Targets:    endpoint.Targets{"5.5.5.5"},
+				Labels: map[string]string{
+					"5.5.5.5":              "random",
+					"10.0.0.0":             "test",
+					"originalText":         "originalText",
+					"prefix":               "prefix",
+					"resource":             "resource",
+					endpoint.OwnerLabelKey: endpoint.OwnerLabelKey,
+				},
+			},
+		},
+	}
+	coredns.ApplyChanges(t.Context(), changes1)
+
+	expectedServices1 := map[string][]*Service{
+		"/skydns/local/domain1":              {{Host: "5.5.5.5", Key: "/skydns/local/domain1/random", Text: "originalText", TargetStrip: 1}},
+		"/skydns/local/domain1/originalText": {{Host: "10.0.0.0"}},
+		"/skydns/local/domain1/prefix":       {{Host: "10.0.0.0"}},
+		"/skydns/local/domain1/resource":     {{Host: "10.0.0.0"}},
+		"/skydns/local/domain1/owner":        {{Host: "10.0.0.0"}},
+	}
+	validateServices(client.services, expectedServices1, t, 1)
+}
+
 func TestRecordsAWithGroupServiceTranslation(t *testing.T) {
 	client := fakeETCDClient{
 		map[string]Service{


### PR DESCRIPTION
## What does it do ?

Add owner to list of skip labels, original list: https://github.com/kubernetes-sigs/external-dns/commit/83ea480c57fcc6beeaf8a6a3e8446cb87e07415d

## Motivation

Unexpected deletion with a key containing the txt-owner, if stricly-owned is active.

### Eample

args:
```
--txt-owner-id=test-owner
--coredns-strictly-owned
```

log line:
```
{"level":"info","msg":"Delete key /skydns/local/domain1/test-owner","time":"2026-02-18T12:13:49Z"} 
```

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
