### PR TITLE
feat(source/gateway-api)!: migrate TLSRoute to v1

### DIFF
--- a/docs/sources/gateway-api.md
+++ b/docs/sources/gateway-api.md
@@ -14,7 +14,7 @@ Experimental channels as summarized below:
 | HTTPRoute          | v1                                  | v1.0.0                               | v1.0.0                          |
 | GRPCRoute          | v1                                  | v1.1.0                               | v1.1.0                          |
 | ListenerSet        | v1                                  | v1.5.0                               | v1.5.0                          |
-| TLSRoute           | v1alpha2                            | v1.5.0                               | v1.0.0                          |
+| TLSRoute           | v1                                  | v1.5.0                               | v1.0.0                          |
 | TCPRoute           | v1alpha2                            | TBD                                  | v1.0.0                          |
 | UDPRoute           | v1alpha2                            | TBD                                  | v1.0.0                          |
 

--- a/source/gateway_tlsroute.go
+++ b/source/gateway_tlsroute.go
@@ -22,19 +22,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	informers "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions"
-	informers_v1a2 "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/apis/v1alpha2"
+	informers_v1 "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/apis/v1"
 )
 
 // NewGatewayTLSRouteSource creates a new Gateway TLSRoute source with the given config.
 func NewGatewayTLSRouteSource(ctx context.Context, clients ClientGenerator, config *Config) (Source, error) {
 	return newGatewayRouteSource(ctx, clients, config, "TLSRoute", func(factory informers.SharedInformerFactory) gatewayRouteInformer {
-		return &gatewayTLSRouteInformer{factory.Gateway().V1alpha2().TLSRoutes()}
+		return &gatewayTLSRouteInformer{factory.Gateway().V1().TLSRoutes()}
 	})
 }
 
-type gatewayTLSRoute struct{ route v1alpha2.TLSRoute } // NOTE: Must update TypeMeta in List when changing the APIVersion.
+type gatewayTLSRoute struct{ route v1.TLSRoute } // NOTE: Must update TypeMeta in List when changing the APIVersion.
 
 func (rt *gatewayTLSRoute) Object() kubeObject               { return &rt.route }
 func (rt *gatewayTLSRoute) Metadata() *metav1.ObjectMeta     { return &rt.route.ObjectMeta }
@@ -44,7 +43,7 @@ func (rt *gatewayTLSRoute) Protocol() v1.ProtocolType        { return v1.TLSProt
 func (rt *gatewayTLSRoute) RouteStatus() v1.RouteStatus      { return rt.route.Status.RouteStatus }
 
 type gatewayTLSRouteInformer struct {
-	informers_v1a2.TLSRouteInformer
+	informers_v1.TLSRouteInformer
 }
 
 func (inf gatewayTLSRouteInformer) List(namespace string, selector labels.Selector) ([]gatewayRoute, error) {
@@ -58,7 +57,7 @@ func (inf gatewayTLSRouteInformer) List(namespace string, selector labels.Select
 		// We make a shallow copy since we're only interested in setting the TypeMeta.
 		clone := *rt
 		clone.TypeMeta = metav1.TypeMeta{
-			APIVersion: v1alpha2.GroupVersion.String(),
+			APIVersion: v1.GroupVersion.String(),
 			Kind:       "TLSRoute",
 		}
 		routes[i] = &gatewayTLSRoute{clone}

--- a/source/gateway_tlsroute_test.go
+++ b/source/gateway_tlsroute_test.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 
 	"sigs.k8s.io/external-dns/endpoint"
@@ -72,7 +71,7 @@ func TestGatewayTLSRouteSourceEndpoints(t *testing.T) {
 	_, err = gwClient.GatewayV1().Gateways(gw.Namespace).Create(ctx, gw, metav1.CreateOptions{})
 	require.NoError(t, err, "failed to create Gateway")
 
-	rt := &v1alpha2.TLSRoute{
+	rt := &v1.TLSRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "api",
 			Namespace: "default",
@@ -80,7 +79,7 @@ func TestGatewayTLSRouteSourceEndpoints(t *testing.T) {
 				annotations.HostnameKey: "api-annotation.foobar.internal",
 			},
 		},
-		Spec: v1alpha2.TLSRouteSpec{
+		Spec: v1.TLSRouteSpec{
 			Hostnames: []v1.Hostname{"api-hostnames.foobar.internal"},
 			CommonRouteSpec: v1.CommonRouteSpec{
 				ParentRefs: []v1.ParentReference{
@@ -88,11 +87,11 @@ func TestGatewayTLSRouteSourceEndpoints(t *testing.T) {
 				},
 			},
 		},
-		Status: v1alpha2.TLSRouteStatus{
+		Status: v1.TLSRouteStatus{
 			RouteStatus: gwRouteStatus(gwParentRef("default", "internal")),
 		},
 	}
-	_, err = gwClient.GatewayV1alpha2().TLSRoutes(rt.Namespace).Create(ctx, rt, metav1.CreateOptions{})
+	_, err = gwClient.GatewayV1().TLSRoutes(rt.Namespace).Create(ctx, rt, metav1.CreateOptions{})
 	require.NoError(t, err, "failed to create TLSRoute")
 
 	src, err := NewGatewayTLSRouteSource(ctx, clients, &Config{


### PR DESCRIPTION
## What does it do ?

This is migrates Gateway API TLSRoutes to version `v1` as it is now fully supported in the standard channel for Gateway API 1.5.0+.  

## Motivation
GKE update 1.34 now blocks experimental channel CRDs from Gateway API.

```
Failed last sync attempt to [1.6.1 477d172e6ac5eccb82b65781ddb8f924afec4170]: one or more objects failed to apply, reason: customresourcedefinitions.apiextensions.k8s.io "tlsroutes.gateway.networking.k8s.io" is forbidden: ValidatingAdmissionPolicy 'enforce-gateway-standard-channel' with binding 'enforce-gateway-standard-channel-binding' denied request: All Gateway API CRDs must belong to the 'standard' channel. Experimental CRDs are not permitted.
```
Since Gateway API 1.5.0 supports TLSRoutes in standard channel, there is no reason to keep experimental channel in use.

Additional support from PR [6291](https://github.com/kubernetes-sigs/external-dns/pull/6291) and feature request  [6247](https://github.com/kubernetes-sigs/external-dns/issues/6247). 

## More

- [X] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Yes, I updated unit tests
- [X] Yes, I updated end user documentation accordingly

