### PR TITLE
feat: implements srv record type for azure private dns provider

### DIFF
--- a/provider/azure/azure_private_dns.go
+++ b/provider/azure/azure_private_dns.go
@@ -420,6 +420,21 @@ func (p *AzurePrivateDNSProvider) newRecordSet(endpoint *endpoint.Endpoint) (pri
 				MxRecords: mxRecords,
 			},
 		}, nil
+	case privatedns.RecordTypeSRV:
+		srvRecords := make([]*privatedns.SrvRecord, len(endpoint.Targets))
+		for i, target := range endpoint.Targets {
+			srvRecord, err := parseSrvTarget[privatedns.SrvRecord](target)
+			if err != nil {
+				return privatedns.RecordSet{}, err
+			}
+			srvRecords[i] = &srvRecord
+		}
+		return privatedns.RecordSet{
+			Properties: &privatedns.RecordSetProperties{
+				TTL:        new(ttl),
+				SrvRecords: srvRecords,
+			},
+		}, nil
 	case privatedns.RecordTypeTXT:
 		return privatedns.RecordSet{
 			Properties: &privatedns.RecordSetProperties{
@@ -476,6 +491,16 @@ func extractAzurePrivateDNSTargets(recordSet *privatedns.RecordSet) []string {
 		targets := make([]string, len(mxRecords))
 		for i, mxRecord := range mxRecords {
 			targets[i] = fmt.Sprintf("%d %s", *mxRecord.Preference, *mxRecord.Exchange)
+		}
+		return targets
+	}
+
+	// Check for SRV records
+	srvRecords := properties.SrvRecords
+	if len(srvRecords) > 0 && (srvRecords)[0].Target != nil {
+		targets := make([]string, len(srvRecords))
+		for i, srvRecord := range srvRecords {
+			targets[i] = fmt.Sprintf("%d %d %d %s", *srvRecord.Priority, *srvRecord.Weight, *srvRecord.Port, *srvRecord.Target)
 		}
 		return targets
 	}

--- a/provider/azure/azure_privatedns_test.go
+++ b/provider/azure/azure_privatedns_test.go
@@ -175,6 +175,18 @@ func privateMXRecordSetPropertiesGetter(values []string, ttl int64) *privatedns.
 	}
 }
 
+func privateSRVRecordSetPropertiesGetter(values []string, ttl int64) *privatedns.RecordSetProperties {
+	srvRecords := make([]*privatedns.SrvRecord, len(values))
+	for i, target := range values {
+		srvRecord, _ := parseSrvTarget[privatedns.SrvRecord](target)
+		srvRecords[i] = &srvRecord
+	}
+	return &privatedns.RecordSetProperties{
+		TTL:        new(ttl),
+		SrvRecords: srvRecords,
+	}
+}
+
 func privateTxtRecordSetPropertiesGetter(values []string, ttl int64) *privatedns.RecordSetProperties {
 	return &privatedns.RecordSetProperties{
 		TTL: new(ttl),
@@ -212,6 +224,8 @@ func createPrivateMockRecordSetMultiWithTTL(name, recordType string, ttl int64, 
 		getterFunc = privateCNameRecordSetPropertiesGetter
 	case endpoint.RecordTypeMX:
 		getterFunc = privateMXRecordSetPropertiesGetter
+	case endpoint.RecordTypeSRV:
+		getterFunc = privateSRVRecordSetPropertiesGetter
 	case endpoint.RecordTypeTXT:
 		getterFunc = privateTxtRecordSetPropertiesGetter
 	default:
@@ -261,6 +275,7 @@ func TestAzurePrivateDNSRecord(t *testing.T) {
 			createPrivateMockRecordSetWithNameAndTTL("nginx", endpoint.RecordTypeTXT, "heritage=external-dns,external-dns/owner=default", recordTTL),
 			createPrivateMockRecordSetWithNameAndTTL("hack", endpoint.RecordTypeCNAME, "hack.azurewebsites.net", 10),
 			createPrivateMockRecordSetWithNameAndTTL("mail", endpoint.RecordTypeMX, "10 example.com", 4000),
+			createPrivateMockRecordSetWithNameAndTTL("_sip._tcp", endpoint.RecordTypeSRV, "10 5 5060 sipserver.example.com.", 3600),
 		}, 3)
 
 	actual, err := provider.Records(t.Context())
@@ -276,6 +291,7 @@ func TestAzurePrivateDNSRecord(t *testing.T) {
 		endpoint.NewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeTXT, recordTTL, "heritage=external-dns,external-dns/owner=default"),
 		endpoint.NewEndpointWithTTL("hack.example.com", endpoint.RecordTypeCNAME, 10, "hack.azurewebsites.net"),
 		endpoint.NewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, 4000, "10 example.com"),
+		endpoint.NewEndpointWithTTL("_sip._tcp.example.com", endpoint.RecordTypeSRV, 3600, "10 5 5060 sipserver.example.com."),
 	}
 
 	validateAzureEndpoints(t, actual, expected)
@@ -297,6 +313,7 @@ func TestAzurePrivateDNSMultiRecord(t *testing.T) {
 			createPrivateMockRecordSetWithNameAndTTL("nginx", endpoint.RecordTypeTXT, "heritage=external-dns,external-dns/owner=default", recordTTL),
 			createPrivateMockRecordSetWithNameAndTTL("hack", endpoint.RecordTypeCNAME, "hack.azurewebsites.net", 10),
 			createPrivateMockRecordSetMultiWithTTL("mail", endpoint.RecordTypeMX, 4000, "10 example.com", "20 backup.example.com"),
+			createPrivateMockRecordSetMultiWithTTL("_sip._tcp", endpoint.RecordTypeSRV, 3600, "10 5 5060 sipserver.example.com.", "20 10 5061 sipbackup.example.com."),
 		}, 3)
 
 	actual, err := provider.Records(t.Context())
