### PR TITLE
docs: add Tencent Cloud webhook provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ from the usage of any externally developed webhook.
 | SAKURA Cloud          | https://github.com/sacloud/external-dns-sacloud-webhook              |
 | Simply                | https://github.com/uozalp/external-dns-simply-webhook                |
 | STACKIT               | https://github.com/stackitcloud/external-dns-stackit-webhook         |
+| Tencent Cloud         | https://github.com/tkestack/external-dns-tencentcloud-webhook        |
 | Unbound               | https://github.com/guillomep/external-dns-unbound-webhook            |
 | Unifi                 | https://github.com/kashalls/external-dns-unifi-webhook               |
 | UniFi                 | https://github.com/lexfrei/external-dns-unifios-webhook              |


### PR DESCRIPTION
## What this PR does

- Adds [external-dns-tencentcloud-webhook](https://github.com/tkestack/external-dns-tencentcloud-webhook) to the webhook provider registry table in README.md
- Creates a dedicated tutorial at \`docs/tutorials/tencentcloud.md\`

## Why

The in-tree Tencent Cloud provider was [removed](https://github.com/kubernetes-sigs/external-dns/commit/640e593f) per the webhook migration plan. This webhook implementation supports both DNSPod (public DNS) and PrivateDNS (VPC-scoped) with two credential modes:

- **Static**: SecretId/SecretKey — works on any Kubernetes cluster
- **OIDC**: TKE RRSA — keyless authentication for TKE managed clusters

## References

- Webhook repo: https://github.com/tkestack/external-dns-tencentcloud-webhook
- Provider registry section in \`docs/tutorials/webhook-provider.md\` encourages PRs to add provider links
