### PR TITLE
refactor(testutils): extract log test helpers into subpackage to fix circular import

### DIFF
--- a/internal/testutils/endpoint_test.go
+++ b/internal/testutils/endpoint_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/external-dns/endpoint"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 )
 
 func TestExampleSameEndpoints(t *testing.T) {
@@ -543,13 +544,13 @@ func TestFilterEndpointsByOwnerIDLogging(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hook := LogsUnderTestWithLogLevel(log.DebugLevel, t)
+			hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
 			endpoint.FilterEndpointsByOwnerID(tt.ownerID, tt.endpoints)
 			for _, m := range tt.messages {
-				TestHelperLogContains(m, hook, t)
+				logtest.TestHelperLogContains(m, hook, t)
 			}
 			for _, m := range tt.messages_not {
-				TestHelperLogNotContains(m, hook, t)
+				logtest.TestHelperLogNotContains(m, hook, t)
 			}
 		})
 	}

--- a/internal/testutils/log/log.go
+++ b/internal/testutils/log/log.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package testutils
+package logtest
 
 import (
 	"strings"

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 )
 
 type MockMetric struct {
@@ -94,13 +94,13 @@ func TestMustRegister(t *testing.T) {
 }
 
 func TestUnsupportedMetricWarning(t *testing.T) {
-	hook := testutils.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+	hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
 	registry := NewMetricsRegister()
 	mockUnsupported := &MockMetric{FQDN: "unsupported_metric"}
 	registry.MustRegister(mockUnsupported)
 	assert.NotContains(t, registry.mName, "unsupported_metric")
 
-	testutils.TestHelperLogContains("Unsupported metric type: *metrics.MockMetric", hook, t)
+	logtest.TestHelperLogContains("Unsupported metric type: *metrics.MockMetric", hook, t)
 }
 
 func TestNewMetricsRegister(t *testing.T) {

--- a/provider/aws/aws_fixtures_test.go
+++ b/provider/aws/aws_fixtures_test.go
@@ -25,7 +25,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
-	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 )
 
 func TestAWSRecordsV1(t *testing.T) {
@@ -102,8 +102,8 @@ func TestAWSZonesSecondRequestHitsTheCache(t *testing.T) {
 	ctx := context.Background()
 	_, err := provider.Zones(ctx)
 	assert.NoError(t, err)
-	hook := testutils.LogsUnderTestWithLogLevel(log.DebugLevel, t)
+	hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
 	_, _ = provider.Zones(ctx)
 
-	testutils.TestHelperLogContainsWithLogLevel("Using cached AWS zones", log.DebugLevel, hook, t)
+	logtest.TestHelperLogContainsWithLogLevel("Using cached AWS zones", log.DebugLevel, hook, t)
 }

--- a/provider/aws/config_test.go
+++ b/provider/aws/config_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 )
 
@@ -114,7 +115,7 @@ func Test_newV2Config(t *testing.T) {
 			"AWS_SECRET_ACCESS_KEY": "topsecret",
 		})
 
-		hook := testutils.LogsUnderTestWithLogLevel(logrus.InfoLevel, t)
+		hook := logtest.LogsUnderTestWithLogLevel(logrus.InfoLevel, t)
 		defer hook.Reset()
 
 		// when
