### PR TITLE
fix: prevent silent overwrite in TXTRegistry ownership conflicts

### DIFF
--- a/registry/txt/registry.go
+++ b/registry/txt/registry.go
@@ -236,10 +236,9 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 			existingOwner, existingOwnerOK := existingLabels[endpoint.OwnerLabelKey]
 			newOwner, newOwnerOK := labels[endpoint.OwnerLabelKey]
 
-			// If owner label missing, don't block — store safely
+			// If owner label is missing, skip to avoid unsafe overwrite and preserve determinism
 			if !existingOwnerOK || !newOwnerOK {
-				log.Warnf("Missing owner label for TXT record %s, allowing overwrite", key.DNSName)
-				labelMap[key] = labels
+				log.Warnf("Missing owner label for TXT record %s, skipping record", key.DNSName)
 				continue
 			}
 

--- a/registry/txt/registry.go
+++ b/registry/txt/registry.go
@@ -231,6 +231,33 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 			RecordType:    recordType,
 			SetIdentifier: record.SetIdentifier,
 		}
+		existingLabels, exists := labelMap[key]
+		if exists {
+			existingOwner, existingOwnerOK := existingLabels[endpoint.OwnerLabelKey]
+			newOwner, newOwnerOK := labels[endpoint.OwnerLabelKey]
+
+			// If owner label missing, don't block — store safely
+			if !existingOwnerOK || !newOwnerOK {
+				log.Warnf("Missing owner label for TXT record %s, allowing overwrite", key.DNSName)
+				labelMap[key] = labels
+				continue
+			}
+
+			// Conflict detected → skip overwrite
+			if existingOwner != newOwner {
+				log.Warnf("Conflicting TXT record owners for %s: '%s' vs '%s'",
+					key.DNSName,
+					existingOwner,
+					newOwner,
+				)
+				continue
+			}
+
+			// Same owner → no need to overwrite
+			continue
+		}
+
+		// First time seeing this key → store it
 		labelMap[key] = labels
 		txtRecordsMap[record.DNSName] = struct{}{}
 		im.existingTXTs.add(record)


### PR DESCRIPTION
Fixes #5457

## Problem

TXTRegistry currently silently overwrites ownership data when multiple TXT records exist for the same DNS name. This can lead to inconsistent and nondeterministic behavior in multi-owner environments.

## Solution

This PR introduces deterministic conflict handling:

- Detects ownership conflicts between TXT records
- Prevents overwrite when owners differ
- Allows safe overwrite when owner labels are missing
- Skips redundant updates when owners match

## Result

- Eliminates silent ownership override
- Improves safety in multi-tenant setups
- Maintains backward compatibility

## Release Note

```release-note
Fixes an issue in TXTRegistry where ownership data could be silently overwritten when multiple TXT records existed for the same DNS name. The behavior is now deterministic: conflicts are detected and overwrite is prevented.