### PR TITLE
feat(test/crd): support CRD integration tests

### DIFF
--- a/source/crd.go
+++ b/source/crd.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
@@ -227,6 +228,10 @@ func buildCacheOptions(namespace string, labelFilter, annotationSelector labels.
 	if err := apiv1alpha1.AddToScheme(scheme); err != nil {
 		return crcache.Options{}, err
 	}
+	// metav1.AddToGroupVersion registers ListOptions (and other meta types) under
+	// apiv1alpha1.GroupVersion so that runtime.NewParameterCodec can encode them
+	// as URL parameters when building watch requests for this group.
+	metav1.AddToGroupVersion(scheme, apiv1alpha1.GroupVersion)
 
 	nsMap := map[string]crcache.Config{
 		namespace: {}, // "" == NamespaceAll

--- a/tests/integration/scenarios/tests.yaml
+++ b/tests/integration/scenarios/tests.yaml
@@ -337,3 +337,136 @@ scenarios:
       - dnsName: example.local
         targets: ["b.elb.example.com"]
         recordType: CNAME
+
+# CRD
+  - name: crd-a-record
+    description: >
+      A DNSEndpoint with an A record creates the correct DNS entry.
+    config:
+      sources: ["crd"]
+    resources:
+      - resource:
+          apiVersion: externaldns.k8s.io/v1alpha1
+          kind: DNSEndpoint
+          metadata:
+            name: my-dns
+            namespace: default
+          spec:
+            endpoints:
+              - dnsName: www.example.com
+                targets:
+                  - 1.2.3.4
+                recordType: A
+                recordTTL: 300
+    expected:
+      - dnsName: www.example.com
+        targets: ["1.2.3.4"]
+        recordType: A
+        recordTTL: 300
+
+  - name: crd-cname-record
+    description: >
+      A DNSEndpoint with a CNAME record creates the correct DNS entry.
+    config:
+      sources: ["crd"]
+    resources:
+      - resource:
+          apiVersion: externaldns.k8s.io/v1alpha1
+          kind: DNSEndpoint
+          metadata:
+            name: my-cname
+            namespace: default
+          spec:
+            endpoints:
+              - dnsName: alias.example.com
+                targets:
+                  - target.example.com
+                recordType: CNAME
+                recordTTL: 180
+    expected:
+      - dnsName: alias.example.com
+        targets: ["target.example.com"]
+        recordType: CNAME
+        recordTTL: 180
+
+  - name: crd-multiple-endpoints
+    description: >
+      A DNSEndpoint with multiple spec.endpoints entries produces one DNS record
+      per entry. MergeEndpoints combines entries sharing the same dnsName and
+      recordType into a single multi-target record.
+    config:
+      sources: ["crd"]
+    resources:
+      - resource:
+          apiVersion: externaldns.k8s.io/v1alpha1
+          kind: DNSEndpoint
+          metadata:
+            name: multi-dns
+            namespace: default
+          spec:
+            endpoints:
+              - dnsName: multi.example.com
+                targets:
+                  - 1.2.3.4
+                  - 5.6.7.8
+                recordType: A
+                recordTTL: 60
+              - dnsName: alias.example.com
+                targets:
+                  - multi.example.com
+                recordType: CNAME
+                recordTTL: 60
+    expected:
+      - dnsName: multi.example.com
+        targets: ["1.2.3.4", "5.6.7.8"]
+        recordType: A
+        recordTTL: 60
+      - dnsName: alias.example.com
+        targets: ["multi.example.com"]
+        recordType: CNAME
+        recordTTL: 60
+
+  - name: crd-and-service
+    description: >
+      When both the crd and service sources are active, endpoints from each
+      source are combined. The crd source contributes an A record for
+      api.example.com and the service source contributes an A record for
+      svc.example.com.
+    config:
+      sources: ["crd", "service"]
+    resources:
+      - resource:
+          apiVersion: externaldns.k8s.io/v1alpha1
+          kind: DNSEndpoint
+          metadata:
+            name: api-dns
+            namespace: default
+          spec:
+            endpoints:
+              - dnsName: api.example.com
+                targets:
+                  - 10.0.0.1
+                recordType: A
+                recordTTL: 120
+      - resource:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: my-svc
+            namespace: default
+            annotations:
+              external-dns.alpha.kubernetes.io/hostname: svc.example.com
+          spec:
+            type: LoadBalancer
+          status:
+            loadBalancer:
+              ingress:
+                - ip: 10.0.0.2
+    expected:
+      - dnsName: api.example.com
+        targets: ["10.0.0.1"]
+        recordType: A
+        recordTTL: 120
+      - dnsName: svc.example.com
+        targets: ["10.0.0.2"]
+        recordType: A

--- a/tests/integration/source_test.go
+++ b/tests/integration/source_test.go
@@ -47,7 +47,8 @@ func TestParseResources(t *testing.T) {
 			parsed, err := toolkit.ParseResources(scenario.Resources)
 			require.NoError(t, err, "failed to parse resources")
 
-			totalParsed := len(parsed.Services) + len(parsed.Ingresses) + len(parsed.Pods) + len(parsed.EndpointSlices)
+			totalParsed := len(parsed.Services) + len(parsed.Ingresses) + len(parsed.Pods) +
+				len(parsed.EndpointSlices) + len(parsed.DNSEndpoints)
 			// Pods and EndpointSlices may be auto-generated from dependencies, so count
 			// only the explicitly declared resources when checking nothing was silently dropped.
 			explicitResources := 0
@@ -69,11 +70,11 @@ func TestSourceIntegration(t *testing.T) {
 		t.Run(scenario.Name, func(t *testing.T) {
 			ctx := t.Context()
 
-			client, err := toolkit.LoadResources(ctx, scenario)
+			loaded, err := toolkit.LoadResources(ctx, scenario)
 			require.NoError(t, err, "failed to populate resources")
 
 			// Create wrapped source
-			wrappedSource, err := toolkit.CreateWrappedSource(ctx, client, scenario.Config)
+			wrappedSource, err := toolkit.CreateWrappedSource(ctx, loaded, scenario.Config)
 			require.NoError(t, err, "failed to create wrapped source")
 
 			// Get endpoints

--- a/tests/integration/toolkit/crd.go
+++ b/tests/integration/toolkit/crd.go
@@ -253,8 +253,7 @@ func (h *dnsEndpointHandler) serveWatch(w http.ResponseWriter, r *http.Request) 
 	}
 	flusher.Flush()
 
-	// Block until the client closes the connection (after initial sync the
-	// reflector calls w.Stop(), canceling the request context).
+	// Block until the client closes the connection.
 	<-r.Context().Done()
 }
 

--- a/tests/integration/toolkit/crd.go
+++ b/tests/integration/toolkit/crd.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package toolkit
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+
+	apiv1alpha1 "sigs.k8s.io/external-dns/apis/v1alpha1"
+	"sigs.k8s.io/external-dns/internal/testutils"
+)
+
+const (
+	dnsEndpointListKind = "DNSEndpointList"
+	dnsEndpointResource = "dnsendpoints"
+	initialEventsEndKey = "k8s.io/initial-events-end"
+)
+
+// crdClientGenerator wraps a StubClientGenerator and overrides RESTConfig to
+// return a fake API server's config, enabling the CRD source's controller-runtime
+// cache to connect without a real cluster.
+type crdClientGenerator struct {
+	testutils.StubClientGenerator
+	restCfg *rest.Config
+}
+
+func (g crdClientGenerator) RESTConfig() (*rest.Config, error) {
+	return g.restCfg, nil
+}
+
+// newCRDClientGenerator builds a crdClientGenerator backed by the given fake
+// Kubernetes clientset (for non-CRD sources) and the REST config of the fake
+// CRD API server.
+func newCRDClientGenerator(k8sClient *fake.Clientset, restCfg *rest.Config) crdClientGenerator {
+	return crdClientGenerator{
+		StubClientGenerator: testutils.NewFakeClientGenerator(k8sClient),
+		restCfg:             restCfg,
+	}
+}
+
+// newFakeDNSEndpointServer starts a minimal in-process HTTP server that serves
+// just enough of the Kubernetes API for the CRD source's controller-runtime cache
+// to initialize and sync:
+//
+//   - /api, /apis, /apis/externaldns.k8s.io — API discovery
+//   - /apis/externaldns.k8s.io/v1alpha1 — APIResourceList
+//   - /apis/externaldns.k8s.io/v1alpha1/dnsendpoints — List + Watch
+//   - /apis/externaldns.k8s.io/v1alpha1/namespaces/{ns}/dnsendpoints — same
+//
+// The server is closed automatically when ctx is canceled.
+func newFakeDNSEndpointServer(ctx context.Context, dnsEndpoints []*apiv1alpha1.DNSEndpoint) *rest.Config {
+	h := &dnsEndpointHandler{endpoints: dnsEndpoints}
+	srv := httptest.NewServer(h)
+	go func() {
+		<-ctx.Done()
+		srv.Close()
+	}()
+	return &rest.Config{Host: srv.URL}
+}
+
+// dnsEndpointHandler is the HTTP handler for the fake Kubernetes API server.
+type dnsEndpointHandler struct {
+	mu        sync.Mutex
+	endpoints []*apiv1alpha1.DNSEndpoint
+}
+
+func (h *dnsEndpointHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Path
+	isWatch := r.URL.Query().Get("watch") == "true"
+
+	switch {
+	case path == "/api":
+		h.serveAPIVersions(w)
+	case path == "/apis":
+		h.serveAPIGroupList(w)
+	case path == "/apis/"+apiv1alpha1.GroupVersion.Group:
+		h.serveAPIGroup(w)
+	case path == "/apis/"+apiv1alpha1.GroupVersion.String():
+		h.serveAPIResourceList(w)
+	case isDNSEndpointPath(path) && isWatch:
+		h.serveWatch(w, r)
+	case isDNSEndpointPath(path):
+		h.serveList(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func isDNSEndpointPath(path string) bool {
+	return path == "/apis/"+apiv1alpha1.GroupVersion.String()+"/"+dnsEndpointResource ||
+		strings.HasSuffix(path, "/"+dnsEndpointResource)
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (h *dnsEndpointHandler) serveAPIVersions(w http.ResponseWriter) {
+	writeJSON(w, &metav1.APIVersions{
+		TypeMeta:                   metav1.TypeMeta{APIVersion: "v1", Kind: "APIVersions"},
+		ServerAddressByClientCIDRs: []metav1.ServerAddressByClientCIDR{},
+		Versions:                   []string{},
+	})
+}
+
+func (h *dnsEndpointHandler) serveAPIGroupList(w http.ResponseWriter) {
+	gv := metav1.GroupVersionForDiscovery{
+		GroupVersion: apiv1alpha1.GroupVersion.String(),
+		Version:      apiv1alpha1.GroupVersion.Version,
+	}
+	writeJSON(w, &metav1.APIGroupList{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "APIGroupList"},
+		Groups: []metav1.APIGroup{
+			{
+				Name:             apiv1alpha1.GroupVersion.Group,
+				Versions:         []metav1.GroupVersionForDiscovery{gv},
+				PreferredVersion: gv,
+			},
+		},
+	})
+}
+
+func (h *dnsEndpointHandler) serveAPIGroup(w http.ResponseWriter) {
+	gv := metav1.GroupVersionForDiscovery{
+		GroupVersion: apiv1alpha1.GroupVersion.String(),
+		Version:      apiv1alpha1.GroupVersion.Version,
+	}
+	writeJSON(w, &metav1.APIGroup{
+		TypeMeta:         metav1.TypeMeta{APIVersion: "v1", Kind: "APIGroup"},
+		Name:             apiv1alpha1.GroupVersion.Group,
+		Versions:         []metav1.GroupVersionForDiscovery{gv},
+		PreferredVersion: gv,
+	})
+}
+
+func (h *dnsEndpointHandler) serveAPIResourceList(w http.ResponseWriter) {
+	writeJSON(w, &metav1.APIResourceList{
+		TypeMeta:     metav1.TypeMeta{APIVersion: "v1", Kind: "APIResourceList"},
+		GroupVersion: apiv1alpha1.GroupVersion.String(),
+		APIResources: []metav1.APIResource{
+			{
+				Name:         dnsEndpointResource,
+				SingularName: "dnsendpoint",
+				Namespaced:   true,
+				Kind:         apiv1alpha1.DNSEndpointKind,
+				Verbs:        metav1.Verbs{"get", "list", "watch"},
+			},
+		},
+	})
+}
+
+// filteredEndpoints returns copies of all endpoints matching the given namespace
+// (or all endpoints if namespace is empty), with TypeMeta set for API responses.
+func (h *dnsEndpointHandler) filteredEndpoints(ns string) []apiv1alpha1.DNSEndpoint {
+	h.mu.Lock()
+	all := h.endpoints
+	h.mu.Unlock()
+
+	result := make([]apiv1alpha1.DNSEndpoint, 0, len(all))
+	for _, ep := range all {
+		if ns != "" && ep.Namespace != ns {
+			continue
+		}
+		item := *ep
+		item.TypeMeta = metav1.TypeMeta{
+			APIVersion: apiv1alpha1.GroupVersion.String(),
+			Kind:       apiv1alpha1.DNSEndpointKind,
+		}
+		result = append(result, item)
+	}
+	return result
+}
+
+func (h *dnsEndpointHandler) serveList(w http.ResponseWriter, r *http.Request) {
+	items := h.filteredEndpoints(extractNamespace(r.URL.Path))
+	writeJSON(w, &apiv1alpha1.DNSEndpointList{
+		TypeMeta: metav1.TypeMeta{APIVersion: apiv1alpha1.GroupVersion.String(), Kind: dnsEndpointListKind},
+		ListMeta: metav1.ListMeta{ResourceVersion: "1"},
+		Items:    items,
+	})
+}
+
+// bookmarkEvent builds the BOOKMARK watch event object. When initialEventsEnd
+// is true it carries the k8s.io/initial-events-end annotation required by the
+// watchList protocol so the reflector marks the informer as synced.
+func bookmarkEvent(initialEventsEnd bool) map[string]any {
+	meta := map[string]any{"resourceVersion": "1"}
+	if initialEventsEnd {
+		meta["annotations"] = map[string]string{initialEventsEndKey: "true"}
+	}
+	return map[string]any{
+		"type": "BOOKMARK",
+		"object": map[string]any{
+			"apiVersion": apiv1alpha1.GroupVersion.String(),
+			"kind":       apiv1alpha1.DNSEndpointKind,
+			"metadata":   meta,
+		},
+	}
+}
+
+// serveWatch streams watch events so the informer's initial sync completes.
+//
+// client-go v0.35+ uses "watchList": the reflector sends a watch request with
+// sendInitialEvents=true and waits for a BOOKMARK carrying the annotation
+// k8s.io/initial-events-end: "true" before it marks the informer as synced.
+func (h *dnsEndpointHandler) serveWatch(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Transfer-Encoding", "chunked")
+	w.WriteHeader(http.StatusOK)
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return
+	}
+
+	enc := json.NewEncoder(w)
+	sendInitialEvents := r.URL.Query().Get("sendInitialEvents") == "true"
+
+	if sendInitialEvents {
+		for _, item := range h.filteredEndpoints(extractNamespace(r.URL.Path)) {
+			if err := enc.Encode(map[string]any{"type": "ADDED", "object": item}); err != nil {
+				return
+			}
+		}
+	}
+	if err := enc.Encode(bookmarkEvent(sendInitialEvents)); err != nil {
+		return
+	}
+	flusher.Flush()
+
+	// Block until the client closes the connection (after initial sync the
+	// reflector calls w.Stop(), canceling the request context).
+	<-r.Context().Done()
+}
+
+func extractNamespace(path string) string {
+	const prefix = "/apis/externaldns.k8s.io/v1alpha1/namespaces/"
+	if !strings.HasPrefix(path, prefix) {
+		return ""
+	}
+	tail := strings.TrimPrefix(path, prefix)
+	if idx := strings.Index(tail, "/"); idx > 0 {
+		return tail[:idx]
+	}
+	return ""
+}

--- a/tests/integration/toolkit/crd.go
+++ b/tests/integration/toolkit/crd.go
@@ -109,8 +109,8 @@ func (h *dnsEndpointHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func isDNSEndpointPath(path string) bool {
-	return path == "/apis/"+apiv1alpha1.GroupVersion.String()+"/"+dnsEndpointResource ||
-		strings.HasSuffix(path, "/"+dnsEndpointResource)
+	return strings.HasPrefix(path, "/apis/"+apiv1alpha1.GroupVersion.String()) && 
+	       strings.HasSuffix(path, "/"+dnsEndpointResource)
 }
 
 func writeJSON(w http.ResponseWriter, v any) {

--- a/tests/integration/toolkit/crd.go
+++ b/tests/integration/toolkit/crd.go
@@ -109,8 +109,8 @@ func (h *dnsEndpointHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func isDNSEndpointPath(path string) bool {
-	return strings.HasPrefix(path, "/apis/"+apiv1alpha1.GroupVersion.String()) && 
-	       strings.HasSuffix(path, "/"+dnsEndpointResource)
+	return strings.HasPrefix(path, "/apis/"+apiv1alpha1.GroupVersion.String()) &&
+		strings.HasSuffix(path, "/"+dnsEndpointResource)
 }
 
 func writeJSON(w http.ResponseWriter, v any) {

--- a/tests/integration/toolkit/models.go
+++ b/tests/integration/toolkit/models.go
@@ -21,6 +21,9 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	apiv1alpha1 "sigs.k8s.io/external-dns/apis/v1alpha1"
 
 	"sigs.k8s.io/external-dns/endpoint"
 )
@@ -74,4 +77,13 @@ type ParsedResources struct {
 	Services       []*corev1.Service
 	EndpointSlices []*discoveryv1.EndpointSlice
 	Pods           []*corev1.Pod
+	DNSEndpoints   []*apiv1alpha1.DNSEndpoint
+}
+
+// LoadedResources holds the fake clients populated by LoadResources.
+type LoadedResources struct {
+	// K8sClient is the fake Kubernetes clientset for core/networking/discovery resources.
+	K8sClient *fake.Clientset
+	// DNSEndpoints are the parsed DNSEndpoint CRD objects ready to be injected into the CRD source fake cache.
+	DNSEndpoints []*apiv1alpha1.DNSEndpoint
 }

--- a/tests/integration/toolkit/models.go
+++ b/tests/integration/toolkit/models.go
@@ -80,7 +80,7 @@ type ParsedResources struct {
 	DNSEndpoints   []*apiv1alpha1.DNSEndpoint
 }
 
-// LoadedResources holds the fake clients populated by LoadResources.
+// LoadedResources holds the clients.
 type LoadedResources struct {
 	// K8sClient is the fake Kubernetes clientset for core/networking/discovery resources.
 	K8sClient *fake.Clientset

--- a/tests/integration/toolkit/toolkit.go
+++ b/tests/integration/toolkit/toolkit.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -31,8 +32,8 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/yaml"
 
+	apiv1alpha1 "sigs.k8s.io/external-dns/apis/v1alpha1"
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
-
 	"sigs.k8s.io/external-dns/source"
 	"sigs.k8s.io/external-dns/source/wrappers"
 )
@@ -44,6 +45,7 @@ var (
 		utilruntime.Must(corev1.AddToScheme(s))
 		utilruntime.Must(discoveryv1.AddToScheme(s))
 		utilruntime.Must(networkingv1.AddToScheme(s))
+		utilruntime.Must(apiv1alpha1.AddToScheme(s))
 		return s
 	}()
 	decoder = serializer.NewCodecFactory(scheme).UniversalDeserializer()
@@ -97,6 +99,8 @@ func ParseResources(resources []ResourceWithDependencies) (*ParsedResources, err
 			parsed.Ingresses = append(parsed.Ingresses, res)
 		case *discoveryv1.EndpointSlice:
 			parsed.EndpointSlices = append(parsed.EndpointSlices, res)
+		case *apiv1alpha1.DNSEndpoint:
+			parsed.DNSEndpoints = append(parsed.DNSEndpoints, res)
 		default:
 			return nil, fmt.Errorf("unsupported resource type %T", obj)
 		}
@@ -194,10 +198,11 @@ func createServiceWithOptionalStatus(ctx context.Context, client *fake.Clientset
 	return nil
 }
 
-// LoadResources creates the resources in the fake client using the API.
+// LoadResources creates the Kubernetes resources in a fake clientset and collects
+// any DNSEndpoint CRD objects for use by the CRD source.
 // This must be called BEFORE creating sources so the informers can see the resources.
-func LoadResources(ctx context.Context, scenario Scenario) (*fake.Clientset, error) {
-	client := fake.NewClientset()
+func LoadResources(ctx context.Context, scenario Scenario) (*LoadedResources, error) {
+	k8sClient := fake.NewClientset()
 
 	// Parse resources from scenario
 	resources, err := ParseResources(scenario.Resources)
@@ -206,28 +211,31 @@ func LoadResources(ctx context.Context, scenario Scenario) (*fake.Clientset, err
 	}
 
 	for _, ing := range resources.Ingresses {
-		if err := createIngressWithOptionalStatus(ctx, client, ing); err != nil {
+		if err := createIngressWithOptionalStatus(ctx, k8sClient, ing); err != nil {
 			return nil, err
 		}
 	}
 	for _, svc := range resources.Services {
-		if err := createServiceWithOptionalStatus(ctx, client, svc); err != nil {
+		if err := createServiceWithOptionalStatus(ctx, k8sClient, svc); err != nil {
 			return nil, err
 		}
 	}
 	for _, pod := range resources.Pods {
-		_, err := client.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+		_, err := k8sClient.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
 		if err != nil {
 			return nil, err
 		}
 	}
 	for _, eps := range resources.EndpointSlices {
-		_, err := client.DiscoveryV1().EndpointSlices(eps.Namespace).Create(ctx, eps, metav1.CreateOptions{})
+		_, err := k8sClient.DiscoveryV1().EndpointSlices(eps.Namespace).Create(ctx, eps, metav1.CreateOptions{})
 		if err != nil {
 			return nil, err
 		}
 	}
-	return client, nil
+	return &LoadedResources{
+		K8sClient:    k8sClient,
+		DNSEndpoints: resources.DNSEndpoints,
+	}, nil
 }
 
 // scenarioToConfig creates a source.Config for testing with the scenario config.
@@ -245,13 +253,23 @@ func scenarioToConfig(scenarioCfg ScenarioConfig, opts ...source.OverrideConfigO
 	}, opts...)
 }
 
-// CreateWrappedSource builds all named sources using a mock client and wraps
-// them with the same pipeline used by the controller.
+// CreateWrappedSource builds all named sources using the loaded resources and
+// wraps them with the same pipeline used by the controller.
+// If the "crd" source is requested, a minimal fake Kubernetes REST API server is
+// started (serving only DNSEndpoint resources) so the CRD source's
+// controller-runtime cache can initialize without a real cluster.
 func CreateWrappedSource(
 	ctx context.Context,
-	client *fake.Clientset,
+	loaded *LoadedResources,
 	scenarioCfg ScenarioConfig) (source.Source, error) {
-	cfg, err := scenarioToConfig(scenarioCfg, source.WithClientGenerator(newMockClientGenerator(client)))
+	var gen = newMockClientGenerator(loaded.K8sClient)
+
+	if slices.Contains(scenarioCfg.Sources, "crd") {
+		restCfg := newFakeDNSEndpointServer(ctx, loaded.DNSEndpoints)
+		gen = newCRDClientGenerator(loaded.K8sClient, restCfg)
+	}
+
+	cfg, err := scenarioToConfig(scenarioCfg, source.WithClientGenerator(gen))
 	if err != nil {
 		return nil, err
 	}

--- a/tests/integration/toolkit/toolkit_test.go
+++ b/tests/integration/toolkit/toolkit_test.go
@@ -125,6 +125,22 @@ addressType: IPv4
 `)
 }
 
+func rawDNSEndpoint() []byte {
+	return []byte(`apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: my-dns
+  namespace: default
+spec:
+  endpoints:
+    - dnsName: www.example.com
+      targets:
+        - 1.2.3.4
+      recordType: A
+      recordTTL: 300
+`)
+}
+
 func TestParseResources_Service(t *testing.T) {
 	parsed, err := ParseResources([]ResourceWithDependencies{
 		{Resource: runtime.RawExtension{Raw: rawService()}},
@@ -174,6 +190,15 @@ func TestParseResources_EndpointSlice(t *testing.T) {
 	assert.Equal(t, "eps", parsed.EndpointSlices[0].Name)
 }
 
+func TestParseResources_DNSEndpoint(t *testing.T) {
+	parsed, err := ParseResources([]ResourceWithDependencies{
+		{Resource: runtime.RawExtension{Raw: rawDNSEndpoint()}},
+	})
+	require.NoError(t, err)
+	require.Len(t, parsed.DNSEndpoints, 1)
+	assert.Equal(t, "my-dns", parsed.DNSEndpoints[0].Name)
+}
+
 func TestParseResources_UnsupportedType(t *testing.T) {
 	raw := []byte(`apiVersion: v1
 kind: ConfigMap
@@ -195,13 +220,13 @@ func TestParseResources_InvalidRaw(t *testing.T) {
 }
 
 func TestLoadResources_Service(t *testing.T) {
-	client, err := LoadResources(t.Context(), Scenario{
+	loaded, err := LoadResources(t.Context(), Scenario{
 		Resources: []ResourceWithDependencies{
 			{Resource: runtime.RawExtension{Raw: rawService()}},
 		},
 	})
 	require.NoError(t, err)
-	svcs, err := client.CoreV1().Services("default").List(t.Context(), metav1.ListOptions{})
+	svcs, err := loaded.K8sClient.CoreV1().Services("default").List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err)
 	assert.Len(t, svcs.Items, 1)
 }
@@ -219,13 +244,13 @@ func TestLoadResources_ServiceWithLoadBalancerStatus(t *testing.T) {
 	raw, err := encodeObject(svc)
 	require.NoError(t, err)
 
-	client, err := LoadResources(t.Context(), Scenario{
+	loaded, err := LoadResources(t.Context(), Scenario{
 		Resources: []ResourceWithDependencies{
 			{Resource: runtime.RawExtension{Raw: raw}},
 		},
 	})
 	require.NoError(t, err)
-	got, err := client.CoreV1().Services("default").Get(t.Context(), "lb-svc", metav1.GetOptions{})
+	got, err := loaded.K8sClient.CoreV1().Services("default").Get(t.Context(), "lb-svc", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, "1.2.3.4", got.Status.LoadBalancer.Ingress[0].IP)
 }
@@ -243,39 +268,50 @@ func TestLoadResources_IngressWithLoadBalancerStatus(t *testing.T) {
 	raw, err := encodeObject(ing)
 	require.NoError(t, err)
 
-	client, err := LoadResources(t.Context(), Scenario{
+	loaded, err := LoadResources(t.Context(), Scenario{
 		Resources: []ResourceWithDependencies{
 			{Resource: runtime.RawExtension{Raw: raw}},
 		},
 	})
 	require.NoError(t, err)
-	got, err := client.NetworkingV1().Ingresses("default").Get(t.Context(), "lb-ing", metav1.GetOptions{})
+	got, err := loaded.K8sClient.NetworkingV1().Ingresses("default").Get(t.Context(), "lb-ing", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, "5.6.7.8", got.Status.LoadBalancer.Ingress[0].IP)
 }
 
 func TestLoadResources_Pods(t *testing.T) {
-	client, err := LoadResources(t.Context(), Scenario{
+	loaded, err := LoadResources(t.Context(), Scenario{
 		Resources: []ResourceWithDependencies{
 			{Resource: runtime.RawExtension{Raw: rawPod()}},
 		},
 	})
 	require.NoError(t, err)
-	pods, err := client.CoreV1().Pods("default").List(t.Context(), metav1.ListOptions{})
+	pods, err := loaded.K8sClient.CoreV1().Pods("default").List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err)
 	assert.Len(t, pods.Items, 1)
 }
 
 func TestLoadResources_EndpointSlices(t *testing.T) {
-	client, err := LoadResources(t.Context(), Scenario{
+	loaded, err := LoadResources(t.Context(), Scenario{
 		Resources: []ResourceWithDependencies{
 			{Resource: runtime.RawExtension{Raw: rawEndpointSlice()}},
 		},
 	})
 	require.NoError(t, err)
-	epsList, err := client.DiscoveryV1().EndpointSlices("default").List(t.Context(), metav1.ListOptions{})
+	epsList, err := loaded.K8sClient.DiscoveryV1().EndpointSlices("default").List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err)
 	assert.Len(t, epsList.Items, 1)
+}
+
+func TestLoadResources_DNSEndpoint(t *testing.T) {
+	loaded, err := LoadResources(t.Context(), Scenario{
+		Resources: []ResourceWithDependencies{
+			{Resource: runtime.RawExtension{Raw: rawDNSEndpoint()}},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, loaded.DNSEndpoints, 1)
+	assert.Equal(t, "my-dns", loaded.DNSEndpoints[0].Name)
 }
 
 func TestLoadResources_ParseError(t *testing.T) {
@@ -288,15 +324,30 @@ func TestLoadResources_ParseError(t *testing.T) {
 }
 
 func TestCreateWrappedSource(t *testing.T) {
-	client, err := LoadResources(t.Context(), Scenario{
+	loaded, err := LoadResources(t.Context(), Scenario{
 		Resources: []ResourceWithDependencies{
 			{Resource: runtime.RawExtension{Raw: rawService()}},
 		},
 	})
 	require.NoError(t, err)
 
-	src, err := CreateWrappedSource(t.Context(), client, ScenarioConfig{
+	src, err := CreateWrappedSource(t.Context(), loaded, ScenarioConfig{
 		Sources: []string{"service"},
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, src)
+}
+
+func TestCreateWrappedSource_CRD(t *testing.T) {
+	loaded, err := LoadResources(t.Context(), Scenario{
+		Resources: []ResourceWithDependencies{
+			{Resource: runtime.RawExtension{Raw: rawDNSEndpoint()}},
+		},
+	})
+	require.NoError(t, err)
+
+	src, err := CreateWrappedSource(t.Context(), loaded, ScenarioConfig{
+		Sources: []string{"crd"},
 	})
 	require.NoError(t, err)
 	assert.NotNil(t, src)


### PR DESCRIPTION
## What does it do ?

 - Add tests/integration/toolkit/crd.go: a minimal in-process fake Kubernetes API server that serves discovery endpoints plus DNSEndpoint List and Watch (including the watchList sendInitialEvents/BOOKMARK protocol), allowing CRD source tests to run without a cluster
  - Extend LoadResources to return a LoadedResources struct that carries both the fake k8s.Clientset and any parsed DNSEndpoint objects, so the CRD fake server is populated from the same scenario YAML

- support more sources/kinds

## Motivation

at the moment the only way to validate where crd source is working - is to execute real end-2-end tests

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
