### PR TITLE
fix(mapper): prevent index out of bounds in ToEndpointName with multi-dot suffix

### DIFF
--- a/registry/mapper/mapper.go
+++ b/registry/mapper/mapper.go
@@ -19,6 +19,8 @@ package mapper
 import (
 	"strings"
 
+	log "github.com/sirupsen/logrus"
+
 	"sigs.k8s.io/external-dns/endpoint"
 )
 
@@ -73,20 +75,22 @@ func (a AffixNameMapper) ToEndpointName(dns string) (string, string) {
 	// drop suffix
 	if a.isSuffix() {
 		dc := strings.Count(a.suffix, ".")
-		DNSName := strings.SplitN(lowerDNSName, ".", 2+dc)
-		domainWithSuffix := strings.Join(DNSName[:1+dc], ".")
-
-		r, rType := a.dropAffixExtractType(domainWithSuffix)
-		if !strings.Contains(lowerDNSName, ".") {
+		parts := strings.SplitN(lowerDNSName, ".", 2+dc)
+		if len(parts) <= dc {
+			log.Debugf("skipping TXT record %q: too few labels for suffix %q", dns, a.suffix)
+			return "", ""
+		}
+		r, rType := a.dropAffixExtractType(strings.Join(parts[:1+dc], "."))
+		if len(parts) <= 1+dc {
 			return r, rType
 		}
-		return r + "." + DNSName[1+dc], rType
+		return r + "." + parts[1+dc], rType
 	}
 	return "", ""
 }
 
 func (a AffixNameMapper) ToTXTName(dns, recordType string) string {
-	DNSName := strings.SplitN(dns, ".", 2)
+	parts := strings.SplitN(dns, ".", 2)
 	recordType = strings.ToLower(recordType)
 	recordT := recordType + "-"
 
@@ -94,19 +98,19 @@ func (a AffixNameMapper) ToTXTName(dns, recordType string) string {
 	suffix := a.normalizeAffixTemplate(a.suffix, recordType)
 
 	// If specified, replace a leading asterisk in the generated txt record name with some other string
-	if a.wildcardReplacement != "" && DNSName[0] == "*" {
-		DNSName[0] = a.wildcardReplacement
+	if a.wildcardReplacement != "" && parts[0] == "*" {
+		parts[0] = a.wildcardReplacement
 	}
 
 	if !a.recordTypeInAffix() {
-		DNSName[0] = recordT + DNSName[0]
+		parts[0] = recordT + parts[0]
 	}
 
-	if len(DNSName) < 2 {
-		return prefix + DNSName[0] + suffix
+	if len(parts) < 2 {
+		return prefix + parts[0] + suffix
 	}
 
-	return prefix + DNSName[0] + suffix + "." + DNSName[1]
+	return prefix + parts[0] + suffix + "." + parts[1]
 }
 
 func (a AffixNameMapper) recordTypeInAffix() bool {

--- a/registry/mapper/mapper_test.go
+++ b/registry/mapper/mapper_test.go
@@ -108,6 +108,27 @@ func TestAffixNameMapper_ToEndpointName(t *testing.T) {
 			wantRecordType:   endpoint.RecordTypeCNAME,
 		},
 		{
+			name:             "suffix with multiple dots and trailing labels",
+			mapper:           NewAffixNameMapper("", ".foo.bar", ""),
+			input:            "a-example.foo.bar.com",
+			wantEndpointName: "example.com",
+			wantRecordType:   endpoint.RecordTypeA,
+		},
+		{
+			name:             "suffix with multiple dots and no trailing labels",
+			mapper:           NewAffixNameMapper("", ".foo.bar", ""),
+			input:            "a-example.foo.bar",
+			wantEndpointName: "example",
+			wantRecordType:   endpoint.RecordTypeA,
+		},
+		{
+			name:             "suffix with multiple dots and too few labels does not panic",
+			mapper:           NewAffixNameMapper("", ".foo.bar", ""),
+			input:            "a-example.foo",
+			wantEndpointName: "",
+			wantRecordType:   "",
+		},
+		{
 			name:             "no affix with A record",
 			mapper:           NewAffixNameMapper("", "", ""),
 			input:            "a-foo.example.com",


### PR DESCRIPTION
## What does it do ?

Adds bounds checks in `AffixNameMapper.ToEndpointName` to prevent two index-out-of-bounds panics when a multi-dot `txt-suffix` (e.g. `.foo.bar`) is configured and DNS names have fewer labels than the suffix expects.

## Motivation

`ToEndpointName` is called on every TXT record during `Records()` in both the TXT and DynamoDB registries. When using a multi-dot suffix, DNS names with fewer labels than the suffix cause slice index panics that crash the controller:

1. `parts[:1+dc]` panics when `len(parts) <= dc`
2. `parts[1+dc]` panics when `len(parts) == 1+dc`

This generalizes the single-label fix from #4885, which only guarded the zero-dot case via `strings.Contains`. The `!strings.Contains` check is replaced with proper length checks that cover all short-label cases.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly