### PR TITLE
fix(source/fake.go): make fakeSource endpoint generation deterministic

### DIFF
--- a/source/fake.go
+++ b/source/fake.go
@@ -45,6 +45,7 @@ import (
 // +externaldns:source:provider-specific=false
 type fakeSource struct {
 	dnsNames []string
+	rand     *rand.Rand
 }
 
 const (
@@ -79,7 +80,8 @@ func NewFakeSource(cfg *Config) (Source, error) {
 			dnsNames = hostnames
 		}
 	}
-	return &fakeSource{dnsNames: dnsNames}, nil
+	rand := rand.New(rand.NewSource(9673))
+	return &fakeSource{dnsNames: dnsNames, rand: rand}, nil
 }
 
 func (sc *fakeSource) AddEventHandler(_ context.Context, _ func()) {
@@ -108,28 +110,28 @@ func (sc *fakeSource) generateEndpointForType(recordType, dnsName string) (*endp
 
 	switch recordType {
 	case endpoint.RecordTypeA:
-		ep = endpoint.NewEndpoint(generateDNSName(4, dnsName), endpoint.RecordTypeA, generateTargets(len(sc.dnsNames), generateIPv4Address)...)
+		ep = endpoint.NewEndpoint(sc.generateDNSName(4, dnsName), endpoint.RecordTypeA, generateTargets(len(sc.dnsNames), sc.generateIPv4Address)...)
 	case endpoint.RecordTypeAAAA:
-		ep = endpoint.NewEndpoint(generateDNSName(4, dnsName), endpoint.RecordTypeAAAA, generateTargets(len(sc.dnsNames), generateIPv6Address)...)
+		ep = endpoint.NewEndpoint(sc.generateDNSName(4, dnsName), endpoint.RecordTypeAAAA, generateTargets(len(sc.dnsNames), sc.generateIPv6Address)...)
 	case endpoint.RecordTypeCNAME:
-		ep = endpoint.NewEndpoint(generateDNSName(4, dnsName), endpoint.RecordTypeCNAME, generateDNSName(4, dnsName))
+		ep = endpoint.NewEndpoint(sc.generateDNSName(4, dnsName), endpoint.RecordTypeCNAME, sc.generateDNSName(4, dnsName))
 	case endpoint.RecordTypeTXT:
-		ep = endpoint.NewEndpoint(generateDNSName(4, dnsName), endpoint.RecordTypeTXT, `"heritage=external-dns,external-dns/owner=fake"`)
+		ep = endpoint.NewEndpoint(sc.generateDNSName(4, dnsName), endpoint.RecordTypeTXT, `"heritage=external-dns,external-dns/owner=fake"`)
 	case endpoint.RecordTypeSRV:
 		// SRV target format: "priority weight port target." (target must end with a dot per RFC 2782)
-		name := generateDNSName(4, dnsName)
+		name := sc.generateDNSName(4, dnsName)
 		ep = endpoint.NewEndpoint(fmt.Sprintf("_sip._udp.%s", dnsName), endpoint.RecordTypeSRV, fmt.Sprintf("10 20 5060 %s.", name))
 	case endpoint.RecordTypeNS:
-		ep = endpoint.NewEndpoint(dnsName, endpoint.RecordTypeNS, generateDNSName(3, dnsName))
+		ep = endpoint.NewEndpoint(dnsName, endpoint.RecordTypeNS, sc.generateDNSName(3, dnsName))
 	case endpoint.RecordTypePTR:
-		name := generateDNSName(4, dnsName)
+		name := sc.generateDNSName(4, dnsName)
 		var err error
-		ep, err = endpoint.NewPTREndpoint(generateIPv4Address(), endpoint.TTL(0), name)
+		ep, err = endpoint.NewPTREndpoint(sc.generateIPv4Address(), endpoint.TTL(0), name)
 		if err != nil {
 			return nil, err
 		}
 	case endpoint.RecordTypeMX:
-		ep = endpoint.NewEndpoint(dnsName, endpoint.RecordTypeMX, fmt.Sprintf("10 %s", generateDNSName(4, dnsName)))
+		ep = endpoint.NewEndpoint(dnsName, endpoint.RecordTypeMX, fmt.Sprintf("10 %s", sc.generateDNSName(4, dnsName)))
 	case endpoint.RecordTypeNAPTR:
 		// NAPTR target format: "order preference flags service regexp replacement"
 		ep = endpoint.NewEndpoint(fmt.Sprintf("_sip._udp.%s", dnsName), endpoint.RecordTypeNAPTR, fmt.Sprintf(`100 10 "u" "E2U+sip" "!^.*$!sip:info@%s!" .`, dnsName))
@@ -148,19 +150,19 @@ func (sc *fakeSource) generateEndpointForType(recordType, dnsName string) (*endp
 	return ep, nil
 }
 
-func generateIPv4Address() string {
+func (sc *fakeSource) generateIPv4Address() string {
 	// 192.0.2.[1-254] is reserved by RFC 5737 for documentation and examples
 	return net.IPv4(
 		byte(192),
 		byte(0),
 		byte(2),
-		byte(rand.Intn(253)+1),
+		byte(sc.rand.Intn(253)+1),
 	).String()
 }
 
-func generateIPv6Address() string {
+func (sc *fakeSource) generateIPv6Address() string {
 	// 2001:db8::/32 is reserved by RFC 3849 for documentation and examples
-	return fmt.Sprintf("2001:db8::%x:%x", rand.Intn(0xffff)+1, rand.Intn(0xffff)+1)
+	return fmt.Sprintf("2001:db8::%x:%x", sc.rand.Intn(0xffff)+1, sc.rand.Intn(0xffff)+1)
 }
 
 // fakePodName returns a valid Kubernetes object name for the fake Pod associated
@@ -183,10 +185,10 @@ func generateTargets(n int, gen func() string) []string {
 	return targets
 }
 
-func generateDNSName(prefixLength int, dnsName string) string {
+func (sc *fakeSource) generateDNSName(prefixLength int, dnsName string) string {
 	prefix := make([]rune, prefixLength)
 	for i := range prefix {
-		prefix[i] = letterRunes[rand.Intn(len(letterRunes))]
+		prefix[i] = letterRunes[sc.rand.Intn(len(letterRunes))]
 	}
 	return fmt.Sprintf("%s.%s", string(prefix), dnsName)
 }


### PR DESCRIPTION
## What does it do ?

Refactors the `fakeSource` implementation to use a deterministic random number generator for generating fake DNS endpoints.

## Motivation

The previous implementation used the global `math/rand` generator, which led to non-deterministic behavior in tests. This caused flaky tests due to occasional random collisions in generated endpoint names or addresses, resulting in an unexpected number of endpoints. By introducing a deterministic random generator, endpoint generation is now stable and repeatable.

Example of flaky test : https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_external-dns/5821/pull-external-dns-unit-test/2050990094071894016
```
 --- FAIL: TestFakeSource_FQDNTemplate_MultiDomain (0.00s)
    fake_test.go:200: 
        	Error Trace:	/home/prow/go/src/github.com/kubernetes-sigs/external-dns/source/fake_test.go:200
        	Error:      	"[hxpm.three.example.com 0 IN TXT fake "heritage=external-dns,external-dns/owner=fake" [] skqb.two.example.com 0 IN A fake 192.0.2.192;192.0.2.238;192.0.2.97 [] cbmi.two.example.com 0 IN AAAA fake 2001:db8::1102:37d3;2001:db8::157d:88e4;2001:db8::a2ba:6215 [] fifx.one.example.com 0 IN AAAA fake 2001:db8::25e8:e20c;2001:db8::b86e:fcdc;2001:db8::cc4d:de7d [] _sip._udp.one.example.com 0 IN SRV fake 10 20 5060 dvaz.one.example.com. [] one.example.com 0 IN NS fake cpp.one.example.com [] 210.2.0.192.in-addr.arpa 0 IN PTR fake eaem.one.example.com;pria.three.example.com [] three.example.com 0 IN NS fake jlo.three.example.com [] ebtp.two.example.com 0 IN TXT fake "heritage=external-dns,external-dns/owner=fake" [] _sip._udp.two.example.com 0 IN SRV fake 10 20 5060 drqz.two.example.com. [] two.example.com 0 IN NS fake iqj.two.example.com [] jmba.one.example.com 0 IN A fake 192.0.2.154;192.0.2.26;192.0.2.49 [] _sip._udp.one.example.com 0 IN NAPTR fake 100 10 "u" "E2U+sip" "!^.*$!sip:info@one.example.com!" . [] _sip._udp.three.example.com 0 IN SRV fake 10 20 5060 vrts.three.example.com. [] three.example.com 0 IN MX fake 10 labt.three.example.com [] tnpm.two.example.com 0 IN CNAME fake zgya.two.example.com [] 158.2.0.192.in-addr.arpa 0 IN PTR fake axul.two.example.com [] two.example.com 0 IN MX fake 10 omnj.two.example.com [] _sip._udp.two.example.com 0 IN NAPTR fake 100 10 "u" "E2U+sip" "!^.*$!sip:info@two.example.com!" . [] pbsv.three.example.com 0 IN A fake 192.0.2.138;192.0.2.171;192.0.2.52 [] _sip._udp.three.example.com 0 IN NAPTR fake 100 10 "u" "E2U+sip" "!^.*$!sip:info@three.example.com!" . [] dpnm.one.example.com 0 IN CNAME fake gbcv.one.example.com [] wdxd.one.example.com 0 IN TXT fake "heritage=external-dns,external-dns/owner=fake" [] one.example.com 0 IN MX fake 10 ldxu.one.example.com [] guft.three.example.com 0 IN AAAA fake 2001:db8::15b2:e744;2001:db8::3cf1:3240;2001:db8::810b:9fc5 [] dhok.three.example.com 0 IN CNAME fake vjik.three.example.com []]" should have 27 item(s), but has 26
        	Test:       	TestFakeSource_FQDNTemplate_MultiDomain
E0503 17:33:20.223608   21922 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: <nil>" logger="UnhandledError"
E0503 17:33:20.326424   21922 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: <nil>" logger="UnhandledError"
FAIL
FAIL	sigs.k8s.io/external-dns/source	82.398s

```
<!-- What inspired you to submit this pull request? -->

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
