### PR TITLE
fix(ci): Cloud Build OOM and empty image revision label

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ REGISTRY      ?= us.gcr.io/k8s-artifacts-prod/external-dns
 IMAGE         ?= $(REGISTRY)/$(BINARY)
 VERSION       ?= $(shell git describe --tags --always --dirty --match "v*")
 GIT_COMMIT    ?= $(shell git rev-parse --short HEAD)
+GIT_REVISION  ?= $(shell git rev-parse HEAD)
 BUILD_FLAGS   ?= -v
 LDFLAGS       ?= -X sigs.k8s.io/external-dns/pkg/apis/externaldns.Version=$(VERSION) -w -s
 LDFLAGS       += -X sigs.k8s.io/external-dns/pkg/apis/externaldns.GitCommit=$(GIT_COMMIT)
@@ -108,7 +109,7 @@ build.push/multiarch: ko
 	VERSION=${VERSION} \
 	ko build --tags ${VERSION} --bare --sbom ${IMG_SBOM} \
 		--image-label org.opencontainers.image.source="https://github.com/kubernetes-sigs/external-dns" \
-		--image-label org.opencontainers.image.revision=$(shell git rev-parse HEAD) \
+		--image-label org.opencontainers.image.revision=$(GIT_REVISION) \
 		--platform=${IMG_PLATFORM}  --push=${IMG_PUSH} .
 
 build.image/multiarch:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,16 +3,44 @@ timeout: 5000s
 options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
+volumes:
+  - name: go-modules
+    path: /go/pkg/mod
 steps:
+  # Pre-warm the Go module cache so test and build steps don't compete for downloads.
+  - name: 'docker.io/library/golang:1.26-bookworm'
+    entrypoint: go
+    volumes:
+      - name: go-modules
+        path: /go/pkg/mod
+    args:
+      - mod
+      - download
+
+  # Run tests in a separate step so the build step starts with a clean memory slate.
   - name: 'docker.io/library/golang:1.26-bookworm'
     entrypoint: make
+    volumes:
+      - name: go-modules
+        path: /go/pkg/mod
+    args:
+      - test
+
+  # Build and push multi-arch images using the pre-warmed cache.
+  - name: 'docker.io/library/golang:1.26-bookworm'
+    entrypoint: make
+    volumes:
+      - name: go-modules
+        path: /go/pkg/mod
     env:
       - VERSION=$_GIT_TAG
-      - PULL_BASE_REF=$_PULL_BASE_REF
+      - GIT_REVISION=$_GIT_COMMIT
+      - IMAGE=gcr.io/k8s-staging-external-dns/external-dns
     args:
-      - release.staging
+      - build.push/multiarch
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution
   _GIT_TAG: "12345"
+  _GIT_COMMIT: ""
   _PULL_BASE_REF: 'master'


### PR DESCRIPTION
## What does it do ?

I'm not sure where this PR fixes cloudbuild, but worth to try, and we should split the one massive job, as currently cloudbuild runs  for quite a while, and hard to understand where exactly it fails.

At most we could rollback certain changes. The split-step + cache-prewarming changes are still worthwhile regardless, because they reduce peak memory, eliminate redundant module downloads, and give cleaner failure  reason. But if the next build fails with INTERNAL_ERROR again, that would suggest it's a transient infra issue rather than resource exhaustion.

- Split the single build step into three: module cache `pre-warm → test → build/push`, each sharing a named volume (go-modules) so dependencies are downloaded once, not as currently per multiple architectures
- Added GIT_REVISION Makefile variable (overridable via env) and wired it to `--image-label org.opencontainers.image.revision`; added _GIT_COMMIT substitution to cloudbuild.yaml so prow can pass the commit SHA
- We could upgrade machine type to N1_HIGHCPU_32 ;-) but not sure if we have it available

Looks like we could also use  N1_HIGHCPU_32 https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/8ee57b6871d5434bef21d05480c4745f97767be1/cloudbuild.yaml#L24


## Motivation

The staging Cloud Build was failing with INTERNAL_ERROR - tests and the multi-arch ko build ran in the same step, causing memory exhaustion on N1_HIGHCPU_8. The org.opencontainers.image.revision label was also always empty because git rev-parse HEAD fails in the tarball-based Cloud Build environment.

Failed cloudbuild jobs

<img width="1593" height="644" alt="Screenshot 2026-03-30 at 12 36 39" src="https://github.com/user-attachments/assets/9cb1b917-c5aa-428a-a8a3-cb07960e7117" />

Example job took ~50 minutes to fail https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-external-dns-push-images/2038528233506344960

```
ERROR: (gcloud.builds.submit) build 11e2415c-9cf5-45f1-b9ad-8321510cf20d completed with status "INTERNAL_ERROR"
```


```
2026/03/30 06:51:46 Using build config #0 for sigs.k8s.io/external-dns
2026/03/30 06:51:46 current folder is not a git repository. Git info will not be available
2026/03/30 06:51:46 Building sigs.k8s.io/external-dns for linux/arm64/v8
2026/03/30 06:51:46 current folder is not a git repository. Git info will not be available
2026/03/30 06:51:46 Building sigs.k8s.io/external-dns for linux/amd64
2026/03/30 06:51:46 Using build config #0 for sigs.k8s.io/external-dns
2026/03/30 06:51:46 current folder is not a git repository. Git info will not be available
2026/03/30 06:51:46 Building sigs.k8s.io/external-dns for linux/arm/v7
```

 ^ No git, so we could not run 
```
--image-label org.opencontainers.image.revision=$(shell git rev-parse HEAD) \
```

 I don't know for certain where there is OOM or similar issue it was an educated guess. What I can say from the logs:

  - The ko build ran ~50 minutes with zero output after the initial "Building for..." lines - suggesting it hung or was killed, not that it failed with an error
  - INTERNAL_ERROR from Cloud Build means the build runner itself failed, not user code - that's distinct from FAILURE (bad exit code) or TIMEOUT
  - Building 3 platforms simultaneously on N1_HIGHCPU_8 is a plausible memory pressure scenario
 
  But it could equally be:
  - A transient Cloud Build infrastructure failure (flaky GCR push, runner crash)
  - Network timeout pushing a large multi-arch manifest to GCR
  - A hang in ko itself for some other reason
  - Disk space exhaustion

Why cache is required, currently in pulls same library multiple times

<img width="632" height="692" alt="Screenshot 2026-04-02 at 09 51 12" src="https://github.com/user-attachments/assets/55aed471-15e0-4930-be4f-767057c51975" />
 

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

Missed version, as there is no git in cloud build (tar/zip archive is only avaialble there)
```
ko build --tags v20260330-v0.20.0-203-g736a2d58 --bare --sbom none \
	--image-label org.opencontainers.image.source="https://github.com/kubernetes-sigs/external-dns" \
	--image-label org.opencontainers.image.revision= \
	--platform=linux/amd64,linux/arm64,linux/arm/v7  --push=true .
```

Another example

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-external-dns-push-images/2039609054623436800

<img width="1148" height="500" alt="Screenshot 2026-04-02 at 09 07 31" src="https://github.com/user-attachments/assets/a60a8ef1-52e6-4e9a-b939-972e164664b7" />
