### PR TITLE
refactor(controller): controller.Run to return error

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -178,7 +178,7 @@ func (c *Controller) ShouldRunOnce(now time.Time) bool {
 }
 
 // Run runs RunOnce in a loop with a delay until context is canceled
-func (c *Controller) Run(ctx context.Context) {
+func (c *Controller) Run(ctx context.Context) error {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 	var softErrorCount int
@@ -190,7 +190,7 @@ func (c *Controller) Run(ctx context.Context) {
 					consecutiveSoftErrors.Gauge.Set(float64(softErrorCount))
 					log.Errorf("Failed to do run once: %v (consecutive soft errors: %d)", err, softErrorCount)
 				} else {
-					log.Fatalf("Failed to do run once: %v", err) // nolint: gocritic // exitAfterDefer
+					return fmt.Errorf("failed to do run once: %w", err)
 				}
 			} else {
 				if softErrorCount > 0 {
@@ -204,7 +204,7 @@ func (c *Controller) Run(ctx context.Context) {
 		case <-ticker.C:
 		case <-ctx.Done():
 			log.Info("Terminating main controller loop")
-			return
+			return nil
 		}
 	}
 }

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -611,9 +611,8 @@ func TestRunOnce_EmitChangeEvent(t *testing.T) {
 }
 
 func TestRun_HardError(t *testing.T) {
-	provider := getTestProvider()
 	cfg := getTestConfig()
-	r, err := registryfactory.Select(cfg, provider)
+	r, err := registryfactory.Select(getTestConfig(), getTestProvider())
 	require.NoError(t, err)
 
 	source := new(testutils.MockSource)
@@ -624,7 +623,7 @@ func TestRun_HardError(t *testing.T) {
 		Registry:           r,
 		Policy:             &plan.SyncPolicy{},
 		ManagedRecordTypes: cfg.ManagedDNSRecordTypes,
-		Interval:           10 * time.Millisecond,
+		Interval:           5 * time.Second,
 	}
 
 	// Set nextRunAt to the past to trigger ShouldRunOnce immediately on the first tick

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -509,6 +509,10 @@ func (r *toggleRegistry) ApplyChanges(_ context.Context, _ *plan.Changes) error 
 	return nil
 }
 
+func (r *toggleRegistry) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
+	return endpoints, nil
+}
+
 func TestToggleRegistry(t *testing.T) {
 	source := getTestSource()
 	cfg := getTestConfig()

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -605,3 +605,35 @@ func TestRunOnce_EmitChangeEvent(t *testing.T) {
 		})
 	}
 }
+
+func TestRun_HardError(t *testing.T) {
+	provider := getTestProvider()
+	cfg := getTestConfig()
+	r, err := registryfactory.Select(cfg, provider)
+	require.NoError(t, err)
+
+	source := new(testutils.MockSource)
+	source.On("Endpoints").Return([]*endpoint.Endpoint(nil), errors.New("simulated hard error"))
+
+	ctrl := &Controller{
+		Source:             source,
+		Registry:           r,
+		Policy:             &plan.SyncPolicy{},
+		ManagedRecordTypes: cfg.ManagedDNSRecordTypes,
+		Interval:           10 * time.Millisecond,
+	}
+
+	// Set nextRunAt to the past to trigger ShouldRunOnce immediately on the first tick
+	ctrl.nextRunAt = time.Now().Add(-time.Millisecond)
+
+	// We don't need a background goroutine for Run because the hard error will cause
+	// it to return immediately instead of entering an infinite ticker loop.
+	err = ctrl.Run(t.Context())
+
+	// Assert the hard error caused Run to terminate and wrap the error accordingly
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to do run once")
+	assert.ErrorContains(t, err, "simulated hard error")
+
+	source.AssertExpectations(t)
+}

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -629,12 +629,8 @@ func TestRun_HardError(t *testing.T) {
 
 	// Set nextRunAt to the past to trigger ShouldRunOnce immediately on the first tick
 	ctrl.nextRunAt = time.Now().Add(-time.Millisecond)
-
-	// We don't need a background goroutine for Run because the hard error will cause
-	// it to return immediately instead of entering an infinite ticker loop.
 	err = ctrl.Run(t.Context())
 
-	// Assert the hard error caused Run to terminate and wrap the error accordingly
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "failed to do run once")
 	assert.ErrorContains(t, err, "simulated hard error")

