### PR TITLE
fix(source): use an invalid kubeconfig instead of empty string in test

### DIFF
--- a/source/store_test.go
+++ b/source/store_test.go
@@ -444,7 +444,7 @@ func TestConfig_ClientGenerator_RESTConfig_Integration(t *testing.T) {
 // TestSingletonClientGenerator_RESTConfig_SharedAcrossClients verifies singleton is shared
 func TestSingletonClientGenerator_RESTConfig_SharedAcrossClients(t *testing.T) {
 	gen := &SingletonClientGenerator{
-		KubeConfig:     "",
+		KubeConfig:     "invalid",
 		APIServerURL:   "",
 		RequestTimeout: 30 * time.Second,
 	}


### PR DESCRIPTION

## What does it do ?



Use an explicitly invalid string for kubeconfig in `TestSingletonClientGenerator_RESTConfig_SharedAcrossClients()` to unsure the test reproducibility.

## Motivation

`GetRestConfig()` (called by `InstrumentedRESTConfig()`) looks for default kubeconfig file when kubeconfig arg is empty.
So an empty string is not an invalid configuration by itself.
The test fails on local machine when you have a valid `~/.kube/config` file.

<details>

```
go test -test.fullpath=true -run ^TestSingletonClientGenerator_RESTConfig_SharedAcrossClients$ sigs.k8s.io/external-dns/source

--- FAIL: TestSingletonClientGenerator_RESTConfig_SharedAcrossClients (0.01s)
    /home/xxx/external-dns/source/store_test.go:466: 
        	Error Trace:	/home/xxx/external-dns/source/store_test.go:466
        	Error:      	An error is expected but got nil.
        	Test:       	TestSingletonClientGenerator_RESTConfig_SharedAcrossClients
        	Messages:   	First call should return error when kubeconfig is invalid
FAIL
coverage: 0.1% of statements
FAIL	sigs.k8s.io/external-dns/source	0.030s
FAIL
```

</details>

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
