### PR TITLE
fix(fake): Fake clientset hangs for 10s per informer with client-go 0.35+

### DIFF
--- a/source/main_test.go
+++ b/source/main_test.go
@@ -28,12 +28,16 @@ func TestMain(m *testing.M) {
 	// Since client-go v0.35, WatchListClient is enabled by default, but fake
 	// clients don't emit the required bookmark events, causing reflectors to
 	// stall for 10 seconds before falling back to the legacy list/watch path.
-	type featureGatesSetter interface {
-		features.Gates
-		Set(features.Feature, bool) error
-	}
-	if gates, ok := features.FeatureGates().(featureGatesSetter); ok {
-		_ = gates.Set(features.WatchListClient, false)
+	// Only disable if it is actually on; pre-v0.35 client-go defaults it to
+	// false so this is a no-op there, but makes the intent explicit.
+	if features.FeatureGates().Enabled(features.WatchListClient) {
+		type featureGatesSetter interface {
+			features.Gates
+			Set(features.Feature, bool) error
+		}
+		if gates, ok := features.FeatureGates().(featureGatesSetter); ok {
+			_ = gates.Set(features.WatchListClient, false)
+		}
 	}
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
## What does it do ?

The change affects tests only, how fake client functionality behavies for `bookmark event` (functionality that is not required to unit tests).

> A Kubernetes bookmark event (BOOKMARK) is a special watch notification (introduced in v1.15+, beta in v1.16) indicating that a client has received all relevant resource updates up to a specific resourceVersion. It serves as a checkpoint to efficiently resume watch streams without needing a full, costly re-list, improving [kube-apiserver](https://www.google.com/search?client=firefox-b-d&q=kube-apiserver&mstk=AUtExfAK0aFzrEAXZQZSzxQBntHH46zVzQuzdlkv-0W7REqkaE7beqO7ZSqN-lrB-JhftE1MMviKAccv4-PI8V9IyU_wo1vENr7sNImmg92rJTHJhliwAstfuASxyPPy3r0wjZ5ep1oUAwV4H8WwNenEjQKK5IDEf_Vzwz-iTrCsYwvkw_0&csui=3&ved=2ahUKEwjwguXH7fySAxXfTEEAHW42KW4QgK4QegQIARAC) performance

Fixes Kubernets Fake WatchListClient for all sources, where IsWatchListSemanticsUnSupported is not yet supported

Bumpred dependencies here, failed https://github.com/gofogo/k8s-sigs-external-dns-fork/actions/runs/22522280591/job/65248859197?pr=64
Green Tests wibh bumped dependencies https://github.com/gofogo/k8s-sigs-external-dns-fork/actions/runs/22522782545


## Motivation

Failed dependenices due to behaviour change in kubernetes/client-go https://github.com/kubernetes-sigs/external-dns/pull/6244

I've created an issue on istio side https://github.com/istio/istio/issues/59268. But it may take a while for them to implement a fix + Same issue will affect any other third-party client-go-based fake that is not yet updated
  this opt-out interface existed (e.g. ambassador, f5, traefik, kong fake clientsets if they also use `SharedInformerFactory` in tests

Root cause — WatchListClient became Beta=true in client-go v0.35, and the istio fake Clientset is missing IsWatchListSemanticsUnSupported() which is the opt-out k8s added to its own fake

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
