### PR TITLE
ci(e2e): use rollout status for etcd instead of kubectl wait

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -60,7 +60,7 @@ kubectl apply -f e2e/provider/etcd.yaml
 
 # wait for etcd to be ready
 echo "Waiting for etcd to be ready..."
-kubectl rollout status statefulset/etcd --timeout=120s
+kubectl rollout status statefulset/etcd --timeout=300s
 
 # apply coredns deployment
 echo "Applying CoreDNS"

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -60,7 +60,7 @@ kubectl apply -f e2e/provider/etcd.yaml
 
 # wait for etcd to be ready
 echo "Waiting for etcd to be ready..."
-kubectl wait --for=condition=ready --timeout=120s pod -l app=etcd
+kubectl rollout status statefulset/etcd --timeout=120s
 
 # apply coredns deployment
 echo "Applying CoreDNS"


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->
Replace `kubectl wait pod -l app=etcd` with `kubectl rollout status statefulset/etcd` in the e2e test script.

## Motivation

<!-- What inspired you to submit this pull request? -->
kubectl wait with a label selector fails immediately with error: `no matching resources found` when no
pods exist yet. 

kubectl rollout status targets the StatefulSet resource itself (which exists immediately after kubectl apply) and blocks until all replicas are ready.

This was observed in CI:
https://github.com/kubernetes-sigs/external-dns/actions/runs/26994091190/job/79660158996

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
