### PR TITLE
feat(source): set transformer on all informers

### DIFF
--- a/source/ambassador_host.go
+++ b/source/ambassador_host.go
@@ -105,7 +105,7 @@ func NewAmbassadorHostSource(
 		return nil, err
 	}
 
-	uc, err := newUnstructuredConverter()
+	uc, err := newAmbassadorUnstructuredConverter()
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup Unstructured Converter: %w", err)
 	}
@@ -273,8 +273,8 @@ type unstructuredConverter struct {
 	scheme *runtime.Scheme
 }
 
-// newUnstructuredConverter returns a new unstructuredConverter initialized
-func newUnstructuredConverter() (*unstructuredConverter, error) {
+// newAmbassadorUnstructuredConverter returns a new unstructuredConverter initialized
+func newAmbassadorUnstructuredConverter() (*unstructuredConverter, error) {
 	uc := &unstructuredConverter{
 		scheme: runtime.NewScheme(),
 	}

--- a/source/ambassador_host.go
+++ b/source/ambassador_host.go
@@ -90,6 +90,11 @@ func NewAmbassadorHostSource(
 	informerFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicKubeClient, 0, cfg.Namespace, nil)
 	ambassadorHostInformer := informerFactory.ForResource(ambHostGVR)
 
+	informers.MustSetTransform(ambassadorHostInformer.Informer(), informers.TransformerWithOptions[*unstructured.Unstructured](
+		informers.TransformRemoveManagedFields(),
+		informers.TransformRemoveLastAppliedConfig(),
+	))
+
 	// Add default resource event handlers to properly initialize informer.
 	informers.MustAddEventHandler(ambassadorHostInformer.Informer(), informers.DefaultEventHandler())
 

--- a/source/ambassador_host_test.go
+++ b/source/ambassador_host_test.go
@@ -657,7 +657,7 @@ func TestAmbassadorHostSource(t *testing.T) {
 
 func createAmbassadorHost(host *ambassador.Host) (*unstructured.Unstructured, error) {
 	obj := &unstructured.Unstructured{}
-	uc, _ := newUnstructuredConverter()
+	uc, _ := newAmbassadorUnstructuredConverter()
 	err := uc.scheme.Convert(host, obj, nil)
 
 	return obj, err
@@ -700,4 +700,25 @@ func TestParseAmbLoadBalancerService(t *testing.T) {
 			t.Errorf("%s: got err \"%s\", wanted \"%s\"", v.input, errstr, v.errstr)
 		}
 	}
+}
+
+func TestAmbassadorHostSource_InformerTransform(t *testing.T) {
+	t.Parallel()
+
+	fakeClient := fakeKube.NewSimpleClientset()
+	uc, err := newAmbassadorUnstructuredConverter()
+	require.NoError(t, err)
+	fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(uc.scheme)
+
+	source, err := NewAmbassadorHostSource(t.Context(), fakeDynamicClient, fakeClient, &Config{})
+	require.NoError(t, err)
+	require.NotNil(t, source)
+
+	testDynamicInformerTransformHelper(t,
+		ambHostGVR,
+		fakeDynamicClient,
+		source.(*ambassadorHostSource).ambassadorHostInformer,
+		withRemovedLastAppliedConfigAnnotation(),
+		withRemovedManagedFields(),
+	)
 }

--- a/source/contour_httpproxy.go
+++ b/source/contour_httpproxy.go
@@ -70,6 +70,12 @@ func NewContourHTTPProxySource(
 	informerFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicKubeClient, 0, cfg.Namespace, nil)
 	httpProxyInformer := informerFactory.ForResource(projectcontour.HTTPProxyGVR)
 
+	informers.MustSetTransform(httpProxyInformer.Informer(), informers.TransformerWithOptions[*unstructured.Unstructured](
+		informers.TransformRemoveManagedFields(),
+		informers.TransformRemoveLastAppliedConfig(),
+		informers.TransformRemoveStatusConditions(),
+	))
+
 	// Add default resource event handlers to properly initialize informer.
 	informers.MustAddEventHandler(httpProxyInformer.Informer(), informers.DefaultEventHandler())
 

--- a/source/contour_httpproxy_test.go
+++ b/source/contour_httpproxy_test.go
@@ -48,7 +48,7 @@ type HTTPProxySuite struct {
 	httpProxy *projectcontour.HTTPProxy
 }
 
-func newDynamicKubernetesClient() (*fakeDynamic.FakeDynamicClient, *runtime.Scheme) {
+func newContourDynamicKubernetesClient() (*fakeDynamic.FakeDynamicClient, *runtime.Scheme) {
 	s := runtime.NewScheme()
 	_ = projectcontour.AddToScheme(s)
 	return fakeDynamic.NewSimpleDynamicClient(s), s
@@ -89,7 +89,7 @@ func (ig fakeLoadBalancerService) Service() *v1.Service {
 }
 
 func (suite *HTTPProxySuite) SetupTest() {
-	fakeDynamicClient, s := newDynamicKubernetesClient()
+	fakeDynamicClient, s := newContourDynamicKubernetesClient()
 	var err error
 
 	suite.source, err = NewContourHTTPProxySource(
@@ -1003,7 +1003,7 @@ func testHTTPProxyEndpoints(t *testing.T) {
 				httpProxies = append(httpProxies, item.HTTPProxy())
 			}
 
-			fakeDynamicClient, scheme := newDynamicKubernetesClient()
+			fakeDynamicClient, scheme := newContourDynamicKubernetesClient()
 			for _, httpProxy := range httpProxies {
 				converted, err := convertHTTPProxyToUnstructured(httpProxy, scheme)
 				require.NoError(t, err)
@@ -1037,7 +1037,7 @@ func testHTTPProxyEndpoints(t *testing.T) {
 
 // httpproxy specific helper functions
 func newTestHTTPProxySource(t *testing.T) (*httpProxySource, error) {
-	fakeDynamicClient, _ := newDynamicKubernetesClient()
+	fakeDynamicClient, _ := newContourDynamicKubernetesClient()
 
 	src, err := NewContourHTTPProxySource(
 		t.Context(),
@@ -1108,4 +1108,22 @@ func (ir fakeHTTPProxy) HTTPProxy() *projectcontour.HTTPProxy {
 	}
 
 	return httpProxy
+}
+
+func TestContourHTTPProxySource_InformerTransform(t *testing.T) {
+	t.Parallel()
+
+	fakeDynamicClient, _ := newContourDynamicKubernetesClient()
+
+	source, err := NewContourHTTPProxySource(t.Context(), fakeDynamicClient, &Config{})
+	require.NoError(t, err)
+	require.IsType(t, &httpProxySource{}, source)
+
+	testDynamicInformerTransformHelper(t,
+		projectcontour.HTTPProxyGVR,
+		fakeDynamicClient, source.(*httpProxySource).httpProxyInformer,
+		withRemovedLastAppliedConfigAnnotation(),
+		withRemovedManagedFields(),
+		withRemovedStatusConditions(),
+	)
 }

--- a/source/f5_transportserver.go
+++ b/source/f5_transportserver.go
@@ -74,6 +74,11 @@ func NewF5TransportServerSource(
 	informerFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicKubeClient, 0, cfg.Namespace, nil)
 	transportServerInformer := informerFactory.ForResource(f5TransportServerGVR)
 
+	informers.MustSetTransform(transportServerInformer.Informer(), informers.TransformerWithOptions[*unstructured.Unstructured](
+		informers.TransformRemoveManagedFields(),
+		informers.TransformRemoveLastAppliedConfig(),
+	))
+
 	informers.MustAddEventHandler(transportServerInformer.Informer(), informers.DefaultEventHandler())
 
 	informerFactory.Start(ctx.Done())

--- a/source/f5_transportserver_test.go
+++ b/source/f5_transportserver_test.go
@@ -399,3 +399,25 @@ func TestF5TransportServerEndpoints(t *testing.T) {
 		})
 	}
 }
+
+func TestF5TransportServerSource_InformerTransform(t *testing.T) {
+	t.Parallel()
+
+	uc, err := newTSUnstructuredConverter()
+	require.NoError(t, err)
+
+	fakeKubernetesClient := fakeKube.NewSimpleClientset()
+	fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(uc.scheme)
+
+	source, err := NewF5TransportServerSource(t.Context(), fakeDynamicClient, fakeKubernetesClient, &Config{})
+	require.NoError(t, err)
+	require.IsType(t, &f5TransportServerSource{}, source)
+
+	testDynamicInformerTransformHelper(t,
+		f5TransportServerGVR,
+		fakeDynamicClient,
+		source.(*f5TransportServerSource).transportServerInformer,
+		withRemovedLastAppliedConfigAnnotation(),
+		withRemovedManagedFields(),
+	)
+}

--- a/source/f5_virtualserver.go
+++ b/source/f5_virtualserver.go
@@ -73,6 +73,11 @@ func NewF5VirtualServerSource(
 	informerFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicKubeClient, 0, cfg.Namespace, nil)
 	virtualServerInformer := informerFactory.ForResource(f5VirtualServerGVR)
 
+	informers.MustSetTransform(virtualServerInformer.Informer(), informers.TransformerWithOptions[*unstructured.Unstructured](
+		informers.TransformRemoveManagedFields(),
+		informers.TransformRemoveLastAppliedConfig(),
+	))
+
 	informers.MustAddEventHandler(virtualServerInformer.Informer(), informers.DefaultEventHandler())
 
 	informerFactory.Start(ctx.Done())

--- a/source/f5_virtualserver_test.go
+++ b/source/f5_virtualserver_test.go
@@ -643,3 +643,25 @@ func TestF5VirtualServerEndpoints(t *testing.T) {
 		})
 	}
 }
+
+func TestF5VirtualServerSource_InformerTransform(t *testing.T) {
+	t.Parallel()
+
+	uc, err := newVSUnstructuredConverter()
+	require.NoError(t, err)
+
+	fakeClient := fakeKube.NewClientset()
+	fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(uc.scheme)
+
+	source, err := NewF5VirtualServerSource(t.Context(), fakeDynamicClient, fakeClient, &Config{})
+	require.NoError(t, err)
+	require.IsType(t, &f5VirtualServerSource{}, source)
+
+	testDynamicInformerTransformHelper(t,
+		f5VirtualServerGVR,
+		fakeDynamicClient,
+		source.(*f5VirtualServerSource).virtualServerInformer,
+		withRemovedLastAppliedConfigAnnotation(),
+		withRemovedManagedFields(),
+	)
+}

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -177,7 +177,12 @@ func newGatewayRouteSource(
 
 	gwInformerFactory := newGatewayInformerFactory(client, config.GatewayNamespace, gwLabels)
 	gwInformer := gwInformerFactory.Gateway().V1().Gateways() // TODO: Gateway informer should be shared across gateway sources.
-	gwInformer.Informer()                                     // Register with factory before starting.
+
+	informers.MustSetTransform(gwInformer.Informer(), informers.TransformerWithOptions[*v1.Gateway](
+		informers.TransformRemoveManagedFields(),
+		informers.TransformRemoveLastAppliedConfig(),
+		informers.TransformRemoveStatusConditions(),
+	))
 
 	var lsInformer informers_v1.ListenerSetInformer
 	lsInformerFactory := gwInformerFactory
@@ -187,7 +192,10 @@ func newGatewayRouteSource(
 			lsInformerFactory = newGatewayInformerFactory(client, "", nil)
 		}
 		lsInformer = lsInformerFactory.Gateway().V1().ListenerSets() // TODO: ListenerSet informer should be shared across gateway sources.
-		lsInformer.Informer()                                        // Register with factory before starting.
+		informers.MustSetTransform(lsInformer.Informer(), informers.TransformerWithOptions[*v1.ListenerSet](
+			informers.TransformRemoveManagedFields(),
+			informers.TransformRemoveLastAppliedConfig(),
+		))
 	}
 
 	rtInformerFactory := gwInformerFactory
@@ -195,7 +203,11 @@ func newGatewayRouteSource(
 		rtInformerFactory = newGatewayInformerFactory(client, config.Namespace, rtLabels)
 	}
 	rtInformer := newInformerFn(rtInformerFactory)
-	rtInformer.Informer() // Register with factory before starting.
+	informers.MustSetTransform(rtInformer.Informer(), informers.TransformerWithOptions[informers.Object](
+		informers.TransformRemoveManagedFields(),
+		informers.TransformRemoveLastAppliedConfig(),
+		informers.TransformRemoveStatusConditions(),
+	))
 
 	kubeClient, err := clients.KubeClient()
 	if err != nil {
@@ -204,7 +216,11 @@ func newGatewayRouteSource(
 
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
 	nsInformer := kubeInformerFactory.Core().V1().Namespaces() // TODO: Namespace informer should be shared across gateway sources.
-	nsInformer.Informer()                                      // Register with factory before starting.
+	informers.MustSetTransform(nsInformer.Informer(), informers.TransformerWithOptions[*corev1.Namespace](
+		informers.TransformRemoveManagedFields(),
+		informers.TransformRemoveLastAppliedConfig(),
+		informers.TransformRemoveStatusConditions(),
+	))
 
 	gwInformerFactory.Start(ctx.Done())
 	if lsInformerFactory != gwInformerFactory {

--- a/source/gateway_grpcroute_test.go
+++ b/source/gateway_grpcroute_test.go
@@ -107,3 +107,32 @@ func TestGatewayGRPCRouteSourceEndpoints(t *testing.T) {
 		newTestEndpoint("api-template.foobar.internal", ips...),
 	})
 }
+
+func TestGatewayGRPCRouteSource_InformerTransform(t *testing.T) {
+	t.Parallel()
+
+	gwClient := gatewayfake.NewSimpleClientset()
+	kubeClient := kubefake.NewClientset()
+
+	rt := &v1.GRPCRoute{ObjectMeta: informerTransformObjectMeta()}
+	require.Contains(t, rt.GetAnnotations(), corev1.LastAppliedConfigAnnotation)
+	require.NotEmpty(t, rt.GetManagedFields())
+
+	_, err := gwClient.GatewayV1().GRPCRoutes(rt.GetNamespace()).Create(t.Context(), rt, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	clients := new(testutils.MockClientGenerator)
+	clients.On("GatewayClient").Return(gwClient, nil)
+	clients.On("KubeClient").Return(kubeClient, nil)
+
+	source, err := NewGatewayGRPCRouteSource(t.Context(), clients, &Config{})
+	require.NoError(t, err)
+	require.IsType(t, &gatewayRouteSource{}, source)
+
+	testInformerTransformHelper(t,
+		source.(*gatewayRouteSource).rtInformer.Informer(),
+		rt,
+		withRemovedLastAppliedConfigAnnotation(),
+		withRemovedManagedFields(),
+	)
+}

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -1693,3 +1693,72 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 		})
 	}
 }
+
+func TestGatewayHTTPRouteSource_RouteInformerTransform(t *testing.T) {
+	t.Parallel()
+
+	gwClient := gatewayfake.NewSimpleClientset()
+	kubeClient := kubefake.NewClientset()
+
+	rt := &v1.HTTPRoute{ObjectMeta: informerTransformObjectMeta()}
+	require.Contains(t, rt.GetAnnotations(), corev1.LastAppliedConfigAnnotation)
+	require.NotEmpty(t, rt.GetManagedFields())
+
+	_, err := gwClient.GatewayV1().HTTPRoutes(rt.GetNamespace()).Create(t.Context(), rt, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	clients := new(testutils.MockClientGenerator)
+	clients.On("GatewayClient").Return(gwClient, nil)
+	clients.On("KubeClient").Return(kubeClient, nil)
+
+	source, err := NewGatewayHTTPRouteSource(t.Context(), clients, &Config{})
+	require.NoError(t, err)
+	require.IsType(t, &gatewayRouteSource{}, source)
+
+	testInformerTransformHelper(t,
+		source.(*gatewayRouteSource).rtInformer.Informer(),
+		rt,
+		withRemovedLastAppliedConfigAnnotation(),
+		withRemovedManagedFields(),
+	)
+}
+
+func TestGatewayHTTPRouteSource_InformerTransform(t *testing.T) {
+	t.Parallel()
+
+	gwClient := gatewayfake.NewSimpleClientset()
+	kubeClient := kubefake.NewClientset()
+
+	// Create Gateway with fields that the transformer should strip.
+	gw := &v1.Gateway{
+		ObjectMeta: informerTransformObjectMeta(),
+		Spec:       v1.GatewaySpec{GatewayClassName: "test"},
+		Status: v1.GatewayStatus{
+			Conditions: []metav1.Condition{{Type: "Ready", Status: metav1.ConditionTrue}},
+		},
+	}
+	require.Contains(t, gw.GetAnnotations(), corev1.LastAppliedConfigAnnotation)
+	require.NotEmpty(t, gw.GetManagedFields())
+	require.NotEmpty(t, gw.Status.Conditions)
+
+	_, err := gwClient.GatewayV1().Gateways(gw.GetNamespace()).Create(t.Context(), gw, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	clients := new(testutils.MockClientGenerator)
+	clients.On("GatewayClient").Return(gwClient, nil)
+	clients.On("KubeClient").Return(kubeClient, nil)
+
+	source, err := NewGatewayHTTPRouteSource(t.Context(), clients, &Config{})
+	require.NoError(t, err)
+	require.IsType(t, &gatewayRouteSource{}, source)
+
+	gatewaySrc := source.(*gatewayRouteSource)
+
+	testInformerTransformHelper(t,
+		gatewaySrc.gwInformer.Informer(),
+		gw,
+		withRemovedLastAppliedConfigAnnotation(),
+		withRemovedManagedFields(),
+		withRemovedStatusConditions(),
+	)
+}

--- a/source/gateway_listenerset_test.go
+++ b/source/gateway_listenerset_test.go
@@ -1522,3 +1522,39 @@ func TestGatewayHTTPRouteWithListenerSetGatewayNotFound(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, endpoints, "expected no endpoints when ListenerSet's parent Gateway doesn't exist")
 }
+
+func TestGatewayListenerSetSource_InformerTransform(t *testing.T) {
+	t.Parallel()
+
+	gwClient := gatewayfake.NewSimpleClientset()
+	kubeClient := kubefake.NewClientset()
+
+	ls := &v1.ListenerSet{
+		ObjectMeta: informerTransformObjectMeta(),
+		Spec:       v1.ListenerSetSpec{ParentRef: v1.ParentGatewayReference{Name: "test-gateway"}},
+		Status:     v1.ListenerSetStatus{Conditions: []metav1.Condition{{}}},
+	}
+	require.Contains(t, ls.GetAnnotations(), corev1.LastAppliedConfigAnnotation)
+	require.NotEmpty(t, ls.GetManagedFields())
+
+	_, err := gwClient.GatewayV1().ListenerSets(ls.GetNamespace()).Create(t.Context(), ls, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	clients := new(testutils.MockClientGenerator)
+	clients.On("GatewayClient").Return(gwClient, nil)
+	clients.On("KubeClient").Return(kubeClient, nil)
+
+	source, err := NewGatewayHTTPRouteSource(t.Context(), clients, &Config{GatewayListenerSets: true})
+	require.NoError(t, err)
+	require.IsType(t, &gatewayRouteSource{}, source)
+
+	gatewaySrc := source.(*gatewayRouteSource)
+	require.NotNil(t, gatewaySrc.lsInformer)
+
+	testInformerTransformHelper(t,
+		gatewaySrc.lsInformer.Informer(),
+		ls,
+		withRemovedLastAppliedConfigAnnotation(),
+		withRemovedManagedFields(),
+	)
+}

--- a/source/gateway_tcproute_test.go
+++ b/source/gateway_tcproute_test.go
@@ -106,3 +106,32 @@ func TestGatewayTCPRouteSourceEndpoints(t *testing.T) {
 		newTestEndpoint("api-template.foobar.internal", ips...),
 	})
 }
+
+func TestGatewayTCPRouteSource_InformerTransform(t *testing.T) {
+	t.Parallel()
+
+	gwClient := gatewayfake.NewSimpleClientset()
+	kubeClient := kubefake.NewClientset()
+
+	rt := &v1alpha2.TCPRoute{ObjectMeta: informerTransformObjectMeta()}
+	require.Contains(t, rt.GetAnnotations(), corev1.LastAppliedConfigAnnotation)
+	require.NotEmpty(t, rt.GetManagedFields())
+
+	_, err := gwClient.GatewayV1alpha2().TCPRoutes(rt.GetNamespace()).Create(t.Context(), rt, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	clients := new(testutils.MockClientGenerator)
+	clients.On("GatewayClient").Return(gwClient, nil)
+	clients.On("KubeClient").Return(kubeClient, nil)
+
+	source, err := NewGatewayTCPRouteSource(t.Context(), clients, &Config{})
+	require.NoError(t, err)
+	require.IsType(t, &gatewayRouteSource{}, source)
+
+	testInformerTransformHelper(t,
+		source.(*gatewayRouteSource).rtInformer.Informer(),
+		rt,
+		withRemovedLastAppliedConfigAnnotation(),
+		withRemovedManagedFields(),
+	)
+}

--- a/source/gateway_tlsroute_test.go
+++ b/source/gateway_tlsroute_test.go
@@ -107,3 +107,32 @@ func TestGatewayTLSRouteSourceEndpoints(t *testing.T) {
 		newTestEndpoint("api-template.foobar.internal", ips...),
 	})
 }
