### PR TITLE
fix(source): SingletonClientGenerator once-init errors

### DIFF
--- a/source/store.go
+++ b/source/store.go
@@ -253,139 +253,117 @@ type ClientGenerator interface {
 //
 // Configuration: Clients are configured using KubeConfig, APIServerURL, RequestTimeout,
 // QPS, and Burst which are set during SingletonClientGenerator initialization.
-//
-// TODO: Fix error handling pattern in client methods. Current implementation has a bug where
-// errors are only returned on the first call due to sync.Once behavior. If initialization fails
-// on the first call, subsequent calls return (nil, nil) instead of (nil, originalError), which
-// can lead to nil pointer dereferences. Solution: Store error in a field alongside the client,
-// similar to how the client itself is stored. Example:
-//
-//	type SingletonClientGenerator struct {
-//	    restConfig    *rest.Config
-//	    restConfigErr error        // Store error persistently
-//	    restConfigOnce sync.Once
-//	}
-//
-//	func (p *SingletonClientGenerator) RESTConfig() (*rest.Config, error) {
-//	    p.restConfigOnce.Do(func() {
-//	        p.restConfig, p.restConfigErr = kubeclient.InstrumentedRESTConfig(...)
-//	    })
-//	    return p.restConfig, p.restConfigErr  // Return stored error
-//	}
-//
-// This pattern should be applied to all client methods: KubeClient, GatewayClient,
-// DynamicKubernetesClient, OpenShiftClient, and RESTConfig.
 type SingletonClientGenerator struct {
-	KubeConfig      string
-	APIServerURL    string
-	RequestTimeout  time.Duration
-	QPS             int
-	Burst           int
-	restConfig      *rest.Config
-	kubeClient      kubernetes.Interface
-	gatewayClient   gateway.Interface
-	istioClient     *istioclient.Clientset
-	dynKubeClient   dynamic.Interface
-	openshiftClient openshift.Interface
-	restConfigOnce  sync.Once
-	kubeOnce        sync.Once
-	gatewayOnce     sync.Once
-	istioOnce       sync.Once
-	dynCliOnce      sync.Once
-	openshiftOnce   sync.Once
+	KubeConfig         string
+	APIServerURL       string
+	RequestTimeout     time.Duration
+	QPS                int
+	Burst              int
+	restConfig         *rest.Config
+	restConfigErr      error
+	kubeClient         kubernetes.Interface
+	kubeClientErr      error
+	gatewayClient      gateway.Interface
+	gatewayClientErr   error
+	istioClient        *istioclient.Clientset
+	istioClientErr     error
+	dynKubeClient      dynamic.Interface
+	dynKubeClientErr   error
+	openshiftClient    openshift.Interface
+	openshiftClientErr error
+	restConfigOnce     sync.Once
+	kubeOnce           sync.Once
+	gatewayOnce        sync.Once
+	istioOnce          sync.Once
+	dynCliOnce         sync.Once
+	openshiftOnce      sync.Once
 }
 
 // KubeClient generates a kube client if it was not created before
 func (p *SingletonClientGenerator) KubeClient() (kubernetes.Interface, error) {
-	var err error
 	p.kubeOnce.Do(func() {
 		var config *rest.Config
-		config, err = p.RESTConfig()
-		if err != nil {
+		config, p.kubeClientErr = p.RESTConfig()
+		if p.kubeClientErr != nil {
 			return
 		}
-		p.kubeClient, err = kubeclient.NewKubeClient(config)
+		p.kubeClient, p.kubeClientErr = kubeclient.NewKubeClient(config)
 	})
-	return p.kubeClient, err
+	return p.kubeClient, p.kubeClientErr
 }
 
 // RESTConfig generates an instrumented REST config if it was not created before.
 // The config includes request timeout handling and metrics instrumentation.
 // This is useful for sources that need to create custom clients (e.g., controller-runtime clients).
 func (p *SingletonClientGenerator) RESTConfig() (*rest.Config, error) {
-	var err error
 	p.restConfigOnce.Do(func() {
-		p.restConfig, err = kubeclient.InstrumentedRESTConfig(p.KubeConfig, p.APIServerURL, p.RequestTimeout, p.QPS, p.Burst)
+		p.restConfig, p.restConfigErr = kubeclient.InstrumentedRESTConfig(p.KubeConfig, p.APIServerURL, p.RequestTimeout, p.QPS, p.Burst)
 	})
-	return p.restConfig, err
+	return p.restConfig, p.restConfigErr
 }
 
 // GatewayClient generates a gateway client if it was not created before
 func (p *SingletonClientGenerator) GatewayClient() (gateway.Interface, error) {
-	var err error
 	p.gatewayOnce.Do(func() {
 		var config *rest.Config
-		config, err = p.RESTConfig()
-		if err != nil {
+		config, p.gatewayClientErr = p.RESTConfig()
+		if p.gatewayClientErr != nil {
 			return
 		}
-		p.gatewayClient, err = gateway.NewForConfig(config)
-		if err != nil {
+		p.gatewayClient, p.gatewayClientErr = gateway.NewForConfig(config)
+		if p.gatewayClientErr != nil {
 			return
 		}
 		log.Infof("Created GatewayAPI client %s", config.Host)
 	})
-	return p.gatewayClient, err
+	return p.gatewayClient, p.gatewayClientErr
 }
 
 // IstioClient generates an istio go client if it was not created before
 func (p *SingletonClientGenerator) IstioClient() (istioclient.Interface, error) {
-	var err error
 	p.istioOnce.Do(func() {
 		var config *rest.Config
-		config, err = p.RESTConfig()
-		if err != nil {
+		config, p.istioClientErr = p.RESTConfig()
+		if p.istioClientErr != nil {
 			return
 		}
-		p.istioClient, err = NewIstioClient(config)
+		p.istioClient, p.istioClientErr = NewIstioClient(config)
 	})
-	return p.istioClient, err
+	return p.istioClient, p.istioClientErr
 }
 
 // DynamicKubernetesClient generates a dynamic client if it was not created before
 func (p *SingletonClientGenerator) DynamicKubernetesClient() (dynamic.Interface, error) {
-	var err error
 	p.dynCliOnce.Do(func() {
 		var config *rest.Config
-		config, err = p.RESTConfig()
-		if err != nil {
+		config, p.dynKubeClientErr = p.RESTConfig()
+		if p.dynKubeClientErr != nil {
 			return
 		}
-		p.dynKubeClient, err = dynamic.NewForConfig(config)
-		if err != nil {
+		p.dynKubeClient, p.dynKubeClientErr = dynamic.NewForConfig(config)
+		if p.dynKubeClientErr != nil {
 			return
 		}
 		log.Infof("Created Dynamic Kubernetes client %s", config.Host)
 	})
-	return p.dynKubeClient, err
+	return p.dynKubeClient, p.dynKubeClientErr
 }
 
 // OpenShiftClient generates an openshift client if it was not created before
 func (p *SingletonClientGenerator) OpenShiftClient() (openshift.Interface, error) {
-	var err error
 	p.openshiftOnce.Do(func() {
 		var config *rest.Config
-		config, err = p.RESTConfig()
-		if err != nil {
+		config, p.openshiftClientErr = p.RESTConfig()
+		if p.openshiftClientErr != nil {
 			return
 		}
-		p.openshiftClient, err = openshift.NewForConfig(config)
-		if err != nil {
+		p.openshiftClient, p.openshiftClientErr = openshift.NewForConfig(config)
+		if p.openshiftClientErr != nil {
 			return
 		}
 		log.Infof("Created OpenShift client %s", config.Host)
 	})
-	return p.openshiftClient, err
+	return p.openshiftClient, p.openshiftClientErr
 }
 
 // ByNames returns multiple Sources given multiple names.

--- a/source/store_test.go
+++ b/source/store_test.go
@@ -314,13 +314,50 @@ func TestSingletonClientGenerator_RESTConfig_SharedAcrossClients(t *testing.T) {
 	assert.Same(t, restConfig1, gen.restConfig,
 		"Internal restConfig field should match returned value")
 
-	// Verify first call had error (no valid kubeconfig)
+	// All calls should return the same error
 	assert.Error(t, err1, "First call should return error when kubeconfig is invalid")
+	assert.Equal(t, err1, err2, "Second call should return same error as first call")
+	assert.Equal(t, err1, err3, "Third call should return same error as first call")
+}
 
-	// Due to sync.Once bug, subsequent calls won't return the error
-	// This is documented in the TODO comment on SingletonClientGenerator
-	require.NoError(t, err2, "Second call does not return error due to sync.Once bug")
-	require.NoError(t, err3, "Third call does not return error due to sync.Once bug")
+// TestSingletonClientGenerator_ErrorPersistence verifies that initialization errors
+// are persisted in struct fields and returned consistently on every subsequent call.
+func TestSingletonClientGenerator_ErrorPersistence(t *testing.T) {
+	gen := &SingletonClientGenerator{
+		KubeConfig:     "/nonexistent/path/to/kubeconfig",
+		APIServerURL:   "",
+		RequestTimeout: 30 * time.Second,
+	}
+
+	methods := []struct {
+		name string
+		call func() (any, error)
+	}{
+		{"RESTConfig", func() (any, error) { return gen.RESTConfig() }},
+		{"KubeClient", func() (any, error) { return gen.KubeClient() }},
+		{"GatewayClient", func() (any, error) { return gen.GatewayClient() }},
+		{"IstioClient", func() (any, error) { return gen.IstioClient() }},
+		{"DynamicKubernetesClient", func() (any, error) { return gen.DynamicKubernetesClient() }},
+		{"OpenShiftClient", func() (any, error) { return gen.OpenShiftClient() }},
+	}
+
+	for _, m := range methods {
+		t.Run(m.name, func(t *testing.T) {
+			client1, err1 := m.call()
+			require.Error(t, err1, "first call must return an error for invalid kubeconfig")
+			assert.Nil(t, client1, "first call must return nil client on error")
+
+			client2, err2 := m.call()
+			require.Error(t, err2, "second call must still return the init error, not nil")
+			assert.Nil(t, client2, "second call must return nil client on error")
+			assert.Equal(t, err1, err2, "second call must return the same error as first call")
+
+			client3, err3 := m.call()
+			require.Error(t, err3, "third call must still return the init error, not nil")
+			assert.Nil(t, client3, "third call must return nil client on error")
+			assert.Equal(t, err1, err3, "third call must return the same error as first call")
+		})
+	}
 }
 
 func TestNewSourceConfig(t *testing.T) {


### PR DESCRIPTION
## What does it do ?

SingletonClientGenerator now keeps initialization errors in struct fields and returns the same error on every later call. Before, a failed sync.Once init could return a non‑nil error once and then (nil, nil) on the next call because the per‑call err variable was reset. RESTConfig, KubeClient, and the other client helpers use this pattern consistently. The old large TODO on this type is removed, and the tests that previously expected the wrong behavior are updated, with an added table test for error persistence across all generator methods.

## Motivation

Initialization failures should be returned reliably so callers (and the rest of the codebase) never see a false “success” (nil error) with a nil client after a failed first attempt. A TODO in the tree already called out this sync.Once + err bug; this change implements that fix and aligns tests with the intended contract.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
