### PR TITLE
WIP feat(source): metric and event for invalid endpoints

### DIFF
--- a/controller/execute_test.go
+++ b/controller/execute_test.go
@@ -268,7 +268,7 @@ func TestBuildSourceWithWrappers(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := buildSource(t.Context(), source.NewSourceConfig(tt.cfg))
+			_, err := buildSource(t.Context(), source.NewSourceConfig(tt.cfg), nil)
 			require.NoError(t, err)
 		})
 	}
@@ -449,7 +449,7 @@ func TestControllerRunCancelContextStopsLoop(t *testing.T) {
 	sCfg := source.NewSourceConfig(cfg)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	src, err := buildSource(ctx, sCfg)
+	src, err := buildSource(ctx, sCfg, nil)
 	require.NoError(t, err)
 	domainFilter := endpoint.NewDomainFilterWithOptions(
 		endpoint.WithDomainFilter(cfg.DomainFilter),
@@ -459,7 +459,7 @@ func TestControllerRunCancelContextStopsLoop(t *testing.T) {
 	)
 	p, err := buildProvider(ctx, cfg, domainFilter)
 	require.NoError(t, err)
-	ctrl, err := buildController(ctx, cfg, sCfg, src, p, domainFilter)
+	ctrl, err := buildController(cfg, src, p, domainFilter, nil)
 	require.NoError(t, err)
 
 	done := make(chan struct{})

--- a/source/wrappers/metrics.go
+++ b/source/wrappers/metrics.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wrappers
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"sigs.k8s.io/external-dns/pkg/metrics"
+)
+
+var invalidEndpointsTotal = metrics.NewGaugedVectorOpts(
+	prometheus.GaugeOpts{
+		Subsystem: "source",
+		Name:      "invalid_endpoints",
+		Help:      "Number of endpoints currently rejected due to invalid configuration, partitioned by record type and source.",
+	},
+	[]string{"record_type", "source_type"},
+)
+
+// TODO: add metric for deduplicated records as well, partitioned by record type and source.
+
+func init() {
+	metrics.RegisterMetric.MustRegister(invalidEndpointsTotal)
+}


### PR DESCRIPTION
 WHY

  Invalid endpoints — misconfigured CNAME self-references, malformed MX/SRV records, unsupported alias types — are silently dropped by the dedup source with only a log
  warning. In production clusters this creates a blind spot: there is no way to alert on broken DNS configurations, measure how many exist, or trace which Kubernetes
  resource is responsible. Operators discover the problem only by grepping logs or noticing that a DNS record never appears.

  ---
  WHAT

  - Adds external_dns_source_invalid_endpoints{record_type, source_type} gauge — resets and refills each reconcile cycle, so it directly answers "how many broken endpoints
  exist right now" per record type and source. source_type is populated from RefObject.Source when available, falls back to "unknown" until source implementations provide
  RefObject.
  - Emits a Kubernetes Event (action=FailedSync, reason=RecordError) per rejected endpoint, gated by the existing --emit-events=RecordError flag, so no extra configuration
  is needed.
  - Extracts buildEventEmitter from buildController in execute.go so the emitter is constructed before the source pipeline and shared with the dedup layer — no duplication.

## More

- [ ] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
