### PR TITLE
feat(endpoint): introduce record-type annotation and PTR endpoint helpers

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/utils/set"
 
@@ -50,6 +51,14 @@ const (
 	RecordTypeMX = "MX"
 	// RecordTypeNAPTR is a RecordType enum value
 	RecordTypeNAPTR = "NAPTR"
+
+	// TODO: review source/annotations package to consolidate alias key definitions;
+	// currently duplicated here to avoid circular dependency.
+	providerSpecificAlias = "alias"
+
+	// ProviderSpecificRecordType is the provider-specific property name used to
+	// request a particular DNS record type (e.g. "ptr") on an endpoint.
+	ProviderSpecificRecordType = "record-type"
 )
 
 var (
@@ -432,6 +441,17 @@ func (e *Endpoint) IsOwnedBy(ownerID string) bool {
 	return ok && endpointOwner == ownerID
 }
 
+// NewPTREndpoint creates a PTR endpoint from a forward IP target and one or more hostnames.
+// It computes the reverse DNS name (in-addr.arpa / ip6.arpa) from the target IP.
+func NewPTREndpoint(target string, ttl TTL, hostnames ...string) (*Endpoint, error) {
+	revAddr, err := dns.ReverseAddr(target)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute reverse address for %s: %w", target, err)
+	}
+	ptrName := strings.TrimSuffix(revAddr, ".")
+	return NewEndpointWithTTL(ptrName, RecordTypePTR, ttl, hostnames...), nil
+}
+
 func (e *Endpoint) String() string {
 	return fmt.Sprintf("%s %d IN %s %s %s %s", e.DNSName, e.RecordTTL, e.RecordType, e.SetIdentifier, e.Targets, e.ProviderSpecific)
 }
@@ -480,9 +500,11 @@ func RemoveDuplicates(endpoints []*Endpoint) []*Endpoint {
 	return result
 }
 
-// TODO: review source/annotations package to consolidate alias key definitions;
-// currently duplicated here to avoid circular dependency.
-const providerSpecificAlias = "alias"
+// RequestedRecordType returns the value of the "record-type" provider-specific
+// property, following the same pattern as the alias accessor.
+func (e *Endpoint) RequestedRecordType() (string, bool) {
+	return e.GetProviderSpecificProperty(ProviderSpecificRecordType)
+}
 
 // TODO: rename to Validate
 // CheckEndpoint Check if endpoint is properly formatted according to RFC standards