@@ -124,7 +125,7 @@ func Test_newV2Config(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		testutils.TestHelperLogContainsWithLogLevel(
+		logtest.TestHelperLogContainsWithLogLevel(
 			"Assuming role: arn:aws:iam::123456789012:role/example",
 			logrus.InfoLevel,
 			hook,
@@ -227,7 +228,7 @@ func TestCreateConfigFatalOnError(t *testing.T) {
 		})
 
 		exitCode := 0
-		_ = testutils.TestHelperWithLogExitFunc(func(code int) {
+		_ = logtest.TestHelperWithLogExitFunc(func(code int) {
 			exitCode = code
 			panic("exit")
 		})
@@ -244,7 +245,7 @@ func TestCreateConfigFatalOnError(t *testing.T) {
 		})
 
 		exitCode := 0
-		_ = testutils.TestHelperWithLogExitFunc(func(code int) {
+		_ = logtest.TestHelperWithLogExitFunc(func(code int) {
 			exitCode = code
 			panic("exit")
 		})

--- a/provider/awssd/aws_sd_test.go
+++ b/provider/awssd/aws_sd_test.go
@@ -29,6 +29,7 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 	"sigs.k8s.io/external-dns/plan"
 )
 
@@ -747,7 +748,7 @@ func TestAWSSDProvider_DeleteServiceEmptyDescription_Logging(t *testing.T) {
 		},
 	}
 
-	logs := testutils.LogsUnderTestWithLogLevel(log.DebugLevel, t)
+	logs := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
 
 	api := &AWSSDClientStub{
 		namespaces: namespaces,
@@ -761,7 +762,7 @@ func TestAWSSDProvider_DeleteServiceEmptyDescription_Logging(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, api.services["private"], 1)
 
-	testutils.TestHelperLogContainsWithLogLevel("Skipping service removal \"service1\" because owner id (service.Description) not set, when should be", log.DebugLevel, logs, t)
+	logtest.TestHelperLogContainsWithLogLevel("Skipping service removal \"service1\" because owner id (service.Description) not set, when should be", log.DebugLevel, logs, t)
 }
 
 func TestAWSSDProvider_DeleteServiceDryRun(t *testing.T) {

--- a/provider/cloudflare/cloudflare_custom_hostnames_test.go
+++ b/provider/cloudflare/cloudflare_custom_hostnames_test.go
@@ -29,7 +29,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/external-dns/endpoint"
-	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 	"sigs.k8s.io/external-dns/plan"
 )
 
@@ -350,7 +350,7 @@ func TestCloudflareCustomHostnameNotFoundOnRecordDeletion(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			hook := testutils.LogsUnderTestWithLogLevel(log.InfoLevel, t)
+			hook := logtest.LogsUnderTestWithLogLevel(log.InfoLevel, t)
 
 			records, err := provider.Records(ctx)
 			if err != nil {
@@ -402,7 +402,7 @@ func TestCloudflareCustomHostnameNotFoundOnRecordDeletion(t *testing.T) {
 				t.Error(e)
 			}
 
-			testutils.TestHelperLogContains(tc.logOutput, hook, t)
+			logtest.TestHelperLogContains(tc.logOutput, hook, t)
 		})
 	}
 }

--- a/provider/cloudflare/cloudflare_regional_test.go
+++ b/provider/cloudflare/cloudflare_regional_test.go
@@ -31,6 +31,7 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/source/annotations"
 )
@@ -1029,14 +1030,14 @@ func TestApplyChangesWithRegionalHostnamesFaillures(t *testing.T) {
 					RegionKey: tt.fields.RegionKey,
 				},
 			}
-			hook := testutils.LogsUnderTestWithLogLevel(log.DebugLevel, t)
+			hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
 			err := p.ApplyChanges(t.Context(), tt.args.changes)
 			assert.Error(t, err, "ApplyChanges should return an error")
 			if tt.errMsg != "" && err != nil {
 				assert.Contains(t, err.Error(), tt.errMsg, "Expected error message to contain: %s", tt.errMsg)
 			}
 			if tt.expectDebug != "" {
-				testutils.TestHelperLogContains(tt.expectDebug, hook, t)
+				logtest.TestHelperLogContains(tt.expectDebug, hook, t)
 			}
 		})
 	}
@@ -1178,11 +1179,11 @@ func TestApplyChangesWithRegionalHostnamesDryRun(t *testing.T) {
 					RegionKey: tt.fields.RegionKey,
 				},
 			}
-			hook := testutils.LogsUnderTestWithLogLevel(log.DebugLevel, t)
+			hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
 			err := p.ApplyChanges(t.Context(), tt.args.changes)
 			assert.NoError(t, err, "ApplyChanges should not fail")
 			if tt.expectDebug != "" {
-				testutils.TestHelperLogContains(tt.expectDebug, hook, t)
+				logtest.TestHelperLogContains(tt.expectDebug, hook, t)
 			}
 		})
 	}

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -37,6 +37,7 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
 	"sigs.k8s.io/external-dns/source/annotations"
@@ -2056,7 +2057,7 @@ func TestCloudflareLongRecordsErrorLog(t *testing.T) {
 			},
 		},
 	})
