### PR TITLE
ci: replace GrantBirki/json-yaml-validate action with jq

### DIFF
--- a/.github/workflows/json-yaml-validate.yml
+++ b/.github/workflows/json-yaml-validate.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write # enable write permissions for pull requests
 
 jobs:
   json-yaml-validate:
@@ -16,10 +15,5 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - name: json-yaml-validate
-        uses: GrantBirki/json-yaml-validate@v4.0.0
-        with:
-          # ref: https://github.com/GrantBirki/json-yaml-validate?tab=readme-ov-file#inputs-
-          comment: "true" # enable comment mode
-          yaml_exclude_regex: "(charts/external-dns/templates.*|mkdocs.yml)"
-          allow_multiple_documents: "true"
+      - name: Validate JSON and YAML
+        run: bash scripts/validate-json-yaml.sh

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,12 @@ licensecheck:
 
 #? lint: Run all the linters
 .PHONY: lint
-lint: licensecheck go-lint
+lint: licensecheck go-lint validate-json-yaml
+
+#? validate-json-yaml: Validate JSON and YAML files
+.PHONY: validate-json-yaml
+validate-json-yaml:
+	bash scripts/validate-json-yaml.sh
 
 #? crd: Generates CRD using controller-gen and copy it into chart
 .PHONY: crd

--- a/scripts/validate-json-yaml.sh
+++ b/scripts/validate-json-yaml.sh
@@ -16,21 +16,11 @@ while IFS= read -r -d '' file; do
   if [[ "$file" =~ $EXCLUDE_PATTERN ]]; then
     continue
   fi
-  if ! python3 -m json.tool "$file" > /dev/null 2>&1; then
-    echo "FAIL: $file"
-    errors=$((errors + 1))
-  fi
-done < <(find . -name '*.json' -print0)
-
-while IFS= read -r -d '' file; do
-  if [[ "$file" =~ $EXCLUDE_PATTERN ]]; then
-    continue
-  fi
   if ! yq '.' "$file" > /dev/null 2>&1; then
     echo "FAIL: $file"
     errors=$((errors + 1))
   fi
-done < <(find . \( -name '*.yaml' -o -name '*.yml' \) -print0)
+done < <(find . \( -name '*.json' -o -name '*.yaml' -o -name '*.yml' \) -print0)
 
 if [ "$errors" -gt 0 ]; then
   echo ""

--- a/scripts/validate-json-yaml.sh
+++ b/scripts/validate-json-yaml.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validates all JSON and YAML files in the repository.
+# Excludes Helm templates and mkdocs.yml which use non-standard syntax.
+#
+# Requirements (pre-installed on GitHub Actions ubuntu-latest):
+#   - python3 (for JSON validation via json.tool)
+#   - yq (for YAML validation, supports multi-document files)
+
+EXCLUDE_PATTERN='(charts/external-dns/templates|mkdocs\.yml)'
+
+errors=0
+
+while IFS= read -r -d '' file; do
+  if [[ "$file" =~ $EXCLUDE_PATTERN ]]; then
+    continue
+  fi
+  if ! python3 -m json.tool "$file" > /dev/null 2>&1; then
+    echo "FAIL: $file"
+    errors=$((errors + 1))
+  fi
+done < <(find . -name '*.json' -print0)
+
+while IFS= read -r -d '' file; do
+  if [[ "$file" =~ $EXCLUDE_PATTERN ]]; then
+    continue
+  fi
+  if ! yq '.' "$file" > /dev/null 2>&1; then
+    echo "FAIL: $file"
+    errors=$((errors + 1))
+  fi
+done < <(find . \( -name '*.yaml' -o -name '*.yml' \) -print0)
+
+if [ "$errors" -gt 0 ]; then
+  echo ""
+  echo "$errors file(s) failed validation."
+  exit 1
+fi
+
+echo "All JSON and YAML files are valid."

--- a/scripts/validate-json-yaml.sh
+++ b/scripts/validate-json-yaml.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 #   - python3 (for JSON validation via json.tool)
 #   - yq (for YAML validation, supports multi-document files)
 
-EXCLUDE_PATTERN='(charts/external-dns/templates|mkdocs\.yml)'
+EXCLUDE_PATTERN='(charts/external-dns/templates)'
 
 errors=0
 

--- a/scripts/validate-json-yaml.sh
+++ b/scripts/validate-json-yaml.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Validates all JSON and YAML files in the repository.
-# Excludes Helm templates and mkdocs.yml which use non-standard syntax.
+# Excludes Helm templates which use non-standard syntax.
 #
 # Requirements (pre-installed on GitHub Actions ubuntu-latest):
 #   - python3 (for JSON validation via json.tool)
@@ -16,8 +16,9 @@ while IFS= read -r -d '' file; do
   if [[ "$file" =~ $EXCLUDE_PATTERN ]]; then
     continue
   fi
-  if ! yq '.' "$file" > /dev/null 2>&1; then
+  if ! err=$(yq '.' "$file" 2>&1); then
     echo "FAIL: $file"
+    echo "  $err"
     errors=$((errors + 1))
   fi
 done < <(find . \( -name '*.json' -o -name '*.yaml' -o -name '*.yml' \) -print0)


### PR DESCRIPTION
## What does it do ?

Replace the third-party GitHub Action with a simple bash script that
uses python3 json.tool and yq (both pre-installed on GitHub runners).

- No external dependencies or pip installs needed
- Same exclusions (Helm templates, mkdocs.yml)
- yq handles multi-document YAML files natively
- Drops PR comment feature (CI output still shows failures clearly)
- Removes pull-requests:write permission (no longer needed)

## Motivation

I want to reduce the surface of actions that we use.


## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
