### PR TITLE
docs(ci): validate docs build on PRs targeting master

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
   # See https://docs.github.com/fr/webhooks/webhook-events-and-payloads#workflow_dispatch
   # Can be used to update doc with latest tag
   workflow_dispatch:
@@ -11,12 +17,33 @@ on:
 permissions: {}
 
 jobs:
+  build_docs:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: "./docs/scripts/requirements.txt"
+
+      - run: |
+          pip install -r docs/scripts/requirements.txt
+
+      - name: Build
+        run: |
+          mkdocs build --strict
+
   release_docs:
     permissions:
       contents: write  #  for mike to push
 
     name: Release Docs
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,4 +1,4 @@
-name: Release Docs
+name: Docs
 
 on:
   pull_request:
@@ -21,7 +21,7 @@ permissions: {}
 
 jobs:
   build_docs:
-    name: Build Docs
+    name: Lint Docs
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,6 +7,7 @@ on:
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      - ".github/workflows/docs.yaml"
   # See https://docs.github.com/fr/webhooks/webhook-events-and-payloads#workflow_dispatch
   # Can be used to update doc with latest tag
   workflow_dispatch:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,12 +35,10 @@ jobs:
           cache: "pip"
           cache-dependency-path: "./docs/scripts/requirements.txt"
 
-      - run: |
-          pip install -r docs/scripts/requirements.txt
+      - run: pip install -r docs/scripts/requirements.txt
 
-      - name: Build
-        run: |
-          mkdocs build --strict
+      - name: lint and build docs
+        run: mkdocs build --strict
 
   release_docs:
     permissions:
@@ -60,8 +58,7 @@ jobs:
           cache: "pip"
           cache-dependency-path: "./docs/scripts/requirements.txt"
 
-      - run: |
-          pip install -r docs/scripts/requirements.txt
+      - run: pip install -r docs/scripts/requirements.txt
 
       - name: Configure Git user
         run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -26,6 +26,8 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/docs/contributing/dev-guide.md
+++ b/docs/contributing/dev-guide.md
@@ -27,7 +27,7 @@ Building and/or testing `external-dns` requires additional tooling.
 
 ### Go Tools
 
-Additional Go-based tools are managed in [`go.tool.mod`](../../go.tool.mod) and used for code generation:
+Additional Go-based tools are managed in `go.tool.mod` and used for code generation:
 
 | Tool                                                                  | Purpose                                            |
 |-----------------------------------------------------------------------|----------------------------------------------------|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
       - Rate Limits: docs/advanced/rate-limits.md
       - TTL: docs/advanced/ttl.md
       - Decisions: docs/proposal/0*.md
+      - Decision Template: docs/proposal/design-template.md
       - Domain Filter: docs/advanced/domain-filter.md
       - Configuration Precedence: docs/advanced/configuration-precedence.md
       - Split Horizon DNS: docs/advanced/split-horizon.md


### PR DESCRIPTION
 What: Adds a build_docs job that runs mkdocs build --strict on PRs to master touching docs/** or mkdocs.yml. Guards release_docs with an explicit condition so it only runs
   on tags or workflow_dispatch.

  Why: Docs were only validated at release time, so broken builds (e.g. missing Python extension mdx_truly_sane_lists) weren't caught until a tag was pushed.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