@@ -495,6 +517,10 @@ func (e *Endpoint) CheckEndpoint() bool {
 	}
 
 	switch recordType := e.RecordType; recordType {
+	case RecordTypeA, RecordTypeAAAA:
+		if !e.isAlias() {
+			return e.Targets.ValidateIPRecord(recordType)
+		}
 	case RecordTypeMX:
 		return e.Targets.ValidateMXRecord()
 	case RecordTypeSRV:
@@ -503,6 +529,12 @@ func (e *Endpoint) CheckEndpoint() bool {
 		return e.ValidatePTRRecord()
 	}
 	return true
+}
+
+// isAlias returns true if the endpoint has the alias provider-specific property set to true.
+func (e *Endpoint) isAlias() bool {
+	val, ok := e.GetBoolProviderSpecificProperty(providerSpecificAlias)
+	return ok && val
 }
 
 func (e *Endpoint) supportsAlias() bool {
@@ -549,6 +581,25 @@ func (m *MXTarget) GetPriority() *uint16 {
 // GetHost returns the host of the MX record target.
 func (m *MXTarget) GetHost() *string {
 	return &m.host
+}
+
+func (t Targets) ValidateIPRecord(recordType string) bool {
+	for _, target := range t {
+		addr, err := netip.ParseAddr(target)
+		if err != nil {
+			log.Debugf("Invalid %s record target: %s is not a valid IP address", recordType, target)
+			return false
+		}
+		if recordType == RecordTypeA && addr.Is6() {
+			log.Debugf("Invalid A record target: %s is an IPv6 address", target)
+			return false
+		}
+		if recordType == RecordTypeAAAA && addr.Is4() {
+			log.Debugf("Invalid AAAA record target: %s is an IPv4 address", target)
+			return false
+		}
+	}
+	return true
 }
 
 func (t Targets) ValidateMXRecord() bool {

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -1079,6 +1079,51 @@ func TestCheckEndpoint(t *testing.T) {
 			expected: true,
 		},
 		{
+			description: "Valid AAAA record",
+			endpoint: Endpoint{
+				DNSName:    "example.com",
+				RecordType: RecordTypeAAAA,
+				Targets:    Targets{"2001:db8::1"},
+			},
+			expected: true,
+		},
+		{
+			description: "Invalid A record - not an IP",
+			endpoint: Endpoint{
+				DNSName:    "example.com",
+				RecordType: RecordTypeA,
+				Targets:    Targets{"not-an-ip"},
+			},
+			expected: false,
+		},
+		{
+			description: "Invalid A record - IPv6 address",
+			endpoint: Endpoint{
+				DNSName:    "example.com",
+				RecordType: RecordTypeA,
+				Targets:    Targets{"2001:db8::1"},
+			},
+			expected: false,
+		},
+		{
+			description: "Invalid AAAA record - IPv4 address",
+			endpoint: Endpoint{
+				DNSName:    "example.com",
+				RecordType: RecordTypeAAAA,
+				Targets:    Targets{"192.168.1.1"},
+			},
+			expected: false,
+		},
+		{
+			description: "Invalid AAAA record - not an IP",
+			endpoint: Endpoint{
+				DNSName:    "example.com",
+				RecordType: RecordTypeAAAA,
+				Targets:    Targets{"not-an-ip"},
+			},
+			expected: false,
+		},
+		{
 			description: "A record with alias=true is valid",
 			endpoint: Endpoint{
 				DNSName:          "example.com",
@@ -1633,6 +1678,70 @@ func TestGetBoolProviderSpecificProperty(t *testing.T) {
 			value, exists := tt.endpoint.GetBoolProviderSpecificProperty(tt.key)
 			assert.Equal(t, tt.expectedValue, value)
 			assert.Equal(t, tt.expectedExists, exists)
+		})
+	}
+}
+
+func TestRequestedRecordType(t *testing.T) {
+	ep := NewEndpoint("example.com", RecordTypeA, "1.2.3.4").
+		WithProviderSpecific(ProviderSpecificRecordType, "ptr")
+	val, ok := ep.RequestedRecordType()
+	assert.True(t, ok)
+	assert.Equal(t, "ptr", val)
+
+	ep2 := NewEndpoint("example.com", RecordTypeA, "1.2.3.4")
+	_, ok = ep2.RequestedRecordType()
+	assert.False(t, ok)
+}
+
+func TestNewPTREndpoint(t *testing.T) {
+	tests := []struct {
+		name      string
+		target    string
+		ttl       TTL
+		hostnames []string
+		wantName  string
+		wantErr   bool
+	}{
+		{
+			name:      "IPv4",
+			target:    "192.168.49.2",
+			ttl:       300,
+			hostnames: []string{"web.example.com"},
+			wantName:  "2.49.168.192.in-addr.arpa",
+		},
+		{
+			name:      "IPv6",
+			target:    "2001:db8::1",
+			ttl:       600,
+			hostnames: []string{"v6.example.com"},
+			wantName:  "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa",
+		},
+		{
+			name:      "multiple hostnames",
+			target:    "10.0.0.1",
+			ttl:       60,
+			hostnames: []string{"a.example.com", "b.example.com"},
+			wantName:  "1.0.0.10.in-addr.arpa",
+		},
+		{
+			name:    "invalid target",
+			target:  "not-an-ip",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep, err := NewPTREndpoint(tt.target, tt.ttl, tt.hostnames...)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantName, ep.DNSName)
+			assert.Equal(t, RecordTypePTR, ep.RecordType)
+			assert.Equal(t, tt.ttl, ep.RecordTTL)
+			assert.Equal(t, Targets(tt.hostnames), ep.Targets)
 		})
 	}
 }

--- a/source/annotations/annotations.go
+++ b/source/annotations/annotations.go
@@ -46,6 +46,7 @@ var (
 	TtlKey           = AnnotationKeyPrefix + "ttl"
 	SetIdentifierKey = AnnotationKeyPrefix + "set-identifier"
 	AliasKey         = AnnotationKeyPrefix + "alias"
+	RecordTypeKey    = AnnotationKeyPrefix + "record-type"
 	TargetKey        = AnnotationKeyPrefix + "target"
 	// ControllerKey The annotation used for figuring out which controller is responsible
 	ControllerKey = AnnotationKeyPrefix + "controller"
@@ -92,6 +93,7 @@ func SetAnnotationPrefix(prefix string) {
 	TtlKey = AnnotationKeyPrefix + "ttl"
 	SetIdentifierKey = AnnotationKeyPrefix + "set-identifier"
 	AliasKey = AnnotationKeyPrefix + "alias"
+	RecordTypeKey = AnnotationKeyPrefix + "record-type"
 	TargetKey = AnnotationKeyPrefix + "target"
 	ControllerKey = AnnotationKeyPrefix + "controller"
 	HostnameKey = AnnotationKeyPrefix + "hostname"

--- a/source/annotations/provider_specific.go
+++ b/source/annotations/provider_specific.go
@@ -29,6 +29,12 @@ func ProviderSpecificAnnotations(annotations map[string]string) (endpoint.Provid
 			Value: "true",
 		})
 	}
