### PR TITLE
fix(crd): require trailing dot for SRV targets

### DIFF
--- a/docs/tutorials/crd.md
+++ b/docs/tutorials/crd.md
@@ -87,8 +87,8 @@ spec:
     recordTTL: 180
     recordType: SRV
     targets:
-    - 1 50 5060 sip1-n1.test.example.com
-    - 1 50 5060 sip1-n2.test.example.com
+    - 1 50 5060 sip1-n1.test.example.com.
+    - 1 50 5060 sip1-n2.test.example.com.
 ```
 
 ### DNSEndpoint with an NAPTR record

--- a/source/crd.go
+++ b/source/crd.go
@@ -126,7 +126,7 @@ func (cs *crdSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 				hasDot := strings.HasSuffix(target, ".")
 
 				switch ep.RecordType {
-				case endpoint.RecordTypeNAPTR:
+				case endpoint.RecordTypeNAPTR, endpoint.RecordTypeSRV:
 					illegalTarget = !hasDot
 				default:
 					illegalTarget = hasDot
@@ -134,7 +134,7 @@ func (cs *crdSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 
 				if illegalTarget {
 					fixed := target + "."
-					if ep.RecordType != endpoint.RecordTypeNAPTR {
+					if ep.RecordType != endpoint.RecordTypeNAPTR && ep.RecordType != endpoint.RecordTypeSRV {
 						fixed = strings.TrimSuffix(target, ".")
 					}
 					log.Warnf("Endpoint %s/%s with DNSName %s has an illegal target %q for %s record — use %q not %q.",

--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -313,12 +313,28 @@ func testCRDSourceEndpoints(t *testing.T) {
 			endpoints: []*endpoint.Endpoint{
 				{
 					DNSName:    "_svc._tcp.example.org",
-					Targets:    endpoint.Targets{"0 0 80 abc.example.org", "0 0 80 def.example.org"},
+					Targets:    endpoint.Targets{"0 0 80 abc.example.org.", "0 0 80 def.example.org."},
 					RecordType: endpoint.RecordTypeSRV,
 					RecordTTL:  180,
 				},
 			},
 			expectEndpoints: true,
+		},
+		{
+			title:           "SRV record missing trailing dot",
+			namespaceFilter: "foo",
+			objectNamespace: "foo",
+			labels:          map[string]string{"test": "that"},
+			labelSelector:   labels.SelectorFromSet(labels.Set{"test": "that"}),
+			endpoints: []*endpoint.Endpoint{
+				{
+					DNSName:    "_svc._tcp.example.org",
+					Targets:    endpoint.Targets{"0 0 80 abc.example.org", "0 0 80 def.example.org"},
+					RecordType: endpoint.RecordTypeSRV,
+					RecordTTL:  180,
+				},
+			},
+			expectEndpoints: false,
 		},
 		{
 			title:           "Create NAPTR record",


### PR DESCRIPTION
## What does it do ?

This brings the CRD validation of SRV record targets in line with the ``ValidateSRVRecord`` function in ``endpoint/endpoint.go``, which was changed in fde978f2d822c83c887175b560e99604b5e1b878 to require a trailing dot.

## Motivation

Fixes #6357.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly