### PR TITLE
fix(txt/registry): Fallback to separate type label for long TXT labels.

### DIFF
--- a/registry/mapper/mapper.go
+++ b/registry/mapper/mapper.go
@@ -228,6 +228,7 @@ func (a AffixNameMapper) dropAffixExtractType(name string) (string, string) {
 // would overflow RFC 1035's per-label limit. The bare "<recordType>" case is
 // encountered in suffix mode after the suffix has been trimmed.
 func extractRecordTypeDefaultPosition(name string) (string, string) {
+	// Inline form: "cname-foo.zone" -> ("foo.zone", "CNAME").
 	if dashIdx := strings.IndexByte(name, '-'); dashIdx > 0 {
 		head := name[:dashIdx]
 		for _, t := range supportedRecords {
@@ -236,6 +237,7 @@ func extractRecordTypeDefaultPosition(name string) (string, string) {
 			}
 		}
 	}
+	// Separate-label fallback form: "cname.foo.zone" -> ("foo.zone", "CNAME").
 	if dotIdx := strings.IndexByte(name, '.'); dotIdx > 0 {
 		head := name[:dotIdx]
 		for _, t := range supportedRecords {
@@ -244,6 +246,8 @@ func extractRecordTypeDefaultPosition(name string) (string, string) {
 			}
 		}
 	}
+	// Bare type token: suffix mode strips the suffix before calling, so
+	// "cname.suf" arrives here as "cname". Empty rest; caller reattaches.
 	for _, t := range supportedRecords {
 		if name == strings.ToLower(t) {
 			return "", t

--- a/registry/mapper/mapper.go
+++ b/registry/mapper/mapper.go
@@ -24,6 +24,9 @@ import (
 
 const (
 	recordTemplate = "%{record_type}"
+
+	// maxDNSLabelLen is the maximum length of a single DNS label per RFC 1035.
+	maxDNSLabelLen = 63
 )
 
 var (
@@ -80,11 +83,35 @@ func (a AffixNameMapper) ToEndpointName(dns string) (string, string) {
 		if !strings.Contains(lowerDNSName, ".") {
 			return r, rType
 		}
+		// In the separate-label fallback form, the suffix-bearing portion
+		// consists of only the record-type token; the parent's first label
+		// sits in the next position. Avoid a stray leading dot in that case.
+		if r == "" {
+			return DNSName[1+dc], rType
+		}
 		return r + "." + DNSName[1+dc], rType
 	}
 	return "", ""
 }
 
+// ToTXTName projects a parent record name onto the TXT registry name.
+//
+// The default "inline" form prepends "<recordType>-" to the parent's first label:
+//
+//	foo.example.com (CNAME) -> cname-foo.example.com
+//
+// When the inline form would push any label past RFC 1035's 63-char limit, the
+// mapper falls back to the "separate-label" form, where the record-type token
+// occupies its own DNS label and the parent's first label is preserved unmodified:
+//
+//	<60-char-label>.example.com (CNAME) -> cname.<60-char-label>.example.com
+//
+// Both forms are recognised by ToEndpointName, so this is transparent to readers
+// and backward-compatible with existing TXT records.
+//
+// The fallback applies only when neither the prefix nor the suffix already
+// templates the record type — templated affixes are left untouched to preserve
+// the user's explicitly-configured layout.
 func (a AffixNameMapper) ToTXTName(dns, recordType string) string {
 	DNSName := strings.SplitN(dns, ".", 2)
 	recordType = strings.ToLower(recordType)
@@ -98,15 +125,33 @@ func (a AffixNameMapper) ToTXTName(dns, recordType string) string {
 		DNSName[0] = a.wildcardReplacement
 	}
 
-	if !a.recordTypeInAffix() {
-		DNSName[0] = recordT + DNSName[0]
+	rest := ""
+	if len(DNSName) >= 2 {
+		rest = "." + DNSName[1]
 	}
 
-	if len(DNSName) < 2 {
-		return prefix + DNSName[0] + suffix
+	if a.recordTypeInAffix() {
+		return prefix + DNSName[0] + suffix + rest
 	}
 
-	return prefix + DNSName[0] + suffix + "." + DNSName[1]
+	inlineHead := prefix + recordT + DNSName[0] + suffix
+	if maxLabelLen(inlineHead) <= maxDNSLabelLen {
+		return inlineHead + rest
+	}
+
+	// Separate-label fallback: <prefix><recordType><suffix>.<firstLabel>.<rest>
+	return prefix + recordType + suffix + "." + DNSName[0] + rest
+}
+
+// maxLabelLen returns the length of the longest dot-separated label in s.
+func maxLabelLen(s string) int {
+	max := 0
+	for _, label := range strings.Split(s, ".") {
+		if len(label) > max {
+			max = len(label)
+		}
+	}
+	return max
 }
 
 func (a AffixNameMapper) recordTypeInAffix() bool {
@@ -176,12 +221,32 @@ func (a AffixNameMapper) dropAffixExtractType(name string) (string, string) {
 }
 
 // extractRecordTypeDefaultPosition extracts record type from the default position
-// when not using '%{record_type}' in the prefix/suffix
+// when not using '%{record_type}' in the prefix/suffix.
+//
+// Recognises both the inline form "<recordType>-<rest>" and the separate-label
+// fallback form "<recordType>.<rest>" emitted by ToTXTName when the inline form
+// would overflow RFC 1035's per-label limit. The bare "<recordType>" case is
+// encountered in suffix mode after the suffix has been trimmed.
 func extractRecordTypeDefaultPosition(name string) (string, string) {
-	nameS := strings.Split(name, "-")
+	if dashIdx := strings.IndexByte(name, '-'); dashIdx > 0 {
+		head := name[:dashIdx]
+		for _, t := range supportedRecords {
+			if head == strings.ToLower(t) {
+				return name[dashIdx+1:], t
+			}
+		}
+	}
+	if dotIdx := strings.IndexByte(name, '.'); dotIdx > 0 {
+		head := name[:dotIdx]
+		for _, t := range supportedRecords {
+			if head == strings.ToLower(t) {
+				return name[dotIdx+1:], t
+			}
+		}
+	}
 	for _, t := range supportedRecords {
-		if nameS[0] == strings.ToLower(t) {
-			return strings.TrimPrefix(name, nameS[0]+"-"), t
+		if name == strings.ToLower(t) {
+			return "", t
 		}
 	}
 	return name, ""

--- a/registry/mapper/mapper_test.go
+++ b/registry/mapper/mapper_test.go
@@ -525,6 +525,82 @@ func TestToEndpointNameNewTXT(t *testing.T) {
 	}
 }
 
+// TestAffixNameMapper_ToTXTName_LongLabelFallback verifies that when the
+// inline TXT name would exceed RFC 1035's 63-char label limit, the mapper
+// emits the separate-label fallback form, and that ToEndpointName round-trips
+// either form back to the original parent name.
+func TestAffixNameMapper_ToTXTName_LongLabelFallback(t *testing.T) {
+	tests := []struct {
+		name        string
+		mapper      AffixNameMapper
+		parentLabel int
+		recordType  string
+		wantTXTHead string
+	}{
+		{
+			name:        "no-affix CNAME at overflow threshold",
+			mapper:      NewAffixNameMapper("", "", ""),
+			parentLabel: 60,
+			recordType:  endpoint.RecordTypeCNAME,
+			wantTXTHead: "cname.",
+		},
+		{
+			name:        "no-affix AAAA at overflow threshold",
+			mapper:      NewAffixNameMapper("", "", ""),
+			parentLabel: 60,
+			recordType:  endpoint.RecordTypeAAAA,
+			wantTXTHead: "aaaa.",
+		},
+		{
+			name:        "no-affix A at overflow threshold",
+			mapper:      NewAffixNameMapper("", "", ""),
+			parentLabel: 62,
+			recordType:  endpoint.RecordTypeA,
+			wantTXTHead: "a.",
+		},
+		{
+			name:        "prefix overflow",
+			mapper:      NewAffixNameMapper("ext-", "", ""),
+			parentLabel: 56,
+			recordType:  endpoint.RecordTypeCNAME,
+			wantTXTHead: "ext-cname.",
+		},
+		{
+			name:        "suffix overflow",
+			mapper:      NewAffixNameMapper("", "-suf", ""),
+			parentLabel: 56,
+			recordType:  endpoint.RecordTypeCNAME,
+			wantTXTHead: "cname-suf.",
+		},
+		{
+			name:        "suffix with dot overflow",
+			mapper:      NewAffixNameMapper("", ".suf", ""),
+			parentLabel: 60,
+			recordType:  endpoint.RecordTypeCNAME,
+			wantTXTHead: "cname.suf.",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			label := strings.Repeat("a", tc.parentLabel)
+			parent := label + ".example.com"
+
+			txt := tc.mapper.ToTXTName(parent, tc.recordType)
+
+			assert.True(t, strings.HasPrefix(txt, tc.wantTXTHead),
+				"want fallback-form TXT (prefix %q), got %q", tc.wantTXTHead, txt)
+			for _, lbl := range strings.Split(txt, ".") {
+				assert.LessOrEqual(t, len(lbl), 63, "label %q exceeds RFC 1035 limit in TXT %q", lbl, txt)
+			}
+
+			gotParent, gotType := tc.mapper.ToEndpointName(txt)
+			assert.Equal(t, parent, gotParent, "round-trip parent name")
+			assert.Equal(t, tc.recordType, gotType, "round-trip record type")
+		})
+	}
+}
+
 func TestDropPrefix(t *testing.T) {
 	mapper := NewAffixNameMapper("foo-%{record_type}-", "", "")
 	expectedOutput := "test.example.com"

--- a/registry/txt/registry_test.go
+++ b/registry/txt/registry_test.go
@@ -1138,6 +1138,95 @@ func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestTXTRegistryApplyChangesLongLabelTXTFallback verifies that when a parent
+// record's first label is long enough that the inline TXT name "<recordType>-<label>"
+// would exceed RFC 1035's 63-char-per-label limit, the registry still creates
+// both the parent and an ownership TXT — using the separate-label fallback form
+// "<recordType>.<label>" produced by the mapper. Without that fallback, the TXT
+// would be silently skipped and the parent would leak as an unreclaimable orphan.
+func TestTXTRegistryApplyChangesLongLabelTXTFallback(t *testing.T) {
+	tests := []struct {
+		name          string
+		txtPrefix     string
+		newParent     func(dnsName string) *endpoint.Endpoint
+		labelLen      int
+		wantTXTPrefix string // dot-separated fallback TXT name head
+	}{
+		{
+			name:          "CNAME",
+			newParent:     func(dn string) *endpoint.Endpoint { return endpoint.NewEndpoint(dn, endpoint.RecordTypeCNAME, "lb.example.com") },
+			labelLen:      60, // cname- (6) + 60 = 66 -> overflow
+			wantTXTPrefix: "cname.",
+		},
+		{
+			name:          "AAAA",
+			newParent:     func(dn string) *endpoint.Endpoint { return endpoint.NewEndpoint(dn, endpoint.RecordTypeAAAA, "fe80::1") },
+			labelLen:      60, // aaaa- (5) + 60 = 65 -> overflow
+			wantTXTPrefix: "aaaa.",
+		},
+		{
+			name:          "A",
+			newParent:     func(dn string) *endpoint.Endpoint { return endpoint.NewEndpoint(dn, endpoint.RecordTypeA, "1.2.3.4") },
+			labelLen:      62, // a- (2) + 62 = 64 -> overflow
+			wantTXTPrefix: "a.",
+		},
+		{
+			name: "AliasA",
+			newParent: func(dn string) *endpoint.Endpoint {
+				return endpoint.NewEndpoint(dn, endpoint.RecordTypeA, "lb.example.com").WithProviderSpecific(endpoint.ProviderSpecificAlias, "true")
+			},
+			labelLen:      60, // alias-A encodes as cname- (6) + 60 = 66 -> overflow
+			wantTXTPrefix: "cname.",
+		},
+		{
+			name:          "WithTxtPrefix",
+			txtPrefix:     "ext-",
+			newParent:     func(dn string) *endpoint.Endpoint { return endpoint.NewEndpoint(dn, endpoint.RecordTypeCNAME, "lb.example.com") },
+			labelLen:      56, // ext- (4) + cname- (6) + 56 = 66 -> overflow
+			wantTXTPrefix: "ext-cname.",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			p := inmemory.NewInMemoryProvider()
+			require.NoError(t, p.CreateZone(testZone))
+
+			r, err := newRegistry(p, tc.txtPrefix, "", "owner", time.Hour, "", []string{}, []string{}, false, nil, "")
+			require.NoError(t, err)
+
+			parentLabel := strings.Repeat("a", tc.labelLen)
+			parent := tc.newParent(parentLabel + "." + testZone)
+			require.NotNil(t, parent, "test setup: parent at %d-char label must itself pass RFC 1035", tc.labelLen)
+
+			var got *plan.Changes
+			p.OnApplyChanges = func(_ context.Context, ch *plan.Changes) {
+				got = ch
+			}
+			require.NoError(t, r.ApplyChanges(ctx, &plan.Changes{
+				Create: []*endpoint.Endpoint{parent},
+			}))
+			require.NotNil(t, got)
+
+			wantTXTName := tc.wantTXTPrefix + parent.DNSName
+			parentSeen, txtSeen := false, false
+			for _, ep := range got.Create {
+				if ep.DNSName == parent.DNSName && ep.RecordType == parent.RecordType {
+					parentSeen = true
+				}
+				if ep.DNSName == wantTXTName && ep.RecordType == endpoint.RecordTypeTXT {
+					txtSeen = true
+				}
+				for _, lbl := range strings.Split(ep.DNSName, ".") {
+					assert.LessOrEqual(t, len(lbl), 63, "label %q in %s exceeds RFC 1035 limit", lbl, ep.DNSName)
+				}
+			}
+			assert.True(t, parentSeen, "parent record must be created at long-label name")
+			assert.True(t, txtSeen, "ownership TXT must be created in fallback form %q", wantTXTName)
+		})
+	}
+}
+
 func testTXTRegistryMissingRecords(t *testing.T) {
 	t.Run("No prefix", testTXTRegistryMissingRecordsNoPrefix)
 	t.Run("With Prefix", testTXTRegistryMissingRecordsWithPrefix)
@@ -1240,6 +1329,15 @@ func testTXTRegistryMissingRecordsNoPrefix(t *testing.T) {
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "owner",
+			},
+			// Long-label records can now migrate to the new TXT format
+			// (in separate-label fallback form), so force-update fires here
+			// just like the other old-format entries above.
+			ProviderSpecific: []endpoint.ProviderSpecificProperty{
+				{
+					Name:  "txt/force-update",
+					Value: "true",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## What does it do ?

Supersedes this PR: https://github.com/kubernetes-sigs/external-dns/pull/6431 

Adds detection logic for records that are being generated that would result in ownership TXT records with labels exceeding the maximum length of 63 chars, resulting in the A/AAAA/CNAME records being created as orphans and can no longer be managed by External DNS.

The new behavior is such that:

- Created records with labels less than ~58 characters: No change, TXT records are created like `cname-label.foo.bar`
- Created records with labels > ~58: Append the type as a a separate label, like: `cname.long-label.foo.bar`

This will allow creation of the desired record, along with the TXT record used to establish ownership.

<!-- A brief description of the change being made with this pull request. -->

## Motivation

Fixes: https://github.com/kubernetes-sigs/external-dns/issues/6430

<!-- What inspired you to submit this pull request? -->

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
