### PR TITLE
docs(webhook): add Porkbun webhook provider to registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ from the usage of any externally developed webhook.
 | Netic                 | https://github.com/neticdk/external-dns-tidydns-webhook              |
 | OpenStack Designate   | https://github.com/inovex/external-dns-designate-webhook             |
 | OpenWRT               | https://github.com/renanqts/external-dns-openwrt-webhook             |
+| Porkbun               | https://github.com/mattgmoser/external-dns-porkbun-webhook           |
 | PS Cloud Services     | https://github.com/supervillain3000/external-dns-pscloud-webhook     |
 | SAKURA Cloud          | https://github.com/sacloud/external-dns-sacloud-webhook              |
 | Simply                | https://github.com/uozalp/external-dns-simply-webhook                |


### PR DESCRIPTION
## What this changes

Adds an entry under "Provider registry" in `docs/tutorials/webhook-provider.md` pointing at a community Porkbun webhook implementation: [mattgmoser/external-dns-porkbun-webhook](https://github.com/mattgmoser/external-dns-porkbun-webhook).

## Why

The doc currently has a "Provider registry" section that explicitly says "we will accept pull requests that will add links to providers in this documentation" but no entries yet. Porkbun isn't a built-in provider; users searching for it find dated/incomplete community webhooks. This adds one canonical pointer.

## About the project

- Apache-2.0
- Multi-arch images on GHCR (`linux/amd64`, `linux/arm64`, `linux/arm/v7`)
- Helm chart with optional `ServiceMonitor`
- Distroless static container (~15 MB), runs as nonroot
- Implements the v1 webhook protocol (Records, ApplyChanges, AdjustEndpoints, GetDomainFilter)
- Built-in rate limiting (Porkbun enforces 1 req/sec per key) and retry-with-backoff
- Comprehensive unit tests with an in-memory mock Porkbun API

## Verification done

- Builds, tests, golangci-lint all green in CI
- Deployed in production (Raspberry Pi k3s cluster) and verified end-to-end: new Ingress hostname → Porkbun A record auto-created within ~75 seconds

Happy to add columns or restructure the table format if you'd prefer something different — also open to a PR template defining what a registry entry should look like, since this is the first.
