### PR TITLE
feat(powerdns): add LUA record support

### DIFF
--- a/docs/tutorials/crd.md
+++ b/docs/tutorials/crd.md
@@ -111,3 +111,23 @@ spec:
     - 50 50 "S" "SIPS+D2T" "" _sips._tcp.test.example.com.
     - 100 50 "S" "SIP+D2U" "" _sip._udp.test.example.com.
 ```
+
+### DNSEndpoint with an LUA record (PowerDNS Exclusive)
+
+Here's an example of a `DNSEndpoint` with an LUA record:
+To test this add --managed-record-types=LUA in the deployment args.
+```yaml
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: test-lua
+  namespace: default
+spec:
+  endpoints:
+  - dnsName: test.example.com
+    recordTTL: 180
+    recordType: LUA
+    targets:
+    - A "ifportup(443, {{' 192.168.1.1'}, {'192.168.1.2'}})
+```

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -51,6 +51,8 @@ const (
 	RecordTypeMX = "MX"
 	// RecordTypeNAPTR is a RecordType enum value
 	RecordTypeNAPTR = "NAPTR"
+	// RecordTypeLUA is a RecordType enum value
+	RecordTypeLUA = "LUA"
 
 	// TODO: review source/annotations package to consolidate alias key definitions;
 	// currently duplicated here to avoid circular dependency.
@@ -72,6 +74,7 @@ var (
 		RecordTypePTR,
 		RecordTypeMX,
 		RecordTypeNAPTR,
+		RecordTypeLUA,
 	}
 )
 
@@ -272,11 +275,11 @@ func NewEndpoint(dnsName, recordType string, targets ...string) *Endpoint {
 func NewEndpointWithTTL(dnsName, recordType string, ttl TTL, targets ...string) *Endpoint {
 	cleanTargets := make([]string, len(targets))
 	for idx, target := range targets {
-		// Only trim trailing dots for domain name record types, not for TXT or NAPTR records
-		// TXT records can contain arbitrary text including multiple dots
+		// Only trim trailing dots for domain name record types, not for TXT, NAPTR or LUA records
+		// TXT and LUA records can contain arbitrary text including multiple dots
 		// SRV can contain dots in their target part (RFC2782)
 		switch recordType {
-		case RecordTypeTXT, RecordTypeNAPTR, RecordTypeSRV:
+		case RecordTypeTXT, RecordTypeNAPTR, RecordTypeSRV, RecordTypeLUA:
 			cleanTargets[idx] = target
 		default:
 			cleanTargets[idx] = strings.TrimSuffix(target, ".")

--- a/provider/pdns/pdns_test.go
+++ b/provider/pdns/pdns_test.go
@@ -158,7 +158,14 @@ var (
 			{Content: "host.example.com", Disabled: false, SetPtr: false},
 		},
 	}
-
+	RRSetLUARecord = pgo.RrSet{
+		Name:  "lua.example.com.",
+		Type_: endpoint.RecordTypeLUA,
+		Ttl:   300,
+		Records: []pgo.Record{
+			{Content: "A \"ifportup(443, {{'192.168.1.1'}, {'192.168.1.1'}})\"", Disabled: false, SetPtr: false},
+		},
+	}
 	endpointsDisabledRecord = []*endpoint.Endpoint{
 		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8"),
 	}

--- a/registry/mapper/mapper.go
+++ b/registry/mapper/mapper.go
@@ -36,6 +36,7 @@ var (
 		endpoint.RecordTypePTR,
 		endpoint.RecordTypeSRV,
 		endpoint.RecordTypeNAPTR,
+		endpoint.RecordTypeLUA,
 	}
 )
 

--- a/registry/mapper/mapper_test.go
+++ b/registry/mapper/mapper_test.go
@@ -94,6 +94,13 @@ func TestAffixNameMapper_ToEndpointName(t *testing.T) {
 			wantRecordType:   endpoint.RecordTypeNAPTR,
 		},
 		{
+			name:             "prefix with LUA record type in affix",
+			mapper:           NewAffixNameMapper("%{record_type}-", "", ""),
+			input:            "lua-foo.example.com",
+			wantEndpointName: "foo.example.com",
+			wantRecordType:   endpoint.RecordTypeLUA,
+		},
+		{
 			name:             "suffix with A record type in affix",
 			mapper:           NewAffixNameMapper("", "-%{record_type}", ""),
 			input:            "foo-a.example.com",
@@ -162,6 +169,13 @@ func TestAffixNameMapper_ToEndpointName(t *testing.T) {
 			input:            "naptr-foo.example.com",
 			wantEndpointName: "foo.example.com",
 			wantRecordType:   endpoint.RecordTypeNAPTR,
+		},
+		{
+			name:             "no affix with LUA record",
+			mapper:           NewAffixNameMapper("", "", ""),
+			input:            "lua-foo.example.com",
+			wantEndpointName: "foo.example.com",
+			wantRecordType:   endpoint.RecordTypeLUA,
 		},
 		{
 			name:             "suffix with txt record",
@@ -258,6 +272,13 @@ func TestAffixNameMapper_ToTXTName(t *testing.T) {
 			wantTXTName: "naptr-foo.example.com",
 		},
 		{
+			name:        "prefix with LUA record type in affix",
+			mapper:      NewAffixNameMapper("%{record_type}-", "", ""),
+			dns:         "foo.example.com",
+			recordType:  endpoint.RecordTypeLUA,
+			wantTXTName: "lua-foo.example.com",
+		},
+		{
 			name:        "suffix with A record type in affix",
 			mapper:      NewAffixNameMapper("", "-%{record_type}", ""),
 			dns:         "foo.example.com",
@@ -340,6 +361,13 @@ func TestAffixNameMapper_ToTXTName(t *testing.T) {
 			dns:         "foo.example.com",
 			recordType:  endpoint.RecordTypeNAPTR,
 			wantTXTName: "naptr-foo.example.com",
+		},
+		{
+			name:        "no affix with LUA record",
+			mapper:      NewAffixNameMapper("", "", ""),
+			dns:         "foo.example.com",
+			recordType:  endpoint.RecordTypeLUA,
+			wantTXTName: "lua-foo.example.com",
 		},
 	}
 

--- a/source/crd.go
+++ b/source/crd.go
@@ -205,8 +205,8 @@ func (cs *crdSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 			illegalTarget := false
 			for _, target := range ep.Targets {
 				switch ep.RecordType {
-				case endpoint.RecordTypeTXT, endpoint.RecordTypeMX:
-					continue // TXT records allow arbitrary text, skip validation; MX records can have trailing dot but it's not required, skip validation
+				case endpoint.RecordTypeTXT, endpoint.RecordTypeMX, endpoint.RecordTypeLUA:
+					continue // TXT records allow arbitrary text, skip validation; MX records can have trailing dot but it's not required, skip validation; LUA records allow arbitrary text, skip validation
 				case endpoint.RecordTypeCNAME:
 					continue // RFC 1035 §5.1: trailing dot denotes an absolute FQDN in zone file notation; both forms are valid
 				}

--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -441,6 +441,27 @@ func testCRDSourceEndpoints(t *testing.T) {
 			expectError:     false,
 		},
 		{
+			title:                "Create LUA record",
+			registeredAPIVersion: apiv1alpha1.GroupVersion.String(),
+			apiVersion:           apiv1alpha1.GroupVersion.String(),
+			registeredKind:       apiv1alpha1.DNSEndpointKind,
+			kind:                 apiv1alpha1.DNSEndpointKind,
+			namespace:            "foo",
+			registeredNamespace:  "foo",
+			labels:               map[string]string{"test": "that"},
+			labelFilter:          "test=that",
+			endpoints: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					Targets:    endpoint.Targets{`A "ifportup(443, {{'192.168.1.1'}, {'192.168.1.1'}})`},
+					RecordType: endpoint.RecordTypeLUA,
+					RecordTTL:  180,
+				},
+			},
+			expectEndpoints: true,
+			expectError:     false,
+		},
+		{
 			title:                "CNAME target with trailing dot (RFC 1035 §5.1 absolute FQDN) is valid",
 			registeredAPIVersion: apiv1alpha1.GroupVersion.String(),
 			apiVersion:           apiv1alpha1.GroupVersion.String(),


### PR DESCRIPTION
## What does it do ?

This PR adds support for the LUA record type (Exclusive to PowerDNS)

## Motivation

PowerDNS supports a LUA record type (https://doc.powerdns.com/authoritative/lua-records/index.html)

It's akin to a TXT record in the fact that by itself it only stores a lua snippet in the form of text, but it is parsed differently by PowerDNS, actually executing the provided script and using the return value as the answer. 
## More

This feature is gated behind the "managed-record-types" argument so it's not enabled by default.

I tested this on k8s 1.32, external-dns v0.20 and powerDNS 4.8.3

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly