### PR TITLE
source/pod: skip internal-hostname pod when PodIP is empty

### DIFF
--- a/source/pod.go
+++ b/source/pod.go
@@ -188,6 +188,16 @@ func (ps *podSource) addInternalHostnameAnnotationEndpoints(endpointMap map[endp
 		domainList := annotations.SplitHostnameAnnotation(domainAnnotation)
 		for _, domain := range domainList {
 			if len(targets) == 0 {
+				// Pods in Pending / Scheduled state without a PodIP must
+				// not emit an endpoint: endpoint.SuitableType("") returns
+				// CNAME, which would create a provider record whose target
+				// is the empty string. Once the pod eventually gets an IP
+				// external-dns then tries to create an A record at the
+				// same name and the provider rejects it because A and
+				// CNAME cannot coexist (#6375, #6199 on Azure / RFC2136).
+				if pod.Status.PodIP == "" {
+					continue
+				}
 				addToEndpointMap(endpointMap, pod, domain, endpoint.SuitableType(pod.Status.PodIP), pod.Status.PodIP)
 			} else {
 				addTargetsToEndpointMap(endpointMap, pod, targets, domain)

--- a/source/pod.go
+++ b/source/pod.go
@@ -188,13 +188,6 @@ func (ps *podSource) addInternalHostnameAnnotationEndpoints(endpointMap map[endp
 		domainList := annotations.SplitHostnameAnnotation(domainAnnotation)
 		for _, domain := range domainList {
 			if len(targets) == 0 {
-				// Pods in Pending / Scheduled state without a PodIP must
-				// not emit an endpoint: endpoint.SuitableType("") returns
-				// CNAME, which would create a provider record whose target
-				// is the empty string. Once the pod eventually gets an IP
-				// external-dns then tries to create an A record at the
-				// same name and the provider rejects it because A and
-				// CNAME cannot coexist (#6375, #6199 on Azure / RFC2136).
 				if pod.Status.PodIP == "" {
 					continue
 				}
@@ -222,6 +215,9 @@ func (ps *podSource) addKopsDNSControllerEndpoints(endpointMap map[endpoint.Endp
 		if domainAnnotation, ok := pod.Annotations[kopsDNSControllerInternalHostnameAnnotationKey]; ok {
 			domainList := annotations.SplitHostnameAnnotation(domainAnnotation)
 			for _, domain := range domainList {
+				if pod.Status.PodIP == "" {
+					continue
+				}
 				addToEndpointMap(endpointMap, pod, domain, endpoint.SuitableType(pod.Status.PodIP), pod.Status.PodIP)
 			}
 		}
@@ -237,6 +233,9 @@ func (ps *podSource) addPodSourceDomainEndpoints(endpointMap map[endpoint.Endpoi
 	if ps.podSourceDomain != "" {
 		domain := pod.Name + "." + ps.podSourceDomain
 		if len(targets) == 0 {
+			if pod.Status.PodIP == "" {
+				return
+			}
 			addToEndpointMap(endpointMap, pod, domain, endpoint.SuitableType(pod.Status.PodIP), pod.Status.PodIP)
 		}
 		addTargetsToEndpointMap(endpointMap, pod, targets, domain)

--- a/source/pod_test.go
+++ b/source/pod_test.go
@@ -797,6 +797,59 @@ func TestPodSource(t *testing.T) {
 				},
 			},
 		},
+		{
+			"kops-dns-controller internal-hostname pod without a PodIP is skipped",
+			"",
+			"kops-dns-controller",
+			true,
+			"",
+			[]*endpoint.Endpoint{},
+			false,
+			nodesFixturesIPv4(),
+			[]*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-pod1",
+						Namespace: "kube-system",
+						Annotations: map[string]string{
+							kopsDNSControllerInternalHostnameAnnotationKey: "internal.a.foo.example.org",
+						},
+					},
+					Spec: corev1.PodSpec{
+						HostNetwork: true,
+						NodeName:    "my-node1",
+					},
+					Status: corev1.PodStatus{
+						PodIP: "",
+					},
+				},
+			},
+		},
+		{
+			"pod-source-domain pod without a PodIP is skipped",
+			"",
+			"",
+			true,
+			"pod.example.org",
+			[]*endpoint.Endpoint{},
+			false,
+			nodesFixturesIPv4(),
+			[]*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-pod1",
+						Namespace: "kube-system",
+					},
+					Spec: corev1.PodSpec{
+						HostNetwork: true,
+						NodeName:    "my-node1",
+					},
+					Status: corev1.PodStatus{
+						PodIP: "",
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
 			kubernetes := fake.NewClientset()


### PR DESCRIPTION
### Description

`addInternalHostnameAnnotationEndpoints` called `endpoint.SuitableType(pod.Status.PodIP)` and `addToEndpointMap` without first checking whether PodIP was empty. Pending / Scheduled pods carrying `external-dns.alpha.kubernetes.io/internal-hostname` emit a CNAME record whose target is the empty string (because `SuitableType("")` falls through to `CNAME`). Once the pod gets a PodIP and external-dns tries to write an A record at the same name, the provider rejects the update (A and CNAME cannot coexist), leaving the zone permanently stuck on the empty-target CNAME, the exact scenario the reporter hit on Azure Private DNS.

### Fix

Skip the pod entirely when `PodIP` is empty. The pod will be reconciled again once the kubelet assigns an address.

### Fixes

Fixes #6375

### Checklist

- [x] Unit tests pass (`go test ./source/...`).
- [x] `go build ./source/...` clean.
- [x] `gofmt` clean.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>