### PR TITLE
feat: add support for k8s networking API gateway backed istio gateways

### DIFF
--- a/docs/annotations/annotations.md
+++ b/docs/annotations/annotations.md
@@ -253,6 +253,59 @@ spec:
     useProxyProto: false
 ```
 
+## external-dns.kubernetes.io/gateway
+
+This annotation allows ExternalDNS to work with Istio Gateways and VirtualServices that don't have a public IP, in setups where a central [Gateway API](https://gateway-api.sigs.k8s.io/) `Gateway` provisions the load balancer that handles all public traffic.
+
+It addresses the same architectural pattern as the [`ingress`](#external-dnskubernetesioingress) annotation, but for environments where a Gateway API `Gateway` provisions the public load balancer rather than a Kubernetes Ingress:
+
+- **The Challenge**: By default, ExternalDNS sources the public IP address for a DNS record from a Service of type LoadBalancer. However, in some setups, a central Gateway API `Gateway` in a shared namespace provisions the public load balancer, and Istio Gateways or VirtualServices in separate namespaces handle routing for individual services. The Istio Gateway's own Service may be of type ClusterIP, leaving ExternalDNS with no public IP to discover.
+
+- **The Solution**: The `gateway` annotation on the Istio Gateway tells ExternalDNS to look up a specified Gateway API `Gateway` resource and use its `status.addresses` as the DNS record targets. The value is in the format `namespace/name` or `name` (defaulting to the annotated resource's namespace). When used with VirtualServices, the annotation is placed on the Istio Gateway that the VirtualService references.
+
+### Use Cases for `external-dns.kubernetes.io/gateway` annotation
+
+#### Getting target from a Gateway API Gateway
+
+```yml
+# The Gateway API Gateway that provisions the load balancer (in a shared namespace)
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: central-gateway
+  namespace: istio-ingress
+spec:
+  gatewayClassName: gke-l7-global-external-managed
+  listeners:
+  - name: https
+    port: 443
+    protocol: HTTPS
+status:
+  addresses:
+  - type: IPAddress
+    value: 34.120.1.2
+---
+# The Istio Gateway in the service's namespace
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: my-service-gateway
+  namespace: my-service-ns
+  annotations:
+    external-dns.kubernetes.io/hostname: my-service.example.com
+    external-dns.kubernetes.io/gateway: istio-ingress/central-gateway
+spec:
+  servers:
+  - port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    hosts:
+    - my-service.example.com
+```
+
+In this example, ExternalDNS creates a DNS A record for `my-service.example.com` pointing to `34.120.1.2`, sourced from the Gateway API `Gateway`'s `status.addresses`.
+
 ## external-dns.kubernetes.io/internal-hostname
 
 Specifies the domain for the resource's DNS records that are for use from internal networks.

--- a/source/annotations/annotations.go
+++ b/source/annotations/annotations.go
@@ -59,8 +59,12 @@ var (
 	AccessKey = AnnotationKeyPrefix + "access"
 	// EndpointsTypeKey The annotation used for specifying the type of endpoints to use for headless services
 	EndpointsTypeKey = AnnotationKeyPrefix + "endpoints-type"
-	// Ingress the annotation used to determine if the gateway is implemented by an Ingress object
+	// Ingress the annotation used to reference an Ingress object for endpoint target resolution.
+	// The value is in the format "namespace/name" or "name".
 	Ingress = AnnotationKeyPrefix + "ingress"
+	// GatewayKey the annotation used to reference a Gateway API Gateway object for endpoint target resolution.
+	// The value is in the format "namespace/name" or "name".
+	GatewayKey = AnnotationKeyPrefix + "gateway"
 	// IngressHostnameSourceKey The annotation used to determine the source of hostnames for ingresses.  This is an optional field - all
 	// available hostname sources are used if not specified.
 	IngressHostnameSourceKey = AnnotationKeyPrefix + "ingress-hostname-source"
@@ -106,6 +110,7 @@ func SetAnnotationPrefix(prefix string) {
 	AccessKey = AnnotationKeyPrefix + "access"
 	EndpointsTypeKey = AnnotationKeyPrefix + "endpoints-type"
 	Ingress = AnnotationKeyPrefix + "ingress"
+	GatewayKey = AnnotationKeyPrefix + "gateway"
 	IngressHostnameSourceKey = AnnotationKeyPrefix + "ingress-hostname-source"
 	InternalHostnameKey = AnnotationKeyPrefix + "internal-hostname"
 	GatewayHostnameSourceKey = AnnotationKeyPrefix + "gateway-hostname-source"

--- a/source/annotations/annotations_test.go
+++ b/source/annotations/annotations_test.go
@@ -50,6 +50,7 @@ func TestSetAnnotationPrefix(t *testing.T) {
 	assert.Equal(t, "custom.io/access", AccessKey)
 	assert.Equal(t, "custom.io/endpoints-type", EndpointsTypeKey)
 	assert.Equal(t, "custom.io/ingress", Ingress)
+	assert.Equal(t, "custom.io/gateway", GatewayKey)
 	assert.Equal(t, "custom.io/ingress-hostname-source", IngressHostnameSourceKey)
 
 	// ControllerValue should remain constant

--- a/source/endpoints.go
+++ b/source/endpoints.go
@@ -16,8 +16,10 @@ package source
 import (
 	"fmt"
 
+	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/labels"
 	coreinformers "k8s.io/client-go/informers/core/v1"
+	gwinformers_v1 "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/apis/v1"
 
 	"sigs.k8s.io/external-dns/endpoint"
 )
@@ -55,4 +57,35 @@ func EndpointTargetsFromServices(svcInformer coreinformers.ServiceInformer, name
 		}
 	}
 	return endpoint.NewTargets(targets...), nil
+}
+
+// EndpointTargetsFromK8sGateway resolves endpoint targets from a Kubernetes
+// Gateway API Gateway object identified by a "namespace/name" or "name" reference.
+// defaultNamespace is used when the reference omits a namespace.
+func EndpointTargetsFromK8sGateway(gwInformer gwinformers_v1.GatewayInformer, ref string, defaultNamespace string) (endpoint.Targets, error) {
+	if gwInformer == nil {
+		return nil, fmt.Errorf("Gateway API client not configured but %q annotation is set", K8sGatewaySource)
+	}
+
+	namespace, name, err := ParseNamespacedName(ref)
+	if err != nil {
+		return nil, err
+	}
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+
+	gw, err := gwInformer.Lister().Gateways(namespace).Get(name)
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
+	targets := make(endpoint.Targets, 0, len(gw.Status.Addresses))
+	for _, addr := range gw.Status.Addresses {
+		if addr.Value != "" {
+			targets = append(targets, addr.Value)
+		}
+	}
+	return targets, nil
 }

--- a/source/endpoints.go
+++ b/source/endpoints.go
@@ -64,7 +64,7 @@ func EndpointTargetsFromServices(svcInformer coreinformers.ServiceInformer, name
 // defaultNamespace is used when the reference omits a namespace.
 func EndpointTargetsFromK8sGateway(gwInformer gwinformers_v1.GatewayInformer, ref string, defaultNamespace string) (endpoint.Targets, error) {
 	if gwInformer == nil {
-		return nil, fmt.Errorf("Gateway API client not configured but %q annotation is set", K8sGatewaySource)
+		return nil, fmt.Errorf("Gateway API client not configured but %q annotation is set", K8sGatewaySource())
 	}
 
 	namespace, name, err := ParseNamespacedName(ref)

--- a/source/gloo_proxy.go
+++ b/source/gloo_proxy.go
@@ -365,7 +365,7 @@ func (gs *glooSource) targetsFromGatewayIngress(proxy *proxy) (endpoint.Targets,
 			}
 
 			if ingressStr, ok := unstructuredGateway.GetAnnotations()[annotations.Ingress]; ok && ingressStr != "" {
-				namespace, name, err := ParseIngress(ingressStr)
+				namespace, name, err := ParseNamespacedName(ingressStr)
 				if err != nil {
 					return nil, fmt.Errorf("failed to parse Ingress annotation on Gateway (%s/%s): %w", unstructuredGateway.GetNamespace(), unstructuredGateway.GetName(), err)
 				}

--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -28,10 +28,15 @@ import (
 	networkingv1informer "istio.io/client-go/pkg/informers/externalversions/networking/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeinformers "k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	netinformers "k8s.io/client-go/informers/networking/v1"
 	"k8s.io/client-go/kubernetes"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+	gwinformers "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions"
+	gwinformers_v1 "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/apis/v1"
 
 	"sigs.k8s.io/external-dns/source/types"
 
@@ -45,6 +50,10 @@ import (
 // instead of a standard LoadBalancer service type
 // Using var instead of const because annotation keys can be customized
 var IstioGatewayIngressSource = annotations.Ingress
+
+// K8sGatewaySource is the annotation used to reference a Kubernetes Gateway API
+// Gateway object for endpoint target resolution.
+var K8sGatewaySource = annotations.GatewayKey
 
 // gatewaySource is an implementation of Source for Istio Gateway objects.
 // The gateway implementation uses the spec.servers.hosts values for the hostnames.
@@ -66,6 +75,7 @@ type gatewaySource struct {
 	serviceInformer          coreinformers.ServiceInformer
 	gatewayInformer          networkingv1informer.GatewayInformer
 	ingressInformer          netinformers.IngressInformer
+	gwAPIInformer            gwinformers_v1.GatewayInformer
 }
 
 // NewIstioGatewaySource creates a new gatewaySource with the given config.
@@ -74,6 +84,7 @@ func NewIstioGatewaySource(
 	kubeClient kubernetes.Interface,
 	istioClient istioclient.Interface,
 	cfg *Config,
+	gwAPIClient gatewayclient.Interface,
 ) (Source, error) {
 	// Use shared informers to listen for add/update/delete of services/pods/nodes in the specified namespace.
 	// Set resync period to 0, to prevent processing when nothing has changed
@@ -108,8 +119,29 @@ func NewIstioGatewaySource(
 	informers.MustAddEventHandler(ingressInformer.Informer(), informers.DefaultEventHandler())
 	informers.MustAddEventHandler(gatewayInformer.Informer(), informers.DefaultEventHandler())
 
+	// Optionally set up a Gateway API Gateway informer if a client is provided
+	// and the Gateway API CRDs are installed in the cluster.
+	var gwAPIInformer gwinformers_v1.GatewayInformer
+	var gwAPIInformerFactory gwinformers.SharedInformerFactory
+	if gwAPIClient != nil {
+		if _, err := gwAPIClient.GatewayV1().Gateways("").List(ctx, metav1.ListOptions{Limit: 1}); err != nil {
+			log.Debugf("Gateway API not available, %q annotation will not be supported: %v", K8sGatewaySource, err)
+		} else {
+			gwAPIInformerFactory = gwinformers.NewSharedInformerFactory(gwAPIClient, 0)
+			gwAPIInformer = gwAPIInformerFactory.Gateway().V1().Gateways()
+			informers.MustSetTransform(gwAPIInformer.Informer(), informers.TransformerWithOptions[*gatewayv1.Gateway](
+				informers.TransformRemoveManagedFields(),
+				informers.TransformRemoveLastAppliedConfig(),
+			))
+			informers.MustAddEventHandler(gwAPIInformer.Informer(), informers.DefaultEventHandler())
+		}
+	}
+
 	informerFactory.Start(ctx.Done())
 	istioInformerFactory.Start(ctx.Done())
+	if gwAPIInformerFactory != nil {
+		gwAPIInformerFactory.Start(ctx.Done())
+	}
 
 	// wait for the local cache to be populated.
 	if err := informers.WaitForCacheSync(ctx, informerFactory); err != nil {
@@ -117,6 +149,11 @@ func NewIstioGatewaySource(
 	}
 	if err := informers.WaitForCacheSync(ctx, istioInformerFactory); err != nil {
 		return nil, err
+	}
+	if gwAPIInformerFactory != nil {
+		if err := informers.WaitForCacheSync(ctx, gwAPIInformerFactory); err != nil {
+			return nil, err
+		}
 	}
 
 	return &gatewaySource{
@@ -127,6 +164,7 @@ func NewIstioGatewaySource(
 		serviceInformer:          serviceInformer,
 		gatewayInformer:          gatewayInformer,
 		ingressInformer:          ingressInformer,
+		gwAPIInformer:            gwAPIInformer,
 	}, nil
 }
 
@@ -189,7 +227,7 @@ func (sc *gatewaySource) AddEventHandler(_ context.Context, handler func()) {
 }
 
 func (sc *gatewaySource) targetsFromIngress(ingressStr string, gateway *networkingv1.Gateway) (endpoint.Targets, error) {
-	namespace, name, err := ParseIngress(ingressStr)
+	namespace, name, err := ParseNamespacedName(ingressStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse Ingress annotation on Gateway (%s/%s): %w", gateway.Namespace, gateway.Name, err)
 	}
@@ -214,6 +252,10 @@ func (sc *gatewaySource) targetsFromIngress(ingressStr string, gateway *networki
 	return targets, nil
 }
 
+func (sc *gatewaySource) targetsFromGatewayAPIGateway(gatewayStr string, gateway *networkingv1.Gateway) (endpoint.Targets, error) {
+	return EndpointTargetsFromK8sGateway(sc.gwAPIInformer, gatewayStr, gateway.Namespace)
+}
+
 func (sc *gatewaySource) targetsFromGateway(gateway *networkingv1.Gateway) (endpoint.Targets, error) {
 	targets := annotations.TargetsFromTargetAnnotation(gateway.Annotations)
 	if len(targets) > 0 {
@@ -223,6 +265,11 @@ func (sc *gatewaySource) targetsFromGateway(gateway *networkingv1.Gateway) (endp
 	ingressStr, ok := gateway.Annotations[IstioGatewayIngressSource]
 	if ok && ingressStr != "" {
 		return sc.targetsFromIngress(ingressStr, gateway)
+	}
+
+	gatewayStr, ok := gateway.Annotations[K8sGatewaySource]
+	if ok && gatewayStr != "" {
+		return sc.targetsFromGatewayAPIGateway(gatewayStr, gateway)
 	}
 
 	return EndpointTargetsFromServices(sc.serviceInformer, sc.namespace, gateway.Spec.Selector)

--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -46,14 +46,15 @@ import (
 	"sigs.k8s.io/external-dns/source/template"
 )
 
-// IstioGatewayIngressSource is the annotation used to determine if the gateway is implemented by an Ingress object
-// instead of a standard LoadBalancer service type
-// Using var instead of const because annotation keys can be customized
-var IstioGatewayIngressSource = annotations.Ingress
+// IstioGatewayIngressSource returns the annotation key used to determine if the gateway
+// is implemented by an Ingress object instead of a standard LoadBalancer service type.
+// This must be a function (not a package-level var) because the annotation prefix can
+// be customized at runtime via --annotation-prefix / SetAnnotationPrefix.
+func IstioGatewayIngressSource() string { return annotations.Ingress }
 
-// K8sGatewaySource is the annotation used to reference a Kubernetes Gateway API
+// K8sGatewaySource returns the annotation key used to reference a Kubernetes Gateway API
 // Gateway object for endpoint target resolution.
-var K8sGatewaySource = annotations.GatewayKey
+func K8sGatewaySource() string { return annotations.GatewayKey }
 
 // gatewaySource is an implementation of Source for Istio Gateway objects.
 // The gateway implementation uses the spec.servers.hosts values for the hostnames.
@@ -125,7 +126,7 @@ func NewIstioGatewaySource(
 	var gwAPIInformerFactory gwinformers.SharedInformerFactory
 	if gwAPIClient != nil {
 		if _, err := gwAPIClient.GatewayV1().Gateways("").List(ctx, metav1.ListOptions{Limit: 1}); err != nil {
-			log.Debugf("Gateway API not available, %q annotation will not be supported: %v", K8sGatewaySource, err)
+			log.Debugf("Gateway API not available, %q annotation will not be supported: %v", K8sGatewaySource(), err)
 		} else {
 			gwAPIInformerFactory = gwinformers.NewSharedInformerFactory(gwAPIClient, 0)
 			gwAPIInformer = gwAPIInformerFactory.Gateway().V1().Gateways()
@@ -190,7 +191,8 @@ func (sc *gatewaySource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, err
 
 		gwEndpoints, err := sc.endpointsFromGateway(gwHostnames, gateway)
 		if err != nil {
-			return nil, err
+			log.Warnf("Could not generate endpoints for gateway '%s/%s': %v", gateway.Namespace, gateway.Name, err)
+			continue
 		}
 
 		// apply template if host is missing on gateway
@@ -205,7 +207,8 @@ func (sc *gatewaySource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, err
 			},
 		)
 		if err != nil {
-			return nil, err
+			log.Warnf("Could not apply template for gateway '%s/%s': %v", gateway.Namespace, gateway.Name, err)
+			continue
 		}
 
 		if endpoint.HasNoEmptyEndpoints(gwEndpoints, types.IstioGateway, gateway) {
@@ -262,12 +265,12 @@ func (sc *gatewaySource) targetsFromGateway(gateway *networkingv1.Gateway) (endp
 		return targets, nil
 	}
 
-	ingressStr, ok := gateway.Annotations[IstioGatewayIngressSource]
+	ingressStr, ok := gateway.Annotations[IstioGatewayIngressSource()]
 	if ok && ingressStr != "" {
 		return sc.targetsFromIngress(ingressStr, gateway)
 	}
 
-	gatewayStr, ok := gateway.Annotations[K8sGatewaySource]
+	gatewayStr, ok := gateway.Annotations[K8sGatewaySource()]
 	if ok && gatewayStr != "" {
 		return sc.targetsFromGatewayAPIGateway(gatewayStr, gateway)
 	}

--- a/source/istio_gateway_fqdn_test.go
+++ b/source/istio_gateway_fqdn_test.go
@@ -62,6 +62,7 @@ func TestIstioGatewaySourceNewSourceWithFqdn(t *testing.T) {
 					TemplateEngine:           templatetest.MustEngine(t, tt.fqdnTemplate, "", "", false),
 					IgnoreHostnameAnnotation: false,
 				},
+				nil,
 			)
 
 			require.NoError(t, err)
@@ -569,6 +570,7 @@ func TestIstioGatewaySourceFqdnTemplatingExamples(t *testing.T) {
 					TemplateEngine:           templatetest.MustEngine(t, tt.fqdnTemplate, "", "", !tt.combineFqdn),
 					IgnoreHostnameAnnotation: false,
 				},
+				nil,
 			)
 			require.NoError(t, err)
 

--- a/source/istio_gateway_test.go
+++ b/source/istio_gateway_test.go
@@ -50,6 +50,34 @@ import (
 // This is a compile-time validation that gatewaySource is a Source.
 var _ Source = &gatewaySource{}
 
+// TestAnnotationPrefixPropagation verifies that IstioGatewayIngressSource() and
+// K8sGatewaySource() reflect changes made by SetAnnotationPrefix at runtime.
+// This is a regression test for a bug where these were package-level vars evaluated
+// at import time — before SetAnnotationPrefix was called — causing annotation lookups
+// to use the wrong prefix and silently produce no endpoints, leading to record deletion.
+func TestAnnotationPrefixPropagation(t *testing.T) {
+	t.Cleanup(func() { annotations.SetAnnotationPrefix(annotations.DefaultAnnotationPrefix) })
+
+	defaultIngress := IstioGatewayIngressSource()
+	defaultGateway := K8sGatewaySource()
+	assert.Equal(t, annotations.DefaultAnnotationPrefix+"ingress", defaultIngress)
+	assert.Equal(t, annotations.DefaultAnnotationPrefix+"gateway", defaultGateway)
+
+	// Simulate --annotation-prefix=custom.io/
+	annotations.SetAnnotationPrefix("custom.io/")
+	assert.Equal(t, "custom.io/ingress", IstioGatewayIngressSource(),
+		"IstioGatewayIngressSource() must reflect updated annotation prefix")
+	assert.Equal(t, "custom.io/gateway", K8sGatewaySource(),
+		"K8sGatewaySource() must reflect updated annotation prefix")
+
+	// Simulate changing it again — must not be cached from first call
+	annotations.SetAnnotationPrefix("another.io/")
+	assert.Equal(t, "another.io/ingress", IstioGatewayIngressSource(),
+		"IstioGatewayIngressSource() must track subsequent prefix changes")
+	assert.Equal(t, "another.io/gateway", K8sGatewaySource(),
+		"K8sGatewaySource() must track subsequent prefix changes")
+}
+
 type GatewaySuite struct {
 	suite.Suite
 	source     Source
@@ -211,7 +239,7 @@ func testEndpointsFromGatewayConfig(t *testing.T) {
 			},
 			config: fakeGatewayConfig{
 				annotations: map[string]string{
-					IstioGatewayIngressSource: "ingress1",
+					IstioGatewayIngressSource(): "ingress1",
 				},
 				dnsnames: [][]string{
 					{"foo.bar"},
@@ -263,7 +291,7 @@ func testEndpointsFromGatewayConfig(t *testing.T) {
 			},
 			config: fakeGatewayConfig{
 				annotations: map[string]string{
-					IstioGatewayIngressSource: "ingress1",
+					IstioGatewayIngressSource(): "ingress1",
 				},
 				dnsnames: [][]string{
 					{"foo.bar"},
@@ -324,7 +352,7 @@ func testEndpointsFromGatewayConfig(t *testing.T) {
 			},
 			config: fakeGatewayConfig{
 				annotations: map[string]string{
-					IstioGatewayIngressSource: "ingress1",
+					IstioGatewayIngressSource(): "ingress1",
 				},
 				dnsnames: [][]string{
 					{""},
@@ -385,7 +413,7 @@ func testEndpointsFromGatewayConfig(t *testing.T) {
 			},
 			config: fakeGatewayConfig{
 				annotations: map[string]string{
-					IstioGatewayIngressSource: "istio-other2/ingress1",
+					IstioGatewayIngressSource(): "istio-other2/ingress1",
 				},
 				dnsnames: [][]string{
 					{"foo.bar"}, // Kubernetes requires removal of trailing dot
@@ -639,7 +667,7 @@ func testGatewayEndpoints(t *testing.T) {
 					namespace: "testing1",
 					dnsnames:  [][]string{{"example.org"}},
 					annotations: map[string]string{
-						IstioGatewayIngressSource: "testing2/ingress1",
+						IstioGatewayIngressSource(): "testing2/ingress1",
 					},
 				},
 			},
@@ -1005,7 +1033,7 @@ func testGatewayEndpoints(t *testing.T) {
 					name:      "fake3",
 					namespace: "",
 					annotations: map[string]string{
-						IstioGatewayIngressSource: "not-real/ingress1",
+						IstioGatewayIngressSource(): "not-real/ingress1",
 						annotations.TargetKey:     "1.2.3.4",
 					},
 					dnsnames: [][]string{{"example3.org"}},
@@ -1147,7 +1175,7 @@ func testGatewayEndpoints(t *testing.T) {
 					name:      "fake1",
 					namespace: "",
 					annotations: map[string]string{
-						IstioGatewayIngressSource: "ingress1",
+						IstioGatewayIngressSource(): "ingress1",
 						annotations.HostnameKey:   "dns-through-hostname.com",
 						annotations.TargetKey:     "gateway-target.com",
 					},
@@ -1322,7 +1350,7 @@ func testGatewayEndpoints(t *testing.T) {
 					name:      "fake1",
 					namespace: "",
 					annotations: map[string]string{
-						IstioGatewayIngressSource: "",
+						IstioGatewayIngressSource(): "",
 					},
 					dnsnames: [][]string{},
 				},
@@ -1456,7 +1484,7 @@ func testGatewayEndpoints(t *testing.T) {
 					name:      "fake1",
 					namespace: "",
 					annotations: map[string]string{
-						IstioGatewayIngressSource: "ingress2",
+						IstioGatewayIngressSource(): "ingress2",
 					},
 					dnsnames: [][]string{{"new.org"}},
 				},
@@ -1782,7 +1810,7 @@ func TestSingleGatewayMultipleServicesPointingToSameLoadBalancer(t *testing.T) {
 				{
 					Hosts: []string{"example.org"},
 					Tls: &istionetworking.ServerTLSSettings{
-						ServerCertificate: IstioGatewayIngressSource,
+						ServerCertificate: IstioGatewayIngressSource(),
 						Mode:              istionetworking.ServerTLSSettings_SIMPLE,
 					},
 				},
@@ -1936,7 +1964,7 @@ func testEndpointsFromGatewayAPIGatewayConfig(t *testing.T) {
 			},
 			config: fakeGatewayConfig{
 				annotations: map[string]string{
-					K8sGatewaySource: "my-gateway",
+					K8sGatewaySource(): "my-gateway",
 				},
 				dnsnames: [][]string{
 					{"foo.bar"},
@@ -1961,7 +1989,7 @@ func testEndpointsFromGatewayAPIGatewayConfig(t *testing.T) {
 			},
 			config: fakeGatewayConfig{
 				annotations: map[string]string{
-					K8sGatewaySource: "my-gateway",
+					K8sGatewaySource(): "my-gateway",
 				},
 				dnsnames: [][]string{
 					{"foo.bar"},
@@ -1986,7 +2014,7 @@ func testEndpointsFromGatewayAPIGatewayConfig(t *testing.T) {
 			},
 			config: fakeGatewayConfig{
 				annotations: map[string]string{
-					K8sGatewaySource: "my-gateway",
+					K8sGatewaySource(): "my-gateway",
 				},
 				dnsnames: [][]string{
 					{"foo.bar"},
@@ -2011,7 +2039,7 @@ func testEndpointsFromGatewayAPIGatewayConfig(t *testing.T) {
 			},
 			config: fakeGatewayConfig{
 				annotations: map[string]string{
-					K8sGatewaySource: "my-gateway",
+					K8sGatewaySource(): "my-gateway",
 				},
 				dnsnames: [][]string{
 					{"foo.bar"},
@@ -2042,7 +2070,7 @@ func testEndpointsFromGatewayAPIGatewayConfig(t *testing.T) {
 			config: fakeGatewayConfig{
 				namespace: "user-ns",
 				annotations: map[string]string{
-					K8sGatewaySource: "istio-ingress/central-gw",
+					K8sGatewaySource(): "istio-ingress/central-gw",
 				},
 				dnsnames: [][]string{
 					{"my-service.example.com"},
@@ -2067,7 +2095,7 @@ func testEndpointsFromGatewayAPIGatewayConfig(t *testing.T) {
 			},
 			config: fakeGatewayConfig{
 				annotations: map[string]string{
-					K8sGatewaySource: "my-gateway",
+					K8sGatewaySource(): "my-gateway",
 				},
 				dnsnames: [][]string{
 					{},
@@ -2086,7 +2114,7 @@ func testEndpointsFromGatewayAPIGatewayConfig(t *testing.T) {
 			},
 			config: fakeGatewayConfig{
 				annotations: map[string]string{
-					K8sGatewaySource: "nonexistent-gw",
+					K8sGatewaySource(): "nonexistent-gw",
 				},
 				dnsnames: [][]string{
 					{"foo.bar"},
@@ -2106,7 +2134,7 @@ func testEndpointsFromGatewayAPIGatewayConfig(t *testing.T) {
 			},
 			config: fakeGatewayConfig{
 				annotations: map[string]string{
-					K8sGatewaySource: "my-gateway",
+					K8sGatewaySource(): "my-gateway",
 					annotations.TargetKey: "override-target.com",
 				},
 				dnsnames: [][]string{
@@ -2132,8 +2160,8 @@ func testEndpointsFromGatewayAPIGatewayConfig(t *testing.T) {
 			},
 			config: fakeGatewayConfig{
 				annotations: map[string]string{
-					K8sGatewaySource:     "my-gateway",
-					IstioGatewayIngressSource: "my-ingress",
+					K8sGatewaySource():     "my-gateway",
+					IstioGatewayIngressSource(): "my-ingress",
 				},
 				dnsnames: [][]string{
 					{"foo.bar"},
@@ -2154,7 +2182,7 @@ func testEndpointsFromGatewayAPIGatewayConfig(t *testing.T) {
 			},
 			config: fakeGatewayConfig{
 				annotations: map[string]string{
-					K8sGatewaySource: "",
+					K8sGatewaySource(): "",
 				},
 				dnsnames: [][]string{
 					{"foo.bar"},
@@ -2214,7 +2242,7 @@ func testGatewayAPIGatewayEndpoints(t *testing.T) {
 					namespace: "testing1",
 					dnsnames:  [][]string{{"example.org"}},
 					annotations: map[string]string{
-						K8sGatewaySource: "istio-ingress/central-gw",
+						K8sGatewaySource(): "istio-ingress/central-gw",
 					},
 				},
 			},
@@ -2246,7 +2274,7 @@ func testGatewayAPIGatewayEndpoints(t *testing.T) {
 					name:      "fake1",
 					namespace: "",
 					annotations: map[string]string{
-						K8sGatewaySource:  "central-gw",
+						K8sGatewaySource():  "central-gw",
 						annotations.HostnameKey: "dns-through-hostname.com",
 					},
 					dnsnames: [][]string{{"example.org"}},
@@ -2280,7 +2308,7 @@ func testGatewayAPIGatewayEndpoints(t *testing.T) {
 					name:      "fake1",
 					namespace: "",
 					annotations: map[string]string{
-						K8sGatewaySource:  "central-gw",
+						K8sGatewaySource():  "central-gw",
 						annotations.HostnameKey: "dns-through-hostname.com",
 						annotations.TargetKey:   "gateway-target.com",
 					},
@@ -2315,7 +2343,7 @@ func testGatewayAPIGatewayEndpoints(t *testing.T) {
 					name:      "fake1",
 					namespace: "",
 					annotations: map[string]string{
-						K8sGatewaySource: "central-gw",
+						K8sGatewaySource(): "central-gw",
 						annotations.TtlKey:    "6",
 					},
 					dnsnames: [][]string{{"example.org"}},
@@ -2345,7 +2373,7 @@ func testGatewayAPIGatewayEndpoints(t *testing.T) {
 					name:      "fake1",
 					namespace: "",
 					annotations: map[string]string{
-						K8sGatewaySource: "central-gw",
+						K8sGatewaySource(): "central-gw",
 					},
 					dnsnames: [][]string{},
 				},
@@ -2374,7 +2402,7 @@ func testGatewayAPIGatewayEndpoints(t *testing.T) {
 					name:      "fake1",
 					namespace: "",
 					annotations: map[string]string{
-						K8sGatewaySource: "central-gw",
+						K8sGatewaySource(): "central-gw",
 					},
 					dnsnames: [][]string{{"example.org"}},
 				},
@@ -2414,7 +2442,7 @@ func testGatewayAPIGatewayEndpoints(t *testing.T) {
 					name:      "fake1",
 					namespace: "",
 					annotations: map[string]string{
-						K8sGatewaySource: "",
+						K8sGatewaySource(): "",
 					},
 					dnsnames: [][]string{},
 				},
@@ -2437,7 +2465,7 @@ func testGatewayAPIGatewayEndpoints(t *testing.T) {
 					name:      "fake1",
 					namespace: "",
 					annotations: map[string]string{
-						K8sGatewaySource:  "central-gw",
+						K8sGatewaySource():  "central-gw",
 						annotations.HostnameKey: "ignore.me",
 					},
 					dnsnames: [][]string{{"example.org"}},
@@ -2467,7 +2495,7 @@ func testGatewayAPIGatewayEndpoints(t *testing.T) {
 					name:      "fake1",
 					namespace: "",
 					annotations: map[string]string{
-						K8sGatewaySource:  "central-gw",
+						K8sGatewaySource():  "central-gw",
 						annotations.HostnameKey: "fake1.dns-through-hostname.com",
 					},
 					dnsnames: [][]string{{"*"}},
@@ -2498,7 +2526,7 @@ func testGatewayAPIGatewayEndpoints(t *testing.T) {
 					namespace: "",
 					annotations: map[string]string{
 						"kubernetes.io/gateway.class": "nginx",
-						K8sGatewaySource:         "central-gw",
+						K8sGatewaySource():         "central-gw",
 					},
 					dnsnames: [][]string{{"example.org"}},
 				},
@@ -2528,7 +2556,7 @@ func testGatewayAPIGatewayEndpoints(t *testing.T) {
 					namespace: "",
 					annotations: map[string]string{
 						"kubernetes.io/gateway.class": "tectonic",
-						K8sGatewaySource:         "central-gw",
+						K8sGatewaySource():         "central-gw",
 					},
 					dnsnames: [][]string{{"example.org"}},
 				},
@@ -2550,13 +2578,13 @@ func testGatewayAPIGatewayEndpoints(t *testing.T) {
 					name:      "fake1",
 					namespace: "",
 					annotations: map[string]string{
-						K8sGatewaySource: "nonexistent-gw",
+						K8sGatewaySource(): "nonexistent-gw",
 					},
 					dnsnames: [][]string{{"example.org"}},
 				},
 			},
 			expected:    []*endpoint.Endpoint{},
-			expectError: true,
+			expectError: false, // bad annotation should be skipped gracefully, not crash the controller
 		},
 	} {
 		t.Run(ti.title, func(t *testing.T) {

--- a/source/istio_gateway_test.go
+++ b/source/istio_gateway_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,6 +36,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 
 	"sigs.k8s.io/external-dns/internal/testutils"
 	"sigs.k8s.io/external-dns/source/annotations"
@@ -105,6 +109,7 @@ func (suite *GatewaySuite) SetupTest() {
 		&Config{
 			TemplateEngine: templatetest.MustEngine(suite.T(), "{{.Name}}", "", "", false),
 		},
+		nil,
 	)
 	suite.NoError(err, "should initialize gateway source")
 	suite.NoError(err, "should succeed")
@@ -1500,6 +1505,7 @@ func testGatewayEndpoints(t *testing.T) {
 					AnnotationFilter:         ti.annotationFilter,
 					LabelFilter:              ti.labelFilter,
 				},
+				nil,
 			)
 			require.NoError(t, err)
 
@@ -1609,6 +1615,7 @@ func TestGatewaySource_GWSelectorMatchServiceSelector(t *testing.T) {
 				fakeKubeClient,
 				fakeIstioClient,
 				&Config{},
+				nil,
 			)
 			require.NoError(t, err)
 			require.NotNil(t, src)
@@ -1624,7 +1631,7 @@ func TestGatewaySource_GWSelectorMatchServiceSelector(t *testing.T) {
 func TestTransformerInIstioGatewaySource(t *testing.T) {
 	newSource := func(t *testing.T, kClient *fake.Clientset, istioClient *istiofake.Clientset) *gatewaySource {
 		t.Helper()
-		src, err := NewIstioGatewaySource(t.Context(), kClient, istioClient, &Config{})
+		src, err := NewIstioGatewaySource(t.Context(), kClient, istioClient, &Config{}, nil)
 		require.NoError(t, err)
 		gs, ok := src.(*gatewaySource)
 		require.True(t, ok)
@@ -1888,6 +1895,7 @@ func TestSingleGatewayMultipleServicesPointingToSameLoadBalancer(t *testing.T) {
 		fakeKubeClient,
 		fakeIstioClient,
 		&Config{},
+		nil,
 	)
 	require.NoError(t, err)
 	require.NotNil(t, src)
@@ -1900,8 +1908,710 @@ func TestSingleGatewayMultipleServicesPointingToSameLoadBalancer(t *testing.T) {
 	})
 }
 
+func TestIstioGatewayWithGatewayAPIAnnotation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("endpointsFromGatewayConfig", testEndpointsFromGatewayAPIGatewayConfig)
+	t.Run("Endpoints", testGatewayAPIGatewayEndpoints)
+}
+
+func testEndpointsFromGatewayAPIGatewayConfig(t *testing.T) {
+	t.Parallel()
+
+	for _, ti := range []struct {
+		title       string
+		gwAPIs      []fakeGatewayAPIGateway
+		config      fakeGatewayConfig
+		expected    []*endpoint.Endpoint
+		expectError bool
+	}{
+		{
+			title: "one rule.host one gateway API IP",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "my-gateway",
+					namespace: "default",
+					addresses: []string{"10.0.0.1"},
+				},
+			},
+			config: fakeGatewayConfig{
+				annotations: map[string]string{
+					K8sGatewaySource: "my-gateway",
+				},
+				dnsnames: [][]string{
+					{"foo.bar"},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"10.0.0.1"},
+				},
+			},
+		},
+		{
+			title: "one rule.host one gateway API hostname",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "my-gateway",
+					namespace: "default",
+					addresses: []string{"lb.example.com"},
+				},
+			},
+			config: fakeGatewayConfig{
+				annotations: map[string]string{
+					K8sGatewaySource: "my-gateway",
+				},
+				dnsnames: [][]string{
+					{"foo.bar"},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.example.com"},
+				},
+			},
+		},
+		{
+			title: "one rule.host two gateway API addresses",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "my-gateway",
+					namespace: "default",
+					addresses: []string{"10.0.0.1", "10.0.0.2"},
+				},
+			},
+			config: fakeGatewayConfig{
+				annotations: map[string]string{
+					K8sGatewaySource: "my-gateway",
+				},
+				dnsnames: [][]string{
+					{"foo.bar"},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"10.0.0.1", "10.0.0.2"},
+				},
+			},
+		},
+		{
+			title: "one rule.host gateway API IP and hostname",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "my-gateway",
+					namespace: "default",
+					addresses: []string{"10.0.0.1", "lb.example.com"},
+				},
+			},
+			config: fakeGatewayConfig{
+				annotations: map[string]string{
+					K8sGatewaySource: "my-gateway",
+				},
+				dnsnames: [][]string{
+					{"foo.bar"},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"10.0.0.1"},
+				},
+				{
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.example.com"},
+				},
+			},
+		},
+		{
+			title: "gateway API in separate namespace",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "central-gw",
+					namespace: "istio-ingress",
+					addresses: []string{"10.0.0.1"},
+				},
+			},
+			config: fakeGatewayConfig{
+				namespace: "user-ns",
+				annotations: map[string]string{
+					K8sGatewaySource: "istio-ingress/central-gw",
+				},
+				dnsnames: [][]string{
+					{"my-service.example.com"},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "my-service.example.com",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"10.0.0.1"},
+				},
+			},
+		},
+		{
+			title: "one empty rule.host with gateway API annotation",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "my-gateway",
+					namespace: "default",
+					addresses: []string{"10.0.0.1"},
+				},
+			},
+			config: fakeGatewayConfig{
+				annotations: map[string]string{
+					K8sGatewaySource: "my-gateway",
+				},
+				dnsnames: [][]string{
+					{},
+				},
+			},
+			expected: []*endpoint.Endpoint{},
+		},
+		{
+			title: "gateway API not found",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "existing-gw",
+					namespace: "default",
+					addresses: []string{"10.0.0.1"},
+				},
+			},
+			config: fakeGatewayConfig{
+				annotations: map[string]string{
+					K8sGatewaySource: "nonexistent-gw",
+				},
+				dnsnames: [][]string{
+					{"foo.bar"},
+				},
+			},
+			expected:    []*endpoint.Endpoint{},
+			expectError: true,
+		},
+		{
+			title: "target annotation takes precedence over gateway annotation",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "my-gateway",
+					namespace: "default",
+					addresses: []string{"10.0.0.1"},
+				},
+			},
+			config: fakeGatewayConfig{
+				annotations: map[string]string{
+					K8sGatewaySource: "my-gateway",
+					annotations.TargetKey: "override-target.com",
+				},
+				dnsnames: [][]string{
+					{"foo.bar"},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"override-target.com"},
+				},
+			},
+		},
+		{
+			title: "ingress annotation takes precedence over gateway annotation",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "my-gateway",
+					namespace: "default",
+					addresses: []string{"10.0.0.1"},
+				},
+			},
+			config: fakeGatewayConfig{
+				annotations: map[string]string{
+					K8sGatewaySource:     "my-gateway",
+					IstioGatewayIngressSource: "my-ingress",
+				},
+				dnsnames: [][]string{
+					{"foo.bar"},
+				},
+			},
+			// ingress "my-ingress" doesn't exist so this errors - but it proves ingress is checked first
+			expected:    []*endpoint.Endpoint{},
+			expectError: true,
+		},
+		{
+			title: "empty gateway annotation falls through to service selector",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "my-gateway",
+					namespace: "default",
+					addresses: []string{"10.0.0.1"},
+				},
+			},
+			config: fakeGatewayConfig{
+				annotations: map[string]string{
+					K8sGatewaySource: "",
+				},
+				dnsnames: [][]string{
+					{"foo.bar"},
+				},
+			},
+			expected: []*endpoint.Endpoint{},
+		},
+	} {
+		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
+
+			src, err := newTestGatewaySourceWithGatewayAPI(t, nil, nil, ti.gwAPIs)
+			require.NoError(t, err)
+
+			gatewayCfg := ti.config.Config()
+			hostnames := src.hostNamesFromGateway(gatewayCfg)
+			endpoints, err := src.endpointsFromGateway(hostnames, gatewayCfg)
+			if ti.expectError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			testutils.ValidateEndpoints(t, endpoints, ti.expected)
+		})
+	}
+}
+
+func testGatewayAPIGatewayEndpoints(t *testing.T) {
+	t.Parallel()
+
+	for _, ti := range []struct {
+		title                    string
+		targetNamespace          string
+		annotationFilter         string
+		labelFilter              labels.Selector
+		gwAPIs                   []fakeGatewayAPIGateway
+		configItems              []fakeGatewayConfig
+		expected                 []*endpoint.Endpoint
+		expectError              bool
+		fqdnTemplate             string
+		combineFQDNAndAnnotation bool
+		ignoreHostnameAnnotation bool
+	}{
+		{
+			title:           "gateway annotation with cross-namespace gateway API reference",
+			targetNamespace: "testing1",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "central-gw",
+					namespace: "istio-ingress",
+					addresses: []string{"8.8.8.8", "lb.com"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: "testing1",
+					dnsnames:  [][]string{{"example.org"}},
+					annotations: map[string]string{
+						K8sGatewaySource: "istio-ingress/central-gw",
+					},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
+				},
+				{
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.com"},
+				},
+			},
+		},
+		{
+			title:           "gateway annotation with hostname annotation",
+			targetNamespace: "",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "central-gw",
+					namespace: "default",
+					addresses: []string{"1.2.3.4"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: "",
+					annotations: map[string]string{
+						K8sGatewaySource:  "central-gw",
+						annotations.HostnameKey: "dns-through-hostname.com",
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"1.2.3.4"},
+				},
+				{
+					DNSName:    "dns-through-hostname.com",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"1.2.3.4"},
+				},
+			},
+		},
+		{
+			title:           "gateway annotation with hostname, target, and gateway annotations combined",
+			targetNamespace: "",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "central-gw",
+					namespace: "default",
+					addresses: []string{"10.0.0.1"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: "",
+					annotations: map[string]string{
+						K8sGatewaySource:  "central-gw",
+						annotations.HostnameKey: "dns-through-hostname.com",
+						annotations.TargetKey:   "gateway-target.com",
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					Targets:    endpoint.Targets{"gateway-target.com"},
+					RecordType: endpoint.RecordTypeCNAME,
+				},
+				{
+					DNSName:    "dns-through-hostname.com",
+					Targets:    endpoint.Targets{"gateway-target.com"},
+					RecordType: endpoint.RecordTypeCNAME,
+				},
+			},
+		},
+		{
+			title:           "gateway annotation with TTL",
+			targetNamespace: "",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "central-gw",
+					namespace: "default",
+					addresses: []string{"1.2.3.4"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: "",
+					annotations: map[string]string{
+						K8sGatewaySource: "central-gw",
+						annotations.TtlKey:    "6",
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+					RecordTTL:  endpoint.TTL(6),
+				},
+			},
+		},
+		{
+			title:           "gateway annotation with FQDN template",
+			targetNamespace: "",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "central-gw",
+					namespace: "default",
+					addresses: []string{"1.2.3.4"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: "",
+					annotations: map[string]string{
+						K8sGatewaySource: "central-gw",
+					},
+					dnsnames: [][]string{},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "fake1.ext-dns.test.com",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"1.2.3.4"},
+				},
+			},
+			fqdnTemplate: "{{.Name}}.ext-dns.test.com",
+		},
+		{
+			title:           "gateway annotation with multiple FQDN template hostnames and combineFQDNAndAnnotation",
+			targetNamespace: "",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "central-gw",
+					namespace: "default",
+					addresses: []string{"1.2.3.4"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: "",
+					annotations: map[string]string{
+						K8sGatewaySource: "central-gw",
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+				},
+				{
+					DNSName:    "fake1.ext-dns.test.com",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+				},
+				{
+					DNSName:    "fake1.ext-dna.test.com",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+				},
+			},
+			fqdnTemplate:             "{{.Name}}.ext-dns.test.com, {{.Name}}.ext-dna.test.com",
+			combineFQDNAndAnnotation: true,
+		},
+		{
+			title:           "gateway annotation with empty gateway annotation and FQDN template",
+			targetNamespace: "",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "central-gw",
+					namespace: "default",
+					addresses: []string{"1.2.3.4"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: "",
+					annotations: map[string]string{
+						K8sGatewaySource: "",
+					},
+					dnsnames: [][]string{},
+				},
+			},
+			expected:     []*endpoint.Endpoint{},
+			fqdnTemplate: "{{.Name}}.ext-dns.test.com",
+		},
+		{
+			title:           "gateway annotation with ignore hostname annotations",
+			targetNamespace: "",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "central-gw",
+					namespace: "default",
+					addresses: []string{"1.2.3.4"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: "",
+					annotations: map[string]string{
+						K8sGatewaySource:  "central-gw",
+						annotations.HostnameKey: "ignore.me",
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"1.2.3.4"},
+				},
+			},
+			ignoreHostnameAnnotation: true,
+		},
+		{
+			title:           "gateway annotation with wildcard host and hostname annotation",
+			targetNamespace: "",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "central-gw",
+					namespace: "default",
+					addresses: []string{"1.2.3.4"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: "",
+					annotations: map[string]string{
+						K8sGatewaySource:  "central-gw",
+						annotations.HostnameKey: "fake1.dns-through-hostname.com",
+					},
+					dnsnames: [][]string{{"*"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "fake1.dns-through-hostname.com",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"1.2.3.4"},
+				},
+			},
+		},
+		{
+			title:            "gateway annotation with matching annotation filter",
+			targetNamespace:  "",
+			annotationFilter: "kubernetes.io/gateway.class in (alb, nginx)",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "central-gw",
+					namespace: "default",
+					addresses: []string{"1.2.3.4"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: "",
+					annotations: map[string]string{
+						"kubernetes.io/gateway.class": "nginx",
+						K8sGatewaySource:         "central-gw",
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"1.2.3.4"},
+				},
+			},
+		},
+		{
+			title:            "gateway annotation with non-matching annotation filter",
+			targetNamespace:  "",
+			annotationFilter: "kubernetes.io/gateway.class in (alb, nginx)",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "central-gw",
+					namespace: "default",
+					addresses: []string{"1.2.3.4"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: "",
+					annotations: map[string]string{
+						"kubernetes.io/gateway.class": "tectonic",
+						K8sGatewaySource:         "central-gw",
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+			},
+			expected: []*endpoint.Endpoint{},
+		},
+		{
+			title:           "gateway annotation not found via Endpoints",
+			targetNamespace: "",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "existing-gw",
+					namespace: "default",
+					addresses: []string{"1.2.3.4"},
+				},
+			},
+			configItems: []fakeGatewayConfig{
+				{
+					name:      "fake1",
+					namespace: "",
+					annotations: map[string]string{
+						K8sGatewaySource: "nonexistent-gw",
+					},
+					dnsnames: [][]string{{"example.org"}},
+				},
+			},
+			expected:    []*endpoint.Endpoint{},
+			expectError: true,
+		},
+	} {
+		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
+
+			fakeKubernetesClient := fake.NewClientset()
+			fakeIstioClient := istiofake.NewSimpleClientset()
+			fakeGwAPIClient := gatewayfake.NewSimpleClientset()
+			targetNamespace := ti.targetNamespace
+
+			for _, gw := range ti.gwAPIs {
+				gwObj := gw.GatewayAPIGateway()
+				_, err := fakeGwAPIClient.GatewayV1().Gateways(gwObj.Namespace).Create(t.Context(), gwObj, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+
+			for _, config := range ti.configItems {
+				gatewayCfg := config.Config()
+				_, err := fakeIstioClient.NetworkingV1().Gateways(gatewayCfg.Namespace).Create(t.Context(), gatewayCfg, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+
+			src, err := NewIstioGatewaySource(
+				t.Context(),
+				fakeKubernetesClient,
+				fakeIstioClient,
+				&Config{
+					Namespace:                targetNamespace,
+					TemplateEngine:           templatetest.MustEngine(t, ti.fqdnTemplate, "", "", ti.combineFQDNAndAnnotation),
+					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
+					AnnotationFilter:         ti.annotationFilter,
+					LabelFilter:              ti.labelFilter,
+				},
+				fakeGwAPIClient,
+			)
+			require.NoError(t, err)
+
+			res, err := src.Endpoints(t.Context())
+			if ti.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			testutils.ValidateEndpoints(t, res, ti.expected)
+		})
+	}
+}
+
 // gateway specific helper functions
 func newTestGatewaySource(t *testing.T, loadBalancerList []fakeIngressGatewayService, ingressList []fakeIngress) (*gatewaySource, error) {
+	return newTestGatewaySourceWithGatewayAPI(t, loadBalancerList, ingressList, nil)
+}
+
+func newTestGatewaySourceWithGatewayAPI(t *testing.T, loadBalancerList []fakeIngressGatewayService, ingressList []fakeIngress, gwAPIs []fakeGatewayAPIGateway) (*gatewaySource, error) {
 	fakeKubernetesClient := fake.NewClientset()
 	fakeIstioClient := istiofake.NewSimpleClientset()
 
@@ -1920,6 +2630,15 @@ func newTestGatewaySource(t *testing.T, loadBalancerList []fakeIngressGatewaySer
 		}
 	}
 
+	fakeGwAPIClient := gatewayfake.NewSimpleClientset()
+	for _, gw := range gwAPIs {
+		gwObj := gw.GatewayAPIGateway()
+		_, err := fakeGwAPIClient.GatewayV1().Gateways(gwObj.Namespace).Create(t.Context(), gwObj, metav1.CreateOptions{})
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	src, err := NewIstioGatewaySource(
 		t.Context(),
 		fakeKubernetesClient,
@@ -1927,6 +2646,7 @@ func newTestGatewaySource(t *testing.T, loadBalancerList []fakeIngressGatewaySer
 		&Config{
 			TemplateEngine: templatetest.MustEngine(t, "{{.FQDN}}", "", "", false),
 		},
+		fakeGwAPIClient,
 	)
 	if err != nil {
 		return nil, err
@@ -2015,6 +2735,48 @@ func (c fakeGatewayConfig) Config() *networkingv1.Gateway {
 	}
 
 	gw.Spec.Servers = servers
+
+	return gw
+}
+
+type fakeGatewayAPIGateway struct {
+	name      string
+	namespace string
+	addresses []string
+}
+
+func (g fakeGatewayAPIGateway) GatewayAPIGateway() *gatewayv1.Gateway {
+	ns := g.namespace
+	if ns == "" {
+		ns = "default"
+	}
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      g.name,
+			Namespace: ns,
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "example",
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     "http",
+					Port:     80,
+					Protocol: gatewayv1.HTTPProtocolType,
+				},
+			},
+		},
+	}
+
+	for _, addr := range g.addresses {
+		addrType := gatewayv1.IPAddressType
+		if net.ParseIP(addr) == nil {
+			addrType = gatewayv1.HostnameAddressType
+		}
+		gw.Status.Addresses = append(gw.Status.Addresses, gatewayv1.GatewayStatusAddress{
+			Type:  &addrType,
+			Value: addr,
+		})
+	}
 
 	return gw
 }

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -31,10 +31,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeinformers "k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	netinformers "k8s.io/client-go/informers/networking/v1"
 	"k8s.io/client-go/kubernetes"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+	gwinformers "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions"
+	gwinformers_v1 "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/apis/v1"
 
 	"sigs.k8s.io/external-dns/source/types"
 
@@ -68,6 +73,7 @@ type virtualServiceSource struct {
 	vServiceInformer         networkingv1informer.VirtualServiceInformer
 	gatewayInformer          networkingv1informer.GatewayInformer
 	ingressInformer          netinformers.IngressInformer
+	gwAPIInformer            gwinformers_v1.GatewayInformer
 }
 
 // NewIstioVirtualServiceSource creates a new virtualServiceSource with the given config.
@@ -76,6 +82,7 @@ func NewIstioVirtualServiceSource(
 	kubeClient kubernetes.Interface,
 	istioClient istioclient.Interface,
 	cfg *Config,
+	gwAPIClient gatewayclient.Interface,
 ) (Source, error) {
 	// Use shared informers to listen for add/update/delete of services/pods/nodes in the specified namespace.
 	// Set resync period to 0, to prevent processing when nothing has changed
@@ -116,8 +123,29 @@ func NewIstioVirtualServiceSource(
 	informers.MustAddEventHandler(virtualServiceInformer.Informer(), informers.DefaultEventHandler())
 	informers.MustAddEventHandler(gatewayInformer.Informer(), informers.DefaultEventHandler())
 
+	// Optionally set up a Gateway API Gateway informer if a client is provided
+	// and the Gateway API CRDs are installed in the cluster.
+	var gwAPIInformer gwinformers_v1.GatewayInformer
+	var gwAPIInformerFactory gwinformers.SharedInformerFactory
+	if gwAPIClient != nil {
+		if _, err := gwAPIClient.GatewayV1().Gateways("").List(ctx, metav1.ListOptions{Limit: 1}); err != nil {
+			log.Debugf("Gateway API not available, %q annotation will not be supported: %v", K8sGatewaySource, err)
+		} else {
+			gwAPIInformerFactory = gwinformers.NewSharedInformerFactory(gwAPIClient, 0)
+			gwAPIInformer = gwAPIInformerFactory.Gateway().V1().Gateways()
+			informers.MustSetTransform(gwAPIInformer.Informer(), informers.TransformerWithOptions[*gatewayv1.Gateway](
+				informers.TransformRemoveManagedFields(),
+				informers.TransformRemoveLastAppliedConfig(),
+			))
+			informers.MustAddEventHandler(gwAPIInformer.Informer(), informers.DefaultEventHandler())
+		}
+	}
+
 	informerFactory.Start(ctx.Done())
 	istioInformerFactory.Start(ctx.Done())
+	if gwAPIInformerFactory != nil {
+		gwAPIInformerFactory.Start(ctx.Done())
+	}
 
 	// wait for the local cache to be populated.
 	if err := informers.WaitForCacheSync(ctx, informerFactory); err != nil {
@@ -125,6 +153,11 @@ func NewIstioVirtualServiceSource(
 	}
 	if err := informers.WaitForCacheSync(ctx, istioInformerFactory); err != nil {
 		return nil, err
+	}
+	if gwAPIInformerFactory != nil {
+		if err := informers.WaitForCacheSync(ctx, gwAPIInformerFactory); err != nil {
+			return nil, err
+		}
 	}
 
 	return &virtualServiceSource{
@@ -136,6 +169,7 @@ func NewIstioVirtualServiceSource(
 		vServiceInformer:         virtualServiceInformer,
 		gatewayInformer:          gatewayInformer,
 		ingressInformer:          ingressInformer,
+		gwAPIInformer:            gwAPIInformer,
 	}, nil
 }
 
@@ -193,7 +227,7 @@ func (sc *virtualServiceSource) getGateway(_ context.Context, gatewayStr string,
 		return nil, nil
 	}
 
-	namespace, name, err := ParseIngress(gatewayStr)
+	namespace, name, err := ParseNamespacedName(gatewayStr)
 	if err != nil {
 		log.Debugf("Failed parsing gatewayStr %s of VirtualService %s/%s", gatewayStr, virtualService.Namespace, virtualService.Name)
 		return nil, err
@@ -371,7 +405,7 @@ func virtualServiceBindsToGateway(vService *networkingv1.VirtualService, gateway
 }
 
 func (sc *virtualServiceSource) targetsFromIngress(ingressStr string, gateway *networkingv1.Gateway) (endpoint.Targets, error) {
-	namespace, name, err := ParseIngress(ingressStr)
+	namespace, name, err := ParseNamespacedName(ingressStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse Ingress annotation on Gateway (%s/%s): %w", gateway.Namespace, gateway.Name, err)
 	}
@@ -397,6 +431,10 @@ func (sc *virtualServiceSource) targetsFromIngress(ingressStr string, gateway *n
 	return targets, nil
 }
 
+func (sc *virtualServiceSource) targetsFromGatewayAPIGateway(gatewayStr string, gateway *networkingv1.Gateway) (endpoint.Targets, error) {
+	return EndpointTargetsFromK8sGateway(sc.gwAPIInformer, gatewayStr, gateway.Namespace)
+}
+
 func (sc *virtualServiceSource) targetsFromGateway(gateway *networkingv1.Gateway) (endpoint.Targets, error) {
 	targets := annotations.TargetsFromTargetAnnotation(gateway.Annotations)
 	if len(targets) > 0 {
@@ -406,6 +444,11 @@ func (sc *virtualServiceSource) targetsFromGateway(gateway *networkingv1.Gateway
 	ingressStr, ok := gateway.Annotations[IstioGatewayIngressSource]
 	if ok && ingressStr != "" {
 		return sc.targetsFromIngress(ingressStr, gateway)
+	}
+
+	gatewayStr, ok := gateway.Annotations[K8sGatewaySource]
+	if ok && gatewayStr != "" {
+		return sc.targetsFromGatewayAPIGateway(gatewayStr, gateway)
 	}
 
 	return EndpointTargetsFromServices(sc.serviceInformer, sc.namespace, gateway.Spec.Selector)

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -129,7 +129,7 @@ func NewIstioVirtualServiceSource(
 	var gwAPIInformerFactory gwinformers.SharedInformerFactory
 	if gwAPIClient != nil {
 		if _, err := gwAPIClient.GatewayV1().Gateways("").List(ctx, metav1.ListOptions{Limit: 1}); err != nil {
-			log.Debugf("Gateway API not available, %q annotation will not be supported: %v", K8sGatewaySource, err)
+			log.Debugf("Gateway API not available, %q annotation will not be supported: %v", K8sGatewaySource(), err)
 		} else {
 			gwAPIInformerFactory = gwinformers.NewSharedInformerFactory(gwAPIClient, 0)
 			gwAPIInformer = gwAPIInformerFactory.Gateway().V1().Gateways()
@@ -191,7 +191,8 @@ func (sc *virtualServiceSource) Endpoints(ctx context.Context) ([]*endpoint.Endp
 
 		gwEndpoints, err := sc.endpointsFromVirtualService(ctx, vService)
 		if err != nil {
-			return nil, err
+			log.Warnf("Could not generate endpoints for VirtualService '%s/%s': %v", vService.Namespace, vService.Name, err)
+			continue
 		}
 
 		// apply template if host is missing on VirtualService
@@ -200,7 +201,8 @@ func (sc *virtualServiceSource) Endpoints(ctx context.Context) ([]*endpoint.Endp
 			func() ([]*endpoint.Endpoint, error) { return sc.endpointsFromTemplate(ctx, vService) },
 		)
 		if err != nil {
-			return nil, err
+			log.Warnf("Could not apply template for VirtualService '%s/%s': %v", vService.Namespace, vService.Name, err)
+			continue
 		}
 
 		if endpoint.HasNoEmptyEndpoints(gwEndpoints, types.IstioVirtualService, vService) {
@@ -441,12 +443,12 @@ func (sc *virtualServiceSource) targetsFromGateway(gateway *networkingv1.Gateway
 		return targets, nil
 	}
 
-	ingressStr, ok := gateway.Annotations[IstioGatewayIngressSource]
+	ingressStr, ok := gateway.Annotations[IstioGatewayIngressSource()]
 	if ok && ingressStr != "" {
 		return sc.targetsFromIngress(ingressStr, gateway)
 	}
 
-	gatewayStr, ok := gateway.Annotations[K8sGatewaySource]
+	gatewayStr, ok := gateway.Annotations[K8sGatewaySource()]
 	if ok && gatewayStr != "" {
 		return sc.targetsFromGatewayAPIGateway(gatewayStr, gateway)
 	}

--- a/source/istio_virtualservice_fqdn_test.go
+++ b/source/istio_virtualservice_fqdn_test.go
@@ -61,6 +61,7 @@ func TestIstioVirtualServiceSourceNewSourceWithFqdn(t *testing.T) {
 					TemplateEngine:           templatetest.MustEngine(t, tt.fqdnTemplate, "", "", false),
 					IgnoreHostnameAnnotation: false,
 				},
+				nil,
 			)
 
 			require.NoError(t, err)
@@ -736,6 +737,7 @@ func TestIstioVirtualServiceSourceFqdnTemplatingExamples(t *testing.T) {
 					TemplateEngine:           templatetest.MustEngine(t, tt.fqdnTemplate, "", "", !tt.combineFqdn),
 					IgnoreHostnameAnnotation: false,
 				},
+				nil,
 			)
 			require.NoError(t, err)
 

--- a/source/istio_virtualservice_test.go
+++ b/source/istio_virtualservice_test.go
@@ -38,6 +38,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 
+	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
+
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source/annotations"
 	templatetest "sigs.k8s.io/external-dns/source/template/testutil"
@@ -124,6 +126,7 @@ func (suite *VirtualServiceSuite) SetupTest() {
 		&Config{
 			TemplateEngine: templatetest.MustEngine(suite.T(), "{{.Name}}", "", "", false),
 		},
+		nil,
 	)
 	suite.NoError(err, "should initialize virtualservice source")
 }
@@ -2083,10 +2086,330 @@ func testVirtualServiceEndpoints(t *testing.T) {
 					TemplateEngine:           templatetest.MustEngine(t, ti.fqdnTemplate, "", "", ti.combineFQDNAndAnnotation),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 				},
+				nil,
 			)
 			require.NoError(t, err)
 
 			res, err := virtualServiceSource.Endpoints(t.Context())
+			if ti.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			testutils.ValidateEndpoints(t, res, ti.expected)
+		})
+	}
+}
+
+func TestVirtualServiceWithGatewayAPIAnnotation(t *testing.T) {
+	t.Parallel()
+
+	namespace := "default"
+
+	for _, ti := range []struct {
+		title       string
+		gwAPIs      []fakeGatewayAPIGateway
+		gwConfigs   []fakeGatewayConfig
+		vsConfigs   []fakeVirtualServiceConfig
+		expected    []*endpoint.Endpoint
+		expectError bool
+	}{
+		{
+			title: "gateway API annotation same namespace",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "central-gw",
+					namespace: namespace,
+					addresses: []string{"10.0.0.1"},
+				},
+			},
+			gwConfigs: []fakeGatewayConfig{
+				{
+					name:      "mygw",
+					namespace: namespace,
+					dnsnames:  [][]string{{"*"}},
+					annotations: map[string]string{
+						K8sGatewaySource: "central-gw",
+					},
+				},
+			},
+			vsConfigs: []fakeVirtualServiceConfig{
+				{
+					name:      "vs1",
+					namespace: namespace,
+					gateways:  []string{"mygw"},
+					dnsnames:  []string{"foo.bar"},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"10.0.0.1"},
+				},
+			},
+		},
+		{
+			title: "gateway API annotation cross-namespace",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "central-gw",
+					namespace: "istio-ingress",
+					addresses: []string{"10.0.0.1", "lb.example.com"},
+				},
+			},
+			gwConfigs: []fakeGatewayConfig{
+				{
+					name:      "mygw",
+					namespace: namespace,
+					dnsnames:  [][]string{{"*"}},
+					annotations: map[string]string{
+						K8sGatewaySource: "istio-ingress/central-gw",
+					},
+				},
+			},
+			vsConfigs: []fakeVirtualServiceConfig{
+				{
+					name:      "vs1",
+					namespace: namespace,
+					gateways:  []string{"mygw"},
+					dnsnames:  []string{"foo.bar"},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"10.0.0.1"},
+				},
+				{
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.example.com"},
+				},
+			},
+		},
+		{
+			title: "gateway API annotation not found",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "existing-gw",
+					namespace: namespace,
+					addresses: []string{"10.0.0.1"},
+				},
+			},
+			gwConfigs: []fakeGatewayConfig{
+				{
+					name:      "mygw",
+					namespace: namespace,
+					dnsnames:  [][]string{{"*"}},
+					annotations: map[string]string{
+						K8sGatewaySource: "nonexistent-gw",
+					},
+				},
+			},
+			vsConfigs: []fakeVirtualServiceConfig{
+				{
+					name:      "vs1",
+					namespace: namespace,
+					gateways:  []string{"mygw"},
+					dnsnames:  []string{"foo.bar"},
+				},
+			},
+			expected:    []*endpoint.Endpoint{},
+			expectError: true,
+		},
+		{
+			title: "target annotation takes precedence over gateway API annotation",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "central-gw",
+					namespace: namespace,
+					addresses: []string{"10.0.0.1"},
+				},
+			},
+			gwConfigs: []fakeGatewayConfig{
+				{
+					name:      "mygw",
+					namespace: namespace,
+					dnsnames:  [][]string{{"*"}},
+					annotations: map[string]string{
+						K8sGatewaySource: "central-gw",
+						annotations.TargetKey: "override-target.com",
+					},
+				},
+			},
+			vsConfigs: []fakeVirtualServiceConfig{
+				{
+					name:      "vs1",
+					namespace: namespace,
+					gateways:  []string{"mygw"},
+					dnsnames:  []string{"foo.bar"},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"override-target.com"},
+				},
+			},
+		},
+		{
+			title: "ingress annotation takes precedence over gateway API annotation",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "central-gw",
+					namespace: namespace,
+					addresses: []string{"10.0.0.1"},
+				},
+			},
+			gwConfigs: []fakeGatewayConfig{
+				{
+					name:      "mygw",
+					namespace: namespace,
+					dnsnames:  [][]string{{"*"}},
+					annotations: map[string]string{
+						K8sGatewaySource:     "central-gw",
+						IstioGatewayIngressSource: "nonexistent-ingress",
+					},
+				},
+			},
+			vsConfigs: []fakeVirtualServiceConfig{
+				{
+					name:      "vs1",
+					namespace: namespace,
+					gateways:  []string{"mygw"},
+					dnsnames:  []string{"foo.bar"},
+				},
+			},
+			expected:    []*endpoint.Endpoint{},
+			expectError: true,
+		},
+		{
+			title: "gateway API annotation with TTL",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "central-gw",
+					namespace: namespace,
+					addresses: []string{"10.0.0.1"},
+				},
+			},
+			gwConfigs: []fakeGatewayConfig{
+				{
+					name:      "mygw",
+					namespace: namespace,
+					dnsnames:  [][]string{{"*"}},
+					annotations: map[string]string{
+						K8sGatewaySource: "central-gw",
+					},
+				},
+			},
+			vsConfigs: []fakeVirtualServiceConfig{
+				{
+					name:      "vs1",
+					namespace: namespace,
+					gateways:  []string{"mygw"},
+					annotations: map[string]string{
+						annotations.TtlKey: "10",
+					},
+					dnsnames: []string{"foo.bar"},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "foo.bar",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"10.0.0.1"},
+					RecordTTL:  endpoint.TTL(10),
+				},
+			},
+		},
+		{
+			title: "gateway API annotation with two virtualservices sharing one gateway",
+			gwAPIs: []fakeGatewayAPIGateway{
+				{
+					name:      "central-gw",
+					namespace: namespace,
+					addresses: []string{"10.0.0.1"},
+				},
+			},
+			gwConfigs: []fakeGatewayConfig{
+				{
+					name:      "mygw",
+					namespace: namespace,
+					dnsnames:  [][]string{{"*"}},
+					annotations: map[string]string{
+						K8sGatewaySource: "central-gw",
+					},
+				},
+			},
+			vsConfigs: []fakeVirtualServiceConfig{
+				{
+					name:      "vs1",
+					namespace: namespace,
+					gateways:  []string{"mygw"},
+					dnsnames:  []string{"example.org"},
+				},
+				{
+					name:      "vs2",
+					namespace: namespace,
+					gateways:  []string{"mygw"},
+					dnsnames:  []string{"new.org"},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"10.0.0.1"},
+				},
+				{
+					DNSName:    "new.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"10.0.0.1"},
+				},
+			},
+		},
+	} {
+		t.Run(ti.title, func(t *testing.T) {
+			t.Parallel()
+
+			fakeKubernetesClient := fake.NewClientset()
+			fakeIstioClient := istiofake.NewSimpleClientset()
+			fakeGwAPIClient := gatewayfake.NewSimpleClientset()
+
+			for _, gw := range ti.gwAPIs {
+				gwObj := gw.GatewayAPIGateway()
+				_, err := fakeGwAPIClient.GatewayV1().Gateways(gwObj.Namespace).Create(t.Context(), gwObj, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+
+			for _, gwItem := range ti.gwConfigs {
+				gwObj := gwItem.Config()
+				_, err := fakeIstioClient.NetworkingV1().Gateways(gwObj.Namespace).Create(t.Context(), gwObj, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+
+			for _, vsItem := range ti.vsConfigs {
+				vsObj := vsItem.Config()
+				_, err := fakeIstioClient.NetworkingV1().VirtualServices(vsObj.Namespace).Create(t.Context(), vsObj, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+
+			src, err := NewIstioVirtualServiceSource(
+				t.Context(),
+				fakeKubernetesClient,
+				fakeIstioClient,
+				&Config{
+					TemplateEngine: templatetest.MustEngine(t, "", "", "", false),
+				},
+				fakeGwAPIClient,
+			)
+			require.NoError(t, err)
+
+			res, err := src.Endpoints(t.Context())
 			if ti.expectError {
 				assert.Error(t, err)
 			} else {
@@ -2135,6 +2458,7 @@ func newTestVirtualServiceSource(t *testing.T, loadBalancerList []fakeIngressGat
 		&Config{
 			TemplateEngine: templatetest.MustEngine(t, "{{ .Name }}", "", "", false),
 		},
+		nil,
 	)
 	if err != nil {
 		return nil, err
@@ -2226,7 +2550,7 @@ func TestVirtualServiceSourceGetGateway(t *testing.T) {
 			ctx:            t.Context(),
 			gatewayStr:     "1/2/3/",
 			virtualService: &networkingv1.VirtualService{},
-		}, want: nil, expectedErrStr: "invalid ingress name (name or namespace/name) found \"1/2/3/\""},
+		}, want: nil, expectedErrStr: "invalid namespaced name (expected name or namespace/name) found \"1/2/3/\""},
 		{name: "ExistingGateway", fields: fields{
 			virtualServiceSource: func() *virtualServiceSource {
 				vs, _ := newTestVirtualServiceSource(t, nil, nil, []fakeGatewayConfig{{
@@ -2376,6 +2700,7 @@ func TestIstioVirtualServiceSource_GWServiceSelectorMatchServiceSelector(t *test
 				fakeKubeClient,
 				fakeIstioClient,
 				&Config{},
+				nil,
 			)
 			require.NoError(t, err)
 			require.NotNil(t, src)
@@ -2391,7 +2716,7 @@ func TestIstioVirtualServiceSource_GWServiceSelectorMatchServiceSelector(t *test
 func TestTransformerInIstioGatewayVirtualServiceSource(t *testing.T) {
 	newSource := func(t *testing.T, kClient *fake.Clientset, istioClient *istiofake.Clientset) *virtualServiceSource {
 		t.Helper()
-		src, err := NewIstioVirtualServiceSource(t.Context(), kClient, istioClient, &Config{})
+		src, err := NewIstioVirtualServiceSource(t.Context(), kClient, istioClient, &Config{}, nil)
 		require.NoError(t, err)
 		vs, ok := src.(*virtualServiceSource)
 		require.True(t, ok)

--- a/source/istio_virtualservice_test.go
+++ b/source/istio_virtualservice_test.go
@@ -586,7 +586,7 @@ func testEndpointsFromVirtualServiceConfig(t *testing.T) {
 				name:     "mygw",
 				dnsnames: [][]string{{"*"}},
 				annotations: map[string]string{
-					IstioGatewayIngressSource: "ingress1",
+					IstioGatewayIngressSource(): "ingress1",
 				},
 			},
 			vsconfig: fakeVirtualServiceConfig{
@@ -619,7 +619,7 @@ func testEndpointsFromVirtualServiceConfig(t *testing.T) {
 				name:     "mygw",
 				dnsnames: [][]string{{"*"}},
 				annotations: map[string]string{
-					IstioGatewayIngressSource: "ingress/ingress2",
+					IstioGatewayIngressSource(): "ingress/ingress2",
 				},
 			},
 			vsconfig: fakeVirtualServiceConfig{
@@ -793,7 +793,7 @@ func testVirtualServiceEndpoints(t *testing.T) {
 					namespace: namespace,
 					dnsnames:  [][]string{{"example.org"}},
 					annotations: map[string]string{
-						IstioGatewayIngressSource: "ingress1",
+						IstioGatewayIngressSource(): "ingress1",
 					},
 				},
 				{
@@ -801,7 +801,7 @@ func testVirtualServiceEndpoints(t *testing.T) {
 					namespace: namespace,
 					dnsnames:  [][]string{{"new.org"}},
 					annotations: map[string]string{
-						IstioGatewayIngressSource: "ingress1",
+						IstioGatewayIngressSource(): "ingress1",
 					},
 				},
 			},
@@ -1066,7 +1066,7 @@ func testVirtualServiceEndpoints(t *testing.T) {
 					namespace: "testing1",
 					dnsnames:  [][]string{{"*"}},
 					annotations: map[string]string{
-						IstioGatewayIngressSource: "ingress1",
+						IstioGatewayIngressSource(): "ingress1",
 					},
 				},
 			},
@@ -1286,7 +1286,7 @@ func testVirtualServiceEndpoints(t *testing.T) {
 			expected: []*endpoint.Endpoint{},
 		},
 		{
-			title: "gateway ingress annotation; ingress not found",
+			title: "gateway ingress annotation; ingress not found — skipped gracefully",
 			ingresses: []fakeIngress{
 				{
 					name:      "ingress1",
@@ -1300,7 +1300,7 @@ func testVirtualServiceEndpoints(t *testing.T) {
 					namespace: namespace,
 					dnsnames:  [][]string{{"*"}},
 					annotations: map[string]string{
-						IstioGatewayIngressSource: "ingress2",
+						IstioGatewayIngressSource(): "ingress2",
 					},
 				},
 			},
@@ -1313,7 +1313,7 @@ func testVirtualServiceEndpoints(t *testing.T) {
 				},
 			},
 			expected:    []*endpoint.Endpoint{},
-			expectError: true,
+			expectError: false, // bad annotation should be skipped gracefully, not crash the controller
 		},
 		{
 			title: "our controller type is dns-controller",
@@ -1606,7 +1606,7 @@ func testVirtualServiceEndpoints(t *testing.T) {
 					dnsnames:  [][]string{{"*"}},
 					annotations: map[string]string{
 						annotations.TargetKey:     "gateway-target.com",
-						IstioGatewayIngressSource: "ingress1",
+						IstioGatewayIngressSource(): "ingress1",
 					},
 				},
 			},
@@ -1960,7 +1960,7 @@ func testVirtualServiceEndpoints(t *testing.T) {
 						"app": "igw4",
 					},
 					annotations: map[string]string{
-						IstioGatewayIngressSource: "testing1/ingress1",
+						IstioGatewayIngressSource(): "testing1/ingress1",
 					},
 				},
 			},
@@ -2130,7 +2130,7 @@ func TestVirtualServiceWithGatewayAPIAnnotation(t *testing.T) {
 					namespace: namespace,
 					dnsnames:  [][]string{{"*"}},
 					annotations: map[string]string{
-						K8sGatewaySource: "central-gw",
+						K8sGatewaySource(): "central-gw",
 					},
 				},
 			},
@@ -2165,7 +2165,7 @@ func TestVirtualServiceWithGatewayAPIAnnotation(t *testing.T) {
 					namespace: namespace,
 					dnsnames:  [][]string{{"*"}},
 					annotations: map[string]string{
-						K8sGatewaySource: "istio-ingress/central-gw",
+						K8sGatewaySource(): "istio-ingress/central-gw",
 					},
 				},
 			},
@@ -2191,7 +2191,7 @@ func TestVirtualServiceWithGatewayAPIAnnotation(t *testing.T) {
 			},
 		},
 		{
-			title: "gateway API annotation not found",
+			title: "gateway API annotation not found — skipped gracefully",
 			gwAPIs: []fakeGatewayAPIGateway{
 				{
 					name:      "existing-gw",
@@ -2205,7 +2205,7 @@ func TestVirtualServiceWithGatewayAPIAnnotation(t *testing.T) {
 					namespace: namespace,
 					dnsnames:  [][]string{{"*"}},
 					annotations: map[string]string{
-						K8sGatewaySource: "nonexistent-gw",
+						K8sGatewaySource(): "nonexistent-gw",
 					},
 				},
 			},
@@ -2218,7 +2218,7 @@ func TestVirtualServiceWithGatewayAPIAnnotation(t *testing.T) {
 				},
 			},
 			expected:    []*endpoint.Endpoint{},
-			expectError: true,
+			expectError: false, // bad annotation should be skipped gracefully, not crash the controller
 		},
 		{
 			title: "target annotation takes precedence over gateway API annotation",
@@ -2235,7 +2235,7 @@ func TestVirtualServiceWithGatewayAPIAnnotation(t *testing.T) {
 					namespace: namespace,
 					dnsnames:  [][]string{{"*"}},
 					annotations: map[string]string{
-						K8sGatewaySource: "central-gw",
+						K8sGatewaySource(): "central-gw",
 						annotations.TargetKey: "override-target.com",
 					},
 				},
@@ -2257,7 +2257,7 @@ func TestVirtualServiceWithGatewayAPIAnnotation(t *testing.T) {
 			},
 		},
 		{
-			title: "ingress annotation takes precedence over gateway API annotation",
+			title: "ingress annotation takes precedence over gateway API annotation — nonexistent ingress skipped gracefully",
 			gwAPIs: []fakeGatewayAPIGateway{
 				{
 					name:      "central-gw",
@@ -2271,8 +2271,8 @@ func TestVirtualServiceWithGatewayAPIAnnotation(t *testing.T) {
 					namespace: namespace,
 					dnsnames:  [][]string{{"*"}},
 					annotations: map[string]string{
-						K8sGatewaySource:     "central-gw",
-						IstioGatewayIngressSource: "nonexistent-ingress",
+						K8sGatewaySource():          "central-gw",
+						IstioGatewayIngressSource(): "nonexistent-ingress",
 					},
 				},
 			},
@@ -2285,7 +2285,7 @@ func TestVirtualServiceWithGatewayAPIAnnotation(t *testing.T) {
 				},
 			},
 			expected:    []*endpoint.Endpoint{},
-			expectError: true,
+			expectError: false, // bad annotation should be skipped gracefully, not crash the controller
 		},
 		{
 			title: "gateway API annotation with TTL",
@@ -2302,7 +2302,7 @@ func TestVirtualServiceWithGatewayAPIAnnotation(t *testing.T) {
 					namespace: namespace,
 					dnsnames:  [][]string{{"*"}},
 					annotations: map[string]string{
-						K8sGatewaySource: "central-gw",
+						K8sGatewaySource(): "central-gw",
 					},
 				},
 			},
@@ -2341,7 +2341,7 @@ func TestVirtualServiceWithGatewayAPIAnnotation(t *testing.T) {
 					namespace: namespace,
 					dnsnames:  [][]string{{"*"}},
 					annotations: map[string]string{
-						K8sGatewaySource: "central-gw",
+						K8sGatewaySource(): "central-gw",
 					},
 				},
 			},

--- a/source/store.go
+++ b/source/store.go
@@ -533,7 +533,7 @@ func buildPodSource(ctx context.Context, p ClientGenerator, cfg *Config) (Source
 }
 
 // buildIstioGatewaySource creates an Istio Gateway source for exposing Istio gateways as DNS records.
-// Requires both Kubernetes and Istio clients. Follows standard parameter pattern.
+// Requires both Kubernetes and Istio clients. Optionally uses a Gateway API client when available.
 func buildIstioGatewaySource(ctx context.Context, p ClientGenerator, cfg *Config) (Source, error) {
 	kubernetesClient, err := p.KubeClient()
 	if err != nil {
@@ -543,11 +543,15 @@ func buildIstioGatewaySource(ctx context.Context, p ClientGenerator, cfg *Config
 	if err != nil {
 		return nil, err
 	}
-	return NewIstioGatewaySource(ctx, kubernetesClient, istioClient, cfg)
+	gwAPIClient, err := p.GatewayClient()
+	if err != nil {
+		return nil, err
+	}
+	return NewIstioGatewaySource(ctx, kubernetesClient, istioClient, cfg, gwAPIClient)
 }
 
 // buildIstioVirtualServiceSource creates an Istio VirtualService source for exposing virtual services as DNS records.
-// Requires both Kubernetes and Istio clients. Follows standard parameter pattern.
+// Requires both Kubernetes and Istio clients. Optionally uses a Gateway API client when available.
 func buildIstioVirtualServiceSource(ctx context.Context, p ClientGenerator, cfg *Config) (Source, error) {
 	kubernetesClient, err := p.KubeClient()
 	if err != nil {
@@ -557,7 +561,11 @@ func buildIstioVirtualServiceSource(ctx context.Context, p ClientGenerator, cfg 
 	if err != nil {
 		return nil, err
 	}
-	return NewIstioVirtualServiceSource(ctx, kubernetesClient, istioClient, cfg)
+	gwAPIClient, err := p.GatewayClient()
+	if err != nil {
+		return nil, err
+	}
+	return NewIstioVirtualServiceSource(ctx, kubernetesClient, istioClient, cfg, gwAPIClient)
 }
 
 func buildAmbassadorHostSource(ctx context.Context, p ClientGenerator, cfg *Config) (Source, error) {

--- a/source/store_test.go
+++ b/source/store_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	fakeDynamic "k8s.io/client-go/dynamic/fake"
 	fakeKube "k8s.io/client-go/kubernetes/fake"
+	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 
 	"sigs.k8s.io/external-dns/internal/testutils"
 	externaldns "sigs.k8s.io/external-dns/pkg/apis/externaldns"
@@ -45,6 +46,7 @@ func (suite *ByNamesTestSuite) TestAllInitialized() {
 	mockClientGenerator := new(testutils.MockClientGenerator)
 	mockClientGenerator.On("KubeClient").Return(fakeKube.NewSimpleClientset(), nil)
 	mockClientGenerator.On("IstioClient").Return(istiofake.NewSimpleClientset(), nil)
+	mockClientGenerator.On("GatewayClient").Return(gatewayfake.NewSimpleClientset(), nil)
 	mockClientGenerator.On("DynamicKubernetesClient").Return(fakeDynamic.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
 		map[schema.GroupVersionResource]string{
 			{
@@ -105,14 +107,14 @@ func (suite *ByNamesTestSuite) TestAllInitialized() {
 		}), nil)
 
 	ss := []string{
-		types.Service, types.Ingress, types.IstioGateway, types.ContourHTTPProxy,
+		types.Service, types.Ingress, types.IstioGateway, types.IstioVirtualService, types.ContourHTTPProxy,
 		types.KongTCPIngress, types.F5VirtualServer, types.F5TransportServer, types.TraefikProxy, types.Fake,
 	}
 	sources, err := ByNames(context.TODO(), &Config{
 		sources: ss,
 	}, mockClientGenerator)
 	suite.NoError(err, "should not generate errors")
-	suite.Len(sources, 9, "should generate all nine sources")
+	suite.Len(sources, 10, "should generate all ten sources")
 }
 
 func (suite *ByNamesTestSuite) TestOnlyFake() {

--- a/source/utils.go
+++ b/source/utils.go
@@ -18,20 +18,20 @@ import (
 	"strings"
 )
 
-// ParseIngress parses an ingress string in the format "namespace/name" or "name".
+// ParseNamespacedName parses a string in the format "namespace/name" or "name".
 // It returns the namespace and name extracted from the string, or an error if the format is invalid.
 // If the namespace is not provided, it defaults to an empty string.
-func ParseIngress(ingress string) (string, string, error) {
+func ParseNamespacedName(ref string) (string, string, error) {
 	var namespace, name string
 	var err error
-	parts := strings.Split(ingress, "/")
+	parts := strings.Split(ref, "/")
 	switch len(parts) {
 	case 2:
 		namespace, name = parts[0], parts[1]
 	case 1:
 		name = parts[0]
 	default:
-		err = fmt.Errorf("invalid ingress name (name or namespace/name) found %q", ingress)
+		err = fmt.Errorf("invalid namespaced name (expected name or namespace/name) found %q", ref)
 	}
 
 	return namespace, name, err

--- a/source/utils_test.go
+++ b/source/utils_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseIngress(t *testing.T) {
+func TestParseNamespacedName(t *testing.T) {
 	tests := []struct {
 		name      string
 		ingress   string
@@ -59,7 +59,7 @@ func TestParseIngress(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotNS, gotName, err := ParseIngress(tt.ingress)
+			gotNS, gotName, err := ParseNamespacedName(tt.ingress)
 			if tt.wantError {
 				assert.Error(t, err)
 			} else {


### PR DESCRIPTION
## What does it do ?

### Feature

This adds support for a new annotation on Istio Gateway objects which acts similarly to the existing ingress annotation, but can point at a `gateway.networking.k8s.io` Gateway object instead. It exists for similar reasons to the original PR adding ingress annotations https://github.com/kubernetes-sigs/external-dns/pull/3842.

If the Gateway API is installed in a cluster, the Istio Gateway and VirtualService sources will use it to enable this feature. If not, the sources will act as before and the annotation will not have an effect. This implements similar test coverage to the original Ingress annotation, ensuring the annotation should work in an identical way but for a different backing resource.

The PR size is large primarily due to test coverage, and the documentation inclusion.

### Bugfixes

During testing of the functionality in a lab, I came across and fixed two other bugs. The first was related to using `--annotation-prefix` to move back to the `*.alpha.*` external-dns annotations, and how this actually wasn't propagated into the Istio source controllers. This led to all `/ingress` annotations having their DNS entries deleted on my test cluster.

The second was that a `/ingress` annotation pointing to a nonexistent object would cause the controller to crashloop. This could cause denial of service in a shared tenanted cluster. This bug was extended to gateway, and the code path was fixed for both.

Tests were added to cover the bugs.

## Motivation

My team has been using the [ingress annotation](https://kubernetes-sigs.github.io/external-dns/latest/docs/annotations/annotations/#external-dnsalphakubernetesioingress) functionality in order to run a single Ingress in the cluster and allow Service owners to hook into a centrally managed Ingress object and create CNAMEs pointing to it. This allows ingress through a shared set of Istio gateways, fronted by a shared cloud provider LB. One big advantage to this process is that we can change anything about that central Ingress (e.g. it's IP address, associated DNS names, etc) and service owners do not need to be aware of these changes. They only need point at `<namespace>/<ingress-name>` via the annotation and external-dns handles updates to their own DNS names automatically.

In GKE clusters we are looking at moving away from provisioning the LB using the Ingress object and instead using the `gateway.networking.k8s.io` Gateway object in order to get access to more modern GCP load balancer implementations. As part of this migration, we could not find a way to use the existing provided annotations to keep the same pattern where services do not need to know implementation details of the centrally provisioned LB. The closest suitable pattern we found was using the `external-dns.alpha.kubernetes.io/target` annotation along with the hostname of the LB, but this leaks more implementation details than we are comfortable with since it requires a hostname to be specified.

This led to the creation of this PR, looking to duplicate the same functionality of looking at an externally provisioned LB and creating CNAMEs to it (or A records if it exposes an IP). If the same pattern was suitable for Ingress objects, it should also be suitable for Gateway objects.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