-	hook := testutils.LogsUnderTestWithLogLevel(log.InfoLevel, t)
+	hook := logtest.LogsUnderTestWithLogLevel(log.InfoLevel, t)
 	p := &CloudFlareProvider{
 		Client:                client,
 		CustomHostnamesConfig: CustomHostnamesConfig{Enabled: true},
@@ -2066,7 +2067,7 @@ func TestCloudflareLongRecordsErrorLog(t *testing.T) {
 	if err != nil {
 		t.Errorf("should not fail - too long record, %s", err)
 	}
-	testutils.TestHelperLogContains("s longer than 63 characters. Cannot create endpoint", hook, t)
+	logtest.TestHelperLogContains("s longer than 63 characters. Cannot create endpoint", hook, t)
 }
 
 // check if the error is expected
@@ -2220,7 +2221,7 @@ func TestZoneHasPaidPlan(t *testing.T) {
 }
 
 func TestCloudflareApplyChanges_AllErrorLogPaths(t *testing.T) {
-	hook := testutils.LogsUnderTestWithLogLevel(log.ErrorLevel, t)
+	hook := logtest.LogsUnderTestWithLogLevel(log.ErrorLevel, t)
 
 	client := NewMockCloudFlareClient()
 	provider := &CloudFlareProvider{
@@ -2802,7 +2803,7 @@ func TestCloudFlareZonesDomainFilter(t *testing.T) {
 	}
 
 	// Capture debug logs to verify the filter log message
-	hook := testutils.LogsUnderTestWithLogLevel(log.DebugLevel, t)
+	hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
 
 	// Call Zones() which should trigger the domain filter logic
 	zones, err := p.Zones(t.Context())
@@ -2814,8 +2815,8 @@ func TestCloudFlareZonesDomainFilter(t *testing.T) {
 	assert.Equal(t, "001", zones[0].ID)
 
 	// Verify that the debug log was written for the filtered zone
-	testutils.TestHelperLogContains("zone \"foo.com\" not in domain filter", hook, t)
-	testutils.TestHelperLogContains("no zoneIDFilter configured, looking at all zones", hook, t)
+	logtest.TestHelperLogContains("zone \"foo.com\" not in domain filter", hook, t)
+	logtest.TestHelperLogContains("no zoneIDFilter configured, looking at all zones", hook, t)
 }
 
 func TestZoneIDByNameIteratorError(t *testing.T) {

--- a/provider/coredns/coredns_test.go
+++ b/provider/coredns/coredns_test.go
@@ -32,6 +32,7 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 	"sigs.k8s.io/external-dns/plan"
 
 	"github.com/stretchr/testify/require"
@@ -435,12 +436,12 @@ func TestCoreDNSApplyChanges_DomainDoNotMatch(t *testing.T) {
 			endpoint.NewEndpoint("domain2.local", endpoint.RecordTypeCNAME, "site.local"),
 		},
 	}
-	hook := testutils.LogsUnderTestWithLogLevel(log.DebugLevel, t)
+	hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
 	err := coredns.ApplyChanges(context.Background(), changes1)
 	require.NoError(t, err)
 
-	testutils.TestHelperLogContains("Skipping record \"domain1.local\" due to domain filter", hook, t)
-	testutils.TestHelperLogContains("Skipping record \"domain2.local\" due to domain filter", hook, t)
+	logtest.TestHelperLogContains("Skipping record \"domain1.local\" due to domain filter", hook, t)
+	logtest.TestHelperLogContains("Skipping record \"domain2.local\" due to domain filter", hook, t)
 }
 
 func applyServiceChanges(provider coreDNSProvider, changes *plan.Changes) error {

--- a/provider/pihole/pihole_test.go
+++ b/provider/pihole/pihole_test.go
@@ -24,7 +24,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/external-dns/endpoint"
-	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 	"sigs.k8s.io/external-dns/plan"
 )
 
@@ -110,11 +110,11 @@ func TestNewPiholeProvider_APIVersions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hook := testutils.LogsUnderTestWithLogLevel(log.DebugLevel, t)
+			hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
 			_, err := NewPiholeProvider(tt.config)
 			require.NoError(t, err)
 			if tt.wantMsg {
-				testutils.TestHelperLogContains(warningMsg, hook, t)
+				logtest.TestHelperLogContains(warningMsg, hook, t)
 			}
 		})
 	}

