### PR TITLE
feat(provider/pdns) support powerdns views

### DIFF
--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -152,6 +152,7 @@ type Config struct {
 	PDNSServerID                                  string
 	PDNSAPIKey                                    string `secure:"yes"`
 	PDNSSkipTLSVerify                             bool
+	PDNSView									  string
 	TLSCA                                         string
 	TLSClientCert                                 string
 	TLSClientCertKey                              string
@@ -341,6 +342,7 @@ var defaultConfig = &Config{
 	PDNSServer:                   "http://localhost:8081",
 	PDNSServerID:                 "localhost",
 	PDNSSkipTLSVerify:            false,
+	PDNSView:                     "",
 	PiholeApiVersion:             "5",
 	PiholePassword:               "",
 	PiholeServer:                 "",
@@ -648,6 +650,7 @@ func bindFlags(b flags.FlagBinder, cfg *Config) {
 	b.StringVar("pdns-server-id", "When using the PowerDNS/PDNS provider, specify the id of the server to retrieve. Should be `localhost` except when the server is behind a proxy (optional when --provider=pdns) (default: localhost)", defaultConfig.PDNSServerID, &cfg.PDNSServerID)
 	b.StringVar("pdns-api-key", "When using the PowerDNS/PDNS provider, specify the API key to use to authorize requests (required when --provider=pdns)", defaultConfig.PDNSAPIKey, &cfg.PDNSAPIKey)
 	b.BoolVar("pdns-skip-tls-verify", "When using the PowerDNS/PDNS provider, disable verification of any TLS certificates (optional when --provider=pdns) (default: false)", defaultConfig.PDNSSkipTLSVerify, &cfg.PDNSSkipTLSVerify)
+	b.StringVar("pdns-view", "When using the PowerDNS/PDNS provider, specify zone view (optional when --provider=pdns)", defaultConfig.PDNSView, &cfg.PDNSView)
 	b.StringVar("ns1-endpoint", "When using the NS1 provider, specify the URL of the API endpoint to target (default: https://api.nsone.net/v1/)", defaultConfig.NS1Endpoint, &cfg.NS1Endpoint)
 	b.BoolVar("ns1-ignoressl", "When using the NS1 provider, specify whether to verify the SSL certificate (default: false)", defaultConfig.NS1IgnoreSSL, &cfg.NS1IgnoreSSL)
 	b.IntVar("ns1-min-ttl", "Minimal TTL (in seconds) for records. This value will be used if the provided TTL for a service/ingress is lower than this.", cfg.NS1MinTTLSeconds, &cfg.NS1MinTTLSeconds)

--- a/pkg/apis/externaldns/types_test.go
+++ b/pkg/apis/externaldns/types_test.go
@@ -105,6 +105,7 @@ var (
 		PDNSServer:                                    "http://localhost:8081",
 		PDNSServerID:                                  "localhost",
 		PDNSAPIKey:                                    "",
+		PDNSView:									   "",
 		Policy:                                        "sync",
 		Registry:                                      "txt",
 		TXTOwnerID:                                    "default",
@@ -219,6 +220,7 @@ var (
 		PDNSServerID:                                  "localhost",
 		PDNSAPIKey:                                    "some-secret-key",
 		PDNSSkipTLSVerify:                             true,
+		PDNSView:									   "",
 		TLSCA:                                         "/path/to/ca.crt",
 		TLSClientCert:                                 "/path/to/cert.pem",
 		TLSClientCertKey:                              "/path/to/key.pem",
@@ -358,6 +360,7 @@ func TestParseFlags(t *testing.T) {
 				"--pdns-server-id=localhost",
 				"--pdns-api-key=some-secret-key",
 				"--pdns-skip-tls-verify",
+				"--pdns-view=internal"
 				"--oci-config-file=oci.yaml",
 				"--oci-zone-scope=PRIVATE",
 				"--oci-zones-cache-duration=30s",

--- a/provider/pdns/pdns.go
+++ b/provider/pdns/pdns.go
@@ -80,6 +80,7 @@ type PDNSConfig struct {
 	ServerID     string
 	APIKey       string
 	TLSConfig    TLSConfig
+	View string
 }
 
 // TLSConfig is comprised of the TLS-related fields necessary to create a new PDNSProvider
@@ -135,6 +136,27 @@ func stringifyHTTPResponseBody(r *http.Response) string {
 	_, _ = buf.ReadFrom(r.Body)
 	return buf.String()
 }
+func parseVariantZone(zoneName string) (base string, view string, isVariant bool) {
+	// PDNS variant format: <base zone with trailing dot>.<variant>
+	// Example: "example.com..internal"
+
+	zn := strings.TrimSpace(zoneName)
+	zn = strings.TrimSuffix(zn, ".") // allow both with/without final dot
+
+	// Variant zones must contain exactly one ".."
+	if !strings.Contains(zn, "..") {
+		return provider.EnsureTrailingDot(zn), "", false
+	}
+
+	parts := strings.SplitN(zn, "..", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return provider.EnsureTrailingDot(zn), "", false
+	}
+
+	// parts[0] is the base without trailing dot
+	// parts[1] is the variant name
+	return provider.EnsureTrailingDot(parts[0]), parts[1], true
+}
 
 // PDNSAPIProvider : Interface used and extended by the PDNSAPIClient struct as
 // well as mock APIClients used in testing
@@ -146,10 +168,12 @@ type PDNSAPIProvider interface {
 
 // PDNSAPIClient : Struct that encapsulates all the PowerDNS specific implementation details
 type PDNSAPIClient struct {
-	dryRun   bool
-	serverID string
-	authCtx  context.Context
-	client   *pgo.APIClient
+	dryRun       bool
+	serverID     string
+	authCtx      context.Context
+	client       *pgo.APIClient
+	domainFilter *endpoint.DomainFilter
+	view         string
 }
 
 // ListZones : Method returns all enabled zones from PowerDNS
@@ -170,6 +194,36 @@ func (c *PDNSAPIClient) ListZones() ([]pgo.Zone, *http.Response, error) {
 	}
 
 	return zones, resp, provider.NewSoftErrorf("unable to list zones: %v", err)
+}
+
+// PartitionZones : Method returns a slice of zones that adhere to the domain filter and a slice of ones that does not adhere to the filter
+func (c *PDNSAPIClient) PartitionZones(zones []pgo.Zone) ([]pgo.Zone, []pgo.Zone) {
+	var filteredZones []pgo.Zone
+	var residualZones []pgo.Zone
+
+	viewWanted := c.view
+
+	for _, zone := range zones {
+		matchName := zone.Name
+
+		if viewWanted != "" {
+			baseName, zoneView, isVariant := parseVariantZone(zone.Name)
+			if !isVariant || zoneView != viewWanted {
+				residualZones = append(residualZones, zone)
+				continue
+			}
+			matchName = baseName
+		}
+
+		if c.domainFilter.IsConfigured() && !c.domainFilter.Match(matchName) {
+			residualZones = append(residualZones, zone)
+			continue
+		}
+
+		filteredZones = append(filteredZones, zone)
+	}
+
+	return filteredZones, residualZones
 }
 
 // partitionZones returns a slice of zones that adhere to the domain filter and a slice of ones that do not adhere to the filter.
@@ -243,6 +297,7 @@ func New(ctx context.Context, cfg *externaldns.Config, domainFilter *endpoint.Do
 			Server:       cfg.PDNSServer,
 			ServerID:     cfg.PDNSServerID,
 			APIKey:       cfg.PDNSAPIKey,
+			View:         cfg.PDNSView,
 			TLSConfig: TLSConfig{
 				SkipTLSVerify:         cfg.PDNSSkipTLSVerify,
 				CAFilePath:            cfg.TLSCA,
@@ -279,10 +334,12 @@ func newProvider(ctx context.Context, config PDNSConfig) (*PDNSProvider, error) 
 
 	provider := &PDNSProvider{
 		client: &PDNSAPIClient{
-			dryRun:   config.DryRun,
-			serverID: config.ServerID,
-			authCtx:  context.WithValue(ctx, pgo.ContextAPIKey, pgo.APIKey{Key: config.APIKey}),
-			client:   pgo.NewAPIClient(pdnsClientConfig),
+			dryRun:       config.DryRun,
+			serverID:     config.ServerID,
+			authCtx:      context.WithValue(ctx, pgo.ContextAPIKey, pgo.APIKey{Key: config.APIKey}),
+			client:       pgo.NewAPIClient(pdnsClientConfig),
+			domainFilter: config.DomainFilter,
+			view:         config.View,
 		},
 		domainFilter: config.DomainFilter,
 	}
@@ -296,6 +353,10 @@ func (p *PDNSProvider) filteredZones() ([]pgo.Zone, []pgo.Zone, error) {
 	zones, _, err := p.client.ListZones()
 	if err != nil {
 		return nil, nil, err
+	}
+	if c, ok := p.client.(*PDNSAPIClient); ok {
+		filtered, residual := c.PartitionZones(zones)
+		return filtered, residual, nil
 	}
 	filtered, residual := partitionZones(zones, p.domainFilter)
 	return filtered, residual, nil
@@ -379,7 +440,14 @@ func (p *PDNSProvider) ConvertEndpointsToZones(eps []*endpoint.Endpoint, changet
 		for i := 0; i < len(endpoints); {
 			ep := endpoints[i]
 			dnsname := provider.EnsureTrailingDot(ep.DNSName)
-			if dnsname == zone.Name || strings.HasSuffix(dnsname, "."+zone.Name) {
+			zoneMatchName := zone.Name
+			if c, ok := p.client.(*PDNSAPIClient); ok && c.view != "" {
+				baseName, _, isVariant := parseVariantZone(zone.Name)
+				if isVariant {
+					zoneMatchName = baseName
+				}
+			}
+			if dnsname == zoneMatchName || strings.HasSuffix(dnsname, "."+zoneMatchName) {
 				records := []pgo.Record{}
 				RecordType_ := ep.RecordType
 				for _, t := range ep.Targets {
@@ -389,12 +457,8 @@ func (p *PDNSProvider) ConvertEndpointsToZones(eps []*endpoint.Endpoint, changet
 					records = append(records, pgo.Record{Content: t})
 				}
 
-				// Check if we should use ALIAS instead of CNAME:
-				// 1. APEX records (dnsname == zone.Name) always use ALIAS
-				// 2. If annotation external-dns.alpha.kubernetes.io/alias=true is set
-				//    (can be set via --prefer-alias flag globally or per-resource annotation)
 				if ep.RecordType == endpoint.RecordTypeCNAME {
-					useAlias := dnsname == zone.Name || p.hasAliasAnnotation(ep)
+					useAlias := dnsname == zoneMatchName || p.hasAliasAnnotation(ep)
 					if useAlias {
 						log.Debugf("Converting CNAME record %q to ALIAS", dnsname)
 						RecordType_ = "ALIAS"
@@ -441,7 +505,16 @@ func (p *PDNSProvider) ConvertEndpointsToZones(eps []*endpoint.Endpoint, changet
 		for i := 0; i < len(endpoints); {
 			ep := endpoints[i]
 			dnsname := provider.EnsureTrailingDot(ep.DNSName)
-			if dnsname == zone.Name || strings.HasSuffix(dnsname, "."+zone.Name) {
+
+			zoneMatchName := zone.Name
+			if c, ok := p.client.(*PDNSAPIClient); ok && c.view != "" {
+				baseName, _, isVariant := parseVariantZone(zone.Name)
+				if isVariant {
+					zoneMatchName = baseName
+				}
+			}
+
+			if dnsname == zoneMatchName || strings.HasSuffix(dnsname, "."+zoneMatchName) {
 				// "pop" endpoint if it's matched to a residual zone... essentially a no-op
 				log.Debugf("Ignoring Endpoint because it was matched to a zone that was not specified within Domain Filter(s): %s", dnsname)
 				endpoints = append(endpoints[0:i], endpoints[i+1:]...)

--- a/provider/pdns/pdns_test.go
+++ b/provider/pdns/pdns_test.go
@@ -1322,6 +1322,203 @@ func TestNewPDNSProviderTestSuite(t *testing.T) {
 	suite.Run(t, new(NewPDNSProviderTestSuite))
 }
 
+// TestParseVariantZone verifies zone name parsing for PDNS view (variant) zones.
+func TestParseVariantZone(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantBase    string
+		wantView    string
+		wantVariant bool
+	}{
+		{
+			name:        "plain zone without trailing dot",
+			input:       "example.com",
+			wantBase:    "example.com.",
+			wantVariant: false,
+		},
+		{
+			name:        "plain zone with trailing dot",
+			input:       "example.com.",
+			wantBase:    "example.com.",
+			wantVariant: false,
+		},
+		{
+			name:        "variant zone internal view",
+			input:       "example.com..internal",
+			wantBase:    "example.com.",
+			wantView:    "internal",
+			wantVariant: true,
+		},
+		{
+			name:        "variant zone external view with trailing dot",
+			input:       "example.com..external.",
+			wantBase:    "example.com.",
+			wantView:    "external",
+			wantVariant: true,
+		},
+		{
+			name:        "variant zone with subdomain base",
+			input:       "sub.example.com..dmz",
+			wantBase:    "sub.example.com.",
+			wantView:    "dmz",
+			wantVariant: true,
+		},
+		{
+			// TrimSuffix removes one trailing dot: "example.com.." → "example.com."
+			// which no longer contains "..", so it is treated as a plain zone.
+			name:        "trailing double-dot collapses to plain zone after TrimSuffix",
+			input:       "example.com..",
+			wantBase:    "example.com.",
+			wantVariant: false,
+		},
+		{
+			name:        "double-dot but empty base part is not a variant",
+			input:       "..internal",
+			wantBase:    "..internal.",
+			wantVariant: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base, view, isVariant := parseVariantZone(tt.input)
+			assert.Equal(t, tt.wantBase, base)
+			assert.Equal(t, tt.wantView, view)
+			assert.Equal(t, tt.wantVariant, isVariant)
+		})
+	}
+}
+
+// TestPDNSClientPartitionZonesWithView verifies view-aware zone partitioning.
+func TestPDNSClientPartitionZonesWithView(t *testing.T) {
+	newZone := func(name string) pgo.Zone {
+		return pgo.Zone{Id: name, Name: name, Type_: "Zone", Kind: "Native", Rrsets: []pgo.RrSet{}}
+	}
+	zoneNames := func(zz []pgo.Zone) []string {
+		names := make([]string, len(zz))
+		for i, z := range zz {
+			names[i] = z.Name
+		}
+		return names
+	}
+
+	allZones := []pgo.Zone{
+		newZone("example.com."),
+		newZone("example.com..internal"),
+		newZone("example.com..external"),
+		newZone("mock.test."),
+		newZone("mock.test..internal"),
+	}
+
+	tests := []struct {
+		name             string
+		view             string
+		domainFilter     *endpoint.DomainFilter
+		wantFiltered     []string
+		wantResidualSize int
+	}{
+		{
+			name:             "no view, no domain filter: all zones pass",
+			view:             "",
+			domainFilter:     endpoint.NewDomainFilter([]string{}),
+			wantFiltered:     []string{"example.com.", "example.com..internal", "example.com..external", "mock.test.", "mock.test..internal"},
+			wantResidualSize: 0,
+		},
+		{
+			name:             "internal view only: only internal variant zones",
+			view:             "internal",
+			domainFilter:     endpoint.NewDomainFilter([]string{}),
+			wantFiltered:     []string{"example.com..internal", "mock.test..internal"},
+			wantResidualSize: 3,
+		},
+		{
+			name:             "internal view + domain filter example.com: intersection",
+			view:             "internal",
+			domainFilter:     endpoint.NewDomainFilter([]string{"example.com"}),
+			wantFiltered:     []string{"example.com..internal"},
+			wantResidualSize: 4,
+		},
+		{
+			name:             "external view: only external variant zones",
+			view:             "external",
+			domainFilter:     endpoint.NewDomainFilter([]string{}),
+			wantFiltered:     []string{"example.com..external"},
+			wantResidualSize: 4,
+		},
+		{
+			name:             "unknown view: no zones match",
+			view:             "unknown",
+			domainFilter:     endpoint.NewDomainFilter([]string{}),
+			wantFiltered:     []string{},
+			wantResidualSize: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &PDNSAPIClient{
+				view:         tt.view,
+				domainFilter: tt.domainFilter,
+			}
+			filtered, residual := client.PartitionZones(allZones)
+			assert.ElementsMatch(t, tt.wantFiltered, zoneNames(filtered))
+			assert.Len(t, residual, tt.wantResidualSize)
+		})
+	}
+}
+
+// PDNSAPIClientStubViewZones returns view-variant zone names from ListZones.
+// It is used to verify that records are NOT placed in view-named zones when no
+// view is configured (negative test), and that view-aware PartitionZones
+// correctly selects only the target view's zones (positive test).
+type PDNSAPIClientStubViewZones struct{}
+
+func (c *PDNSAPIClientStubViewZones) ListZones() ([]pgo.Zone, *http.Response, error) {
+	return []pgo.Zone{
+		{Id: "example.com.", Name: "example.com.", Type_: "Zone", Kind: "Native", Rrsets: []pgo.RrSet{}},
+		{Id: "example.com..internal", Name: "example.com..internal", Type_: "Zone", Kind: "Native", Rrsets: []pgo.RrSet{}},
+		{Id: "example.com..external", Name: "example.com..external", Type_: "Zone", Kind: "Native", Rrsets: []pgo.RrSet{}},
+	}, nil, nil
+}
+
+func (c *PDNSAPIClientStubViewZones) ListZone(_ string) (pgo.Zone, *http.Response, error) {
+	return pgo.Zone{}, nil, nil
+}
+
+func (c *PDNSAPIClientStubViewZones) PatchZone(_ string, _ pgo.Zone) (*http.Response, error) {
+	return &http.Response{}, nil
+}
+
+// TestPDNSConvertEndpointsToZonesViewNameMatching verifies the zone-name matching
+// behaviour when view-variant zones (e.g. "example.com..internal") are present.
+//
+// Without a *PDNSAPIClient as the provider client, the type assertion inside
+// ConvertEndpointsToZones is false, so zoneMatchName == zone.Name and a plain
+// DNS name like "example.com." will not match "example.com..internal".
+// This confirms that view-aware matching only kicks in when a *PDNSAPIClient
+// with a non-empty view field is used (covered by TestPDNSClientPartitionZonesWithView).
+func TestPDNSConvertEndpointsToZonesViewNameMatching(t *testing.T) {
+	p := &PDNSProvider{
+		client:       &PDNSAPIClientStubViewZones{},
+		domainFilter: endpoint.NewDomainFilter([]string{}),
+	}
+
+	eps := []*endpoint.Endpoint{
+		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "1.2.3.4"),
+	}
+
+	// Without view: the plain zone "example.com." matches; the two variant zones
+	// ("example.com..internal", "example.com..external") do not because the double-dot
+	// name never matches "example.com." by simple string comparison.
+	zones, err := p.ConvertEndpointsToZones(eps, PdnsReplace)
+	assert.NoError(t, err)
+	assert.Len(t, zones, 1, "record should be placed in the plain zone only")
+	assert.Equal(t, "example.com.", zones[0].Name)
+	assert.Len(t, zones[0].Rrsets, 1)
+	assert.Equal(t, "example.com.", zones[0].Rrsets[0].Name)
+}
+
 // TestPDNSPartitionZonesRegexBehavior compares two regex forms for --domain-filter
 // and shows how the choice of regex affects zone partitioning correctness.
 func TestPDNSPartitionZonesRegexBehavior(t *testing.T) {


### PR DESCRIPTION
## What does it do ?

Adds `--pdns-view` flag to the PowerDNS provider, allowing external-dns to target a specific named view (zone variant) when a PDNS server exposes multiple views for the same base zone.

Zone variants follow the PowerDNS convention: `<base>..<view>` (e.g. `example.com..internal`). When `--pdns-view=internal` is set, external-dns filters and manages only zones belonging to that view, stripping the variant suffix for DNS name matching.

## Motivation

PowerDNS [zone views](https://doc.powerdns.com/authoritative/views.html) are widely used to serve split-horizon DNS — different answers for the same name depending on the client network (e.g. internal vs external). 
Without this flag, external-dns has no way to target a specific view and may write records to the wrong zone variant or fail to match zones at all.

## More

- [X] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Yes, I added unit tests
- [X] Yes, I updated end user documentation accordingly