### PR TITLE
fix(source/crd): allow SRV targets with trailing dot in DNSEndpoint

### DIFF
--- a/source/crd.go
+++ b/source/crd.go
@@ -121,6 +121,14 @@ func (cs *crdSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 					continue // no format constraint on targets
 				case endpoint.RecordTypeCNAME:
 					continue // RFC 1035 §5.1: trailing dot denotes an absolute FQDN in zone file notation; both forms are valid
+				case endpoint.RecordTypeSRV:
+					// SRV targets are "<prio> <weight> <port> <host>"; RFC 2782
+					// requires the host to be an absolute FQDN and
+					// Endpoint.ValidateSRVRecord enforces the trailing dot.
+					// Reject-on-trailing-dot (the default branch below) would
+					// loop users between this warning and ValidateSRVRecord's
+					// "does not end with a dot" error (#6357).
+					continue
 				}
 
 				hasDot := strings.HasSuffix(target, ".")

--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -321,6 +321,22 @@ func testCRDSourceEndpoints(t *testing.T) {
 			expectEndpoints: true,
 		},
 		{
+			title:           "SRV target with trailing dot (RFC 2782 absolute FQDN host) is valid (#6357)",
+			namespaceFilter: "foo",
+			objectNamespace: "foo",
+			labels:          map[string]string{"test": "that"},
+			labelSelector:   labels.SelectorFromSet(labels.Set{"test": "that"}),
+			endpoints: []*endpoint.Endpoint{
+				{
+					DNSName:    "_svc._tcp.example.org",
+					Targets:    endpoint.Targets{"0 0 80 abc.example.org.", "10 20 443 def.example.org."},
+					RecordType: endpoint.RecordTypeSRV,
+					RecordTTL:  180,
+				},
+			},
+			expectEndpoints: true,
+		},
+		{
 			title:           "Create NAPTR record",
 			namespaceFilter: "foo",
 			objectNamespace: "foo",
@@ -544,6 +560,18 @@ func TestCRDSourceIllegalTargetWarnings(t *testing.T) {
 					DNSName:    "example.org",
 					Targets:    endpoint.Targets{},
 					RecordType: endpoint.RecordTypeCNAME,
+					RecordTTL:  180,
+				},
+			},
+			wantWarning: ``,
+		},
+		{
+			title: "SRV target with trailing dot produces no warning (#6357)",
+			endpoints: []*endpoint.Endpoint{
+				{
+					DNSName:    "_svc._tcp.example.org",
+					Targets:    endpoint.Targets{"0 0 80 abc.example.org."},
+					RecordType: endpoint.RecordTypeSRV,
 					RecordTTL:  180,
 				},
 			},


### PR DESCRIPTION
### Description

The DNSEndpoint CRD validator warned and skipped SRV targets that ended with a trailing dot, telling the user to remove it. Dropping the dot satisfied `source/crd.go`'s default branch, but then `Endpoint.ValidateSRVRecord` rejected the endpoint in `CheckEndpoint` because RFC 2782 requires the target host to be an absolute FQDN with a trailing dot. The net effect: SRV records could not be created via a DNSEndpoint CRD — the user looped between both errors.

### Fix

Treat SRV like CNAME in the crd.go validator. The SRV record format is `<prio> <weight> <port> <host>` and `ValidateSRVRecord` already enforces the trailing dot on the host, so crd.go should accept it and let the downstream validator decide.

### Related

Fixes #6357.

### Checklist

- [x] `go test ./source/...` green (including CRD suite).
- [x] `go build` clean.
- [x] `gofmt` clean.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
