### PR TITLE
chore: follow the OpenSSF recommendations for github permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -10,6 +10,8 @@ on:
   - cron: '35 13 * * 5'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/dependency-update.yaml
+++ b/.github/workflows/dependency-update.yaml
@@ -8,14 +8,15 @@ on:
     # once a day
     - cron: '0 0 * * *'
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   update-versions-with-renovate:
     runs-on: ubuntu-latest
     if: github.repository == 'kubernetes-sigs/external-dns'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/gh-workflow-approve.yaml
+++ b/.github/workflows/gh-workflow-approve.yaml
@@ -8,6 +8,8 @@ on:
     branches:
       - master
 
+permissions: {}
+
 jobs:
   approve:
     name: Approve ok-to-test

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions: {}
+
 jobs:
   lint:
     name: Markdown and Go


### PR DESCRIPTION
## What does it do ?

This PR updates the github workflows to always specify permissions that are set to no permission and then have the individual jobs override that. This is essentially a noop and introduces no added security, rather implements a weak form of defense in depth in case a new job gets added and someone forgets to set the permissions on the job.



<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
