### PR TITLE
feat(chart): ability to watch other namespace

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Added
+
+- Add value `.sourceNamespace` to watch a namespace which is different from the one that external-dns is installed into when `.namespaced` is true. ([#6297](https://github.com/kubernetes-sigs/external-dns/pull/6297)) _@jplitza_
+
 ### Fixed
 
 - Avoid creating cluster-scoped RBAC for Gateway API sources when running namespaced with `gatewayNamespace` set. Namespace listing permissions are now only added when `gatewayNamespace` is unset. ([#5843](https://github.com/kubernetes-sigs/external-dns/pull/5843)) _@TobyTheHutt_

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -60,7 +60,7 @@ For set up for a specific provider using the Helm chart, see the following links
 ## Namespace Scoped Installation
 
 `external-dns` supports running on a namespace-only scope, too.
-If `namespaced=true` is defined, the Helm chart will setup `Roles` and `RoleBindings` instead of `ClusterRoles` and `ClusterRoleBindings`.
+If `namespaced=true` is defined, the Helm chart will setup `Roles` and `RoleBindings` instead of `ClusterRoles` and `ClusterRoleBindings`. By default, they are set up in the same namespace that `external-dns` itself is installed to. This can be changed via the `sourceNamespace` value.
 
 Note: When using Gateway API sources in namespaced mode, a cluster-scoped permission to list namespaces is required, unless you also set `gatewayNamespace`. If you set `gatewayNamespace`, all RBAC remains namespaced and no `ClusterRole`/`ClusterRoleBinding` is created.
 
@@ -180,6 +180,7 @@ If `namespaced` is set to `true`, please ensure that `sources` only contains sup
 | serviceMonitor.targetLabels | list | `[]` | Provide target labels for the `ServiceMonitor`. |
 | serviceMonitor.tlsConfig | object | `{}` | Configure the `ServiceMonitor` [TLS config](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig). |
 | shareProcessNamespace | bool | `false` | If `true`, the `Pod` will have [process namespace sharing](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/) enabled. |
+| sourceNamespace | string | `nil` | Source namespace to watch for Kubernetes resources other than Gateway API gateways. Used only when `namespaced=true`. Defaults to Release.Namespace |
 | sources | list | `["service","ingress"]` | _Kubernetes_ resources to monitor for DNS entries. |
 | terminationGracePeriodSeconds | int | `nil` | Termination grace period for the `Pod` in seconds. |
 | tolerations | list | `[]` | Node taints which will be tolerated for `Pod` [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). |

--- a/charts/external-dns/README.md.gotmpl
+++ b/charts/external-dns/README.md.gotmpl
@@ -54,7 +54,7 @@ For set up for a specific provider using the Helm chart, see the following links
 ## Namespace Scoped Installation
 
 `external-dns` supports running on a namespace-only scope, too.
-If `namespaced=true` is defined, the Helm chart will setup `Roles` and `RoleBindings` instead of `ClusterRoles` and `ClusterRoleBindings`.
+If `namespaced=true` is defined, the Helm chart will setup `Roles` and `RoleBindings` instead of `ClusterRoles` and `ClusterRoleBindings`. By default, they are set up in the same namespace that `external-dns` itself is installed to. This can be changed via the `sourceNamespace` value.
 
 Note: When using Gateway API sources in namespaced mode, a cluster-scoped permission to list namespaces is required, unless you also set `gatewayNamespace`. If you set `gatewayNamespace`, all RBAC remains namespaced and no `ClusterRole`/`ClusterRoleBinding` is created.
 

--- a/charts/external-dns/templates/clusterrole.yaml
+++ b/charts/external-dns/templates/clusterrole.yaml
@@ -3,6 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ .Values.namespaced | ternary "Role" "ClusterRole" }}
 metadata:
   name: {{ template "external-dns.fullname" . }}
+  {{- if and .Values.namespaced .Values.sourceNamespace }}
+  namespace: {{ .Values.sourceNamespace }}
+  {{- end }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
 rules:

--- a/charts/external-dns/templates/clusterrolebinding.yaml
+++ b/charts/external-dns/templates/clusterrolebinding.yaml
@@ -3,6 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ .Values.namespaced | ternary "RoleBinding" "ClusterRoleBinding" }}
 metadata:
   name: {{ printf "%s-viewer" (include "external-dns.fullname" .) }}
+  {{- if and .Values.namespaced .Values.sourceNamespace }}
+  namespace: {{ .Values.sourceNamespace }}
+  {{- end }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
 roleRef:

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -109,7 +109,7 @@ spec:
             - --txt-suffix={{ .Values.txtSuffix }}
             {{- end }}
             {{- if .Values.namespaced }}
-            - --namespace={{ .Release.Namespace }}
+            - --namespace={{ default .Release.Namespace .Values.sourceNamespace }}
             {{- end }}
             {{- if .Values.gatewayNamespace }}
             - --gateway-namespace={{ .Values.gatewayNamespace }}

--- a/charts/external-dns/tests/rbac_test.yaml
+++ b/charts/external-dns/tests/rbac_test.yaml
@@ -229,6 +229,40 @@ tests:
           value: rbac-external-dns-viewer
         template: clusterrolebinding.yaml
 
+  - it: should create Role in other namespace when sourceNamespace is set and namespaced is true
+    set:
+      namespaced: true
+      sources:
+        - service
+      sourceNamespace: secondary
+    asserts:
+      - isKind:
+          of: Role
+        template: clusterrole.yaml
+      - equal:
+          path: metadata.name
+          value: rbac-external-dns
+        template: clusterrole.yaml
+      - equal:
+          path: metadata.namespace
+          value: secondary
+        template: clusterrole.yaml
+
+  - it: should create RoleBinding in other namespace when sourceNamespace is set and namespaced is true
+    set:
+      namespaced: true
+      sources:
+        - service
+      sourceNamespace: secondary
+    asserts:
+      - isKind:
+          of: RoleBinding
+        template: clusterrolebinding.yaml
+      - equal:
+          path: metadata.namespace
+          value: secondary
+        template: clusterrolebinding.yaml
+
   - it: should create only namespaced RBAC when namespaced=true and gatewayNamespace is specified
     set:
       namespaced: true

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -840,6 +840,13 @@
       "description": "If `true`, the `Pod` will have [process namespace sharing](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/) enabled.",
       "type": "boolean"
     },
+    "sourceNamespace": {
+      "description": "Source namespace to watch for Kubernetes resources other than Gateway API gateways. Used only when `namespaced=true`. Defaults to Release.Namespace",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "sources": {
       "description": "_Kubernetes_ resources to monitor for DNS entries.",
       "type": "array",

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -210,6 +210,10 @@ namespaced: false
 # (no ClusterRole/ClusterRoleBinding) for Gateway sources.
 gatewayNamespace:  # @schema type:[string, null]; default: null
 
+# -- Source namespace to watch for Kubernetes resources other than Gateway API gateways.
+# Used only when `namespaced=true`. Defaults to Release.Namespace
+sourceNamespace:  # @schema type:[string, null]; default: null
+
 # -- _Kubernetes_ resources to monitor for DNS entries.
 sources:
   - service


### PR DESCRIPTION
## What does it do ?

Add the ability to let external-dns monitor only one namespace which is different from the one it is installed into.

## Motivation

The namespaced mode of the Helm Chart assumes that external-dns should watch ressources in the same namespace it is installed to. It already has a value to set a different namespace to watch for Gateway API gateways. But at least since the introduction of the unstructured data source in #6172, there are infinitely many other resource kinds where this makes sense.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
