### PR TITLE
fix(aws): unescape wildcard alias target on read

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -550,8 +550,9 @@ func (p *AWSProvider) records(ctx context.Context, zones map[string]*profiledZon
 					if ttl == 0 {
 						ttl = defaultTTL
 					}
+					aliasTarget := convertOctalToAscii(wildcardUnescape(*r.AliasTarget.DNSName))
 					ep := endpoint.
-						NewEndpointWithTTL(name, string(r.Type), ttl, *r.AliasTarget.DNSName).
+						NewEndpointWithTTL(name, string(r.Type), ttl, aliasTarget).
 						WithProviderSpecific(providerSpecificEvaluateTargetHealth, fmt.Sprintf("%t", r.AliasTarget.EvaluateTargetHealth)).
 						WithAliasProperty(endpoint.AliasTrue)
 					newEndpoints = append(newEndpoints, ep)

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -483,6 +483,17 @@ func TestAWSRecords(t *testing.T) {
 			},
 		},
 		{
+			// Alias whose target is a wildcard hostname. Route53 stores the
+			// target escaped (\052.foo), so it must be unescaped on read.
+			Name: aws.String("wildcard-alias-target.zone-1.ext-dns-test-2.teapot.zalan.do."),
+			Type: route53types.RRTypeA,
+			AliasTarget: &route53types.AliasTarget{
+				DNSName:              aws.String(wildcardEscape("*.wildcard-target.zone-1.ext-dns-test-2.teapot.zalan.do.")),
+				EvaluateTargetHealth: false,
+				HostedZoneId:         aws.String("Z215JYRZR1TBD5"),
+			},
+		},
+		{
 			Name: aws.String("list-test-alias-evaluate.zone-1.ext-dns-test-2.teapot.zalan.do."),
 			Type: route53types.RRTypeA,
 			AliasTarget: &route53types.AliasTarget{
@@ -665,6 +676,7 @@ func TestAWSRecords(t *testing.T) {
 		endpoint.NewEndpointWithTTL("list-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(defaultTTL), "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false").WithAliasProperty(endpoint.AliasTrue),
 		endpoint.NewEndpointWithTTL("*.wildcard-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false").WithAliasProperty(endpoint.AliasTrue),
 		endpoint.NewEndpointWithTTL("*.wildcard-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(defaultTTL), "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false").WithAliasProperty(endpoint.AliasTrue),
+		endpoint.NewEndpointWithTTL("wildcard-alias-target.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "*.wildcard-target.zone-1.ext-dns-test-2.teapot.zalan.do").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false").WithAliasProperty(endpoint.AliasTrue),
 		endpoint.NewEndpointWithTTL("list-test-alias-evaluate.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true").WithAliasProperty(endpoint.AliasTrue),
 		endpoint.NewEndpointWithTTL("list-test-alias-evaluate.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(defaultTTL), "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true").WithAliasProperty(endpoint.AliasTrue),
 		endpoint.NewEndpointWithTTL("list-test-multiple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "8.8.8.8", "8.8.4.4"),


### PR DESCRIPTION
**Description**

Route53 stores wildcards escaped (`\052`). The AWS provider already unescapes the record *name* when reading records (`convertOctalToAscii(wildcardUnescape(*r.Name))`), but it read the alias target (`AliasTarget.DNSName`) raw.

For an alias record whose target is a wildcard hostname (for example an alias to `*.example.com`), the provider returned `\052.example.com` instead of `*.example.com`. The plan then compared the provider's `\052.example.com` against the desired `*.example.com`, never found a match, and external-dns issued an `UPSERT` on every reconcile loop.

This applies the same `wildcardUnescape` / `convertOctalToAscii` to the alias target that is already applied to the record name, and adds a regression test in `TestAWSRecords` covering an alias whose target is a wildcard.

**Fixes #6137**

**Checklist**

- [x] Unit tests updated (`provider/aws`: added a wildcard alias-target fixture and expected endpoint)
- [x] `go test ./provider/aws/...` passes, `go vet` and `gofmt` clean
