### PR TITLE
refactor: use Set structs instead of map[]struct{}

### DIFF
--- a/controller/metrics.go
+++ b/controller/metrics.go
@@ -18,9 +18,9 @@ package controller
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/pkg/metrics"
 )
 

--- a/controller/metrics.go
+++ b/controller/metrics.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/pkg/metrics"
@@ -151,14 +152,14 @@ type dnsKey struct {
 func countMatchingAddressRecords(endpoints []*endpoint.Endpoint, registryRecords []*endpoint.Endpoint, metric metrics.GaugeVecMetric) {
 	metric.Gauge.Reset()
 
-	registry := make(map[dnsKey]struct{}, len(registryRecords))
+	registry := make(sets.Set[dnsKey], len(registryRecords))
 	for _, r := range registryRecords {
-		registry[dnsKey{r.DNSName, r.RecordType}] = struct{}{}
+		registry.Insert(dnsKey{r.DNSName, r.RecordType})
 	}
 
 	counts := make(map[string]float64)
 	for _, ep := range endpoints {
-		if _, found := registry[dnsKey{ep.DNSName, ep.RecordType}]; found {
+		if registry.Has(dnsKey{ep.DNSName, ep.RecordType}) {
 			counts[ep.RecordType]++
 		}
 	}

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/set"
 
 	"sigs.k8s.io/external-dns/pkg/events"
@@ -538,15 +539,15 @@ func FilterEndpointsByOwnerID(ownerID string, eps []*Endpoint) []*Endpoint {
 // This function doesn't contemplate the Targets of an Endpoint
 // as part of the primary Key
 func RemoveDuplicates(endpoints []*Endpoint) []*Endpoint {
-	visited := make(map[EndpointKey]struct{})
+	visited := make(sets.Set[EndpointKey], len(endpoints))
 	result := []*Endpoint{}
 
 	for _, ep := range endpoints {
 		key := ep.Key()
 
-		if _, found := visited[key]; !found {
+		if !visited.Has(key) {
 			result = append(result, ep)
-			visited[key] = struct{}{}
+			visited.Insert(key)
 		} else {
 			log.Debugf(`Skipping duplicated endpoint: %v`, ep)
 		}

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -27,9 +27,9 @@ import (
 
 	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/set"
 
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/pkg/events"
 )
 

--- a/internal/sets/set.go
+++ b/internal/sets/set.go
@@ -41,7 +41,7 @@ func New[T comparable](items ...T) Set[T] {
 func NewFromMapKeys[T comparable, V any](m map[T]V) Set[T] {
 	s := make(Set[T], len(m))
 	for k := range m {
-		s[k] = Empty{}
+		s.Insert(k)
 	}
 	return s
 }

--- a/internal/sets/set.go
+++ b/internal/sets/set.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package sets provides a generic set implementation using maps.
+package sets
+
+import (
+	"cmp"
+	"slices"
+)
+
+// Empty is a placeholder type for the value of the set map, since we only care about the keys.
+type Empty struct{}
+
+// Set is a generic set implementation using a map with empty struct values.
+type Set[T comparable] map[T]Empty
+
+// New creates a new set containing the provided items.
+func New[T comparable](items ...T) Set[T] {
+	s := make(Set[T], len(items))
+	for _, item := range items {
+		s.Insert(item)
+	}
+	return s
+}
+
+// NewFromMapKeys creates a new set from the keys of the provided map.
+func NewFromMapKeys[T comparable, V any](m map[T]V) Set[T] {
+	s := make(Set[T], len(m))
+	for k := range m {
+		s[k] = Empty{}
+	}
+	return s
+}
+
+// Insert adds item to the set.
+func (s Set[T]) Insert(item T) {
+	s[item] = Empty{}
+}
+
+// Delete removes item from the set.
+func (s Set[T]) Delete(item T) {
+	delete(s, item)
+}
+
+// Has returns true if the set contains the item.
+func (s Set[T]) Has(item T) bool {
+	_, exists := s[item]
+	return exists
+}
+
+// List returns the items in the set as a slice.
+// The order of the items is not guaranteed to be stable.
+func (s Set[T]) List() []T {
+	keys := make([]T, 0, len(s))
+	for k := range s {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// Sorted returns the items in the set as a sorted slice.
+func Sorted[T cmp.Ordered](s Set[T]) []T {
+	l := s.List()
+	slices.Sort(l)
+	return l
+}

--- a/internal/sets/set_test.go
+++ b/internal/sets/set_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sets_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"sigs.k8s.io/external-dns/internal/sets"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name  string
+		items []int
+		want  sets.Set[int]
+	}{
+		{
+			name:  "empty",
+			items: []int{},
+			want:  sets.New[int](),
+		},
+		{
+			name:  "single item",
+			items: []int{1},
+			want:  sets.New(1),
+		},
+		{
+			name:  "multiple items with duplicates",
+			items: []int{1, 2, 3, 2, 1},
+			want:  sets.New(1, 2, 3),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := sets.New(tt.items...)
+			assert.Equal(t, tt.want, s)
+		})
+	}
+}
+
+func TestNewFromMapKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		m    map[int]int
+		want sets.Set[int]
+	}{
+		{
+			name: "empty map",
+			m:    map[int]int{},
+			want: sets.New[int](),
+		},
+		{
+			name: "map with unique keys",
+			m:    map[int]int{1: 10, 2: 20, 3: 30},
+			want: sets.New(1, 2, 3),
+		},
+		{
+			name: "map with duplicate values",
+			m:    map[int]int{1: 10, 2: 20, 3: 10},
+			want: sets.New(1, 2, 3),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := sets.NewFromMapKeys(tt.m)
+			assert.Equal(t, tt.want, s)
+		})
+	}
+}
+
+func TestSet_Insert(t *testing.T) {
+	tests := []struct {
+		name string
+		s    sets.Set[int]
+		item int
+		want sets.Set[int]
+	}{
+		{
+			name: "insert into empty set",
+			s:    sets.New[int](),
+			item: 1,
+			want: sets.New(1),
+		},
+		{
+			name: "insert existing item",
+			s:    sets.New(1, 2, 3),
+			item: 2,
+			want: sets.New(1, 2, 3),
+		},
+		{
+			name: "insert new item",
+			s:    sets.New(1, 2, 3),
+			item: 4,
+			want: sets.New(1, 2, 3, 4),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.s.Insert(tt.item)
+			assert.Equal(t, tt.want, tt.s)
+		})
+	}
+}
+
+func TestSet_Delete(t *testing.T) {
+	tests := []struct {
+		name string
+		set  sets.Set[int]
+		item int
+		want sets.Set[int]
+	}{
+		{
+			name: "delete from empty set",
+			set:  sets.New[int](),
+			item: 1,
+			want: sets.New[int](),
+		},
+		{
+			name: "delete existing item",
+			set:  sets.New(1, 2, 3),
+			item: 2,
+			want: sets.New(1, 3),
+		},
+		{
+			name: "delete non-existing item",
+			set:  sets.New(1, 2, 3),
+			item: 4,
+			want: sets.New(1, 2, 3),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.set.Delete(tt.item)
+			assert.Equal(t, tt.want, tt.set)
+		})
+	}
+}
+
+func TestSet_Has(t *testing.T) {
+	tests := []struct {
+		name string
+		set  sets.Set[int]
+		item int
+		want bool
+	}{
+		{
+			name: "item in set",
+			set:  sets.New(1, 2, 3),
+			item: 2,
+			want: true,
+		},
+		{
+			name: "item not in set",
+			set:  sets.New(1, 2, 3),
+			item: 4,
+			want: false,
+		},
+		{
+			name: "empty set",
+			set:  sets.New[int](),
+			item: 1,
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.set.Has(tt.item))
+		})
+	}
+}
+
+func TestSet_List(t *testing.T) {
+	tests := []struct {
+		name string
+		set  sets.Set[int]
+		want []int
+	}{
+		{
+			name: "empty set",
+			set:  sets.New[int](),
+			want: []int{},
+		},
+		{
+			name: "set with unique items",
+			set:  sets.New(1, 2, 3),
+			want: []int{1, 2, 3},
+		},
+		{
+			name: "set with duplicates (should not affect output)",
+			set:  sets.New(1, 2, 3, 2, 1),
+			want: []int{1, 2, 3},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tt.want, tt.set.List())
+		})
+	}
+}
+
+func TestSorted(t *testing.T) {
+	tests := []struct {
+		name string
+		s    sets.Set[int]
+		want []int
+	}{
+		{
+			name: "empty set",
+			s:    sets.New[int](),
+			want: []int{},
+		},
+		{
+			name: "set with unique items",
+			s:    sets.New(3, 1, 2),
+			want: []int{1, 2, 3},
+		},
+		{
+			name: "set with duplicates",
+			s:    sets.New(3, 1, 2, 2, 1),
+			want: []int{1, 2, 3},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := sets.Sorted(tt.s)
+			assert.Equal(t, tt.want, s)
+		})
+	}
+}

