### PR TITLE
fix(helm): missing quotes on container arguments when extraArgs is a map

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Avoid creating cluster-scoped RBAC for Gateway API sources when running namespaced with `gatewayNamespace` set. Namespace listing permissions are now only added when `gatewayNamespace` is unset. ([#5843](https://github.com/kubernetes-sigs/external-dns/pull/5843)) _@TobyTheHutt_
+- Ensure container arguments are passed in as strings when extraArgs is a map ([#6284](https://github.com/kubernetes-sigs/external-dns/pull/6284)) _@vflaux_
 
 ## [v1.20.0]
 

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -138,13 +138,13 @@ spec:
             {{- if not (kindIs "invalid" $value) }}
             {{- if kindIs "slice" $value }}
             {{- range $value }}
-            - --{{ $key }}={{ tpl (. | toString) $ }}
+            - {{ print "--" $key "=" (tpl (. | toString) $) | quote }}
             {{- end }}
             {{- else }}
-            - --{{ $key }}={{ tpl ($value | toString) $ }}
+            - {{ print "--" $key "=" (tpl ($value | toString) $) | quote }}
             {{- end }}
             {{- else }}
-            - --{{ $key }}
+            - {{ print "--" $key | quote }}
             {{- end }}
             {{- end }}
             {{- end }}

--- a/charts/external-dns/tests/deployment-flags_test.yaml
+++ b/charts/external-dns/tests/deployment-flags_test.yaml
@@ -138,6 +138,7 @@ tests:
         extraArgC:
           - valueC-1
           - valueC-2
+        extraArgD: "valueD: D"
 
     asserts:
       - equal:
@@ -155,6 +156,7 @@ tests:
             - --extraArgB=valueB
             - --extraArgC=valueC-1
             - --extraArgC=valueC-2
+            - "--extraArgD=valueD: D"
 
 
   - it: should throw error when txtPrefix and txtSuffix are set


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->
Ensure `extraArgs` in helm chart values produces string arguments when it's a map.

(Fix for slice version: https://github.com/kubernetes-sigs/external-dns/pull/6264)

## Motivation

<!-- What inspired you to submit this pull request? -->

When there is a ": " in an argument value, the rendered item is a map instead of a string.

```yaml
extraArgs:
  some-flag: "some: value"
```

```yaml
args:
- --some-flag=some: value
```

with the fix:

```yaml
args:
- "--some-flag=some: value"
```

This could be triggered by flags like `--cloudflare-record-comment` which accept ": " in it's value (e.g. `--cloudflare-record-comment=env: prod`).

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
