### PR TITLE
feat(chart): add namespaceOverride

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add value `.sourceNamespace` to watch a namespace which is different from the one that external-dns is installed into when `.namespaced` is true. ([#6297](https://github.com/kubernetes-sigs/external-dns/pull/6297)) _@jplitza_
 - Add option to enable Gateway API ListenerSet support. ([#6381](https://github.com/kubernetes-sigs/external-dns/pull/6381)) _@speer_
 - Add support for bool in extraArgs. ([#6179](https://github.com/kubernetes-sigs/external-dns/pull/6179)) _@farodin91_
+- Add value `.namespaceOverride` to render chart resources into a namespace different from the release namespace, for subchart installs that want their own namespace. ([#6389](https://github.com/kubernetes-sigs/external-dns/pull/6389)) _@alliasgher_
 
 ### Fixed
 

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -128,6 +128,7 @@ If `namespaced` is set to `true`, please ensure that `sources` only contains sup
 | logLevel | string | `"info"` | Log level. |
 | managedRecordTypes | list | `[]` | Record types to manage (default: A, AAAA, CNAME) |
 | nameOverride | string | `nil` | Override the name of the chart. |
+| namespaceOverride | string | `nil` | Override the namespace that chart resources are rendered into. Defaults to the release namespace. Useful when installing the chart as a subchart that should live in its own namespace, separate from the umbrella release namespace. |
 | namespaced | bool | `false` | if `true`, _ExternalDNS_ will run in a namespaced scope (`Role`` and `Rolebinding`` will be namespaced too). |
 | nodeSelector | object | `{}` | Node labels to match for `Pod` [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). |
 | podAnnotations | object | `{}` | Annotations to add to the `Pod`. |

--- a/charts/external-dns/templates/_helpers.tpl
+++ b/charts/external-dns/templates/_helpers.tpl
@@ -6,6 +6,16 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+Allow overriding the namespace that chart resources are rendered into
+(e.g. when external-dns is installed as a subchart that should live in a
+dedicated namespace, separate from the umbrella chart's release namespace).
+Falls back to .Release.Namespace when namespaceOverride is not set.
+*/}}
+{{- define "external-dns.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride }}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/charts/external-dns/templates/clusterrolebinding.yaml
+++ b/charts/external-dns/templates/clusterrolebinding.yaml
@@ -15,7 +15,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "external-dns.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "external-dns.namespace" . }}
 {{- if and .Values.rbac.create .Values.namespaced (include "external-dns.hasGatewaySources" .) }}
 {{- /*
      If namespaced=true and gatewayNamespace is NOT set, bind the namespaces ClusterRole.
@@ -36,7 +36,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "external-dns.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "external-dns.namespace" . }}
 {{- end }}
 {{- if .Values.gatewayNamespace }}
 ---
@@ -54,7 +54,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "external-dns.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "external-dns.namespace" . }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "external-dns.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "external-dns.namespace" . }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
   {{- with .Values.deploymentAnnotations }}
@@ -109,7 +109,7 @@ spec:
             - --txt-suffix={{ .Values.txtSuffix }}
             {{- end }}
             {{- if .Values.namespaced }}
-            - --namespace={{ default .Release.Namespace .Values.sourceNamespace }}
+            - --namespace={{ default (include "external-dns.namespace" .) .Values.sourceNamespace }}
             {{- end }}
             {{- if .Values.gatewayNamespace }}
             - --gateway-namespace={{ .Values.gatewayNamespace }}

--- a/charts/external-dns/templates/secret.yaml
+++ b/charts/external-dns/templates/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "external-dns.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "external-dns.namespace" . }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
 data:

--- a/charts/external-dns/templates/service.yaml
+++ b/charts/external-dns/templates/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "external-dns.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "external-dns.namespace" . }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}

--- a/charts/external-dns/templates/serviceaccount.yaml
+++ b/charts/external-dns/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "external-dns.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "external-dns.namespace" . }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.labels }}

--- a/charts/external-dns/templates/servicemonitor.yaml
+++ b/charts/external-dns/templates/servicemonitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "external-dns.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.serviceMonitor.namespace }}
+  namespace: {{ default (include "external-dns.namespace" .) .Values.serviceMonitor.namespace }}
   {{- with .Values.serviceMonitor.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -18,7 +18,7 @@ spec:
   jobLabel: app.kubernetes.io/instance
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "external-dns.namespace" . }}
   selector:
     matchLabels:
       {{- include "external-dns.selectorLabels" . | nindent 6 }}

--- a/charts/external-dns/tests/namespace-override_test.yaml
+++ b/charts/external-dns/tests/namespace-override_test.yaml
@@ -14,10 +14,13 @@ tests:
       - service.yaml
       - serviceaccount.yaml
       - secret.yaml
+      - servicemonitor.yaml
     set:
       secretConfiguration:
         enabled: true
         mountPath: "/etc/kubernetes/"
+      serviceMonitor:
+        enabled: true
     asserts:
       - equal:
           path: metadata.namespace
@@ -29,11 +32,14 @@ tests:
       - service.yaml
       - serviceaccount.yaml
       - secret.yaml
+      - servicemonitor.yaml
     set:
       namespaceOverride: chart-ns
       secretConfiguration:
         enabled: true
         mountPath: "/etc/kubernetes/"
+      serviceMonitor:
+        enabled: true
     asserts:
       - equal:
           path: metadata.namespace

--- a/charts/external-dns/tests/namespace-override_test.yaml
+++ b/charts/external-dns/tests/namespace-override_test.yaml
@@ -1,0 +1,74 @@
+suite: namespaceOverride
+templates:
+  - "*.yaml"
+release:
+  name: external-dns
+  namespace: release-ns
+chart:
+  version: "1.15.0"
+  appVersion: "0.15.0"
+tests:
+  - it: "defaults metadata.namespace to the release namespace when namespaceOverride is unset"
+    templates:
+      - deployment.yaml
+      - service.yaml
+      - serviceaccount.yaml
+      - secret.yaml
+    set:
+      secretConfiguration:
+        enabled: true
+        mountPath: "/etc/kubernetes/"
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: release-ns
+
+  - it: "routes metadata.namespace through namespaceOverride when it is set"
+    templates:
+      - deployment.yaml
+      - service.yaml
+      - serviceaccount.yaml
+      - secret.yaml
+    set:
+      namespaceOverride: chart-ns
+      secretConfiguration:
+        enabled: true
+        mountPath: "/etc/kubernetes/"
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: chart-ns
+
+  - it: "cascades namespaceOverride into the --namespace flag when namespaced is true"
+    templates:
+      - deployment.yaml
+    set:
+      namespaceOverride: chart-ns
+      namespaced: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --namespace=chart-ns
+
+  - it: "still lets serviceMonitor.namespace override namespaceOverride for the ServiceMonitor resource"
+    templates:
+      - servicemonitor.yaml
+    set:
+      namespaceOverride: chart-ns
+      serviceMonitor:
+        enabled: true
+        namespace: metrics-ns
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: metrics-ns
+
+  - it: "ClusterRoleBinding subjects[].namespace follows namespaceOverride"
+    templates:
+      - clusterrolebinding.yaml
+    set:
+      namespaceOverride: chart-ns
+    asserts:
+      - equal:
+          path: subjects[0].namespace
+          value: chart-ns

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -253,6 +253,13 @@
         "null"
       ]
     },
+    "namespaceOverride": {
+      "description": "Override the namespace that chart resources are rendered into. Defaults to the release namespace. Useful when installing the chart as a subchart that should live in its own namespace, separate from the umbrella release namespace.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "namespaced": {
       "description": "if `true`, _ExternalDNS_ will run in a namespaced scope (`Role`` and `Rolebinding`` will be namespaced too).",
       "type": "boolean"

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -23,6 +23,12 @@ nameOverride:  # @schema type:[string, null]; default: null
 # -- (string) Override the full name of the chart.
 fullnameOverride:  # @schema type:[string, null]; default: null
 
+# -- (string) Override the namespace that chart resources are rendered into.
+# Defaults to the release namespace. Useful when installing the chart as a
+# subchart that should live in its own namespace, separate from the umbrella
+# release namespace.
+namespaceOverride:  # @schema type:[string, null]; default: null
+
 # -- Labels to add to all chart resources.
 commonLabels: {}
 


### PR DESCRIPTION
## Description

When external-dns is installed as a subchart of an umbrella chart, every resource it renders is pinned to `.Release.Namespace`, which is the umbrella chart's namespace. Users who want the subchart's resources to land in a dedicated namespace (as is common for contour/cert-manager/etc) have no way to override it today, short of forking the chart. This is the scenario described in #6379.

### Changes

- Added a `namespaceOverride` value in `values.yaml` (null by default, preserving existing behaviour).
- Added an `external-dns.namespace` template helper in `_helpers.tpl` that falls back to `.Release.Namespace` when the override is unset.
- Routed every `{{ .Release.Namespace }}` reference in the chart templates through the helper (8 files, 10 references).
- Adjusted the ServiceMonitor template's existing `serviceMonitor.namespace` override to cascade against `external-dns.namespace` rather than the raw release namespace, so chart-level and resource-level overrides compose.

### Verification

```
$ helm template test charts/external-dns --namespace release-ns | grep '^  namespace:' | sort -u
  namespace: release-ns

$ helm template test charts/external-dns --namespace release-ns --set namespaceOverride=chart-ns | grep '^  namespace:' | sort -u
  namespace: chart-ns
```

Closes #6379