### PR TITLE
fix(txt): skip migration for zone root TXT records outside managed zone

### DIFF
--- a/registry/txt/registry.go
+++ b/registry/txt/registry.go
@@ -271,7 +271,13 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 				desiredTXTs := im.generateTXTRecord(ep)
 				for _, desiredTXT := range desiredTXTs {
 					if _, exists := txtRecordsMap[desiredTXT.DNSName]; !exists {
-						ep.WithProviderSpecific(providerSpecificForceUpdate, "true")
+						// Only force update if the TXT record is within the managed zone.
+						// For zone roots without explicit txt-prefix, the generated TXT name
+						// may fall outside the zone (e.g., zone "example.com" generates "a-example.com"
+						// which is not a subdomain of "example.com").
+						if im.provider.GetDomainFilter().Match(desiredTXT.DNSName) {
+							ep.WithProviderSpecific(providerSpecificForceUpdate, "true")
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #4790

## Summary

Fixed an issue where External-DNS constantly deletes and recreates DNS records for zone roots (apex domains) when using the TXT registry without an explicit `--txt-prefix`.

The root cause was that for zone root records (e.g., `example.com` in zone `example.com`), the new format TXT record name (e.g., `a-example.com`) falls outside the managed zone. The migration logic would detect the missing new-format TXT record and set `providerSpecificForceUpdate`, triggering a constant delete/recreate cycle.

## Changes

- Added a check in the TXT registry migration logic to verify that the desired TXT record name is within the managed zone before setting `providerSpecificForceUpdate`
- For zone roots where the generated TXT record would be outside the zone, the migration is skipped, preventing the constant delete/recreate cycle

## Technical Details

For a zone root like `devnet.aptoslabs.com`:
- The `ToTXTName` function generates `a-devnet.aptoslabs.com`
- This is NOT within the zone `devnet.aptoslabs.com` (it's a sibling, not a subdomain)
- For non-zone roots like `val0.devnet.aptoslabs.com`, the TXT at `a-val0.devnet.aptoslabs.com` IS within the zone

The fix checks if the generated TXT record name matches the domain filter before forcing an update.

## Testing

- All existing TXT registry tests pass
- The fix is minimal and surgical, only affecting the migration logic

## Diff Stats

```
 registry/txt/registry.go | 7 ++++++-
 1 file changed, 7 insertions(+), 1 deletion(-)
```