### PR TITLE
fix: support ownership recognition of txt records

### DIFF
--- a/registry/mapper/mapper.go
+++ b/registry/mapper/mapper.go
@@ -36,6 +36,7 @@ var (
 		endpoint.RecordTypePTR,
 		endpoint.RecordTypeSRV,
 		endpoint.RecordTypeNAPTR,
+		endpoint.RecordTypeTXT,
 	}
 )
 

--- a/registry/mapper/mapper_test.go
+++ b/registry/mapper/mapper_test.go
@@ -167,8 +167,8 @@ func TestAffixNameMapper_ToEndpointName(t *testing.T) {
 			name:             "suffix with txt record",
 			mapper:           NewAffixNameMapper("", "", ""),
 			input:            "txt-foo.example.com",
-			wantEndpointName: "txt-foo.example.com",
-			wantRecordType:   "",
+			wantEndpointName: "foo.example.com",
+			wantRecordType:   endpoint.RecordTypeTXT,
 		},
 		{
 			name:             "both prefix and suffix set returns empty",
@@ -265,6 +265,13 @@ func TestAffixNameMapper_ToTXTName(t *testing.T) {
 			wantTXTName: "naptr-foo.example.com",
 		},
 		{
+			name:        "prefix with TXT record type in affix",
+			mapper:      NewAffixNameMapper("%{record_type}-", "", ""),
+			dns:         "foo.example.com",
+			recordType:  endpoint.RecordTypeTXT,
+			wantTXTName: "txt-foo.example.com",
+		},
+		{
 			name:        "suffix with A record type in affix",
 			mapper:      NewAffixNameMapper("", "-%{record_type}", ""),
 			dns:         "foo.example.com",
@@ -279,6 +286,13 @@ func TestAffixNameMapper_ToTXTName(t *testing.T) {
 			wantTXTName: "foo-cname.example.com",
 		},
 		{
+			name:        "suffix with TXT record type in affix",
+			mapper:      NewAffixNameMapper("", "-%{record_type}", ""),
+			dns:         "foo.example.com",
+			recordType:  endpoint.RecordTypeTXT,
+			wantTXTName: "foo-txt.example.com",
+		},
+		{
 			name:        "wildcard replacement with A record",
 			mapper:      NewAffixNameMapper("txt-", "", "wild"),
 			dns:         "*.example.com",
@@ -291,6 +305,13 @@ func TestAffixNameMapper_ToTXTName(t *testing.T) {
 			dns:         "*.example.com",
 			recordType:  endpoint.RecordTypeMX,
 			wantTXTName: "txt-mx-wild.example.com",
+		},
+		{
+			name:        "wildcard replacement with TXT record",
+			mapper:      NewAffixNameMapper("txt-", "", "wild"),
+			dns:         "*.example.com",
+			recordType:  endpoint.RecordTypeTXT,
+			wantTXTName: "txt-txt-wild.example.com",
 		},
 		{
 			name:        "no affix with A record",
@@ -347,6 +368,13 @@ func TestAffixNameMapper_ToTXTName(t *testing.T) {
 			dns:         "foo.example.com",
 			recordType:  endpoint.RecordTypeNAPTR,
 			wantTXTName: "naptr-foo.example.com",
+		},
+		{
+			name:        "no affix with TXT record",
+			mapper:      NewAffixNameMapper("", "", ""),
+			dns:         "foo.example.com",
+			recordType:  endpoint.RecordTypeTXT,
+			wantTXTName: "txt-foo.example.com",
 		},
 	}
 


### PR DESCRIPTION
## What does it do ?

Adds support for managing txt records in a txt registry properly
<!-- A brief description of the change being made with this pull request. -->

## Motivation
The support was already working partly, but was having issues when checking ownership records of txt records. This breaks the general management of a zone in external dns, because other records aren't properly managed in that case as well.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
