### PR TITLE
feat(pdns): support GetDomainFilter interface

### DIFF
--- a/provider/pdns/pdns.go
+++ b/provider/pdns/pdns.go
@@ -137,7 +137,6 @@ func stringifyHTTPResponseBody(r *http.Response) string {
 // well as mock APIClients used in testing
 type PDNSAPIProvider interface {
 	ListZones() ([]pgo.Zone, *http.Response, error)
-	PartitionZones(zones []pgo.Zone, domainFilter *endpoint.DomainFilter) ([]pgo.Zone, []pgo.Zone)
 	ListZone(zoneID string) (pgo.Zone, *http.Response, error)
 	PatchZone(zoneID string, zoneStruct pgo.Zone) (*http.Response, error)
 }
@@ -170,23 +169,22 @@ func (c *PDNSAPIClient) ListZones() ([]pgo.Zone, *http.Response, error) {
 	return zones, resp, provider.NewSoftErrorf("unable to list zones: %v", err)
 }
 
-// PartitionZones : Method returns a slice of zones that adhere to the domain filter and a slice of ones that does not adhere to the filter
-func (c *PDNSAPIClient) PartitionZones(zones []pgo.Zone, domainFilter *endpoint.DomainFilter) ([]pgo.Zone, []pgo.Zone) {
-	var filteredZones []pgo.Zone
-	var residualZones []pgo.Zone
-
-	if domainFilter.IsConfigured() {
-		for _, zone := range zones {
-			if domainFilter.Match(zone.Name) {
-				filteredZones = append(filteredZones, zone)
-			} else {
-				residualZones = append(residualZones, zone)
-			}
-		}
-	} else {
-		filteredZones = zones
+// partitionZones returns a slice of zones that adhere to the domain filter and a slice of ones that do not adhere to the filter.
+func partitionZones(zones []pgo.Zone, domainFilter *endpoint.DomainFilter) ([]pgo.Zone, []pgo.Zone) {
+	if domainFilter == nil || !domainFilter.IsConfigured() {
+		return zones, nil
 	}
-	return filteredZones, residualZones
+
+	var filtered, residual []pgo.Zone
+	for _, zone := range zones {
+		if domainFilter.Match(zone.Name) {
+			filtered = append(filtered, zone)
+		} else {
+			residual = append(residual, zone)
+		}
+	}
+
+	return filtered, residual
 }
 
 // ListZone : Method returns the details of a specific zone from PowerDNS
@@ -276,7 +274,7 @@ func (p *PDNSProvider) filteredZones() ([]pgo.Zone, []pgo.Zone, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	filtered, residual := p.client.PartitionZones(zones, p.domainFilter)
+	filtered, residual := partitionZones(zones, p.domainFilter)
 	return filtered, residual, nil
 }
 
@@ -292,7 +290,7 @@ func (p *PDNSProvider) GetDomainFilter() endpoint.DomainFilterInterface {
 		return &endpoint.DomainFilter{}
 	}
 
-	var zoneNames []string
+	zoneNames := make([]string, 0, 2*len(zones))
 	for _, zone := range zones {
 		zoneNames = append(zoneNames, zone.Name, "."+zone.Name)
 	}

--- a/provider/pdns/pdns_test.go
+++ b/provider/pdns/pdns_test.go
@@ -671,12 +671,6 @@ var (
 	DomainFilterListEmpty = endpoint.NewDomainFilter([]string{})
 
 	RegexDomainFilter = endpoint.NewRegexDomainFilter(regexp.MustCompile("example.com"), nil)
-
-	DomainFilterClient = &PDNSAPIClient{
-		dryRun:  false,
-		authCtx: context.WithValue(context.Background(), pgo.ContextAPIKey, pgo.APIKey{Key: "TEST-API-KEY"}),
-		client:  pgo.NewAPIClient(pgo.NewConfiguration()),
-	}
 )
 
 /******************************************************************************/
@@ -685,10 +679,6 @@ type PDNSAPIClientStub struct{}
 
 func (c *PDNSAPIClientStub) ListZones() ([]pgo.Zone, *http.Response, error) {
 	return []pgo.Zone{ZoneMixed}, nil, nil
-}
-
-func (c *PDNSAPIClientStub) PartitionZones(zones []pgo.Zone, _ *endpoint.DomainFilter) ([]pgo.Zone, []pgo.Zone) {
-	return zones, nil
 }
 
 func (c *PDNSAPIClientStub) ListZone(_ string) (pgo.Zone, *http.Response, error) {
@@ -708,10 +698,6 @@ type PDNSAPIClientStubEmptyZones struct {
 
 func (c *PDNSAPIClientStubEmptyZones) ListZones() ([]pgo.Zone, *http.Response, error) {
 	return []pgo.Zone{ZoneEmpty, ZoneEmptyLong, ZoneEmpty2}, nil, nil
-}
-
-func (c *PDNSAPIClientStubEmptyZones) PartitionZones(zones []pgo.Zone, _ *endpoint.DomainFilter) ([]pgo.Zone, []pgo.Zone) {
-	return zones, nil
 }
 
 func (c *PDNSAPIClientStubEmptyZones) ListZone(zoneID string) (pgo.Zone, *http.Response, error) {
@@ -775,7 +761,7 @@ type PDNSAPIClientStubPartitionZones struct {
 }
 
 func (c *PDNSAPIClientStubPartitionZones) ListZones() ([]pgo.Zone, *http.Response, error) {
-	return []pgo.Zone{ZoneEmpty, ZoneEmptyLong, ZoneEmpty2, ZoneEmptySimilar}, nil, nil
+	return []pgo.Zone{ZoneEmpty, ZoneEmpty2, ZoneEmptySimilar}, nil, nil
 }
 
 func (c *PDNSAPIClientStubPartitionZones) ListZone(zoneID string) (pgo.Zone, *http.Response, error) {
@@ -784,17 +770,10 @@ func (c *PDNSAPIClientStubPartitionZones) ListZone(zoneID string) (pgo.Zone, *ht
 		return ZoneEmpty, nil, nil
 	case strings.Contains(zoneID, "mock.test"):
 		return ZoneEmpty2, nil, nil
-	case strings.Contains(zoneID, "long.domainname.example.com"):
-		return ZoneEmptyLong, nil, nil
 	case strings.Contains(zoneID, "simexample.com"):
 		return ZoneEmptySimilar, nil, nil
 	}
 	return pgo.Zone{}, nil, nil
-}
-
-// Just overwrite the ListZones method to introduce a failure
-func (c *PDNSAPIClientStubPartitionZones) PartitionZones(_ []pgo.Zone, _ *endpoint.DomainFilter) ([]pgo.Zone, []pgo.Zone) {
-	return []pgo.Zone{ZoneEmpty}, []pgo.Zone{ZoneEmptyLong, ZoneEmpty2}
 }
 
 /******************************************************************************/
@@ -811,22 +790,6 @@ func (c *PDNSAPIClientStubConfigurable) ListZones() ([]pgo.Zone, *http.Response,
 		return nil, nil, c.listErr
 	}
 	return c.zones, nil, nil
-}
-
-func (c *PDNSAPIClientStubConfigurable) PartitionZones(zones []pgo.Zone, domainFilter *endpoint.DomainFilter) ([]pgo.Zone, []pgo.Zone) {
-	var filtered, residual []pgo.Zone
-	if domainFilter.IsConfigured() {
-		for _, zone := range zones {
-			if domainFilter.Match(zone.Name) {
-				filtered = append(filtered, zone)
-			} else {
-				residual = append(residual, zone)
-			}
-		}
-	} else {
-		filtered = zones
-	}
-	return filtered, residual
 }
 
 func (c *PDNSAPIClientStubConfigurable) ListZone(_ string) (pgo.Zone, *http.Response, error) {
@@ -1091,7 +1054,8 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSConvertEndpointsToZones() {
 func (suite *NewPDNSProviderTestSuite) TestPDNSConvertEndpointsToZonesPartitionZones() {
 	// Test DomainFilters
 	p := &PDNSProvider{
-		client: &PDNSAPIClientStubPartitionZones{},
+		client:       &PDNSAPIClientStubPartitionZones{},
+		domainFilter: endpoint.NewDomainFilter([]string{"example.com"}),
 	}
 
 	// Check inserting endpoints from a single zone which is specified in DomainFilter
@@ -1195,21 +1159,21 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSClientPartitionZones() {
 	}
 
 	// Check filtered, residual zones when no domain filter specified
-	filteredZones, residualZones := DomainFilterClient.PartitionZones(zoneList, DomainFilterListEmpty)
+	filteredZones, residualZones := partitionZones(zoneList, DomainFilterListEmpty)
 	suite.Equal(partitionResultFilteredEmptyFilter, filteredZones)
 	suite.Equal(partitionResultResidualEmptyFilter, residualZones)
 
 	// Check filtered, residual zones when a single domain filter specified
-	filteredZones, residualZones = DomainFilterClient.PartitionZones(zoneList, DomainFilterListSingle)
+	filteredZones, residualZones = partitionZones(zoneList, DomainFilterListSingle)
 	suite.Equal(partitionResultFilteredSingleFilter, filteredZones)
 	suite.Equal(partitionResultResidualSingleFilter, residualZones)
 
 	// Check filtered, residual zones when a multiple domain filter specified
-	filteredZones, residualZones = DomainFilterClient.PartitionZones(zoneList, DomainFilterListMultiple)
+	filteredZones, residualZones = partitionZones(zoneList, DomainFilterListMultiple)
 	suite.Equal(partitionResultFilteredMultipleFilter, filteredZones)
 	suite.Equal(partitionResultResidualMultipleFilter, residualZones)
 
-	filteredZones, residualZones = DomainFilterClient.PartitionZones(zoneList, RegexDomainFilter)
+	filteredZones, residualZones = partitionZones(zoneList, RegexDomainFilter)
 	suite.Equal(partitionResultFilteredSingleFilter, filteredZones)
 	suite.Equal(partitionResultResidualSingleFilter, residualZones)
 }


### PR DESCRIPTION
## What does it do ?

Overrides `GetDomainFilter()` for PDNSProvider to return real domain filters. before it was returning empty as of the `BaseProvider` struct.

## Motivation

From https://github.com/kubernetes-sigs/external-dns/pull/6232#discussion_r2864801368

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly