### PR TITLE
feat: add support for PTR, MX and DS record types

### DIFF
--- a/provider/recordfilter.go
+++ b/provider/recordfilter.go
@@ -20,7 +20,7 @@ package provider
 // Currently A, AAAA, CNAME, SRV, TXT and NS record types are supported.
 func SupportedRecordType(recordType string) bool {
 	switch recordType {
-	case "A", "AAAA", "CNAME", "SRV", "TXT", "NS":
+	case "A", "AAAA", "CNAME", "SRV", "TXT", "NS", "PTR", "MX", "DS":
 		return true
 	default:
 		return false

--- a/provider/recordfilter_test.go
+++ b/provider/recordfilter_test.go
@@ -41,6 +41,22 @@ func TestRecordTypeFilter(t *testing.T) {
 		},
 		{
 			"MX",
+			true,
+		},
+		{
+			"PTR",
+			true,
+		},
+		{
+			"DA",
+			true,
+		},
+		{
+			"SOA",
+			false,
+		},
+		{
+			"SPF",
 			false,
 		},
 	}

--- a/provider/recordfilter_test.go
+++ b/provider/recordfilter_test.go
@@ -48,7 +48,7 @@ func TestRecordTypeFilter(t *testing.T) {
 			true,
 		},
 		{
-			"DA",
+			"DS",
 			true,
 		},
 		{


### PR DESCRIPTION
## What does it do ?

This PR allows use of the following record types:
* **PTR** - Reverse IP mapping to forward records,
* **MX** - Mail server record for domain,
* **DS** - Delegations signer (used to establish a chain of trust for DNSSEC)

## Motivation

While setting up `external-dns` as provisioner for reverse zones I noticed that the controller gets in a conflict loop while trying to create records which already exist. It creates records and then in the next loop attempts to create these again. This is caused by a simple omission of allowed record types in the `recordfilter.go` file. This will allow users to manage wider range of records.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly
  - not much to update as the docs basically states that this should work
 
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
