### PR TITLE
feat: add --provider-cache-patch-on-apply flag to avoid full re-fetch on large zones

### DIFF
--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -81,6 +81,7 @@ type Config struct {
 	ConnectorSourceServer                         string
 	Provider                                      string
 	ProviderCacheTime                             time.Duration
+	ProviderCachePatchOnApply                     bool
 	CreatePTR                                     bool
 	GoogleProject                                 string
 	GoogleBatchChangeSize                         int
@@ -349,6 +350,7 @@ var defaultConfig = &Config{
 	Policy:                       "sync",
 	Provider:                     "",
 	ProviderCacheTime:            0,
+	ProviderCachePatchOnApply:    false,
 	CreatePTR:                    false,
 	PublishHostIP:                false,
 	PublishInternal:              false,
@@ -578,6 +580,7 @@ func bindFlags(b flags.FlagBinder, cfg *Config) {
 	b.StringsVar("unstructured-resource", "When using the unstructured source, specify resources in resource.version.group format (e.g., virtualmachineinstances.v1.kubevirt.io, configmap.v1); specify multiple times for multiple resources", nil, &cfg.UnstructuredResources)
 	b.StringsVar("events-emit", "Events that should be emitted. Specify multiple times for multiple events support (optional, default: none, expected: RecordReady, RecordDeleted, RecordError)", defaultConfig.EmitEvents, &cfg.EmitEvents)
 	b.DurationVar("provider-cache-time", "The time to cache the DNS provider record list requests.", defaultConfig.ProviderCacheTime, &cfg.ProviderCacheTime)
+	b.BoolVar("provider-cache-patch-on-apply", "When enabled, successful ApplyChanges calls patch the in-memory record cache instead of invalidating it. Avoids full re-fetches on large zones (e.g. 100k+ Route53 records).", defaultConfig.ProviderCachePatchOnApply, &cfg.ProviderCachePatchOnApply)
 	b.BoolVar("create-ptr", "When enabled, automatically create PTR records for A/AAAA records. Per-resource annotations can override this default. The provider must have authority over the reverse DNS zones (e.g. in-addr.arpa). Include reverse zones in --domain-filter.", defaultConfig.CreatePTR, &cfg.CreatePTR)
 	b.StringsVar("domain-filter", "Limit possible target zones by a domain suffix; specify multiple times for multiple domains (optional)", []string{""}, &cfg.DomainFilter)
 	b.StringsVar("exclude-domains", "Exclude subdomains (optional)", []string{""}, &cfg.DomainExclude)

--- a/provider/cached_provider.go
+++ b/provider/cached_provider.go
@@ -24,6 +24,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	"sigs.k8s.io/external-dns/pkg/metrics"
 	"sigs.k8s.io/external-dns/plan"
 )
@@ -55,15 +56,17 @@ func init() {
 
 type CachedProvider struct {
 	Provider
-	RefreshDelay time.Duration
-	lastRead     time.Time
-	cache        []*endpoint.Endpoint
+	RefreshDelay   time.Duration
+	PatchOnApply   bool
+	lastRead       time.Time
+	cache          []*endpoint.Endpoint
 }
 
-func NewCachedProvider(provider Provider, refreshDelay time.Duration) *CachedProvider {
+func NewCachedProvider(provider Provider, cfg *externaldns.Config) *CachedProvider {
 	return &CachedProvider{
 		Provider:     provider,
-		RefreshDelay: refreshDelay,
+		RefreshDelay: cfg.ProviderCacheTime,
+		PatchOnApply: cfg.ProviderCachePatchOnApply,
 	}
 }
 
@@ -89,9 +92,36 @@ func (c *CachedProvider) ApplyChanges(ctx context.Context, changes *plan.Changes
 		log.Info("Records cache provider: no changes to be applied")
 		return nil
 	}
-	c.Reset()
 	cachedApplyChangesCallsTotal.Counter.Inc()
-	return c.Provider.ApplyChanges(ctx, changes)
+	if err := c.Provider.ApplyChanges(ctx, changes); err != nil {
+		c.Reset()
+		return err
+	}
+	if c.PatchOnApply && c.cache != nil {
+		c.cache = applyChangesToCache(c.cache, changes)
+	} else {
+		c.Reset()
+	}
+	return nil
+}
+
+func applyChangesToCache(cache []*endpoint.Endpoint, changes *plan.Changes) []*endpoint.Endpoint {
+	remove := make(map[string]bool, len(changes.Delete)+len(changes.UpdateOld))
+	for _, ep := range changes.Delete {
+		remove[ep.DNSName+"/"+ep.RecordType] = true
+	}
+	for _, ep := range changes.UpdateOld {
+		remove[ep.DNSName+"/"+ep.RecordType] = true
+	}
+	updated := make([]*endpoint.Endpoint, 0, len(cache))
+	for _, ep := range cache {
+		if !remove[ep.DNSName+"/"+ep.RecordType] {
+			updated = append(updated, ep)
+		}
+	}
+	updated = append(updated, changes.Create...)
+	updated = append(updated, changes.UpdateNew...)
+	return updated
 }
 
 func (c *CachedProvider) Reset() {

--- a/provider/cached_provider_test.go
+++ b/provider/cached_provider_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	"sigs.k8s.io/external-dns/plan"
 )
 
@@ -96,9 +97,10 @@ func newTestProviderFunc(t *testing.T) *testProviderFunc {
 func TestNewCachedProvider(t *testing.T) {
 	inner := newTestProviderFunc(t)
 	delay := 5 * time.Minute
-	cp := NewCachedProvider(inner, delay)
+	cp := NewCachedProvider(inner, &externaldns.Config{ProviderCacheTime: delay})
 	assert.Equal(t, inner, cp.Provider)
 	assert.Equal(t, delay, cp.RefreshDelay)
+	assert.False(t, cp.PatchOnApply)
 	assert.Nil(t, cp.cache)
 	assert.True(t, cp.lastRead.IsZero())
 }
@@ -108,7 +110,7 @@ func TestCachedProviderRecordsError(t *testing.T) {
 	testProvider.records = func(_ context.Context) ([]*endpoint.Endpoint, error) {
 		return nil, assert.AnError
 	}
-	cp := NewCachedProvider(testProvider, 0)
+	cp := NewCachedProvider(testProvider, &externaldns.Config{})
 	_, err := cp.Records(t.Context())
 	require.ErrorIs(t, err, assert.AnError)
 	assert.Nil(t, cp.cache)
@@ -223,6 +225,72 @@ func TestCachedProviderForcesCacheRefreshOnUpdate(t *testing.T) {
 			require.Len(t, endpoints, 1)
 			require.NotNil(t, endpoints[0])
 			assert.Equal(t, "new.domain.fqdn", endpoints[0].DNSName)
+		})
+	})
+}
+
+func TestCachedProviderPatchOnApply(t *testing.T) {
+	testProvider := newTestProviderFunc(t)
+	testProvider.records = func(_ context.Context) ([]*endpoint.Endpoint, error) {
+		return []*endpoint.Endpoint{{DNSName: "domain.fqdn"}}, nil
+	}
+	provider := CachedProvider{
+		RefreshDelay: 30 * time.Second,
+		PatchOnApply: true,
+		Provider:     testProvider,
+	}
+	_, err := provider.Records(context.Background())
+	require.NoError(t, err)
+
+	t.Run("Successful apply patches cache without hitting provider", func(t *testing.T) {
+		testProvider.applyChanges = func(_ context.Context, _ *plan.Changes) error {
+			return nil
+		}
+		err := provider.ApplyChanges(context.Background(), &plan.Changes{
+			Create: []*endpoint.Endpoint{
+				{DNSName: "hello.world"},
+			},
+			Delete: []*endpoint.Endpoint{
+				{DNSName: "domain.fqdn", RecordType: ""},
+			},
+		})
+		assert.NoError(t, err)
+		t.Run("Next call to Records uses patched cache without hitting provider", func(t *testing.T) {
+			testProvider.applyChanges = applyChangesNotCalled(t)
+			testProvider.records = recordsNotCalled(t)
+			endpoints, err := provider.Records(context.Background())
+
+			assert.NoError(t, err)
+			require.NotNil(t, endpoints)
+			dnsNames := make([]string, len(endpoints))
+			for i, ep := range endpoints {
+				dnsNames[i] = ep.DNSName
+			}
+			assert.Contains(t, dnsNames, "hello.world")
+			assert.NotContains(t, dnsNames, "domain.fqdn")
+		})
+	})
+
+	t.Run("Failed apply resets cache and forces provider re-fetch", func(t *testing.T) {
+		testProvider.records = func(_ context.Context) ([]*endpoint.Endpoint, error) {
+			return []*endpoint.Endpoint{{DNSName: "fresh.domain.fqdn"}}, nil
+		}
+		testProvider.applyChanges = func(_ context.Context, _ *plan.Changes) error {
+			return errors.New("provider error")
+		}
+		err := provider.ApplyChanges(context.Background(), &plan.Changes{
+			Create: []*endpoint.Endpoint{
+				{DNSName: "should.not.cache"},
+			},
+		})
+		assert.Error(t, err)
+		t.Run("Next call to Records hits provider after reset", func(t *testing.T) {
+			testProvider.applyChanges = applyChangesNotCalled(t)
+			endpoints, err := provider.Records(context.Background())
+
+			assert.NoError(t, err)
+			require.Len(t, endpoints, 1)
+			assert.Equal(t, "fresh.domain.fqdn", endpoints[0].DNSName)
 		})
 	})
 }

--- a/provider/factory/provider.go
+++ b/provider/factory/provider.go
@@ -71,7 +71,7 @@ func Select(
 		return nil, err
 	}
 	if p != nil && cfg.ProviderCacheTime > 0 {
-		return provider.NewCachedProvider(p, cfg.ProviderCacheTime), nil
+		return provider.NewCachedProvider(p, cfg), nil
 	}
 	return p, nil
 }

