### PR TITLE
fix(istio): resolve annotation prefix not applied to gateway/ingress annotation keys

### DIFF
--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -41,11 +41,6 @@ import (
 	"sigs.k8s.io/external-dns/source/template"
 )
 
-// IstioGatewayIngressSource is the annotation used to determine if the gateway is implemented by an Ingress object
-// instead of a standard LoadBalancer service type
-// Using var instead of const because annotation keys can be customized
-var IstioGatewayIngressSource = annotations.Ingress
-
 // gatewaySource is an implementation of Source for Istio Gateway objects.
 // The gateway implementation uses the spec.servers.hosts values for the hostnames.
 // Use annotations.TargetKey to explicitly set Endpoint.
@@ -220,7 +215,7 @@ func (sc *gatewaySource) targetsFromGateway(gateway *networkingv1.Gateway) (endp
 		return targets, nil
 	}
 
-	ingressStr, ok := gateway.Annotations[IstioGatewayIngressSource]
+	ingressStr, ok := gateway.Annotations[annotations.Ingress]
 	if ok && ingressStr != "" {
 		return sc.targetsFromIngress(ingressStr, gateway)
 	}

--- a/source/istio_gateway_test.go
+++ b/source/istio_gateway_test.go
@@ -46,6 +46,27 @@ import (
 // This is a compile-time validation that gatewaySource is a Source.
 var _ Source = &gatewaySource{}
 
+// TestAnnotationPrefixPropagation verifies that annotations.Ingress reflects
+// changes made by SetAnnotationPrefix at runtime. This is a regression test for a bug
+// where it was a package-level var evaluated at import time — before SetAnnotationPrefix
+// was called — causing annotation lookups to use the wrong prefix and silently produce
+// no endpoints, leading to record deletion under sync policy.
+func TestAnnotationPrefixPropagation(t *testing.T) {
+	t.Cleanup(func() { annotations.SetAnnotationPrefix(annotations.DefaultAnnotationPrefix) })
+
+	assert.Equal(t, annotations.DefaultAnnotationPrefix+"ingress", annotations.Ingress)
+
+	// Simulate --annotation-prefix=custom.io/
+	annotations.SetAnnotationPrefix("custom.io/")
+	assert.Equal(t, "custom.io/ingress", annotations.Ingress,
+		"annotations.Ingress must reflect updated annotation prefix")
+
+	// Simulate changing it again — must not be cached from first call
+	annotations.SetAnnotationPrefix("another.io/")
+	assert.Equal(t, "another.io/ingress", annotations.Ingress,
+		"annotations.Ingress must track subsequent prefix changes")
+}
+
 type GatewaySuite struct {
 	suite.Suite
 	source     Source
@@ -206,7 +227,7 @@ func testEndpointsFromGatewayConfig(t *testing.T) {
 			},
 			config: fakeGatewayConfig{
 				annotations: map[string]string{
-					IstioGatewayIngressSource: "ingress1",
+					annotations.Ingress: "ingress1",
 				},
 				dnsnames: [][]string{
 					{"foo.bar"},
@@ -258,7 +279,7 @@ func testEndpointsFromGatewayConfig(t *testing.T) {
 			},
 			config: fakeGatewayConfig{
 				annotations: map[string]string{
-					IstioGatewayIngressSource: "ingress1",
+					annotations.Ingress: "ingress1",
 				},
 				dnsnames: [][]string{
 					{"foo.bar"},
@@ -319,7 +340,7 @@ func testEndpointsFromGatewayConfig(t *testing.T) {
 			},
 			config: fakeGatewayConfig{
 				annotations: map[string]string{
-					IstioGatewayIngressSource: "ingress1",
+					annotations.Ingress: "ingress1",
 				},
 				dnsnames: [][]string{
 					{""},
@@ -380,7 +401,7 @@ func testEndpointsFromGatewayConfig(t *testing.T) {
 			},
 			config: fakeGatewayConfig{
 				annotations: map[string]string{
-					IstioGatewayIngressSource: "istio-other2/ingress1",
+					annotations.Ingress: "istio-other2/ingress1",
 				},
 				dnsnames: [][]string{
 					{"foo.bar"}, // Kubernetes requires removal of trailing dot
@@ -634,7 +655,7 @@ func testGatewayEndpoints(t *testing.T) {
 					namespace: "testing1",
 					dnsnames:  [][]string{{"example.org"}},
 					annotations: map[string]string{
-						IstioGatewayIngressSource: "testing2/ingress1",
+						annotations.Ingress: "testing2/ingress1",
 					},
 				},
 			},
@@ -1000,8 +1021,8 @@ func testGatewayEndpoints(t *testing.T) {
 					name:      "fake3",
 					namespace: "",
 					annotations: map[string]string{
-						IstioGatewayIngressSource: "not-real/ingress1",
-						annotations.TargetKey:     "1.2.3.4",
+						annotations.Ingress:   "not-real/ingress1",
+						annotations.TargetKey: "1.2.3.4",
 					},
 					dnsnames: [][]string{{"example3.org"}},
 				},
@@ -1142,9 +1163,9 @@ func testGatewayEndpoints(t *testing.T) {
 					name:      "fake1",
 					namespace: "",
 					annotations: map[string]string{
-						IstioGatewayIngressSource: "ingress1",
-						annotations.HostnameKey:   "dns-through-hostname.com",
-						annotations.TargetKey:     "gateway-target.com",
+						annotations.Ingress:     "ingress1",
+						annotations.HostnameKey: "dns-through-hostname.com",
+						annotations.TargetKey:   "gateway-target.com",
 					},
 					dnsnames: [][]string{{"example.org"}},
 				},
@@ -1317,7 +1338,7 @@ func testGatewayEndpoints(t *testing.T) {
 					name:      "fake1",
 					namespace: "",
 					annotations: map[string]string{
-						IstioGatewayIngressSource: "",
+						annotations.Ingress: "",
 					},
 					dnsnames: [][]string{},
 				},
@@ -1451,7 +1472,7 @@ func testGatewayEndpoints(t *testing.T) {
 					name:      "fake1",
 					namespace: "",
 					annotations: map[string]string{
-						IstioGatewayIngressSource: "ingress2",
+						annotations.Ingress: "ingress2",
 					},
 					dnsnames: [][]string{{"new.org"}},
 				},
@@ -1775,7 +1796,7 @@ func TestSingleGatewayMultipleServicesPointingToSameLoadBalancer(t *testing.T) {
 				{
 					Hosts: []string{"example.org"},
 					Tls: &istionetworking.ServerTLSSettings{
-						ServerCertificate: IstioGatewayIngressSource,
+						ServerCertificate: annotations.Ingress,
 						Mode:              istionetworking.ServerTLSSettings_SIMPLE,
 					},
 				},

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -403,7 +403,7 @@ func (sc *virtualServiceSource) targetsFromGateway(gateway *networkingv1.Gateway
 		return targets, nil
 	}
 
-	ingressStr, ok := gateway.Annotations[IstioGatewayIngressSource]
+	ingressStr, ok := gateway.Annotations[annotations.Ingress]
 	if ok && ingressStr != "" {
 		return sc.targetsFromIngress(ingressStr, gateway)
 	}

--- a/source/istio_virtualservice_test.go
+++ b/source/istio_virtualservice_test.go
@@ -583,7 +583,7 @@ func testEndpointsFromVirtualServiceConfig(t *testing.T) {
 				name:     "mygw",
 				dnsnames: [][]string{{"*"}},
 				annotations: map[string]string{
-					IstioGatewayIngressSource: "ingress1",
+					annotations.Ingress: "ingress1",
 				},
 			},
 			vsconfig: fakeVirtualServiceConfig{
@@ -616,7 +616,7 @@ func testEndpointsFromVirtualServiceConfig(t *testing.T) {
 				name:     "mygw",
 				dnsnames: [][]string{{"*"}},
 				annotations: map[string]string{
-					IstioGatewayIngressSource: "ingress/ingress2",
+					annotations.Ingress: "ingress/ingress2",
 				},
 			},
 			vsconfig: fakeVirtualServiceConfig{
@@ -790,7 +790,7 @@ func testVirtualServiceEndpoints(t *testing.T) {
 					namespace: namespace,
 					dnsnames:  [][]string{{"example.org"}},
 					annotations: map[string]string{
-						IstioGatewayIngressSource: "ingress1",
+						annotations.Ingress: "ingress1",
 					},
 				},
 				{
@@ -798,7 +798,7 @@ func testVirtualServiceEndpoints(t *testing.T) {
 					namespace: namespace,
 					dnsnames:  [][]string{{"new.org"}},
 					annotations: map[string]string{
-						IstioGatewayIngressSource: "ingress1",
+						annotations.Ingress: "ingress1",
 					},
 				},
 			},
@@ -1063,7 +1063,7 @@ func testVirtualServiceEndpoints(t *testing.T) {
 					namespace: "testing1",
 					dnsnames:  [][]string{{"*"}},
 					annotations: map[string]string{
-						IstioGatewayIngressSource: "ingress1",
+						annotations.Ingress: "ingress1",
 					},
 				},
 			},
@@ -1297,7 +1297,7 @@ func testVirtualServiceEndpoints(t *testing.T) {
 					namespace: namespace,
 					dnsnames:  [][]string{{"*"}},
 					annotations: map[string]string{
-						IstioGatewayIngressSource: "ingress2",
+						annotations.Ingress: "ingress2",
 					},
 				},
 			},
@@ -1602,8 +1602,8 @@ func testVirtualServiceEndpoints(t *testing.T) {
 					namespace: namespace,
 					dnsnames:  [][]string{{"*"}},
 					annotations: map[string]string{
-						annotations.TargetKey:     "gateway-target.com",
-						IstioGatewayIngressSource: "ingress1",
+						annotations.TargetKey: "gateway-target.com",
+						annotations.Ingress:   "ingress1",
 					},
 				},
 			},
@@ -1957,7 +1957,7 @@ func testVirtualServiceEndpoints(t *testing.T) {
 						"app": "igw4",
 					},
 					annotations: map[string]string{
-						IstioGatewayIngressSource: "testing1/ingress1",
+						annotations.Ingress: "testing1/ingress1",
 					},
 				},
 			},


### PR DESCRIPTION
## What does it do ?

IstioGatewayIngressSource and K8sGatewaySource were package-level vars evaluated at import time, before --annotation-prefix is applied. This caused Istio gateways using the /ingress or /gateway annotations to silently produce no endpoints, resulting in record deletion under sync policy.

This PR fixes this problem by directly referencing the configuration variable, rather than having a layer of indirection. This indirection was only contained in the Istio related packages, so does not need fixing elsewhere. See comment [here](https://github.com/kubernetes-sigs/external-dns/pull/6439#discussion_r3247260446).

### Bug Information

Supply `--annotation-prefix=external-dns.alpha.kubernetes.io/` argument to pod. Start up pod in a cluster where `external-dns.alpha.kubernetes.io/ingress` type annotations are in use. Observe the following immediate deletions of resources using this pathway:

```
time="2026-05-14T13:07:59Z" level=info msg="Created Kubernetes client https://10.35.128.1:443"
time="2026-05-14T13:08:00Z" level=info msg="Created GatewayAPI client https://10.35.128.1:443"
time="2026-05-14T13:08:00Z" level=info msg="Records cache provider: refreshing records list cache"
time="2026-05-14T13:08:00Z" level=info msg="Desired change: DELETE argocd.<redacted> A" profile=default zoneID=/hostedzone/<redacted> zoneName=<redacted>
time="2026-05-14T13:08:00Z" level=info msg="Desired change: DELETE ckkj-argocd-proxy.<redacted> A" profile=default zoneID=/hostedzone/<redacted> zoneName=<redacted>
time="2026-05-14T13:08:00Z" level=info msg="Desired change: DELETE cname-argocd.<redacted> TXT" profile=default zoneID=/hostedzone/<redacted> zoneName=<redacted>
time="2026-05-14T13:08:00Z" level=info msg="Desired change: DELETE cname-ckkj-argocd-proxy.<redacted> TXT" profile=default zoneID=/hostedzone/<redacted> zoneName=<redacted>
...etc
```

After fix, these are recreated (or never deleted):

```
time="2026-05-14T13:20:24Z" level=info msg="Created Kubernetes client https://10.35.128.1:443"
time="2026-05-14T13:20:25Z" level=info msg="Created GatewayAPI client https://10.35.128.1:443"
time="2026-05-14T13:20:25Z" level=info msg="Records cache provider: refreshing records list cache"
time="2026-05-14T13:20:25Z" level=info msg="Desired change: CREATE argocd.<redacted> A" profile=default zoneID=/hostedzone/<redacted> zoneName=<redacted>
time="2026-05-14T13:20:25Z" level=info msg="Desired change: CREATE ckkj-argocd-proxy.<redacted> A" profile=default zoneID=/hostedzone/<redacted> zoneName=<redacted>
time="2026-05-14T13:20:25Z" level=info msg="Desired change: CREATE cname-argocd.<redacted> TXT" profile=default zoneID=/hostedzone/<redacted> zoneName=<redacted>
time="2026-05-14T13:20:25Z" level=info msg="Desired change: CREATE cname-ckkj-argocd-proxy.<redacted> TXT" profile=default zoneID=/hostedzone/<redacted> zoneName=<redacted>
...etc
```

## Motivation

These bugs stop us using external-dns for the purposes we need it for internally. The crash provides an avenue for a denial of service attack in multi-tenant clusters.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
