### PR TITLE
feat(cloudflare): custom hostname SNI overrides and migration support

### DIFF
--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -360,6 +360,8 @@ Origin SNI overrides require a Cloudflare account entitlement — contact your C
 
 Multiple hostnames are supported via a comma-separated list: `external-dns.alpha.kubernetes.io/cloudflare-custom-hostname: <custom hostname 1>,<custom hostname 2>`.
 
+Setting the annotation to `-` tells external-dns to skip custom hostname management for this record entirely — existing custom hostnames in Cloudflare are left untouched. This is useful when migrating CH ownership to another controller.
+
 See [Cloudflare for Platforms](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/domain-support/) for more information on custom hostnames.
 
 This feature is disabled by default and supports the `--cloudflare-custom-hostnames-min-tls-version` and `--cloudflare-custom-hostnames-certificate-authority` flags.

--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -356,6 +356,8 @@ Currently, requires SuperAdmin or Admin role.
 
 Automatic configuration of Cloudflare custom hostnames (using A/CNAME DNS records as custom origin servers) is enabled by the `--cloudflare-custom-hostnames` flag and the `external-dns.alpha.kubernetes.io/cloudflare-custom-hostname: <custom hostname>` annotation.
 
+Origin SNI overrides require a Cloudflare account entitlement — contact your Cloudflare account team to request access (see [Custom origin server](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/custom-origin/)). When enabled, the Origin SNI defaults to the origin hostname and can be overridden using the `<customHostname>=<customOriginSNI>` annotation format. A trailing `=` with no value (`<customHostname>=`) sets the Origin SNI to the request's Host header instead.
+
 Multiple hostnames are supported via a comma-separated list: `external-dns.alpha.kubernetes.io/cloudflare-custom-hostname: <custom hostname 1>,<custom hostname 2>`.
 
 See [Cloudflare for Platforms](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/domain-support/) for more information on custom hostnames.

