### PR TITLE
ci: add rebase and upstream sync checks to lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -61,3 +61,24 @@ jobs:
 
     - name: Check Go version consistency across cloudbuild.yaml, go.mod and go.tool.mod
       run: ./scripts/go-version-consistency.sh
+
+  rebase-check:
+    name: Rebased on fork base
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Check out code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Check PR is rebased on fork base
+      run: |
+        git fetch origin "${{ github.base_ref }}"
+        git fetch origin "${{ github.head_ref }}"
+
+        if git merge-base --is-ancestor "origin/${{ github.base_ref }}" "origin/${{ github.head_ref }}"; then
+          echo "PR is based on the fork base branch."
+        else
+          echo "PR needs a rebase onto the fork base branch."
+          exit 1
+        fi

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -64,6 +64,7 @@ jobs:
 
   rebase-check:
     name: Rebased on fork base
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -69,6 +69,8 @@ jobs:
       contents: read
     steps:
     - name: Check PR is rebased on fork base
+      env:
+        GH_TOKEN: ${{ github.token }} # read-only token, explicitly set for visibility
       run: |
         BEHIND=$(gh api repos/${{ github.repository }}/compare/${{ github.base_ref }}...${{ github.event.pull_request.head.sha }} --jq '.behind_by')
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -68,18 +68,13 @@ jobs:
     permissions:
       contents: read
     steps:
-    - name: Check out code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-
     - name: Check PR is rebased on fork base
       run: |
-        git fetch origin "${{ github.base_ref }}"
+        BEHIND=$(gh api repos/${{ github.repository }}/compare/${{ github.base_ref }}...${{ github.event.pull_request.head.sha }} --jq '.behind_by')
 
-        if git merge-base --is-ancestor "origin/${{ github.base_ref }}" HEAD; then
-          echo "PR is based on the fork base branch."
-        else
-          echo "PR needs a rebase onto the fork base branch."
+        if [ "$BEHIND" -gt 0 ]; then
+          echo "PR is $BEHIND commit(s) behind base branch. Please rebase."
           exit 1
         fi
+
+        echo "PR is up to date with base branch."

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -70,13 +70,14 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Check PR is rebased on fork base
       run: |
         git fetch origin "${{ github.base_ref }}"
-        git fetch origin "${{ github.head_ref }}"
 
-        if git merge-base --is-ancestor "origin/${{ github.base_ref }}" "origin/${{ github.head_ref }}"; then
+        if git merge-base --is-ancestor "origin/${{ github.base_ref }}" HEAD; then
           echo "PR is based on the fork base branch."
         else
           echo "PR needs a rebase onto the fork base branch."


### PR DESCRIPTION
## What does it do ?

  - Added rebase-check job - fails if PR branch is not rebased on fork's master
  - Runs on every PR push

Example failed 
- https://github.com/kubernetes-sigs/external-dns/actions/runs/23842424398/job/69501172120?pr=6333

<img width="980" height="275" alt="Screenshot 2026-04-01 at 10 44 20" src="https://github.com/user-attachments/assets/31d54002-8a7c-4092-a4fc-8824c49d3ed8" />

Command 
```
/test pull-external-dns-unit-test
```

Helps, but there are edge cases, that better to avoid.

## Motivation

Prevent merging stale PRs and ensure the fork doesn't silently drift behind upstream security/bug fixes.
Catches stale branches -> prevents merging code that was branched off an old state of master, which could reintroduce already-removed code or conflict silently.
Reduces hidden conflicts - a PR that's behind master may not have textual conflicts but can have logical ones (e.g., a function it calls was removed upstream).

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

Will simplify debugging of things. Minus one issue to look at

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-external-dns-push-images/2039609054623436800

<img width="1148" height="500" alt="Screenshot 2026-04-02 at 09 07 31" src="https://github.com/user-attachments/assets/1d9186bf-e4d1-4561-8d0a-3777ccf00956" />

