### PR TITLE
feat(provider/cloudflare): add SRV and NAPTR record support

### DIFF
--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -43,26 +43,20 @@ The batch API is transactional — if a chunk fails, the entire chunk is rolled 
 In that case, ExternalDNS automatically retries each record change in the chunk individually.
 Record types whose batch PUT body the SDK does not support (e.g. CAA) are submitted individually rather than through the batch API.
 
-### Supported record types
-
-A, AAAA, CNAME, TXT, MX, NS, SRV, and NAPTR. SRV and NAPTR carry structured `Data`
-(priority/weight/port/target and order/preference/flags/service/regexp/replacement
-respectively) and travel through the batch API as typed union members.
-
-SRV and NAPTR target strings should use single-space field separators (RFC canonical form).
-The provider rebuilds canonical content from Cloudflare's structured `Data` on read, so
-endpoints declared with multi-space or tab separators will be re-emitted as plan changes
-on every reconcile.
-
-NAPTR `regexp` fields containing literal double-quote characters (RFC 2915 allows them
-when backslash-escaped) are not currently supported: the canonical-content round-trip
-through the parser loses the escapes. Avoid embedded `"` in NAPTR regexp; use the
-alternative delimiter forms allowed by RFC 2915 instead.
-
 | Flag | Default | Description |
 | :--- | :------ | :---------- |
 | `--batch-change-size` | `200` | Maximum number of DNS operations (creates + updates + deletes) per batch chunk. |
 | `--batch-change-interval` | `1s` | Pause between consecutive batch chunks. |
+
+## Supported record types
+
+A, AAAA, CNAME, TXT, MX, NS, SRV, NAPTR.
+
+SRV and NAPTR targets should use single-space field separators. Multi-space or
+tab separators cause the record to be re-emitted as a plan change on every
+reconcile.
+
+NAPTR `regexp` fields with literal double-quote characters are not supported.
 
 ## Deploy ExternalDNS
 

--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -52,10 +52,6 @@ Record types whose batch PUT body the SDK does not support (e.g. CAA) are submit
 
 A, AAAA, CNAME, TXT, MX, NS, SRV, NAPTR.
 
-SRV and NAPTR targets should use single-space field separators. Multi-space or
-tab separators cause the record to be re-emitted as a plan change on every
-reconcile.
-
 NAPTR `regexp` fields with literal double-quote characters are not supported.
 
 ## Deploy ExternalDNS

--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -41,7 +41,23 @@ significantly reducing the total number of requests made.
 
 The batch API is transactional — if a chunk fails, the entire chunk is rolled back by Cloudflare.
 In that case, ExternalDNS automatically retries each record change in the chunk individually.
-Record types that are not supported by the batch PUT operation (e.g. SRV, CAA) are always submitted individually rather than through the batch API.
+Record types whose batch PUT body the SDK does not support (e.g. CAA) are submitted individually rather than through the batch API.
+
+### Supported record types
+
+A, AAAA, CNAME, TXT, MX, NS, SRV, and NAPTR. SRV and NAPTR carry structured `Data`
+(priority/weight/port/target and order/preference/flags/service/regexp/replacement
+respectively) and travel through the batch API as typed union members.
+
+SRV and NAPTR target strings should use single-space field separators (RFC canonical form).
+The provider rebuilds canonical content from Cloudflare's structured `Data` on read, so
+endpoints declared with multi-space or tab separators will be re-emitted as plan changes
+on every reconcile.
+
+NAPTR `regexp` fields containing literal double-quote characters (RFC 2915 allows them
+when backslash-escaped) are not currently supported: the canonical-content round-trip
+through the parser loses the escapes. Avoid embedded `"` in NAPTR regexp; use the
+alternative delimiter forms allowed by RFC 2915 instead.
 
 | Flag | Default | Description |
 | :--- | :------ | :---------- |

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -672,6 +672,20 @@ func (p *CloudFlareProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]
 			}
 		}
 
+		// Canonicalize SRV/NAPTR targets to the read-back form so multi-space, tab,
+		// or missing-dot input does not re-emit an update on every reconcile.
+		switch e.RecordType {
+		case endpoint.RecordTypeSRV, endpoint.RecordTypeNAPTR:
+			for i, t := range e.Targets {
+				canonical, err := canonicalizeStructuredTarget(e.RecordType, t)
+				if err != nil {
+					log.Debugf("cloudflare: leaving %s target %q unchanged: %v", e.RecordType, t, err)
+					continue
+				}
+				e.Targets[i] = canonical
+			}
+		}
+
 		adjustedEndpoints = append(adjustedEndpoints, e)
 	}
 	return adjustedEndpoints, nil
@@ -793,15 +807,7 @@ func naptrContent(r dns.RecordResponse) string {
 			return r.Content
 		}
 	}
-	rr := &miekg.NAPTR{
-		Order:       uint16(data.Order),
-		Preference:  uint16(data.Preference),
-		Flags:       data.Flags,
-		Service:     data.Service,
-		Regexp:      data.Regex,
-		Replacement: provider.EnsureTrailingDot(data.Replacement),
-	}
-	return strings.TrimPrefix(rr.String(), rr.Hdr.String())
+	return naptrCanonical(uint16(data.Order), uint16(data.Preference), data.Flags, data.Service, data.Regex, data.Replacement)
 }
 
 // srvContent rebuilds the canonical SRV target from a record's structured Data,
@@ -823,13 +829,64 @@ func srvContent(r dns.RecordResponse) string {
 			return r.Content
 		}
 	}