@@ -312,6 +329,7 @@ func TestAzurePrivateDNSMultiRecord(t *testing.T) {
 		endpoint.NewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeTXT, recordTTL, "heritage=external-dns,external-dns/owner=default"),
 		endpoint.NewEndpointWithTTL("hack.example.com", endpoint.RecordTypeCNAME, 10, "hack.azurewebsites.net"),
 		endpoint.NewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, 4000, "10 example.com", "20 backup.example.com"),
+		endpoint.NewEndpointWithTTL("_sip._tcp.example.com", endpoint.RecordTypeSRV, 3600, "10 5 5060 sipserver.example.com.", "20 10 5061 sipbackup.example.com."),
 	}
 
 	validateAzureEndpoints(t, actual, expected)
@@ -346,6 +364,8 @@ func TestAzurePrivateDNSApplyChanges(t *testing.T) {
 		endpoint.NewEndpointWithTTL("newmail.example.com", endpoint.RecordTypeMX, 7200, "40 bar.other.com"),
 		endpoint.NewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, endpoint.TTL(recordTTL), "10 other.com"),
 		endpoint.NewEndpointWithTTL("mail.example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
+		endpoint.NewEndpointWithTTL("_sip._tcp.example.com", endpoint.RecordTypeSRV, endpoint.TTL(recordTTL), "10 5 5060 sipserver.other.com."),
+		endpoint.NewEndpointWithTTL("_new._tcp.example.com", endpoint.RecordTypeSRV, 3600, "20 10 5061 newsrv.other.com."),
 	})
 }
 
@@ -394,6 +414,7 @@ func testAzurePrivateDNSApplyChangesInternal(t *testing.T, dryRun bool, client P
 		endpoint.NewEndpoint("nope.com", endpoint.RecordTypeTXT, "tag"),
 		endpoint.NewEndpoint("mail.example.com", endpoint.RecordTypeMX, "10 other.com"),
 		endpoint.NewEndpoint("mail.example.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.NewEndpoint("_sip._tcp.example.com", endpoint.RecordTypeSRV, "10 5 5060 sipserver.other.com."),
 	}
 
 	currentRecords := []*endpoint.Endpoint{
@@ -401,6 +422,7 @@ func testAzurePrivateDNSApplyChangesInternal(t *testing.T, dryRun bool, client P
 		endpoint.NewEndpoint("oldcname.example.com", endpoint.RecordTypeCNAME, "other.com"),
 		endpoint.NewEndpoint("old.nope.com", endpoint.RecordTypeA, "121.212.121.212"),
 		endpoint.NewEndpoint("oldmail.example.com", endpoint.RecordTypeMX, "20 foo.other.com"),
+		endpoint.NewEndpoint("_old._tcp.example.com", endpoint.RecordTypeSRV, "30 15 6000 oldsrv.other.com."),
 	}
 	updatedRecords := []*endpoint.Endpoint{
 		endpoint.NewEndpointWithTTL("new.example.com", endpoint.RecordTypeA, 3600, "111.222.111.222"),
@@ -409,6 +431,7 @@ func testAzurePrivateDNSApplyChangesInternal(t *testing.T, dryRun bool, client P
 		endpoint.NewEndpoint("new.nope.com", endpoint.RecordTypeA, "222.111.222.111"),
 		endpoint.NewEndpoint("new.nope.com", endpoint.RecordTypeAAAA, "2001::222:111:222:111"),
 		endpoint.NewEndpointWithTTL("newmail.example.com", endpoint.RecordTypeMX, 7200, "40 bar.other.com"),
+		endpoint.NewEndpointWithTTL("_new._tcp.example.com", endpoint.RecordTypeSRV, 3600, "20 10 5061 newsrv.other.com."),
 	}
 
 	deleteRecords := []*endpoint.Endpoint{

--- a/provider/azure/common.go
+++ b/provider/azure/common.go
@@ -44,3 +44,32 @@ func parseMxTarget[T dns.MxRecord | privatedns.MxRecord](mxTarget string) (T, er
 		Exchange:   new(exchange),
 	}, nil
 }
+
+// Helper function (shared with test code)
+func parseSrvTarget[T dns.SrvRecord | privatedns.SrvRecord](srvTarget string) (T, error) {
+	targetParts := strings.SplitN(srvTarget, " ", 4)
+	if len(targetParts) != 4 {
+		return T{}, fmt.Errorf("srv target needs to be of form '10 5 5060 example.com.'")
+	}
+
+	priority, err := strconv.ParseInt(targetParts[0], 10, 32)
+	if err != nil {
+		return T{}, fmt.Errorf("invalid srv priority specified")
+	}
+	weight, err := strconv.ParseInt(targetParts[1], 10, 32)
+	if err != nil {
+		return T{}, fmt.Errorf("invalid srv weight specified")
+	}
+	port, err := strconv.ParseInt(targetParts[2], 10, 32)
+	if err != nil {
+		return T{}, fmt.Errorf("invalid srv port specified")
+	}
+	target := targetParts[3]
+
+	return T{
+		Priority: new(int32(priority)),
+		Weight:   new(int32(weight)),
+		Port:     new(int32(port)),
+		Target:   new(target),
+	}, nil
+}


### PR DESCRIPTION
## What does it do ?

It implements SRV record type for Azure Private DNS provider

## Motivation

While External DNS itself has support for SRV records, Azure private DNS provider does not. It should already be supported, it is useful for exposing NodePort services.

## More

- [X] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Yes, I added unit tests
- [] it doesn't require documentation change
