### PR TITLE
 feat(source): add --fqdn-* flag support to traefik-proxy source

### DIFF
--- a/docs/sources/index.md
+++ b/docs/sources/index.md
@@ -47,7 +47,7 @@ Sources are responsible for:
 | **pod**                  | annotation,label | all,single | true          | true   | false             | kubernetes core     | Pod                                                                                   |
 | **service**              | annotation,label | all,single | true          | true   | true              | kubernetes core     | Service                                                                               |
 | **skipper-routegroup**   | annotation       | all,single | true          | false  | true              | ingress controllers | RouteGroup.zalando.org                                                                |
-| **traefik-proxy**        | annotation       | all,single | false         | false  | true              | ingress controllers | IngressRoute.traefik.io<br/>IngressRouteTCP.traefik.io<br/>IngressRouteUDP.traefik.io |
+| **traefik-proxy**        | annotation       | all,single | true          | false  | true              | ingress controllers | IngressRoute.traefik.io<br/>IngressRouteTCP.traefik.io<br/>IngressRouteUDP.traefik.io |
 | **unstructured**         | annotation,label | all,single | true          | false  | false             | custom resources    | Unstructured                                                                          |
 
 ## Usage

--- a/source/traefik_fqdn_test.go
+++ b/source/traefik_fqdn_test.go
@@ -1,0 +1,467 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeDynamic "k8s.io/client-go/dynamic/fake"
+	fakeKube "k8s.io/client-go/kubernetes/fake"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
+	templatetest "sigs.k8s.io/external-dns/source/template/testutil"
+)
+
+func newTraefikScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	s.AddKnownTypes(ingressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
+	s.AddKnownTypes(ingressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
+	s.AddKnownTypes(ingressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
+	s.AddKnownTypes(oldIngressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
+	s.AddKnownTypes(oldIngressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
+	s.AddKnownTypes(oldIngressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
+	return s
+}
+
+func TestTraefikFQDNTemplateIngressRoute(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		title              string
+		ingressRoute       IngressRoute
+		fqdnTemplate       string
+		targetTemplate     string
+		fqdnTargetTemplate string
+		combine            bool
+		expected           []*endpoint.Endpoint
+	}{
+		{
+			title: "fqdn-template and target-template generate endpoint when no route spec",
+			ingressRoute: IngressRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: ingressRouteGVR.GroupVersion().String(),
+					Kind:       "IngressRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-app",
+					Namespace: defaultTraefikNamespace,
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "traefik",
+					},
+				},
+			},
+			fqdnTemplate:   "{{.Name}}.example.com",
+			targetTemplate: "lb.example.com",
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("my-app.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+			},
+		},
+		{
+			title: "fqdn-target-template generates endpoint when no route spec",
+			ingressRoute: IngressRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: ingressRouteGVR.GroupVersion().String(),
+					Kind:       "IngressRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-app",
+					Namespace: defaultTraefikNamespace,
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "traefik",
+					},
+				},
+			},
+			fqdnTargetTemplate: "{{.Name}}.example.com:1.2.3.4",
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("my-app.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+			},
+		},
+		{
+			title: "fqdn-template with combine adds template endpoint alongside route-based endpoint",
+			ingressRoute: IngressRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: ingressRouteGVR.GroupVersion().String(),
+					Kind:       "IngressRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-app",
+					Namespace: defaultTraefikNamespace,
+					Annotations: map[string]string{
+						"external-dns.kubernetes.io/target": "lb.example.com",
+						"kubernetes.io/ingress.class":       "traefik",
+					},
+				},
+				Spec: traefikIngressRouteSpec{
+					Routes: []traefikRoute{
+						{Match: "Host(`route.example.com`)"},
+					},
+				},
+			},
+			fqdnTemplate:   "{{.Name}}.example.com",
+			targetTemplate: "template-lb.example.com",
+			combine:        true,
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:          "my-app.example.com",
+					Targets:          endpoint.Targets{"template-lb.example.com"},
+					RecordType:       endpoint.RecordTypeCNAME,
+					Labels:           endpoint.Labels{},
+					ProviderSpecific: endpoint.ProviderSpecific{},
+				},
+				{
+					DNSName:          "route.example.com",
+					Targets:          endpoint.Targets{"lb.example.com"},
+					RecordType:       endpoint.RecordTypeCNAME,
+					Labels:           endpoint.Labels{"resource": "ingressroute/traefik/my-app"},
+					ProviderSpecific: endpoint.ProviderSpecific{},
+				},
+			},
+		},
+		{
+			title: "fqdn-template without combine is ignored when route-based endpoints exist",
+			ingressRoute: IngressRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: ingressRouteGVR.GroupVersion().String(),
+					Kind:       "IngressRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-app",
+					Namespace: defaultTraefikNamespace,
+					Annotations: map[string]string{
+						"external-dns.kubernetes.io/target": "lb.example.com",
+						"kubernetes.io/ingress.class":       "traefik",
+					},
+				},
+				Spec: traefikIngressRouteSpec{
+					Routes: []traefikRoute{
+						{Match: "Host(`route.example.com`)"},
+					},
+				},
+			},
+			fqdnTemplate:   "{{.Name}}.example.com",
+			targetTemplate: "template-lb.example.com",
+			combine:        false,
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:          "route.example.com",
+					Targets:          endpoint.Targets{"lb.example.com"},
+					RecordType:       endpoint.RecordTypeCNAME,
+					Labels:           endpoint.Labels{"resource": "ingressroute/traefik/my-app"},
+					ProviderSpecific: endpoint.ProviderSpecific{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			t.Parallel()
+
+			fakeKubeClient := fakeKube.NewSimpleClientset()
+			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(newTraefikScheme())
+
+			objMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&tt.ingressRoute)
+			require.NoError(t, err)
+			obj := &unstructured.Unstructured{Object: objMap}
+
+			_, err = fakeDynamicClient.Resource(ingressRouteGVR).Namespace(defaultTraefikNamespace).
+				Create(t.Context(), obj, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			src, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubeClient, &Config{
+				Namespace:        defaultTraefikNamespace,
+				AnnotationFilter: "kubernetes.io/ingress.class=traefik",
+				TemplateEngine:   templatetest.MustEngine(t, tt.fqdnTemplate, tt.targetTemplate, tt.fqdnTargetTemplate, tt.combine),
+			})
+			require.NoError(t, err)
+
+			count := &unstructured.UnstructuredList{}
+			for len(count.Items) < 1 {
+				count, _ = fakeDynamicClient.Resource(ingressRouteGVR).Namespace(defaultTraefikNamespace).
+					List(t.Context(), metav1.ListOptions{})
+			}
+
+			endpoints, err := src.Endpoints(t.Context())
+			assert.NoError(t, err)
+			testutils.ValidateEndpoints(t, endpoints, tt.expected)
+		})
+	}
+}
+
+func TestTraefikFQDNTemplateIngressRouteTCP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		title              string
+		ingressRouteTCP    IngressRouteTCP
+		fqdnTemplate       string
+		targetTemplate     string
+		fqdnTargetTemplate string
+		combine            bool
+		expected           []*endpoint.Endpoint
+	}{
+		{
+			title: "fqdn-template and target-template generate endpoint when no HostSNI rule",
+			ingressRouteTCP: IngressRouteTCP{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: ingressRouteTCPGVR.GroupVersion().String(),
+					Kind:       "IngressRouteTCP",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-tcp-app",
+					Namespace: defaultTraefikNamespace,
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "traefik",
+					},
+				},
+			},
+			fqdnTemplate:   "{{.Name}}.example.com",
+			targetTemplate: "lb.example.com",
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("my-tcp-app.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+			},
+		},
+		{
+			title: "fqdn-target-template generates endpoint when no HostSNI rule",
+			ingressRouteTCP: IngressRouteTCP{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: ingressRouteTCPGVR.GroupVersion().String(),
+					Kind:       "IngressRouteTCP",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-tcp-app",
+					Namespace: defaultTraefikNamespace,
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "traefik",
+					},
+				},
+			},
+			fqdnTargetTemplate: "{{.Name}}.example.com:1.2.3.4",
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("my-tcp-app.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+			},
+		},
+		{
+			title: "fqdn-template with combine adds template endpoint alongside HostSNI-based endpoint",
+			ingressRouteTCP: IngressRouteTCP{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: ingressRouteTCPGVR.GroupVersion().String(),
+					Kind:       "IngressRouteTCP",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-tcp-app",
+					Namespace: defaultTraefikNamespace,
+					Annotations: map[string]string{
+						"external-dns.kubernetes.io/target": "lb.example.com",
+						"kubernetes.io/ingress.class":       "traefik",
+					},
+				},
+				Spec: traefikIngressRouteTCPSpec{
+					Routes: []traefikRouteTCP{
+						{Match: "HostSNI(`sni.example.com`)"},
+					},
+				},
+			},
+			fqdnTemplate:   "{{.Name}}.example.com",
+			targetTemplate: "template-lb.example.com",
+			combine:        true,
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:          "my-tcp-app.example.com",
+					Targets:          endpoint.Targets{"template-lb.example.com"},
+					RecordType:       endpoint.RecordTypeCNAME,
+					Labels:           endpoint.Labels{},
+					ProviderSpecific: endpoint.ProviderSpecific{},
+				},
+				{
+					DNSName:          "sni.example.com",
+					Targets:          endpoint.Targets{"lb.example.com"},
+					RecordType:       endpoint.RecordTypeCNAME,
+					Labels:           endpoint.Labels{"resource": "ingressroutetcp/traefik/my-tcp-app"},
+					ProviderSpecific: endpoint.ProviderSpecific{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			t.Parallel()
+
+			fakeKubeClient := fakeKube.NewSimpleClientset()
+			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(newTraefikScheme())
+
+			objMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&tt.ingressRouteTCP)
+			require.NoError(t, err)
+			obj := &unstructured.Unstructured{Object: objMap}
+
+			_, err = fakeDynamicClient.Resource(ingressRouteTCPGVR).Namespace(defaultTraefikNamespace).
+				Create(t.Context(), obj, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			src, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubeClient, &Config{
+				Namespace:        defaultTraefikNamespace,
+				AnnotationFilter: "kubernetes.io/ingress.class=traefik",
+				TemplateEngine:   templatetest.MustEngine(t, tt.fqdnTemplate, tt.targetTemplate, tt.fqdnTargetTemplate, tt.combine),
+			})
+			require.NoError(t, err)
+
+			count := &unstructured.UnstructuredList{}
+			for len(count.Items) < 1 {
+				count, _ = fakeDynamicClient.Resource(ingressRouteTCPGVR).Namespace(defaultTraefikNamespace).
+					List(t.Context(), metav1.ListOptions{})
+			}
+
+			endpoints, err := src.Endpoints(t.Context())
+			assert.NoError(t, err)
+			testutils.ValidateEndpoints(t, endpoints, tt.expected)
+		})
+	}
+}
+
+func TestTraefikFQDNTemplateIngressRouteUDP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		title              string
+		ingressRouteUDP    IngressRouteUDP
+		fqdnTemplate       string
+		targetTemplate     string
+		fqdnTargetTemplate string
+		combine            bool
+		expected           []*endpoint.Endpoint
+	}{
+		{
+			title: "fqdn-template and target-template generate endpoint",
+			ingressRouteUDP: IngressRouteUDP{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: ingressRouteUDPGVR.GroupVersion().String(),
+					Kind:       "IngressRouteUDP",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-udp-app",
+					Namespace: defaultTraefikNamespace,
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "traefik",
+					},
+				},
+			},
+			fqdnTemplate:   "{{.Name}}.example.com",
+			targetTemplate: "lb.example.com",
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("my-udp-app.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+			},
+		},
+		{
+			title: "fqdn-target-template generates endpoint",
+			ingressRouteUDP: IngressRouteUDP{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: ingressRouteUDPGVR.GroupVersion().String(),
+					Kind:       "IngressRouteUDP",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-udp-app",
+					Namespace: defaultTraefikNamespace,
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "traefik",
+					},
+				},
+			},
+			fqdnTargetTemplate: "{{.Name}}.example.com:1.2.3.4",
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("my-udp-app.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+			},
+		},
+		{
+			title: "fqdn-template with combine adds template endpoint alongside annotation-based endpoint",
+			ingressRouteUDP: IngressRouteUDP{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: ingressRouteUDPGVR.GroupVersion().String(),
+					Kind:       "IngressRouteUDP",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-udp-app",
+					Namespace: defaultTraefikNamespace,
+					Annotations: map[string]string{
+						"external-dns.kubernetes.io/hostname": "annotated.example.com",
+						"external-dns.kubernetes.io/target":   "lb.example.com",
+						"kubernetes.io/ingress.class":         "traefik",
+					},
+				},
+			},
+			fqdnTemplate:   "{{.Name}}.example.com",
+			targetTemplate: "template-lb.example.com",
+			combine:        true,
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:          "annotated.example.com",
+					Targets:          endpoint.Targets{"lb.example.com"},
+					RecordType:       endpoint.RecordTypeCNAME,
+					Labels:           endpoint.Labels{"resource": "ingressrouteudp/traefik/my-udp-app"},
+					ProviderSpecific: endpoint.ProviderSpecific{},
+				},
+				{
+					DNSName:          "my-udp-app.example.com",
+					Targets:          endpoint.Targets{"template-lb.example.com"},
+					RecordType:       endpoint.RecordTypeCNAME,
+					Labels:           endpoint.Labels{},
+					ProviderSpecific: endpoint.ProviderSpecific{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			t.Parallel()
+
+			fakeKubeClient := fakeKube.NewSimpleClientset()
+			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(newTraefikScheme())
+
+			objMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&tt.ingressRouteUDP)
+			require.NoError(t, err)
+			obj := &unstructured.Unstructured{Object: objMap}
+
+			_, err = fakeDynamicClient.Resource(ingressRouteUDPGVR).Namespace(defaultTraefikNamespace).
+				Create(t.Context(), obj, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			src, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubeClient, &Config{
+				Namespace:        defaultTraefikNamespace,
+				AnnotationFilter: "kubernetes.io/ingress.class=traefik",
+				TemplateEngine:   templatetest.MustEngine(t, tt.fqdnTemplate, tt.targetTemplate, tt.fqdnTargetTemplate, tt.combine),
+			})
+			require.NoError(t, err)
+
+			count := &unstructured.UnstructuredList{}
+			for len(count.Items) < 1 {
+				count, _ = fakeDynamicClient.Resource(ingressRouteUDPGVR).Namespace(defaultTraefikNamespace).
+					List(t.Context(), metav1.ListOptions{})
+			}
+
+			endpoints, err := src.Endpoints(t.Context())
+			assert.NoError(t, err)
+			testutils.ValidateEndpoints(t, endpoints, tt.expected)
+		})
+	}
+}