--- a/provider/zonefinder_test.go
+++ b/provider/zonefinder_test.go
@@ -22,7 +22,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
-	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 )
 
 func TestZoneIDName(t *testing.T) {
@@ -101,8 +101,8 @@ func TestZoneIDName(t *testing.T) {
 	assert.Equal(t, "testécassé.fr", zoneName)
 	assert.Equal(t, "234567", zoneID)
 
-	hook := testutils.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+	hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
 	_, _ = z.FindZone("xn--not-a-valid-punycode")
 
-	testutils.TestHelperLogContains("Failed to convert label \"xn--not-a-valid-punycode\" of hostname \"xn--not-a-valid-punycode\" to its Unicode form: idna: invalid label", hook, t)
+	logtest.TestHelperLogContains("Failed to convert label \"xn--not-a-valid-punycode\" of hostname \"xn--not-a-valid-punycode\" to its Unicode form: idna: invalid label", hook, t)
 }

--- a/registry/txt/registry_test.go
+++ b/registry/txt/registry_test.go
@@ -32,6 +32,7 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
 	"sigs.k8s.io/external-dns/provider/inmemory"
@@ -1741,7 +1742,7 @@ func TestTXTRegistryRecordsWithEmptyTargets(t *testing.T) {
 	require.NoError(t, err)
 
 	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour, "", []string{}, []string{}, false, nil, "")
-	hook := testutils.LogsUnderTestWithLogLevel(log.ErrorLevel, t)
+	hook := logtest.LogsUnderTestWithLogLevel(log.ErrorLevel, t)
 	records, err := r.Records(ctx)
 	require.NoError(t, err)
 
@@ -1756,7 +1757,7 @@ func TestTXTRegistryRecordsWithEmptyTargets(t *testing.T) {
 
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
 
-	testutils.TestHelperLogContains("TXT record has no targets empty-targets.test-zone.example.org", hook, t)
+	logtest.TestHelperLogContains("TXT record has no targets empty-targets.test-zone.example.org", hook, t)
 }
 
 // TestTXTRegistryRecreatesMissingRecords reproduces issue #4914.

--- a/source/annotations/filter_test.go
+++ b/source/annotations/filter_test.go
@@ -19,7 +19,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 )
 
 // Mock object implementing AnnotatedObject
@@ -123,7 +123,7 @@ func TestFilter(t *testing.T) {
 }
 
 func TestFilter_LogOutput(t *testing.T) {
-	hook := testutils.LogsUnderTestWithLogLevel(log.DebugLevel, t)
+	hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
 
 	items := []mockObj{
 		{annotations: map[string]string{"foo": "bar"}},
@@ -132,5 +132,5 @@ func TestFilter_LogOutput(t *testing.T) {
 	filter := "foo=bar"
 	_, _ = Filter(items, filter)
 
-	testutils.TestHelperLogContains("filtered '1' services out of '2' with annotation filter 'foo=bar'", hook, t)
+	logtest.TestHelperLogContains("filtered '1' services out of '2' with annotation filter 'foo=bar'", hook, t)
 }

--- a/source/annotations/processors_test.go
+++ b/source/annotations/processors_test.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/external-dns/endpoint"
-	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 )
 
 // helper implementing metav1.ObjectMetaAccessor for tests
@@ -432,15 +432,15 @@ func TestIsControllerMismatch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hook := testutils.LogsUnderTestWithLogLevel(log.DebugLevel, t)
+			hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
 
 			result := IsControllerMismatch(&tt.entity, tt.resourceType)
 			assert.Equal(t, tt.expected, result)
 
 			if tt.debugMsg != "" {
-				testutils.TestHelperLogContains(tt.debugMsg, hook, t)
+				logtest.TestHelperLogContains(tt.debugMsg, hook, t)
 			} else {
-				testutils.TestHelperLogNotContains("Skipping", hook, t)
+				logtest.TestHelperLogNotContains("Skipping", hook, t)
 			}
 		})
 	}

--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -46,7 +46,7 @@ import (
 
 	apiv1alpha1 "sigs.k8s.io/external-dns/apis/v1alpha1"
 	"sigs.k8s.io/external-dns/endpoint"
-	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 )
 
 type CRDSuite struct {
@@ -675,7 +675,7 @@ func TestCRDSourceIllegalTargetWarnings(t *testing.T) {
 		},
 	} {
 		t.Run(ti.title, func(t *testing.T) {
-			hook := testutils.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+			hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
 
 			restClient := fakeRESTClient(ti.endpoints, apiv1alpha1.GroupVersion.String(), apiv1alpha1.DNSEndpointKind, "foo", "test", nil, nil, t)
 
@@ -691,7 +691,7 @@ func TestCRDSourceIllegalTargetWarnings(t *testing.T) {
 			if ti.wantWarning == "" {
 				require.Empty(t, hook.Entries, "expected no warnings to be logged")
 			} else {
-				testutils.TestHelperLogContainsWithLogLevel(ti.wantWarning, log.WarnLevel, hook, t)
+				logtest.TestHelperLogContainsWithLogLevel(ti.wantWarning, log.WarnLevel, hook, t)
 			}
 		})
 	}

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -32,7 +32,7 @@ import (
 	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 
 	"sigs.k8s.io/external-dns/endpoint"
-	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 	"sigs.k8s.io/external-dns/source/annotations"
 )
 
@@ -1680,14 +1680,14 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			src, err := NewGatewayHTTPRouteSource(ctx, clients, &tt.config)
 			require.NoError(t, err, "failed to create Gateway HTTPRoute Source")
 
-			hook := testutils.LogsUnderTestWithLogLevel(log.DebugLevel, t)
+			hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
 
 			endpoints, err := src.Endpoints(ctx)
 			require.NoError(t, err, "failed to get Endpoints")
 			validateEndpoints(t, endpoints, tt.endpoints)
 
 			for _, msg := range tt.logExpectations {
-				testutils.TestHelperLogContains(msg, hook, t)
+				logtest.TestHelperLogContains(msg, hook, t)
 			}
 		})
 	}

--- a/source/node_test.go
+++ b/source/node_test.go
@@ -29,7 +29,7 @@ import (
 	corev1lister "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 
-	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 	"sigs.k8s.io/external-dns/source/annotations"
 
 	"github.com/stretchr/testify/assert"
@@ -405,7 +405,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
-			hook := testutils.LogsUnderTestWithLogLevel(log.DebugLevel, t)
+			hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
 
 			labelSelector := labels.Everything()
 			if tc.labelSelector != "" {
@@ -458,10 +458,10 @@ func testNodeSourceEndpoints(t *testing.T) {
 			validateEndpoints(t, endpoints, tc.expected)
 
 			for _, entry := range tc.expectedLogs {
-				testutils.TestHelperLogContains(entry, hook, t)
+				logtest.TestHelperLogContains(entry, hook, t)
 			}
 			for _, entry := range tc.expectedAbsentLogs {
-				testutils.TestHelperLogNotContains(entry, hook, t)
+				logtest.TestHelperLogNotContains(entry, hook, t)
 			}
 		})
 	}

--- a/source/pod_test.go
+++ b/source/pod_test.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"sigs.k8s.io/external-dns/endpoint"
-	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 	"sigs.k8s.io/external-dns/source/annotations"
 
 	"k8s.io/client-go/kubernetes/fake"
@@ -894,7 +894,7 @@ func TestPodSourceLogs(t *testing.T) {
 			client, err := NewPodSource(ctx, kubernetes, "", "", tc.ignoreNonHostNetworkPods, "", "", false, "", nil)
 			require.NoError(t, err)
 
-			hook := testutils.LogsUnderTestWithLogLevel(log.DebugLevel, t)
+			hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
 
 			_, err = client.Endpoints(ctx)
 			require.NoError(t, err)
@@ -903,13 +903,13 @@ func TestPodSourceLogs(t *testing.T) {
 			// We don't do an exact match because logs are globally shared,
 			// making precise comparisons difficult
 			for _, expectedLog := range tc.expectedDebugLogs {
-				testutils.TestHelperLogContains(expectedLog, hook, t)
+				logtest.TestHelperLogContains(expectedLog, hook, t)
 			}
 
 			// Check that no unexpected logs are present.
 			// This ensures that logs are not generated inappropriately.
 			for _, unexpectedLog := range tc.unexpectedDebugLogs {
-				testutils.TestHelperLogNotContains(unexpectedLog, hook, t)
+				logtest.TestHelperLogNotContains(unexpectedLog, hook, t)
 			}
 		})
 	}

