### PR TITLE
fix(exoscale): handle apex DNS records

### DIFF
--- a/provider/exoscale/exoscale.go
+++ b/provider/exoscale/exoscale.go
@@ -253,7 +253,11 @@ func (ep *ExoscaleProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, 
 				continue
 			}
 
-			e := endpoint.NewEndpointWithTTL((*record.Name)+"."+(*domain.UnicodeName), *record.Type, endpoint.TTL(*record.TTL), *record.Content)
+			fqdn := *domain.UnicodeName
+			if *record.Name != "" {
+				fqdn = (*record.Name) + "." + (*domain.UnicodeName)
+			}
+			e := endpoint.NewEndpointWithTTL(fqdn, *record.Type, endpoint.TTL(*record.TTL), *record.Content)
 			endpoints = append(endpoints, e)
 		}
 	}
@@ -313,6 +317,11 @@ func (f *zoneFilter) EndpointZoneID(endpoint *endpoint.Endpoint, zones map[strin
 			matchZoneName = zoneName
 			matchZoneID = zoneID
 			name = strings.TrimSuffix(endpoint.DNSName, "."+zoneName)
+		} else if endpoint.DNSName == zoneName && len(zoneName) > len(matchZoneName) {
+			// apex record: the DNS name is exactly the zone name, record name is empty
+			matchZoneName = zoneName
+			matchZoneID = zoneID
+			name = ""
 		}
 	}
 	return matchZoneID, name

--- a/provider/exoscale/exoscale_test.go
+++ b/provider/exoscale/exoscale_test.go
@@ -55,10 +55,12 @@ var (
 
 var defaultTTL int64 = 3600
 var domainIDs = []string{uuid.New().String(), uuid.New().String(), uuid.New().String(), uuid.New().String()}
+var apexRecordID = uuid.New().String()
 var groups = map[string][]egoscale.DNSDomainRecord{
 	domainIDs[0]: {
 		{ID: new(uuid.New().String()), Name: new("v1"), Type: new("TXT"), Content: new("test"), TTL: &defaultTTL},
 		{ID: new(uuid.New().String()), Name: new("v2"), Type: new("CNAME"), Content: new("test"), TTL: &defaultTTL},
+		{ID: &apexRecordID, Name: new(""), Type: new("A"), Content: new("1.2.3.4"), TTL: &defaultTTL},
 	},
 	domainIDs[1]: {
 		{ID: new(uuid.New().String()), Name: new("v2"), Type: new("A"), Content: new("test"), TTL: &defaultTTL},
@@ -120,15 +122,78 @@ func TestExoscaleGetRecords(t *testing.T) {
 
 	recs, err := provider.Records(t.Context())
 	if err == nil {
-		assert.Len(t, recs, 3)
+		assert.Len(t, recs, 4)
 		assert.True(t, contains(recs, "v1.foo.com"))
 		assert.True(t, contains(recs, "v2.bar.com"))
 		assert.True(t, contains(recs, "v2.foo.com"))
+		assert.True(t, contains(recs, "foo.com"))  // apex record
+		assert.False(t, contains(recs, ".foo.com")) // old broken form must not appear
 		assert.False(t, contains(recs, "v3.bar.com"))
 		assert.False(t, contains(recs, "v1.foobar.com"))
 	} else {
 		assert.Error(t, err)
 	}
+}
+
+func TestExoscaleApplyChanges_ApexRecord(t *testing.T) {
+	provider := NewExoscaleProviderWithClient(NewExoscaleClientStub(), "", "", false)
+
+	changes := &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			{DNSName: "foo.com", RecordType: "A", Targets: []string{"5.6.7.8"}},
+		},
+		Delete: []*endpoint.Endpoint{
+			{DNSName: "foo.com", RecordType: "A", Targets: []string{"1.2.3.4"}},
+		},
+		UpdateNew: []*endpoint.Endpoint{
+			{DNSName: "foo.com", RecordType: "A", Targets: []string{"5.6.7.8"}},
+		},
+		UpdateOld: []*endpoint.Endpoint{
+			{DNSName: "foo.com", RecordType: "A", Targets: []string{"1.2.3.4"}},
+		},
+	}
+	createExoscale = make([]createRecordExoscale, 0)
+	deleteExoscale = make([]deleteRecordExoscale, 0)
+	updateExoscale = make([]updateRecordExoscale, 0)
+
+	err := provider.ApplyChanges(t.Context(), changes)
+	assert.NoError(t, err)
+
+	// create: apex record should be sent with empty name
+	assert.Len(t, createExoscale, 1)
+	assert.Equal(t, domainIDs[0], createExoscale[0].domainID)
+	assert.Equal(t, "", *createExoscale[0].record.Name)
+
+	// delete: apex record should be matched and deleted
+	assert.Len(t, deleteExoscale, 1)
+	assert.Equal(t, apexRecordID, deleteExoscale[0].recordID)
+
+	// update: apex record should be matched and updated
+	assert.Len(t, updateExoscale, 1)
+	assert.Equal(t, domainIDs[0], updateExoscale[0].domainID)
+}
+
+func TestEndpointZoneID_ApexRecord(t *testing.T) {
+	zones := map[string]string{
+		"zone-1": "example.com",
+		"zone-2": "other.com",
+	}
+	f := &zoneFilter{}
+
+	// subdomain: existing behavior
+	zoneID, name := f.EndpointZoneID(&endpoint.Endpoint{DNSName: "sub.example.com"}, zones)
+	assert.Equal(t, "zone-1", zoneID)
+	assert.Equal(t, "sub", name)
+
+	// apex: DNS name exactly equals zone name
+	zoneID, name = f.EndpointZoneID(&endpoint.Endpoint{DNSName: "example.com"}, zones)
+	assert.Equal(t, "zone-1", zoneID)
+	assert.Equal(t, "", name)
+
+	// no match
+	zoneID, name = f.EndpointZoneID(&endpoint.Endpoint{DNSName: "notexist.com"}, zones)
+	assert.Equal(t, "", zoneID)
+	assert.Equal(t, "", name)
 }
 
 func TestExoscaleApplyChanges(t *testing.T) {
@@ -186,6 +251,7 @@ func TestExoscaleApplyChanges(t *testing.T) {
 	}
 	createExoscale = make([]createRecordExoscale, 0)
 	deleteExoscale = make([]deleteRecordExoscale, 0)
+	updateExoscale = make([]updateRecordExoscale, 0)
 
 	provider.ApplyChanges(t.Context(), plan)
 


### PR DESCRIPTION
# 1. external-dns info

This came in as a customer report (no direct cluster access), so I traced it through the source code.

Version: unconfirmed from the customer, but the bug is present in current master ([`dc28c3e`](https://github.com/kubernetes-sigs/external-dns/commit/dc28c3e499cd51ad2faffd30be2127cbd09c8e74)).

Startup flags (from customer description, approximate):

```
--provider=exoscale
--source=service
--domain-filter=xxx.yy
```

Debug logs: not available. Based on the code path, `EndpointZoneID` returns `""` for apex records so they are dropped before any change is scheduled. You would never see a `CREATE xxx.yy` line in the logs.

# 2. Kubernetes resources

Not available (proprietary infrastructure). The relevant annotation was:

```
external-dns.alpha.kubernetes.io/hostname: xxx.yy
```

# 3. DNS provider: existing vs expected records

| Name                | Type | Exists | Expected           |
| ------------------- | ---- | ------ | ------------------ |
| `www.xxx.yy` | A    | yes    | yes, works fine    |
| `xxx.yy`     | A    | no     | yes, never created |

# 4. TXT ownership records

Not available.

---

**Demonstrating the bug with tests**

I added tests that fail against master and pass after the fix. Here is the output against the unpatched code:

```
$ go test ./provider/exoscale/... -v -run "TestExoscaleApplyChanges_ApexRecord|TestEndpointZoneID_ApexRecord|TestExoscaleGetRecords"

=== RUN   TestExoscaleGetRecords
    exoscale_test.go:129: Error: Should be true     <- "foo.com" not found in Records() output
    exoscale_test.go:130: Error: Should be false    <- ".foo.com" IS present (Records() returns leading dot for apex)
--- FAIL: TestExoscaleGetRecords

=== RUN   TestExoscaleApplyChanges_ApexRecord
    exoscale_test.go:163: Error: "[]" should have 1 item(s), but has 0
--- FAIL: TestExoscaleApplyChanges_ApexRecord
panic: runtime error: index out of range [0] with length 0

FAIL    sigs.k8s.io/external-dns/provider/exoscale
```

After the fix:

```
$ go test ./provider/exoscale/... -v -run "TestExoscaleApplyChanges_ApexRecord|TestEndpointZoneID_ApexRecord|TestExoscaleGetRecords"

--- PASS: TestExoscaleGetRecords
--- PASS: TestExoscaleApplyChanges_ApexRecord
--- PASS: TestEndpointZoneID_ApexRecord
ok  sigs.k8s.io/external-dns/provider/exoscale
```

> [!NOTE]
>  This PR description was drafted with AI assistance (GitHub Copilot).
