### PR TITLE
fix(events): re-enqueue failed events in controller work queue

### DIFF
--- a/pkg/events/controller.go
+++ b/pkg/events/controller.go
@@ -111,6 +111,7 @@ func (ec *Controller) processNextWorkItem(ctx context.Context) bool {
 	if err != nil && !apierrors.IsNotFound(err) {
 		if ec.queue.NumRequeues(key) < maxTriesPerEvent {
 			log.Errorf("not able to create event, retrying for key/%s. %v", key, err)
+			ec.queue.AddRateLimited(key)
 			return true
 		}
 		log.Errorf("dropping event %s/%s with key/%q after %d retries. %v", event.Namespace, event.Name, key, ec.queue.NumRequeues(key), err)

--- a/pkg/events/controller_test.go
+++ b/pkg/events/controller_test.go
@@ -182,3 +182,64 @@ func TestController_Queue_EmitEvents(t *testing.T) {
 	assert.Contains(t, value.Name, "fake-object.")
 	assert.Contains(t, value.Reason, RecordReady)
 }
+
+func TestController_ProcessNextWorkItem_RequeuesOnError(t *testing.T) {
+	log.SetLevel(log.ErrorLevel)
+	ctx := t.Context()
+
+	createAttempts := 0
+	kubeClient := fake.NewClientset()
+	kubeClient.PrependReactor("create", "events", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+		createAttempts++
+		if createAttempts <= maxTriesPerEvent {
+			return true, nil, fmt.Errorf("transient API error")
+		}
+		return true, nil, nil
+	})
+
+	eventCreated := make(chan struct{}, 1)
+	kubeClient.PrependReactor("create", "events", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+		createAttempts++
+		if createAttempts <= maxTriesPerEvent {
+			return true, nil, fmt.Errorf("transient API error")
+		}
+		eventCreated <- struct{}{}
+		return true, nil, nil
+	})
+
+	ctrl := &Controller{
+		client:     kubeClient.EventsV1(),
+		emitEvents: sets.New[Reason](RecordReady),
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig[any](
+			workqueue.NewTypedMaxOfRateLimiter[any](
+				workqueue.NewTypedItemFastSlowRateLimiter[any](1*time.Millisecond, 1*time.Millisecond, 5),
+			),
+			workqueue.TypedRateLimitingQueueConfig[any]{Name: controllerName},
+		),
+		hostname:        controllerName,
+		maxQueuedEvents: maxQueuedEvents,
+	}
+
+	ctrl.Run(ctx)
+
+	event := NewEvent(NewObjectReference(&v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake-object",
+			Namespace: v1.NamespaceDefault,
+			UID:       "9de3fc19-8aeb-4e76-865d-ada955403103",
+		},
+	}, "fake-source"), "record created", ActionCreate, RecordReady)
+
+	ctrl.Add(event)
+
+	select {
+	case <-eventCreated:
+		assert.Greater(t, createAttempts, 1, "event should have been retried at least once")
+	case <-time.After(5 * time.Second):
+		t.Fatalf("event was not retried and delivered; only %d attempt(s) made", createAttempts)
+	}
+}


### PR DESCRIPTION
## What does it do ?

Adds the missing `AddRateLimited` call when event creation fails with a
transient error. Without it the item was marked `Done` but never put back
into the queue, so retries never actually happened and events were silently
dropped.

## Motivation

While investigating memory behaviour reported in #5965 I noticed the
standard workqueue retry contract was not followed in `processNextWorkItem`:
the code checked `NumRequeues < maxTriesPerEvent` and logged a retry message,
but returned without calling `AddRateLimited`, which meant the item left
the queue permanently after the first failure.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly