### PR TITLE
feat(chart): add enableGatewayListenerSets flag

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add value `.sourceNamespace` to watch a namespace which is different from the one that external-dns is installed into when `.namespaced` is true. ([#6297](https://github.com/kubernetes-sigs/external-dns/pull/6297)) _@jplitza_
+- Add option to enable Gateway API ListenerSet support. ([#6381](https://github.com/kubernetes-sigs/external-dns/pull/6381)) _@speer_
 
 ### Fixed
 

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -105,6 +105,7 @@ If `namespaced` is set to `true`, please ensure that `sources` only contains sup
 | dnsConfig | object | `nil` | [DNS config](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config) for the pod, if not set the default will be used. |
 | dnsPolicy | string | `nil` | [DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) for the pod, if not set the default will be used. |
 | domainFilters | list | `[]` | Limit possible target zones by domain suffixes. |
+| enableGatewayListenerSets | bool | `false` | if `true`, the Gateway API ListenerSet flag will be enabled. |
 | enabled | bool | `nil` | No effect - reserved for use in sub-charting. |
 | env | list | `[]` | [Environment variables](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for the `external-dns` container. |
 | excludeDomains | list | `[]` | Intentionally exclude domains from being managed. |

--- a/charts/external-dns/templates/clusterrole.yaml
+++ b/charts/external-dns/templates/clusterrole.yaml
@@ -68,6 +68,11 @@ rules:
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["gateways"]
     verbs: ["get","watch","list"]
+{{- if .Values.enableGatewayListenerSets }}
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["listenersets"]
+    verbs: ["get","watch","list"]
+{{- end }}
 {{- end }}
 {{- if not .Values.namespaced }}
   - apiGroups: [""]
@@ -169,6 +174,11 @@ rules:
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["gateways"]
     verbs: ["get","watch","list"]
+{{- if .Values.enableGatewayListenerSets }}
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["listenersets"]
+    verbs: ["get","watch","list"]
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -114,6 +114,9 @@ spec:
             {{- if .Values.gatewayNamespace }}
             - --gateway-namespace={{ .Values.gatewayNamespace }}
             {{- end }}
+            {{- if .Values.enableGatewayListenerSets }}
+            - --gateway-listener-sets
+            {{- end }}
             {{- range .Values.domainFilters }}
             - --domain-filter={{ . }}
             {{- end }}

--- a/charts/external-dns/tests/deployment-flags_test.yaml
+++ b/charts/external-dns/tests/deployment-flags_test.yaml
@@ -216,3 +216,19 @@ tests:
       - contains:
           path: spec.template.spec.containers[?(@.name == "external-dns")].args
           content: "5000"
+
+  - it: should not include gateway-listener-sets flag when not set
+    set:
+      enableGatewayListenerSets: null
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name == "external-dns")].args
+          value: "--gateway-listener-sets"
+
+  - it: should include gateway-listener-sets flag when set
+    set:
+      enableGatewayListenerSets: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "external-dns")].args
+          content: "--gateway-listener-sets"

--- a/charts/external-dns/tests/rbac_test.yaml
+++ b/charts/external-dns/tests/rbac_test.yaml
@@ -584,3 +584,50 @@ tests:
             - apiGroups: ["gloo.solo.io","gateway.solo.io"]
               resources: ["proxies","virtualservices","gateways"]
               verbs: ["get","watch","list"]
+
+  - it: should include 'listenersets' in clusterwide RBAC rules for 'gateway-api' with a Gateway source being present and 'enableGatewayListenerSets' being set
+    set:
+      enableGatewayListenerSets: true
+      namespaced: false
+      sources:
+        - gateway-httproute
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["gateway.networking.k8s.io"]
+            resources: ["listenersets"]
+            verbs: ["get","watch","list"]
+        template: clusterrole.yaml
+
+  - it: should include 'listenersets' in namespaced RBAC rules for 'gateway-api' with a Gateway source being present and 'enableGatewayListenerSets' being set
+    set:
+      enableGatewayListenerSets: true
+      namespaced: true
+      gatewayNamespace: gateway-ns
+      sources:
+        - gateway-httproute
+    asserts:
+      # Gateway clusterrole should not have listenersets permissions
+      - notContains:
+          path: rules
+          content:
+            apiGroups: ["gateway.networking.k8s.io"]
+            resources: ["listenersets"]
+            verbs: ["get","watch","list"]
+        documentSelector:
+          path: metadata.name
+          value: rbac-external-dns
+        template: clusterrole.yaml
+
+      # Gateway role should exist and have listenersets permissions
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["gateway.networking.k8s.io"]
+            resources: ["listenersets"]
+            verbs: ["get","watch","list"]
+        documentSelector:
+          path: metadata.name
+          value: rbac-external-dns-gateway
+        template: clusterrole.yaml

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -65,6 +65,10 @@
       "description": "Limit possible target zones by domain suffixes.",
       "type": "array"
     },
+    "enableGatewayListenerSets": {
+      "description": "if `true`, the Gateway API ListenerSet flag will be enabled.",
+      "type": "boolean"
+    },
     "enabled": {
       "description": "No effect - reserved for use in sub-charting",
       "type": [

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -205,6 +205,9 @@ triggerLoopOnEvent: false
 # -- if `true`, _ExternalDNS_ will run in a namespaced scope (`Role`` and `Rolebinding`` will be namespaced too).
 namespaced: false
 
+# -- if `true`, the Gateway API ListenerSet flag will be enabled.
+enableGatewayListenerSets: false
+
 # -- _Gateway API_ gateway namespace to watch.
 # When `namespaced=true`, setting this value avoids creating any cluster-scoped RBAC
 # (no ClusterRole/ClusterRoleBinding) for Gateway sources.


### PR DESCRIPTION
## What does it do ?

[#6254](https://github.com/kubernetes-sigs/external-dns/pull/6254) introduced a new flag to enable [Gateway API ListenerSet](https://gateway-api.sigs.k8s.io/guides/listener-set) support. With this PR we make it available to the helm chart and also add the RBAC it requires.

## Motivation

To simplify and standardize the use of the `--gateway-listener-sets` flag.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
