### PR TITLE
fix(source): use correct key when checking for existing alias in postProcessor

### DIFF
--- a/source/wrappers/post_processor.go
+++ b/source/wrappers/post_processor.go
@@ -25,7 +25,6 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source"
-	"sigs.k8s.io/external-dns/source/annotations"
 )
 
 type postProcessor struct {
@@ -101,7 +100,7 @@ func (pp *postProcessor) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, e
 		// Set alias annotation for CNAME records when preferAlias is enabled
 		// Only set if not already explicitly configured at the source level
 		if pp.cfg.preferAlias && ep.RecordType == endpoint.RecordTypeCNAME {
-			if _, exists := ep.GetProviderSpecificProperty(annotations.AliasKey); !exists {
+			if _, exists := ep.GetProviderSpecificProperty(endpoint.ProviderSpecificAlias); !exists {
 				ep.WithProviderSpecific(endpoint.ProviderSpecificAlias, "true")
 			}
 		}

--- a/source/wrappers/post_processor_test.go
+++ b/source/wrappers/post_processor_test.go
@@ -492,6 +492,26 @@ func TestPostProcessorEndpointsWithPreferAlias(t *testing.T) {
 				endpoint.NewEndpoint("cname.example.com", endpoint.RecordTypeCNAME, "target.example.com").WithProviderSpecific(endpoint.ProviderSpecificAlias, "true"),
 			},
 		},
+		{
+			title:       "existing alias=false is not overridden by preferAlias",
+			preferAlias: true,
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeCNAME, "target.example.com").WithProviderSpecific(endpoint.ProviderSpecificAlias, "false"),
+			},
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeCNAME, "target.example.com").WithProviderSpecific(endpoint.ProviderSpecificAlias, "false"),
+			},
+		},
+		{
+			title:       "existing alias=true is preserved when preferAlias is enabled",
+			preferAlias: true,
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeCNAME, "target.example.com").WithProviderSpecific(endpoint.ProviderSpecificAlias, "true"),
+			},
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeCNAME, "target.example.com").WithProviderSpecific(endpoint.ProviderSpecificAlias, "true"),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.title, func(t *testing.T) {


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->

Fixes `postProcessor` incorrectly using `annotations.AliasKey` (`"external-dns.alpha.kubernetes.io/alias"`) as the lookup key when checking whether an alias property is already set on an endpoint. 
The correct key is `endpoint.ProviderSpecificAlias` (`"alias"`), which is what `ProviderSpecificAnnotations` actually stores.
## Motivation

<!-- What inspired you to submit this pull request? -->
The guard was checking the wrong key (`annotations.AliasKey` instead of `endpoint.ProviderSpecificAlias`), so it never functioned as intended.
While no current source sets `alias=false` directly in ProviderSpecific, the broken guard meant any future source doing so would have it silently verwritten by `--prefer-alias`.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