--- a/controller/execute.go
+++ b/controller/execute.go
@@ -134,7 +134,9 @@ func Execute() {
 	}
 
 	ctrl.ScheduleRunOnce(time.Now())
-	ctrl.Run(ctx)
+	if err := ctrl.Run(ctx); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func buildController(

--- a/controller/execute.go
+++ b/controller/execute.go
@@ -62,8 +62,7 @@ func Execute() {
 		log.Infof("Using custom annotation prefix: %s", cfg.AnnotationPrefix)
 	}
 
-	err := configureLogger(cfg)
-	if err != nil {
+	if err := configureLogger(cfg); err != nil {
 		log.Fatal(err)
 	}
 

--- a/controller/execute.go
+++ b/controller/execute.go
@@ -62,7 +62,10 @@ func Execute() {
 		log.Infof("Using custom annotation prefix: %s", cfg.AnnotationPrefix)
 	}
 
-	configureLogger(cfg)
+	err := configureLogger(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	if cfg.DryRun {
 		log.Info("running in dry-run mode. No changes to DNS records will be made.")
@@ -187,15 +190,16 @@ func buildController(
 }
 
 // This function configures the logger format and level based on the provided configuration.
-func configureLogger(cfg *externaldns.Config) {
+func configureLogger(cfg *externaldns.Config) error {
 	if cfg.LogFormat == "json" {
 		log.SetFormatter(&log.JSONFormatter{})
 	}
 	ll, err := log.ParseLevel(cfg.LogLevel)
 	if err != nil {
-		log.Fatalf("failed to parse log level: %v", err)
+		return err
 	}
 	log.SetLevel(ll)
+	return nil
 }
 
 // handleSigterm listens for a SIGTERM signal and triggers the provided cancel function

--- a/controller/execute_test.go
+++ b/controller/execute_test.go
@@ -71,30 +71,15 @@ func TestConfigureLogger(t *testing.T) {
 			},
 			wantLevel:  log.InfoLevel,
 			wantErr:    true,
-			wantErrMsg: "failed to parse log level",
+			wantErrMsg: "not a valid logrus Level: \"invalid\"",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.wantErr {
-				// Capture and suppress fatal exit; restore logger after test
-				logger := log.StandardLogger()
-				prevOut := logger.Out
-				prevExit := logger.ExitFunc
-				b := new(bytes.Buffer)
-				var captureLogFatal bool
-				logger.ExitFunc = func(int) { captureLogFatal = true }
-				logger.SetOutput(b)
-				t.Cleanup(func() {
-					logger.SetOutput(prevOut)
-					logger.ExitFunc = prevExit
-				})
-
-				configureLogger(tt.cfg)
-
-				assert.True(t, captureLogFatal)
-				assert.Contains(t, b.String(), tt.wantErrMsg)
+				err := configureLogger(tt.cfg)
+				require.Error(t, err)
 			} else {
 				// Save and restore logger state to avoid leaking between tests
 				logger := log.StandardLogger()
@@ -105,7 +90,9 @@ func TestConfigureLogger(t *testing.T) {
 					logger.SetFormatter(prevFormatter)
 				})
 
-				configureLogger(tt.cfg)
+				err := configureLogger(tt.cfg)
+				require.NoError(t, err)
+
 				assert.Equal(t, tt.wantLevel, log.GetLevel())
 
 				if tt.wantJSON {


### PR DESCRIPTION
## Motivation

Run() now returns an error instead of calling log.Fatalf directly, making the hard-error path unit-testable. The caller in execute.go handles the fatal log.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