+
+func TestGatewayTLSRouteSource_InformerTransform(t *testing.T) {
+	t.Parallel()
+
+	gwClient := gatewayfake.NewSimpleClientset()
+	kubeClient := kubefake.NewClientset()
+
+	rt := &v1.TLSRoute{ObjectMeta: informerTransformObjectMeta()}
+	require.Contains(t, rt.GetAnnotations(), corev1.LastAppliedConfigAnnotation)
+	require.NotEmpty(t, rt.GetManagedFields())
+
+	_, err := gwClient.GatewayV1().TLSRoutes(rt.GetNamespace()).Create(t.Context(), rt, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	clients := new(testutils.MockClientGenerator)
+	clients.On("GatewayClient").Return(gwClient, nil)
+	clients.On("KubeClient").Return(kubeClient, nil)
+
+	source, err := NewGatewayTLSRouteSource(t.Context(), clients, &Config{})
+	require.NoError(t, err)
+	require.IsType(t, &gatewayRouteSource{}, source)
+
+	testInformerTransformHelper(t,
+		source.(*gatewayRouteSource).rtInformer.Informer(),
+		rt,
+		withRemovedLastAppliedConfigAnnotation(),
+		withRemovedManagedFields(),
+	)
+}

--- a/source/gateway_udproute_test.go
+++ b/source/gateway_udproute_test.go
@@ -106,3 +106,32 @@ func TestGatewayUDPRouteSourceEndpoints(t *testing.T) {
 		newTestEndpoint("api-template.foobar.internal", ips...),
 	})
 }
