### PR TITLE
ci(docs): use latest as alias

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -68,5 +68,5 @@ jobs:
       - name: build and push
         run: |
           VERSION="${{ inputs.tag }}"
-          mike deploy $VERSION --push --update-aliases
+          mike deploy $VERSION latest --push --update-aliases
           mike set-default --push latest

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ theme:
 extra:
   version:
     provider: mike
+    alias: true
 
 markdown_extensions:
   - meta


### PR DESCRIPTION
## What does it do ?

Set _latest_ as an alias to latest version.

## Motivation

Based on #6187
Supersede #6187

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