+	return srvCanonical(uint16(data.Priority), uint16(data.Weight), uint16(data.Port), data.Target)
+}
+
+// srvCanonical renders SRV fields in the canonical single-space, trailing-dot form
+// read-back produces, so a desired target normalized here matches the read-back
+// record and the plan converges instead of churning an update every reconcile.
+func srvCanonical(priority, weight, port uint16, target string) string {
 	rr := &miekg.SRV{
-		Priority: uint16(data.Priority),
-		Weight:   uint16(data.Weight),
-		Port:     uint16(data.Port),
-		Target:   provider.EnsureTrailingDot(data.Target),
+		Priority: priority,
+		Weight:   weight,
+		Port:     port,
+		Target:   provider.EnsureTrailingDot(target),
 	}
 	return strings.TrimPrefix(rr.String(), rr.Hdr.String())
+}
+
+// naptrCanonical mirrors srvCanonical for NAPTR.
+func naptrCanonical(order, preference uint16, flags, service, regexp, replacement string) string {
+	rr := &miekg.NAPTR{
+		Order:       order,
+		Preference:  preference,
+		Flags:       flags,
+		Service:     service,
+		Regexp:      regexp,
+		Replacement: provider.EnsureTrailingDot(replacement),
+	}
+	return strings.TrimPrefix(rr.String(), rr.Hdr.String())
+}
+
+// canonicalizeStructuredTarget rewrites an SRV or NAPTR target into the same
+// canonical form read-back produces. Multi-space, tab, or missing-dot targets
+// otherwise differ from the canonical read-back and re-emit an update every
+// reconcile. The input is returned unchanged on a parse error, so a malformed
+// target still surfaces downstream as a SoftError.
+func canonicalizeStructuredTarget(recordType, target string) (string, error) {
+	switch recordType {
+	case endpoint.RecordTypeSRV:
+		rr, err := miekg.NewRR("x. 0 IN SRV " + target)
+		if err != nil || rr == nil {
+			return target, fmt.Errorf("invalid SRV target %q: %w", target, err)
+		}
+		srv, ok := rr.(*miekg.SRV)
+		if !ok {
+			return target, fmt.Errorf("invalid SRV target %q: parsed as %T", target, rr)
+		}
+		return srvCanonical(srv.Priority, srv.Weight, srv.Port, srv.Target), nil
+	case endpoint.RecordTypeNAPTR:
+		rr, err := miekg.NewRR("x. 0 IN NAPTR " + target)
+		if err != nil || rr == nil {
+			return target, fmt.Errorf("invalid NAPTR target %q: %w", target, err)
+		}
+		naptr, ok := rr.(*miekg.NAPTR)
+		if !ok {
+			return target, fmt.Errorf("invalid NAPTR target %q: parsed as %T", target, rr)
+		}
+		return naptrCanonical(naptr.Order, naptr.Preference, naptr.Flags, naptr.Service, naptr.Regexp, naptr.Replacement), nil
+	}
+	return target, nil
 }
 
 // getDNSRecordsMap retrieves all DNS records for a given zone and returns them as a DNSRecordsMap.

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -18,6 +18,7 @@ package cloudflare
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -34,6 +35,7 @@ import (
 	"github.com/cloudflare/cloudflare-go/v5/dns"
 	"github.com/cloudflare/cloudflare-go/v5/option"
 	"github.com/cloudflare/cloudflare-go/v5/zones"
+	miekg "github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/publicsuffix"
 
@@ -92,6 +94,7 @@ var recordTypeProxyNotSupported = sets.New(
 	"SPF",
 	"TXT",
 	"SRV",
+	"NAPTR",
 )
 
 // cloudFlareDNS is the subset of the CloudFlare API that we actually use.  Add methods as required. Signatures must match exactly.
@@ -768,6 +771,64 @@ func newDNSRecordIndex(r dns.RecordResponse) DNSRecordIndex {
 	return DNSRecordIndex{Name: r.Name, Type: string(r.Type), Content: r.Content}
 }
 
+// naptrContent rebuilds the canonical NAPTR target from a record's structured Data,
+// adding the quoting and trailing dot that Cloudflare's flat Content drops.
+func naptrContent(r dns.RecordResponse) string {
+	data, ok := r.Data.(dns.NAPTRRecordData)
+	if !ok {
+		// Fallback for cloudflare-go#4300: v5.1.0 union decoder leaves Data nil on List.
+		var naptr dns.NAPTRRecord
+		raw := r.JSON.RawJSON()
+		var unmarshalErr error
+		if raw != "" {
+			unmarshalErr = json.Unmarshal([]byte(raw), &naptr)
+		}
+		if unmarshalErr == nil && raw != "" && (naptr.Data.Service != "" || naptr.Data.Replacement != "") {
+			data = naptr.Data
+		} else {
+			log.Warnf("NAPTR record %q has no structured data (unmarshal err: %v); using raw content %q, which may not match desired targets", r.Name, unmarshalErr, r.Content)
+			return r.Content
+		}
+	}
+	rr := &miekg.NAPTR{
+		Order:       uint16(data.Order),
+		Preference:  uint16(data.Preference),
+		Flags:       data.Flags,
+		Service:     data.Service,
+		Regexp:      data.Regex,
+		Replacement: provider.EnsureTrailingDot(data.Replacement),
+	}
+	return strings.TrimPrefix(rr.String(), rr.Hdr.String())
+}
+
+// srvContent rebuilds the canonical SRV target from a record's structured Data,
+// adding the priority and trailing dot that Cloudflare's flat Content drops.
+func srvContent(r dns.RecordResponse) string {
+	data, ok := r.Data.(dns.SRVRecordData)
+	if !ok {
+		// Fallback for cloudflare-go#4300: v5.1.0 union decoder leaves Data nil on List.
+		var srv dns.SRVRecord
+		raw := r.JSON.RawJSON()
+		var unmarshalErr error
+		if raw != "" {
+			unmarshalErr = json.Unmarshal([]byte(raw), &srv)
+		}
+		if unmarshalErr == nil && raw != "" && srv.Data.Target != "" {
+			data = srv.Data
+		} else {
+			log.Warnf("SRV record %q has no structured data (unmarshal err: %v); using raw content %q, which may not match desired targets", r.Name, unmarshalErr, r.Content)
+			return r.Content
+		}
+	}
+	rr := &miekg.SRV{
+		Priority: uint16(data.Priority),
+		Weight:   uint16(data.Weight),
+		Port:     uint16(data.Port),
+		Target:   provider.EnsureTrailingDot(data.Target),
+	}
+	return strings.TrimPrefix(rr.String(), rr.Hdr.String())
+}
+
 // getDNSRecordsMap retrieves all DNS records for a given zone and returns them as a DNSRecordsMap.
 func (p *CloudFlareProvider) getDNSRecordsMap(ctx context.Context, zoneID string) (DNSRecordsMap, error) {
 	// for faster getRecordID lookup
@@ -778,6 +839,12 @@ func (p *CloudFlareProvider) getDNSRecordsMap(ctx context.Context, zoneID string
 	}
 	iter := p.Client.ListDNSRecords(ctx, params)
 	for record := range autoPagerIterator(iter) {
+		switch record.Type {
+		case dns.RecordResponseTypeSRV:
+			record.Content = srvContent(record)
+		case dns.RecordResponseTypeNAPTR:
+			record.Content = naptrContent(record)
+		}
 		recordsMap[newDNSRecordIndex(record)] = record
 	}
 	if iter.Err() != nil {
@@ -891,7 +958,7 @@ func (p *CloudFlareProvider) groupByNameAndTypeWithCustomHostnames(records DNSRe
 // SupportedRecordType returns true if the record type is supported by the provider
 func (p *CloudFlareProvider) SupportedAdditionalRecordTypes(recordType string) bool {
 	switch recordType {
-	case endpoint.RecordTypeMX:
+	case endpoint.RecordTypeMX, endpoint.RecordTypeNAPTR:
 		return true
 	default:
 		return provider.SupportedRecordType(recordType)

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -587,6 +587,9 @@ func (p *CloudFlareProvider) submitChanges(ctx context.Context, changes []*cloud
 			failedChange = true
 		}
 		bc := p.buildBatchCollections(zoneID, zoneChanges, records)
+		if bc.failed {
+			failedChange = true
+		}
 
 		if p.submitDNSRecordChanges(ctx, zoneID, bc, records) {
 			failedChange = true

--- a/provider/cloudflare/cloudflare_batch.go
+++ b/provider/cloudflare/cloudflare_batch.go
@@ -55,6 +55,8 @@ type batchCollections struct {
 	// requires structured Data fields (e.g. SRV, CAA). These are submitted
 	// via individual UpdateDNSRecord calls instead of the batch API.
 	fallbackUpdates []*cloudFlareChange
+
+	failed bool
 }
 
 // batchChunk holds a DNS record batch request alongside the source changes
@@ -406,6 +408,7 @@ func buildBatchPutParam(id string, r dns.RecordResponse) (dns.BatchPutUnionParam
 // buildBatchCollections classifies per-zone changes into batch collections.
 // Custom hostname side-effects are handled separately by
 // processCustomHostnameChanges before this is called.
+// Sets bc.failed when a change is skipped and a retry would help reconcile it.
 func (p *CloudFlareProvider) buildBatchCollections(
 	zoneID string,
 	changes []*cloudFlareChange,
@@ -427,6 +430,7 @@ func (p *CloudFlareProvider) buildBatchCollections(
 			postParam, err := buildBatchPostParam(change.ResourceRecord)
 			if err != nil {
 				log.WithFields(logFields).Errorf("failed to build batch POST param, skipping record: %v", err)
+				bc.failed = true
 				continue
 			}
 			bc.batchPosts = append(bc.batchPosts, postParam)
@@ -435,7 +439,8 @@ func (p *CloudFlareProvider) buildBatchCollections(
 		case cloudFlareDelete:
 			recordID := p.getRecordID(records, change.ResourceRecord)
 			if recordID == "" {
-				log.WithFields(logFields).Errorf("failed to find previous record: %v", change.ResourceRecord)
+				// Record already gone is the desired state; no retry needed.
+				log.WithFields(logFields).Infof("record already gone, treating delete as success: %v", change.ResourceRecord)
 				continue
 			}
 			bc.batchDeletes = append(bc.batchDeletes, dns.RecordBatchParamsDelete{ID: cloudflare.F(recordID)})
@@ -445,14 +450,14 @@ func (p *CloudFlareProvider) buildBatchCollections(
 			recordID := p.getRecordID(records, change.ResourceRecord)
 			if recordID == "" {
 				log.WithFields(logFields).Errorf("failed to find previous record: %v", change.ResourceRecord)
+				bc.failed = true
 				continue
 			}
 			if putParam, ok := buildBatchPutParam(recordID, change.ResourceRecord); ok {
 				bc.batchPuts = append(bc.batchPuts, putParam)
 				bc.updateChanges = append(bc.updateChanges, change)
 			} else {
-				// Parse errors are re-logged by fallbackIndividualChanges; type-unsupported
-				// cases (e.g. CAA) silently fall back here as designed.
+				// Routing only; parse errors surface in the fallbackUpdates drain.
 				log.WithFields(logFields).Debugf("batch PUT not supported by SDK for this type or content; routing to individual update")
 				bc.fallbackUpdates = append(bc.fallbackUpdates, change)
 			}
@@ -582,8 +587,9 @@ func (p *CloudFlareProvider) fallbackIndividualChanges(
 			case cloudFlareUpdate:
 				recordID := p.getRecordID(records, change.ResourceRecord)
 				if recordID == "" {
-					// Record is gone; let the next sync cycle issue a fresh CREATE.
-					log.WithFields(logFields).Info("fallback: record unexpectedly not found for update, will re-evaluate on next sync")
+					// Mirror buildBatchCollections: flag retry on stale UPDATE.
+					log.WithFields(logFields).Errorf("fallback: failed to find previous record: %v", change.ResourceRecord)
+					failed = true
 					continue
 				}
 				params, paramErr := getUpdateDNSRecordParam(zoneID, *change)

--- a/provider/cloudflare/cloudflare_batch.go
+++ b/provider/cloudflare/cloudflare_batch.go
@@ -18,10 +18,13 @@ package cloudflare
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cloudflare/cloudflare-go/v5"
 	"github.com/cloudflare/cloudflare-go/v5/dns"
+	miekg "github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -68,8 +71,109 @@ func (z zoneService) BatchDNSRecords(ctx context.Context, params dns.RecordBatch
 	return z.service.DNS.Records.Batch(ctx, params)
 }
 
+// buildSRVData parses an SRV target "<priority> <weight> <port> <target>" into the
+// structured data Cloudflare's batch endpoint requires (a flat content string is
+// rejected). Parsing goes through miekg/dns; the trailing dot on target is stripped.
+func buildSRVData(content string) (dns.SRVRecordDataParam, error) {
+	rr, err := miekg.NewRR("x. 0 IN SRV " + content)
+	if err != nil || rr == nil {
+		return dns.SRVRecordDataParam{}, fmt.Errorf("invalid SRV target %q: %w", content, err)
+	}
+	srv, ok := rr.(*miekg.SRV)
+	if !ok {
+		return dns.SRVRecordDataParam{}, fmt.Errorf("invalid SRV target %q: parsed as %T", content, rr)
+	}
+	target := srv.Target
+	if target != "." {
+		target = strings.TrimRight(target, ".")
+	}
+	return dns.SRVRecordDataParam{
+		Priority: cloudflare.F(float64(srv.Priority)),
+		Weight:   cloudflare.F(float64(srv.Weight)),
+		Port:     cloudflare.F(float64(srv.Port)),
+		Target:   cloudflare.F(target),
+	}, nil
+}
+
+// buildNAPTRData parses a NAPTR target into the structured data Cloudflare's batch
+// endpoint requires (a flat content string is rejected). Parsing goes through
+// miekg/dns; the trailing dot on replacement is stripped.
+func buildNAPTRData(content string) (dns.NAPTRRecordDataParam, error) {
+	rr, err := miekg.NewRR("x. 0 IN NAPTR " + content)
+	if err != nil || rr == nil {
+		return dns.NAPTRRecordDataParam{}, fmt.Errorf("invalid NAPTR target %q: %w", content, err)
+	}
+	naptr, ok := rr.(*miekg.NAPTR)
+	if !ok {
+		return dns.NAPTRRecordDataParam{}, fmt.Errorf("invalid NAPTR target %q: parsed as %T", content, rr)
+	}
+	replacement := naptr.Replacement
+	if replacement != "." {
+		replacement = strings.TrimRight(replacement, ".")
+	}
+	return dns.NAPTRRecordDataParam{
+		Order:       cloudflare.F(float64(naptr.Order)),
+		Preference:  cloudflare.F(float64(naptr.Preference)),
+		Flags:       cloudflare.F(naptr.Flags),
+		Service:     cloudflare.F(naptr.Service),
+		Regex:       cloudflare.F(naptr.Regexp),
+		Replacement: cloudflare.F(replacement),
+	}, nil
+}
+
+// naptrRecordParam builds the typed NAPTR record body, shared by the typed batch
+// POST / PUT paths and the individual-fallback chunk retry.
+func naptrRecordParam(r dns.RecordResponse) (dns.NAPTRRecordParam, error) {
+	data, err := buildNAPTRData(r.Content)
+	if err != nil {
+		return dns.NAPTRRecordParam{}, err
+	}
+	return dns.NAPTRRecordParam{
+		Name:    cloudflare.F(r.Name),
+		TTL:     cloudflare.F(r.TTL),
+		Type:    cloudflare.F(dns.NAPTRRecordTypeNAPTR),
+		Proxied: cloudflare.F(r.Proxied),
+		Comment: cloudflare.F(r.Comment),
+		Tags:    cloudflare.F(tagsFromResponse(r.Tags)),
+		Data:    cloudflare.F(data),
+	}, nil
+}
+
+// srvRecordParam builds the typed SRV record body, shared by the typed batch
+// POST / PUT paths and the individual-fallback chunk retry.
+func srvRecordParam(r dns.RecordResponse) (dns.SRVRecordParam, error) {
+	data, err := buildSRVData(r.Content)
+	if err != nil {
+		return dns.SRVRecordParam{}, err
+	}
+	return dns.SRVRecordParam{
+		Name:    cloudflare.F(r.Name),
+		TTL:     cloudflare.F(r.TTL),
+		Type:    cloudflare.F(dns.SRVRecordTypeSRV),
+		Proxied: cloudflare.F(r.Proxied),
+		Comment: cloudflare.F(r.Comment),
+		Tags:    cloudflare.F(tagsFromResponse(r.Tags)),
+		Data:    cloudflare.F(data),
+	}, nil
+}
+
 // getUpdateDNSRecordParam returns the RecordUpdateParams for an individual update.
-func getUpdateDNSRecordParam(zoneID string, cfc cloudFlareChange) dns.RecordUpdateParams {
+// SRV and NAPTR use typed bodies with structured Data; other types use the generic body.
+func getUpdateDNSRecordParam(zoneID string, cfc cloudFlareChange) (dns.RecordUpdateParams, error) {
+	switch cfc.ResourceRecord.Type {
+	case dns.RecordResponseTypeSRV:
+		body, err := srvRecordParam(cfc.ResourceRecord)
+		if err != nil {
+			return dns.RecordUpdateParams{}, err
+		}
+		return dns.RecordUpdateParams{ZoneID: cloudflare.F(zoneID), Body: body}, nil
+	case dns.RecordResponseTypeNAPTR:
+		body, err := naptrRecordParam(cfc.ResourceRecord)
+		if err != nil {
+			return dns.RecordUpdateParams{}, err
+		}
+		return dns.RecordUpdateParams{ZoneID: cloudflare.F(zoneID), Body: body}, nil
+	}
 	return dns.RecordUpdateParams{
 		ZoneID: cloudflare.F(zoneID),
 		Body: dns.RecordUpdateParamsBody{
@@ -82,11 +186,26 @@ func getUpdateDNSRecordParam(zoneID string, cfc cloudFlareChange) dns.RecordUpda
 			Comment:  cloudflare.F(cfc.ResourceRecord.Comment),
 			Tags:     cloudflare.F(cfc.ResourceRecord.Tags),
 		},
-	}
+	}, nil
 }
 
 // getCreateDNSRecordParam returns the RecordNewParams for an individual create.
-func getCreateDNSRecordParam(zoneID string, cfc *cloudFlareChange) dns.RecordNewParams {
+// SRV and NAPTR use typed bodies with structured Data; other types use the generic body.
+func getCreateDNSRecordParam(zoneID string, cfc *cloudFlareChange) (dns.RecordNewParams, error) {
+	switch cfc.ResourceRecord.Type {
+	case dns.RecordResponseTypeSRV:
+		body, err := srvRecordParam(cfc.ResourceRecord)
+		if err != nil {
+			return dns.RecordNewParams{}, err
+		}
+		return dns.RecordNewParams{ZoneID: cloudflare.F(zoneID), Body: body}, nil
+	case dns.RecordResponseTypeNAPTR:
+		body, err := naptrRecordParam(cfc.ResourceRecord)
+		if err != nil {
+			return dns.RecordNewParams{}, err
+		}
+		return dns.RecordNewParams{ZoneID: cloudflare.F(zoneID), Body: body}, nil
+	}
 	return dns.RecordNewParams{
 		ZoneID: cloudflare.F(zoneID),
 		Body: dns.RecordNewParamsBody{
@@ -99,7 +218,7 @@ func getCreateDNSRecordParam(zoneID string, cfc *cloudFlareChange) dns.RecordNew
 			Comment:  cloudflare.F(cfc.ResourceRecord.Comment),
 			Tags:     cloudflare.F(cfc.ResourceRecord.Tags),
 		},
-	}
+	}, nil
 }
 
 // chunkBatchChanges splits DNS record batch operations into batchChunks,
@@ -156,8 +275,16 @@ func tagsFromResponse(tags any) []dns.RecordTagsParam {
 	return nil
 }
 
-// buildBatchPostParam constructs a RecordBatchParamsPost for creating a DNS record in a batch.
-func buildBatchPostParam(r dns.RecordResponse) dns.RecordBatchParamsPost {
+// buildBatchPostParam constructs the batch-POST create param for a DNS record.
+// SRV and NAPTR use typed union members; other types use the generic flat body.
+// Returns an error when typed parsing fails so the caller can skip the record.
+func buildBatchPostParam(r dns.RecordResponse) (dns.RecordBatchParamsPostUnion, error) {
+	switch r.Type {
+	case dns.RecordResponseTypeSRV:
+		return srvRecordParam(r)
+	case dns.RecordResponseTypeNAPTR:
+		return naptrRecordParam(r)
+	}
 	return dns.RecordBatchParamsPost{
 		Name:     cloudflare.F(r.Name),
 		TTL:      cloudflare.F(r.TTL),
@@ -167,7 +294,7 @@ func buildBatchPostParam(r dns.RecordResponse) dns.RecordBatchParamsPost {
 		Priority: cloudflare.F(r.Priority),
 		Comment:  cloudflare.F(r.Comment),
 		Tags:     cloudflare.F[any](tagsFromResponse(r.Tags)),
-	}
+	}, nil
 }
 
 // buildBatchPutParam constructs a BatchPutUnionParam for updating a DNS record in a batch.
@@ -256,8 +383,21 @@ func buildBatchPutParam(id string, r dns.RecordResponse) (dns.BatchPutUnionParam
 				Tags:    cloudflare.F(tags),
 			},
 		}, true
+	case dns.RecordResponseTypeSRV:
+		body, err := srvRecordParam(r)
+		if err != nil {
+			// Fall back to individual UPDATE, which re-parses and logs the error.
+			return nil, false
+		}
+		return dns.BatchPutSRVRecordParam{ID: cloudflare.F(id), SRVRecordParam: body}, true
+	case dns.RecordResponseTypeNAPTR:
+		body, err := naptrRecordParam(r)
+		if err != nil {
+			return nil, false
+		}
+		return dns.BatchPutNAPTRRecordParam{ID: cloudflare.F(id), NAPTRRecordParam: body}, true
 	default:
-		// Record types that use structured Data fields (SRV, CAA, etc.) are not
+		// Record types that use structured Data fields (e.g. CAA) are not
 		// supported in the generic batch put and fall back to individual updates.
 		return nil, false
 	}
@@ -284,7 +424,12 @@ func (p *CloudFlareProvider) buildBatchCollections(
 
 		switch change.Action {
 		case cloudFlareCreate:
-			bc.batchPosts = append(bc.batchPosts, buildBatchPostParam(change.ResourceRecord))
+			postParam, err := buildBatchPostParam(change.ResourceRecord)
+			if err != nil {
+				log.WithFields(logFields).Errorf("failed to build batch POST param, skipping record: %v", err)
+				continue
+			}
+			bc.batchPosts = append(bc.batchPosts, postParam)
 			bc.createChanges = append(bc.createChanges, change)
 
 		case cloudFlareDelete:
@@ -306,7 +451,9 @@ func (p *CloudFlareProvider) buildBatchCollections(
 				bc.batchPuts = append(bc.batchPuts, putParam)
 				bc.updateChanges = append(bc.updateChanges, change)
 			} else {
-				log.WithFields(logFields).Debugf("batch PUT not supported for type %s, using individual update", change.ResourceRecord.Type)
+				// Parse errors are re-logged by fallbackIndividualChanges; type-unsupported
+				// cases (e.g. CAA) silently fall back here as designed.
+				log.WithFields(logFields).Debugf("batch PUT not supported by SDK for this type or content; routing to individual update")
 				bc.fallbackUpdates = append(bc.fallbackUpdates, change)
 			}
 		}
@@ -360,7 +507,12 @@ func (p *CloudFlareProvider) submitDNSRecordChanges(
 			"zone":   zoneID,
 		}
 		recordID := p.getRecordID(records, change.ResourceRecord)
-		recordParam := getUpdateDNSRecordParam(zoneID, *change)
+		recordParam, err := getUpdateDNSRecordParam(zoneID, *change)
+		if err != nil {
+			failed = true
+			log.WithFields(logFields).Errorf("failed to build update params: %v", err)
+			continue
+		}
 		if _, err := p.Client.UpdateDNSRecord(ctx, recordID, recordParam); err != nil {
 			failed = true
 			log.WithFields(logFields).Errorf("failed to update record: %v", err)
@@ -409,7 +561,11 @@ func (p *CloudFlareProvider) fallbackIndividualChanges(
 			var err error
 			switch change.Action {
 			case cloudFlareCreate:
-				params := getCreateDNSRecordParam(zoneID, change)
+				params, paramErr := getCreateDNSRecordParam(zoneID, change)
+				if paramErr != nil {
+					err = paramErr
+					break
+				}
 				_, err = p.Client.CreateDNSRecord(ctx, params)
 
 			case cloudFlareDelete:
@@ -430,7 +586,11 @@ func (p *CloudFlareProvider) fallbackIndividualChanges(
 					log.WithFields(logFields).Info("fallback: record unexpectedly not found for update, will re-evaluate on next sync")
 					continue
 				}
-				params := getUpdateDNSRecordParam(zoneID, *change)
+				params, paramErr := getUpdateDNSRecordParam(zoneID, *change)
+				if paramErr != nil {
+					err = paramErr
+					break
+				}
 				_, err = p.Client.UpdateDNSRecord(ctx, recordID, params)
 			}
 

--- a/provider/cloudflare/cloudflare_batch_test.go
+++ b/provider/cloudflare/cloudflare_batch_test.go
@@ -799,6 +799,7 @@ func TestBuildSRVData(t *testing.T) {
 		wantErrText string
 	}{
 		{"valid 4-field", "10 5 5060 sip.example.com.", 5060, "sip.example.com", ""},
+		{"valid 4-field no trailing dot", "10 5 5060 sip.example.com", 5060, "sip.example.com", ""},
 		{"preserves bare-dot (RFC 2782 service unavailable)", "0 0 0 .", 0, ".", ""},
 		{"target without trailing dot", "1 1 80 host", 80, "host", ""},
 		{"wrong field count", "10 5 sip.example.com.", 0, "", "invalid SRV target"},
@@ -943,6 +944,7 @@ func TestBuildNAPTRData(t *testing.T) {
 	}{
 		{"valid 6-field", `100 50 "U" "E2U+sip" "!^.*$!sip:info@bar.com!" .`, 100, "E2U+sip", ".", ""},
 		{"strips trailing dot on replacement", `10 20 "S" "SIP+D2U" "" _sip._udp.bar.com.`, 10, "SIP+D2U", "_sip._udp.bar.com", ""},
+		{"no trailing dot on replacement", `10 20 "S" "SIP+D2U" "" _sip._udp.bar.com`, 10, "SIP+D2U", "_sip._udp.bar.com", ""},
 		{"5 fields rejected (missing preference)", `10 "U" "SIP+D2U" "" host.`, 0, "", "", "invalid NAPTR target"},
 		{"non-numeric order rejected", `x 20 "S" "SIP+D2U" "" host.`, 0, "", "", "invalid NAPTR target"},
 		{"order out of uint16 range", `99999 20 "S" "SIP+D2U" "" host.`, 0, "", "", "invalid NAPTR target"},

--- a/provider/cloudflare/cloudflare_batch_test.go
+++ b/provider/cloudflare/cloudflare_batch_test.go
@@ -18,6 +18,7 @@ package cloudflare
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -31,6 +32,7 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
 )
 
 func (m *mockCloudFlareClient) BatchDNSRecords(_ context.Context, params dns.RecordBatchParams) (*dns.RecordBatchResponse, error) {
@@ -93,20 +95,11 @@ func (m *mockCloudFlareClient) BatchDNSRecords(_ context.Context, params dns.Rec
 
 	// Process Posts (creates).
 	for _, postUnion := range params.Posts.Value {
-		post, ok := postUnion.(dns.RecordBatchParamsPost)
-		if !ok {
+		record := extractBatchPostData(postUnion)
+		if record.Name == "" {
 			continue
 		}
-		typeStr := string(post.Type.Value)
-		record := dns.RecordResponse{
-			ID:       generateDNSRecordID(typeStr, post.Name.Value, post.Content.Value),
-			Name:     post.Name.Value,
-			TTL:      dns.TTL(post.TTL.Value),
-			Proxied:  post.Proxied.Value,
-			Type:     dns.RecordResponseType(typeStr),
-			Content:  post.Content.Value,
-			Priority: post.Priority.Value,
-		}
+		record.ID = generateDNSRecordID(string(record.Type), record.Name, record.Content)
 		m.Actions = append(m.Actions, MockAction{
 			Name:       "Create",
 			ZoneId:     zoneID,
@@ -131,6 +124,70 @@ func (m *mockCloudFlareClient) BatchDNSRecords(_ context.Context, params dns.Rec
 	}
 
 	return &dns.RecordBatchResponse{}, nil
+}
+
+// srvResponseFromParam rebuilds a mock RecordResponse from a typed SRVRecordParam,
+// shared by the mock client and the batch-extract helpers so canonical Content
+// formatting lives in one place.
+func srvResponseFromParam(p dns.SRVRecordParam) dns.RecordResponse {
+	d := p.Data.Value
+	return dns.RecordResponse{
+		Name:     p.Name.Value,
+		TTL:      dns.TTL(p.TTL.Value),
+		Proxied:  p.Proxied.Value,
+		Type:     dns.RecordResponseTypeSRV,
+		Content:  fmt.Sprintf("%d %d %d %s", int64(d.Priority.Value), int64(d.Weight.Value), int64(d.Port.Value), d.Target.Value),
+		Priority: d.Priority.Value,
+		Data: dns.SRVRecordData{
+			Priority: d.Priority.Value,
+			Weight:   d.Weight.Value,
+			Port:     d.Port.Value,
+			Target:   d.Target.Value,
+		},
+	}
+}
+
+// naptrResponseFromParam mirrors srvResponseFromParam for NAPTR.
+func naptrResponseFromParam(p dns.NAPTRRecordParam) dns.RecordResponse {
+	d := p.Data.Value
+	return dns.RecordResponse{
+		Name:    p.Name.Value,
+		TTL:     dns.TTL(p.TTL.Value),
+		Proxied: p.Proxied.Value,
+		Type:    dns.RecordResponseTypeNAPTR,
+		Content: fmt.Sprintf("%d %d \"%s\" \"%s\" \"%s\" %s", int64(d.Order.Value), int64(d.Preference.Value), d.Flags.Value, d.Service.Value, d.Regex.Value, d.Replacement.Value),
+		Data: dns.NAPTRRecordData{
+			Order:       d.Order.Value,
+			Preference:  d.Preference.Value,
+			Flags:       d.Flags.Value,
+			Service:     d.Service.Value,
+			Regex:       d.Regex.Value,
+			Replacement: d.Replacement.Value,
+		},
+	}
+}
+
+// extractBatchPostData unpacks a RecordBatchParamsPostUnion into a RecordResponse
+// for the mock's Actions list. Typed SRV/NAPTR bodies route through the shared
+// srvResponseFromParam / naptrResponseFromParam helpers.
+func extractBatchPostData(post dns.RecordBatchParamsPostUnion) dns.RecordResponse {
+	switch p := post.(type) {
+	case dns.RecordBatchParamsPost:
+		return dns.RecordResponse{
+			Name:     p.Name.Value,
+			TTL:      dns.TTL(p.TTL.Value),
+			Proxied:  p.Proxied.Value,
+			Type:     dns.RecordResponseType(p.Type.Value),
+			Content:  p.Content.Value,
+			Priority: p.Priority.Value,
+		}
+	case dns.SRVRecordParam:
+		return srvResponseFromParam(p)
+	case dns.NAPTRRecordParam:
+		return naptrResponseFromParam(p)
+	default:
+		panic(fmt.Sprintf("extractBatchPostData: unexpected RecordBatchParamsPostUnion type %T", post))
+	}
 }
 
 // extractBatchPutData unpacks a BatchPutUnionParam into a record ID and a RecordResponse
@@ -192,6 +249,14 @@ func extractBatchPutData(put dns.BatchPutUnionParam) (string, dns.RecordResponse
 			Type:    dns.RecordResponseTypeNS,
 			Content: p.Content.Value,
 		}
+	case dns.BatchPutSRVRecordParam:
+		r := srvResponseFromParam(p.SRVRecordParam)
+		r.ID = p.ID.Value
+		return p.ID.Value, r
+	case dns.BatchPutNAPTRRecordParam:
+		r := naptrResponseFromParam(p.NAPTRRecordParam)
+		r.ID = p.ID.Value
+		return p.ID.Value, r
 	default:
 		panic(fmt.Sprintf("extractBatchPutData: unexpected BatchPutUnionParam type %T", put))
 	}
@@ -494,12 +559,28 @@ func TestBuildBatchPutParam(t *testing.T) {
 		assert.Equal(t, dns.NSRecordTypeNS, p.Type.Value)
 	})
 
-	t.Run("SRV record falls back (returns nil, false)", func(t *testing.T) {
+	t.Run("SRV record uses typed batch PUT", func(t *testing.T) {
 		r := base
 		r.Type = dns.RecordResponseTypeSRV
 		r.Content = "10 20 443 target.bar.com"
 		param, ok := buildBatchPutParam("id-srv", r)
-		assert.False(t, ok)
+		require.True(t, ok)
+		p, cast := param.(dns.BatchPutSRVRecordParam)
+		require.True(t, cast)
+		assert.Equal(t, "id-srv", p.ID.Value)
+		assert.Equal(t, dns.SRVRecordTypeSRV, p.Type.Value)
+		assert.InDelta(t, 10, p.Data.Value.Priority.Value, 0)
+		assert.InDelta(t, 20, p.Data.Value.Weight.Value, 0)
+		assert.InDelta(t, 443, p.Data.Value.Port.Value, 0)
+		assert.Equal(t, "target.bar.com", p.Data.Value.Target.Value)
+	})
+
+	t.Run("SRV with invalid content falls back to individual update", func(t *testing.T) {
+		r := base
+		r.Type = dns.RecordResponseTypeSRV
+		r.Content = "not a valid srv target"
+		param, ok := buildBatchPutParam("id-srv-bad", r)
+		assert.False(t, ok, "bad SRV data should fall back so the drain re-parses and logs")
 		assert.Nil(t, param)
 	})
 
@@ -534,7 +615,7 @@ func TestBuildBatchCollections_EdgeCases(t *testing.T) {
 		assert.Empty(t, bc.fallbackUpdates)
 	})
 
-	t.Run("SRV update goes to fallbackUpdates", func(t *testing.T) {
+	t.Run("SRV update goes through typed batch PUT", func(t *testing.T) {
 		srvRecord := dns.RecordResponse{
 			ID:      "srv-1",
 			Name:    "srv.bar.com",
@@ -551,10 +632,11 @@ func TestBuildBatchCollections_EdgeCases(t *testing.T) {
 			},
 		}
 		bc := p.buildBatchCollections("zone1", changes, records)
-		assert.Empty(t, bc.batchPuts, "SRV should not be in batch puts")
-		assert.Empty(t, bc.updateChanges)
-		require.Len(t, bc.fallbackUpdates, 1)
-		assert.Equal(t, "srv.bar.com", bc.fallbackUpdates[0].ResourceRecord.Name)
+		require.Len(t, bc.batchPuts, 1, "SRV update should use typed batch PUT")
+		_, ok := bc.batchPuts[0].(dns.BatchPutSRVRecordParam)
+		assert.True(t, ok, "batch put should be the typed SRV param")
+		assert.Len(t, bc.updateChanges, 1)
+		assert.Empty(t, bc.fallbackUpdates, "SRV no longer falls back to individual update")
 	})
 
 	t.Run("delete with missing record ID is skipped", func(t *testing.T) {
@@ -706,4 +788,344 @@ func TestFallbackIndividualChanges_MissingRecord(t *testing.T) {
 		failed := p.fallbackIndividualChanges(t.Context(), "001", chunk, emptyRecords)
 		assert.False(t, failed, "update of missing record should not report failure")
 	})
+}
+
+func TestBuildSRVData(t *testing.T) {
+	cases := []struct {
+		name        string
+		content     string
+		wantPort    float64
+		wantTarget  string
+		wantErrText string
+	}{
+		{"valid 4-field", "10 5 5060 sip.example.com.", 5060, "sip.example.com", ""},
+		{"preserves bare-dot (RFC 2782 service unavailable)", "0 0 0 .", 0, ".", ""},
+		{"target without trailing dot", "1 1 80 host", 80, "host", ""},
+		{"wrong field count", "10 5 sip.example.com.", 0, "", "invalid SRV target"},
+		{"non-numeric priority", "x 5 5060 sip.example.com.", 0, "", "invalid SRV target"},
+		{"port out of uint16 range", "10 5 65536 sip.example.com.", 0, "", "invalid SRV target"},
+		{"empty content", "", 0, "", "invalid SRV target"},
+		{"multi-dot trailing rejected", "10 5 5060 sip.example.com..", 0, "", "invalid SRV target"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			data, err := buildSRVData(c.content)
+			if c.wantErrText != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), c.wantErrText)
+				return
+			}
+			require.NoError(t, err)
+			assert.InDelta(t, c.wantPort, data.Port.Value, 0)
+			assert.Equal(t, c.wantTarget, data.Target.Value)
+		})
+	}
+}
+
+func TestSRVRecordParam(t *testing.T) {
+	cfc := cloudFlareChange{
+		ResourceRecord: dns.RecordResponse{
+			Name:    "_sip._udp.bar.com",
+			TTL:     120,
+			Type:    dns.RecordResponseTypeSRV,
+			Content: "10 5 5060 target.bar.com.",
+			Comment: "managed",
+		},
+	}
+	p, err := srvRecordParam(cfc.ResourceRecord)
+	require.NoError(t, err)
+	assert.Equal(t, "_sip._udp.bar.com", p.Name.Value)
+	assert.Equal(t, dns.SRVRecordTypeSRV, p.Type.Value)
+	assert.Equal(t, "managed", p.Comment.Value)
+	assert.InDelta(t, 5060, p.Data.Value.Port.Value, 0)
+	assert.Equal(t, "target.bar.com", p.Data.Value.Target.Value)
+}
+
+func TestBuildBatchPostParam_SRV(t *testing.T) {
+	r := dns.RecordResponse{
+		Name:    "_sip._udp.bar.com",
+		Type:    dns.RecordResponseTypeSRV,
+		TTL:     120,
+		Content: "10 5 5060 target.bar.com.",
+	}
+	param, err := buildBatchPostParam(r)
+	require.NoError(t, err)
+	srv, ok := param.(dns.SRVRecordParam)
+	require.True(t, ok, "SRV should produce a typed SRVRecordParam")
+	assert.InDelta(t, 5060, srv.Data.Value.Port.Value, 0)
+	assert.Equal(t, "target.bar.com", srv.Data.Value.Target.Value)
+}
+
+func TestGetCreateDNSRecordParam_SRV(t *testing.T) {
+	cfc := &cloudFlareChange{
+		ResourceRecord: dns.RecordResponse{
+			Name:    "_sip._udp.bar.com",
+			Type:    dns.RecordResponseTypeSRV,
+			Content: "10 5 5060 target.bar.com.",
+		},
+	}
+	params, err := getCreateDNSRecordParam("zone-1", cfc)
+	require.NoError(t, err)
+	body, ok := params.Body.(dns.SRVRecordParam)
+	require.True(t, ok, "SRV should use typed body, not the generic flat body")
+	assert.Equal(t, dns.SRVRecordTypeSRV, body.Type.Value)
+}
+
+func TestGetUpdateDNSRecordParam_SRV(t *testing.T) {
+	cfc := cloudFlareChange{
+		ResourceRecord: dns.RecordResponse{
+			Name:    "_sip._udp.bar.com",
+			Type:    dns.RecordResponseTypeSRV,
+			Content: "10 5 5060 target.bar.com.",
+		},
+	}
+	params, err := getUpdateDNSRecordParam("zone-1", cfc)
+	require.NoError(t, err)
+	body, ok := params.Body.(dns.SRVRecordParam)
+	require.True(t, ok, "SRV should use typed body, not the generic flat body")
+	assert.Equal(t, dns.SRVRecordTypeSRV, body.Type.Value)
+}
+
+func TestSRVContent(t *testing.T) {
+	r := dns.RecordResponse{
+		Name:    "_sip._udp.bar.com",
+		Type:    dns.RecordResponseTypeSRV,
+		Content: "5 5060 sip1.bar.com", // raw 3-field Cloudflare content (priority dropped)
+		Data: dns.SRVRecordData{
+			Priority: 10,
+			Weight:   5,
+			Port:     5060,
+			Target:   "sip1.bar.com",
+		},
+	}
+	// Canonical rebuild adds priority and trailing dot.
+	assert.Equal(t, "10 5 5060 sip1.bar.com.", srvContent(r))
+}
+
+func TestSRVContentFromListResponse(t *testing.T) {
+	// Mirrors Cloudflare's list payload: 3-field flat Content, structured Data nested.
+	raw := `{"id":"abc","type":"SRV","name":"_sip._udp.bar.com","content":"5 5060 sip1.bar.com","ttl":300,"priority":10,"data":{"priority":10,"weight":5,"port":5060,"target":"sip1.bar.com"}}`
+	var r dns.RecordResponse
+	require.NoError(t, json.Unmarshal([]byte(raw), &r))
+	assert.Equal(t, "10 5 5060 sip1.bar.com.", srvContent(r))
+}
+
+func TestSRVContentNoData(t *testing.T) {
+	// When neither structured Data nor recoverable raw JSON is present, srvContent
+	// logs a warning and returns the raw Content unchanged (best effort).
+	r := dns.RecordResponse{
+		Name:    "_sip._udp.bar.com",
+		Type:    dns.RecordResponseTypeSRV,
+		Content: "5 5060 sip1.bar.com",
+	}
+	assert.Equal(t, "5 5060 sip1.bar.com", srvContent(r))
+}
+
+// TestSRVDataNilOnSDKUnionBug pins the cloudflare-go v5.1.0 union-decoder bug
+// (cloudflare-go#4300). Fails when the SDK is upgraded and populates Data,
+// signalling that the raw-JSON fallback in srvContent can be removed.
+func TestSRVDataNilOnSDKUnionBug(t *testing.T) {
+	raw := `{"id":"abc","type":"SRV","name":"_sip._udp.bar.com","content":"5 5060 sip1.bar.com","ttl":300,"priority":10,"data":{"priority":10,"weight":5,"port":5060,"target":"sip1.bar.com"}}`
+	var r dns.RecordResponse
+	require.NoError(t, json.Unmarshal([]byte(raw), &r))
+	_, ok := r.Data.(dns.SRVRecordData)
+	require.False(t, ok, "SDK now populates Data on List for SRV; remove the raw-JSON fallback in srvContent (cloudflare-go#4300 fixed)")
+}
+
+func TestBuildNAPTRData(t *testing.T) {
+	cases := []struct {
+		name        string
+		content     string
+		wantOrder   float64
+		wantSvc     string
+		wantRepl    string
+		wantErrText string
+	}{
+		{"valid 6-field", `100 50 "U" "E2U+sip" "!^.*$!sip:info@bar.com!" .`, 100, "E2U+sip", ".", ""},
+		{"strips trailing dot on replacement", `10 20 "S" "SIP+D2U" "" _sip._udp.bar.com.`, 10, "SIP+D2U", "_sip._udp.bar.com", ""},
+		{"5 fields rejected (missing preference)", `10 "U" "SIP+D2U" "" host.`, 0, "", "", "invalid NAPTR target"},
+		{"non-numeric order rejected", `x 20 "S" "SIP+D2U" "" host.`, 0, "", "", "invalid NAPTR target"},
+		{"order out of uint16 range", `99999 20 "S" "SIP+D2U" "" host.`, 0, "", "", "invalid NAPTR target"},
+		{"preference out of uint16 range", `10 99999 "S" "SIP+D2U" "" host.`, 0, "", "", "invalid NAPTR target"},
+		{"empty content", "", 0, "", "", "invalid NAPTR target"},
+		{"multi-dot trailing rejected", `10 20 "S" "SIP+D2U" "" host..`, 0, "", "", "invalid NAPTR target"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			data, err := buildNAPTRData(c.content)
+			if c.wantErrText != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), c.wantErrText)
+				return
+			}
+			require.NoError(t, err)
+			assert.InDelta(t, c.wantOrder, data.Order.Value, 0)
+			assert.Equal(t, c.wantSvc, data.Service.Value)
+			assert.Equal(t, c.wantRepl, data.Replacement.Value)
+		})
+	}
+}
+
+func TestNAPTRRecordParam(t *testing.T) {
+	cfc := cloudFlareChange{
+		ResourceRecord: dns.RecordResponse{
+			Name:    "bar.com",
+			TTL:     120,
+			Type:    dns.RecordResponseTypeNAPTR,
+			Content: `10 20 "S" "SIP+D2U" "" _sip._udp.bar.com.`,
+			Comment: "managed",
+		},
+	}
+	p, err := naptrRecordParam(cfc.ResourceRecord)
+	require.NoError(t, err)
+	assert.Equal(t, "bar.com", p.Name.Value)
+	assert.Equal(t, dns.NAPTRRecordTypeNAPTR, p.Type.Value)
+	assert.Equal(t, "managed", p.Comment.Value)
+	assert.Equal(t, "_sip._udp.bar.com", p.Data.Value.Replacement.Value)
+	assert.Equal(t, "SIP+D2U", p.Data.Value.Service.Value)
+}
+
+func TestBuildBatchPostParam_NAPTR(t *testing.T) {
+	r := dns.RecordResponse{
+		Name:    "bar.com",
+		Type:    dns.RecordResponseTypeNAPTR,
+		TTL:     120,
+		Content: `10 20 "S" "SIP+D2U" "" _sip._udp.bar.com.`,
+	}
+	param, err := buildBatchPostParam(r)
+	require.NoError(t, err)
+	naptr, ok := param.(dns.NAPTRRecordParam)
+	require.True(t, ok, "NAPTR should produce a typed NAPTRRecordParam")
+	assert.Equal(t, "_sip._udp.bar.com", naptr.Data.Value.Replacement.Value)
+}
+
+func TestGetCreateDNSRecordParam_NAPTR(t *testing.T) {
+	cfc := &cloudFlareChange{
+		ResourceRecord: dns.RecordResponse{
+			Name:    "bar.com",
+			Type:    dns.RecordResponseTypeNAPTR,
+			Content: `10 20 "S" "SIP+D2U" "" _sip._udp.bar.com.`,
+		},
+	}
+	params, err := getCreateDNSRecordParam("zone-1", cfc)
+	require.NoError(t, err)
+	body, ok := params.Body.(dns.NAPTRRecordParam)
+	require.True(t, ok, "NAPTR should use typed body")
+	assert.Equal(t, dns.NAPTRRecordTypeNAPTR, body.Type.Value)
+}
+
+func TestGetUpdateDNSRecordParam_NAPTR(t *testing.T) {
+	cfc := cloudFlareChange{
+		ResourceRecord: dns.RecordResponse{
+			Name:    "bar.com",
+			Type:    dns.RecordResponseTypeNAPTR,
+			Content: `10 20 "S" "SIP+D2U" "" _sip._udp.bar.com.`,
+		},
+	}
+	params, err := getUpdateDNSRecordParam("zone-1", cfc)
+	require.NoError(t, err)
+	body, ok := params.Body.(dns.NAPTRRecordParam)
+	require.True(t, ok, "NAPTR should use typed body")
+	assert.Equal(t, dns.NAPTRRecordTypeNAPTR, body.Type.Value)
+}
+
+func TestNAPTRContent(t *testing.T) {
+	r := dns.RecordResponse{
+		Name:    "bar.com",
+		Type:    dns.RecordResponseTypeNAPTR,
+		Content: `10 20 "S" "SIP+D2U" "" _sip._udp.bar.com`,
+		Data: dns.NAPTRRecordData{
+			Order:       10,
+			Preference:  20,
+			Flags:       "S",
+			Service:     "SIP+D2U",
+			Regex:       "",
+			Replacement: "_sip._udp.bar.com",
+		},
+	}
+	assert.Equal(t, `10 20 "S" "SIP+D2U" "" _sip._udp.bar.com.`, naptrContent(r))
+}
+
+func TestNAPTRContentFromListResponse(t *testing.T) {
+	// Cloudflare's list payload for NAPTR: structured data in the JSON envelope.
+	raw := `{"id":"def","type":"NAPTR","name":"bar.com","content":"order 10 ...","ttl":300,"data":{"order":10,"preference":20,"flags":"S","service":"SIP+D2U","regex":"","replacement":"_sip._udp.bar.com"}}`
+	var r dns.RecordResponse
+	require.NoError(t, json.Unmarshal([]byte(raw), &r))
+	assert.Equal(t, `10 20 "S" "SIP+D2U" "" _sip._udp.bar.com.`, naptrContent(r))
+}
+
+func TestNAPTRContentNoData(t *testing.T) {
+	r := dns.RecordResponse{
+		Name:    "bar.com",
+		Type:    dns.RecordResponseTypeNAPTR,
+		Content: "raw fallback content",
+	}
+	assert.Equal(t, "raw fallback content", naptrContent(r))
+}
+
+// TestNAPTRDataNilOnSDKUnionBug pins the cloudflare-go v5.1.0 union-decoder bug
+// for NAPTR. Same intent as the SRV sibling.
+func TestNAPTRDataNilOnSDKUnionBug(t *testing.T) {
+	raw := `{"id":"def","type":"NAPTR","name":"bar.com","content":"order 10 ...","ttl":300,"data":{"order":10,"preference":20,"flags":"S","service":"SIP+D2U","regex":"","replacement":"_sip._udp.bar.com"}}`
+	var r dns.RecordResponse
+	require.NoError(t, json.Unmarshal([]byte(raw), &r))
+	_, ok := r.Data.(dns.NAPTRRecordData)
+	require.False(t, ok, "SDK now populates Data on List for NAPTR; remove the raw-JSON fallback in naptrContent (cloudflare-go#4300 fixed)")
+}
+
+func TestCloudflareNAPTRRoundTrip(t *testing.T) {
+	client := NewMockCloudFlareClient()
+	p := &CloudFlareProvider{Client: client, zoneIDFilter: provider.NewZoneIDFilter([]string{"001"})}
+
+	endpoints := []*endpoint.Endpoint{
+		{
+			RecordType: "NAPTR",
+			DNSName:    "bar.com",
+			Targets:    endpoint.Targets{`10 20 "S" "SIP+D2U" "" _sip._udp.bar.com.`},
+			RecordTTL:  120,
+		},
+	}
+
+	require.NoError(t, p.ApplyChanges(t.Context(), &plan.Changes{Create: endpoints}))
+
+	records, err := p.Records(t.Context())
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, "NAPTR", records[0].RecordType)
+	require.Len(t, records[0].Targets, 1)
+	assert.Equal(t, `10 20 "S" "SIP+D2U" "" _sip._udp.bar.com.`, records[0].Targets[0])
+
+	require.NoError(t, p.ApplyChanges(t.Context(), &plan.Changes{Delete: records}))
+	records2, err := p.Records(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, records2)
+}
+
+func TestCloudflareSRVRoundTrip(t *testing.T) {
+	client := NewMockCloudFlareClient()
+	p := &CloudFlareProvider{Client: client, zoneIDFilter: provider.NewZoneIDFilter([]string{"001"})}
+
+	endpoints := []*endpoint.Endpoint{
+		{
+			RecordType: "SRV",
+			DNSName:    "_sip._udp.bar.com",
+			Targets:    endpoint.Targets{"10 5 5060 sip.bar.com."},
+			RecordTTL:  120,
+		},
+	}
+
+	require.NoError(t, p.ApplyChanges(t.Context(), &plan.Changes{Create: endpoints}))
+
+	records, err := p.Records(t.Context())
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, "SRV", records[0].RecordType)
+	assert.Equal(t, "_sip._udp.bar.com", records[0].DNSName)
+	require.Len(t, records[0].Targets, 1)
+	assert.Equal(t, "10 5 5060 sip.bar.com.", records[0].Targets[0])
+
+	require.NoError(t, p.ApplyChanges(t.Context(), &plan.Changes{Delete: records}))
+	records2, err := p.Records(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, records2)
 }

--- a/provider/cloudflare/cloudflare_batch_test.go
+++ b/provider/cloudflare/cloudflare_batch_test.go
@@ -610,6 +610,7 @@ func TestBuildBatchCollections_EdgeCases(t *testing.T) {
 		}
 		// Empty records map — getRecordID will return ""
 		bc := p.buildBatchCollections("zone1", changes, make(DNSRecordsMap))
+		assert.True(t, bc.failed, "UPDATE missing-target should flag retry")
 		assert.Empty(t, bc.batchPuts, "missing record should not be added to batch puts")
 		assert.Empty(t, bc.updateChanges)
 		assert.Empty(t, bc.fallbackUpdates)
@@ -632,6 +633,7 @@ func TestBuildBatchCollections_EdgeCases(t *testing.T) {
 			},
 		}
 		bc := p.buildBatchCollections("zone1", changes, records)
+		assert.False(t, bc.failed, "successful build")
 		require.Len(t, bc.batchPuts, 1, "SRV update should use typed batch PUT")
 		_, ok := bc.batchPuts[0].(dns.BatchPutSRVRecordParam)
 		assert.True(t, ok, "batch put should be the typed SRV param")
@@ -651,6 +653,7 @@ func TestBuildBatchCollections_EdgeCases(t *testing.T) {
 			},
 		}
 		bc := p.buildBatchCollections("zone1", changes, make(DNSRecordsMap))
+		assert.False(t, bc.failed, "DELETE missing-record is benign")
 		assert.Empty(t, bc.batchDeletes, "missing record should not be added to batch deletes")
 		assert.Empty(t, bc.deleteChanges)
 	})
@@ -772,7 +775,7 @@ func TestFallbackIndividualChanges_MissingRecord(t *testing.T) {
 		assert.False(t, failed, "delete of already-absent record should not report failure")
 	})
 
-	t.Run("update where record is not found skips gracefully", func(t *testing.T) {
+	t.Run("update where record is not found flags retry", func(t *testing.T) {
 		chunk := batchChunk{
 			updateChanges: []*cloudFlareChange{
 				{
@@ -786,7 +789,7 @@ func TestFallbackIndividualChanges_MissingRecord(t *testing.T) {
 			},
 		}
 		failed := p.fallbackIndividualChanges(t.Context(), "001", chunk, emptyRecords)
-		assert.False(t, failed, "update of missing record should not report failure")
+		assert.True(t, failed, "update of missing record should flag retry (mirrors buildBatchCollections)")
 	})
 }
 

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -141,18 +141,41 @@ func NewMockCloudFlareClientWithRecords(records map[string][]dns.RecordResponse)
 	return m
 }
 
-func (m *mockCloudFlareClient) CreateDNSRecord(_ context.Context, params dns.RecordNewParams) (*dns.RecordResponse, error) {
-	body := params.Body.(dns.RecordNewParamsBody)
-
-	record := dns.RecordResponse{
-		ID:       generateDNSRecordID(body.Type.String(), body.Name.Value, body.Content.Value),
-		Name:     body.Name.Value,
-		TTL:      dns.TTL(body.TTL.Value),
-		Proxied:  body.Proxied.Value,
-		Type:     dns.RecordResponseType(body.Type.String()),
-		Content:  body.Content.Value,
-		Priority: body.Priority.Value,
+// recordResponseFromBody reconstructs a mock RecordResponse from a create/update
+// param body. Typed SRV bodies carry structured Data; the mock rebuilds canonical
+// Content from it.
+func recordResponseFromBody(body any) dns.RecordResponse {
+	switch b := body.(type) {
+	case dns.RecordNewParamsBody:
+		return dns.RecordResponse{
+			Name:     b.Name.Value,
+			TTL:      dns.TTL(b.TTL.Value),
+			Proxied:  b.Proxied.Value,
+			Type:     dns.RecordResponseType(b.Type.String()),
+			Content:  b.Content.Value,
+			Priority: b.Priority.Value,
+		}
+	case dns.RecordUpdateParamsBody:
+		return dns.RecordResponse{
+			Name:     b.Name.Value,
+			TTL:      dns.TTL(b.TTL.Value),
+			Proxied:  b.Proxied.Value,
+			Type:     dns.RecordResponseType(b.Type.String()),
+			Content:  b.Content.Value,
+			Priority: b.Priority.Value,
+		}
+	case dns.SRVRecordParam:
+		return srvResponseFromParam(b)
+	case dns.NAPTRRecordParam:
+		return naptrResponseFromParam(b)
+	default:
+		panic(fmt.Sprintf("mock: unsupported DNS record body type %T", body))
 	}
+}
+
+func (m *mockCloudFlareClient) CreateDNSRecord(_ context.Context, params dns.RecordNewParams) (*dns.RecordResponse, error) {
+	record := recordResponseFromBody(params.Body)
+	record.ID = generateDNSRecordID(string(record.Type), record.Name, record.Content)
 
 	m.Actions = append(m.Actions, MockAction{
 		Name:       "Create",
@@ -191,17 +214,8 @@ func (m *mockCloudFlareClient) ListDNSRecords(ctx context.Context, params dns.Re
 
 func (m *mockCloudFlareClient) UpdateDNSRecord(_ context.Context, recordID string, params dns.RecordUpdateParams) (*dns.RecordResponse, error) {
 	zoneID := params.ZoneID.String()
-	body := params.Body.(dns.RecordUpdateParamsBody)
-
-	record := dns.RecordResponse{
-		ID:       recordID,
-		Name:     body.Name.Value,
-		TTL:      dns.TTL(body.TTL.Value),
-		Proxied:  body.Proxied.Value,
-		Type:     dns.RecordResponseType(body.Type.String()),
-		Content:  body.Content.Value,
-		Priority: body.Priority.Value,
-	}
+	record := recordResponseFromBody(params.Body)
+	record.ID = recordID
 
 	m.Actions = append(m.Actions, MockAction{
 		Name:       "Update",
@@ -677,11 +691,17 @@ func TestCloudflareSetProxied(t *testing.T) {
 			var content string
 			var priority float64
 
-			if testCase.recordType == "MX" {
+			switch testCase.recordType {
+			case "MX":
 				targets = endpoint.Targets{"10 mx.example.com"}
 				content = "mx.example.com"
 				priority = 10
-			} else {
+			case "SRV":
+				// SRV uses structured Data; the mock returns the canonical Content
+				// rebuilt from Data ("<priority> <weight> <port> <target>").
+				targets = endpoint.Targets{"10 20 443 target.example.com"}
+				content = "10 20 443 target.example.com"
+			default:
 				targets = endpoint.Targets{"127.0.0.1"}
 				content = "127.0.0.1"
 			}
@@ -708,8 +728,14 @@ func TestCloudflareSetProxied(t *testing.T) {
 				TTL:     1,
 				Proxied: testCase.proxiable,
 			}
-			if testCase.recordType == "MX" {
+			switch testCase.recordType {
+			case "MX":
 				recordData.Priority = priority
+			case "SRV":
+				// SRV records carry structured Data instead of a flat Content string;
+				// the mock rebuilds Content from Data so Priority surfaces here too.
+				recordData.Priority = 10
+				recordData.Data = dns.SRVRecordData{Priority: 10, Weight: 20, Port: 443, Target: "target.example.com"}
 			}
 			AssertActions(t, &CloudFlareProvider{}, endpoints, []MockAction{
 				{
@@ -2382,6 +2408,7 @@ func TestCloudFlareProvider_SupportedAdditionalRecordTypes(t *testing.T) {
 		{endpoint.RecordTypeTXT, true},
 		{endpoint.RecordTypeNS, true},
 		{"SRV", true},
+		{endpoint.RecordTypeNAPTR, true},
 		{"SPF", false},
 		{"LOC", false},
 		{"UNKNOWN", false},
@@ -2890,7 +2917,8 @@ func TestGetUpdateDNSRecordParam(t *testing.T) {
 		},
 	}
 
-	params := getUpdateDNSRecordParam("zone-123", cfc)
+	params, err := getUpdateDNSRecordParam("zone-123", cfc)
+	require.NoError(t, err)
 	body := params.Body.(dns.RecordUpdateParamsBody)
 
 	assert.Equal(t, "zone-123", params.ZoneID.Value)
@@ -2925,7 +2953,8 @@ func TestZoneService(t *testing.T) {
 
 	t.Run("CreateDNSRecord", func(t *testing.T) {
 		t.Parallel()
-		params := getCreateDNSRecordParam(zoneID, &cloudFlareChange{})
+		params, err := getCreateDNSRecordParam(zoneID, &cloudFlareChange{})
+		require.NoError(t, err)
 		record, err := client.CreateDNSRecord(ctx, params)
 		assert.Empty(t, record)
 		assert.ErrorIs(t, err, context.Canceled)
@@ -2933,8 +2962,9 @@ func TestZoneService(t *testing.T) {
 
 	t.Run("UpdateDNSRecord", func(t *testing.T) {
 		t.Parallel()
-		recordParam := getUpdateDNSRecordParam(zoneID, cloudFlareChange{})
-		_, err := client.UpdateDNSRecord(ctx, "1234", recordParam)
+		recordParam, err := getUpdateDNSRecordParam(zoneID, cloudFlareChange{})
+		require.NoError(t, err)
+		_, err = client.UpdateDNSRecord(ctx, "1234", recordParam)
 		assert.ErrorIs(t, err, context.Canceled)
 	})
 

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -1122,6 +1122,44 @@ func TestCloudflareApplyChangesError(t *testing.T) {
 	}
 }
 
+// NAPTR field-count errors aren't caught by upstream validation; provider must surface SoftError.
+func TestCloudflareInvalidCreateReturnsSoftError(t *testing.T) {
+	client := NewMockCloudFlareClient()
+	p := &CloudFlareProvider{Client: client, zoneIDFilter: provider.NewZoneIDFilter([]string{"001"})}
+
+	endpoints := []*endpoint.Endpoint{
+		{
+			RecordType: "NAPTR",
+			DNSName:    "bar.com",
+			Targets:    endpoint.Targets{`10 20`},
+			RecordTTL:  120,
+		},
+	}
+
+	err := p.ApplyChanges(t.Context(), &plan.Changes{Create: endpoints})
+	require.Error(t, err, "invalid create must not be silently swallowed")
+	assert.ErrorIs(t, err, provider.SoftError, "must be a soft error so the controller retries")
+}
+
+// UPDATE against an unknown record (stale cache) must surface SoftError so the controller retries.
+func TestCloudflareUpdateMissingRecordReturnsSoftError(t *testing.T) {
+	client := NewMockCloudFlareClient()
+	p := &CloudFlareProvider{Client: client, zoneIDFilter: provider.NewZoneIDFilter([]string{"001"})}
+
+	endpoints := []*endpoint.Endpoint{
+		{
+			RecordType: endpoint.RecordTypeA,
+			DNSName:    "missing.bar.com",
+			Targets:    endpoint.Targets{"1.2.3.4"},
+			RecordTTL:  120,
+		},
+	}
+
+	err := p.ApplyChanges(t.Context(), &plan.Changes{UpdateNew: endpoints, UpdateOld: endpoints})
+	require.Error(t, err, "update of a record not present in cache must not be silently swallowed")
+	assert.ErrorIs(t, err, provider.SoftError, "must be a soft error so the controller retries")
+}
+
 func TestCloudflareGetRecordID(t *testing.T) {
 	p := &CloudFlareProvider{}
 	recordsMap := DNSRecordsMap{

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -1834,6 +1834,103 @@ func TestCustomTTLWithEnabledProxyNotChanged(t *testing.T) {
 	assert.Empty(t, planned.Changes.Delete, "no new changes should be here")
 }
 
+func TestCanonicalizeStructuredTarget(t *testing.T) {
+	cases := []struct {
+		name       string
+		recordType string
+		in         string
+		want       string
+		wantErr    bool
+	}{
+		{"SRV canonical unchanged", endpoint.RecordTypeSRV, "10 5 5060 sip.bar.com.", "10 5 5060 sip.bar.com.", false},
+		{"SRV multi-space collapsed", endpoint.RecordTypeSRV, "10  5  5060  sip.bar.com.", "10 5 5060 sip.bar.com.", false},
+		{"SRV tab collapsed", endpoint.RecordTypeSRV, "10\t5\t5060\tsip.bar.com.", "10 5 5060 sip.bar.com.", false},
+		{"SRV trailing dot added", endpoint.RecordTypeSRV, "10 5 5060 sip.bar.com", "10 5 5060 sip.bar.com.", false},
+		{"SRV malformed kept", endpoint.RecordTypeSRV, "10 5 sip.bar.com.", "10 5 sip.bar.com.", true},
+		{"NAPTR canonical unchanged", endpoint.RecordTypeNAPTR, `10 20 "S" "SIP+D2U" "" _sip._udp.bar.com.`, `10 20 "S" "SIP+D2U" "" _sip._udp.bar.com.`, false},
+		{"NAPTR multi-space collapsed", endpoint.RecordTypeNAPTR, `10  20  "S"  "SIP+D2U"  ""  _sip._udp.bar.com.`, `10 20 "S" "SIP+D2U" "" _sip._udp.bar.com.`, false},
+		{"NAPTR trailing dot added", endpoint.RecordTypeNAPTR, `10 20 "S" "SIP+D2U" "" _sip._udp.bar.com`, `10 20 "S" "SIP+D2U" "" _sip._udp.bar.com.`, false},
+		{"NAPTR malformed kept", endpoint.RecordTypeNAPTR, "10 20", "10 20", true},
+		{"non-structured type unchanged", endpoint.RecordTypeA, "1.2.3.4", "1.2.3.4", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := canonicalizeStructuredTarget(c.recordType, c.in)
+			if c.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, c.want, got)
+		})
+	}
+}
+
+// replanAfterApply applies a single SRV/NAPTR endpoint, reads it back, and re-plans
+// against the same desired endpoint. Because AdjustEndpoints canonicalizes the
+// desired target to the read-back form, the second plan must be empty; otherwise the
+// record churns an update on every reconcile.
+func replanAfterApply(t *testing.T, recordType, dnsName, target string) *plan.Plan {
+	t.Helper()
+	client := NewMockCloudFlareClient()
+	p := &CloudFlareProvider{Client: client}
+	ctx := t.Context()
+
+	desired := func() []*endpoint.Endpoint {
+		return []*endpoint.Endpoint{{
+			DNSName:    dnsName,
+			RecordType: recordType,
+			Targets:    endpoint.Targets{target},
+			RecordTTL:  endpoint.TTL(defaultTTL),
+			Labels:     endpoint.Labels{},
+		}}
+	}
+
+	create, err := p.AdjustEndpoints(desired())
+	require.NoError(t, err)
+	require.NoError(t, p.ApplyChanges(ctx, &plan.Changes{Create: create}))
+
+	records, err := p.Records(ctx)
+	require.NoError(t, err)
+
+	adjusted, err := p.AdjustEndpoints(desired())
+	require.NoError(t, err)
+
+	pl := &plan.Plan{
+		Current:        records,
+		Desired:        adjusted,
+		DomainFilter:   endpoint.MatchAllDomainFilters{endpoint.NewDomainFilter([]string{"bar.com"})},
+		ManagedRecords: []string{endpoint.RecordTypeSRV, endpoint.RecordTypeNAPTR},
+	}
+	return pl.Calculate()
+}
+
+func TestCloudflareSRVNAPTRConverge(t *testing.T) {
+	cases := []struct {
+		name       string
+		recordType string
+		dnsName    string
+		target     string
+	}{
+		{"SRV canonical", endpoint.RecordTypeSRV, "_sip._udp.bar.com", "10 5 5060 sip.bar.com."},
+		{"SRV multi-space", endpoint.RecordTypeSRV, "_sip._udp.bar.com", "10  5  5060  sip.bar.com."},
+		{"SRV tab", endpoint.RecordTypeSRV, "_sip._udp.bar.com", "10\t5\t5060\tsip.bar.com."},
+		{"SRV no trailing dot", endpoint.RecordTypeSRV, "_sip._udp.bar.com", "10 5 5060 sip.bar.com"},
+		{"NAPTR canonical", endpoint.RecordTypeNAPTR, "bar.com", `10 20 "S" "SIP+D2U" "" _sip._udp.bar.com.`},
+		{"NAPTR multi-space", endpoint.RecordTypeNAPTR, "bar.com", `10  20  "S"  "SIP+D2U"  ""  _sip._udp.bar.com.`},
+		{"NAPTR tab", endpoint.RecordTypeNAPTR, "bar.com", "10\t20\t\"S\"\t\"SIP+D2U\"\t\"\"\t_sip._udp.bar.com."},
+		{"NAPTR no trailing dot", endpoint.RecordTypeNAPTR, "bar.com", `10 20 "S" "SIP+D2U" "" _sip._udp.bar.com`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			planned := replanAfterApply(t, c.recordType, c.dnsName, c.target)
+			assert.Empty(t, planned.Changes.Create, "should converge: unexpected create on second reconcile")
+			assert.Empty(t, planned.Changes.UpdateNew, "should converge: unexpected update on second reconcile")
+			assert.Empty(t, planned.Changes.Delete, "should converge: unexpected delete on second reconcile")
+		})
+	}
+}
+
 func TestCloudFlareProvider_Region(t *testing.T) {
 	testutils.TestHelperEnvSetter(t, map[string]string{
 		cfAPITokenEnvKey: "abc123def",


### PR DESCRIPTION
## What does it do?

Fixes SRV record creation/update in the Cloudflare provider (today fails with HTTP 400 / error 9101) and adds NAPTR support.

Cloudflare's API needs structured `Data` for SRV and NAPTR. Upstream sends the canonical target as flat `Content`, which CF rejects. This routes both through cloudflare-go's typed batch union members (`dns.SRVRecordParam`, `dns.NAPTRRecordParam` for POST; `dns.BatchPutSRVRecordParam`, `dns.BatchPutNAPTRRecordParam` for PUT). The records carry structured Data and go through the same batch endpoint as every other record type. 

On read-back, cloudflare-go v5.1.0 leaves `RecordResponse.Data` nil on List (see cloudflare/cloudflare-go#4300). The new `srvContent` / `naptrContent` helpers re-decode the raw JSON to recover the structured data, then rebuild the canonical content. The fallback can be revisited when the SDK is upgraded.

Fixes #5551. Refs #4751.

## Smoke test

Tested against a real Cloudflare zone, one batch chunk, 6 records (SRV + NAPTR + A + 3 TXT registry records).

Before, on upstream master:

```
level=warning msg="Batch DNS operation failed ... 400 Bad Request {... 9101,
  \"message\":\"... weight is a required data field.\" ... port is a required
  data field.\" ... target is a required data field.\" ...}, falling back to
  individual operations"
level=error   msg="fallback: individual CREATE failed: ... 9101 ... weight is
  a required data field, port is a required data field, target is a required
  data field" action=CREATE content="10 5 5060 edge..." type=SRV
level=error   msg="Failed to do run once: soft error"
```

After, this branch:

```
level=info  msg="Changing record." action=CREATE type=SRV
level=info  msg="Changing record." action=CREATE type=NAPTR
level=info  msg="Changing record." action=CREATE type=A
level=debug msg="Submitting batch DNS records for zone ... (chunk 1/1): 0 deletes, 6 creates, 0 updates"
level=debug msg="Successfully submitted batch DNS records for zone ... (chunk 1/1)"
```

Re-reconcile (no churn, read-back path holds):

```
level=info msg="All records are already up to date"
```

Field changes (SRV port 5060 to 5061, NAPTR preference 20 to 25) and deletion both run through the same batch endpoint with no errors.

`dig` against 1.1.1.1 returns the expected records:

```
$ dig +short SRV   _sip._udp.<zone>
10 5 5060 edge.<zone>.
$ dig +short NAPTR <zone>
10 20 "S" "SIP+D2U" "" _sip._udp.<zone>.
$ dig +short A     edge.<zone>
192.0.2.1
```

## Tests

Unit tests cover parsers, typed param builders, batch POST/PUT, chunk-retry, read-back, and end-to-end round-trip via the mock client. Package coverage 94.1%.

`endpoint.ValidateNAPTRRecord` is out of scope here. Happy to send a follow-up if you want it.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

/cc @ivankatliarchuk @mloiseleur

/kind feature
/kind bug

Related, stalled: #4754, #5569.