+
+func TestGatewayUDPRouteSource_InformerTransform(t *testing.T) {
+	t.Parallel()
+
+	gwClient := gatewayfake.NewSimpleClientset()
+	kubeClient := kubefake.NewClientset()
+
+	rt := &v1alpha2.UDPRoute{ObjectMeta: informerTransformObjectMeta()}
+	require.Contains(t, rt.GetAnnotations(), corev1.LastAppliedConfigAnnotation)
+	require.NotEmpty(t, rt.GetManagedFields())
+
+	_, err := gwClient.GatewayV1alpha2().UDPRoutes(rt.GetNamespace()).Create(t.Context(), rt, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	clients := new(testutils.MockClientGenerator)
+	clients.On("GatewayClient").Return(gwClient, nil)
+	clients.On("KubeClient").Return(kubeClient, nil)
+
+	source, err := NewGatewayUDPRouteSource(t.Context(), clients, &Config{})
+	require.NoError(t, err)
+	require.IsType(t, &gatewayRouteSource{}, source)
+
+	testInformerTransformHelper(t,
+		source.(*gatewayRouteSource).rtInformer.Informer(),
+		rt,
+		withRemovedLastAppliedConfigAnnotation(),
+		withRemovedManagedFields(),
+	)
+}

--- a/source/informers/transformers.go
+++ b/source/informers/transformers.go
@@ -22,12 +22,20 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
 )