--- a/internal/sets/set_test.go
+++ b/internal/sets/set_test.go
@@ -85,104 +85,238 @@ func TestNewFromMapKeys(t *testing.T) {
 }
 
 func TestSet_Insert(t *testing.T) {
-	tests := []struct {
-		name string
-		s    sets.Set[int]
-		item int
-		want sets.Set[int]
-	}{
-		{
-			name: "insert into empty set",
-			s:    sets.New[int](),
-			item: 1,
-			want: sets.New(1),
-		},
-		{
-			name: "insert existing item",
-			s:    sets.New(1, 2, 3),
-			item: 2,
-			want: sets.New(1, 2, 3),
-		},
-		{
-			name: "insert new item",
-			s:    sets.New(1, 2, 3),
-			item: 4,
-			want: sets.New(1, 2, 3, 4),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tt.s.Insert(tt.item)
-			assert.Equal(t, tt.want, tt.s)
-		})
-	}
+	t.Run("value", func(t *testing.T) {
+		tests := []struct {
+			name string
+			s    sets.Set[int]
+			item int
+			want sets.Set[int]
+		}{
+			{
+				name: "insert into empty set",
+				s:    sets.New[int](),
+				item: 1,
+				want: sets.New(1),
+			},
+			{
+				name: "insert existing item",
+				s:    sets.New(1, 2, 3),
+				item: 2,
+				want: sets.New(1, 2, 3),
+			},
+			{
+				name: "insert new item",
+				s:    sets.New(1, 2, 3),
+				item: 4,
+				want: sets.New(1, 2, 3, 4),
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				tt.s.Insert(tt.item)
+				assert.Equal(t, tt.want, tt.s)
+			})
+		}
+	})
+
+	t.Run("pointer", func(t *testing.T) {
+		zero, zero2 := new(0), new(0)
+		tests := []struct {
+			name string
+			s    sets.Set[*int]
+			item *int
+			want sets.Set[*int]
+		}{
+			{
+				name: "insert nil pointer to empty set",
+				s:    sets.New[*int](),
+				item: nil,
+				want: sets.New[*int](nil),
+			},
+			{
+				name: "insert non-nil pointer to empty set",
+				s:    sets.New[*int](),
+				item: zero,
+				want: sets.New(zero),
+			},
+			{
+				name: "insert duplicate nil pointer",
+				s:    sets.New[*int](nil),
+				item: nil,
+				want: sets.New[*int](nil),
+			},
+			{
+				name: "insert duplicate non-nil pointer",
+				s:    sets.New(zero),
+				item: zero,
+				want: sets.New(zero),
+			},
+			{
+				name: "insert different non-nil pointer with same value",
+				s:    sets.New(zero),
+				item: zero2,
+				want: sets.New(zero, zero2),
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				tt.s.Insert(tt.item)
+				assert.Equal(t, tt.want, tt.s)
+			})
+		}
+	})
 }
 
 func TestSet_Delete(t *testing.T) {
-	tests := []struct {
-		name string
-		set  sets.Set[int]
-		item int
-		want sets.Set[int]
-	}{
-		{
-			name: "delete from empty set",
-			set:  sets.New[int](),
-			item: 1,
-			want: sets.New[int](),
-		},
-		{
-			name: "delete existing item",
-			set:  sets.New(1, 2, 3),
-			item: 2,
-			want: sets.New(1, 3),
-		},
-		{
-			name: "delete non-existing item",
-			set:  sets.New(1, 2, 3),
-			item: 4,
-			want: sets.New(1, 2, 3),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tt.set.Delete(tt.item)
-			assert.Equal(t, tt.want, tt.set)
-		})
-	}
+	t.Run("value", func(t *testing.T) {
+		tests := []struct {
+			name string
+			set  sets.Set[int]
+			item int
+			want sets.Set[int]
+		}{
+			{
+				name: "delete from empty set",
+				set:  sets.New[int](),
+				item: 1,
+				want: sets.New[int](),
+			},
+			{
+				name: "delete existing item",
+				set:  sets.New(1, 2, 3),
+				item: 2,
+				want: sets.New(1, 3),
+			},
+			{
+				name: "delete non-existing item",
+				set:  sets.New(1, 2, 3),
+				item: 4,
+				want: sets.New(1, 2, 3),
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				tt.set.Delete(tt.item)
+				assert.Equal(t, tt.want, tt.set)
+			})
+		}
+	})
+
+	t.Run("pointer", func(t *testing.T) {
+		zero, zero2 := new(0), new(0)
+		tests := []struct {
+			name string
+			set  sets.Set[*int]
+			item *int
+			want sets.Set[*int]
+		}{
+			{
+				name: "delete from empty set",
+				set:  sets.New[*int](),
+				item: zero,
+				want: sets.New[*int](),
+			},
+			{
+				name: "delete existing item",
+				set:  sets.New(zero, zero2),
+				item: zero,
+				want: sets.New(zero2),
+			},
+			{
+				name: "delete non-existing item",
+				set:  sets.New(zero),
+				item: zero2,
+				want: sets.New(zero),
+			},
+			{
+				name: "delete nil pointer",
+				set:  sets.New[*int](nil),
+				item: nil,
+				want: sets.New[*int](),
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				tt.set.Delete(tt.item)
+				assert.Equal(t, tt.want, tt.set)
+			})
+		}
+	})
 }
 
 func TestSet_Has(t *testing.T) {
-	tests := []struct {
-		name string
-		set  sets.Set[int]
-		item int
-		want bool
-	}{
-		{
-			name: "item in set",
-			set:  sets.New(1, 2, 3),
-			item: 2,
-			want: true,
-		},
-		{
-			name: "item not in set",
-			set:  sets.New(1, 2, 3),
-			item: 4,
-			want: false,
-		},
-		{
-			name: "empty set",
-			set:  sets.New[int](),
-			item: 1,
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.set.Has(tt.item))
-		})
-	}
+	t.Run("value", func(t *testing.T) {
+		tests := []struct {
+			name string
+			set  sets.Set[int]
+			item int
+			want bool
+		}{
+			{
+				name: "item in set",
+				set:  sets.New(1, 2, 3),
+				item: 2,
+				want: true,
+			},
+			{
+				name: "item not in set",
+				set:  sets.New(1, 2, 3),
+				item: 4,
+				want: false,
+			},
+			{
+				name: "empty set",
+				set:  sets.New[int](),
+				item: 1,
+				want: false,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				assert.Equal(t, tt.want, tt.set.Has(tt.item))
+			})
+		}
+	})
+
+	t.Run("pointer", func(t *testing.T) {
+		zero, zero2 := new(0), new(0)
+		tests := []struct {
+			name string
+			set  sets.Set[*int]
+			item *int
+			want bool
+		}{
+			{
+				name: "item in set",
+				set:  sets.New(zero, zero2),
+				item: zero2,
+				want: true,
+			},
+			{
+				name: "item not in set",
+				set:  sets.New(zero),
+				item: zero2,
+				want: false,
+			},
+			{
+				name: "empty set",
+				set:  sets.New[*int](),
+				item: zero,
+				want: false,
+			},
+			{
+				name: "nil pointer in set",
+				set:  sets.New[*int](nil),
+				item: nil,
+				want: true,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				assert.Equal(t, tt.want, tt.set.Has(tt.item))
+			})
+		}
+	})
 }
 
 func TestSet_List(t *testing.T) {

--- a/pkg/events/controller.go
+++ b/pkg/events/controller.go
@@ -24,10 +24,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	v1 "k8s.io/client-go/kubernetes/typed/events/v1"
 	"k8s.io/client-go/util/workqueue"
+
+	"sigs.k8s.io/external-dns/internal/sets"
 )
 
 const (

--- a/pkg/events/controller_test.go
+++ b/pkg/events/controller_test.go
@@ -33,13 +33,13 @@ import (
 	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
 	eventsclient "k8s.io/client-go/kubernetes/typed/events/v1"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"sigs.k8s.io/external-dns/internal/sets"
 	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 )
 

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -30,9 +30,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/scheme"
 	runtime "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/external-dns/internal/sets"
 )
 
 const (

--- a/pkg/events/types_test.go
+++ b/pkg/events/types_test.go
@@ -29,8 +29,9 @@ import (
 	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	ctrlruntime "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/external-dns/internal/sets"
 )
 
 func TestNewObjectReference_DoesNotMutateObject(t *testing.T) {
@@ -219,9 +220,9 @@ func TestWithEmitEvents(t *testing.T) {
 		{
 			name:     "valid events",
 			input:    []string{string(RecordReady), string(RecordError)},
-			expected: sets.New[Reason](RecordReady, RecordError),
+			expected: sets.New(RecordReady, RecordError),
 			assert: func(c *Config) {
-				require.Equal(t, sets.New[Reason](RecordReady, RecordError), c.emitEvents)
+				require.Equal(t, sets.New(RecordReady, RecordError), c.emitEvents)
 				require.True(t, c.IsEnabled())
 			},
 		},
@@ -237,9 +238,9 @@ func TestWithEmitEvents(t *testing.T) {
 		{
 			name:     "mixed valid and invalid",
 			input:    []string{string(RecordReady), "InvalidEvent"},
-			expected: sets.New[Reason](RecordReady),
+			expected: sets.New(RecordReady),
 			assert: func(c *Config) {
-				require.Equal(t, sets.New[Reason](RecordReady), c.emitEvents)
+				require.Equal(t, sets.New(RecordReady), c.emitEvents)
 				require.True(t, c.IsEnabled())
 			},
 		},

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/common/version"
 	log "github.com/sirupsen/logrus"
 
+	"sigs.k8s.io/external-dns/internal/sets"
 	cfg "sigs.k8s.io/external-dns/pkg/apis/externaldns"
 )
 
@@ -59,7 +60,7 @@ func NewMetricsRegister() *MetricRegistry {
 	return &MetricRegistry{
 		Registerer: reg,
 		Metrics:    []*Metric{},
-		mName:      make(map[string]bool),
+		mName:      sets.New[string](),
 	}
 }
 
@@ -74,11 +75,10 @@ func NewMetricsRegister() *MetricRegistry {
 func (m *MetricRegistry) MustRegister(cs IMetric) {
 	switch v := cs.(type) {
 	case CounterMetric, GaugeMetric, SummaryVecMetric, CounterVecMetric, GaugeVecMetric, GaugeFuncMetric:
-		if _, exists := m.mName[cs.Get().FQDN]; exists {
+		if m.mName.Has(cs.Get().FQDN) {
 			return
-		} else {
-			m.mName[cs.Get().FQDN] = true
 		}
+		m.mName.Insert(cs.Get().FQDN)
 		m.Metrics = append(m.Metrics, cs.Get())
 		switch metric := v.(type) {
 		case CounterMetric:

--- a/pkg/metrics/models.go
+++ b/pkg/metrics/models.go
@@ -23,12 +23,14 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+
+	"sigs.k8s.io/external-dns/internal/sets"
 )
 
 type MetricRegistry struct {
 	Registerer prometheus.Registerer
 	Metrics    []*Metric
-	mName      map[string]bool
+	mName      sets.Set[string]
 }
 
 type Metric struct {

--- a/provider/awssd/aws_sd.go
+++ b/provider/awssd/aws_sd.go
@@ -28,9 +28,9 @@ import (
 	sd "github.com/aws/aws-sdk-go-v2/service/servicediscovery"
 	sdtypes "github.com/aws/aws-sdk-go-v2/service/servicediscovery/types"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"

--- a/provider/awssd/aws_sd.go
+++ b/provider/awssd/aws_sd.go
@@ -28,13 +28,13 @@ import (
 	sd "github.com/aws/aws-sdk-go-v2/service/servicediscovery"
 	sdtypes "github.com/aws/aws-sdk-go-v2/service/servicediscovery/types"
 	log "github.com/sirupsen/logrus"
-
-	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
-	extdnsaws "sigs.k8s.io/external-dns/provider/aws"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
+	extdnsaws "sigs.k8s.io/external-dns/provider/aws"
 )
 
 const (
@@ -276,15 +276,12 @@ func (p *AWSSDProvider) updatesToCreates(changes *plan.Changes) ([]*endpoint.End
 		current := updateNewMap[old.DNSName]
 
 		if !old.Targets.Same(current.Targets) {
-			currentTargetsMap := make(map[string]struct{}, len(current.Targets))
-			for _, newTarget := range current.Targets {
-				currentTargetsMap[newTarget] = struct{}{}
-			}
+			currentTargetsSet := sets.New(current.Targets...)
 
 			// If targets changed, only deregister removed targets (i.e. in `UpdateOld` but not in `UpdateNew`)
 			targetsToRemove := make(endpoint.Targets, 0)
 			for _, oldTarget := range old.Targets {
-				if _, found := currentTargetsMap[oldTarget]; !found {
+				if !currentTargetsSet.Has(oldTarget) {
 					targetsToRemove = append(targetsToRemove, oldTarget)
 				}
 			}

--- a/provider/azure/azure.go
+++ b/provider/azure/azure.go
@@ -573,7 +573,7 @@ func extractMetadataFromEndpoint(ep *endpoint.Endpoint) map[string]*string {
 // and adds individual metadata properties to the endpoint.
 // Returns the list of unique metadata keys that were parsed.
 func parseAzureTagsAnnotation(ep *endpoint.Endpoint, tagString string) []string {
-	keys := make(sets.Set[string], len(tagString))
+	keys := make(sets.Set[string])
 	for tag := range strings.SplitSeq(tagString, ",") {
 		tag = strings.TrimSpace(tag)
 		if tag == "" {

--- a/provider/azure/azure.go
+++ b/provider/azure/azure.go
@@ -25,6 +25,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 
 	"sigs.k8s.io/external-dns/provider/blueprint"
@@ -237,7 +238,7 @@ func (p *AzureProvider) SupportedRecordType(recordType string) bool {
 type azureChangeMap map[string][]*endpoint.Endpoint
 
 func (p *AzureProvider) mapChanges(zones []dns.Zone, changes *plan.Changes) (azureChangeMap, azureChangeMap) {
-	ignored := map[string]bool{}
+	ignored := sets.New[string]()
 	deleted := azureChangeMap{}
 	updated := azureChangeMap{}
 	zoneNameIDMapper := provider.ZoneIDName{}
@@ -249,8 +250,8 @@ func (p *AzureProvider) mapChanges(zones []dns.Zone, changes *plan.Changes) (azu
 	mapChange := func(changeMap azureChangeMap, change *endpoint.Endpoint) {
 		zone, _ := zoneNameIDMapper.FindZone(change.DNSName)
 		if zone == "" {
-			if _, ok := ignored[change.DNSName]; !ok {
-				ignored[change.DNSName] = true
+			if !ignored.Has(change.DNSName) {
+				ignored.Insert(change.DNSName)
 				log.Infof("Ignoring changes to '%s' because a suitable Azure DNS zone was not found.", change.DNSName)
 			}
 			return
@@ -572,7 +573,7 @@ func extractMetadataFromEndpoint(ep *endpoint.Endpoint) map[string]*string {
 // and adds individual metadata properties to the endpoint.
 // Returns the list of unique metadata keys that were parsed.
 func parseAzureTagsAnnotation(ep *endpoint.Endpoint, tagString string) []string {
-	keys := make(map[string]struct{})
+	keys := make(sets.Set[string], len(tagString))
 	for tag := range strings.SplitSeq(tagString, ",") {
 		tag = strings.TrimSpace(tag)
 		if tag == "" {
@@ -584,15 +585,11 @@ func parseAzureTagsAnnotation(ep *endpoint.Endpoint, tagString string) []string 
 			value := strings.TrimSpace(parts[1])
 			if key != "" && value != "" {
 				ep.WithProviderSpecific(providerSpecificMetadataPrefix+key, value)
-				keys[key] = struct{}{}
+				keys.Insert(key)
 			}
 		}
 	}
-	result := make([]string, 0, len(keys))
-	for k := range keys {
-		result = append(result, k)
-	}
-	return result
+	return keys.List()
 }
 
 // AdjustEndpoints modifies the endpoints as needed by the Azure provider.

--- a/provider/azure/azure_private_dns.go
+++ b/provider/azure/azure_private_dns.go
@@ -27,6 +27,7 @@ import (
 	privatedns "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
 	log "github.com/sirupsen/logrus"
 
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/provider/blueprint"
 
 	"sigs.k8s.io/external-dns/endpoint"
@@ -233,7 +234,7 @@ func (p *AzurePrivateDNSProvider) zones(ctx context.Context) ([]privatedns.Priva
 type azurePrivateDNSChangeMap map[string][]*endpoint.Endpoint
 
 func (p *AzurePrivateDNSProvider) mapChanges(zones []privatedns.PrivateZone, changes *plan.Changes) (azurePrivateDNSChangeMap, azurePrivateDNSChangeMap) {
-	ignored := map[string]bool{}
+	ignored := sets.New[string]()
 	deleted := azurePrivateDNSChangeMap{}
 	updated := azurePrivateDNSChangeMap{}
 	zoneNameIDMapper := provider.ZoneIDName{}
@@ -245,8 +246,8 @@ func (p *AzurePrivateDNSProvider) mapChanges(zones []privatedns.PrivateZone, cha
 	mapChange := func(changeMap azurePrivateDNSChangeMap, change *endpoint.Endpoint) {
 		zone, _ := zoneNameIDMapper.FindZone(change.DNSName)
 		if zone == "" {
-			if _, ok := ignored[change.DNSName]; !ok {
-				ignored[change.DNSName] = true
+			if !ignored.Has(change.DNSName) {
+				ignored.Insert(change.DNSName)
 				log.Infof("Ignoring changes to '%s' because a suitable Azure Private DNS zone was not found.", change.DNSName)
 			}
 			return

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -38,6 +38,7 @@ import (
 	"golang.org/x/net/publicsuffix"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
@@ -84,14 +85,14 @@ type DNSRecordIndex struct {
 
 type DNSRecordsMap map[DNSRecordIndex]dns.RecordResponse
 
-var recordTypeProxyNotSupported = map[string]bool{
-	"LOC": true,
-	"MX":  true,
-	"NS":  true,
-	"SPF": true,
-	"TXT": true,
-	"SRV": true,
-}
+var recordTypeProxyNotSupported = sets.New(
+	"LOC",
+	"MX",
+	"NS",
+	"SPF",
+	"TXT",
+	"SRV",
+)
 
 // cloudFlareDNS is the subset of the CloudFlare API that we actually use.  Add methods as required. Signatures must match exactly.
 type cloudFlareDNS interface {
@@ -800,7 +801,7 @@ func shouldBeProxied(ep *endpoint.Endpoint, proxiedByDefault bool) bool {
 		}
 	}
 
-	if recordTypeProxyNotSupported[ep.RecordType] {
+	if recordTypeProxyNotSupported.Has(ep.RecordType) {
 		proxied = false
 	}
 	return proxied

--- a/provider/cloudflare/cloudflare_custom_hostnames.go
+++ b/provider/cloudflare/cloudflare_custom_hostnames.go
@@ -25,9 +25,11 @@ import (
 
 	"github.com/cloudflare/cloudflare-go/v5"
 	"github.com/cloudflare/cloudflare-go/v5/custom_hostnames"
+	"github.com/cloudflare/cloudflare-go/v5/dns"
 	"github.com/cloudflare/cloudflare-go/v5/option"
 	log "github.com/sirupsen/logrus"
 
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/provider"
 )
 
@@ -67,10 +69,10 @@ type CustomHostnamesConfig struct {
 	CertificateAuthority string
 }
 
-var recordTypeCustomHostnameSupported = map[string]bool{
-	"A":     true,
-	"CNAME": true,
-}
+var recordTypeCustomHostnameSupported = sets.New[dns.RecordResponseType](
+	"A",
+	"CNAME",
+)
 
 func (z zoneService) CustomHostnames(ctx context.Context, zoneID string) autoPager[custom_hostnames.CustomHostnameListResponse] {
 	params := custom_hostnames.CustomHostnameListParams{
@@ -141,7 +143,7 @@ func (p *CloudFlareProvider) submitCustomHostnameChanges(ctx context.Context, zo
 }
 
 func (p *CloudFlareProvider) processCustomHostnameUpdate(ctx context.Context, zoneID string, change *cloudFlareChange, chs customHostnamesMap, logFields log.Fields) bool {
-	if !recordTypeCustomHostnameSupported[string(change.ResourceRecord.Type)] {
+	if !recordTypeCustomHostnameSupported.Has(change.ResourceRecord.Type) {
 		return true
 	}
 	failedChange := false
@@ -175,7 +177,7 @@ func (p *CloudFlareProvider) processCustomHostnameUpdate(ctx context.Context, zo
 func (p *CloudFlareProvider) processCustomHostnameDelete(ctx context.Context, zoneID string, change *cloudFlareChange, chs customHostnamesMap, logFields log.Fields) bool {
 	failedChange := false
 	for _, changeCH := range change.CustomHostnames {
-		if recordTypeCustomHostnameSupported[string(change.ResourceRecord.Type)] && changeCH.hostname != "" {
+		if recordTypeCustomHostnameSupported.Has(change.ResourceRecord.Type) && changeCH.hostname != "" {
 			log.WithFields(logFields).Infof("Deleting custom hostname %q", changeCH.hostname)
 			if ch, err := getCustomHostname(chs, changeCH.hostname); err == nil {
 				chID := ch.id
@@ -196,7 +198,7 @@ func (p *CloudFlareProvider) processCustomHostnameDelete(ctx context.Context, zo
 func (p *CloudFlareProvider) processCustomHostnameCreate(ctx context.Context, zoneID string, change *cloudFlareChange, chs customHostnamesMap, logFields log.Fields) bool {
 	failedChange := false
 	for _, changeCH := range change.CustomHostnames {
-		if recordTypeCustomHostnameSupported[string(change.ResourceRecord.Type)] && changeCH.hostname != "" {
+		if recordTypeCustomHostnameSupported.Has(change.ResourceRecord.Type) && changeCH.hostname != "" {
 			log.WithFields(logFields).Infof("Creating custom hostname %q", changeCH.hostname)
 			if ch, err := getCustomHostname(chs, changeCH.hostname); err == nil {
 				if changeCH.customOriginServer == ch.customOriginServer {

--- a/provider/cloudflare/cloudflare_regional.go
+++ b/provider/cloudflare/cloudflare_regional.go
@@ -28,6 +28,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/source/annotations"
 )
 
@@ -36,11 +37,11 @@ type RegionalServicesConfig struct {
 	RegionKey string
 }
 
-var recordTypeRegionalHostnameSupported = map[string]bool{
-	"A":     true,
-	"AAAA":  true,
-	"CNAME": true,
-}
+var recordTypeRegionalHostnameSupported = sets.New(
+	"A",
+	"AAAA",
+	"CNAME",
+)
 
 type regionalHostname struct {
 	hostname  string
@@ -181,7 +182,7 @@ func (p *CloudFlareProvider) listDataLocalisationRegionalHostnames(ctx context.C
 // it returns an empty regionalHostname.
 // If the endpoint has a specific region key set, it uses that; otherwise, it defaults to the region key configured in the provider.
 func (p *CloudFlareProvider) regionalHostname(ep *endpoint.Endpoint) regionalHostname {
-	if !p.RegionalServicesConfig.Enabled || !recordTypeRegionalHostnameSupported[ep.RecordType] {
+	if !p.RegionalServicesConfig.Enabled || !recordTypeRegionalHostnameSupported.Has(ep.RecordType) {
 		return regionalHostname{}
 	}
 	regionKey := p.RegionalServicesConfig.RegionKey
@@ -208,7 +209,7 @@ func (p *CloudFlareProvider) addEnpointsProviderSpecificRegionKeyProperty(ctx co
 	// so we can skip regional hostname lookups if not needed.
 	var supportedEndpoints []*endpoint.Endpoint
 	for _, ep := range endpoints {
-		if recordTypeRegionalHostnameSupported[ep.RecordType] {
+		if recordTypeRegionalHostnameSupported.Has(ep.RecordType) {
 			supportedEndpoints = append(supportedEndpoints, ep)
 		}
 	}
@@ -240,7 +241,7 @@ func (p *CloudFlareProvider) addEnpointsProviderSpecificRegionKeyProperty(ctx co
 //
 // The endpoint is modified in place and any explicitly set region key is left unchanged.
 func (p *CloudFlareProvider) adjustEndpointProviderSpecificRegionKeyProperty(ep *endpoint.Endpoint) {
-	if !p.RegionalServicesConfig.Enabled || !recordTypeRegionalHostnameSupported[ep.RecordType] {
+	if !p.RegionalServicesConfig.Enabled || !recordTypeRegionalHostnameSupported.Has(ep.RecordType) {
 		ep.DeleteProviderSpecificProperty(annotations.CloudflareRegionKey)
 		return
 	}

--- a/provider/coredns/coredns.go
+++ b/provider/coredns/coredns.go
@@ -32,6 +32,7 @@ import (
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	etcdcv3 "go.etcd.io/etcd/client/v3"
 
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 
 	"sigs.k8s.io/external-dns/pkg/tlsutils"
@@ -120,7 +121,7 @@ func (c etcdClient) GetServices(ctx context.Context, prefix string) ([]*Service,
 	}
 
 	var svcs []*Service
-	bx := make(map[Service]bool)
+	bx := sets.New[Service]()
 	for _, n := range r.Kvs {
 		svc, err := c.unmarshalService(n)
 		if err != nil {
@@ -137,12 +138,12 @@ func (c etcdClient) GetServices(ctx context.Context, prefix string) ([]*Service,
 			Text:     svc.Text,
 			Key:      string(n.Key),
 		}
-		if _, ok := bx[b]; ok {
+		if bx.Has(b) {
 			// skip the service if already added to service list.
 			// the same service might be found in multiple etcd nodes.
 			continue
 		}
-		bx[b] = true
+		bx.Insert(b)
 
 		svc.Key = string(n.Key)
 		if svc.Priority == 0 {

--- a/provider/godaddy/godaddy.go
+++ b/provider/godaddy/godaddy.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
@@ -396,29 +397,27 @@ func (p *GDProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) er
 
 	allChanges = p.appendChange(gdDelete, changes.Delete, allChanges)
 
-	iOldSkip := make(map[int]bool)
-	iNewSkip := make(map[int]bool)
+	iOldSkip := sets.New[int]()
+	iNewSkip := sets.New[int]()
 
 	for iOld, recOld := range changes.UpdateOld {
 		for iNew, recNew := range changes.UpdateNew {
 			if recOld.DNSName == recNew.DNSName && recOld.RecordType == recNew.RecordType {
 				ReplaceEndpoints := []*endpoint.Endpoint{recNew}
 				allChanges = p.appendChange(gdReplace, ReplaceEndpoints, allChanges)
-				iOldSkip[iOld] = true
-				iNewSkip[iNew] = true
+				iOldSkip.Insert(iOld)
+				iNewSkip.Insert(iNew)
 				break
 			}
 		}
 	}
 
 	for iOld, recOld := range changes.UpdateOld {
-		_, found := iOldSkip[iOld]
-		if found {
+		if iOldSkip.Has(iOld) {
 			continue
 		}
 		for iNew, recNew := range changes.UpdateNew {
-			_, found := iNewSkip[iNew]
-			if found {
+			if iNewSkip.Has(iNew) {
 				continue
 			}
 

--- a/provider/inmemory/inmemory.go
+++ b/provider/inmemory/inmemory.go
@@ -23,11 +23,10 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/util/sets"
-
-	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/sets"
+	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
 )

--- a/provider/pdns/pdns_test.go
+++ b/provider/pdns/pdns_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/provider"
 )
 
@@ -1028,18 +1029,18 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSConvertEndpointsToZones() {
 	zlist, err = p.ConvertEndpointsToZones(endpointsMixedRecords, PdnsReplace)
 	suite.NoError(err)
 
-	trailingTypes := map[string]bool{
-		endpoint.RecordTypeCNAME: true,
-		"ALIAS":                  true,
-		endpoint.RecordTypeMX:    true,
-		endpoint.RecordTypeSRV:   true,
-		endpoint.RecordTypeNS:    true,
-		endpoint.RecordTypePTR:   true,
-	}
+	trailingTypes := sets.New(
+		endpoint.RecordTypeCNAME,
+		"ALIAS",
+		endpoint.RecordTypeMX,
+		endpoint.RecordTypeSRV,
+		endpoint.RecordTypeNS,
+		endpoint.RecordTypePTR,
+	)
 
 	for _, z := range zlist {
 		for _, rs := range z.Rrsets {
-			if trailingTypes[rs.Type_] {
+			if trailingTypes.Has(rs.Type_) {
 				for _, r := range rs.Records {
 					suite.Equal(uint8(0x2e), r.Content[len(r.Content)-1])
 				}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -23,9 +23,8 @@ import (
 	"net"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/plan"
 )
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -23,6 +23,8 @@ import (
 	"net"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 )
@@ -95,18 +97,14 @@ func EnsureTrailingDot(hostname string) string {
 // added, removed, or left untouched for "current" to be transformed to "desired"
 func Difference(current, desired []string) ([]string, []string, []string) {
 	add, remove, leave := []string{}, []string{}, []string{}
-	index := make(map[string]struct{}, len(current))
-	for _, x := range current {
-		index[x] = struct{}{}
-	}
+	index := sets.New(current...)
 	for _, x := range desired {
-		if _, found := index[x]; found {
+		if index.Has(x) {
 			leave = append(leave, x)
-			delete(index, x)
 		} else {
 			add = append(add, x)
-			delete(index, x)
 		}
+		index.Delete(x)
 	}
 	for x := range index {
 		remove = append(remove, x)

--- a/registry/dynamodb/registry.go
+++ b/registry/dynamodb/registry.go
@@ -30,9 +30,9 @@ import (
 	awsdynamodb "github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	dynamodbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
@@ -155,7 +155,7 @@ func (im *DynamoDBRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, 
 		return nil, err
 	}
 
-	orphanedLabels := sets.KeySet(im.labels)
+	orphanedLabels := sets.NewFromMapKeys(im.labels)
 	endpoints := make([]*endpoint.Endpoint, 0, len(records))
 	labelMap := map[endpoint.EndpointKey]endpoint.Labels{}
 	txtRecordsMap := map[endpoint.EndpointKey]*endpoint.Endpoint{}
@@ -275,12 +275,12 @@ func (im *DynamoDBRegistry) ApplyChanges(ctx context.Context, changes *plan.Chan
 	}
 
 	oldLabels := make(map[endpoint.EndpointKey]endpoint.Labels, len(filteredChanges.UpdateOld))
-	needMigration := map[endpoint.EndpointKey]bool{}
+	needMigration := sets.New[endpoint.EndpointKey]()
 	for _, r := range filteredChanges.UpdateOld {
 		oldLabels[r.Key()] = r.Labels
 
 		if _, ok := r.GetProviderSpecificProperty(dynamodbAttributeMigrate); ok {
-			needMigration[r.Key()] = true
+			needMigration.Insert(r.Key())
 		}
 
 		// remove old version of record from cache
@@ -291,7 +291,7 @@ func (im *DynamoDBRegistry) ApplyChanges(ctx context.Context, changes *plan.Chan
 
 	for _, r := range filteredChanges.UpdateNew {
 		key := r.Key()
-		if needMigration[key] {
+		if needMigration.Has(key) {
 			statements = im.appendInsert(statements, key, r.Labels)
 			// Invalidate the records cache so the next sync deletes the TXT ownership record
 			im.recordsCache = nil

--- a/registry/dynamodb/registry_test.go
+++ b/registry/dynamodb/registry_test.go
@@ -28,9 +28,9 @@ import (
 	dynamodbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/internal/testutils"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"

--- a/registry/mapper/mapper_test.go
+++ b/registry/mapper/mapper_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/sets"
 )
 
 var (
@@ -209,15 +210,15 @@ func TestAffixNameMapper_ToEndpointName(t *testing.T) {
 	}
 
 	// Verify all supported records are tested
-	testedRecords := make(map[string]bool)
+	testedRecords := sets.New[string]()
 	for _, tt := range tests {
 		if tt.wantRecordType != "" {
-			testedRecords[tt.wantRecordType] = true
+			testedRecords.Insert(tt.wantRecordType)
 		}
 	}
 
 	for _, recordType := range supportedRecords {
-		assert.True(t, testedRecords[recordType], "Record type %s is in supportedRecords but not tested in TestAffixNameMapper_ToEndpointName", recordType)
+		assert.True(t, testedRecords.Has(recordType), "Record type %s is in supportedRecords but not tested in TestAffixNameMapper_ToEndpointName", recordType)
 	}
 }
 
@@ -407,13 +408,13 @@ func TestAffixNameMapper_ToTXTName(t *testing.T) {
 	}
 
 	// Verify all supported records are tested
-	testedRecords := make(map[string]bool)
+	testedRecords := sets.New[string]()
 	for _, tt := range tests {
-		testedRecords[tt.recordType] = true
+		testedRecords.Insert(tt.recordType)
 	}
 
 	for _, recordType := range supportedRecords {
-		assert.True(t, testedRecords[recordType], "Record type %s is in supportedRecords but not tested in TestAffixNameMapper_ToTXTName", recordType)
+		assert.True(t, testedRecords.Has(recordType), "Record type %s is in supportedRecords but not tested in TestAffixNameMapper_ToTXTName", recordType)
 	}
 }
 

--- a/registry/txt/encryption_test.go
+++ b/registry/txt/encryption_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider/inmemory"
 )
@@ -258,14 +259,14 @@ func TestApplyRecordsOnEncryptionKeyChangeWithKeyIdLabel(t *testing.T) {
 	records, _ := p.Records(ctx)
 	assert.Len(t, records, 14)
 
-	encryptionNonce := map[string]bool{}
+	encryptionNonce := sets.New[string]()
 
 	for _, r := range records {
 		if slices.Contains([]string{"A", "AAAA"}, r.RecordType) || (r.RecordType == "CNAME" && strings.HasPrefix(r.DNSName, "new-")) {
 			assert.Contains(t, r.Labels, "key-id")
 			assert.Equal(t, "key-id-2", r.Labels["key-id"])
 			// add encryption nonce to track the number of unique nonce
-			encryptionNonce[r.Labels["txt-encryption-nonce"]] = true
+			encryptionNonce.Insert(r.Labels["txt-encryption-nonce"])
 		} else if r.RecordType == endpoint.RecordTypeTXT {
 			if hasPrefixFromSlice(r.DNSName, []string{"cname-", "txt-new-", "a-", "aaaa-", "txt-"}) {
 				assert.NotContains(t, r.Labels, "key-id")
@@ -273,7 +274,7 @@ func TestApplyRecordsOnEncryptionKeyChangeWithKeyIdLabel(t *testing.T) {
 				assert.Contains(t, r.Labels, "key-id", r.DNSName)
 				assert.Equal(t, "key-id-0", r.Labels["key-id"], r.DNSName)
 				// add encryption nonce to track the number of unique nonce
-				encryptionNonce[r.Labels["txt-encryption-nonce"]] = true
+				encryptionNonce.Insert(r.Labels["txt-encryption-nonce"])
 			}
 		}
 	}

--- a/registry/txt/registry.go
+++ b/registry/txt/registry.go
@@ -25,9 +25,9 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
@@ -84,7 +84,7 @@ type recordKey struct {
 
 func newExistingTXTs() *existingTXTs {
 	return &existingTXTs{
-		entries: make(sets.Set[recordKey]),
+		entries: sets.New[recordKey](),
 	}
 }
 
@@ -109,7 +109,7 @@ func (im *existingTXTs) isAbsent(ep *endpoint.Endpoint) bool {
 func (im *existingTXTs) reset() {
 	// Reset the existing TXT records for the next reconciliation loop.
 	// This is necessary because the existing TXT records are only relevant for the current reconciliation cycle.
-	im.entries = make(sets.Set[recordKey])
+	im.entries = sets.New[recordKey]()
 }
 
 // New creates a TXTRegistry from the given configuration.

--- a/registry/txt/registry.go
+++ b/registry/txt/registry.go
@@ -18,23 +18,21 @@ package txt
 
 import (
 	"context"
+	b64 "encoding/base64"
 	"errors"
 	"maps"
-
 	"strings"
 	"time"
 
-	b64 "encoding/base64"
-
 	log "github.com/sirupsen/logrus"
-
-	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
-	"sigs.k8s.io/external-dns/registry"
-	"sigs.k8s.io/external-dns/registry/mapper"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
+	"sigs.k8s.io/external-dns/registry"
+	"sigs.k8s.io/external-dns/registry/mapper"
 )
 
 const (
@@ -76,7 +74,7 @@ type TXTRegistry struct {
 // It relies on the fact that Records() is always called **before** ApplyChanges()
 // within a single reconciliation cycle.
 type existingTXTs struct {
-	entries map[recordKey]struct{}
+	entries sets.Set[recordKey]
 }
 
 type recordKey struct {
@@ -86,7 +84,7 @@ type recordKey struct {
 
 func newExistingTXTs() *existingTXTs {
 	return &existingTXTs{
-		entries: make(map[recordKey]struct{}),
+		entries: make(sets.Set[recordKey]),
 	}
 }
 
@@ -95,7 +93,7 @@ func (im *existingTXTs) add(r *endpoint.Endpoint) {
 		dnsName:       r.DNSName,
 		setIdentifier: r.SetIdentifier,
 	}
-	im.entries[key] = struct{}{}
+	im.entries.Insert(key)
 }
 
 // isAbsent returns true when there is no entry for the given name in the store.
@@ -105,14 +103,13 @@ func (im *existingTXTs) isAbsent(ep *endpoint.Endpoint) bool {
 		dnsName:       ep.DNSName,
 		setIdentifier: ep.SetIdentifier,
 	}
-	_, ok := im.entries[key]
-	return !ok
+	return !im.entries.Has(key)
 }
 
 func (im *existingTXTs) reset() {
 	// Reset the existing TXT records for the next reconciliation loop.
 	// This is necessary because the existing TXT records are only relevant for the current reconciliation cycle.
-	im.entries = make(map[recordKey]struct{})
+	im.entries = make(sets.Set[recordKey])
 }
 
 // New creates a TXTRegistry from the given configuration.
@@ -203,7 +200,7 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 	endpoints := []*endpoint.Endpoint{}
 
 	labelMap := map[endpoint.EndpointKey]endpoint.Labels{}
-	txtRecordsMap := map[string]struct{}{}
+	txtRecordsSet := make(sets.Set[string], len(records))
 
 	for _, record := range records {
 		if record.RecordType != endpoint.RecordTypeTXT {
@@ -232,7 +229,7 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 			SetIdentifier: record.SetIdentifier,
 		}
 		labelMap[key] = labels
-		txtRecordsMap[record.DNSName] = struct{}{}
+		txtRecordsSet.Insert(record.DNSName)
 		im.existingTXTs.add(record)
 	}
 
@@ -273,12 +270,12 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 		// TODO: remove this migration logic in some future release
 		// Handle the migration of TXT records created before the new format (introduced in v0.12.0).
 		// The migration is done for the TXT records owned by this instance only.
-		if len(txtRecordsMap) > 0 && ep.Labels[endpoint.OwnerLabelKey] == im.ownerID {
+		if len(txtRecordsSet) > 0 && ep.Labels[endpoint.OwnerLabelKey] == im.ownerID {
 			if plan.IsManagedRecord(ep.RecordType, im.managedRecordTypes, im.excludeRecordTypes) {
 				// Get desired TXT records and detect the missing ones
 				desiredTXTs := im.generateTXTRecord(ep)
 				for _, desiredTXT := range desiredTXTs {
-					if _, exists := txtRecordsMap[desiredTXT.DNSName]; !exists {
+					if !txtRecordsSet.Has(desiredTXT.DNSName) {
 						ep.WithProviderSpecific(providerSpecificForceUpdate, "true")
 					}
 				}

--- a/source/pod_indexer_test.go
+++ b/source/pod_indexer_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/source/annotations"
 	templatetest "sigs.k8s.io/external-dns/source/template/testutil"
 )
@@ -132,11 +133,11 @@ func TestPodsWithAnnotationsAndLabels(t *testing.T) {
 
 	client := fake.NewClientset()
 
-	nodes := map[string]bool{}
+	nodes := sets.New[string]()
 
 	for _, pod := range pods {
-		if _, exists := nodes[pod.Spec.NodeName]; !exists {
-			nodes[pod.Spec.NodeName] = true
+		if !nodes.Has(pod.Spec.NodeName) {
+			nodes.Insert(pod.Spec.NodeName)
 			node := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: pod.Spec.NodeName,

--- a/source/service.go
+++ b/source/service.go
@@ -29,7 +29,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/sets"
 	kubeinformers "k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	discoveryinformers "k8s.io/client-go/informers/discovery/v1"
@@ -37,6 +36,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/pkg/events"
 	"sigs.k8s.io/external-dns/provider"
 	"sigs.k8s.io/external-dns/source/annotations"
@@ -46,12 +46,12 @@ import (
 )
 
 var (
-	knownServiceTypes = map[v1.ServiceType]struct{}{
-		v1.ServiceTypeClusterIP:    {}, // Default service type exposes the service on a cluster-internal IP.
-		v1.ServiceTypeNodePort:     {}, // Exposes the service on each node's IP at a static port.
-		v1.ServiceTypeLoadBalancer: {}, // Exposes the service externally using a cloud provider's load balancer.
-		v1.ServiceTypeExternalName: {}, // Maps the service to an external DNS name.
-	}
+	knownServiceTypes = sets.New(
+		v1.ServiceTypeClusterIP,    // Default service type exposes the service on a cluster-internal IP.
+		v1.ServiceTypeNodePort,     // Exposes the service on each node's IP at a static port.
+		v1.ServiceTypeLoadBalancer, // Exposes the service externally using a cloud provider's load balancer.
+		v1.ServiceTypeExternalName, // Maps the service to an external DNS name.
+	)
 )
 
 // serviceSource is an implementation of Source for Kubernetes service objects.
@@ -786,7 +786,7 @@ func (sc *serviceSource) AddEventHandler(_ context.Context, handler func()) {
 
 type serviceTypes struct {
 	enabled bool
-	types   map[v1.ServiceType]bool
+	types   sets.Set[v1.ServiceType]
 }
 
 // newServiceTypesFilter processes a slice of service type filter strings and returns a serviceTypes struct.
@@ -798,12 +798,12 @@ func newServiceTypesFilter(filter []string) (*serviceTypes, error) {
 			enabled: false,
 		}, nil
 	}
-	result := make(map[v1.ServiceType]bool)
+	result := sets.New[v1.ServiceType]()
 	for _, serviceType := range filter {
-		if _, ok := knownServiceTypes[v1.ServiceType(serviceType)]; !ok {
-			return nil, fmt.Errorf("unsupported service type filter: %q. Supported types are: %q", serviceType, slices.Collect(maps.Keys(knownServiceTypes)))
+		if !knownServiceTypes.Has(v1.ServiceType(serviceType)) {
+			return nil, fmt.Errorf("unsupported service type filter: %q. Supported types are: %q", serviceType, sets.Sorted(knownServiceTypes))
 		}
-		result[v1.ServiceType(serviceType)] = true
+		result.Insert(v1.ServiceType(serviceType))
 	}
 
 	return &serviceTypes{
@@ -813,7 +813,7 @@ func newServiceTypesFilter(filter []string) (*serviceTypes, error) {
 }
 
 func (sc *serviceTypes) isProcessed(serviceType v1.ServiceType) bool {
-	return !sc.enabled || sc.types[serviceType]
+	return !sc.enabled || sc.types.Has(serviceType)
 }
 
 // predicate returns a typed filter function suitable for use with

--- a/source/service.go
+++ b/source/service.go
@@ -29,6 +29,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 	kubeinformers "k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	discoveryinformers "k8s.io/client-go/informers/discovery/v1"
@@ -447,13 +448,13 @@ func buildHeadlessEndpoints(svc *v1.Service, targetsByHeadlessDomainAndType map[
 	for _, headlessKey := range headlessKeys {
 		allTargets := targetsByHeadlessDomainAndType[headlessKey]
 		targets := make([]string, 0, len(allTargets))
-		deduppedTargets := map[string]struct{}{}
+		deduppedTargets := make(sets.Set[string], len(allTargets))
 		for _, target := range allTargets {
-			if _, ok := deduppedTargets[target]; ok {
+			if deduppedTargets.Has(target) {
 				log.Debugf("Removing duplicate target %s", target)
 				continue
 			}
-			deduppedTargets[target] = struct{}{}
+			deduppedTargets.Insert(target)
 			targets = append(targets, target)
 		}
 		ep := endpoint.NewEndpointWithTTL(headlessKey.DNSName, headlessKey.RecordType, ttl, targets...)

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -43,6 +43,7 @@ import (
 	"sigs.k8s.io/external-dns/source/types"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/internal/testutils"
 	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/source/informers"
@@ -4702,7 +4703,7 @@ func TestNewServiceTypes(t *testing.T) {
 		name        string
 		filter      []string
 		wantEnabled bool
-		wantTypes   map[v1.ServiceType]bool
+		wantTypes   sets.Set[v1.ServiceType]
 		wantErr     bool
 	}{
 		{
@@ -4723,10 +4724,10 @@ func TestNewServiceTypes(t *testing.T) {
 			name:        "valid filter enables serviceTypes",
 			filter:      []string{string(v1.ServiceTypeClusterIP), string(v1.ServiceTypeNodePort)},
 			wantEnabled: true,
-			wantTypes: map[v1.ServiceType]bool{
-				v1.ServiceTypeClusterIP: true,
-				v1.ServiceTypeNodePort:  true,
-			},
+			wantTypes: sets.New(
+				v1.ServiceTypeClusterIP,
+				v1.ServiceTypeNodePort,
+			),
 			wantErr: false,
 		},
 		{

--- a/source/template/engine.go
+++ b/source/template/engine.go
@@ -28,9 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/utils/set"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/sets"
 )
 
 // Engine holds the parsed Go templates used to derive DNS names and targets
@@ -205,7 +205,7 @@ func execTemplate(tmpl *template.Template, obj kubeObject) ([]string, error) {
 		return nil, fmt.Errorf("failed to apply template on %s %s/%s: %w", kind, obj.GetNamespace(), obj.GetName(), err)
 	}
 	hosts := strings.Split(buf.String(), ",")
-	hostnames := make(set.Set[string], len(hosts))
+	hostnames := make(sets.Set[string], len(hosts))
 	for _, name := range hosts {
 		name = strings.TrimSpace(name)
 		name = strings.TrimSuffix(name, ".")
@@ -213,5 +213,5 @@ func execTemplate(tmpl *template.Template, obj kubeObject) ([]string, error) {
 			hostnames.Insert(name)
 		}
 	}
-	return hostnames.SortedList(), nil
+	return sets.Sorted(hostnames), nil
 }

--- a/source/template/engine.go
+++ b/source/template/engine.go
@@ -19,9 +19,7 @@ package template
 import (
 	"bytes"
 	"fmt"
-	"maps"
 	"reflect"
-	"slices"
 	"strings"
 	"text/template"
 
@@ -30,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/set"
 
 	"sigs.k8s.io/external-dns/endpoint"
 )
@@ -206,13 +205,13 @@ func execTemplate(tmpl *template.Template, obj kubeObject) ([]string, error) {
 		return nil, fmt.Errorf("failed to apply template on %s %s/%s: %w", kind, obj.GetNamespace(), obj.GetName(), err)
 	}
 	hosts := strings.Split(buf.String(), ",")
-	hostnames := make(map[string]struct{}, len(hosts))
+	hostnames := make(set.Set[string], len(hosts))
 	for _, name := range hosts {
 		name = strings.TrimSpace(name)
 		name = strings.TrimSuffix(name, ".")
 		if name != "" {
-			hostnames[name] = struct{}{}
+			hostnames.Insert(name)
 		}
 	}
-	return slices.Sorted(maps.Keys(hostnames)), nil
+	return hostnames.SortedList(), nil
 }

--- a/source/template/engine_test.go
+++ b/source/template/engine_test.go
@@ -317,7 +317,7 @@ func TestExecFQDN(t *testing.T) {
 					Name: "test",
 				},
 			},
-			want: nil,
+			want: []string{},
 		},
 		{
 			name: "ignore trailing comma output",

--- a/source/unstructured.go
+++ b/source/unstructured.go
@@ -34,9 +34,9 @@ import (
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/utils/set"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/pkg/events"
 	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/source/informers"
@@ -353,14 +353,14 @@ func EndpointsForHostsAndTargets(hostnames, targets []string) []*endpoint.Endpoi
 	}
 
 	// Deduplicate hostnames
-	sortedHosts := set.New(hostnames...).SortedList()
+	sortedHosts := sets.Sorted(sets.New(hostnames...))
 
 	// Group and deduplicate targets by record type
-	targetsByType := make(map[string]set.Set[string])
+	targetsByType := make(map[string]sets.Set[string])
 	for _, target := range targets {
 		recordType := endpoint.SuitableType(target)
 		if targetsByType[recordType] == nil {
-			targetsByType[recordType] = set.New(target)
+			targetsByType[recordType] = sets.New(target)
 		} else {
 			targetsByType[recordType].Insert(target)
 		}

--- a/source/unstructured.go
+++ b/source/unstructured.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/set"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/pkg/events"
@@ -352,20 +353,17 @@ func EndpointsForHostsAndTargets(hostnames, targets []string) []*endpoint.Endpoi
 	}
 
 	// Deduplicate hostnames
-	hostSet := make(map[string]struct{}, len(hostnames))
-	for _, h := range hostnames {
-		hostSet[h] = struct{}{}
-	}
-	sortedHosts := slices.Sorted(maps.Keys(hostSet))
+	sortedHosts := set.New(hostnames...).SortedList()
 
 	// Group and deduplicate targets by record type
-	targetsByType := make(map[string]map[string]struct{})
+	targetsByType := make(map[string]set.Set[string])
 	for _, target := range targets {
 		recordType := endpoint.SuitableType(target)
 		if targetsByType[recordType] == nil {
-			targetsByType[recordType] = make(map[string]struct{})
+			targetsByType[recordType] = set.New(target)
+		} else {
+			targetsByType[recordType].Insert(target)
 		}
-		targetsByType[recordType][target] = struct{}{}
 	}
 
 	// Resolve to sorted slices once

--- a/source/wrappers/dedupsource.go
+++ b/source/wrappers/dedupsource.go
@@ -21,9 +21,9 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/source"
 )
 

--- a/source/wrappers/dedupsource.go
+++ b/source/wrappers/dedupsource.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source"
@@ -40,13 +41,14 @@ func NewDedupSource(source source.Source) source.Source {
 func (ms *dedupSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error) {
 	log.Debug("dedupSource: collecting endpoints and removing duplicates")
 	resetMetrics()
-	result := make([]*endpoint.Endpoint, 0)
-	collected := make(map[string]struct{})
 
 	endpoints, err := ms.source.Endpoints(ctx)
 	if err != nil {
 		return nil, err
 	}
+
+	result := make([]*endpoint.Endpoint, 0, len(endpoints))
+	collected := make(sets.Set[string], len(endpoints))
 
 	for _, ep := range endpoints {
 		if ep == nil {
@@ -66,13 +68,13 @@ func (ms *dedupSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, err
 
 		identifier := strings.Join([]string{ep.RecordType, ep.DNSName, ep.SetIdentifier, ep.Targets.String()}, "/")
 
-		if _, ok := collected[identifier]; ok {
+		if collected.Has(identifier) {
 			log.Debugf("Removing duplicate endpoint %s", ep)
 			deduplicatedEndpoints.AddWithLabels(1, ep.RecordType, endpointSource(ep))
 			continue
 		}
 
-		collected[identifier] = struct{}{}
+		collected.Insert(identifier)
 		result = append(result, ep)
 	}
 

--- a/source/wrappers/targetfiltersource_test.go
+++ b/source/wrappers/targetfiltersource_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/internal/testutils"
 	"sigs.k8s.io/external-dns/source"
 
@@ -29,19 +30,15 @@ import (
 )
 
 type mockTargetNetFilter struct {
-	targets map[string]bool
+	targets sets.Set[string]
 }
 
 func NewMockTargetNetFilter(targets []string) endpoint.TargetFilterInterface {
-	targetMap := make(map[string]bool)
-	for _, target := range targets {
-		targetMap[target] = true
-	}
-	return &mockTargetNetFilter{targets: targetMap}
+	return &mockTargetNetFilter{targets: sets.New(targets...)}
 }
 
 func (m *mockTargetNetFilter) Match(target string) bool {
-	return m.targets[target]
+	return m.targets.Has(target)
 }
 
 func (m *mockTargetNetFilter) IsEnabled() bool {

--- a/source/wrappers/types.go
+++ b/source/wrappers/types.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/source"
 )
 
@@ -33,9 +34,9 @@ type Config struct {
 	excludeTargetNets   []string
 	minTTL              time.Duration
 	preferAlias         bool
-	ptrSupported        bool            // PTR is in --managed-record-types
-	createPTR           bool            // --create-ptr default for all A/AAAA records
-	sourceWrappers      map[string]bool // map of source wrappers, e.g. "targetfilter", "nat64"
+	ptrSupported        bool             // PTR is in --managed-record-types
+	createPTR           bool             // --create-ptr default for all A/AAAA records
+	sourceWrappers      sets.Set[string] // set of source wrappers, e.g. "targetfilter", "nat64"
 }
 
 func NewConfig(opts ...Option) *Config {
@@ -121,18 +122,17 @@ func WithCreatePTR(enabled bool) Option {
 // It initializes the sourceWrappers map if it is nil.
 func (o *Config) addSourceWrapper(name string) {
 	if o.sourceWrappers == nil {
-		o.sourceWrappers = make(map[string]bool)
+		o.sourceWrappers = sets.New[string]()
 	}
-	o.sourceWrappers[name] = true
+	o.sourceWrappers.Insert(name)
 }
 
 // isSourceWrapperInstrumented returns whether a source wrapper is enabled or not.
 func (o *Config) isSourceWrapperInstrumented(name string) bool {
-	if o.sourceWrappers == nil {
+	if len(o.sourceWrappers) == 0 {
 		return false
 	}
-	_, ok := o.sourceWrappers[name]
-	return ok
+	return o.sourceWrappers.Has(name)
 }
 
 // wrapSources combines multiple sources into a single source,


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->
Implements a Set data structure using `map[T]struct{}`.
Use this new implementation instead of `k8s.io/apimachinery/pkg/util/sets.Set`, `map[T]struct{}` and `map[T]bool` ,

## Motivation

While `map[]struct{}` is idiomatic to implement a set, it's clearer and more readable to use a dedicated `Set` struct.
<!-- What inspired you to submit this pull request? -->

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
