### PR TITLE
docs(tutorials/aws): fix grammatical error

### DIFF
--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -693,7 +693,7 @@ helm upgrade --install external-dns external-dns/external-dns --values values.ya
 
 ## Arguments
 
-This list is not the full list, but a few arguments that were chosen.
+This is not a complete list, but a few selected items.
 
 ### aws-zone-type
 

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -693,7 +693,7 @@ helm upgrade --install external-dns external-dns/external-dns --values values.ya
 
 ## Arguments
 
-This list is not the full list, but a few arguments that where chosen.
+This list is not the full list, but a few arguments that were chosen.
 
 ### aws-zone-type
 


### PR DESCRIPTION
Fixed the grammar of the word "where" to were

## What does it do ?

There is a grammer mistake of the word where which defines a location but the sentence itself is a past tense of are = were

## Motivation

Improve clarity and correctness of documentation.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