+
+// Object is a composite interface that combines runtime.Object and metav1.Object.
+// It represents a Kubernetes resource object that has both metadata and runtime information.
+type Object interface {
+	runtime.Object
+	metav1.Object
+}
 
 // TransformOptions holds the configuration for TransformerWithOptions.
 // All options operate on the metav1.Object interface (or via reflection for Status
@@ -103,10 +111,7 @@ func TransformRequireAnnotation(selector labels.Selector) func(*TransformOptions
 //	    informers.TransformRemoveManagedFields(),
 //	    informers.TransformRemoveLastAppliedConfig(),
 //	))
-func TransformerWithOptions[T interface {
-	metav1.Object
-	runtime.Object
-}](optFns ...func(*TransformOptions)) cache.TransformFunc {
+func TransformerWithOptions[T Object](optFns ...func(*TransformOptions)) cache.TransformFunc {
 	options := TransformOptions{}
 	for _, fn := range optFns {
 		fn(&options)
@@ -172,12 +177,17 @@ func populateGVK(obj runtime.Object) {
 }
 
 // clearStatusConditions zeroes out the Status.Conditions field on obj if it exists.
+//
 // It handles all condition types (metav1.Condition, corev1.PodCondition, etc.) uniformly.
-// Reflection is used because Status.Conditions is a structural convention shared by all
-// Kubernetes types but not codified in any interface — element types differ per resource.
+// Reflection is used — unless if the object is an Unstructured object — because Status.Conditions is a structural
+// convention shared by all Kubernetes types but not codified in any interface — element types differ per resource.
 // The reflection cost is negligible: paid once per object at cache-population time,
 // not on the hot path of every endpoint reconciliation.
 func clearStatusConditions(obj any) {
+	if unstructuredObj, ok := obj.(*unstructured.Unstructured); ok {
+		unstructured.RemoveNestedField(unstructuredObj.Object, "status", "conditions")
+		return
+	}
 	val := reflect.ValueOf(obj)
 	if val.Kind() == reflect.Pointer {
 		val = val.Elem()

--- a/source/informers/transformers_test.go
+++ b/source/informers/transformers_test.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -132,6 +133,36 @@ func TestTransformRemoveStatusConditions(t *testing.T) {
 		assert.Empty(t, result.Status.Conditions)
 		// Status.Addresses must be preserved
 		assert.NotEmpty(t, result.Status.Addresses)
+	})
+
+	t.Run("removes conditions from Unstructured", func(t *testing.T) {
+		svc := fakeService()
+		require.NotEmpty(t, svc.Status.Conditions)
+		unstructuredSvc, err := runtime.DefaultUnstructuredConverter.ToUnstructured(svc)
+		require.NoError(t, err)
+		unstructuredSvcObj := &unstructured.Unstructured{Object: unstructuredSvc}
+		initialConditions, found, err := unstructured.NestedSlice(unstructuredSvcObj.Object, "status", "conditions")
+		require.NoError(t, err)
+		require.True(t, found)
+		require.NotEmpty(t, initialConditions)
+
+		transform := TransformerWithOptions[*unstructured.Unstructured](TransformRemoveStatusConditions())
+		got, err := transform(unstructuredSvcObj)
+		require.NoError(t, err)
+		require.IsType(t, new(unstructured.Unstructured), got)
+		result := got.(*unstructured.Unstructured)
+
+		conditions, found, err := unstructured.NestedSlice(unstructuredSvcObj.Object, "status", "conditions")
+		require.NoError(t, err)
+		assert.False(t, found)
+		assert.Nil(t, conditions)
+
+		// Status.LoadBalancer must be preserved
+		assert.Contains(t, result.Object["status"], "loadBalancer")
+		loadBalancerStatus, found, err := unstructured.NestedMap(unstructuredSvcObj.Object, "status", "loadBalancer")
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.NotNil(t, loadBalancerStatus)
 	})
 
 	t.Run("no-op when conditions are already empty", func(t *testing.T) {

--- a/source/kong_tcpingress.go
+++ b/source/kong_tcpingress.go
@@ -78,6 +78,11 @@ func NewKongTCPIngressSource(
 	informerFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicKubeClient, 0, cfg.Namespace, nil)
 	kongTCPIngressInformer := informerFactory.ForResource(kongGroupdVersionResource)
 
+	informers.MustSetTransform(kongTCPIngressInformer.Informer(), informers.TransformerWithOptions[*unstructured.Unstructured](
+		informers.TransformRemoveManagedFields(),
+		informers.TransformRemoveLastAppliedConfig(),
+	))
+
 	// Add default resource event handlers to properly initialize informer.
 	informers.MustAddEventHandler(kongTCPIngressInformer.Informer(), informers.DefaultEventHandler())
 

--- a/source/kong_tcpingress_test.go
+++ b/source/kong_tcpingress_test.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/external-dns/internal/testutils"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -425,4 +426,26 @@ func TestKongTCPIngressEndpoints(t *testing.T) {
 			testutils.ValidateEndpoints(t, endpoints, ti.expected)
 		})
 	}
+}
+
+func TestKongTCPIngressSource_InformerTransform(t *testing.T) {
+	t.Parallel()
+
+	uc, err := newKongUnstructuredConverter()
+	require.NoError(t, err)
+
+	fakeClient := fakeKube.NewSimpleClientset()
+	fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(uc.scheme)
+
+	source, err := NewKongTCPIngressSource(t.Context(), fakeDynamicClient, fakeClient, &Config{})
+	require.NoError(t, err)
+	require.IsType(t, &kongTCPIngressSource{}, source)
+
+	testDynamicInformerTransformHelper(t,
+		kongGroupdVersionResource,
+		fakeDynamicClient,
+		source.(*kongTCPIngressSource).kongTCPIngressInformer,
+		withRemovedLastAppliedConfigAnnotation(),
+		withRemovedManagedFields(),
+	)
 }

--- a/source/openshift_route.go
+++ b/source/openshift_route.go
@@ -73,6 +73,11 @@ func NewOcpRouteSource(
 	informerFactory := extInformers.NewSharedInformerFactoryWithOptions(ocpClient, 0*time.Second, extInformers.WithNamespace(cfg.Namespace))
 	informer := informerFactory.Route().V1().Routes()
 
+	informers.MustSetTransform(informer.Informer(), informers.TransformerWithOptions[*routev1.Route](
+		informers.TransformRemoveManagedFields(),
+		informers.TransformRemoveLastAppliedConfig(),
+	))
+
 	// Add default resource event handlers to properly initialize informer.
 	informers.MustAddEventHandler(informer.Informer(), informers.DefaultEventHandler())
 

--- a/source/openshift_route_test.go
+++ b/source/openshift_route_test.go
@@ -522,3 +522,28 @@ func testOcpRouteSourceEndpoints(t *testing.T) {
 		})
 	}
 }
+
+func TestOcpRouteSource_InformerTransform(t *testing.T) {
+	t.Parallel()
+
+	route := &routev1.Route{
+		ObjectMeta: informerTransformObjectMeta(),
+	}
+	assert.Contains(t, route.GetAnnotations(), corev1.LastAppliedConfigAnnotation)
+	assert.NotEmpty(t, route.GetManagedFields())
+
+	fakeClient := fake.NewClientset()
+	_, err := fakeClient.RouteV1().Routes(route.GetNamespace()).Create(t.Context(), route, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	source, err := NewOcpRouteSource(t.Context(), fakeClient, &Config{})
+	require.NoError(t, err)
+	require.IsType(t, &ocpRouteSource{}, source)
+
+	testInformerTransformHelper(t,
+		source.(*ocpRouteSource).routeInformer.Informer(),
+		route,
+		withRemovedLastAppliedConfigAnnotation(),
+		withRemovedManagedFields(),
+	)
+}

--- a/source/traefik_proxy.go
+++ b/source/traefik_proxy.go
@@ -121,6 +121,18 @@ func NewTraefikSource(
 		ingressRouteInformer = informerFactory.ForResource(ingressRouteGVR)
 		ingressRouteTcpInformer = informerFactory.ForResource(ingressRouteTCPGVR)
 		ingressRouteUdpInformer = informerFactory.ForResource(ingressRouteUDPGVR)
+		informers.MustSetTransform(ingressRouteInformer.Informer(), informers.TransformerWithOptions[*unstructured.Unstructured](
+			informers.TransformRemoveManagedFields(),
+			informers.TransformRemoveLastAppliedConfig(),
+		))
+		informers.MustSetTransform(ingressRouteTcpInformer.Informer(), informers.TransformerWithOptions[*unstructured.Unstructured](
+			informers.TransformRemoveManagedFields(),
+			informers.TransformRemoveLastAppliedConfig(),
+		))
+		informers.MustSetTransform(ingressRouteUdpInformer.Informer(), informers.TransformerWithOptions[*unstructured.Unstructured](
+			informers.TransformRemoveManagedFields(),
+			informers.TransformRemoveLastAppliedConfig(),
+		))
 		informers.MustAddEventHandler(ingressRouteInformer.Informer(), informers.DefaultEventHandler())
 		informers.MustAddEventHandler(ingressRouteTcpInformer.Informer(), informers.DefaultEventHandler())
 		informers.MustAddEventHandler(ingressRouteUdpInformer.Informer(), informers.DefaultEventHandler())
@@ -129,6 +141,18 @@ func NewTraefikSource(
 		oldIngressRouteInformer = informerFactory.ForResource(oldIngressRouteGVR)
 		oldIngressRouteTcpInformer = informerFactory.ForResource(oldIngressRouteTCPGVR)
 		oldIngressRouteUdpInformer = informerFactory.ForResource(oldIngressRouteUDPGVR)
+		informers.MustSetTransform(oldIngressRouteInformer.Informer(), informers.TransformerWithOptions[*unstructured.Unstructured](
+			informers.TransformRemoveManagedFields(),
+			informers.TransformRemoveLastAppliedConfig(),
+		))
+		informers.MustSetTransform(oldIngressRouteTcpInformer.Informer(), informers.TransformerWithOptions[*unstructured.Unstructured](
+			informers.TransformRemoveManagedFields(),
+			informers.TransformRemoveLastAppliedConfig(),
+		))
+		informers.MustSetTransform(oldIngressRouteUdpInformer.Informer(), informers.TransformerWithOptions[*unstructured.Unstructured](
+			informers.TransformRemoveManagedFields(),
+			informers.TransformRemoveLastAppliedConfig(),
+		))
 		informers.MustAddEventHandler(oldIngressRouteInformer.Informer(), informers.DefaultEventHandler())
 		informers.MustAddEventHandler(oldIngressRouteTcpInformer.Informer(), informers.DefaultEventHandler())
 		informers.MustAddEventHandler(oldIngressRouteUdpInformer.Informer(), informers.DefaultEventHandler())

--- a/source/traefik_proxy_test.go
+++ b/source/traefik_proxy_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/stretchr/testify/assert"
@@ -1872,4 +1873,87 @@ type testInformer struct {
 func (t *testInformer) AddEventHandler(_ cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
 	t.times += 1
 	return nil, fmt.Errorf("not implemented")
+}
+
+func TestTraefikSource_InformerTransform(t *testing.T) {
+	t.Parallel()
+
+	uc, err := newTraefikUnstructuredConverter()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		gvr           schema.GroupVersionResource
+		getSource     func(source *traefikSource) informers.GenericInformer
+		enabledLegacy bool
+	}{
+		{
+			name: "IngressRoute",
+			gvr:  ingressRouteGVR,
+			getSource: func(source *traefikSource) informers.GenericInformer {
+				return source.ingressRouteInformer
+			},
+			enabledLegacy: false,
+		},
+		{
+			name: "IngressRouteTCP",
+			gvr:  ingressRouteTCPGVR,
+			getSource: func(source *traefikSource) informers.GenericInformer {
+				return source.ingressRouteTcpInformer
+			},
+			enabledLegacy: false,
+		},
+		{
+			name: "IngressRouteUDP",
+			gvr:  ingressRouteUDPGVR,
+			getSource: func(source *traefikSource) informers.GenericInformer {
+				return source.ingressRouteUdpInformer
+			},
+			enabledLegacy: false,
+		},
+		{
+			name: "IngressRoute with legacy API group",
+			gvr:  oldIngressRouteGVR,
+			getSource: func(source *traefikSource) informers.GenericInformer {
+				return source.oldIngressRouteInformer
+			},
+			enabledLegacy: true,
+		},
+		{
+			name: "IngressRouteTCP with legacy API group",
+			gvr:  oldIngressRouteTCPGVR,
+			getSource: func(source *traefikSource) informers.GenericInformer {
+				return source.oldIngressRouteTcpInformer
+			},
+			enabledLegacy: true,
+		},
+		{
+			name: "IngressRouteUDP with legacy API group",
+			gvr:  oldIngressRouteUDPGVR,
+			getSource: func(source *traefikSource) informers.GenericInformer {
+				return source.oldIngressRouteUdpInformer
+			},
+			enabledLegacy: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fakeKube.NewSimpleClientset()
+			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(uc.scheme)
+
+			source, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeClient, &Config{
+				TraefikEnableLegacy: tt.enabledLegacy,
+			})
+			require.NoError(t, err)
+			require.IsType(t, &traefikSource{}, source)
+
+			testDynamicInformerTransformHelper(t,
+				tt.gvr,
+				fakeDynamicClient,
+				tt.getSource(source.(*traefikSource)),
+				withRemovedLastAppliedConfigAnnotation(),
+				withRemovedManagedFields(),
+			)
+		})
+	}
 }

--- a/source/utils_test.go
+++ b/source/utils_test.go
@@ -14,9 +14,20 @@ limitations under the License.
 package source
 
 import (
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
 )
 
 func TestParseIngress(t *testing.T) {
@@ -68,5 +79,165 @@ func TestParseIngress(t *testing.T) {
 			assert.Equal(t, tt.wantNS, gotNS)
 			assert.Equal(t, tt.wantName, gotName)
 		})
+	}
+}
+
+// informerTransformObjectMeta returns an ObjectMeta populated with
+// LastAppliedConfigAnnotation and ManagedFields — the fields that the
+// informer transformers are expected to strip.
+func informerTransformObjectMeta() metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:      "test",
+		Namespace: metav1.NamespaceDefault,
+		Annotations: map[string]string{
+			corev1.LastAppliedConfigAnnotation: "test",
+		},
+		ManagedFields: []metav1.ManagedFieldsEntry{
+			{Manager: "test-manager"},
+		},
+	}
+}
+
+// informerTransformHelperConfig is a struct that holds configuration for the informerTransformHelper functions.
+type informerTransformHelperConfig struct {
+	removedLastAppliedConfigAnnotation bool
+	removedManagedFields               bool
+	removedStatusConditions            bool
+}
+
+// informerTransformHelperOptions are options for configuring the behavior of the informerTransformHelper functions.
+type informerTransformHelperOptions func(*informerTransformHelperConfig)
+
+// withRemovedLastAppliedConfigAnnotation indicates that the informer transformer should have removed the
+// "metadata.annotations['kubectl.kubernetes.io/last-applied']" annotation
+func withRemovedLastAppliedConfigAnnotation() informerTransformHelperOptions {
+	return func(config *informerTransformHelperConfig) {
+		config.removedLastAppliedConfigAnnotation = true
+	}
+}
+
+// withRemovedManagedFields indicates that the informer transformer should have removed the "metadata.managedFields" field
+func withRemovedManagedFields() informerTransformHelperOptions {
+	return func(config *informerTransformHelperConfig) {
+		config.removedManagedFields = true
+	}
+}
+
+// withRemovedStatusConditions indicates that the informer transformer should hav removed the "status.conditions" field
+// from the cached object.
+func withRemovedStatusConditions() informerTransformHelperOptions {
+	return func(config *informerTransformHelperConfig) {
+		config.removedStatusConditions = true
+	}
+}
+
+// testDynamicInformerTransformHelper creates an unstructured object via the
+// dynamic client and waits for it to appear in the generic informer cache, then
+// asserts whether the informer transformer stripped the fields selected by opts.
+func testDynamicInformerTransformHelper(
+	t *testing.T,
+	gvr schema.GroupVersionResource,
+	client dynamic.Interface,
+	informer informers.GenericInformer,
+	opts ...informerTransformHelperOptions,
+) {
+	t.Helper()
+
+	cfg := &informerTransformHelperConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	meta := informerTransformObjectMeta()
+
+	obj := &unstructured.Unstructured{}
+	obj.SetName(meta.Name)
+	obj.SetNamespace(meta.Namespace)
+	obj.SetAnnotations(meta.Annotations)
+	obj.SetManagedFields(meta.ManagedFields)
+
+	if cfg.removedStatusConditions {
+		err := unstructured.SetNestedField(obj.Object, []any{}, "status", "conditions")
+		require.NoError(t, err)
+	}
+
+	_, err := client.Resource(gvr).Namespace(obj.GetNamespace()).Create(t.Context(), obj, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	var gotObj runtime.Object
+	require.Eventually(t, func() bool {
+		var err error
+		gotObj, err = informer.Lister().ByNamespace(obj.GetNamespace()).Get(obj.GetName())
+		return err == nil
+	}, 5*time.Second, 10*time.Millisecond)
+	require.IsType(t, &unstructured.Unstructured{}, gotObj)
+
+	assertObjectTransformedHelper(t, gotObj.(*unstructured.Unstructured), cfg)
+}
+
+// testInformerTransformHelper verifies that the informer transformer stripped
+// the fields configured via opts from the single cached object.
+func testInformerTransformHelper(t *testing.T, informer cache.SharedIndexInformer, obj metav1.Object, opts ...informerTransformHelperOptions) {
+	t.Helper()
+
+	cfg := &informerTransformHelperConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	item, exists, err := informer.GetStore().Get(obj)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.Implements(t, (*metav1.Object)(nil), item)
+
+	assertObjectTransformedHelper(t, item.(metav1.Object), cfg)
+}
+
+// assertObjectTransformedHelper asserts whether the informer transformer stripped the fields selected by cfg from obj.
+func assertObjectTransformedHelper(t *testing.T, obj metav1.Object, cfg *informerTransformHelperConfig) {
+	t.Helper()
+
+	if cfg.removedLastAppliedConfigAnnotation {
+		assert.NotContains(t, obj.GetAnnotations(), corev1.LastAppliedConfigAnnotation)
+	} else {
+		assert.Contains(t, obj.GetAnnotations(), corev1.LastAppliedConfigAnnotation)
+	}
+
+	if cfg.removedManagedFields {
+		assert.Empty(t, obj.GetManagedFields())
+	} else {
+		assert.NotEmpty(t, obj.GetManagedFields())
+	}
+
+	if obj, ok := obj.(*unstructured.Unstructured); ok {
+		conditions, found, err := unstructured.NestedFieldNoCopy(obj.Object, "status", "conditions")
+		require.NoError(t, err)
+		if cfg.removedStatusConditions {
+			require.False(t, found)
+			require.Nil(t, conditions)
+		} else if found {
+			require.NotNil(t, conditions)
+		}
+		return
+	}
+
+	val := reflect.ValueOf(obj)
+	if val.Kind() == reflect.Pointer {
+		val = val.Elem()
+	}
+	require.True(t, val.IsValid(), "object is not valid")
+	statusField := val.FieldByName("Status")
+	if cfg.removedStatusConditions {
+		require.True(t, statusField.IsValid(), "object does not have a Status field")
+		condField := statusField.FieldByName("Conditions")
+		require.True(t, condField.IsValid(), "Status does not have a Conditions field")
+		require.IsType(t, reflect.Slice, condField.Kind())
+		assert.Zero(t, condField.Len())
+	} else if statusField.IsValid() {
+		condField := statusField.FieldByName("Conditions")
+		if condField.IsValid() {
+			require.IsType(t, reflect.Slice, condField.Kind())
+			assert.NotZero(t, condField.Len())
+		}
 	}
 }


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->
Setup a transformer on all sources informers that removes kubectl last applied config annotation, managed fields and status condition (when it exists and is not needed).

Update `clearStatusConditions()` to support `Unstructured` resources.

## Motivation

<!-- What inspired you to submit this pull request? -->
We need the transformer to support multiple annotation prefixes. Split from https://github.com/kubernetes-sigs/external-dns/pull/6449 from easier review.
Should also minimize memory usage.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