--- a/provider/factory/provider_test.go
+++ b/provider/factory/provider_test.go
@@ -28,6 +28,7 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
+	"sigs.k8s.io/external-dns/provider"
 )
 
 func TestSelectProvider(t *testing.T) {
@@ -138,6 +139,20 @@ func TestSelectProvider(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSelectCachedProviderPatchOnApply(t *testing.T) {
+	domainFilter := endpoint.NewDomainFilter([]string{"example.com"})
+	cfg := &externaldns.Config{
+		Provider:                  externaldns.ProviderInMemory,
+		ProviderCacheTime:         10 * time.Millisecond,
+		ProviderCachePatchOnApply: true,
+	}
+	p, err := Select(t.Context(), cfg, domainFilter)
+	require.NoError(t, err)
+	cp, ok := p.(*provider.CachedProvider)
+	require.True(t, ok, "expected *provider.CachedProvider")
+	assert.True(t, cp.PatchOnApply)
 }
 
 func TestKnownProviders(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Adds a `--provider-cache-patch-on-apply` boolean flag (default `false`) to `CachedProvider`.

When enabled, a successful `ApplyChanges` call patches the in-memory record cache in-place rather than invalidating it. This avoids a full provider re-fetch (e.g. `ListResourceRecordSets`) on the next reconcile loop after every write.

## Why is this needed?

When `--provider-cache-time` is set, the previous behaviour unconditionally called `Reset()` before writing to the provider, invalidating the cache regardless of success or failure. On the next `Records()` call, external-dns would re-fetch the entire zone.

For large zones (e.g. 100k+ Route53 records with creates/deletes every minute) this means a full zone list on every sync cycle — negating the cache entirely and generating significant API cost and latency.

## How does it work?

- On **successful** `ApplyChanges`: removes deleted/updated-old entries and appends created/updated-new entries directly in the cache slice — no provider round-trip.
- On **failed** `ApplyChanges`: still calls `Reset()` to guarantee consistency with the provider state.
- Default is `false` — existing behaviour is fully preserved for users who do not set the flag.

## Usage

```
--provider-cache-time=10m --provider-cache-patch-on-apply=true
```
