### PR TITLE
docs(webhook): add reference to netbird external-dns provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ from the usage of any externally developed webhook.
 | Infomaniak            | https://github.com/M0NsTeRRR/external-dns-webhook-infomaniak         |
 | Mikrotik              | https://github.com/mirceanton/external-dns-provider-mikrotik         |
 | Myra Security         | https://github.com/Myra-Security-GmbH/external-dns-myrasec-webhook   |
+| Netbird               | https://codeberg.org/ccbash-oss/external-dns-netbird-webhook         |
 | Netcup                | https://github.com/mrueg/external-dns-netcup-webhook                 |
 | Netic                 | https://github.com/neticdk/external-dns-tidydns-webhook              |
 | OpenStack Designate   | https://github.com/inovex/external-dns-designate-webhook             |


### PR DESCRIPTION
## What does it do ?

- add reference to a new webhook provider:  [external-dns-netbird-webhook](https://codeberg.org/ccbash-oss/external-dns-netbird-webhook) 

## Motivation

Netbird connects internal resources via wireguard  mesh, this includes Services provided by Kubernetes. It also provides DNS Service for internal clients. Making Kubernetes Services available internally only requires managing this DNS Service, thus an external-dns-netbird-webhook. 

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

## References

- webhook repo: https://codeberg.org/ccbash-oss/external-dns-netbird-webhook
- webhook documentation: https://codeberg.org/ccbash-oss/external-dns-netbird-webhook#readme
- registry: https://codeberg.org/ccbash-oss/-/packages/container/external-dns-netbird-webhook/latest