### PR TITLE
fix(coredns): prevent duplicated refs for endpoint

### DIFF
--- a/provider/coredns/coredns.go
+++ b/provider/coredns/coredns.go
@@ -356,7 +356,9 @@ func (p coreDNSProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, err
 			ep.Labels[originalTextLabel] = service.Text
 			ep.Labels[randomPrefixLabel] = prefix
 			ep.Labels[service.Host] = prefix
-			result = append(result, ep)
+			if !found {
+				result = append(result, ep)
+			}
 		}
 		if service.Text != "" {
 			ep := endpoint.NewEndpoint(

--- a/provider/coredns/coredns_test.go
+++ b/provider/coredns/coredns_test.go
@@ -1793,3 +1793,34 @@ func TestPTRRecords(t *testing.T) {
 		assert.Equal(t, "txt-value", services[0].Text)
 	})
 }
+
+func TestRecordsTargetStripToSources(t *testing.T) {
+	expectedTargetA := "1.2.3.4"
+	expectedTargetB := "1.2.3.5"
+	expectedDNSName := "bla.example.com"
+
+	client := &fakeETCDClient{
+		services: map[string]Service{
+			"/skydns/com/example/bla/foo": {Host: expectedTargetA, TargetStrip: 1},
+			"/skydns/com/example/bla/bar": {Host: expectedTargetB, TargetStrip: 1},
+		},
+	}
+	provider := coreDNSProvider{
+		client:        client,
+		coreDNSPrefix: defaultCoreDNSPrefix,
+	}
+	endpoints, err := provider.Records(context.Background())
+	require.NoError(t, err)
+	if len(endpoints) != 1 {
+		t.Fatalf("got unexpected number of endpoints: %d", len(endpoints))
+	}
+	if endpoints[0].DNSName != expectedDNSName {
+		t.Errorf("got unexpected DNS name: %s != %s", endpoints[0].DNSName, expectedDNSName)
+	}
+	if endpoints[0].Labels[expectedTargetA] != "foo" {
+		t.Errorf("got unexpected host to prefix: %s != %s", endpoints[0].Labels[expectedTargetA], "foo")
+	}
+	if endpoints[0].Labels[expectedTargetB] != "bar" {
+		t.Errorf("got unexpected host to prefix: %s != %s", endpoints[0].Labels[expectedTargetA], "bar")
+	}
+}


### PR DESCRIPTION
## What does it do ?

Do not append on, if service was found in results.

## Motivation

Prevent duplicated data to be returned by coredns for non text services. 

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
