### PR TITLE
feat(chart): add image digest

### DIFF
--- a/.github/workflows/lint-test-chart.yaml
+++ b/.github/workflows/lint-test-chart.yaml
@@ -102,6 +102,17 @@ jobs:
           check_command: mdq --version
           version: latest
 
+      - name: Run image digest check
+        run: |
+          set -euo pipefail
+
+          make helm-image-digest
+          if [[ -n "$(git status --porcelain --untracked-files=no)" ]]
+          then
+            echo "Image digest not up to date. Please run make helm-image-digest and commit changes!" >&2
+            exit 1
+          fi
+
       - name: Run CHANGELOG check
         run: |
           set -euo pipefail

--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,11 @@ helm-lint:
 	scripts/helm-tools.sh --schema
 	scripts/helm-tools.sh --docs
 
+.PHONY: helm-image-digest
+#? helm-image-digest: Update image digest in values.yaml from registry
+helm-image-digest:
+	scripts/helm-tools.sh --digest
+
 .PHONY: go-dependency
 #? go-dependency: Dependency maintanance
 go-dependency:

--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Avoid creating cluster-scoped RBAC for Gateway API sources when running namespaced with `gatewayNamespace` set. Namespace listing permissions are now only added when `gatewayNamespace` is unset. ([#5843](https://github.com/kubernetes-sigs/external-dns/pull/5843)) _@TobyTheHutt_
 
+### Changed
+
+- Use image tag and digest by default to ensure immutability of the image used by the chart.
+  ([#6355](https://github.com/kubernetes-sigs/external-dns/pull/6355)) _@vflaux_
+
 ## [v1.20.0]
 
 ### Added

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -115,6 +115,7 @@ If `namespaced` is set to `true`, please ensure that `sources` only contains sup
 | fullnameOverride | string | `nil` | Override the full name of the chart. |
 | gatewayNamespace | string | `nil` | _Gateway API_ gateway namespace to watch. When `namespaced=true`, setting this value avoids creating any cluster-scoped RBAC (no ClusterRole/ClusterRoleBinding) for Gateway sources. |
 | global.imagePullSecrets | list | `[]` | Global image pull secrets. |
+| image.digest | string | `"sha256:ddc7f4212ed09a21024deb1f470a05240837712e74e4b9f6d1f2632ff10672e7"` | Image digest (SHA256) for the `external-dns` container (e.g. sha256:abcd1234...). |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the `external-dns` container. |
 | image.repository | string | `"registry.k8s.io/external-dns/external-dns"` | Image repository for the `external-dns` container. |
 | image.tag | string | `nil` | Image tag for the `external-dns` container, this will default to `.Chart.AppVersion` if not set. |

--- a/charts/external-dns/templates/_helpers.tpl
+++ b/charts/external-dns/templates/_helpers.tpl
@@ -68,7 +68,18 @@ Create the name of the service account to use
 The image to use
 */}}
 {{- define "external-dns.image" -}}
-{{- printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) }}
+{{- $image := .Values.image.repository -}}
+{{- if ne "" .Values.image.tag -}}
+{{- $tag := default (printf "v%s" .Chart.AppVersion) .Values.image.tag  }}
+{{- $image = printf "%s:%s" $image $tag }}
+{{- end }}
+{{- if not (empty .Values.image.digest) -}}
+{{- $image = printf "%s@%s" $image .Values.image.digest }}
+{{- end }}
+{{- if eq .Values.image.repository $image -}}
+{{- fail "should have at least one of image tag or image digest" }}
+{{- end }}
+{{- $image }}
 {{- end }}
 
 {{/*

--- a/charts/external-dns/tests/deployment-image_test.yaml
+++ b/charts/external-dns/tests/deployment-image_test.yaml
@@ -1,0 +1,59 @@
+suite: Deployment image configurations
+templates:
+  - deployment.yaml
+release:
+  namespace: default
+chart:
+  appVersion: 0.15.0
+tests:
+  - it: should use image tag and digest by default
+    set:
+      image:
+        repository: registry.k8s.io/external-dns/external-dns
+        digest: sha256:deadbeef
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "external-dns")].image
+          value: registry.k8s.io/external-dns/external-dns:v0.15.0@sha256:deadbeef
+
+  - it: should use image tag only when digest is null
+    set:
+      image:
+        repository: registry.k8s.io/external-dns/external-dns
+        digest: ~
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "external-dns")].image
+          value: registry.k8s.io/external-dns/external-dns:v0.15.0
+
+  - it: should use image digest only when tag is empty string
+    set:
+      image:
+        repository: registry.k8s.io/external-dns/external-dns
+        tag: ""
+        digest: sha256:deadbeef
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "external-dns")].image
+          value: registry.k8s.io/external-dns/external-dns@sha256:deadbeef
+
+  - it: should use overridden image tag
+    set:
+      image:
+        repository: registry.k8s.io/external-dns/external-dns
+        tag: v0.1.0
+        digest: sha256:deadbeef
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "external-dns")].image
+          value: registry.k8s.io/external-dns/external-dns:v0.1.0@sha256:deadbeef
+
+  - it: should fails if tag is empty string and digest is empty
+    set:
+      image:
+        repository: registry.k8s.io/external-dns/external-dns
+        tag: ""
+        digest: ~
+    asserts:
+      - failedTemplate:
+          errorMessage: "should have at least one of image tag or image digest"

--- a/charts/external-dns/tests/notes_test.yaml
+++ b/charts/external-dns/tests/notes_test.yaml
@@ -9,6 +9,8 @@ tests:
     set:
       rbac:
         namespaced: true
+      image:
+        digest: sha256:deadbeef
     asserts:
       - equalRaw:
           value: |
@@ -17,5 +19,5 @@ tests:
             ***********************************************************************
               Chart version: 1.15.0
               App version:   0.15.0
-              Image tag:     registry.k8s.io/external-dns/external-dns:v0.15.0
+              Image tag:     registry.k8s.io/external-dns/external-dns:v0.15.0@sha256:deadbeef
             ***********************************************************************

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -133,6 +133,13 @@
     "image": {
       "type": "object",
       "properties": {
+        "digest": {
+          "description": "Image digest (SHA256) for the `external-dns` container (e.g. sha256:abcd1234...).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "pullPolicy": {
           "description": "Image pull policy for the `external-dns` container.",
           "type": "string",

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -13,6 +13,8 @@ image:  # @schema additionalProperties: false
   tag:  # @schema type:[string, null]
   # -- Image pull policy for the `external-dns` container.
   pullPolicy: IfNotPresent  # @schema enum:[IfNotPresent, Always]
+  # -- Image digest (SHA256) for the `external-dns` container (e.g. sha256:abcd1234...).
+  digest: "sha256:ddc7f4212ed09a21024deb1f470a05240837712e74e4b9f6d1f2632ff10672e7"  # @schema type:[string, null]
 
 # -- Image pull secrets.
 imagePullSecrets: []  # @schema item: object

--- a/docs/release.md
+++ b/docs/release.md
@@ -67,5 +67,6 @@ The chart needs to be released in response to an ExternalDNS image release or on
 ### Steps
 
 - Create a PR to update _Chart.yaml_ with the ExternalDNS version in `appVersion`, agreed on chart release version in `version` and `annotations` showing the changes
+- Update the `image.digest` field in _values.yaml_ with the new image digest (SHA256) using `make helm-image-digest`
 - Validate that the chart linting is successful
 - Merge the PR to trigger a GitHub action to release the chart

--- a/scripts/helm-tools.sh
+++ b/scripts/helm-tools.sh
@@ -23,6 +23,7 @@ cat << EOF
 
 Usage: $(basename "$0") <options>
     -d, --diff          Schema diff validation
+    --digest            Update image digest in values.yaml from registry
     --docs              Re-generate helm documentation
     -h, --help          Display help
     -i, --install       Install required tooling
@@ -107,6 +108,26 @@ show_docs() {
   open "https://github.com/losisin/helm-values-schema-json?tab=readme-ov-file"
 }
 
+image_digest() {
+  APP_VERSION=$(yq '.appVersion' charts/external-dns/Chart.yaml)
+  REPOSITORY=$(yq '.image.repository' charts/external-dns/values.yaml)
+  IMAGE_DIGEST=$(
+    curl -sIL https://${REPOSITORY%%/*}/v2/${REPOSITORY#*/}/manifests/v${APP_VERSION} | \
+      grep "^docker-content-digest:" | head -1 | cut -d' ' -f2 | tr -d '\r'
+  )
+
+  sed -i '/^$/s// #BLANK_LINE/' charts/external-dns/values.yaml # hack to preserve blank lines as yq removes them
+  digest=${IMAGE_DIGEST} yq eval -i ".image.digest = strenv(digest)" charts/external-dns/values.yaml
+  sed -i "s/ *#BLANK_LINE//g" charts/external-dns/values.yaml # restore blank lines
+  go tool -modfile=go.tool.mod yamlfmt \
+    -formatter pad_line_comments=2 \
+    -formatter retain_line_breaks=true \
+    charts/external-dns/values.yaml
+
+  echo "Image digest set to $(yq '.image.digest' charts/external-dns/values.yaml) in values.yaml"
+}
+
+
 function main() {
   case $1 in
     --show-docs)
@@ -120,6 +141,9 @@ function main() {
       ;;
     -d|--diff)
       diff_schema
+      ;;
+    --digest)
+      image_digest
       ;;
     --docs)
       helm_docs


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->
Add the image digest to manifests generated by the chart.

- Add the `image.digest` field in `values.yaml`
- Allow to use only the tag or the digest
- Add a Makefile target to update the digest
- Add a check in CI

## Motivation

<!-- What inspired you to submit this pull request? -->
Tags on a registry can be updated. Using a digest ensure the image pulled is the right one.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
