### PR TITLE
chore: update maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -13,6 +13,7 @@ approvers:
   - mloiseleur
   - raffo
   - szuecs
+  - vflaux
 
 reviewers:
   - ivankatliarchuk


### PR DESCRIPTION
## What does it do ?

It updates OWNERS file with a new maintainer: @vflaux

## Motivation

I ran [monocle](https://github.com/change-metrics/monocle) on external-dns for the last year with this config:

```yaml
---
workspaces:
  - name: monocle
    crawlers:
      - name: github-external-dns
        provider:
          github_organization: kubernetes-sigs
          github_repositories:
            - external-dns
        update_since: '2025-06-01'
```

I saw on monocle that:

<img width="671" height="355" alt="image" src="https://github.com/user-attachments/assets/e812d32b-298f-43bb-a6cd-df1088ec6f5f" />

<br/> 

<img width="659" height="384" alt="image" src="https://github.com/user-attachments/assets/4adccfa7-aa98-4b48-b323-5646469330f2" />

It seems to me that @vflaux has clearly passed the [requirements](https://github.com/kubernetes/community/blob/master/community-membership.md#requirements-2):

- [x] Reviewer of the codebase for at least 3 months
- [x] Primary reviewer for at least 10 substantial PRs to the codebase
- [x] Reviewed or merged at least 30 PRs to the codebase

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
