### PR TITLE
test(integration/crd): add SRV record scenario covering RFC 2782 trailing dot

### DIFF
--- a/tests/integration/scenarios/tests.yaml
+++ b/tests/integration/scenarios/tests.yaml
@@ -426,6 +426,53 @@ scenarios:
         recordType: CNAME
         recordTTL: 60
 
+  - name: crd-srv-record
+    description: >
+      A DNSEndpoint with SRV records is accepted by the CRD source. Per RFC 2782
+      the target host must be an absolute FQDN; the CRD source accepts both forms
+      (with and without trailing dot) without stripping or warning. Covers the fix
+      in
+    config:
+      sources: ["crd"]
+    resources:
+      - resource:
+          apiVersion: externaldns.k8s.io/v1alpha1
+          kind: DNSEndpoint
+          metadata:
+            name: srv-plain
+            namespace: default
+          spec:
+            endpoints:
+              - dnsName: _svc._tcp.example.com
+                targets:
+                  - "0 0 80 abc.example.com"
+                  - "0 0 80 def.example.com"
+                recordType: SRV
+                recordTTL: 180
+      - resource:
+          apiVersion: externaldns.k8s.io/v1alpha1
+          kind: DNSEndpoint
+          metadata:
+            name: srv-trailing-dot
+            namespace: default
+          spec:
+            endpoints:
+              - dnsName: _secure._tcp.example.com
+                targets:
+                  - "0 0 443 abc.example.com."
+                  - "10 20 443 def.example.com."
+                recordType: SRV
+                recordTTL: 180
+    expected:
+      - dnsName: _svc._tcp.example.com
+        targets: ["0 0 80 abc.example.com", "0 0 80 def.example.com"]
+        recordType: SRV
+        recordTTL: 180
+      - dnsName: _secure._tcp.example.com
+        targets: ["0 0 443 abc.example.com.", "10 20 443 def.example.com."]
+        recordType: SRV
+        recordTTL: 180
+
   - name: crd-and-service
     description: >
       When both the crd and service sources are active, endpoints from each

--- a/tests/integration/scenarios/tests.yaml
+++ b/tests/integration/scenarios/tests.yaml
@@ -428,10 +428,11 @@ scenarios:
 
   - name: crd-srv-record
     description: >
-      A DNSEndpoint with SRV records is accepted by the CRD source. Per RFC 2782
-      the target host must be an absolute FQDN; the CRD source accepts both forms
-      (with and without trailing dot) without stripping or warning. Covers the fix
-      in
+      A DNSEndpoint with SRV targets missing the trailing dot is rejected by
+      ValidateSRVRecord (RFC 2782 requires absolute FQDNs) and produces no
+      endpoint. A DNSEndpoint with properly dotted targets is accepted by the
+      CRD source and produces an endpoint; the CRD source no longer strips or
+      warns on the trailing dot.
     config:
       sources: ["crd"]
     resources:
@@ -439,7 +440,7 @@ scenarios:
           apiVersion: externaldns.k8s.io/v1alpha1
           kind: DNSEndpoint
           metadata:
-            name: srv-plain
+            name: srv-invalid
             namespace: default
           spec:
             endpoints:
@@ -453,7 +454,7 @@ scenarios:
           apiVersion: externaldns.k8s.io/v1alpha1
           kind: DNSEndpoint
           metadata:
-            name: srv-trailing-dot
+            name: srv-valid
             namespace: default
           spec:
             endpoints:
@@ -464,10 +465,6 @@ scenarios:
                 recordType: SRV
                 recordTTL: 180
     expected:
-      - dnsName: _svc._tcp.example.com
-        targets: ["0 0 80 abc.example.com", "0 0 80 def.example.com"]
-        recordType: SRV
-        recordTTL: 180
       - dnsName: _secure._tcp.example.com
         targets: ["0 0 443 abc.example.com.", "10 20 443 def.example.com."]
         recordType: SRV


### PR DESCRIPTION
## What does it do ?

  - Adds a crd-srv-record integration scenario with two DNSEndpoint resources:
    - One using plain targets ("0 0 80 abc.example.com") to cover the baseline SRV case
    - One using RFC 2782 trailing-dot targets ("0 0 443 abc.example.com.") to cover the fix from #6383
  - Expected endpoints assert both forms are passed through by the CRD source without modification or warning

## Motivation

  - PR #6383 fixed a catch-22 where the CRD source rejected SRV targets with trailing dots, but downstream ValidateSRVRecord requires them per RFC 2782
  - No integration test existed to exercise SRV records through the CRD source at all
  - Without a regression test, the fix could be silently reverted

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
