### PR TITLE
fix(pdns): skip zone partitioning for regex domain filters

### DIFF
--- a/endpoint/domain_filter.go
+++ b/endpoint/domain_filter.go
@@ -180,6 +180,14 @@ func matchRegex(regex *regexp.Regexp, negativeRegex *regexp.Regexp, domain strin
 	return true
 }
 
+// HasRegex returns true if the filter uses regex-based matching.
+func (df *DomainFilter) HasRegex() bool {
+	if df == nil {
+		return false
+	}
+	return (df.regex != nil && df.regex.String() != "") || (df.regexExclusion != nil && df.regexExclusion.String() != "")
+}
+
 // IsConfigured returns true if any inclusion or exclusion rules have been specified.
 func (df *DomainFilter) IsConfigured() bool {
 	if df == nil {

--- a/endpoint/domain_filter_test.go
+++ b/endpoint/domain_filter_test.go
@@ -720,6 +720,26 @@ func TestRegexDomainFilterIsConfigured(t *testing.T) {
 	}
 }
 
+func TestDomainFilterHasRegex(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		df       *DomainFilter
+		expected bool
+	}{
+		{"nil filter", nil, false},
+		{"empty string filter", NewDomainFilter([]string{}), false},
+		{"string filter only", NewDomainFilter([]string{"example.com"}), false},
+		{"regex include only", NewRegexDomainFilter(regexp.MustCompile(`\.example\.com$`), nil), true},
+		{"regex exclude only", NewRegexDomainFilter(nil, regexp.MustCompile(`^api\.`)), true},
+		{"regex both", NewRegexDomainFilter(regexp.MustCompile(`\.example\.com$`), regexp.MustCompile(`^api\.`)), true},
+		{"empty regex", NewRegexDomainFilter(regexp.MustCompile(""), nil), false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.df.HasRegex())
+		})
+	}
+}
+
 func TestDomainFilterDeserializeError(t *testing.T) {
 	for _, tt := range []struct {
 		name          string

--- a/provider/pdns/pdns.go
+++ b/provider/pdns/pdns.go
@@ -171,17 +171,27 @@ func (c *PDNSAPIClient) ListZones() ([]pgo.Zone, *http.Response, error) {
 	return zones, resp, provider.NewSoftErrorf("unable to list zones: %v", err)
 }
 
-// PartitionZones : Method returns a slice of zones that adhere to the domain filter and a slice of ones that does not adhere to the filter
+// PartitionZones returns a slice of zones that adhere to the domain filter and a slice of ones that do not.
+// When regex-based domain filters are configured, all zones are included because a regex that matches
+// record names (e.g. "^sub\.example\.com$") may not match the parent zone name ("example.com"),
+// and endpoint-level filtering in the plan already ensures only matching records are managed.
 func (c *PDNSAPIClient) PartitionZones(zones []pgo.Zone) ([]pgo.Zone, []pgo.Zone) {
 	var filteredZones []pgo.Zone
 	var residualZones []pgo.Zone
 
 	if c.domainFilter.IsConfigured() {
-		for _, zone := range zones {
-			if c.domainFilter.Match(zone.Name) {
-				filteredZones = append(filteredZones, zone)
-			} else {
-				residualZones = append(residualZones, zone)
+		if c.domainFilter.HasRegex() {
+			// Regex filters cannot reliably partition zones because a regex
+			// designed for record names won't match parent zone names.
+			// Include all zones; record-level filtering handles the rest.
+			filteredZones = zones
+		} else {
+			for _, zone := range zones {
+				if c.domainFilter.Match(zone.Name) {
+					filteredZones = append(filteredZones, zone)
+				} else {
+					residualZones = append(residualZones, zone)
+				}
 			}
 		}
 	} else {

--- a/provider/pdns/pdns_test.go
+++ b/provider/pdns/pdns_test.go
@@ -676,6 +676,12 @@ var (
 
 	RegexDomainFilter = endpoint.NewRegexDomainFilter(regexp.MustCompile("example.com"), nil)
 
+	// Regex that matches subdomains but not the zone name itself (issue #5591)
+	RegexDomainFilterSubdomainOnly = endpoint.NewRegexDomainFilter(regexp.MustCompile(`^[\w-]+\.example\.com$`), nil)
+
+	// Regex exclusion only (no include regex)
+	RegexDomainFilterExcludeOnly = endpoint.NewRegexDomainFilter(nil, regexp.MustCompile(`^staging\.`))
+
 	DomainFilterEmptyClient = &PDNSAPIClient{
 		dryRun:       false,
 		authCtx:      context.WithValue(context.Background(), pgo.ContextAPIKey, pgo.APIKey{Key: "TEST-API-KEY"}),
@@ -716,6 +722,20 @@ var (
 		authCtx:      context.WithValue(context.Background(), pgo.ContextAPIKey, pgo.APIKey{Key: "TEST-API-KEY"}),
 		client:       pgo.NewAPIClient(pgo.NewConfiguration()),
 		domainFilter: RegexDomainFilter,
+	}
+
+	RegexDomainFilterSubdomainOnlyClient = &PDNSAPIClient{
+		dryRun:       false,
+		authCtx:      context.WithValue(context.Background(), pgo.ContextAPIKey, pgo.APIKey{Key: "TEST-API-KEY"}),
+		client:       pgo.NewAPIClient(pgo.NewConfiguration()),
+		domainFilter: RegexDomainFilterSubdomainOnly,
+	}
+
+	RegexDomainFilterExcludeOnlyClient = &PDNSAPIClient{
+		dryRun:       false,
+		authCtx:      context.WithValue(context.Background(), pgo.ContextAPIKey, pgo.APIKey{Key: "TEST-API-KEY"}),
+		client:       pgo.NewAPIClient(pgo.NewConfiguration()),
+		domainFilter: RegexDomainFilterExcludeOnly,
 	}
 )
 
@@ -1209,9 +1229,23 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSClientPartitionZones() {
 	suite.Equal(partitionResultFilteredMultipleFilter, filteredZones)
 	suite.Equal(partitionResultResidualMultipleFilter, residualZones)
 
+	// Regex domain filters include all zones because the regex may match record
+	// names but not parent zone names. Endpoint-level filtering handles the rest.
 	filteredZones, residualZones = RegexDomainFilterClient.PartitionZones(zoneList)
-	suite.Equal(partitionResultFilteredSingleFilter, filteredZones)
-	suite.Equal(partitionResultResidualSingleFilter, residualZones)
+	suite.Equal(partitionResultFilteredEmptyFilter, filteredZones)
+	suite.Equal(([]pgo.Zone)(nil), residualZones)
+
+	// Regex that matches subdomains (e.g. "foo.example.com") but not the zone
+	// name itself ("example.com"). Before the fix for #5591, this would put
+	// example.com into residualZones and discard all its records.
+	filteredZones, residualZones = RegexDomainFilterSubdomainOnlyClient.PartitionZones(zoneList)
+	suite.Equal(partitionResultFilteredEmptyFilter, filteredZones)
+	suite.Equal(([]pgo.Zone)(nil), residualZones)
+
+	// Regex exclusion only — all zones should be included
+	filteredZones, residualZones = RegexDomainFilterExcludeOnlyClient.PartitionZones(zoneList)
+	suite.Equal(partitionResultFilteredEmptyFilter, filteredZones)
+	suite.Equal(([]pgo.Zone)(nil), residualZones)
 }
 
 // Validate whether invalid endpoints are removed by AdjustEndpoints


### PR DESCRIPTION
Fixes #5591

`PartitionZones` applies `domainFilter.Match()` to zone names, but a regex meant for record names
(e.g. `^[\w-]+\.example\.com$`) won't match the parent zone `example.com`. Every zone ends up in
residualZones and all records get the "Ignoring Endpoint" log.

String-based `--domain-filter` doesn't hit this because `matchFilter` uses suffix semantics that
naturally handle parent zones.

I added `HasRegex()` to `DomainFilter` and skip zone partitioning when regex is active. This is safe
because `plan.go`'s `filterRecordsForPlan` already filters records by `domainFilter.Match(DNSName)`
before anything reaches the provider.

This is the other half of #3869 which removed `MatchParent` from PDNS for the same class of bug
(#3816) — regex can't do parent matching, and it can't partition zones either.

The existing `ConvertEndpointsToZones` tests use stubs for the API client so the full
`PartitionZones` → `ConvertEndpointsToZones` → "Ignoring Endpoint" path isn't exercised
end-to-end. That's a pre-existing gap — didn't want to expand scope here.

Other providers that partition zones by domain filter (Scaleway, Akamai, Civo, DigitalOcean, etc.)
have the same latent bug. Happy to file follow-up issues or close this if maintainers prefer a fix
at the `DomainFilter` level (e.g. a `MatchZone` method).