### PR TITLE
feat(source): apply controller annotation filter at indexer level

### DIFF
--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -100,6 +100,7 @@ func NewIstioGatewaySource(
 	informers.MustAddIndexers(gatewayInformer.Informer(), informers.IndexerWithOptions[*networkingv1.Gateway](
 		informers.IndexSelectorWithAnnotationFilter(cfg.AnnotationFilter),
 		informers.IndexSelectorWithLabelSelector(cfg.LabelFilter),
+		informers.IndexSelectorWithConditions(annotations.IsControllerMatch[*networkingv1.Gateway]),
 	))
 
 	// Add default resource event handlers to properly initialize informer.
@@ -142,10 +143,6 @@ func (sc *gatewaySource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, err
 	for _, key := range indexKeys {
 		gateway, err := informers.GetByKey[*networkingv1.Gateway](indexer, key)
 		if err != nil || gateway == nil {
-			continue
-		}
-
-		if annotations.IsControllerMismatch(gateway, types.IstioGateway) {
 			continue
 		}
 

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -107,6 +107,7 @@ func NewIstioVirtualServiceSource(
 	informers.MustAddIndexers(virtualServiceInformer.Informer(), informers.IndexerWithOptions[*networkingv1.VirtualService](
 		informers.IndexSelectorWithAnnotationFilter(cfg.AnnotationFilter),
 		informers.IndexSelectorWithLabelSelector(cfg.LabelFilter),
+		informers.IndexSelectorWithConditions(annotations.IsControllerMatch[*networkingv1.VirtualService]),
 	))
 
 	// Add default resource event handlers to properly initialize informer.
@@ -151,10 +152,6 @@ func (sc *virtualServiceSource) Endpoints(ctx context.Context) ([]*endpoint.Endp
 	for _, key := range indexKeys {
 		vService, err := informers.GetByKey[*networkingv1.VirtualService](indexer, key)
 		if err != nil || vService == nil {
-			continue
-		}
-
-		if annotations.IsControllerMismatch(vService, types.IstioVirtualService) {
 			continue
 		}
 

--- a/source/pod.go
+++ b/source/pod.go
@@ -78,6 +78,7 @@ func NewPodSource(
 	informers.MustAddIndexers(podInformer.Informer(), informers.IndexerWithOptions[*v1.Pod](
 		informers.IndexSelectorWithAnnotationFilter(annotationFilter),
 		informers.IndexSelectorWithLabelSelector(labelSelector),
+		informers.IndexSelectorWithConditions(annotations.IsControllerMatch[*v1.Pod]),
 	))
 	informers.MustSetTransform(podInformer.Informer(), informers.TransformerWithOptions[*v1.Pod](
 		informers.TransformRemoveManagedFields(),

--- a/source/pod_test.go
+++ b/source/pod_test.go
@@ -737,6 +737,66 @@ func TestPodSource(t *testing.T) {
 				},
 			},
 		},
+		{
+			"our controller type is dns-controller",
+			"",
+			"",
+			true,
+			"",
+			[]*endpoint.Endpoint{
+				{DNSName: "a.foo.example.org", Targets: endpoint.Targets{"54.10.11.1"}, RecordType: endpoint.RecordTypeA},
+			},
+			false,
+			nodesFixturesIPv4(),
+			[]*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-pod1",
+						Namespace: "kube-system",
+						Annotations: map[string]string{
+							annotations.ControllerKey: annotations.ControllerValue,
+							annotations.HostnameKey:   "a.foo.example.org",
+						},
+					},
+					Spec: corev1.PodSpec{
+						HostNetwork: true,
+						NodeName:    "my-node1",
+					},
+					Status: corev1.PodStatus{
+						PodIP: "10.0.1.1",
+					},
+				},
+			},
+		},
+		{
+			"different controller types are ignored",
+			"",
+			"",
+			true,
+			"",
+			[]*endpoint.Endpoint{},
+			false,
+			nodesFixturesIPv4(),
+			[]*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-pod1",
+						Namespace: "kube-system",
+						Annotations: map[string]string{
+							annotations.ControllerKey: "some-other-tool",
+							annotations.HostnameKey:   "a.foo.example.org",
+						},
+					},
+					Spec: corev1.PodSpec{
+						HostNetwork: true,
+						NodeName:    "my-node1",
+					},
+					Status: corev1.PodStatus{
+						PodIP: "10.0.1.1",
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
 			kubernetes := fake.NewClientset()

--- a/source/unstructured.go
+++ b/source/unstructured.go
@@ -88,6 +88,9 @@ func NewUnstructuredFQDNSource(
 		informers.MustAddIndexers(informer.Informer(), informers.IndexerWithOptions[*unstructured.Unstructured](
 			informers.IndexSelectorWithAnnotationFilter(cfg.AnnotationFilter),
 			informers.IndexSelectorWithLabelSelector(cfg.LabelFilter),
+			informers.IndexSelectorWithConditions(func(u *unstructured.Unstructured) bool {
+				return annotations.IsControllerMatch(newUnstructuredWrapper(u))
+			}),
 		))
 		informers.MustSetTransform(informer.Informer(), informers.TransformerWithOptions[*unstructured.Unstructured](
 			informers.TransformRemoveManagedFields(),
@@ -140,10 +143,6 @@ func (us *unstructuredSource) endpointsFromInformer(informer kubeinformers.Gener
 		}
 
 		el := newUnstructuredWrapper(obj)
-
-		if annotations.IsControllerMismatch(el, types.Unstructured) {
-			continue
-		}
 
 		hosts := annotations.HostnamesFromAnnotations(el.GetAnnotations())
 		addrs := annotations.TargetsFromTargetAnnotation(el.GetAnnotations())


### PR DESCRIPTION
## What does it do ?

Controller annotation filtering moved from loop-time guard (IsControllerMismatch) to indexer-time predicate (IsControllerMatch) for istio_gateway, istio_virtualservice, and unstructured sources

follow-up
- other sources to support indexers

## Motivation

  - Controller annotation mismatches were caught late — inside the reconcile loop — meaning objects were fetched from the cache only to be discarded
  - service.go already used the early-filter pattern (IsControllerMatch at indexer time); the remaining sources were inconsistent
  - Pod source had no controller annotation filtering at all, silently including pods with mismatched controllers

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