--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -372,6 +372,24 @@ The custom hostname DNS must resolve to the Cloudflare DNS record (`external-dns
 
 Requires [Cloudflare for SaaS](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/) product and "SSL and Certificates" API permission.
 
+### Known limitation: `-` sentinel and DNS record lifecycle
+
+The `-` sentinel prevents external-dns from **creating or updating** custom hostnames. However, when a DNS record is deleted (e.g., due to an HTTPRoute parentRef change that causes zero resolved targets), external-dns deletes all custom hostnames associated with that record as part of the DNS record cleanup -- regardless of the `-` annotation.
+
+This means that infrastructure changes affecting DNS record lifecycle (gateway transitions, parentRef changes) can trigger custom hostname deletion and re-creation even when the annotation is set to `-`. The custom hostname will be re-created by whatever controller manages it (e.g., an operator), but SSL re-provisioning (~1-3 minutes) causes a brief disruption.
+
+### Migrating custom hostname management to another controller
+
+To fully migrate custom hostname management away from external-dns (e.g., to a dedicated Kubernetes operator):
+
+1. **Set the annotation to `-`** on all relevant endpoints. This tells external-dns to stop creating and updating custom hostnames. The other controller can now manage them.
+
+2. **Verify the other controller is managing all custom hostnames correctly.** Both can coexist safely at this stage -- `-` prevents external-dns from interfering with creates/updates.
+
+3. **Disable custom hostnames in external-dns entirely** by removing the `--cloudflare-custom-hostnames` flag (or setting it to false) and redeploying. When disabled, external-dns does not perform any custom hostname operations -- no creates, no updates, and no deletes. DNS record lifecycle (A/CNAME records) continues normally without any custom hostname side effects.
+
+Step 3 is important: until custom hostnames are fully disabled in external-dns, DNS record changes (such as gateway transitions) can still trigger custom hostname deletion as a side effect. Disabling the feature cleanly breaks this tie.
+
 ## Setting Cloudflare DNS Record Tags
 
 Cloudflare allows you to add descriptive tags to DNS records. This can be useful for organizing your records.

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"os"
 	"sort"
@@ -222,6 +223,7 @@ type CloudFlareProvider struct {
 	proxiedByDefault       bool
 	DryRun                 bool
 	CustomHostnamesConfig  CustomHostnamesConfig
+	CustomHostnamesCurrent customHostnamesMap // set by Records(), used by AdjustEndpoints()
 	DNSRecordsConfig       DNSRecordsConfig
 	RegionalServicesConfig RegionalServicesConfig
 }
@@ -404,6 +406,7 @@ func (p *CloudFlareProvider) Records(ctx context.Context) ([]*endpoint.Endpoint,
 		return nil, err
 	}
 
+	p.CustomHostnamesCurrent = make(customHostnamesMap)
 	var endpoints []*endpoint.Endpoint
 	for _, zone := range zones {
 		records, err := p.getDNSRecordsMap(ctx, zone.ID)
@@ -416,6 +419,7 @@ func (p *CloudFlareProvider) Records(ctx context.Context) ([]*endpoint.Endpoint,
 		if chErr != nil {
 			return nil, chErr
 		}
+		maps.Copy(p.CustomHostnamesCurrent, chs)
 
 		// As CloudFlare does not support "sets" of targets, but instead returns
 		// a single entry for each name/type/target, we have to group by name
@@ -642,8 +646,16 @@ func (p *CloudFlareProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]
 		e.SetProviderSpecificProperty(annotations.CloudflareProxiedKey, strconv.FormatBool(proxied))
 
 		if p.CustomHostnamesConfig.Enabled {
-			// sort custom hostnames in annotation to properly detect changes
-			if customHostnames := getEndpointCustomHostnames(e); len(customHostnames) > 1 {
+			customHostnames := getEndpointCustomHostnames(e)
+			if customHostnames == nil {
+				// managed externally: match desired to current CF state to avoid no-op updates
+				if ann := p.chAnnotationForOrigin(e.DNSName); ann != "" {
+					e.SetProviderSpecificProperty(annotations.CloudflareCustomHostnameKey, ann)
+				} else {
+					e.DeleteProviderSpecificProperty(annotations.CloudflareCustomHostnameKey)
+				}
+			} else if len(customHostnames) > 1 {
+				// sort custom hostnames in annotation to properly detect changes
 				sort.Strings(customHostnames)
 				e.SetProviderSpecificProperty(annotations.CloudflareCustomHostnameKey, strings.Join(customHostnames, ","))
 			}
@@ -809,6 +821,32 @@ func shouldBeProxied(ep *endpoint.Endpoint, proxiedByDefault bool) bool {
 	return proxied
 }
 
+// chAnnotationHostname returns "<hostname>[=<sni>]" for the CH annotation format.
+func (c customHostname) chAnnotationHostname() string {
+	h := c.hostname
+	if c.customOriginSNI == ":request_host_header:" {
+		h += "="
+	} else if c.customOriginSNI != "" && c.customOriginSNI != c.customOriginServer {
+		h += "=" + c.customOriginSNI
+	}
+	return h
+}
+
+// chAnnotationForOrigin builds the CH annotation value from current CF state for a DNS name.
+func (p *CloudFlareProvider) chAnnotationForOrigin(origin string) string {
+	var hostnames []string
+	for _, c := range p.CustomHostnamesCurrent {
+		if c.customOriginServer == origin {
+			hostnames = append(hostnames, c.chAnnotationHostname())
+		}
+	}
+	if len(hostnames) == 0 {
+		return ""
+	}
+	sort.Strings(hostnames)
+	return strings.Join(hostnames, ",")
+}
+
 func getEndpointCustomHostnames(ep *endpoint.Endpoint) []string {
 	for _, v := range ep.ProviderSpecific {
 		if v.Name == annotations.CloudflareCustomHostnameKey {
@@ -844,15 +882,7 @@ func (p *CloudFlareProvider) groupByNameAndTypeWithCustomHostnames(records DNSRe
 	customHostnamesMap := map[string][]string{}
 
 	for _, c := range chs {
-		annotationHostname := c.hostname
-		// for custom hostnames with Origin SNI overrides use the "<customHostname>=<customOriginSNI>" format to be able to detect changes and update accordingly.
-		// if Origin SNI Value from API is ":request_host_header:", we will be using "<customHostname>=" in annotation and internally for brevity.
-		if c.customOriginSNI == ":request_host_header:" {
-			annotationHostname += "="
-		} else if c.customOriginSNI != "" && c.customOriginSNI != c.customOriginServer {
-			annotationHostname += "=" + c.customOriginSNI
-		}
-		customHostnamesMap[c.customOriginServer] = append(customHostnamesMap[c.customOriginServer], annotationHostname)
+		customHostnamesMap[c.customOriginServer] = append(customHostnamesMap[c.customOriginServer], c.chAnnotationHostname())
 	}
 
 	// create a single endpoint with all the targets for each name/type

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -836,10 +836,18 @@ func (p *CloudFlareProvider) groupByNameAndTypeWithCustomHostnames(records DNSRe
 	}
 
 	// map custom origin to custom hostname, custom origin should match to a dns record
-	customHostnames := map[string][]string{}
+	customHostnamesMap := map[string][]string{}
 
 	for _, c := range chs {
-		customHostnames[c.customOriginServer] = append(customHostnames[c.customOriginServer], c.hostname)
+		annotationHostname := c.hostname
+		// for custom hostnames with Origin SNI overrides use the "<customHostname>=<customOriginSNI>" format to be able to detect changes and update accordingly.
+		// if Origin SNI Value from API is ":request_host_header:", we will be using "<customHostname>=" in annotation and internally for brevity.
+		if c.customOriginSNI == ":request_host_header:" {
+			annotationHostname += "="
+		} else if c.customOriginSNI != "" && c.customOriginSNI != c.customOriginServer {
+			annotationHostname += "=" + c.customOriginSNI
+		}
+		customHostnamesMap[c.customOriginServer] = append(customHostnamesMap[c.customOriginServer], annotationHostname)
 	}
 
 	// create a single endpoint with all the targets for each name/type
@@ -866,7 +874,7 @@ func (p *CloudFlareProvider) groupByNameAndTypeWithCustomHostnames(records DNSRe
 		}
 		e = e.WithProviderSpecific(annotations.CloudflareProxiedKey, strconv.FormatBool(proxied))
 		// noop (customHostnames is empty) if custom hostnames feature is not in use
-		if customHostnames, ok := customHostnames[records[0].Name]; ok {
+		if customHostnames, ok := customHostnamesMap[records[0].Name]; ok {
 			sort.Strings(customHostnames)
 			e = e.WithProviderSpecific(annotations.CloudflareCustomHostnameKey, strings.Join(customHostnames, ","))
 		}

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -710,11 +710,14 @@ func (p *CloudFlareProvider) newCloudFlareChange(action changeAction, ep *endpoi
 	prevCustomHostnames := []string{}
 	newCustomHostnames := map[string]customHostname{}
 	if p.CustomHostnamesConfig.Enabled {
-		if current != nil {
-			prevCustomHostnames = getEndpointCustomHostnames(current)
-		}
-		for _, v := range getEndpointCustomHostnames(ep) {
-			newCustomHostnames[v] = p.newCustomHostname(v, ep.DNSName)
+		desiredCHs := getEndpointCustomHostnames(ep)
+		if desiredCHs != nil { // nil = managed externally, skip CH lifecycle
+			if current != nil {
+				prevCustomHostnames = getEndpointCustomHostnames(current)
+			}
+			for _, v := range desiredCHs {
+				newCustomHostnames[v] = p.newCustomHostname(v, ep.DNSName)
+			}
 		}
 	}
 
@@ -809,8 +812,10 @@ func shouldBeProxied(ep *endpoint.Endpoint, proxiedByDefault bool) bool {
 func getEndpointCustomHostnames(ep *endpoint.Endpoint) []string {
 	for _, v := range ep.ProviderSpecific {
 		if v.Name == annotations.CloudflareCustomHostnameKey {
-			customHostnames := strings.Split(v.Value, ",")
-			return customHostnames
+			if v.Value == "-" {
+				return nil // managed externally, skip
+			}
+			return strings.Split(v.Value, ",")
 		}
 	}
 	return []string{}

--- a/provider/cloudflare/cloudflare_custom_hostnames.go
+++ b/provider/cloudflare/cloudflare_custom_hostnames.go
@@ -169,9 +169,13 @@ func (p *CloudFlareProvider) processCustomHostnameUpdate(ctx context.Context, zo
 		}
 	}
 	for _, changeCH := range add {
-		log.WithFields(logFields).Infof("Adding custom hostname %q(%q=%q)",
-			change.CustomHostnames[changeCH].hostname, change.CustomHostnames[changeCH].customOriginServer, change.CustomHostnames[changeCH].customOriginSNI)
-		chErr := p.Client.CreateCustomHostname(ctx, zoneID, change.CustomHostnames[changeCH])
+		ch := change.CustomHostnames[changeCH]
+		if ch.hostname == change.ResourceRecord.Name {
+			log.WithFields(logFields).Warnf("skipping custom hostname %q: it matches the DNS record name (self-referential)", ch.hostname)
+			continue
+		}
+		log.WithFields(logFields).Infof("Adding custom hostname %q(%q=%q)", ch.hostname, ch.customOriginServer, ch.customOriginSNI)
+		chErr := p.Client.CreateCustomHostname(ctx, zoneID, ch)
 		if chErr != nil {
 			failedChange = true
 			log.WithFields(logFields).Errorf("failed to add custom hostname %q: %v", changeCH, chErr)
@@ -205,6 +209,10 @@ func (p *CloudFlareProvider) processCustomHostnameCreate(ctx context.Context, zo
 	failedChange := false
 	for _, changeCH := range change.CustomHostnames {
 		if recordTypeCustomHostnameSupported[string(change.ResourceRecord.Type)] && changeCH.hostname != "" {
+			if changeCH.hostname == change.ResourceRecord.Name {
+				log.WithFields(logFields).Warnf("skipping custom hostname %q: it matches the DNS record name (self-referential)", changeCH.hostname)
+				continue
+			}
 			log.WithFields(logFields).Infof("Creating custom hostname %q(%q=%q)", changeCH.hostname, changeCH.customOriginServer, changeCH.customOriginSNI)
 			if ch, err := getCustomHostname(chs, changeCH.hostname); err == nil {
 				if changeCH.customOriginServer == ch.customOriginServer {

--- a/provider/cloudflare/cloudflare_custom_hostnames_test.go
+++ b/provider/cloudflare/cloudflare_custom_hostnames_test.go
@@ -1019,6 +1019,97 @@ func TestManagedExternallySkipsCHLifecycle(t *testing.T) {
 	assert.Equal(t, "ch1", client.customHostnames["zone1"][0].id)
 }
 
+func TestManagedExternallyNoOpUpdate(t *testing.T) {
+	provider := &CloudFlareProvider{
+		CustomHostnamesConfig: CustomHostnamesConfig{Enabled: true},
+		CustomHostnamesCurrent: customHostnamesMap{
+			customHostnameIndex{hostname: "app.example.com"}: {
+				hostname:           "app.example.com",
+				customOriginServer: "origin.example.com",
+				customOriginSNI:    ":request_host_header:",
+			},
+		},
+	}
+
+	// simulate Records() output (current side)
+	currentEP := &endpoint.Endpoint{
+		DNSName:    "origin.example.com",
+		RecordType: "A",
+		Targets:    endpoint.Targets{"1.2.3.4"},
+		ProviderSpecific: endpoint.ProviderSpecific{
+			{Name: annotations.CloudflareProxiedKey, Value: "true"},
+			{Name: annotations.CloudflareCustomHostnameKey, Value: "app.example.com="},
+		},
+	}
+
+	// simulate source output (desired side) with "-" annotation
+	desiredEP := &endpoint.Endpoint{
+		DNSName:    "origin.example.com",
+		RecordType: "A",
+		Targets:    endpoint.Targets{"1.2.3.4"},
+		ProviderSpecific: endpoint.ProviderSpecific{
+			{Name: annotations.CloudflareProxiedKey, Value: "true"},
+			{Name: annotations.CloudflareCustomHostnameKey, Value: "-"},
+		},
+	}
+
+	adjusted, err := provider.AdjustEndpoints([]*endpoint.Endpoint{desiredEP})
+	assert.NoError(t, err)
+
+	// after adjustment, desired CH annotation should match current
+	desiredVal, _ := adjusted[0].GetProviderSpecificProperty(annotations.CloudflareCustomHostnameKey)
+	currentVal, _ := currentEP.GetProviderSpecificProperty(annotations.CloudflareCustomHostnameKey)
+	assert.Equal(t, currentVal, desiredVal, "desired should match current to avoid no-op update")
+}
+
+func TestManagedExternallyNoCHsInCF(t *testing.T) {
+	provider := &CloudFlareProvider{
+		CustomHostnamesConfig:  CustomHostnamesConfig{Enabled: true},
+		CustomHostnamesCurrent: customHostnamesMap{},
+	}
+
+	ep := &endpoint.Endpoint{
+		DNSName:    "origin.example.com",
+		RecordType: "A",
+		Targets:    endpoint.Targets{"1.2.3.4"},
+		ProviderSpecific: endpoint.ProviderSpecific{
+			{Name: annotations.CloudflareProxiedKey, Value: "true"},
+			{Name: annotations.CloudflareCustomHostnameKey, Value: "-"},
+		},
+	}
+
+	adjusted, err := provider.AdjustEndpoints([]*endpoint.Endpoint{ep})
+	assert.NoError(t, err)
+
+	_, ok := adjusted[0].GetProviderSpecificProperty(annotations.CloudflareCustomHostnameKey)
+	assert.False(t, ok, "CH property should be deleted when no CHs in CF")
+}
+
+func TestChAnnotationForOrigin(t *testing.T) {
+	provider := &CloudFlareProvider{
+		CustomHostnamesCurrent: customHostnamesMap{
+			customHostnameIndex{hostname: "a.example.com"}: {
+				hostname:           "a.example.com",
+				customOriginServer: "origin.example.com",
+				customOriginSNI:    "origin.example.com",
+			},
+			customHostnameIndex{hostname: "b.example.com"}: {
+				hostname:           "b.example.com",
+				customOriginServer: "origin.example.com",
+				customOriginSNI:    ":request_host_header:",
+			},
+			customHostnameIndex{hostname: "other.example.com"}: {
+				hostname:           "other.example.com",
+				customOriginServer: "other-origin.example.com",
+			},
+		},
+	}
+
+	assert.Equal(t, "a.example.com,b.example.com=", provider.chAnnotationForOrigin("origin.example.com"))
+	assert.Equal(t, "other.example.com", provider.chAnnotationForOrigin("other-origin.example.com"))
+	assert.Equal(t, "", provider.chAnnotationForOrigin("nonexistent.example.com"))
+}
+
 func TestGroupByNameAndTypeWithCustomHostnames_SNI(t *testing.T) {
 	provider := &CloudFlareProvider{
 		CustomHostnamesConfig: CustomHostnamesConfig{Enabled: true},

--- a/provider/cloudflare/cloudflare_custom_hostnames_test.go
+++ b/provider/cloudflare/cloudflare_custom_hostnames_test.go
@@ -862,6 +862,48 @@ func TestSubmitCustomHostnameChanges(t *testing.T) {
 			"Custom hostname should have updated SNI",
 		)
 	})
+
+	t.Run("CustomHostnames_Create_SkipSelfReferential", func(t *testing.T) {
+		// When the custom hostname is in the same managed zone as the origin, the annotation propagates
+		// to the DNS record for the custom hostname itself. That self-referential change must be skipped;
+		// the change for the origin record must still create the custom hostname correctly.
+		client := NewMockCloudFlareClient()
+		provider := &CloudFlareProvider{Client: client, CustomHostnamesConfig: CustomHostnamesConfig{Enabled: true}}
+
+		selfRef := &cloudFlareChange{
+			Action:          cloudFlareCreate,
+			ResourceRecord:  dns.RecordResponse{Name: "custom.fancybar.com", Type: "A"},
+			CustomHostnames: map[string]customHostname{"custom.fancybar.com": {hostname: "custom.fancybar.com", customOriginServer: "custom.fancybar.com"}},
+		}
+		assert.True(t, provider.submitCustomHostnameChanges(ctx, "zone1", selfRef, customHostnamesMap{}, nil))
+		assert.Empty(t, client.customHostnames["zone1"], "Self-referential custom hostname should not be created")
+
+		originChange := &cloudFlareChange{
+			Action:          cloudFlareCreate,
+			ResourceRecord:  dns.RecordResponse{Name: "origin.fancybar.com", Type: "A"},
+			CustomHostnames: map[string]customHostname{"custom.fancybar.com": {hostname: "custom.fancybar.com", customOriginServer: "origin.fancybar.com"}},
+		}
+		assert.True(t, provider.submitCustomHostnameChanges(ctx, "zone1", originChange, customHostnamesMap{}, nil))
+		assert.Contains(t, client.customHostnames["zone1"],
+			customHostname{id: "ID-custom.fancybar.com", hostname: "custom.fancybar.com", customOriginServer: "origin.fancybar.com"},
+			"Custom hostname should point to origin, not itself",
+		)
+	})
+
+	t.Run("CustomHostnames_Update_SkipSelfReferential", func(t *testing.T) {
+		// Same scenario via the UPDATE add path.
+		client := NewMockCloudFlareClient()
+		provider := &CloudFlareProvider{Client: client, CustomHostnamesConfig: CustomHostnamesConfig{Enabled: true}}
+
+		change := &cloudFlareChange{
+			Action:              cloudFlareUpdate,
+			ResourceRecord:      dns.RecordResponse{Name: "custom.fancybar.com", Type: "A"},
+			CustomHostnames:     map[string]customHostname{"custom.fancybar.com": {hostname: "custom.fancybar.com", customOriginServer: "custom.fancybar.com"}},
+			CustomHostnamesPrev: []string{},
+		}
+		assert.True(t, provider.submitCustomHostnameChanges(ctx, "zone1", change, customHostnamesMap{}, nil))
+		assert.Empty(t, client.customHostnames["zone1"], "Self-referential custom hostname should not be created")
+	})
 }
 
 func TestNewCustomHostname(t *testing.T) {

--- a/provider/cloudflare/cloudflare_custom_hostnames_test.go
+++ b/provider/cloudflare/cloudflare_custom_hostnames_test.go
@@ -31,6 +31,7 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
+	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/plan"
 )
 
@@ -942,6 +943,80 @@ func TestNewCustomHostname(t *testing.T) {
 			assert.Equal(t, tt.wantSNI, ch.customOriginSNI)
 		})
 	}
+}
+
+func TestGetEndpointCustomHostnames(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected []string
+	}{
+		{"normal hostname", "app.example.com", []string{"app.example.com"}},
+		{"multiple hostnames", "a.example.com,b.example.com", []string{"a.example.com", "b.example.com"}},
+		{"managed externally", "-", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := &endpoint.Endpoint{
+				ProviderSpecific: endpoint.ProviderSpecific{
+					{Name: annotations.CloudflareCustomHostnameKey, Value: tt.value},
+				},
+			}
+			result := getEndpointCustomHostnames(ep)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+
+	t.Run("no annotation", func(t *testing.T) {
+		ep := &endpoint.Endpoint{}
+		result := getEndpointCustomHostnames(ep)
+		assert.Equal(t, []string{}, result)
+	})
+}
+
+func TestManagedExternallySkipsCHLifecycle(t *testing.T) {
+	ctx := t.Context()
+	client := NewMockCloudFlareClient()
+	provider := &CloudFlareProvider{
+		Client: client,
+		CustomHostnamesConfig: CustomHostnamesConfig{
+			Enabled: true,
+		},
+	}
+
+	// Existing CH in CF that should NOT be deleted
+	client.customHostnames = map[string][]customHostname{
+		"zone1": {
+			{
+				id:                 "ch1",
+				hostname:           "app.example.com",
+				customOriginServer: "origin.example.com",
+			},
+		},
+	}
+	chs := customHostnamesMap{
+		customHostnameIndex{hostname: "app.example.com"}: {
+			id:                 "ch1",
+			hostname:           "app.example.com",
+			customOriginServer: "origin.example.com",
+		},
+	}
+
+	// UPDATE with annotation="-": both prev and new are empty (skipped by nil check)
+	change := &cloudFlareChange{
+		Action: cloudFlareUpdate,
+		ResourceRecord: dns.RecordResponse{
+			Type: "A",
+		},
+		CustomHostnamesPrev: []string{},
+		CustomHostnames:     map[string]customHostname{},
+	}
+
+	result := provider.submitCustomHostnameChanges(ctx, "zone1", change, chs, nil)
+	assert.True(t, result)
+	assert.Len(t, client.customHostnames["zone1"], 1, "Existing CH should NOT be deleted")
+	assert.Equal(t, "ch1", client.customHostnames["zone1"][0].id)
 }
 
 func TestGroupByNameAndTypeWithCustomHostnames_SNI(t *testing.T) {

--- a/provider/cloudflare/cloudflare_custom_hostnames_test.go
+++ b/provider/cloudflare/cloudflare_custom_hostnames_test.go
@@ -55,6 +55,7 @@ func (m *mockCloudFlareClient) CustomHostnames(ctx context.Context, zoneID strin
 				ID:                 ch.id,
 				Hostname:           ch.hostname,
 				CustomOriginServer: ch.customOriginServer,
+				CustomOriginSNI:    ch.customOriginSNI,
 			})
 		}
 	}
@@ -805,4 +806,167 @@ func TestSubmitCustomHostnameChanges(t *testing.T) {
 			"Custom hostname should be updated in mock client",
 		)
 	})
+
+	t.Run("CustomHostnames_Update_SNI", func(t *testing.T) {
+		client := NewMockCloudFlareClient()
+		client.customHostnames = map[string][]customHostname{
+			"zone1": {
+				{
+					id:                 "ch1",
+					hostname:           "app.fancybar.com",
+					customOriginServer: "origin.bar.com",
+					customOriginSNI:    "origin.bar.com",
+				},
+			},
+		}
+		provider := &CloudFlareProvider{
+			Client:                client,
+			CustomHostnamesConfig: CustomHostnamesConfig{Enabled: true},
+		}
+
+		// SNI-only change: same hostname, annotation goes from "app.fancybar.com" to "app.fancybar.com=sni.bar.com"
+		change := &cloudFlareChange{
+			Action: cloudFlareUpdate,
+			ResourceRecord: dns.RecordResponse{
+				Type: "A",
+			},
+			CustomHostnames: map[string]customHostname{
+				"app.fancybar.com=sni.bar.com": {
+					hostname:           "app.fancybar.com",
+					customOriginServer: "origin.bar.com",
+					customOriginSNI:    "sni.bar.com",
+				},
+			},
+			CustomHostnamesPrev: []string{"app.fancybar.com"},
+		}
+
+		chs := customHostnamesMap{
+			customHostnameIndex{hostname: "app.fancybar.com"}: {
+				id:                 "ch1",
+				hostname:           "app.fancybar.com",
+				customOriginServer: "origin.bar.com",
+				customOriginSNI:    "origin.bar.com",
+			},
+		}
+
+		result := provider.submitCustomHostnameChanges(ctx, "zone1", change, chs, nil)
+		assert.True(t, result, "Should successfully update custom hostname SNI")
+		assert.Len(t, client.customHostnames["zone1"], 1, "One custom hostname should exist after SNI update")
+		assert.Contains(t, client.customHostnames["zone1"],
+			customHostname{
+				id:                 "ID-app.fancybar.com",
+				hostname:           "app.fancybar.com",
+				customOriginServer: "origin.bar.com",
+				customOriginSNI:    "sni.bar.com",
+			},
+			"Custom hostname should have updated SNI",
+		)
+	})
+}
+
+func TestNewCustomHostname(t *testing.T) {
+	provider := &CloudFlareProvider{
+		CustomHostnamesConfig: CustomHostnamesConfig{},
+	}
+	origin := "origin.bar.com"
+
+	tests := []struct {
+		annotation string
+		wantHost   string
+		wantSNI    string
+	}{
+		{
+			annotation: "app.fancybar.com",
+			wantHost:   "app.fancybar.com",
+			wantSNI:    "origin.bar.com", // no "=": SNI defaults to origin
+		},
+		{
+			annotation: "app.fancybar.com=",
+			wantHost:   "app.fancybar.com",
+			wantSNI:    ":request_host_header:", // trailing "=": host header mode
+		},
+		{
+			annotation: "app.fancybar.com=sni.bar.com",
+			wantHost:   "app.fancybar.com",
+			wantSNI:    "sni.bar.com", // explicit SNI override
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.annotation, func(t *testing.T) {
+			ch := provider.newCustomHostname(tt.annotation, origin)
+			assert.Equal(t, tt.wantHost, ch.hostname)
+			assert.Equal(t, origin, ch.customOriginServer)
+			assert.Equal(t, tt.wantSNI, ch.customOriginSNI)
+		})
+	}
+}
+
+func TestGroupByNameAndTypeWithCustomHostnames_SNI(t *testing.T) {
+	provider := &CloudFlareProvider{
+		CustomHostnamesConfig: CustomHostnamesConfig{Enabled: true},
+	}
+
+	record := dns.RecordResponse{
+		ID:      "rec1",
+		Name:    "origin.bar.com",
+		Type:    "A",
+		Content: "1.2.3.4",
+	}
+	records := DNSRecordsMap{
+		{Name: "origin.bar.com", Type: "A", Content: "1.2.3.4"}: record,
+	}
+
+	getAnnotation := func(chs customHostnamesMap) string {
+		endpoints := provider.groupByNameAndTypeWithCustomHostnames(records, chs)
+		if len(endpoints) == 0 {
+			return ""
+		}
+		for _, ps := range endpoints[0].ProviderSpecific {
+			if ps.Name == "external-dns.alpha.kubernetes.io/cloudflare-custom-hostname" {
+				return ps.Value
+			}
+		}
+		return ""
+	}
+
+	tests := []struct {
+		name            string
+		customOriginSNI string
+		wantAnnotation  string
+	}{
+		{
+			name:            "SNI equals origin: no suffix",
+			customOriginSNI: "origin.bar.com",
+			wantAnnotation:  "app.fancybar.com",
+		},
+		{
+			name:            "SNI empty: no suffix",
+			customOriginSNI: "",
+			wantAnnotation:  "app.fancybar.com",
+		},
+		{
+			name:            "SNI is host header: trailing =",
+			customOriginSNI: ":request_host_header:",
+			wantAnnotation:  "app.fancybar.com=",
+		},
+		{
+			name:            "SNI differs from origin: explicit suffix",
+			customOriginSNI: "sni.bar.com",
+			wantAnnotation:  "app.fancybar.com=sni.bar.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chs := customHostnamesMap{
+				customHostnameIndex{hostname: "app.fancybar.com"}: {
+					hostname:           "app.fancybar.com",
+					customOriginServer: "origin.bar.com",
+					customOriginSNI:    tt.customOriginSNI,
+				},
+			}
+			assert.Equal(t, tt.wantAnnotation, getAnnotation(chs))
+		})
+	}
 }

--- a/registry/txt/utils_test.go
+++ b/registry/txt/utils_test.go
@@ -79,9 +79,7 @@ func cloneEndpointWithOpts(e *endpoint.Endpoint, opt ...func(*endpoint.Endpoint)
 	var providerSpecific endpoint.ProviderSpecific
 	if e.ProviderSpecific != nil {
 		providerSpecific = make(endpoint.ProviderSpecific, len(e.ProviderSpecific))
-		for i, p := range e.ProviderSpecific {
-			providerSpecific[i] = p
-		}
+		copy(providerSpecific, e.ProviderSpecific)
 	}
 
 	ttl := e.RecordTTL


### PR DESCRIPTION
## What does it do ?

Three improvements to Cloudflare custom hostname management:

### 1. Origin SNI overrides

Extends the `cloudflare-custom-hostname` annotation to support [Origin SNI
overrides](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/custom-origin/#sni-rewrites) using the format `<customHostname>=<customOriginSNI>`.

- No `=` suffix: SNI defaults to the origin server (existing behaviour, unchanged)
- Trailing `=` with no value: SNI is set to the request Host header
- `=<value>`: SNI is set to the specified hostname

The `custom_origin_sni` field is only sent to the Cloudflare API when
explicitly overridden (i.e. when SNI differs from the origin server),
since the field requires a Cloudflare account entitlement.

### 2. Skip self-referential custom hostnames

When a custom hostname resolves to a DNS name in the same managed zone,
creating a CH would be self-referential and is skipped with a warning.
This prevents Cloudflare API errors when the custom hostname and origin
are in the same zone.

### 3. Skip CH lifecycle with annotation value "-"

Setting the annotation to `-` tells external-dns to skip custom hostname
management for that record entirely — no create, update, or delete.
Existing custom hostnames in Cloudflare are left untouched.

This enables migrating CH ownership to another controller (e.g. a
Kubernetes operator) without triggering SSL re-validation from
delete+create cycles.

## Motivation

Cloudflare for SaaS supports routing custom hostname traffic to different
backends based on SNI. Without SNI control, all custom hostnames must share
the same TLS routing, which is too restrictive for multi-tenant setups where
different customers need traffic routed to different origins at the TLS layer.

For example, when using Envoy Gateway in Merged Gateways deployment mode,
each custom hostname needs its own SNI to correctly route TLS traffic to the
right backend — something that wasn't possible before without manual
Cloudflare configuration.

The `-` sentinel value solves a critical migration problem: removing the
CH annotation causes external-dns to delete existing custom hostnames,
which triggers SSL re-validation (DCV). Cloudflare rate-limits DCV
attempts, and a delete+create loop can cause SSL outages that persist
until the rate limit expires (hours).

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly