### PR TITLE
fix(ci): failed to download the coveralls binary from GitHub releases

### DIFF
--- a/pkg/apis/externaldns/version_test.go
+++ b/pkg/apis/externaldns/version_test.go
@@ -22,10 +22,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAlwaysFail(t *testing.T) {
-	t.Fatal("intentional failure to test CI behaviour")
-}
-
 func TestBanner(t *testing.T) {
 	// Set variables to known values
 	Version = "1.0.0"


### PR DESCRIPTION
## What does it do ?

  The finish job's step has no continue-on-error: true, so when the download fails there, the whole finish job is marked as failed. We have no controll over Github binary availability, and this Coveralls step is optional, should not block PRs

  Likely cause: Transient network issue or temporary unavailability of github.com/coverallsapp/coverage-reporter/releases from the GitHub Actions runner.

There was already a `continue-on-error: true`, but not to final step

<img width="734" height="706" alt="Screenshot 2026-02-26 at 09 01 42" src="https://github.com/user-attachments/assets/e06c3f17-fb54-4741-9919-e0a5e0d6bf8e" />

tested with 
```
func TestAlwaysFail(t *testing.T) {
	t.Fatal("intentional failure to test CI behaviour")
}
```

To make sure the test failure are still failing the build. Job failed correctly https://github.com/kubernetes-sigs/external-dns/actions/runs/22436001863/job/64965864352?pr=6228

## Motivation

Jobs are failing on coveralls step, when. Examples of failures
- https://github.com/kubernetes-sigs/external-dns/actions/runs/22433351422/job/64961915403?pr=6227
- https://github.com/kubernetes-sigs/external-dns/actions/runs/22417906935/job/64908701553?pr=6208

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
