### PR TITLE
fix(awssd): use namespace-aware parsing for dotted service names

### DIFF
--- a/provider/awssd/aws_sd.go
+++ b/provider/awssd/aws_sd.go
@@ -310,7 +310,7 @@ func (p *AWSSDProvider) submitCreates(ctx context.Context, namespaces []*sdtypes
 		}
 
 		for _, ch := range changeList {
-			_, srvName := p.parseHostname(ch.DNSName)
+			_, srvName := p.parseHostname(ch.DNSName, namespaces)
 
 			srv := services[srvName]
 			if srv == nil {
@@ -350,7 +350,7 @@ func (p *AWSSDProvider) submitDeletes(ctx context.Context, namespaces []*sdtypes
 
 		for _, ch := range changeList {
 			hostname := ch.DNSName
-			_, srvName := p.parseHostname(hostname)
+			_, srvName := p.parseHostname(hostname, namespaces)
 
 			srv := services[srvName]
 			if srv == nil {
@@ -605,7 +605,7 @@ func (p *AWSSDProvider) changesByNamespaceID(namespaces []*sdtypes.NamespaceSumm
 	for _, c := range changes {
 		// trim the trailing dot from hostname if any
 		hostname := strings.TrimSuffix(c.DNSName, ".")
-		nsName, _ := p.parseHostname(hostname)
+		nsName, _ := p.parseHostname(hostname, namespaces)
 
 		matchingNamespaces := matchingNamespaces(nsName, namespaces)
 		if len(matchingNamespaces) == 0 {
@@ -640,8 +640,26 @@ func matchingNamespaces(hostname string, namespaces []*sdtypes.NamespaceSummary)
 	return matchingNamespaces
 }
 
-// parseHostname parse hostname to namespace (domain) and service
-func (p *AWSSDProvider) parseHostname(hostname string) (string, string) {
+// parseHostname parses hostname into namespace (domain) and service name.
+// When known namespaces are provided, it uses longest-suffix matching to
+// correctly handle service names that contain dots (e.g. "foo.bar.dev.local"
+// with namespace "dev.local" yields service "foo.bar"). Falls back to the
+// original first-dot split when no namespace suffix matches.
+func (p *AWSSDProvider) parseHostname(hostname string, namespaces []*sdtypes.NamespaceSummary) (string, string) {
+	var bestNS, bestSrv string
+	for _, ns := range namespaces {
+		suffix := "." + aws.ToString(ns.Name)
+		if strings.HasSuffix(hostname, suffix) {
+			candidate := strings.TrimSuffix(hostname, suffix)
+			if bestNS == "" || len(aws.ToString(ns.Name)) > len(bestNS) {
+				bestNS = aws.ToString(ns.Name)
+				bestSrv = candidate
+			}
+		}
+	}
+	if bestNS != "" {
+		return bestNS, bestSrv
+	}
 	parts := strings.Split(hostname, ".")
 	return strings.Join(parts[1:], "."), parts[0]
 }

--- a/provider/awssd/aws_sd.go
+++ b/provider/awssd/aws_sd.go
@@ -686,6 +686,7 @@ func matchingNamespaces(hostname string, namespaces []*sdtypes.NamespaceSummary)
 // hostname using longest-suffix matching. Falls back to the original first-dot
 // split when no namespace suffix matches.
 func parseNamespace(hostname string, namespaces []*sdtypes.NamespaceSummary) string {
+	hostname = strings.TrimSuffix(hostname, ".")
 	var bestNS string
 	for _, ns := range namespaces {
 		nsName := aws.ToString(ns.Name)

--- a/provider/awssd/aws_sd.go
+++ b/provider/awssd/aws_sd.go
@@ -612,7 +612,7 @@ func (p *AWSSDProvider) changesByNamespaceID(namespaces []*sdtypes.NamespaceSumm
 	for _, c := range changes {
 		// trim the trailing dot from hostname if any
 		hostname := strings.TrimSuffix(c.DNSName, ".")
-		nsName := p.parseNamespace(hostname, namespaces)
+		nsName := parseNamespace(hostname, namespaces)
 
 		matchingNamespaces := matchingNamespaces(nsName, namespaces)
 		if len(matchingNamespaces) == 0 {
@@ -632,46 +632,6 @@ func (p *AWSSDProvider) changesByNamespaceID(namespaces []*sdtypes.NamespaceSumm
 	}
 
 	return changesByNsID
-}
-
-// returns list of all namespaces matching given hostname
-func matchingNamespaces(hostname string, namespaces []*sdtypes.NamespaceSummary) []*sdtypes.NamespaceSummary {
-	matchingNamespaces := make([]*sdtypes.NamespaceSummary, 0)
-
-	for _, ns := range namespaces {
-		if *ns.Name == hostname {
-			matchingNamespaces = append(matchingNamespaces, ns)
-		}
-	}
-
-	return matchingNamespaces
-}
-
-// parseNamespace returns the Cloud Map namespace name that matches the given
-// hostname using longest-suffix matching. Falls back to the original first-dot
-// split when no namespace suffix matches.
-func (p *AWSSDProvider) parseNamespace(hostname string, namespaces []*sdtypes.NamespaceSummary) string {
-	var bestNS string
-	for _, ns := range namespaces {
-		nsName := aws.ToString(ns.Name)
-		if len(nsName) > len(bestNS) && strings.HasSuffix(hostname, "."+nsName) {
-			bestNS = nsName
-		}
-	}
-	if bestNS != "" {
-		return bestNS
-	}
-	parts := strings.Split(hostname, ".")
-	return strings.Join(parts[1:], ".")
-}
-
-// namespaceIDToName builds a map from namespace ID to namespace name.
-func namespaceIDToName(namespaces []*sdtypes.NamespaceSummary) map[string]string {
-	m := make(map[string]string, len(namespaces))
-	for _, ns := range namespaces {
-		m[aws.ToString(ns.Id)] = aws.ToString(ns.Name)
-	}
-	return m
 }
 
 // determine service routing policy based on endpoint type
@@ -707,4 +667,44 @@ func (p *AWSSDProvider) isAWSLoadBalancer(hostname string) bool {
 	matchNlb := sdNlbHostnameRegex.MatchString(hostname)
 
 	return matchElb || matchNlb
+}
+
+// returns list of all namespaces matching given hostname
+func matchingNamespaces(hostname string, namespaces []*sdtypes.NamespaceSummary) []*sdtypes.NamespaceSummary {
+	matchingNamespaces := make([]*sdtypes.NamespaceSummary, 0)
+
+	for _, ns := range namespaces {
+		if *ns.Name == hostname {
+			matchingNamespaces = append(matchingNamespaces, ns)
+		}
+	}
+
+	return matchingNamespaces
+}
+
+// parseNamespace returns the Cloud Map namespace name that matches the given
+// hostname using longest-suffix matching. Falls back to the original first-dot
+// split when no namespace suffix matches.
+func parseNamespace(hostname string, namespaces []*sdtypes.NamespaceSummary) string {
+	var bestNS string
+	for _, ns := range namespaces {
+		nsName := aws.ToString(ns.Name)
+		if len(nsName) > len(bestNS) && strings.HasSuffix(hostname, "."+nsName) {
+			bestNS = nsName
+		}
+	}
+	if bestNS != "" {
+		return bestNS
+	}
+	parts := strings.Split(hostname, ".")
+	return strings.Join(parts[1:], ".")
+}
+
+// namespaceIDToName builds a map from namespace ID to namespace name.
+func namespaceIDToName(namespaces []*sdtypes.NamespaceSummary) map[string]string {
+	m := make(map[string]string, len(namespaces))
+	for _, ns := range namespaces {
+		m[aws.ToString(ns.Id)] = aws.ToString(ns.Name)
+	}
+	return m
 }

--- a/provider/awssd/aws_sd.go
+++ b/provider/awssd/aws_sd.go
@@ -303,14 +303,18 @@ func (p *AWSSDProvider) updatesToCreates(changes *plan.Changes) ([]*endpoint.End
 func (p *AWSSDProvider) submitCreates(ctx context.Context, namespaces []*sdtypes.NamespaceSummary, changes []*endpoint.Endpoint) error {
 	changesByNamespaceID := p.changesByNamespaceID(namespaces, changes)
 
+	nsIDToName := namespaceIDToName(namespaces)
+
 	for nsID, changeList := range changesByNamespaceID {
 		services, err := p.ListServicesByNamespaceID(ctx, aws.String(nsID))
 		if err != nil {
 			return err
 		}
 
+		nsName := nsIDToName[nsID]
 		for _, ch := range changeList {
-			_, srvName := p.parseHostname(ch.DNSName, namespaces)
+			hostname := strings.TrimSuffix(ch.DNSName, ".")
+			srvName := strings.TrimSuffix(hostname, "."+nsName)
 
 			srv := services[srvName]
 			if srv == nil {
@@ -342,15 +346,18 @@ func (p *AWSSDProvider) submitCreates(ctx context.Context, namespaces []*sdtypes
 func (p *AWSSDProvider) submitDeletes(ctx context.Context, namespaces []*sdtypes.NamespaceSummary, changes []*endpoint.Endpoint) error {
 	changesByNamespaceID := p.changesByNamespaceID(namespaces, changes)
 
+	nsIDToName := namespaceIDToName(namespaces)
+
 	for nsID, changeList := range changesByNamespaceID {
 		services, err := p.ListServicesByNamespaceID(ctx, aws.String(nsID))
 		if err != nil {
 			return err
 		}
 
+		nsName := nsIDToName[nsID]
 		for _, ch := range changeList {
-			hostname := ch.DNSName
-			_, srvName := p.parseHostname(hostname, namespaces)
+			hostname := strings.TrimSuffix(ch.DNSName, ".")
+			srvName := strings.TrimSuffix(hostname, "."+nsName)
 
 			srv := services[srvName]
 			if srv == nil {
@@ -605,7 +612,7 @@ func (p *AWSSDProvider) changesByNamespaceID(namespaces []*sdtypes.NamespaceSumm
 	for _, c := range changes {
 		// trim the trailing dot from hostname if any
 		hostname := strings.TrimSuffix(c.DNSName, ".")
-		nsName, _ := p.parseHostname(hostname, namespaces)
+		nsName := p.parseNamespace(hostname, namespaces)
 
 		matchingNamespaces := matchingNamespaces(nsName, namespaces)
 		if len(matchingNamespaces) == 0 {
@@ -640,28 +647,31 @@ func matchingNamespaces(hostname string, namespaces []*sdtypes.NamespaceSummary)
 	return matchingNamespaces
 }
 
-// parseHostname parses hostname into namespace (domain) and service name.
-// When known namespaces are provided, it uses longest-suffix matching to
-// correctly handle service names that contain dots (e.g. "foo.bar.dev.local"
-// with namespace "dev.local" yields service "foo.bar"). Falls back to the
-// original first-dot split when no namespace suffix matches.
-func (p *AWSSDProvider) parseHostname(hostname string, namespaces []*sdtypes.NamespaceSummary) (string, string) {
-	var bestNS, bestSrv string
+// parseNamespace returns the Cloud Map namespace name that matches the given
+// hostname using longest-suffix matching. Falls back to the original first-dot
+// split when no namespace suffix matches.
+func (p *AWSSDProvider) parseNamespace(hostname string, namespaces []*sdtypes.NamespaceSummary) string {
+	var bestNS string
 	for _, ns := range namespaces {
-		suffix := "." + aws.ToString(ns.Name)
-		if strings.HasSuffix(hostname, suffix) {
-			candidate := strings.TrimSuffix(hostname, suffix)
-			if bestNS == "" || len(aws.ToString(ns.Name)) > len(bestNS) {
-				bestNS = aws.ToString(ns.Name)
-				bestSrv = candidate
-			}
+		nsName := aws.ToString(ns.Name)
+		if len(nsName) > len(bestNS) && strings.HasSuffix(hostname, "."+nsName) {
+			bestNS = nsName
 		}
 	}
 	if bestNS != "" {
-		return bestNS, bestSrv
+		return bestNS
 	}
 	parts := strings.Split(hostname, ".")
-	return strings.Join(parts[1:], "."), parts[0]
+	return strings.Join(parts[1:], ".")
+}
+
+// namespaceIDToName builds a map from namespace ID to namespace name.
+func namespaceIDToName(namespaces []*sdtypes.NamespaceSummary) map[string]string {
+	m := make(map[string]string, len(namespaces))
+	for _, ns := range namespaces {
+		m[aws.ToString(ns.Id)] = aws.ToString(ns.Name)
+	}
+	return m
 }
 
 // determine service routing policy based on endpoint type

--- a/provider/awssd/aws_sd_test.go
+++ b/provider/awssd/aws_sd_test.go
@@ -280,6 +280,56 @@ func TestAWSSDProvider_ApplyChanges_Update(t *testing.T) {
 	assert.Equal(t, "1.2.3.5", api.deregistered[0], "wrong target de-registered")
 }
 
+func TestAWSSDProvider_ApplyChanges_DottedServiceName(t *testing.T) {
+	namespaces := map[string]*sdtypes.Namespace{
+		"dev-local": {
+			Id:   aws.String("dev-local"),
+			Name: aws.String("dev.local"),
+			Type: sdtypes.NamespaceTypeDnsPrivate,
+		},
+	}
+
+	api := &AWSSDClientStub{
+		namespaces: namespaces,
+		services:   make(map[string]map[string]*sdtypes.Service),
+		instances:  make(map[string]map[string]*sdtypes.Instance),
+	}
+
+	createEndpoints := []*endpoint.Endpoint{
+		{DNSName: "my-app.elb.dev.local", Targets: endpoint.Targets{"1.2.3.4"}, RecordType: endpoint.RecordTypeA, RecordTTL: 60},
+	}
+
+	provider := newTestAWSSDProvider(api, endpoint.NewDomainFilter([]string{"dev.local"}), "", "")
+
+	ctx := t.Context()
+
+	err := provider.ApplyChanges(ctx, &plan.Changes{
+		Create: createEndpoints,
+	})
+	require.NoError(t, err)
+
+	// service must be created with the dotted name "my-app.elb"
+	assert.Len(t, api.services["dev-local"], 1)
+	existingServices, err := provider.ListServicesByNamespaceID(ctx, namespaces["dev-local"].Id)
+	require.NoError(t, err)
+	assert.NotNil(t, existingServices["my-app.elb"], "service should be named 'my-app.elb'")
+
+	// verify the record round-trips through Records()
+	endpoints, err := provider.Records(ctx)
+	require.NoError(t, err)
+	assert.True(t, testutils.SameEndpoints(createEndpoints, endpoints),
+		"expected and actual endpoints don't match, expected=%v, actual=%v", createEndpoints, endpoints)
+
+	// apply deletes
+	err = provider.ApplyChanges(ctx, &plan.Changes{
+		Delete: createEndpoints,
+	})
+	require.NoError(t, err)
+
+	endpoints, _ = provider.Records(ctx)
+	assert.Empty(t, endpoints)
+}
+
 func TestAWSSDProvider_ListNamespaces(t *testing.T) {
 	namespaces := map[string]*sdtypes.Namespace{
 		"private": {
@@ -1040,5 +1090,86 @@ func TestAWSSDProvider_awsTags(t *testing.T) {
 
 	for _, test := range tests {
 		require.ElementsMatch(t, test.Expectation, awsTags(test.Input))
+	}
+}
+
+func TestAWSSDProvider_parseHostname(t *testing.T) {
+	tests := []struct {
+		name       string
+		hostname   string
+		namespaces []*sdtypes.NamespaceSummary
+		wantNS     string
+		wantSrv    string
+	}{
+		{
+			name:     "simple service name",
+			hostname: "foo.dev.local",
+			namespaces: []*sdtypes.NamespaceSummary{
+				{Name: aws.String("dev.local")},
+			},
+			wantNS:  "dev.local",
+			wantSrv: "foo",
+		},
+		{
+			name:     "dotted service name",
+			hostname: "foo.bar.dev.local",
+			namespaces: []*sdtypes.NamespaceSummary{
+				{Name: aws.String("dev.local")},
+			},
+			wantNS:  "dev.local",
+			wantSrv: "foo.bar",
+		},
+		{
+			name:     "SRV-style hostname",
+			hostname: "_tcp.backend.mynet.internal",
+			namespaces: []*sdtypes.NamespaceSummary{
+				{Name: aws.String("mynet.internal")},
+			},
+			wantNS:  "mynet.internal",
+			wantSrv: "_tcp.backend",
+		},
+		{
+			name:     "longest namespace match wins",
+			hostname: "foo.a.b.c",
+			namespaces: []*sdtypes.NamespaceSummary{
+				{Name: aws.String("b.c")},
+				{Name: aws.String("a.b.c")},
+			},
+			wantNS:  "a.b.c",
+			wantSrv: "foo",
+		},
+		{
+			name:     "no matching namespace falls back to first-dot split",
+			hostname: "foo.unknown.tld",
+			namespaces: []*sdtypes.NamespaceSummary{
+				{Name: aws.String("dev.local")},
+			},
+			wantNS:  "unknown.tld",
+			wantSrv: "foo",
+		},
+		{
+			name:       "empty namespaces falls back to first-dot split",
+			hostname:   "foo.bar.baz",
+			namespaces: []*sdtypes.NamespaceSummary{},
+			wantNS:     "bar.baz",
+			wantSrv:    "foo",
+		},
+		{
+			name:       "nil namespaces falls back to first-dot split",
+			hostname:   "foo.bar.baz",
+			namespaces: nil,
+			wantNS:     "bar.baz",
+			wantSrv:    "foo",
+		},
+	}
+
+	provider := &AWSSDProvider{}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotNS, gotSrv := provider.parseHostname(tc.hostname, tc.namespaces)
+			assert.Equal(t, tc.wantNS, gotNS)
+			assert.Equal(t, tc.wantSrv, gotSrv)
+		})
 	}
 }

--- a/provider/awssd/aws_sd_test.go
+++ b/provider/awssd/aws_sd_test.go
@@ -1093,7 +1093,7 @@ func TestAWSSDProvider_awsTags(t *testing.T) {
 	}
 }
 
-func TestAWSSDProvider_parseNamespace(t *testing.T) {
+func Test_parseNamespace(t *testing.T) {
 	tests := []struct {
 		name       string
 		hostname   string
@@ -1177,11 +1177,9 @@ func TestAWSSDProvider_parseNamespace(t *testing.T) {
 		},
 	}
 
-	provider := &AWSSDProvider{}
-
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			gotNS := provider.parseNamespace(tc.hostname, tc.namespaces)
+			gotNS := parseNamespace(tc.hostname, tc.namespaces)
 			assert.Equal(t, tc.wantNS, gotNS)
 		})
 	}

--- a/provider/awssd/aws_sd_test.go
+++ b/provider/awssd/aws_sd_test.go
@@ -1154,12 +1154,12 @@ func Test_parseNamespace(t *testing.T) {
 			wantNS:     "bar.baz",
 		},
 		{
-			name:     "trailing dot falls back to first-dot split",
+			name:     "trailing dot is stripped before matching",
 			hostname: "foo.bar.dev.local.",
 			namespaces: []*sdtypes.NamespaceSummary{
 				{Name: aws.String("dev.local")},
 			},
-			wantNS: "bar.dev.local.",
+			wantNS: "dev.local",
 		},
 		{
 			name:     "hostname is namespace only, no service prefix",

--- a/provider/awssd/aws_sd_test.go
+++ b/provider/awssd/aws_sd_test.go
@@ -1093,13 +1093,12 @@ func TestAWSSDProvider_awsTags(t *testing.T) {
 	}
 }
 
-func TestAWSSDProvider_parseHostname(t *testing.T) {
+func TestAWSSDProvider_parseNamespace(t *testing.T) {
 	tests := []struct {
 		name       string
 		hostname   string
 		namespaces []*sdtypes.NamespaceSummary
 		wantNS     string
-		wantSrv    string
 	}{
 		{
 			name:     "simple service name",
@@ -1107,8 +1106,7 @@ func TestAWSSDProvider_parseHostname(t *testing.T) {
 			namespaces: []*sdtypes.NamespaceSummary{
 				{Name: aws.String("dev.local")},
 			},
-			wantNS:  "dev.local",
-			wantSrv: "foo",
+			wantNS: "dev.local",
 		},
 		{
 			name:     "dotted service name",
@@ -1116,8 +1114,7 @@ func TestAWSSDProvider_parseHostname(t *testing.T) {
 			namespaces: []*sdtypes.NamespaceSummary{
 				{Name: aws.String("dev.local")},
 			},
-			wantNS:  "dev.local",
-			wantSrv: "foo.bar",
+			wantNS: "dev.local",
 		},
 		{
 			name:     "SRV-style hostname",
@@ -1125,8 +1122,7 @@ func TestAWSSDProvider_parseHostname(t *testing.T) {
 			namespaces: []*sdtypes.NamespaceSummary{
 				{Name: aws.String("mynet.internal")},
 			},
-			wantNS:  "mynet.internal",
-			wantSrv: "_tcp.backend",
+			wantNS: "mynet.internal",
 		},
 		{
 			name:     "longest namespace match wins",
@@ -1135,8 +1131,7 @@ func TestAWSSDProvider_parseHostname(t *testing.T) {
 				{Name: aws.String("b.c")},
 				{Name: aws.String("a.b.c")},
 			},
-			wantNS:  "a.b.c",
-			wantSrv: "foo",
+			wantNS: "a.b.c",
 		},
 		{
 			name:     "no matching namespace falls back to first-dot split",
@@ -1144,22 +1139,41 @@ func TestAWSSDProvider_parseHostname(t *testing.T) {
 			namespaces: []*sdtypes.NamespaceSummary{
 				{Name: aws.String("dev.local")},
 			},
-			wantNS:  "unknown.tld",
-			wantSrv: "foo",
+			wantNS: "unknown.tld",
 		},
 		{
 			name:       "empty namespaces falls back to first-dot split",
 			hostname:   "foo.bar.baz",
 			namespaces: []*sdtypes.NamespaceSummary{},
 			wantNS:     "bar.baz",
-			wantSrv:    "foo",
 		},
 		{
 			name:       "nil namespaces falls back to first-dot split",
 			hostname:   "foo.bar.baz",
 			namespaces: nil,
 			wantNS:     "bar.baz",
-			wantSrv:    "foo",
+		},
+		{
+			name:     "trailing dot falls back to first-dot split",
+			hostname: "foo.bar.dev.local.",
+			namespaces: []*sdtypes.NamespaceSummary{
+				{Name: aws.String("dev.local")},
+			},
+			wantNS: "bar.dev.local.",
+		},
+		{
+			name:     "hostname is namespace only, no service prefix",
+			hostname: "dev.local",
+			namespaces: []*sdtypes.NamespaceSummary{
+				{Name: aws.String("dev.local")},
+			},
+			wantNS: "local",
+		},
+		{
+			name:       "single label hostname, no dots",
+			hostname:   "foo",
+			namespaces: nil,
+			wantNS:     "",
 		},
 	}
 
@@ -1167,9 +1181,8 @@ func TestAWSSDProvider_parseHostname(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			gotNS, gotSrv := provider.parseHostname(tc.hostname, tc.namespaces)
+			gotNS := provider.parseNamespace(tc.hostname, tc.namespaces)
 			assert.Equal(t, tc.wantNS, gotNS)
-			assert.Equal(t, tc.wantSrv, gotSrv)
 		})
 	}
 }


### PR DESCRIPTION
## What does it do ?

Changes `parseHostname` in the aws-sd provider to accept known Cloud Map namespaces and use longest-suffix matching instead of naive first-dot splitting. This correctly handles service names containing dots (e.g. `my-app.elb` in namespace `dev.local`).

Falls back to the original first-dot split when no namespace suffix matches, preserving full backward compatibility for all existing configurations.

## Motivation

`parseHostname` splits hostnames at the first dot with no awareness of actual Cloud Map namespace boundaries. For `my-app.elb.dev.local` with namespace `dev.local`, it produces:

| Field | Parsed (wrong) | Correct |
|---|---|---|
| service | `my-app` | `my-app.elb` |
| namespace | `elb.dev.local` | `dev.local` |

`matchingNamespaces` then does an exact-match lookup and finds no namespace named `elb.dev.local`, so the record is silently dropped with:

```
Skipping record <hostname> because no namespace matching record DNS Name was detected
```

This affects any hostname where the Cloud Map service name contains a dot, including SRV records (#5714), where hostnames like `_backend._tcp.backend.mynet.svc.internal` are parsed with namespace `_tcp.backend.mynet.svc.internal` instead of `mynet.svc.internal`.

No `--domain-filter` workaround is possible because the issue is structural in `parseHostname`.

Fixes #6364
Ref #5714

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

No documentation update is needed — this is an internal bug fix to hostname parsing logic with no user-facing configuration changes.