### PR TITLE
fix(chart): rbac compliance checkbox for dnsendpoints/status

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add value `.service.enabled` to enable the creation of the Kubernetes service.
 
+### Fixed
+
+- RBAC compliance checkbox for dnsendpoints/status [#6442](https://github.com/kubernetes-sigs/external-dns/pull/6442) _@vflaux_
+
 ## [v1.21.1]
 
 ### Added

--- a/charts/external-dns/templates/clusterrole.yaml
+++ b/charts/external-dns/templates/clusterrole.yaml
@@ -61,7 +61,7 @@ rules:
     verbs: ["get","watch","list"]
   - apiGroups: ["externaldns.k8s.io"]
     resources: ["dnsendpoints/status"]
-    verbs: ["*"]
+    verbs: ["update"]
 {{- end }}
 {{- if include "external-dns.hasGatewaySources" . }}
 {{- if or (not .Values.namespaced) (and .Values.namespaced (not .Values.gatewayNamespace)) }}

--- a/charts/external-dns/tests/rbac_test.yaml
+++ b/charts/external-dns/tests/rbac_test.yaml
@@ -124,7 +124,7 @@ tests:
               verbs: ["get","watch","list"]
             - apiGroups: ["externaldns.k8s.io"]
               resources: ["dnsendpoints/status"]
-              verbs: ["*"]
+              verbs: ["update"]
             - apiGroups: ["traefik.containo.us", "traefik.io"]
               resources: ["ingressroutes", "ingressroutetcps", "ingressrouteudps"]
               verbs: ["get","watch","list"]


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->

Restrict RBAC permissions for `dnsendpoints/status` resource to `patch` and `update` verbs.

## Motivation

fix https://github.com/kubernetes-sigs/external-dns/issues/6434
<!-- What inspired you to submit this pull request? -->

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
