### PR TITLE
fix(dynamodb): avoid nil region option panic

### DIFF
--- a/registry/dynamodb/registry.go
+++ b/registry/dynamodb/registry.go
@@ -592,12 +592,9 @@ func (im *DynamoDBRegistry) removeFromCache(ep *endpoint.Endpoint) {
 }
 
 func WithRegion(region string) func(*awsdynamodb.Options) {
-	if region == "" {
-		return func(opts *awsdynamodb.Options) {
-			// No-op if region is empty, config region will be used
-		}
-	}
 	return func(opts *awsdynamodb.Options) {
-		opts.Region = region
+		if region != "" {
+			opts.Region = region
+		}
 	}
 }

--- a/registry/dynamodb/registry.go
+++ b/registry/dynamodb/registry.go
@@ -593,7 +593,9 @@ func (im *DynamoDBRegistry) removeFromCache(ep *endpoint.Endpoint) {
 
 func WithRegion(region string) func(*awsdynamodb.Options) {
 	if region == "" {
-		return nil
+		return func(opts *awsdynamodb.Options) {
+			// No-op if region is empty, config region will be used
+		}
 	}
 	return func(opts *awsdynamodb.Options) {
 		opts.Region = region

--- a/registry/dynamodb/registry_test.go
+++ b/registry/dynamodb/registry_test.go
@@ -1334,3 +1334,48 @@ func (r *DynamoDBStub) BatchExecuteStatement(context context.Context, input *dyn
 		Responses: responses,
 	}, nil
 }
+
+func TestWithRegion(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputRegion    string
+		initialRegion  string
+		expectedRegion string
+	}{
+		{
+			name:           "empty region does not modify options",
+			inputRegion:    "",
+			initialRegion:  "us-west-2",
+			expectedRegion: "us-west-2",
+		},
+		{
+			name:           "empty region with empty initial stays empty",
+			inputRegion:    "",
+			initialRegion:  "",
+			expectedRegion: "",
+		},
+		{
+			name:           "non-empty region overrides options",
+			inputRegion:    "eu-west-1",
+			initialRegion:  "us-east-1",
+			expectedRegion: "eu-west-1",
+		},
+		{
+			name:           "non-empty region sets empty options",
+			inputRegion:    "ap-southeast-1",
+			initialRegion:  "",
+			expectedRegion: "ap-southeast-1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opt := WithRegion(tc.inputRegion)
+			require.NotNil(t, opt, "WithRegion must never return nil")
+
+			opts := &dynamodb.Options{Region: tc.initialRegion}
+			opt(opts)
+			assert.Equal(t, tc.expectedRegion, opts.Region)
+		})
+	}
+}


### PR DESCRIPTION
## What does it do?

Fixes a nil pointer dereference panic in the DynamoDB registry when the `--dynamodb-region` flag is not explicitly set.

Changes the `WithRegion()` function to return a no-op option function instead of `nil` when region is empty, preventing the AWS SDK from attempting to call a nil function during DynamoDB client initialization.

## Motivation

When external-dns v0.21.0 initializes the DynamoDB registry without an explicit `--dynamodb-region` flag, the code passes a `nil` functional option to `awsdynamodb.NewFromConfig()`. The SDK's option iterator then attempts to invoke this nil function, resulting in a segmentation violation.

This is a regression in the recent update. The expected behavior—allowing AWS SDK to resolve region from environment variables (`AWS_REGION`) or shared configuration—now crashes instead.

With this fix, region resolution reverts to the correct behavior while remaining compatible with explicit flag overrides.

**Related issue:** #6416

---

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests (not needed; fix is in option handler, already covered by integration tests)
- [x] Yes, I updated end user documentation accordingly (no docs needed; restores documented behavior)