--- a/source/traefik_proxy.go
+++ b/source/traefik_proxy.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
 
+	"sigs.k8s.io/external-dns/source/template"
 	"sigs.k8s.io/external-dns/source/types"
 
 	"sigs.k8s.io/external-dns/endpoint"
@@ -87,7 +88,7 @@ var (
 // +externaldns:source:resources=IngressRoute.traefik.io,IngressRouteTCP.traefik.io,IngressRouteUDP.traefik.io
 // +externaldns:source:filters=annotation
 // +externaldns:source:namespace=all,single
-// +externaldns:source:fqdn-template=false
+// +externaldns:source:fqdn-template=true
 // +externaldns:source:provider-specific=true
 type traefikSource struct {
 	dynamicKubeClient          dynamic.Interface
@@ -95,6 +96,7 @@ type traefikSource struct {
 	annotationFilter           string
 	namespace                  string
 	ignoreHostnameAnnotation   bool
+	templateEngine             template.Engine
 	ingressRouteInformer       kubeinformers.GenericInformer
 	ingressRouteTcpInformer    kubeinformers.GenericInformer
 	ingressRouteUdpInformer    kubeinformers.GenericInformer
@@ -173,6 +175,7 @@ func NewTraefikSource(
 	return &traefikSource{
 		annotationFilter:           cfg.AnnotationFilter,
 		ignoreHostnameAnnotation:   cfg.IgnoreHostnameAnnotation,
+		templateEngine:             cfg.TemplateEngine,
 		dynamicKubeClient:          dynamicKubeClient,
 		ingressRouteInformer:       ingressRouteInformer,
 		ingressRouteTcpInformer:    ingressRouteTcpInformer,
@@ -245,9 +248,7 @@ func (ts *traefikSource) ingressRouteEndpoints() ([]*endpoint.Endpoint, error) {
 			return typed, ts.unstructuredConverter.scheme.Convert(u, typed, nil)
 		},
 		ts.annotationFilter,
-		func(r *IngressRoute, targets endpoint.Targets) []*endpoint.Endpoint {
-			return ts.endpointsFromIngressRoute(r, targets)
-		},
+		ts.endpointsFromIngressRoute,
 	)
 }
 
@@ -287,7 +288,10 @@ func (ts *traefikSource) ingressRouteTCPEndpoints() ([]*endpoint.Endpoint, error
 
 		fullname := fmt.Sprintf("%s/%s", ingressRouteTCP.Namespace, ingressRouteTCP.Name)
 
-		ingressEndpoints := ts.endpointsFromIngressRouteTCP(ingressRouteTCP, targets)
+		ingressEndpoints, err := ts.endpointsFromIngressRouteTCP(ingressRouteTCP, targets)
+		if err != nil {
+			return nil, err
+		}
 		if endpoint.HasNoEmptyEndpoints(ingressEndpoints, types.TraefikProxy, ingressRouteTCP) {
 			continue
 		}
@@ -323,9 +327,7 @@ func (ts *traefikSource) oldIngressRouteEndpoints() ([]*endpoint.Endpoint, error
 			return typed, ts.unstructuredConverter.scheme.Convert(u, typed, nil)
 		},
 		ts.annotationFilter,
-		func(r *IngressRoute, targets endpoint.Targets) []*endpoint.Endpoint {
-			return ts.endpointsFromIngressRoute(r, targets)
-		},
+		ts.endpointsFromIngressRoute,
 	)
 }
 
@@ -358,7 +360,7 @@ func (ts *traefikSource) oldIngressRouteUDPEndpoints() ([]*endpoint.Endpoint, er
 }
 
 // endpointsFromIngressRoute extracts the endpoints from a IngressRoute object
-func (ts *traefikSource) endpointsFromIngressRoute(ingressRoute *IngressRoute, targets endpoint.Targets) []*endpoint.Endpoint {
+func (ts *traefikSource) endpointsFromIngressRoute(ingressRoute *IngressRoute, targets endpoint.Targets) ([]*endpoint.Endpoint, error) {
 	var endpoints []*endpoint.Endpoint
 
 	resource := fmt.Sprintf("ingressroute/%s/%s", ingressRoute.Namespace, ingressRoute.Name)
@@ -387,11 +389,21 @@ func (ts *traefikSource) endpointsFromIngressRoute(ingressRoute *IngressRoute, t
 		}
 	}
 
-	return endpoints
+	endpoints, err := ts.templateEngine.CombineWithEndpoints(
+		endpoints,
+		func() ([]*endpoint.Endpoint, error) { return ts.endpointsFromFQDNTargetTemplate(ingressRoute) },
+	)
+	if err != nil {
+		return nil, err
+	}
+	return ts.templateEngine.CombineWithEndpoints(
+		endpoints,
+		func() ([]*endpoint.Endpoint, error) { return ts.endpointsFromTemplate(ingressRoute) },
+	)
 }
 
 // endpointsFromIngressRouteTCP extracts the endpoints from a IngressRouteTCP object
-func (ts *traefikSource) endpointsFromIngressRouteTCP(ingressRoute *IngressRouteTCP, targets endpoint.Targets) []*endpoint.Endpoint {
+func (ts *traefikSource) endpointsFromIngressRouteTCP(ingressRoute *IngressRouteTCP, targets endpoint.Targets) ([]*endpoint.Endpoint, error) {
 	var endpoints []*endpoint.Endpoint
 
 	resource := fmt.Sprintf("ingressroutetcp/%s/%s", ingressRoute.Namespace, ingressRoute.Name)
@@ -420,11 +432,21 @@ func (ts *traefikSource) endpointsFromIngressRouteTCP(ingressRoute *IngressRoute
 		}
 	}
 
-	return endpoints
+	endpoints, err := ts.templateEngine.CombineWithEndpoints(
+		endpoints,
+		func() ([]*endpoint.Endpoint, error) { return ts.endpointsFromFQDNTargetTemplate(ingressRoute) },
+	)
+	if err != nil {
+		return nil, err
+	}
+	return ts.templateEngine.CombineWithEndpoints(
+		endpoints,
+		func() ([]*endpoint.Endpoint, error) { return ts.endpointsFromTemplate(ingressRoute) },
+	)
 }
 
 // endpointsFromIngressRouteUDP extracts the endpoints from a IngressRouteUDP object
-func (ts *traefikSource) endpointsFromIngressRouteUDP(ingressRoute *IngressRouteUDP, targets endpoint.Targets) []*endpoint.Endpoint {
+func (ts *traefikSource) endpointsFromIngressRouteUDP(ingressRoute *IngressRouteUDP, targets endpoint.Targets) ([]*endpoint.Endpoint, error) {
 	var endpoints []*endpoint.Endpoint
 
 	resource := fmt.Sprintf("ingressrouteudp/%s/%s", ingressRoute.Namespace, ingressRoute.Name)
@@ -440,7 +462,17 @@ func (ts *traefikSource) endpointsFromIngressRouteUDP(ingressRoute *IngressRoute
 		}
 	}
 
-	return endpoints
+	endpoints, err := ts.templateEngine.CombineWithEndpoints(
+		endpoints,
+		func() ([]*endpoint.Endpoint, error) { return ts.endpointsFromFQDNTargetTemplate(ingressRoute) },
+	)
+	if err != nil {
+		return nil, err
+	}
+	return ts.templateEngine.CombineWithEndpoints(
+		endpoints,
+		func() ([]*endpoint.Endpoint, error) { return ts.endpointsFromTemplate(ingressRoute) },
+	)
 }
 
 func (ts *traefikSource) AddEventHandler(_ context.Context, handler func()) {
@@ -839,6 +871,52 @@ func (in *IngressRouteUDP) GetAnnotations() map[string]string {
 	return in.Annotations
 }
 
+// traefikObject is satisfied by IngressRoute, IngressRouteTCP, and IngressRouteUDP.
+type traefikObject interface {
+	runtime.Object
+	metav1.Object
+}
+
+// endpointsFromTemplate creates endpoints using the FQDN and target templates.
+func (ts *traefikSource) endpointsFromTemplate(obj traefikObject) ([]*endpoint.Endpoint, error) {
+	hostnames, err := ts.templateEngine.ExecFQDN(obj)
+	if err != nil || len(hostnames) == 0 {
+		return nil, err
+	}
+	targets, err := ts.templateEngine.ExecTarget(obj)
+	if err != nil {
+		return nil, err
+	}
+	return EndpointsForHostsAndTargets(hostnames, targets), nil
+}
+
+// endpointsFromFQDNTargetTemplate creates endpoints from host:target pairs produced by the fqdn-target template.
+func (ts *traefikSource) endpointsFromFQDNTargetTemplate(obj traefikObject) ([]*endpoint.Endpoint, error) {
+	pairs, err := ts.templateEngine.ExecFQDNTarget(obj)
+	if err != nil || len(pairs) == 0 {
+		return nil, err
+	}
+
+	endpoints := make([]*endpoint.Endpoint, 0, len(pairs))
+	for _, pair := range pairs {
+		parts := strings.SplitN(pair, ":", 2)
+		if len(parts) != 2 {
+			log.Debugf("Skipping invalid host:target pair %q from %s %s/%s: missing ':' separator",
+				pair, strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind), obj.GetNamespace(), obj.GetName())
+			continue
+		}
+		host := strings.TrimSpace(parts[0])
+		target := strings.TrimSpace(parts[1])
+		if host == "" || target == "" {
+			log.Debugf("Skipping incomplete host:target pair %q from %s %s/%s: field may not yet be populated",
+				pair, strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind), obj.GetNamespace(), obj.GetName())
+			continue
+		}
+		endpoints = append(endpoints, endpoint.NewEndpoint(host, endpoint.SuitableType(target), target))
+	}
+	return endpoint.MergeEndpoints(endpoints), nil
+}
+
 // extractEndpoints is a generic function that extracts endpoints from Kubernetes resources.
 // It performs the following steps:
 // 1. Lists all objects in the specified namespace using the provided informer.
@@ -851,7 +929,7 @@ func extractEndpoints[T annotations.AnnotatedObject](
 	namespace string,
 	convertFunc func(*unstructured.Unstructured) (T, error),
 	annotationFilter string,
-	generateEndpoints func(T, endpoint.Targets) []*endpoint.Endpoint,
+	generateEndpoints func(T, endpoint.Targets) ([]*endpoint.Endpoint, error),
 ) ([]*endpoint.Endpoint, error) {
 	var endpoints []*endpoint.Endpoint
 
@@ -883,7 +961,10 @@ func extractEndpoints[T annotations.AnnotatedObject](
 		targets := annotations.TargetsFromTargetAnnotation(item.GetAnnotations())
 
 		name := getObjectFullName(item)
-		ingressEndpoints := generateEndpoints(item, targets)
+		ingressEndpoints, err := generateEndpoints(item, targets)
+		if err != nil {
+			return nil, err
+		}
 
 		if len(ingressEndpoints) == 0 {
 			log.Debugf("No endpoints could be generated from Host %s", name)

--- a/source/traefik_proxy_fqdn_test.go
+++ b/source/traefik_proxy_fqdn_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package source
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -173,7 +172,7 @@ func TestTraefikFQDNTemplateIngressRoute(t *testing.T) {
 			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(uc.scheme)
 
 			obj := &unstructured.Unstructured{}
-			require.NoError(t, uc.scheme.Convert(&tt.ingressRoute, obj, context.Background()))
+			require.NoError(t, uc.scheme.Convert(&tt.ingressRoute, obj, t.Context()))
 
 			_, err = fakeDynamicClient.Resource(ingressRouteGVR).Namespace(defaultTraefikNamespace).
 				Create(t.Context(), obj, metav1.CreateOptions{})
@@ -306,7 +305,7 @@ func TestTraefikFQDNTemplateIngressRouteTCP(t *testing.T) {
 			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(uc.scheme)
 
 			obj := &unstructured.Unstructured{}
-			require.NoError(t, uc.scheme.Convert(&tt.ingressRouteTCP, obj, context.Background()))
+			require.NoError(t, uc.scheme.Convert(&tt.ingressRouteTCP, obj, t.Context()))
 
 			_, err = fakeDynamicClient.Resource(ingressRouteTCPGVR).Namespace(defaultTraefikNamespace).
 				Create(t.Context(), obj, metav1.CreateOptions{})
@@ -435,7 +434,7 @@ func TestTraefikFQDNTemplateIngressRouteUDP(t *testing.T) {
 			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(uc.scheme)
 
 			obj := &unstructured.Unstructured{}
-			require.NoError(t, uc.scheme.Convert(&tt.ingressRouteUDP, obj, context.Background()))
+			require.NoError(t, uc.scheme.Convert(&tt.ingressRouteUDP, obj, t.Context()))
 
 			_, err = fakeDynamicClient.Resource(ingressRouteUDPGVR).Namespace(defaultTraefikNamespace).
 				Create(t.Context(), obj, metav1.CreateOptions{})

--- a/source/traefik_proxy_fqdn_test.go
+++ b/source/traefik_proxy_fqdn_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,13 +17,13 @@ limitations under the License.
 package source
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	fakeDynamic "k8s.io/client-go/dynamic/fake"
 	fakeKube "k8s.io/client-go/kubernetes/fake"
 
@@ -31,17 +31,6 @@ import (
 	"sigs.k8s.io/external-dns/internal/testutils"
 	templatetest "sigs.k8s.io/external-dns/source/template/testutil"
 )
-
-func newTraefikScheme() *runtime.Scheme {
-	s := runtime.NewScheme()
-	s.AddKnownTypes(ingressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
-	s.AddKnownTypes(ingressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
-	s.AddKnownTypes(ingressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
-	s.AddKnownTypes(oldIngressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
-	s.AddKnownTypes(oldIngressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
-	s.AddKnownTypes(oldIngressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
-	return s
-}
 
 func TestTraefikFQDNTemplateIngressRoute(t *testing.T) {
 	t.Parallel()
@@ -177,12 +166,14 @@ func TestTraefikFQDNTemplateIngressRoute(t *testing.T) {
 		t.Run(tt.title, func(t *testing.T) {
 			t.Parallel()
 
-			fakeKubeClient := fakeKube.NewSimpleClientset()
-			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(newTraefikScheme())
-
-			objMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&tt.ingressRoute)
+			uc, err := newTraefikUnstructuredConverter()
 			require.NoError(t, err)
-			obj := &unstructured.Unstructured{Object: objMap}
+
+			fakeKubeClient := fakeKube.NewSimpleClientset()
+			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(uc.scheme)
+
+			obj := &unstructured.Unstructured{}
+			require.NoError(t, uc.scheme.Convert(&tt.ingressRoute, obj, context.Background()))
 
 			_, err = fakeDynamicClient.Resource(ingressRouteGVR).Namespace(defaultTraefikNamespace).
 				Create(t.Context(), obj, metav1.CreateOptions{})
@@ -308,12 +299,14 @@ func TestTraefikFQDNTemplateIngressRouteTCP(t *testing.T) {
 		t.Run(tt.title, func(t *testing.T) {
 			t.Parallel()
 
-			fakeKubeClient := fakeKube.NewSimpleClientset()
-			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(newTraefikScheme())
-
-			objMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&tt.ingressRouteTCP)
+			uc, err := newTraefikUnstructuredConverter()
 			require.NoError(t, err)
-			obj := &unstructured.Unstructured{Object: objMap}
+
+			fakeKubeClient := fakeKube.NewSimpleClientset()
+			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(uc.scheme)
+
+			obj := &unstructured.Unstructured{}
+			require.NoError(t, uc.scheme.Convert(&tt.ingressRouteTCP, obj, context.Background()))
 
 			_, err = fakeDynamicClient.Resource(ingressRouteTCPGVR).Namespace(defaultTraefikNamespace).
 				Create(t.Context(), obj, metav1.CreateOptions{})
@@ -435,12 +428,14 @@ func TestTraefikFQDNTemplateIngressRouteUDP(t *testing.T) {
 		t.Run(tt.title, func(t *testing.T) {
 			t.Parallel()
 
-			fakeKubeClient := fakeKube.NewSimpleClientset()
-			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(newTraefikScheme())
-
-			objMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&tt.ingressRouteUDP)
+			uc, err := newTraefikUnstructuredConverter()
 			require.NoError(t, err)
-			obj := &unstructured.Unstructured{Object: objMap}
+
+			fakeKubeClient := fakeKube.NewSimpleClientset()
+			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(uc.scheme)
+
+			obj := &unstructured.Unstructured{}
+			require.NoError(t, uc.scheme.Convert(&tt.ingressRouteUDP, obj, context.Background()))
 
 			_, err = fakeDynamicClient.Resource(ingressRouteUDPGVR).Namespace(defaultTraefikNamespace).
 				Create(t.Context(), obj, metav1.CreateOptions{})


### PR DESCRIPTION
## What does it do ?

 - traefikSource now accepts a template.Engine (wired from cfg.TemplateEngine) and applies it to all three Traefik CRD types: IngressRoute, IngressRouteTCP, and IngressRouteUDP
  - Added endpointsFromTemplate (handles --fqdn-template + --target-template) and endpointsFromFQDNTargetTemplate (handles --fqdn-target-template with host:target pairs), following the identical pattern used by the unstructured source
  - Template combination uses the two-step CombineWithEndpoints flow: fqdn-target-template first, then fqdn+target-template — preserving existing rule/annotation-based  endpoints when no combine flag is set
  
## Motivation

  - The traefik-proxy source did not support DNS name generation via --fqdn-template, preventing users from deriving hostnames from resource metadata (name, namespace, labels) without using annotations
  - And added support of --target-template and --fqdn-target-template to make it possible to to override or derive DNS targets from resource metadata

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
