### PR TITLE
fix: preserve equals signs in endpoint label values

### DIFF
--- a/endpoint/labels.go
+++ b/endpoint/labels.go
@@ -63,11 +63,10 @@ func NewLabelsFromStringPlain(labelText string) (Labels, error) {
 	tokens := strings.Split(labelText, ",")
 	foundExternalDNSHeritage := false
 	for _, token := range tokens {
-		if len(strings.Split(token, "=")) != 2 {
+		key, val, ok := strings.Cut(token, "=")
+		if !ok {
 			continue
 		}
-		key := strings.Split(token, "=")[0]
-		val := strings.Split(token, "=")[1]
 		if key == "heritage" && val != heritage {
 			return nil, ErrInvalidHeritage
 		}

--- a/endpoint/labels_test.go
+++ b/endpoint/labels_test.go
@@ -181,3 +181,47 @@ func (suite *LabelsSuite) TestDeserialize() {
 func TestLabels(t *testing.T) {
 	suite.Run(t, new(LabelsSuite))
 }
+
+func TestParseLabels(t *testing.T) {
+	testCases := []struct {
+		name      string
+		labelText string
+		expected  Labels
+	}{
+		{
+			name:      "parses regular owner value",
+			labelText: "heritage=external-dns,external-dns/owner=team-platform,external-dns/resource=ingress/default/example",
+			expected: Labels{
+				"owner":    "team-platform",
+				"resource": "ingress/default/example",
+			},
+		},
+		{
+			name:      "preserves equals in owner value",
+			labelText: "heritage=external-dns,external-dns/owner=team=platform,external-dns/resource=ingress/default/example",
+			expected: Labels{
+				"owner":    "team=platform",
+				"resource": "ingress/default/example",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := NewLabelsFromStringPlain(tc.labelText)
+			if err != nil {
+				t.Fatalf("NewLabelsFromStringPlain(%q) returned error: %v", tc.labelText, err)
+			}
+
+			if len(parsed) != len(tc.expected) {
+				t.Fatalf("NewLabelsFromStringPlain(%q) returned %#v, want %#v", tc.labelText, parsed, tc.expected)
+			}
+
+			for key, expectedValue := range tc.expected {
+				if parsed[key] != expectedValue {
+					t.Fatalf("NewLabelsFromStringPlain(%q) returned value %q for key %q, want %q", tc.labelText, parsed[key], key, expectedValue)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does it do ?

Preserves `=` inside endpoint label values when TXT registry labels are parsed.

Before this, `heritage=external-dns,external-dns/owner=team=platform` parsed without `owner`. Tiny parser footgun, tbh.

## Motivation

`--txt-owner-id` is a plain string flag, so values like `team=platform` can get written into TXT ownership records. TXT records can contain `=`, so this is a real input, not some impossible edge-case.

Repro before the fix:

```sh
go test ./endpoint -run TestLabels/TestSerializeDeserializeWithEqualsInValue -count=1
```

It fails because `owner` gets dropped after the round trip.

Fixed by splitting labels on the first `=` only. Existing malformed tokens without `=` are still skipped, same as before.

Tested:

```sh
go test ./endpoint
go test ./endpoint ./registry/txt ./registry/dynamodb ./registry/awssd
go test ./...
```

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly
