### PR TITLE
docs(tutorials/ovh): Add single-link credential creation

### DIFF
--- a/docs/tutorials/ovh.md
+++ b/docs/tutorials/ovh.md
@@ -20,7 +20,9 @@ You first need to create an OVHcloud application: follow the
 [OVHcloud documentation](https://help.ovhcloud.com/csm/en-gb-api-getting-started-ovhcloud-api?id=kb_article_view&sysparm_article=KB0042784#advanced-usage-pair-ovhcloud-apis-with-an-application)
  you will have your `Application key` and `Application secret`
 
-And you will need to generate your consumer key, here the permissions needed :
+And you will need to generate your consumer key, just open this link in a browser and sign in with your OVHCloud account: https://auth.eu.ovhcloud.com/api/createToken?GET=/domain/zone&GET=/domain/zone/*/record&GET=/domain/zone/*/record/*&PUT=/domain/zone/*/record/*&POST=/domain/zone/*/record&DELETE=/domain/zone/*/record/*&GET=/domain/zone/*/soa&POST=/domain/zone/*/refresh
+
+or check here the permissions needed :
 
 - GET on `/domain/zone`
 - GET on `/domain/zone/*/record`


### PR DESCRIPTION
## What does it do ?

Add single link credential creation to OVHCloud docs instead of sending to their own confusing docs for credential creation.

## Motivation

I got confused by the current docs and then a friend showed me the single link with HTTP query params way of creating a token with specific credentials.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