+	if v, ok := annotations[RecordTypeKey]; ok {
+		providerSpecificAnnotations = append(providerSpecificAnnotations, endpoint.ProviderSpecificProperty{
+			Name:  endpoint.ProviderSpecificRecordType,
+			Value: v,
+		})
+	}
 	setIdentifier := ""
 	for k, v := range annotations {
 		if k == SetIdentifierKey {

--- a/source/annotations/provider_specific_test.go
+++ b/source/annotations/provider_specific_test.go
@@ -84,6 +84,16 @@ func TestProviderSpecificAnnotations(t *testing.T) {
 			expected:      endpoint.ProviderSpecific{},
 			setIdentifier: "identifier",
 		},
+		{
+			name: "Record type annotation",
+			annotations: map[string]string{
+				RecordTypeKey: "ptr",
+			},
+			expected: endpoint.ProviderSpecific{
+				{Name: endpoint.ProviderSpecificRecordType, Value: "ptr"},
+			},
+			setIdentifier: "",
+		},
 	}
 
 	for _, tt := range tests {

--- a/source/wrappers/dedupsource_test.go
+++ b/source/wrappers/dedupsource_test.go
@@ -108,11 +108,11 @@ func testDedupEndpoints(t *testing.T) {
 			"two endpoints with same dnsname, different record type, and same target return two endpoints",
 			[]*endpoint.Endpoint{
 				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
-				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:db8::1"}},
 			},
 			[]*endpoint.Endpoint{
 				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
-				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"1.2.3.4"}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:db8::1"}},
 			},
 		},
 		{
@@ -291,9 +291,7 @@ func TestDedupEndpointsValidation(t *testing.T) {
 				{DNSName: "example.org", RecordType: endpoint.RecordTypeTXT, Targets: endpoint.Targets{"v=spf1 include:example.com ~all"}},
 				{DNSName: "example.org", RecordType: endpoint.RecordTypeTXT, Targets: endpoint.Targets{""}},
 				{DNSName: "example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"192.168.1.1"}},
-				{DNSName: "example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"not-an-ip"}},
 				{DNSName: "example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"2001:db8::1"}},
-				{DNSName: "example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"invalid-ipv6"}},
 			},
 		},
 		{
@@ -318,6 +316,35 @@ func TestDedupEndpointsValidation(t *testing.T) {
 				{DNSName: "1.0.0.10.in-addr.arpa", RecordType: endpoint.RecordTypePTR, Targets: endpoint.Targets{"10.0.0.1"}},
 			},
 			expected: []*endpoint.Endpoint{},
+		},
+		{
+			name: "A record with record-type annotation passes through",
+			endpoints: []*endpoint.Endpoint{
+				{DNSName: "example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}, ProviderSpecific: endpoint.ProviderSpecific{{Name: endpoint.ProviderSpecificRecordType, Value: "PTR"}}},
+			},
+			expected: []*endpoint.Endpoint{
+				{DNSName: "example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}, ProviderSpecific: endpoint.ProviderSpecific{{Name: endpoint.ProviderSpecificRecordType, Value: "PTR"}}},
+			},
+		},
+		{
+			name: "duplicate A records with same record-type annotation are deduped",
+			endpoints: []*endpoint.Endpoint{
+				{DNSName: "example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}, ProviderSpecific: endpoint.ProviderSpecific{{Name: endpoint.ProviderSpecificRecordType, Value: "PTR"}}},
+				{DNSName: "example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}, ProviderSpecific: endpoint.ProviderSpecific{{Name: endpoint.ProviderSpecificRecordType, Value: "PTR"}}},
+			},
+			expected: []*endpoint.Endpoint{
+				{DNSName: "example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}, ProviderSpecific: endpoint.ProviderSpecific{{Name: endpoint.ProviderSpecificRecordType, Value: "PTR"}}},
+			},
+		},
+		{
+			name: "A records with and without record-type annotation are deduped by identity key",
+			endpoints: []*endpoint.Endpoint{
+				{DNSName: "example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}, ProviderSpecific: endpoint.ProviderSpecific{{Name: endpoint.ProviderSpecificRecordType, Value: "PTR"}}},
+				{DNSName: "example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}},
+			},
+			expected: []*endpoint.Endpoint{
+				{DNSName: "example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"1.2.3.4"}, ProviderSpecific: endpoint.ProviderSpecific{{Name: endpoint.ProviderSpecificRecordType, Value: "PTR"}}},
+			},
 		},
 	}
 


### PR DESCRIPTION
## What does it do ?

- Introduces the `external-dns.alpha.kubernetes.io/record-type` annotation, allowing users to explicitly request a specific DNS record type (e.g., PTR) for a source.
- Adds `NewPTREndpoint()` — a constructor that creates a properly formed PTR endpoint with reversed IP as the DNS name.
- Adds `ValidateIPRecord()` — validates that A/AAAA endpoints have valid IP targets.
- Adds `RequestedRecordType()` — reads the record-type annotation from an endpoint's provider-specific properties.
- Extends `CheckEndpoint()` with A/AAAA target validation.
- Adds the `record-type` annotation to the provider-specific annotation parser.

## Motivation

PTR record creation requires reversing an IP address into its `.in-addr.arpa` / `.ip6.arpa` form and associating it with a hostname target. These utilities centralize that logic in the `endpoint` package so that sources and wrappers don't need to implement it independently. The `record-type` annotation gives users explicit control over which record type is generated from a given source, which is essential for the PTR source wrapper.
As of https://github.com/kubernetes-sigs/external-dns/pull/6232

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly