### PR TITLE
fix(istio): skip gateways with bad annotations instead of crashing the controller

### DIFF
--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -201,8 +201,8 @@ func (sc *gatewaySource) targetsFromIngress(ingressStr string, gateway *networki
 
 	ingress, err := sc.ingressInformer.Lister().Ingresses(namespace).Get(name)
 	if err != nil {
-		log.Error(err)
-		return nil, err
+		log.Warnf("Could not get ingress '%s/%s' referenced by Gateway '%s/%s': %v", namespace, name, gateway.Namespace, gateway.Name, err)
+		return targets, nil
 	}
 	for _, lb := range ingress.Status.LoadBalancer.Ingress {
 		if lb.IP != "" {

--- a/source/istio_gateway_test.go
+++ b/source/istio_gateway_test.go
@@ -1457,7 +1457,7 @@ func testGatewayEndpoints(t *testing.T) {
 				},
 			},
 			expected:    []*endpoint.Endpoint{},
-			expectError: true,
+			expectError: false, // bad annotation should be skipped gracefully, not crash the controller
 		},
 	} {
 

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -379,13 +379,13 @@ func (sc *virtualServiceSource) targetsFromIngress(ingressStr string, gateway *n
 		namespace = gateway.Namespace
 	}
 
+	targets := make(endpoint.Targets, 0)
+
 	ingress, err := sc.ingressInformer.Lister().Ingresses(namespace).Get(name)
 	if err != nil {
-		log.Error(err)
-		return nil, err
+		log.Warnf("Could not get ingress '%s/%s' referenced by Gateway '%s/%s': %v", namespace, name, gateway.Namespace, gateway.Name, err)
+		return targets, nil
 	}
-
-	targets := make(endpoint.Targets, 0)
 
 	for _, lb := range ingress.Status.LoadBalancer.Ingress {
 		if lb.IP != "" {

--- a/source/istio_virtualservice_test.go
+++ b/source/istio_virtualservice_test.go
@@ -1310,7 +1310,7 @@ func testVirtualServiceEndpoints(t *testing.T) {
 				},
 			},
 			expected:    []*endpoint.Endpoint{},
-			expectError: true,
+			expectError: false, // bad annotation should be skipped gracefully, not crash the controller
 		},
 		{
 			title: "our controller type is dns-controller",


### PR DESCRIPTION
## What does it do ?

Discovered during development of https://github.com/kubernetes-sigs/external-dns/pull/6438 which is unlikely to see a merge as-is, so I have separated the fixes into other PRs to avoid issues with v0.22.0 when it launches.

A nonexistent gateway or ingress reference in an annotation caused a fatal error that killed the pod. Now logs a warning and continues processing remaining resources.

### Bug information

Before fix:

```
time="2026-05-14T13:07:09Z" level=info msg="GitCommitShort=unknown, GoVersion=go1.26.1, Platform=linux/amd64, UserAgent=ExternalDNS/v0.21.0-dirty"
time="2026-05-14T13:07:09Z" level=info msg="Created Kubernetes client https://10.35.128.1:443"
time="2026-05-14T13:07:09Z" level=info msg="Created GatewayAPI client https://10.35.128.1:443"
time="2026-05-14T13:07:09Z" level=info msg="Records cache provider: refreshing records list cache"
time="2026-05-14T13:07:10Z" level=error msg="ingress.networking.k8s.io \"default\" not found"
time="2026-05-14T13:07:10Z" level=fatal msg="Failed to do run once: ingress.networking.k8s.io \"default\" not found"
<pod crashes here>
```


After fix:

```
time="2026-05-14T13:20:36Z" level=error msg="ingress.networking.k8s.io \"default\" not found"
time="2026-05-14T13:20:36Z" level=warning msg="Could not generate endpoints for VirtualService 'mwhittington-test/mwhittington-test-vsvc': ingress.networking.k8s.io \"default\" not found"
```

Pod does not crash.

## Motivation

These bugs stop us using external-dns for the purposes we need it for internally and would do so in quite a destructive way by removing records that are receiving live traffic.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->