### PR TITLE
feat(chart): add support to create kubernetes service

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add value `.service.enabled` to enable the creation of the Kubernetes service.
 - Add value `.sourceNamespace` to watch a namespace which is different from the one that external-dns is installed into when `.namespaced` is true. ([#6297](https://github.com/kubernetes-sigs/external-dns/pull/6297)) _@jplitza_
 - Add option to enable Gateway API ListenerSet support. ([#6381](https://github.com/kubernetes-sigs/external-dns/pull/6381)) _@speer_
 - Add support for bool in extraArgs. ([#6179](https://github.com/kubernetes-sigs/external-dns/pull/6179)) _@farodin91_

--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -327,11 +327,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 RELEASE LINKS
 -->
 [UNRELEASED]: https://github.com/kubernetes-sigs/external-dns/tree/master/charts/external-dns
-<<<<<<< HEAD
 [v1.21.1]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.21.1
-=======
-[v1.21.0]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.21.0
->>>>>>> 0d116fa6 (chore(chart): release for v0.21.0 (#6354))
 [v1.20.0]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.20.0
 [v1.19.0]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.19.0
 [v1.18.0]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.18.0

--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,11 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+- Add value `.service.enabled` to enable the creation of the Kubernetes service.
+
 ## [v1.21.1]
 
 ### Added
 
-- Add value `.service.enabled` to enable the creation of the Kubernetes service.
 - Add value `.sourceNamespace` to watch a namespace which is different from the one that external-dns is installed into when `.namespaced` is true. ([#6297](https://github.com/kubernetes-sigs/external-dns/pull/6297)) _@jplitza_
 - Add option to enable Gateway API ListenerSet support. ([#6381](https://github.com/kubernetes-sigs/external-dns/pull/6381)) _@speer_
 - Add support for bool in extraArgs. ([#6179](https://github.com/kubernetes-sigs/external-dns/pull/6179)) _@farodin91_
@@ -326,7 +327,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 RELEASE LINKS
 -->
 [UNRELEASED]: https://github.com/kubernetes-sigs/external-dns/tree/master/charts/external-dns
+<<<<<<< HEAD
 [v1.21.1]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.21.1
+=======
+[v1.21.0]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.21.0
+>>>>>>> 0d116fa6 (chore(chart): release for v0.21.0 (#6354))
 [v1.20.0]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.20.0
 [v1.19.0]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.19.0
 [v1.18.0]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.18.0

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -161,6 +161,7 @@ If `namespaced` is set to `true`, please ensure that `sources` only contains sup
 | secretConfiguration.subPath | string | `nil` | Sub-path for mounting the `Secret`, this can be templated. |
 | securityContext | object | See _values.yaml_ | [Security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) for the `external-dns` container. |
 | service.annotations | object | `{}` | Service annotations. |
+| service.enabled | bool | `true` | If `true`, create a `Service` Kubernetes. |
 | service.ipFamilies | list | `[]` | Service IP families (e.g. IPv4 and/or IPv6). |
 | service.ipFamilyPolicy | string | `nil` | Service IP family policy. |
 | service.port | int | `7979` | Service HTTP port. |

--- a/charts/external-dns/templates/service.yaml
+++ b/charts/external-dns/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service.enabled -}}
 {{- $providerName := include "external-dns.providerName" . }}
 apiVersion: v1
 kind: Service
@@ -34,3 +35,4 @@ spec:
       protocol: TCP
     {{- end }}
     {{- end }}
+{{- end }}

--- a/charts/external-dns/tests/service_test.yaml
+++ b/charts/external-dns/tests/service_test.yaml
@@ -1,0 +1,26 @@
+suite: Service configuration
+templates:
+  - service.yaml
+release:
+  namespace: default
+tests:
+  - it: should provide a single service by default
+    asserts:
+      - isKind:
+            of: Service
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].port
+          value: 7979
+
+  - it: should provide a way to disable the service
+    set:
+      service:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -713,6 +713,10 @@
           "description": "Service annotations.",
           "type": "object"
         },
+        "enabled": {
+          "description": "If `true`, create a `Service` Kubernetes.",
+          "type": "boolean"
+        },
         "ipFamilies": {
           "description": "Service IP families (e.g. IPv4 and/or IPv6).",
           "type": [
@@ -748,10 +752,6 @@
           "default": 7979,
           "type": "integer",
           "minimum": 0
-        },
-        "enabled": {
-          "description": "If `true`, create a `Service` Kubernetes.",
-          "type": "boolean"
         }
       }
     },

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -748,6 +748,10 @@
           "default": 7979,
           "type": "integer",
           "minimum": 0
+        },
+        "enabled": {
+          "description": "If `true`, create a `Service` Kubernetes.",
+          "type": "boolean"
         }
       }
     },

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -55,6 +55,8 @@ service:
   #  - IPv6
   # -- Service IP family policy.
   ipFamilyPolicy:  # @schema type: [string, null];  enum:[SingleStack, PreferDualStack, RequireDualStack, null]
+  # -- If `true`, create a `Service` Kubernetes.
+  enabled: true
 
 rbac:  # @schema additionalProperties: true
   # -- If `true`, create a `ClusterRole` & `ClusterRoleBinding` with access to the Kubernetes API.


### PR DESCRIPTION
## What does it do ?
It provides the possibility to disable the creation of the Kubernetes service for the service.
<!-- A brief description of the change being made with this pull request. -->

## Motivation
In cases where you don't want a Service to be created, for security reasons or something similar, disabling service creation is essential.

For example, in cases where we have Google Managed Prometheus PodMonitoring, the metrics collector communicates directly with the Pod's port. This way, a Service exposing the Pod's port is not needed.
<!-- What inspired you to submit this pull request? -->

## More

- [ ] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