--- a/source/utils_test.go
+++ b/source/utils_test.go
@@ -19,7 +19,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/external-dns/endpoint"
-	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 )
 
 func TestSuitableType(t *testing.T) {
@@ -305,48 +305,48 @@ func TestMergeEndpoints(t *testing.T) {
 
 func TestMergeEndpointsLogging(t *testing.T) {
 	t.Run("warns on CNAME conflict", func(t *testing.T) {
-		hook := testutils.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
 
 		MergeEndpoints([]*endpoint.Endpoint{
 			endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "a.elb.com"),
 			endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "b.elb.com"),
 		})
 
-		testutils.TestHelperLogContainsWithLogLevel("Only one CNAME per name", log.WarnLevel, hook, t)
-		testutils.TestHelperLogContains("example.com CNAME a.elb.com", hook, t)
-		testutils.TestHelperLogContains("example.com CNAME b.elb.com", hook, t)
+		logtest.TestHelperLogContainsWithLogLevel("Only one CNAME per name", log.WarnLevel, hook, t)
+		logtest.TestHelperLogContains("example.com CNAME a.elb.com", hook, t)
+		logtest.TestHelperLogContains("example.com CNAME b.elb.com", hook, t)
 	})
 
 	t.Run("no warning for identical CNAMEs", func(t *testing.T) {
-		hook := testutils.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
 
 		MergeEndpoints([]*endpoint.Endpoint{
 			endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "a.elb.com"),
 			endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "a.elb.com"),
 		})
 
-		testutils.TestHelperLogNotContains("Only one CNAME per name", hook, t)
+		logtest.TestHelperLogNotContains("Only one CNAME per name", hook, t)
 	})
 
 	t.Run("no warning for same DNSName with different SetIdentifier", func(t *testing.T) {
-		hook := testutils.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
 
 		MergeEndpoints([]*endpoint.Endpoint{
 			endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "a.elb.com").WithSetIdentifier("weight-1"),
 			endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "b.elb.com").WithSetIdentifier("weight-2"),
 		})
 
-		testutils.TestHelperLogNotContains("Only one CNAME per name", hook, t)
+		logtest.TestHelperLogNotContains("Only one CNAME per name", hook, t)
 	})
 
 	t.Run("debug log for CNAME with no targets", func(t *testing.T) {
-		hook := testutils.LogsUnderTestWithLogLevel(log.DebugLevel, t)
+		hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
 
 		MergeEndpoints([]*endpoint.Endpoint{
 			endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME),
 		})
 
-		testutils.TestHelperLogContainsWithLogLevel("Skipping CNAME endpoint", log.DebugLevel, hook, t)
-		testutils.TestHelperLogContains("example.com", hook, t)
+		logtest.TestHelperLogContainsWithLogLevel("Skipping CNAME endpoint", log.DebugLevel, hook, t)
+		logtest.TestHelperLogContains("example.com", hook, t)
 	})
 }

--- a/source/wrappers/dedupsource_test.go
+++ b/source/wrappers/dedupsource_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 	"sigs.k8s.io/external-dns/source"
 )
 
@@ -342,7 +343,7 @@ func TestDedupSource_WarnsOnInvalidEndpoint(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hook := testutils.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+			hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
 
 			mockSource := new(testutils.MockSource)
 			mockSource.On("Endpoints").Return([]*endpoint.Endpoint{tt.endpoint}, nil)
@@ -351,7 +352,7 @@ func TestDedupSource_WarnsOnInvalidEndpoint(t *testing.T) {
 			_, err := src.Endpoints(context.Background())
 			require.NoError(t, err)
 
-			testutils.TestHelperLogContains(tt.wantLogMsg, hook, t)
+			logtest.TestHelperLogContains(tt.wantLogMsg, hook, t)
 		})
 	}
 }


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->
Move log test helpers from internal/testutils into a new dedicated subpackage `internal/testutils/log.`

All test files that used these helpers have been updated to import the new logtest package.

## Motivation
`endpoint_test.go` needed to use the log test helpers, but `internal/testutils` imports 
from the endpoint package, causing a circular import. 
Splitting the log helpers into a separate subpackage breaks the cycle.

<!-- What inspired you to submit this pull request? -->

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
