### PR TITLE
feat(txt): add PTR record support to TXT registry mapper and PowerDNS trailing-dot handling

### DIFF
--- a/provider/pdns/pdns.go
+++ b/provider/pdns/pdns.go
@@ -66,6 +66,7 @@ var trailingTypes = []string{
 	endpoint.RecordTypeMX,
 	endpoint.RecordTypeSRV,
 	endpoint.RecordTypeNS,
+	endpoint.RecordTypePTR,
 	"ALIAS",
 }
 

--- a/provider/pdns/pdns_test.go
+++ b/provider/pdns/pdns_test.go
@@ -148,6 +148,16 @@ var (
 		},
 	}
 
+	// RRSet with PTR record
+	RRSetPTRRecord = pgo.RrSet{
+		Name:  "4.3.2.1.in-addr.arpa.",
+		Type_: endpoint.RecordTypePTR,
+		Ttl:   300,
+		Records: []pgo.Record{
+			{Content: "host.example.com", Disabled: false, SetPtr: false},
+		},
+	}
+
 	endpointsDisabledRecord = []*endpoint.Endpoint{
 		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8"),
 	}
@@ -196,6 +206,7 @@ var (
 		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeMX, endpoint.TTL(300), "10 mailhost1.example.com", "10 mailhost2.example.com"),
 		endpoint.NewEndpointWithTTL("_service._tls.example.com", endpoint.RecordTypeSRV, endpoint.TTL(300), "100 1 443 service.example.com"),
 		endpoint.NewEndpointWithTTL("sub.example.com", endpoint.RecordTypeNS, endpoint.TTL(300), "ns1.example.com", "ns2.example.com"),
+		endpoint.NewEndpointWithTTL("4.3.2.1.in-addr.arpa", endpoint.RecordTypePTR, endpoint.TTL(300), "host.example.com"),
 	}
 
 	endpointsMultipleZones = []*endpoint.Endpoint{
@@ -341,7 +352,7 @@ var (
 		Type_:  "Zone",
 		Url:    "/api/v1/servers/localhost/zones/example.com.",
 		Kind:   "Native",
-		Rrsets: []pgo.RrSet{RRSetCNAMERecord, RRSetTXTRecord, RRSetMultipleRecords, RRSetALIASRecord, RRSetMXRecord, RRSetSRVRecord, RRSetNSRecord},
+		Rrsets: []pgo.RrSet{RRSetCNAMERecord, RRSetTXTRecord, RRSetMultipleRecords, RRSetALIASRecord, RRSetMXRecord, RRSetSRVRecord, RRSetNSRecord, RRSetPTRRecord},
 	}
 
 	ZoneEmptyToSimplePatch = pgo.Zone{
@@ -1022,6 +1033,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSConvertEndpointsToZones() {
 		endpoint.RecordTypeMX:    true,
 		endpoint.RecordTypeSRV:   true,
 		endpoint.RecordTypeNS:    true,
+		endpoint.RecordTypePTR:   true,
 	}
 
 	for _, z := range zlist {

--- a/registry/mapper/mapper.go
+++ b/registry/mapper/mapper.go
@@ -33,6 +33,7 @@ var (
 		endpoint.RecordTypeCNAME,
 		endpoint.RecordTypeNS,
 		endpoint.RecordTypeMX,
+		endpoint.RecordTypePTR,
 		endpoint.RecordTypeSRV,
 		endpoint.RecordTypeNAPTR,
 	}

--- a/registry/mapper/mapper_test.go
+++ b/registry/mapper/mapper_test.go
@@ -80,6 +80,13 @@ func TestAffixNameMapper_ToEndpointName(t *testing.T) {
 			wantRecordType:   endpoint.RecordTypeSRV,
 		},
 		{
+			name:             "prefix with PTR record type in affix",
+			mapper:           NewAffixNameMapper("%{record_type}-", "", ""),
+			input:            "ptr-2.49.168.192.in-addr.arpa",
+			wantEndpointName: "2.49.168.192.in-addr.arpa",
+			wantRecordType:   endpoint.RecordTypePTR,
+		},
+		{
 			name:             "prefix with NAPTR record type in affix",
 			mapper:           NewAffixNameMapper("%{record_type}-", "", ""),
 			input:            "naptr-foo.example.com",
@@ -141,6 +148,13 @@ func TestAffixNameMapper_ToEndpointName(t *testing.T) {
 			input:            "srv-foo.example.com",
 			wantEndpointName: "foo.example.com",
 			wantRecordType:   endpoint.RecordTypeSRV,
+		},
+		{
+			name:             "default prefix with PTR record",
+			mapper:           NewAffixNameMapper("", "", ""),
+			input:            "ptr-2.49.168.192.in-addr.arpa",
+			wantEndpointName: "2.49.168.192.in-addr.arpa",
+			wantRecordType:   endpoint.RecordTypePTR,
 		},
 		{
 			name:             "no affix with NAPTR record",
@@ -230,6 +244,13 @@ func TestAffixNameMapper_ToTXTName(t *testing.T) {
 			wantTXTName: "srv-foo.example.com",
 		},
 		{
+			name:        "prefix with PTR record type in affix",
+			mapper:      NewAffixNameMapper("%{record_type}-", "", ""),
+			dns:         "2.49.168.192.in-addr.arpa",
+			recordType:  endpoint.RecordTypePTR,
+			wantTXTName: "ptr-2.49.168.192.in-addr.arpa",
+		},
+		{
 			name:        "prefix with NAPTR record type in affix",
 			mapper:      NewAffixNameMapper("%{record_type}-", "", ""),
 			dns:         "foo.example.com",
@@ -305,6 +326,13 @@ func TestAffixNameMapper_ToTXTName(t *testing.T) {
 			dns:         "foo.example.com",
 			recordType:  endpoint.RecordTypeSRV,
 			wantTXTName: "srv-foo.example.com",
+		},
+		{
+			name:        "default prefix with PTR record",
+			mapper:      NewAffixNameMapper("", "", ""),
+			dns:         "2.49.168.192.in-addr.arpa",
+			recordType:  endpoint.RecordTypePTR,
+			wantTXTName: "ptr-2.49.168.192.in-addr.arpa",
 		},
 		{
 			name:        "no affix with NAPTR record",
@@ -545,8 +573,8 @@ func TestExtractRecordTypeDefaultPosition(t *testing.T) {
 		},
 		{
 			input:        "ptr-zone.example.com",
-			expectedName: "ptr-zone.example.com",
-			expectedType: "",
+			expectedName: "zone.example.com",
+			expectedType: "PTR",
 		},
 		{
 			input:        "zone.example.com",


### PR DESCRIPTION
## What does it do ?

- Adds `endpoint.RecordTypePTR` to the registry mapper's supported record types, so PTR records are properly mapped through the txt-based registry.
- Adds PTR to the PowerDNS provider's trailing-dot record types list, ensuring PTR record targets are handled correctly.

## Motivation

These are small, low-risk prerequisite changes needed before PTR records can flow through the system end-to-end in https://github.com/kubernetes-sigs/external-dns/pull/6232. Without the mapper change, PTR records would be silently dropped by the TXT registry. Without the pdns change, PTR targets would lack the required trailing dot.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly