### PR TITLE
feat: resolve endpoint target CNAME to A/AAAA records with external-dns.alpha.kubernetes.io/resolve-target

### DIFF
--- a/docs/annotations/annotations.md
+++ b/docs/annotations/annotations.md
@@ -301,7 +301,8 @@ spec:
 
 ## external-dns.alpha.kubernetes.io/resolve-target
 
-Controls whether load balancer hostname targets when they are CNAME records. When the annotation is set to `"true"` the CNAME records are resolved to their underlying
+Controls load balancer hostname targets with CNAME records. 
+When the annotation is set to `"true"` the CNAME records are resolved to their underlying
 A/AAAA records at sync time, ExternalDNS performs a DNS lookup for each hostname target and emits the
 resulting IP addresses as A and/or AAAA endpoints. If resolution fails (e.g. the hostname is
 temporarily unresolvable), that target is silently skipped.

--- a/docs/annotations/annotations.md
+++ b/docs/annotations/annotations.md
@@ -299,6 +299,52 @@ spec:
 
 > ExternalDNS will create an internal DNS record for `my-pod.internal.example.com` targeting the Pod `Status.PodIP`.
 
+## external-dns.alpha.kubernetes.io/resolve-target
+
+Controls whether load balancer hostname targets when they are CNAME records. When the annotation is set to `"true"` the CNAME records are resolved to their underlying
+A/AAAA records at sync time, ExternalDNS performs a DNS lookup for each hostname target and emits the
+resulting IP addresses as A and/or AAAA endpoints. If resolution fails (e.g. the hostname is
+temporarily unresolvable), that target is silently skipped.
+
+This is useful when a DNS provider does not support CNAME flattening
+or ALIAS records and a flat IP address record is required.
+
+### Use Cases for `external-dns.alpha.kubernetes.io/resolve-target` annotation
+
+#### Opt in to resolution for a single Source
+
+Resolve load balancer hostnames to IPs for one Ingress:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: test-ingress
+  namespace: default
+  annotations:
+    external-dns.alpha.kubernetes.io/resolve-target: "true"
+spec:
+  rules:
+    - host: svc.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: my-service
+                port:
+                  number: 80
+status:
+  loadBalancer:
+    ingress:
+      - hostname: example.com
+```
+
+> ExternalDNS will resolve the Ingress load balancer hostname and publish A/AAAA records instead of a CNAME.
+Let's take an example, "example.com" CNAME resolves to A record "104.20.23.154" and AAAA record "2606:4700:10::ac42:93f3".
+ExternalDNS will create an A record for "svc.example.com" with target "104.20.23.154" and an AAAA record for "svc.example.com" with target "2606:4700:10::ac42:93f3".
+
 ## external-dns.kubernetes.io/target
 
 Specifies a comma-separated list of values to override the resource's DNS record targets (RDATA).
@@ -451,9 +497,9 @@ spec:
 ## Gateway API Annotation Placement
 
 When using Gateway API sources (`gateway-httproute`, `gateway-grpcroute`, `gateway-tlsroute`, etc.), annotations
-are read from different resources: **Gateway resource** reads only `target` annotation, while **Route resources**
-(HTTPRoute, GRPCRoute, TLSRoute, etc.) read all other annotations (`hostname`, `ttl`, `controller`, and
-provider-specific annotations like `cloudflare-*`, `aws-*`, `scw-*`).
+are read from different resources: **Gateway resource** reads only the `target` annotation, while **Route resources**
+(HTTPRoute, GRPCRoute, TLSRoute, etc.) read all other annotations (`hostname`, `ttl`, `controller`,
+`resolve-target`, and provider-specific annotations like `cloudflare-*`, `aws-*`, `scw-*`).
 
 **ListenerSet resources** also support the `target` annotation. When a Route references a ListenerSet
 as its parent, the ListenerSet's target annotation takes precedence over the parent Gateway's target annotation.

--- a/docs/contributing/source-wrappers.md
+++ b/docs/contributing/source-wrappers.md
@@ -29,6 +29,7 @@ Wrappers solve these key challenges:
 |:--------------------:|:----------------------------------------|:----------------------------------------------------|
 |    `MultiSource`     | Combine multiple sources.               | Aggregate `Ingress`, `Service`, etc.                |
 |    `DedupSource`     | Remove duplicate DNS records.           | Avoid duplicate records from sources.               |
+|   `ResolveTarget`    | Resolve CNAME targets to A/AAAA values. | Source hostnames into IP records.                   |
 | `TargetFilterSource` | Include/exclude targets based on CIDRs. | Exclude internal IPs.                               |
 |    `NAT64Source`     | Add NAT64-prefixed AAAA records.        | Support IPv6 with NAT64.                            |
 |   `PostProcessor`    | Add records post-processing.            | Configure TTL, filter provider-specific properties. |
@@ -56,6 +57,12 @@ Converts IPv4 targets to IPv6 using NAT64 prefixes.
 ```yaml
 --nat64-prefix=64:ff9b::/96
 ```
+
+### 2.2 `ResolveTarget`
+
+Resolves `CNAME` targets to concrete IP targets when the endpoint has the `resolve-target` provider-specific property set to `true`. If all target resolutions fail, the endpoint is skipped.
+
+📌 **Use case**: A Service or Gateway exposes a load balancer hostname (for example, `xxx.elb.amazonaws.com`), but the desired DNS output should be `A`/`AAAA` records rather than a `CNAME`.
 
 ### 3.1 `PostProcessor`
 
@@ -116,6 +123,7 @@ Wrappers are often composed like this:
 ```go
 source := NewMultiSource(actualSources, defaultTargets)
 source = NewDedupSource(source)
+source = NewResolveTarget(source)
 source = NewNAT64Source(source, cfg.NAT64Networks)
 source = NewTargetFilterSource(source, targetFilter)
 source = NewPostProcessor(source, WithTTL(minTTL), WithPostProcessorPreferAlias(preferAlias))

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -313,6 +313,26 @@ func (e *Endpoint) WithSetIdentifier(setIdentifier string) *Endpoint {
 	return e
 }
 
+// WithTargets returns a shallow copy of the endpoint with only Targets and RecordType replaced.
+// The RecordType is derived from the first target using SuitableType.
+// All other fields remain intact (shared with the original endpoint).
+func (e *Endpoint) WithTargets(targets Targets) *Endpoint {
+	recordType := e.RecordType
+	if len(targets) > 0 {
+		recordType = SuitableType(targets[0])
+	}
+	return &Endpoint{
+		DNSName:          e.DNSName,
+		Targets:          targets,
+		RecordType:       recordType,
+		SetIdentifier:    e.SetIdentifier,
+		RecordTTL:        e.RecordTTL,
+		Labels:           e.Labels,
+		ProviderSpecific: e.ProviderSpecific,
+		refObject:        e.refObject,
+	}
+}
+
 // WithProviderSpecific attaches a key/value pair to the Endpoint and returns the Endpoint.
 // This can be used to pass additional data through the stages of ExternalDNS's Endpoint processing.
 // The assumption is that most of the time this will be provider specific metadata that doesn't

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -205,7 +205,7 @@ func TestEndpoint_WithTargets(t *testing.T) {
 	t.Run("non-empty targets derives record type from first target and preserves other fields", func(t *testing.T) {
 		labels := Labels{"owner": "team-a"}
 		providerSpecific := ProviderSpecific{{Name: "foo", Value: "bar"}}
-		ref := &events.ObjectReference{Kind: "Service", Name: "svc-1", Namespace: "default"}
+		ref := events.NewObjectReferenceFromParts("Service", "", "default", "svc-1", "", "")
 
 		ep := &Endpoint{
 			DNSName:          "example.com",

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -201,6 +201,43 @@ func TestEndpoint_WithLabel(t *testing.T) {
 	})
 }
 
+func TestEndpoint_WithTargets(t *testing.T) {
+	t.Run("non-empty targets derives record type from first target and preserves other fields", func(t *testing.T) {
+		labels := Labels{"owner": "team-a"}
+		providerSpecific := ProviderSpecific{{Name: "foo", Value: "bar"}}
+		ref := &events.ObjectReference{Kind: "Service", Name: "svc-1", Namespace: "default"}
+
+		ep := &Endpoint{
+			DNSName:          "example.com",
+			Targets:          Targets{"old.example.net"},
+			RecordType:       RecordTypeCNAME,
+			SetIdentifier:    "set-1",
+			RecordTTL:        TTL(300),
+			Labels:           labels,
+			ProviderSpecific: providerSpecific,
+			refObject:        ref,
+		}
+
+		newTargets := Targets{"1.2.3.4", "example.net"}
+		got := ep.WithTargets(newTargets)
+
+		require.NotNil(t, got)
+		assert.NotSame(t, ep, got)
+		assert.Equal(t, "example.com", got.DNSName)
+		assert.Equal(t, newTargets, got.Targets)
+		assert.Equal(t, RecordTypeA, got.RecordType)
+		assert.Equal(t, "set-1", got.SetIdentifier)
+		assert.Equal(t, TTL(300), got.RecordTTL)
+		assert.Equal(t, labels, got.Labels)
+		assert.Equal(t, providerSpecific, got.ProviderSpecific)
+		assert.Equal(t, ref, got.refObject)
+
+		// Original endpoint remains unchanged.
+		assert.Equal(t, Targets{"old.example.net"}, ep.Targets)
+		assert.Equal(t, RecordTypeCNAME, ep.RecordType)
+	})
+}
+
 func TestSame_ParseErrorLogged(t *testing.T) {
 	hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
 

--- a/source/annotations/annotations.go
+++ b/source/annotations/annotations.go
@@ -70,6 +70,9 @@ var (
 	InternalHostnameKey = AnnotationKeyPrefix + "internal-hostname"
 	// The annotation used for defining the desired hostname source for gateways
 	GatewayHostnameSourceKey = AnnotationKeyPrefix + "gateway-hostname-source"
+	// ResolveTargetKey is the per-resource annotation that controls whether
+	// the resolveTarget Wrapper should resolve the LoadBalancer hostname to IP addresses
+	ResolveTargetKey = AnnotationKeyPrefix + "resolve-target"
 )
 
 // SetAnnotationPrefix sets a custom annotation prefix and rebuilds all annotation keys.
@@ -109,4 +112,5 @@ func SetAnnotationPrefix(prefix string) {
 	IngressHostnameSourceKey = AnnotationKeyPrefix + "ingress-hostname-source"
 	InternalHostnameKey = AnnotationKeyPrefix + "internal-hostname"
 	GatewayHostnameSourceKey = AnnotationKeyPrefix + "gateway-hostname-source"
+	ResolveTargetKey = AnnotationKeyPrefix + "resolve-target"
 }

--- a/source/annotations/annotations_test.go
+++ b/source/annotations/annotations_test.go
@@ -51,6 +51,7 @@ func TestSetAnnotationPrefix(t *testing.T) {
 	assert.Equal(t, "custom.io/endpoints-type", EndpointsTypeKey)
 	assert.Equal(t, "custom.io/ingress", Ingress)
 	assert.Equal(t, "custom.io/ingress-hostname-source", IngressHostnameSourceKey)
+	assert.Equal(t, "custom.io/resolve-target", ResolveTargetKey)
 
 	// ControllerValue should remain constant
 	assert.Equal(t, "dns-controller", ControllerValue)

--- a/source/annotations/provider_specific.go
+++ b/source/annotations/provider_specific.go
@@ -100,5 +100,11 @@ func ProviderSpecificAnnotations(annotations map[string]string) (endpoint.Provid
 			}
 		}
 	}
+	if v, ok := annotations[ResolveTargetKey]; ok {
+		providerSpecificAnnotations = append(providerSpecificAnnotations, endpoint.ProviderSpecificProperty{
+			Name:  "resolve-target",
+			Value: v,
+		})
+	}
 	return providerSpecificAnnotations, setIdentifier
 }

--- a/source/annotations/provider_specific_test.go
+++ b/source/annotations/provider_specific_test.go
@@ -121,6 +121,22 @@ func TestProviderSpecificAnnotations(t *testing.T) {
 			},
 			setIdentifier: "",
 		},
+		{
+			name: "resolve-target annotation",
+			annotations: map[string]string{
+				ResolveTargetKey: "true",
+			},
+			expected: endpoint.ProviderSpecific{
+				{Name: "resolve-target", Value: "true"},
+			},
+			setIdentifier: "",
+		},
+		{
+			name:          "resolve-target annotation absent",
+			annotations:   map[string]string{},
+			expected:      endpoint.ProviderSpecific{},
+			setIdentifier: "",
+		},
 	}
 
 	for _, tt := range tests {

--- a/source/wrappers/build.go
+++ b/source/wrappers/build.go
@@ -25,7 +25,8 @@ import (
 // Build creates all named sources using cfg's ClientGenerator and wraps them
 // with the standard pipeline (dedup, optional NAT64, optional target filter,
 // post-processor). Inject a custom ClientGenerator via source.WithClientGenerator.
-func Build(ctx context.Context, cfg *source.Config) (source.Source, error) {
+// Additional Options can be passed to customize the wrapper behavior (e.g., custom lookupIP).
+func Build(ctx context.Context, cfg *source.Config, extraOpts ...Option) (source.Source, error) {
 	sources, err := source.ByNames(ctx, cfg, cfg.ClientGenerator())
 	if err != nil {
 		return nil, err
@@ -42,5 +43,9 @@ func Build(ctx context.Context, cfg *source.Config) (source.Source, error) {
 		WithPTRSupported(cfg.PTRSupported),
 		WithCreatePTR(cfg.CreatePTR),
 	)
+	// Apply any extra options passed by the caller.
+	for _, opt := range extraOpts {
+		opt(opts)
+	}
 	return wrapSources(sources, opts)
 }

--- a/source/wrappers/build_test.go
+++ b/source/wrappers/build_test.go
@@ -104,3 +104,11 @@ func TestBuildWrappedSource(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildAppliesExtraOptions(t *testing.T) {
+	cfg := stubConfig(t, &externaldns.Config{Sources: []string{types.Fake}})
+
+	_, err := Build(t.Context(), cfg, WithNAT64Networks([]string{"not-a-cidr"}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create NAT64 source wrapper")
+}

--- a/source/wrappers/resolvetarget.go
+++ b/source/wrappers/resolvetarget.go
@@ -81,16 +81,13 @@ func (rs *resolveTarget) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, e
 			continue
 		}
 
-		// Skip early if not a CNAME record, as only those can have hostname targets that need resolution.
-		if ep.RecordType != endpoint.RecordTypeCNAME {
-			result = append(result, ep)
-			continue
-		}
-
-		// Check if the "resolve-target" provider-specific property is set to "true" for this endpoint.
-		v, _ := ep.GetProviderSpecificProperty(resolveTargetPropertyName)
+		// Always consume the "resolve-target" property so it never leaks downstream,
+		// regardless of record type or value otherwise it won't converge with a non-empty UpdateNew in the plan.
+		resolve, _ := ep.GetProviderSpecificProperty(resolveTargetPropertyName)
 		ep.DeleteProviderSpecificProperty(resolveTargetPropertyName)
-		if v != "true" {
+
+		// Only CNAME endpoints opted in via "true" are resolved; everything else passes through.
+		if ep.RecordType != endpoint.RecordTypeCNAME || resolve != "true" {
 			result = append(result, ep)
 			continue
 		}

--- a/source/wrappers/resolvetarget.go
+++ b/source/wrappers/resolvetarget.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wrappers
+
+import (
+	"context"
+	"net"
+	"sort"
+
+	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/source"
+)
+
+const resolveTargetPropertyName = "resolve-target"
+
+// resolveTarget is a Source wrapper that resolves CNAME targets (load balancer hostnames)
+// to their underlying A/AAAA IP addresses via DNS lookup.
+//
+// Resolution is controlled per-endpoint via the "resolve-target" provider-specific property:
+//
+//	"true"  – resolve this endpoint's hostname targets to A/AAAA records
+//	"false" – keep this endpoint's hostname targets as CNAME records
+//
+// The property is always consumed (deleted) by this wrapper so it does not leak
+// to downstream components.
+type resolveTarget struct {
+	source   source.Source
+	lookupIP func(string) ([]net.IP, error)
+}
+
+// resolveTargetOption is a functional option for resolveTarget.
+type resolveTargetOption func(*resolveTarget)
+
+// WithResolveTargetLookupIP is a helper to create a resolveTargetOption that sets a custom lookupIP function for testing.
+// If fn is nil, the default net.LookupIP is preserved.
+func WithResolveTargetLookupIP(fn func(string) ([]net.IP, error)) resolveTargetOption {
+	return func(rs *resolveTarget) {
+		if fn != nil {
+			rs.lookupIP = fn
+		}
+	}
+}
+
+// NewResolveTarget creates a new resolveTarget wrapping src.
+func NewResolveTarget(src source.Source, opts ...resolveTargetOption) source.Source {
+	rs := &resolveTarget{
+		source:   src,
+		lookupIP: net.LookupIP,
+	}
+	for _, opt := range opts {
+		opt(rs)
+	}
+	return rs
+}
+
+func (rs *resolveTarget) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	endpoints, err := rs.source.Endpoints(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]*endpoint.Endpoint, 0, len(endpoints))
+	for _, ep := range endpoints {
+		if ep == nil {
+			continue
+		}
+
+		// Skip early if not a CNAME record, as only those can have hostname targets that need resolution.
+		if ep.RecordType != endpoint.RecordTypeCNAME {
+			result = append(result, ep)
+			continue
+		}
+
+		// Check if the "resolve-target" provider-specific property is set to "true" for this endpoint.
+		v, _ := ep.GetProviderSpecificProperty(resolveTargetPropertyName)
+		ep.DeleteProviderSpecificProperty(resolveTargetPropertyName)
+		if v != "true" {
+			result = append(result, ep)
+			continue
+		}
+
+		var ipTargets endpoint.Targets
+		for _, target := range ep.Targets {
+			ips, err := rs.lookupIP(target)
+			if err != nil {
+				log.Debugf("Unable to resolve %q, skipping target: %v", target, err)
+				continue
+			}
+			for _, ip := range ips {
+				ipTargets = append(ipTargets, ip.String())
+			}
+		}
+		if len(ipTargets) == 0 {
+			// All resolutions failed; skip this endpoint entirely.
+			continue
+		}
+
+		// Sort targets before grouping for deterministic output.
+		sort.Strings(ipTargets)
+
+		// Group targets by record type (A vs AAAA)
+		byType := map[string]endpoint.Targets{}
+		for _, t := range ipTargets {
+			rt := endpoint.SuitableType(t)
+			byType[rt] = append(byType[rt], t)
+		}
+
+		// Emit one endpoint per record type with the same DNSName and provider-specific properties.
+		for _, rt := range []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA} {
+			if targets := byType[rt]; len(targets) > 0 {
+				result = append(result, ep.WithTargets(targets))
+			}
+		}
+
+		log.Debugf("resolveTarget: resolved endpoint %q into %d IP target(s)", ep.DNSName, len(ipTargets))
+	}
+
+	return result, nil
+}
+
+func (rs *resolveTarget) AddEventHandler(ctx context.Context, handler func()) {
+	log.Debug("resolveTarget: adding event handler")
+	rs.source.AddEventHandler(ctx, handler)
+}

--- a/source/wrappers/resolvetarget_test.go
+++ b/source/wrappers/resolvetarget_test.go
@@ -21,11 +21,13 @@ import (
 	"net"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/internal/testutils"
 	"sigs.k8s.io/external-dns/pkg/events"
+	"sigs.k8s.io/external-dns/plan"
 )
 
 func TestResolveTargetEndpoints(t *testing.T) {
@@ -364,4 +366,29 @@ func TestResolveTarget_RefObjectIsPreserved(t *testing.T) {
 	require.Len(t, got, 1)
 	require.Equal(t, endpoint.RecordTypeA, got[0].RecordType)
 	require.Equal(t, ref, got[0].RefObject(), "RefObject should be preserved after resolution")
+}
+
+func TestLeakedPropertyShouldNotUpdate(t *testing.T) {
+	current := endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.4")
+
+	desired := endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.4")
+	desired.WithProviderSpecific("resolve-target", "true")
+
+	ms := new(testutils.MockSource)
+	ms.On("Endpoints").Return([]*endpoint.Endpoint{desired}, nil)
+	wrapped := NewResolveTarget(ms)
+
+	desiredEndpoints, err := wrapped.Endpoints(t.Context())
+	require.NoError(t, err)
+
+	changes := (&plan.Plan{
+		Current:        []*endpoint.Endpoint{current},
+		Desired:        desiredEndpoints,
+		ManagedRecords: []string{endpoint.RecordTypeA},
+	}).Calculate().Changes
+
+	assert.Empty(t, changes.Create, "no create expected")
+	assert.Empty(t, changes.Delete, "no delete expected")
+	// Correct: unchanged record must NOT be updated. Fails today due to the leak.
+	assert.Empty(t, changes.UpdateNew, "unchanged record should not be updated")
 }

--- a/source/wrappers/resolvetarget_test.go
+++ b/source/wrappers/resolvetarget_test.go
@@ -349,12 +349,7 @@ func TestResolveTarget_RefObjectIsPreserved(t *testing.T) {
 		return []net.IP{net.ParseIP("1.2.3.4")}, nil
 	}
 
-	ref := &events.ObjectReference{
-		ApiVersion: "networking.k8s.io/v1",
-		Kind:       "Ingress",
-		Namespace:  "default",
-		Name:       "my-ingress",
-	}
+	ref := events.NewObjectReferenceFromParts("Ingress", "networking.k8s.io/v1", "default", "my-ingress", "", "")
 
 	ep := endpoint.NewEndpoint("test.example.internal", endpoint.RecordTypeCNAME, "lb.example.com")
 	ep.WithRefObject(ref)

--- a/source/wrappers/resolvetarget_test.go
+++ b/source/wrappers/resolvetarget_test.go
@@ -1,0 +1,372 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wrappers
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
+	"sigs.k8s.io/external-dns/pkg/events"
+)
+
+func TestResolveTargetEndpoints(t *testing.T) {
+	tests := []struct {
+		title     string
+		lookupIP  func(string) ([]net.IP, error)
+		endpoints []*endpoint.Endpoint
+		expected  []*endpoint.Endpoint
+	}{
+		{
+			title:    "A/AAAA endpoints pass through unchanged",
+			lookupIP: func(string) ([]net.IP, error) { return nil, errors.New("should not be called") },
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeAAAA, "2001:db8::1"),
+			},
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeAAAA, "2001:db8::1"),
+			},
+		},
+		{
+			title:    "nil endpoints are skipped",
+			lookupIP: func(string) ([]net.IP, error) { return nil, errors.New("should not be called") },
+			endpoints: []*endpoint.Endpoint{
+				nil,
+				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				nil,
+			},
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+			},
+		},
+		{
+			title: "CNAME with resolve-target:true is replaced by A and AAAA records",
+			lookupIP: func(string) ([]net.IP, error) {
+				return []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("2001:db8::1")}, nil
+			},
+			endpoints: []*endpoint.Endpoint{
+				func() *endpoint.Endpoint {
+					ep := endpoint.NewEndpoint("test.example.internal", endpoint.RecordTypeCNAME, "lb.example.com")
+					ep.WithProviderSpecific(resolveTargetPropertyName, "true")
+					return ep
+				}(),
+			},
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("test.example.internal", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.NewEndpoint("test.example.internal", endpoint.RecordTypeAAAA, "2001:db8::1"),
+			},
+		},
+		{
+			title:    "CNAME with resolve-target:true and unresolvable hostname is skipped",
+			lookupIP: func(string) ([]net.IP, error) { return nil, errors.New("no such host") },
+			endpoints: []*endpoint.Endpoint{
+				func() *endpoint.Endpoint {
+					ep := endpoint.NewEndpoint("test.example.internal", endpoint.RecordTypeCNAME, "lb.example.com")
+					ep.WithProviderSpecific(resolveTargetPropertyName, "true")
+					return ep
+				}(),
+			},
+			expected: []*endpoint.Endpoint{},
+		},
+		{
+			title:    "CNAME without resolve-target annotation passes through unchanged",
+			lookupIP: func(string) ([]net.IP, error) { return nil, errors.New("should not be called") },
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("test.example.internal", endpoint.RecordTypeCNAME, "lb.example.com"),
+			},
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("test.example.internal", endpoint.RecordTypeCNAME, "lb.example.com"),
+			},
+		},
+		{
+			title: "TTL is preserved on resolved endpoints",
+			lookupIP: func(string) ([]net.IP, error) {
+				return []net.IP{net.ParseIP("1.2.3.4")}, nil
+			},
+			endpoints: []*endpoint.Endpoint{
+				func() *endpoint.Endpoint {
+					ep := endpoint.NewEndpointWithTTL("test.example.internal", endpoint.RecordTypeCNAME, endpoint.TTL(300), "lb.example.com")
+					ep.WithProviderSpecific(resolveTargetPropertyName, "true")
+					return ep
+				}(),
+			},
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpointWithTTL("test.example.internal", endpoint.RecordTypeA, endpoint.TTL(300), "1.2.3.4"),
+			},
+		},
+		{
+			title: "labels are preserved on resolved endpoints",
+			lookupIP: func(string) ([]net.IP, error) {
+				return []net.IP{net.ParseIP("1.2.3.4")}, nil
+			},
+			endpoints: []*endpoint.Endpoint{
+				func() *endpoint.Endpoint {
+					ep := endpoint.NewEndpoint("test.example.internal", endpoint.RecordTypeCNAME, "lb.example.com")
+					ep.Labels = endpoint.Labels{"resource": "gateway/default/test"}
+					ep.WithProviderSpecific(resolveTargetPropertyName, "true")
+					return ep
+				}(),
+			},
+			expected: []*endpoint.Endpoint{
+				func() *endpoint.Endpoint {
+					ep := endpoint.NewEndpoint("test.example.internal", endpoint.RecordTypeA, "1.2.3.4")
+					ep.Labels = endpoint.Labels{"resource": "gateway/default/test"}
+					return ep
+				}(),
+			},
+		},
+		{
+			title: "SetIdentifier is preserved on resolved endpoints",
+			lookupIP: func(string) ([]net.IP, error) {
+				return []net.IP{net.ParseIP("1.2.3.4")}, nil
+			},
+			endpoints: []*endpoint.Endpoint{
+				func() *endpoint.Endpoint {
+					ep := endpoint.NewEndpoint("test.example.internal", endpoint.RecordTypeCNAME, "lb.example.com")
+					ep.SetIdentifier = "weighted-routing-1"
+					ep.WithProviderSpecific(resolveTargetPropertyName, "true")
+					return ep
+				}(),
+			},
+			expected: []*endpoint.Endpoint{
+				func() *endpoint.Endpoint {
+					ep := endpoint.NewEndpoint("test.example.internal", endpoint.RecordTypeA, "1.2.3.4")
+					ep.SetIdentifier = "weighted-routing-1"
+					return ep
+				}(),
+			},
+		},
+		{
+			title: "ProviderSpecific properties other than resolve-target are preserved",
+			lookupIP: func(string) ([]net.IP, error) {
+				return []net.IP{net.ParseIP("1.2.3.4")}, nil
+			},
+			endpoints: []*endpoint.Endpoint{
+				func() *endpoint.Endpoint {
+					ep := endpoint.NewEndpoint("test.example.internal", endpoint.RecordTypeCNAME, "lb.example.com")
+					ep.WithProviderSpecific("aws/weight", "100")
+					ep.WithProviderSpecific("cloudflare-proxied", "true")
+					ep.WithProviderSpecific(resolveTargetPropertyName, "true")
+					return ep
+				}(),
+			},
+			expected: []*endpoint.Endpoint{
+				func() *endpoint.Endpoint {
+					ep := endpoint.NewEndpoint("test.example.internal", endpoint.RecordTypeA, "1.2.3.4")
+					ep.WithProviderSpecific("aws/weight", "100")
+					ep.WithProviderSpecific("cloudflare-proxied", "true")
+					return ep
+				}(),
+			},
+		},
+		{
+			title: "multiple targets with partial resolution failure keeps successful ones",
+			lookupIP: func(host string) ([]net.IP, error) {
+				if host == "lb1.example.com" {
+					return []net.IP{net.ParseIP("1.2.3.4")}, nil
+				}
+				return nil, errors.New("no such host")
+			},
+			endpoints: []*endpoint.Endpoint{
+				func() *endpoint.Endpoint {
+					ep := endpoint.NewEndpoint("test.example.internal", endpoint.RecordTypeCNAME, "lb1.example.com", "lb2.example.com")
+					ep.WithProviderSpecific(resolveTargetPropertyName, "true")
+					return ep
+				}(),
+			},
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("test.example.internal", endpoint.RecordTypeA, "1.2.3.4"),
+			},
+		},
+		{
+			title: "multiple targets all resolved produces merged A and AAAA records",
+			lookupIP: func(host string) ([]net.IP, error) {
+				if host == "lb1.example.com" {
+					return []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("2001:db8::1")}, nil
+				}
+				if host == "lb2.example.com" {
+					return []net.IP{net.ParseIP("5.6.7.8"), net.ParseIP("2001:db8::2")}, nil
+				}
+				return nil, errors.New("no such host")
+			},
+			endpoints: []*endpoint.Endpoint{
+				func() *endpoint.Endpoint {
+					ep := endpoint.NewEndpoint("test.example.internal", endpoint.RecordTypeCNAME, "lb1.example.com", "lb2.example.com")
+					ep.WithProviderSpecific(resolveTargetPropertyName, "true")
+					return ep
+				}(),
+			},
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("test.example.internal", endpoint.RecordTypeA, "1.2.3.4", "5.6.7.8"),
+				endpoint.NewEndpoint("test.example.internal", endpoint.RecordTypeAAAA, "2001:db8::1", "2001:db8::2"),
+			},
+		},
+		{
+			title: "resolved targets are sorted before grouping for deterministic output",
+			// lookupIP returns IPs in reverse/unsorted order to verify sorting is applied.
+			lookupIP: func(string) ([]net.IP, error) {
+				return []net.IP{
+					net.ParseIP("2001:db8::2"),
+					net.ParseIP("9.8.7.6"),
+					net.ParseIP("1.2.3.4"),
+					net.ParseIP("2001:db8::1"),
+				}, nil
+			},
+			endpoints: []*endpoint.Endpoint{
+				func() *endpoint.Endpoint {
+					ep := endpoint.NewEndpoint("test.example.internal", endpoint.RecordTypeCNAME, "lb.example.com")
+					ep.WithProviderSpecific(resolveTargetPropertyName, "true")
+					return ep
+				}(),
+			},
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("test.example.internal", endpoint.RecordTypeA, "1.2.3.4", "9.8.7.6"),
+				endpoint.NewEndpoint("test.example.internal", endpoint.RecordTypeAAAA, "2001:db8::1", "2001:db8::2"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			ms := new(testutils.MockSource)
+			ms.On("Endpoints").Return(tt.endpoints, nil)
+			src := NewResolveTarget(ms, WithResolveTargetLookupIP(tt.lookupIP))
+
+			got, err := src.Endpoints(t.Context())
+			require.NoError(t, err)
+			require.Len(t, got, len(tt.expected))
+			for i, ep := range got {
+				require.Equal(t, tt.expected[i].DNSName, ep.DNSName, "DNSName mismatch at index %d", i)
+				require.Equal(t, tt.expected[i].RecordType, ep.RecordType, "RecordType mismatch at index %d", i)
+				require.Equal(t, tt.expected[i].Targets, ep.Targets, "Targets mismatch at index %d", i)
+				require.Equal(t, tt.expected[i].RecordTTL, ep.RecordTTL, "RecordTTL mismatch at index %d", i)
+				require.Equal(t, tt.expected[i].Labels, ep.Labels, "Labels mismatch at index %d", i)
+				require.Equal(t, tt.expected[i].SetIdentifier, ep.SetIdentifier, "SetIdentifier mismatch at index %d", i)
+				require.ElementsMatch(t, tt.expected[i].ProviderSpecific, ep.ProviderSpecific, "ProviderSpecific mismatch at index %d", i)
+			}
+		})
+	}
+}
+
+func TestResolveTargetEndpointsPerAnnotation(t *testing.T) {
+	stubLookup := func(string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("1.2.3.4")}, nil
+	}
+	tests := []struct {
+		title           string
+		annotationValue string // empty means annotation absent
+		expectResolved  bool
+	}{
+		{
+			title:           "annotation true → resolves",
+			annotationValue: "true",
+			expectResolved:  true,
+		},
+		{
+			title:           "annotation false → keeps CNAME",
+			annotationValue: "false",
+			expectResolved:  false,
+		},
+		{
+			title:          "no annotation → keeps CNAME",
+			expectResolved: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			ep := endpoint.NewEndpoint("test.example.com", endpoint.RecordTypeCNAME, "lb.example.com")
+			if tt.annotationValue != "" {
+				ep.WithProviderSpecific(resolveTargetPropertyName, tt.annotationValue)
+			}
+
+			ms := new(testutils.MockSource)
+			ms.On("Endpoints").Return([]*endpoint.Endpoint{ep}, nil)
+			src := NewResolveTarget(ms, WithResolveTargetLookupIP(stubLookup))
+
+			got, err := src.Endpoints(t.Context())
+			require.NoError(t, err)
+
+			if tt.expectResolved {
+				require.Len(t, got, 1)
+				require.Equal(t, endpoint.RecordTypeA, got[0].RecordType)
+			} else {
+				require.Len(t, got, 1)
+				require.Equal(t, endpoint.RecordTypeCNAME, got[0].RecordType)
+			}
+			// resolve-target property must always be consumed
+			_, ok := got[0].GetProviderSpecificProperty(resolveTargetPropertyName)
+			require.False(t, ok, "resolve-target property should have been removed")
+		})
+	}
+}
+
+func TestResolveTarget_AddEventHandler(t *testing.T) {
+	t.Run("should delegate to underlying source", func(t *testing.T) {
+		mockSource := testutils.NewMockSource()
+
+		src := NewResolveTarget(mockSource)
+		src.AddEventHandler(t.Context(), func() {})
+
+		mockSource.AssertNumberOfCalls(t, "AddEventHandler", 1)
+	})
+}
+
+func TestResolveTarget_SourceError(t *testing.T) {
+	t.Run("should propagate error from underlying source", func(t *testing.T) {
+		expectedErr := errors.New("source error")
+		ms := new(testutils.MockSource)
+		ms.On("Endpoints").Return(nil, expectedErr)
+
+		src := NewResolveTarget(ms)
+		got, err := src.Endpoints(t.Context())
+
+		require.Nil(t, got)
+		require.ErrorIs(t, err, expectedErr)
+	})
+}
+
+func TestResolveTarget_RefObjectIsPreserved(t *testing.T) {
+	stubLookup := func(string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("1.2.3.4")}, nil
+	}
+
+	ref := &events.ObjectReference{
+		ApiVersion: "networking.k8s.io/v1",
+		Kind:       "Ingress",
+		Namespace:  "default",
+		Name:       "my-ingress",
+	}
+
+	ep := endpoint.NewEndpoint("test.example.internal", endpoint.RecordTypeCNAME, "lb.example.com")
+	ep.WithRefObject(ref)
+	ep.WithProviderSpecific(resolveTargetPropertyName, "true")
+
+	ms := new(testutils.MockSource)
+	ms.On("Endpoints").Return([]*endpoint.Endpoint{ep}, nil)
+	src := NewResolveTarget(ms, WithResolveTargetLookupIP(stubLookup))
+
+	got, err := src.Endpoints(t.Context())
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, endpoint.RecordTypeA, got[0].RecordType)
+	require.Equal(t, ref, got[0].RefObject(), "RefObject should be preserved after resolution")
+}

--- a/source/wrappers/types.go
+++ b/source/wrappers/types.go
@@ -18,6 +18,7 @@ package wrappers
 
 import (
 	"fmt"
+	"net"
 	"time"
 
 	"sigs.k8s.io/external-dns/endpoint"
@@ -33,9 +34,10 @@ type Config struct {
 	excludeTargetNets   []string
 	minTTL              time.Duration
 	preferAlias         bool
-	ptrSupported        bool            // PTR is in --managed-record-types
-	createPTR           bool            // --create-ptr default for all A/AAAA records
-	sourceWrappers      map[string]bool // map of source wrappers, e.g. "targetfilter", "nat64"
+	ptrSupported        bool                           // PTR is in --managed-record-types
+	createPTR           bool                           // --create-ptr default for all A/AAAA records
+	sourceWrappers      map[string]bool                // map of source wrappers, e.g. "targetfilter", "nat64"
+	lookupIP            func(string) ([]net.IP, error) // nil means use net.LookupIP
 }
 
 func NewConfig(opts ...Option) *Config {
@@ -98,6 +100,14 @@ func WithPreferAlias(enabled bool) Option {
 	}
 }
 
+// WithLookupIP sets a custom DNS lookup function for resolving hostnames to IPs.
+// If nil, the default net.LookupIP is used.
+func WithLookupIP(fn func(string) ([]net.IP, error)) Option {
+	return func(o *Config) {
+		o.lookupIP = fn
+	}
+}
+
 // WithPTRSupported indicates whether PTR is included in --managed-record-types.
 // When false the PTR source wrapper is not installed at all, so no reverse
 // records are generated regardless of the --create-ptr flag.
@@ -144,6 +154,8 @@ func wrapSources(
 ) (source.Source, error) {
 	combinedSource := NewDedupSource(NewMultiSource(sources, opts.defaultTargets, opts.forceDefaultTargets))
 	opts.addSourceWrapper("dedup")
+	combinedSource = NewResolveTarget(combinedSource, WithResolveTargetLookupIP(opts.lookupIP))
+	opts.addSourceWrapper("resolve")
 	if len(opts.nat64Networks) > 0 {
 		var err error
 		combinedSource, err = NewNAT64Source(combinedSource, opts.nat64Networks)

--- a/source/wrappers/types_test.go
+++ b/source/wrappers/types_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package wrappers
 
 import (
+	"net"
 	"testing"
 	"time"
 
@@ -57,6 +58,7 @@ func TestWrapSources(t *testing.T) {
 			cfg:  NewConfig(),
 			asserts: func(t *testing.T, cfg *Config) {
 				assert.True(t, cfg.isSourceWrapperInstrumented("dedup"))
+				assert.True(t, cfg.isSourceWrapperInstrumented("resolve"))
 				assert.False(t, cfg.isSourceWrapperInstrumented("nat64"))
 				assert.False(t, cfg.isSourceWrapperInstrumented("target-filter"))
 				assert.False(t, cfg.isSourceWrapperInstrumented("ptr"))
@@ -180,6 +182,37 @@ func TestWithMinTTL(t *testing.T) {
 	opt := WithMinTTL(300 * time.Second)
 	opt(cfg)
 	assert.Equal(t, 300*time.Second, cfg.minTTL)
+}
+
+func TestWithLookupIP(t *testing.T) {
+	cfg := &Config{}
+	calledWith := ""
+	opt := WithLookupIP(func(host string) ([]net.IP, error) {
+		calledWith = host
+		return []net.IP{net.ParseIP("127.0.0.1")}, nil
+	})
+
+	opt(cfg)
+
+	if assert.NotNil(t, cfg.lookupIP) {
+		ips, err := cfg.lookupIP("example.org")
+		require.NoError(t, err)
+		require.Len(t, ips, 1)
+		assert.Equal(t, net.ParseIP("127.0.0.1"), ips[0])
+		assert.Equal(t, "example.org", calledWith)
+	}
+}
+
+func TestWithLookupIPNil(t *testing.T) {
+	cfg := &Config{
+		lookupIP: func(string) ([]net.IP, error) {
+			return []net.IP{net.ParseIP("192.0.2.1")}, nil
+		},
+	}
+
+	WithLookupIP(nil)(cfg)
+
+	assert.Nil(t, cfg.lookupIP)
 }
 
 func TestAddSourceWrapperAndIsSourceWrapperInstrumented(t *testing.T) {

--- a/tests/integration/scenarios/tests.yaml
+++ b/tests/integration/scenarios/tests.yaml
@@ -517,7 +517,7 @@ scenarios:
   - name: ingress-loadbalancer-hostname-resolved-via-annotation
     description: >
       Test that the per-resource annotation
-      external-dns.alpha.kubernetes.io/resolve-target: "true"
+      external-dns.kubernetes.io/resolve-target: "true"
       triggers hostname resolution.
     config:
       sources: ["ingress"]
@@ -532,7 +532,7 @@ scenarios:
             namespace: default
             annotations:
               kubernetes.io/ingress.class: "nginx"
-              external-dns.alpha.kubernetes.io/resolve-target: "true"
+              external-dns.kubernetes.io/resolve-target: "true"
           spec:
             rules:
               - host: svc.example.com

--- a/tests/integration/scenarios/tests.yaml
+++ b/tests/integration/scenarios/tests.yaml
@@ -514,3 +514,45 @@ scenarios:
       - dnsName: svc.example.com
         targets: ["10.0.0.2"]
         recordType: A
+  - name: ingress-loadbalancer-hostname-resolved-via-annotation
+    description: >
+      Test that the per-resource annotation
+      external-dns.alpha.kubernetes.io/resolve-target: "true"
+      triggers hostname resolution.
+    config:
+      sources: ["ingress"]
+      hostOverrides:
+        "example.com": ["104.20.23.154", "172.66.147.243", "2606:4700:10::ac42:93f3", "2606:4700:10::6814:179a"]
+    resources:
+      - resource:
+          apiVersion: networking.k8s.io/v1
+          kind: Ingress
+          metadata:
+            name: test-ingress
+            namespace: default
+            annotations:
+              kubernetes.io/ingress.class: "nginx"
+              external-dns.alpha.kubernetes.io/resolve-target: "true"
+          spec:
+            rules:
+              - host: svc.example.com
+                http:
+                  paths:
+                    - path: /
+                      pathType: Prefix
+                      backend:
+                        service:
+                          name: my-service
+                          port:
+                            number: 80
+          status:
+            loadBalancer:
+              ingress:
+                - hostname: example.com
+    expected:
+      - dnsName: svc.example.com
+        recordType: A
+        targets: ["104.20.23.154", "172.66.147.243"]
+      - dnsName: svc.example.com
+        recordType: AAAA
+        targets: ["2606:4700:10::ac42:93f3", "2606:4700:10::6814:179a"]

--- a/tests/integration/toolkit/models.go
+++ b/tests/integration/toolkit/models.go
@@ -60,15 +60,16 @@ type PodDependencies struct {
 
 // ScenarioConfig holds the wrapper configuration for a scenario.
 type ScenarioConfig struct {
-	Sources             []string `json:"sources"`
-	DefaultTargets      []string `json:"defaultTargets"`
-	ForceDefaultTargets bool     `json:"forceDefaultTargets"`
-	TargetNetFilter     []string `json:"targetNetFilter"`
-	ExcludeTargetNets   []string `json:"excludeTargetNets"`
-	NAT64Networks       []string `json:"nat64Networks"`
-	ServiceTypeFilter   []string `json:"serviceTypeFilter"`
-	Provider            string   `json:"provider"`
-	PreferAlias         bool     `json:"preferAlias"`
+	Sources             []string            `json:"sources"`
+	DefaultTargets      []string            `json:"defaultTargets"`
+	ForceDefaultTargets bool                `json:"forceDefaultTargets"`
+	TargetNetFilter     []string            `json:"targetNetFilter"`
+	ExcludeTargetNets   []string            `json:"excludeTargetNets"`
+	NAT64Networks       []string            `json:"nat64Networks"`
+	ServiceTypeFilter   []string            `json:"serviceTypeFilter"`
+	Provider            string              `json:"provider"`
+	PreferAlias         bool                `json:"preferAlias"`
+	HostOverrides       map[string][]string `json:"hostOverrides"` // hostname -> list of IPs for stubbing DNS lookups
 }
 
 // ParsedResources holds the parsed Kubernetes resources from a scenario.

--- a/tests/integration/toolkit/toolkit.go
+++ b/tests/integration/toolkit/toolkit.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"maps"
 	"net"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -260,10 +261,17 @@ func scenarioToConfig(scenarioCfg ScenarioConfig, opts ...source.OverrideConfigO
 // controller-runtime cache can initialize without a real cluster.
 func CreateWrappedSource(
 	ctx context.Context,
-	client *fake.Clientset,
+	loaded *LoadedResources,
 	scenarioCfg ScenarioConfig,
 ) (source.Source, error) {
-	cfg, err := scenarioToConfig(scenarioCfg, source.WithClientGenerator(newMockClientGenerator(client)))
+	var gen = newMockClientGenerator(loaded.K8sClient)
+
+	if slices.Contains(scenarioCfg.Sources, "crd") {
+		restCfg := newFakeDNSEndpointServer(ctx, loaded.DNSEndpoints)
+		gen = newCRDClientGenerator(loaded.K8sClient, restCfg)
+	}
+
+	cfg, err := scenarioToConfig(scenarioCfg, source.WithClientGenerator(gen))
 	if err != nil {
 		return nil, err
 	}

--- a/tests/integration/toolkit/toolkit.go
+++ b/tests/integration/toolkit/toolkit.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"slices"
+	"net"
 
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -260,18 +260,38 @@ func scenarioToConfig(scenarioCfg ScenarioConfig, opts ...source.OverrideConfigO
 // controller-runtime cache can initialize without a real cluster.
 func CreateWrappedSource(
 	ctx context.Context,
-	loaded *LoadedResources,
-	scenarioCfg ScenarioConfig) (source.Source, error) {
-	var gen = newMockClientGenerator(loaded.K8sClient)
-
-	if slices.Contains(scenarioCfg.Sources, "crd") {
-		restCfg := newFakeDNSEndpointServer(ctx, loaded.DNSEndpoints)
-		gen = newCRDClientGenerator(loaded.K8sClient, restCfg)
-	}
-
-	cfg, err := scenarioToConfig(scenarioCfg, source.WithClientGenerator(gen))
+	client *fake.Clientset,
+	scenarioCfg ScenarioConfig,
+) (source.Source, error) {
+	cfg, err := scenarioToConfig(scenarioCfg, source.WithClientGenerator(newMockClientGenerator(client)))
 	if err != nil {
 		return nil, err
 	}
-	return wrappers.Build(ctx, cfg)
+
+	var extraOpts []wrappers.Option
+	if len(scenarioCfg.HostOverrides) > 0 {
+		extraOpts = append(extraOpts, wrappers.WithLookupIP(stubLookupIP(scenarioCfg.HostOverrides)))
+	}
+
+	return wrappers.Build(ctx, cfg, extraOpts...)
+}
+
+// stubLookupIP returns a DNS lookup function that returns pre-configured IPs for
+// hostnames in the overrides map. For hostnames not in the map, it returns an error.
+func stubLookupIP(overrides map[string][]string) func(string) ([]net.IP, error) {
+	return func(hostname string) ([]net.IP, error) {
+		ipStrings, ok := overrides[hostname]
+		if !ok {
+			return nil, fmt.Errorf("stubLookupIP: no override for %q", hostname)
+		}
+		ips := make([]net.IP, 0, len(ipStrings))
+		for _, s := range ipStrings {
+			ip := net.ParseIP(s)
+			if ip == nil {
+				return nil, fmt.Errorf("stubLookupIP: invalid IP %q for %q", s, hostname)
+			}
+			ips = append(ips, ip)
+		}
+		return ips, nil
+	}
 }

--- a/tests/integration/toolkit/toolkit_test.go
+++ b/tests/integration/toolkit/toolkit_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"encoding/json"
+	"net"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -363,6 +364,53 @@ func TestScenarioToConfig(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.NotNil(t, cfg)
+}
+func TestCreateWrappedSource_WithHostOverrides_SourceBuilds(t *testing.T) {
+	// When HostOverrides is non-empty, the stub lookupIP option is appended and
+	// wrappers.Build should still return a valid source.
+	client, err := LoadResources(t.Context(), Scenario{
+		Resources: []ResourceWithDependencies{
+			{Resource: runtime.RawExtension{Raw: rawService()}},
+		},
+	})
+	require.NoError(t, err)
+
+	src, err := CreateWrappedSource(t.Context(), client, ScenarioConfig{
+		Sources: []string{"service"},
+		HostOverrides: map[string][]string{
+			"elb.example.com": {"1.2.3.4"},
+		},
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, src)
+}
+
+func TestStubLookupIP_ReturnsConfiguredIPs(t *testing.T) {
+	lookup := stubLookupIP(map[string][]string{
+		"example.com": {"1.2.3.4", "2001:db8::1"},
+	})
+
+	ips, err := lookup("example.com")
+	require.NoError(t, err)
+	require.Len(t, ips, 2)
+	assert.Equal(t, net.ParseIP("1.2.3.4"), ips[0])
+	assert.Equal(t, net.ParseIP("2001:db8::1"), ips[1])
+}
+
+func TestStubLookupIP_NoOverride(t *testing.T) {
+	lookup := stubLookupIP(map[string][]string{"example.com": {"1.2.3.4"}})
+
+	ips, err := lookup("missing.example.com")
+	assert.Nil(t, ips)
+	assert.EqualError(t, err, "stubLookupIP: no override for \"missing.example.com\"")
+}
+
+func TestStubLookupIP_InvalidIP(t *testing.T) {
+	lookup := stubLookupIP(map[string][]string{"example.com": {"not-an-ip"}})
+
+	ips, err := lookup("example.com")
+	assert.Nil(t, ips)
+	assert.EqualError(t, err, "stubLookupIP: invalid IP \"not-an-ip\" for \"example.com\"")
 }
 
 // encodeObject serializes a runtime.Object to JSON for use as RawExtension.Raw.


### PR DESCRIPTION
## What does this PR do?

This Pr adds per-resource annotation: `external-dns.alpha.kubernetes.io/resolve-target`. Setting this annotation to `true` causes ExternalDNS to resolve any CNAME target (i.e. a hostname returned by a cloud load balancer) to its A and AAAA records at sync time, and emit those IP addresses as A/AAAA endpoints instead. DNS resolution uses net.LookupIP and honours the system resolver.
Implementation
Resolution is implemented as a Source Wrapper in resolvetarget.go, wrapping any source. Each source propagates the annotation value as an endpoint label using provider_specific.go; the resolvesource wrapper reads the label and resolves the hostname

If resolution fails for a target (e.g. the hostname is temporarily unresolvable), that target is silently skipped and a debug log entry is emitted.


## Motivation

Some DNS providers or configurations do not support `CNAME` records (e.g., internal Dns), requiring IP-based records.  
For example

In a public cloud provider, when we create a Gateway and an Http Route or an Ingress we usually end up with something like this:
When we create a Gateway we end up with a hostname in the status which points to the loadbalancer's ips.
<img width="1042" height="641" alt="Diagramme sans nom drawio(1)" src="https://github.com/user-attachments/assets/3fcf39f1-7283-4dc5-afec-abff0fe75242" />

The loadbalancer IPs are then routed in an infrastructure where we can't resolve external Records like `example-gateway.region.mycloud.com`. 

If we create a CNAME `my-app.internal` to `example-gateway.region.mycloud.com` it won't work as the app `my-second-app` won't be able to resolve the  `example-gateway.region.mycloud.com` Record

We must then create an A Record in the air-gapped infrastructure instead of a CNAME. 
<img width="1271" height="1031" alt="image" src="https://github.com/user-attachments/assets/71966e33-3e63-443c-87fc-79d7445c7ea2" />
## More

The discussion over this PR is also in https://github.com/kubernetes-sigs/external-dns/pull/6289. The old PR was closed due to a bug in the CI workflow

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly