### PR TITLE
fix(events): encapsulate ObjectReference fields

### DIFF
--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -1570,11 +1570,7 @@ func TestCheckEndpoint_PTRValidationLog(t *testing.T) {
 
 func TestEndpoint_WithRefObject(t *testing.T) {
 	ep := &Endpoint{}
-	ref := &events.ObjectReference{
-		Kind:      "Service",
-		Namespace: "default",
-		Name:      "my-service",
-	}
+	ref := events.NewObjectReferenceFromParts("Service", "", "default", "my-service", "", "")
 	result := ep.WithRefObject(ref)
 
 	assert.Equal(t, ref, ep.RefObject(), "refObject should be set")

--- a/endpoint/utils_test.go
+++ b/endpoint/utils_test.go
@@ -228,7 +228,7 @@ func TestEndpointsForHostname(t *testing.T) {
 }
 
 func TestAttachRefObject(t *testing.T) {
-	ref := &events.ObjectReference{Kind: "Service", Namespace: "default", Name: "svc"}
+	ref := events.NewObjectReferenceFromParts("Service", "", "default", "svc", "", "")
 	eps := []*Endpoint{
 		NewEndpoint("a.example.com", RecordTypeA, "1.2.3.4"),
 		NewEndpoint("b.example.com", RecordTypeA, "5.6.7.8"),
@@ -438,9 +438,9 @@ func TestMergeEndpoints_RefObjects(t *testing.T) {
 			},
 			expected: func(t *testing.T, ep []*Endpoint) {
 				assert.Len(t, ep, 1)
-				assert.Equal(t, "service", ep[0].RefObject().Source)
-				assert.Equal(t, "foo", ep[0].RefObject().Name)
-				assert.Equal(t, "123", string(ep[0].RefObject().UID))
+				assert.Equal(t, "service", ep[0].RefObject().Source())
+				assert.Equal(t, "foo", ep[0].RefObject().Name())
+				assert.Equal(t, "123", string(ep[0].RefObject().UID()))
 			},
 		},
 		{
@@ -459,10 +459,10 @@ func TestMergeEndpoints_RefObjects(t *testing.T) {
 			},
 			expected: func(t *testing.T, ep []*Endpoint) {
 				assert.Len(t, ep, 1)
-				assert.Equal(t, "service", ep[0].RefObject().Source)
-				assert.Equal(t, "foo", ep[0].RefObject().Name)
-				assert.Equal(t, "123", string(ep[0].RefObject().UID))
-				assert.NotEqual(t, "345", string(ep[0].RefObject().UID))
+				assert.Equal(t, "service", ep[0].RefObject().Source())
+				assert.Equal(t, "foo", ep[0].RefObject().Name())
+				assert.Equal(t, "123", string(ep[0].RefObject().UID()))
+				assert.NotEqual(t, "345", string(ep[0].RefObject().UID()))
 			},
 		},
 		{
@@ -483,9 +483,9 @@ func TestMergeEndpoints_RefObjects(t *testing.T) {
 				assert.Len(t, ep, 2)
 				assert.NotEqual(t, ep[0], ep[1])
 				for _, el := range ep {
-					assert.Equal(t, "service", el.RefObject().Source)
-					assert.Contains(t, []string{"foo", "bar"}, el.RefObject().Name)
-					assert.Contains(t, []string{"123", "345"}, string(el.RefObject().UID))
+					assert.Equal(t, "service", el.RefObject().Source())
+					assert.Contains(t, []string{"foo", "bar"}, el.RefObject().Name())
+					assert.Contains(t, []string{"123", "345"}, string(el.RefObject().UID()))
 				}
 			},
 		},

--- a/internal/testutils/endpoint.go
+++ b/internal/testutils/endpoint.go
@@ -219,8 +219,8 @@ func AssertEndpointsHaveRefObject(
 	assert.Len(t, endpoints, expectedCount)
 	for _, ep := range endpoints {
 		assert.NotNil(t, ep.RefObject())
-		assert.NotEmpty(t, ep.RefObject().UID)
-		assert.Equal(t, expectedSource, ep.RefObject().Source)
+		assert.NotEmpty(t, ep.RefObject().UID())
+		assert.Equal(t, expectedSource, ep.RefObject().Source())
 	}
 }
 

--- a/pkg/events/controller.go
+++ b/pkg/events/controller.go
@@ -97,12 +97,14 @@ func (ec *Controller) processNextWorkItem(ctx context.Context) bool {
 	}
 	defer ec.queue.Done(event)
 	_, err := ec.client.Events(event.Namespace).Create(ctx, event, ec.createOpts)
-	if err != nil && !apierrors.IsNotFound(err) {
-		if ec.queue.NumRequeues(event) < maxRetriesPerEvent {
-			log.Errorf("not able to create event, retrying for key/%s. %v", event.Name, err)
-			ec.queue.AddRateLimited(event)
-			return true
-		}
+	switch {
+	case apierrors.IsNotFound(err):
+		log.Warnf("dropping event %s/%s: namespace not found. %v", event.Namespace, event.Name, err)
+	case err != nil && ec.queue.NumRequeues(event) < maxRetriesPerEvent:
+		log.Errorf("not able to create event %s/%s, retrying. %v", event.Namespace, event.Name, err)
+		ec.queue.AddRateLimited(event)
+		return true
+	case err != nil:
 		log.Errorf("dropping event %s/%s after %d retries. %v", event.Namespace, event.Name, ec.queue.NumRequeues(event), err)
 	}
 	ec.queue.Forget(event)
@@ -110,16 +112,20 @@ func (ec *Controller) processNextWorkItem(ctx context.Context) bool {
 }
 
 func (ec *Controller) Add(events ...Event) {
-	if ec.queue.Len() >= ec.maxQueuedEvents {
-		log.Warnf("event queue is full, dropping %d events", len(events))
-		return
-	}
+	dropped := 0
 	for _, e := range events {
+		if ec.queue.Len() >= ec.maxQueuedEvents {
+			dropped++
+			continue
+		}
 		event := e.event()
 		if event == nil {
 			continue
 		}
 		ec.emit(event)
+	}
+	if dropped > 0 {
+		log.Warnf("event queue is full, dropped %d events", dropped)
 	}
 }
 

--- a/pkg/events/controller_test.go
+++ b/pkg/events/controller_test.go
@@ -172,9 +172,9 @@ func TestController_Add(t *testing.T) {
 		{
 			title:           "queue full drops events and logs warning",
 			maxQueuedEvents: 0, // 0 >= 0 is always true, so queue is immediately "full"
-			events:          []Event{NewEvent(&ObjectReference{Name: "test", Namespace: "default"}, "msg", ActionCreate, RecordReady)},
+			events:          []Event{NewEvent(&ObjectReference{name: "test", namespace: "default"}, "msg", ActionCreate, RecordReady)},
 			wantQueueLen:    0,
-			wantWarnLog:     "event queue is full, dropping 1 events",
+			wantWarnLog:     "event queue is full, dropped 1 events",
 		},
 		{
 			title:           "nil event is skipped",

--- a/pkg/events/fake/fake_test.go
+++ b/pkg/events/fake/fake_test.go
@@ -48,9 +48,9 @@ func TestEventEmitter_Add_MultipleEvents(t *testing.T) {
 	event1 := events.NewEvent(nil, "test message 1", events.ActionCreate, events.RecordReady)
 	event2 := events.NewEvent(nil, "test message 2", events.ActionUpdate, events.RecordReady)
 
-	// Note: The implementation only processes events[0], so we test that behavior
 	emitter.Add(event1, event2)
 
+	emitter.AssertNumberOfCalls(t, "Add", 2)
 	emitter.AssertExpectations(t)
 }
 

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -73,14 +73,13 @@ type (
 	}
 
 	// ObjectReference holds metadata about a Kubernetes object for event correlation.
-	// TODO: consider make fields private. Ensuring data integrity, encapsulation and immutability.
 	ObjectReference struct {
-		Kind       string
-		ApiVersion string
-		Namespace  string
-		Name       string
-		UID        types.UID
-		Source     string
+		kind       string
+		apiVersion string
+		namespace  string
+		name       string
+		uid        types.UID
+		source     string
 	}
 
 	Config struct {
@@ -113,12 +112,12 @@ func NewObjectReference(obj runtime.Object, source string) *ObjectReference {
 		}
 	}
 	return &ObjectReference{
-		Kind:       gvk.Kind,
-		ApiVersion: gvk.GroupVersion().String(),
-		Namespace:  obj.GetNamespace(),
-		Name:       obj.GetName(),
-		UID:        obj.GetUID(),
-		Source:     source,
+		kind:       gvk.Kind,
+		apiVersion: gvk.GroupVersion().String(),
+		namespace:  obj.GetNamespace(),
+		name:       obj.GetName(),
+		uid:        obj.GetUID(),
+		source:     source,
 	}
 }
 
@@ -132,7 +131,7 @@ func NewEvent(obj *ObjectReference, msg string, a Action, r Reason) Event {
 		eType:   EventTypeNormal,
 		action:  a,
 		reason:  r,
-		source:  obj.Source,
+		source:  obj.source,
 	}
 }
 
@@ -148,7 +147,7 @@ func NewEventFromEndpoint(ep EndpointInfo, a Action, r Reason) Event {
 }
 
 func (e *Event) description() string {
-	return fmt.Sprintf("%s/%s/%s", e.ref.Kind, e.ref.Namespace, e.ref.Name)
+	return fmt.Sprintf("%s/%s/%s", e.ref.kind, e.ref.namespace, e.ref.name)
 }
 
 // Action returns the action associated with the event (e.g. Created, Updated, Deleted).
@@ -167,7 +166,7 @@ func (e *Event) EventType() EventType {
 }
 
 func (e *Event) event() *eventsv1.Event {
-	if e.ref.Name == "" {
+	if e.ref.name == "" {
 		log.Debug("skipping event for resources as the name is not generated yet")
 		return nil
 	}
@@ -181,28 +180,28 @@ func (e *Event) event() *eventsv1.Event {
 
 	// Events are namespaced resources. For cluster-scoped objects like Nodes,
 	// the namespace is empty, so we default to "default" namespace.
-	namespace := e.ref.Namespace
+	namespace := e.ref.namespace
 	if namespace == "" {
 		namespace = "default"
 	}
 
 	event := &eventsv1.Event{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      sanitize(e.ref.Name, timestamp.Time),
+			Name:      sanitize(e.ref.name, timestamp.Time),
 			Namespace: namespace,
 		},
 		EventTime:           timestamp,
-		ReportingInstance:   controllerName + "/source/" + e.ref.Source,
+		ReportingInstance:   controllerName + "/source/" + e.ref.source,
 		ReportingController: controllerName,
 		Action:              string(e.action),
 		Reason:              string(e.reason),
 		Note:                message,
 		Type:                string(e.eType),
 	}
-	if e.ref.Name != "" {
+	if e.ref.name != "" {
 		ref := e.ref.objectRef()
 		event.Regarding = *ref
-		if e.ref.UID != "" {
+		if e.ref.uid != "" {
 			event.Related = ref
 		}
 	}
@@ -265,12 +264,46 @@ func (c *Config) IsEnabled() bool {
 	return len(c.emitEvents) > 0
 }
 
+// Kind returns the Kubernetes kind of the referenced object (e.g. "Service", "Ingress").
+func (r *ObjectReference) Kind() string {
+	return r.kind
+}
+
+// Name returns the name of the referenced Kubernetes object.
+func (r *ObjectReference) Name() string {
+	return r.name
+}
+
+// Source returns the source identifier of the ObjectReference (e.g. "ingress", "service").
+func (r *ObjectReference) Source() string {
+	return r.source
+}
+
+// UID returns the UID of the referenced Kubernetes object.
+func (r *ObjectReference) UID() types.UID {
+	return r.uid
+}
+
 func (r *ObjectReference) objectRef() *apiv1.ObjectReference {
 	return &apiv1.ObjectReference{
-		Kind:       r.Kind,
-		Namespace:  r.Namespace,
-		Name:       r.Name,
-		UID:        r.UID,
-		APIVersion: r.ApiVersion,
+		Kind:       r.kind,
+		Namespace:  r.namespace,
+		Name:       r.name,
+		UID:        r.uid,
+		APIVersion: r.apiVersion,
+	}
+}
+
+// NewObjectReferenceFromParts constructs an ObjectReference directly from its components.
+// Use this when you don't have a runtime.Object (e.g., in tests or when constructing
+// references from non-Kubernetes data sources).
+func NewObjectReferenceFromParts(kind, apiVersion, namespace, name string, uid types.UID, source string) *ObjectReference {
+	return &ObjectReference{
+		kind:       kind,
+		apiVersion: apiVersion,
+		namespace:  namespace,
+		name:       name,
+		uid:        uid,
+		source:     source,
 	}
 }

--- a/pkg/events/types_test.go
+++ b/pkg/events/types_test.go
@@ -90,10 +90,10 @@ func TestEvent_Reference(t *testing.T) {
 	for _, tt := range tests {
 		ev := Event{
 			ref: ObjectReference{
-				Kind:      tt.kind,
-				Namespace: tt.namespace,
-				Name:      tt.name,
-				Source:    "fake-source",
+				kind:      tt.kind,
+				namespace: tt.namespace,
+				name:      tt.name,
+				source:    "fake-source",
 			},
 		}
 		require.Equal(t, tt.expected, ev.description())
@@ -165,14 +165,14 @@ func TestEvent_NewEvents(t *testing.T) {
 
 func TestEvent_Transpose(t *testing.T) {
 	ev := NewEvent(&ObjectReference{
-		Kind:      "Pod",
-		Namespace: "default",
-		Name:      "nginx",
+		kind:      "Pod",
+		namespace: "default",
+		name:      "nginx",
 	}, "test message", ActionCreate, RecordReady)
 
 	event := ev.event()
 	require.NotNil(t, event)
-	require.Contains(t, event.ObjectMeta.Name, ev.ref.Name)
+	require.Contains(t, event.ObjectMeta.Name, ev.ref.name)
 	require.Equal(t, "default", event.ObjectMeta.Namespace)
 	require.Equal(t, string(ActionCreate), event.Action)
 	require.Equal(t, string(RecordReady), event.Reason)
@@ -186,7 +186,7 @@ func TestEvent_Transpose(t *testing.T) {
 	event = ev.event()
 	require.Equal(t, longMsg[:1021]+"...", event.Note)
 
-	ev.ref.Name = ""
+	ev.ref.name = ""
 	require.Nil(t, ev.event())
 }
 
@@ -196,7 +196,7 @@ func TestEvent_NameAndEventTimeConsistent(t *testing.T) {
 		expectedSuffix := fmt.Sprintf(".%x", now.UnixNano())
 
 		ev := NewEvent(&ObjectReference{
-			Kind: "Pod", Namespace: "default", Name: "nginx",
+			kind: "Pod", namespace: "default", name: "nginx",
 		}, "msg", ActionCreate, RecordReady)
 
 		k8sEvent := ev.event()
@@ -323,10 +323,10 @@ func TestNewEventFromEndpoint(t *testing.T) {
 				targets:    []string{"10.0.0.1", "10.0.0.2"},
 				owner:      "my-owner",
 				refObject: &ObjectReference{
-					Kind:      "Service",
-					Namespace: "default",
-					Name:      "my-service",
-					Source:    "service",
+					kind:      "Service",
+					namespace: "default",
+					name:      "my-service",
+					source:    "service",
 				},
 			},
 			action: ActionCreate,
@@ -335,9 +335,9 @@ func TestNewEventFromEndpoint(t *testing.T) {
 				require.Equal(t, ActionCreate, ev.action)
 				require.Equal(t, RecordReady, ev.reason)
 				require.Equal(t, EventTypeNormal, ev.eType)
-				require.Equal(t, "Service", ev.ref.Kind)
-				require.Equal(t, "default", ev.ref.Namespace)
-				require.Equal(t, "my-service", ev.ref.Name)
+				require.Equal(t, "Service", ev.ref.kind)
+				require.Equal(t, "default", ev.ref.namespace)
+				require.Equal(t, "my-service", ev.ref.name)
 				require.Contains(t, ev.message, "record:test.example.com")
 				require.Contains(t, ev.message, "owner:my-owner")
 				require.Contains(t, ev.message, "type:A")
@@ -355,10 +355,10 @@ func TestNewEventFromEndpoint(t *testing.T) {
 				targets:    []string{"target.example.com"},
 				owner:      "",
 				refObject: &ObjectReference{
-					Kind:      "Ingress",
-					Namespace: "prod",
-					Name:      "my-ingress",
-					Source:    "ingress",
+					kind:      "Ingress",
+					namespace: "prod",
+					name:      "my-ingress",
+					source:    "ingress",
 				},
 			},
 			action: ActionDelete,
@@ -380,17 +380,17 @@ func TestNewEventFromEndpoint(t *testing.T) {
 				targets:    []string{"192.168.1.1"},
 				owner:      "default",
 				refObject: &ObjectReference{
-					Kind:      "Node",
-					Namespace: "", // cluster-scoped
-					Name:      "node1",
-					Source:    "node",
+					kind:      "Node",
+					namespace: "", // cluster-scoped
+					name:      "node1",
+					source:    "node",
 				},
 			},
 			action: ActionCreate,
 			reason: RecordReady,
 			asserts: func(t *testing.T, ev Event) {
 				require.Equal(t, ActionCreate, ev.action)
-				require.Empty(t, ev.ref.Namespace)
+				require.Empty(t, ev.ref.namespace)
 
 				k8sEvent := ev.event()
 				require.NotNil(t, k8sEvent)
@@ -429,12 +429,12 @@ func TestNewObjectReference(t *testing.T) {
 			},
 			source: "pod",
 			expected: &ObjectReference{
-				Kind:       "Pod",
-				ApiVersion: "v1",
-				Namespace:  "default",
-				Name:       "my-pod",
-				UID:        "pod-uid-123",
-				Source:     "pod",
+				kind:       "Pod",
+				apiVersion: "v1",
+				namespace:  "default",
+				name:       "my-pod",
+				uid:        "pod-uid-123",
+				source:     "pod",
 			},
 		},
 		{
@@ -448,12 +448,12 @@ func TestNewObjectReference(t *testing.T) {
 			},
 			source: "pod",
 			expected: &ObjectReference{
-				Kind:       "Pod",
-				ApiVersion: "v1",
-				Namespace:  "kube-system",
-				Name:       "informer-pod",
-				UID:        "informer-uid-456",
-				Source:     "pod",
+				kind:       "Pod",
+				apiVersion: "v1",
+				namespace:  "kube-system",
+				name:       "informer-pod",
+				uid:        "informer-uid-456",
+				source:     "pod",
 			},
 		},
 		{
@@ -467,12 +467,12 @@ func TestNewObjectReference(t *testing.T) {
 			},
 			source: "service",
 			expected: &ObjectReference{
-				Kind:       "Service",
-				ApiVersion: "v1",
-				Namespace:  "prod",
-				Name:       "my-service",
-				UID:        "svc-uid-789",
-				Source:     "service",
+				kind:       "Service",
+				apiVersion: "v1",
+				namespace:  "prod",
+				name:       "my-service",
+				uid:        "svc-uid-789",
+				source:     "service",
 			},
 		},
 		{
@@ -485,12 +485,12 @@ func TestNewObjectReference(t *testing.T) {
 			},
 			source: "node",
 			expected: &ObjectReference{
-				Kind:       "Node",
-				ApiVersion: "v1",
-				Namespace:  "",
-				Name:       "worker-node-1",
-				UID:        "node-uid-abc",
-				Source:     "node",
+				kind:       "Node",
+				apiVersion: "v1",
+				namespace:  "",
+				name:       "worker-node-1",
+				uid:        "node-uid-abc",
+				source:     "node",
 			},
 		},
 		{
@@ -504,12 +504,12 @@ func TestNewObjectReference(t *testing.T) {
 			},
 			source: "endpoints",
 			expected: &ObjectReference{
-				Kind:       "Endpoints",
-				ApiVersion: "v1",
-				Namespace:  "default",
-				Name:       "my-endpoints",
-				UID:        "ep-uid-def",
-				Source:     "endpoints",
+				kind:       "Endpoints",
+				apiVersion: "v1",
+				namespace:  "default",
+				name:       "my-endpoints",
+				uid:        "ep-uid-def",
+				source:     "endpoints",
 			},
 		},
 	}
@@ -517,12 +517,12 @@ func TestNewObjectReference(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := NewObjectReference(tt.obj, tt.source)
-			require.Equal(t, tt.expected.Kind, result.Kind)
-			require.Equal(t, tt.expected.ApiVersion, result.ApiVersion)
-			require.Equal(t, tt.expected.Namespace, result.Namespace)
-			require.Equal(t, tt.expected.Name, result.Name)
-			require.Equal(t, tt.expected.UID, result.UID)
-			require.Equal(t, tt.expected.Source, result.Source)
+			require.Equal(t, tt.expected.kind, result.kind)
+			require.Equal(t, tt.expected.apiVersion, result.apiVersion)
+			require.Equal(t, tt.expected.namespace, result.namespace)
+			require.Equal(t, tt.expected.name, result.name)
+			require.Equal(t, tt.expected.uid, result.uid)
+			require.Equal(t, tt.expected.source, result.source)
 		})
 	}
 }
@@ -541,7 +541,7 @@ func (c *customObject) DeepCopyObject() runtime.Object {
 }
 
 func TestEvent_Accessors(t *testing.T) {
-	ref := &ObjectReference{Kind: "Pod", Namespace: "default", Name: "nginx"}
+	ref := &ObjectReference{kind: "Pod", namespace: "default", name: "nginx"}
 	ev := NewEvent(ref, "msg", ActionDelete, RecordDeleted)
 
 	assert.Equal(t, ActionDelete, ev.Action())
@@ -570,11 +570,11 @@ func TestNewObjectReference_ReflectionFallback(t *testing.T) {
 	ref := NewObjectReference(obj, "custom")
 
 	// Kind should be derived from reflection (struct name)
-	require.Equal(t, "customObject", ref.Kind)
+	require.Equal(t, "customObject", ref.kind)
 	// APIVersion will be empty since it's not in scheme
-	require.Empty(t, ref.ApiVersion)
-	require.Equal(t, "custom-ns", ref.Namespace)
-	require.Equal(t, "custom-resource", ref.Name)
-	require.Equal(t, "custom-uid-123", string(ref.UID))
-	require.Equal(t, "custom", ref.Source)
+	require.Empty(t, ref.apiVersion)
+	require.Equal(t, "custom-ns", ref.namespace)
+	require.Equal(t, "custom-resource", ref.name)
+	require.Equal(t, "custom-uid-123", string(ref.uid))
+	require.Equal(t, "custom", ref.source)
 }

--- a/source/fake_test.go
+++ b/source/fake_test.go
@@ -66,7 +66,7 @@ func TestFakeSource_RecordTypes(t *testing.T) {
 				assert.NotNil(t, ip, "A record target %q is not a valid IP", ep.Targets[0])
 				assert.NotNil(t, ip.To4(), "A record target %q must be IPv4", ep.Targets[0])
 				require.NotNil(t, ep.RefObject())
-				assert.Equal(t, "Pod", ep.RefObject().Kind)
+				assert.Equal(t, "Pod", ep.RefObject().Kind())
 			},
 		},
 		{

--- a/source/wrappers/dedupsource_test.go
+++ b/source/wrappers/dedupsource_test.go
@@ -485,9 +485,9 @@ func TestDedupSource_RefObjects(t *testing.T) {
 			expected: func(t *testing.T, ep []*endpoint.Endpoint) {
 				require.Len(t, ep, 1)
 				require.NotNil(t, ep[0].RefObject())
-				require.Equal(t, types.Service, ep[0].RefObject().Source)
-				require.Equal(t, "foo", ep[0].RefObject().Name)
-				require.Equal(t, "123", string(ep[0].RefObject().UID))
+				require.Equal(t, types.Service, ep[0].RefObject().Source())
+				require.Equal(t, "foo", ep[0].RefObject().Name())
+				require.Equal(t, "123", string(ep[0].RefObject().UID()))
 			},
 		},
 		{
@@ -505,9 +505,9 @@ func TestDedupSource_RefObjects(t *testing.T) {
 			expected: func(t *testing.T, ep []*endpoint.Endpoint) {
 				require.Len(t, ep, 1)
 				require.NotNil(t, ep[0].RefObject())
-				require.Equal(t, types.Service, ep[0].RefObject().Source)
-				require.Equal(t, "first-svc", ep[0].RefObject().Name)
-				require.Equal(t, "uid-first", string(ep[0].RefObject().UID))
+				require.Equal(t, types.Service, ep[0].RefObject().Source())
+				require.Equal(t, "first-svc", ep[0].RefObject().Name())
+				require.Equal(t, "uid-first", string(ep[0].RefObject().UID()))
 			},
 		},
 		{
@@ -526,9 +526,9 @@ func TestDedupSource_RefObjects(t *testing.T) {
 				require.Len(t, ep, 1)
 				require.NotNil(t, ep[0].RefObject())
 				// First endpoint (Service) wins, Ingress is discarded
-				require.Equal(t, types.Service, ep[0].RefObject().Source)
-				require.Equal(t, "my-service", ep[0].RefObject().Name)
-				require.Equal(t, "svc-uid", string(ep[0].RefObject().UID))
+				require.Equal(t, types.Service, ep[0].RefObject().Source())
+				require.Equal(t, "my-service", ep[0].RefObject().Name())
+				require.Equal(t, "svc-uid", string(ep[0].RefObject().UID()))
 			},
 		},
 		{
@@ -547,9 +547,9 @@ func TestDedupSource_RefObjects(t *testing.T) {
 				require.Len(t, ep, 1)
 				require.NotNil(t, ep[0].RefObject())
 				// First endpoint (Ingress) wins, Service is discarded
-				require.Equal(t, types.Ingress, ep[0].RefObject().Source)
-				require.Equal(t, "my-ingress", ep[0].RefObject().Name)
-				require.Equal(t, "ing-uid", string(ep[0].RefObject().UID))
+				require.Equal(t, types.Ingress, ep[0].RefObject().Source())
+				require.Equal(t, "my-ingress", ep[0].RefObject().Name())
+				require.Equal(t, "ing-uid", string(ep[0].RefObject().UID()))
 			},
 		},
 		{
@@ -580,13 +580,13 @@ func TestDedupSource_RefObjects(t *testing.T) {
 
 				require.NotNil(t, svcEndpoint)
 				require.NotNil(t, svcEndpoint.RefObject())
-				require.Equal(t, types.Service, svcEndpoint.RefObject().Source)
-				require.Equal(t, "my-service", svcEndpoint.RefObject().Name)
+				require.Equal(t, types.Service, svcEndpoint.RefObject().Source())
+				require.Equal(t, "my-service", svcEndpoint.RefObject().Name())
 
 				require.NotNil(t, ingEndpoint)
 				require.NotNil(t, ingEndpoint.RefObject())
-				require.Equal(t, types.Ingress, ingEndpoint.RefObject().Source)
-				require.Equal(t, "my-ingress", ingEndpoint.RefObject().Name)
+				require.Equal(t, types.Ingress, ingEndpoint.RefObject().Source())
+				require.Equal(t, "my-ingress", ingEndpoint.RefObject().Name())
 			},
 		},
 		{
@@ -608,9 +608,9 @@ func TestDedupSource_RefObjects(t *testing.T) {
 				require.Len(t, ep, 1)
 				require.NotNil(t, ep[0].RefObject())
 				// First endpoint (Service) wins
-				require.Equal(t, types.Service, ep[0].RefObject().Source)
-				require.Equal(t, "my-service", ep[0].RefObject().Name)
-				require.Equal(t, "123", string(ep[0].RefObject().UID))
+				require.Equal(t, types.Service, ep[0].RefObject().Source())
+				require.Equal(t, "my-service", ep[0].RefObject().Name())
+				require.Equal(t, "123", string(ep[0].RefObject().UID()))
 			},
 		},
 		{
@@ -626,8 +626,8 @@ func TestDedupSource_RefObjects(t *testing.T) {
 			expected: func(t *testing.T, ep []*endpoint.Endpoint) {
 				require.Len(t, ep, 1)
 				require.NotNil(t, ep[0].RefObject())
-				require.Equal(t, types.Service, ep[0].RefObject().Source)
-				require.Equal(t, "123", string(ep[0].RefObject().UID))
+				require.Equal(t, types.Service, ep[0].RefObject().Source())
+				require.Equal(t, "123", string(ep[0].RefObject().UID()))
 			},
 		},
 		{

--- a/source/wrappers/metrics.go
+++ b/source/wrappers/metrics.go
@@ -47,8 +47,8 @@ var (
 // or "unknown" if the reference is not set. Sources that set RefObject will
 // populate this with their name (e.g. "ingress", "service").
 func endpointSource(ep *endpoint.Endpoint) string {
-	if ref := ep.RefObject(); ref != nil && ref.Source != "" {
-		return ref.Source
+	if ref := ep.RefObject(); ref != nil && ref.Source() != "" {
+		return ref.Source()
 	}
 	return "unknown"
 }


### PR DESCRIPTION
## What does it do ?

- Made ObjectReference fields private;

## Motivation

ObjectReference had public fields with a TODO noting the encapsulation debt.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
