### PR TITLE
feat(source): add --fqdn-* flag support to gloo-proxy source

### DIFF
--- a/docs/sources/index.md
+++ b/docs/sources/index.md
@@ -37,7 +37,7 @@ Sources are responsible for:
 | **gateway-tcproute**     | annotation,label | all,single | true          | false  | true              | gateway api         | TCPRoute.gateway.networking.k8s.io                                                    |
 | **gateway-tlsroute**     | annotation,label | all,single | true          | false  | true              | gateway api         | TLSRoute.gateway.networking.k8s.io                                                    |
 | **gateway-udproute**     | annotation,label | all,single | true          | false  | true              | gateway api         | UDPRoute.gateway.networking.k8s.io                                                    |
-| **gloo-proxy**           |                  | all,single | false         | false  | true              | service mesh        | Proxy.gloo.solo.io                                                                    |
+| **gloo-proxy**           |                  | all,single | true          | false  | true              | service mesh        | Proxy.gloo.solo.io                                                                    |
 | **ingress**              | annotation,label | all,single | true          | true   | true              | kubernetes core     | Ingress                                                                               |
 | **istio-gateway**        | annotation,label | all,single | true          | false  | true              | service mesh        | Gateway.networking.istio.io                                                           |
 | **istio-virtualservice** | annotation,label | all,single | true          | false  | true              | service mesh        | VirtualService.networking.istio.io                                                    |

--- a/source/gloo_proxy.go
+++ b/source/gloo_proxy.go
@@ -288,22 +288,17 @@ func (gs *glooSource) generateEndpointsFromProxy(p *proxy, targets endpoint.Targ
 		}
 	}
 
-	var err error
-	endpoints, err = gs.templateEngine.CombineWithEndpoints(
+	endpoints, err := gs.templateEngine.CombineWithEndpoints(
 		endpoints,
 		func() ([]*endpoint.Endpoint, error) { return gs.endpointsFromProxyFQDNTargetTemplate(p) },
 	)
 	if err != nil {
 		return nil, err
 	}
-	endpoints, err = gs.templateEngine.CombineWithEndpoints(
+	return gs.templateEngine.CombineWithEndpoints(
 		endpoints,
 		func() ([]*endpoint.Endpoint, error) { return gs.endpointsFromProxyTemplate(p) },
 	)
-	if err != nil {
-		return nil, err
-	}
-	return endpoints, nil
 }
 
 func (gs *glooSource) endpointsFromProxyTemplate(p *proxy) ([]*endpoint.Endpoint, error) {

--- a/source/gloo_proxy.go
+++ b/source/gloo_proxy.go
@@ -231,8 +231,6 @@ func (gs *glooSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, error)
 				return nil, err
 			}
 
-			unstructuredObj.SetGroupVersionKind(proxyGVR.GroupVersion().WithKind("Proxy"))
-
 			jsonData, err := json.Marshal(unstructuredObj.Object)
 			if err != nil {
 				return nil, err

--- a/source/gloo_proxy.go
+++ b/source/gloo_proxy.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
@@ -41,6 +42,7 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/source/informers"
+	"sigs.k8s.io/external-dns/source/template"
 )
 
 var (
@@ -63,9 +65,14 @@ var (
 
 // Basic redefinition of "Proxy" CRD : https://github.com/solo-io/gloo/blob/v1.4.6/projects/gloo/pkg/api/v1/proxy.pb.go
 type proxy struct {
-	metav1.TypeMeta `json:",inline"`
-	Metadata        metav1.ObjectMeta `json:"metadata"`
-	Spec            proxySpec         `json:"spec"`
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata"`
+	Spec              proxySpec `json:"spec"`
+}
+
+func (p *proxy) DeepCopyObject() runtime.Object {
+	cp := *p
+	return &cp
 }
 
 type proxySpec struct {
@@ -134,7 +141,7 @@ type proxyVirtualHostMetadataSourceResourceRef struct {
 // +externaldns:source:resources=Proxy.gloo.solo.io
 // +externaldns:source:filters=
 // +externaldns:source:namespace=all,single
-// +externaldns:source:fqdn-template=false
+// +externaldns:source:fqdn-template=true
 // +externaldns:source:provider-specific=true
 type glooSource struct {
 	serviceInformer        coreinformers.ServiceInformer
@@ -144,6 +151,7 @@ type glooSource struct {
 	gatewayInformer        kubeinformers.GenericInformer
 	// TODO: glooNamespaces is the list of namespaces to scan for Gloo Proxies. All namespace access is still required
 	glooNamespaces []string
+	templateEngine template.Engine
 }
 
 // NewGlooSource creates a new glooSource with the given config
@@ -194,12 +202,13 @@ func NewGlooSource(
 	}
 
 	return &glooSource{
-		serviceInformer,
-		ingressInformer,
-		proxyInformer,
-		virtualServiceInformer,
-		gatewayInformer,
-		cfg.GlooNamespaces,
+		serviceInformer:        serviceInformer,
+		ingressInformer:        ingressInformer,
+		proxyInformer:          proxyInformer,
+		virtualServiceInformer: virtualServiceInformer,
+		gatewayInformer:        gatewayInformer,
+		glooNamespaces:         cfg.GlooNamespaces,
+		templateEngine:         cfg.TemplateEngine,
 	}, nil
 }
 
@@ -222,6 +231,8 @@ func (gs *glooSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, error)
 				return nil, err
 			}
 
+			unstructuredObj.SetGroupVersionKind(proxyGVR.GroupVersion().WithKind("Proxy"))
+
 			jsonData, err := json.Marshal(unstructuredObj.Object)
 			if err != nil {
 				return nil, err
@@ -231,9 +242,9 @@ func (gs *glooSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, error)
 			if err = json.Unmarshal(jsonData, &proxy); err != nil {
 				return nil, err
 			}
-			log.Debugf("Gloo: Find %s proxy", proxy.Metadata.Name)
+			log.Debugf("Gloo: Find %s proxy", proxy.Name)
 
-			proxyTargets := annotations.TargetsFromTargetAnnotation(proxy.Metadata.Annotations)
+			proxyTargets := annotations.TargetsFromTargetAnnotation(proxy.Annotations)
 			if len(proxyTargets) == 0 {
 				proxyTargets, err = gs.targetsFromGatewayIngress(&proxy)
 				if err != nil {
@@ -242,30 +253,30 @@ func (gs *glooSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, error)
 			}
 
 			if len(proxyTargets) == 0 {
-				proxyTargets, err = gs.proxyTargets(proxy.Metadata.Name, ns)
+				proxyTargets, err = gs.proxyTargets(proxy.Name, ns)
 				if err != nil {
 					return nil, err
 				}
 			}
-			log.Debugf("Gloo[%s]: Find %d target(s) (%+v)", proxy.Metadata.Name, len(proxyTargets), proxyTargets)
+			log.Debugf("Gloo[%s]: Find %d target(s) (%+v)", proxy.Name, len(proxyTargets), proxyTargets)
 
 			proxyEndpoints, err := gs.generateEndpointsFromProxy(&proxy, proxyTargets)
 			if err != nil {
 				return nil, err
 			}
-			log.Debugf("Gloo[%s]: Generate %d endpoint(s)", proxy.Metadata.Name, len(proxyEndpoints))
+			log.Debugf("Gloo[%s]: Generate %d endpoint(s)", proxy.Name, len(proxyEndpoints))
 			endpoints = append(endpoints, proxyEndpoints...)
 		}
 	}
 	return endpoint.MergeEndpoints(endpoints), nil
 }
 
-func (gs *glooSource) generateEndpointsFromProxy(proxy *proxy, targets endpoint.Targets) ([]*endpoint.Endpoint, error) {
-	endpoints := []*endpoint.Endpoint{}
+func (gs *glooSource) generateEndpointsFromProxy(p *proxy, targets endpoint.Targets) ([]*endpoint.Endpoint, error) {
+	var endpoints []*endpoint.Endpoint
 
-	resource := fmt.Sprintf("proxy/%s/%s", proxy.Metadata.Namespace, proxy.Metadata.Name)
+	resource := fmt.Sprintf("proxy/%s/%s", p.Namespace, p.Name)
 
-	for _, listener := range proxy.Spec.Listeners {
+	for _, listener := range p.Spec.Listeners {
 		for _, virtualHost := range listener.HTTPListener.VirtualHosts {
 			ants, err := gs.annotationsFromProxySource(virtualHost)
 			if err != nil {
@@ -278,7 +289,60 @@ func (gs *glooSource) generateEndpointsFromProxy(proxy *proxy, targets endpoint.
 			}
 		}
 	}
+
+	var err error
+	endpoints, err = gs.templateEngine.CombineWithEndpoints(
+		endpoints,
+		func() ([]*endpoint.Endpoint, error) { return gs.endpointsFromProxyFQDNTargetTemplate(p) },
+	)
+	if err != nil {
+		return nil, err
+	}
+	endpoints, err = gs.templateEngine.CombineWithEndpoints(
+		endpoints,
+		func() ([]*endpoint.Endpoint, error) { return gs.endpointsFromProxyTemplate(p) },
+	)
+	if err != nil {
+		return nil, err
+	}
 	return endpoints, nil
+}
+
+func (gs *glooSource) endpointsFromProxyTemplate(p *proxy) ([]*endpoint.Endpoint, error) {
+	hostnames, err := gs.templateEngine.ExecFQDN(p)
+	if err != nil || len(hostnames) == 0 {
+		return nil, err
+	}
+	targets, err := gs.templateEngine.ExecTarget(p)
+	if err != nil {
+		return nil, err
+	}
+	return EndpointsForHostsAndTargets(hostnames, targets), nil
+}
+
+func (gs *glooSource) endpointsFromProxyFQDNTargetTemplate(p *proxy) ([]*endpoint.Endpoint, error) {
+	pairs, err := gs.templateEngine.ExecFQDNTarget(p)
+	if err != nil || len(pairs) == 0 {
+		return nil, err
+	}
+	endpoints := make([]*endpoint.Endpoint, 0, len(pairs))
+	for _, pair := range pairs {
+		parts := strings.SplitN(pair, ":", 2)
+		if len(parts) != 2 {
+			log.Debugf("Skipping invalid host:target pair %q from proxy %s/%s: missing ':' separator",
+				pair, p.GetNamespace(), p.GetName())
+			continue
+		}
+		host := strings.TrimSpace(parts[0])
+		target := strings.TrimSpace(parts[1])
+		if host == "" || target == "" {
+			log.Debugf("Skipping incomplete host:target pair %q from proxy %s/%s: field may not yet be populated",
+				pair, p.GetNamespace(), p.GetName())
+			continue
+		}
+		endpoints = append(endpoints, endpoint.NewEndpoint(host, endpoint.SuitableType(target), target))
+	}
+	return endpoint.MergeEndpoints(endpoints), nil
 }
 
 func (gs *glooSource) annotationsFromProxySource(virtualHost proxyVirtualHost) (map[string]string, error) {

--- a/source/gloo_proxy_fqdn_test.go
+++ b/source/gloo_proxy_fqdn_test.go
@@ -87,6 +87,7 @@ func TestGlooProxyFQDNTemplate(t *testing.T) {
 	tests := []struct {
 		title              string
 		proxyName          string
+		customProxy        *proxy // overrides makeProxy when set
 		svc                corev1.Service
 		fqdnTemplate       string
 		targetTemplate     string
@@ -193,6 +194,84 @@ func TestGlooProxyFQDNTemplate(t *testing.T) {
 				},
 			},
 		},
+		{
+			title:          "fqdn-template can reference .Kind",
+			proxyName:      "my-proxy",
+			svc:            makeEmptySvc("my-proxy"),
+			fqdnTemplate:   "{{.Kind | toLower}}.{{.Name}}.example.com",
+			targetTemplate: "lb.example.com",
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("proxy.my-proxy.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+			},
+		},
+		{
+			title:              "fqdn-target-template can reference .APIVersion",
+			proxyName:          "my-proxy",
+			svc:                makeEmptySvc("my-proxy"),
+			fqdnTargetTemplate: `{{.Name}}.{{replace "/" "." .APIVersion}}.example.com:1.2.3.4`,
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("my-proxy.gloo.solo.io.v1.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+			},
+		},
+		{
+			title: "fqdn-template with combine alongside multiple virtual-host domains",
+			customProxy: &proxy{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: proxyGVR.GroupVersion().String(),
+					Kind:       "Proxy",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "multi-host-proxy",
+					Namespace: ns,
+				},
+				Spec: proxySpec{
+					Listeners: []proxySpecListener{
+						{
+							HTTPListener: proxySpecHTTPListener{
+								VirtualHosts: []proxyVirtualHost{
+									{Domains: []string{"host1.example.com", "host2.example.com"}},
+									{Domains: []string{"host3.example.com"}},
+								},
+							},
+						},
+					},
+				},
+			},
+			svc:            makeIPSvc("multi-host-proxy", "10.0.0.2"),
+			fqdnTemplate:   "{{.Name}}.dns.example.com",
+			targetTemplate: "lb.example.com",
+			combine:        true,
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:          "host1.example.com",
+					Targets:          endpoint.Targets{"10.0.0.2"},
+					RecordType:       endpoint.RecordTypeA,
+					Labels:           endpoint.Labels{},
+					ProviderSpecific: endpoint.ProviderSpecific{},
+				},
+				{
+					DNSName:          "host2.example.com",
+					Targets:          endpoint.Targets{"10.0.0.2"},
+					RecordType:       endpoint.RecordTypeA,
+					Labels:           endpoint.Labels{},
+					ProviderSpecific: endpoint.ProviderSpecific{},
+				},
+				{
+					DNSName:          "host3.example.com",
+					Targets:          endpoint.Targets{"10.0.0.2"},
+					RecordType:       endpoint.RecordTypeA,
+					Labels:           endpoint.Labels{},
+					ProviderSpecific: endpoint.ProviderSpecific{},
+				},
+				{
+					DNSName:          "multi-host-proxy.dns.example.com",
+					Targets:          endpoint.Targets{"lb.example.com"},
+					RecordType:       endpoint.RecordTypeCNAME,
+					Labels:           endpoint.Labels{},
+					ProviderSpecific: endpoint.ProviderSpecific{},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -200,6 +279,9 @@ func TestGlooProxyFQDNTemplate(t *testing.T) {
 			t.Parallel()
 
 			p := makeProxy(tt.proxyName)
+			if tt.customProxy != nil {
+				p = *tt.customProxy
+			}
 			proxyJSON, err := json.Marshal(p)
 			require.NoError(t, err)
 

--- a/source/gloo_proxy_fqdn_test.go
+++ b/source/gloo_proxy_fqdn_test.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	fakeKube "k8s.io/client-go/kubernetes/fake"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
+	templatetest "sigs.k8s.io/external-dns/source/template/testutil"
+)
+
+func TestGlooProxyFQDNTemplate(t *testing.T) {
+	t.Parallel()
+
+	const ns = defaultGlooNamespace
+
+	// A proxy with one virtual host whose domain is "static.example.com".
+	// The backing LoadBalancer service has no IP (simulating IPAM not yet populated).
+	makeProxy := func(name string) proxy {
+		return proxy{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: proxyGVR.GroupVersion().String(),
+				Kind:       "Proxy",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+			},
+			Spec: proxySpec{
+				Listeners: []proxySpecListener{
+					{
+						HTTPListener: proxySpecHTTPListener{
+							VirtualHosts: []proxyVirtualHost{
+								{Domains: []string{"static.example.com"}},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	// Service with no LoadBalancer IP — simulates IPAM not yet populated.
+	makeEmptySvc := func(name string) corev1.Service {
+		return corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+		}
+	}
+
+	// Service with a real LoadBalancer IP.
+	makeIPSvc := func(name, ip string) corev1.Service {
+		return corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{{IP: ip}},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		title              string
+		proxyName          string
+		svc                corev1.Service
+		fqdnTemplate       string
+		targetTemplate     string
+		fqdnTargetTemplate string
+		combine            bool
+		expected           []*endpoint.Endpoint
+	}{
+		{
+			title:          "fqdn-template + target-template generate endpoint when no service IP",
+			proxyName:      "my-proxy",
+			svc:            makeEmptySvc("my-proxy"),
+			fqdnTemplate:   "{{.Name}}.example.com",
+			targetTemplate: "lb.example.com",
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("my-proxy.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+			},
+		},
+		{
+			title:              "fqdn-target-template generates endpoint when no service IP",
+			proxyName:          "my-proxy",
+			svc:                makeEmptySvc("my-proxy"),
+			fqdnTargetTemplate: "{{.Name}}.example.com:1.2.3.4",
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("my-proxy.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+			},
+		},
+		{
+			title:          "fqdn-template with combine adds template endpoint alongside virtual-host endpoint",
+			proxyName:      "my-proxy",
+			svc:            makeIPSvc("my-proxy", "10.0.0.1"),
+			fqdnTemplate:   "{{.Name}}.example.com",
+			targetTemplate: "lb.example.com",
+			combine:        true,
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:          "static.example.com",
+					Targets:          endpoint.Targets{"10.0.0.1"},
+					RecordType:       endpoint.RecordTypeA,
+					Labels:           endpoint.Labels{},
+					ProviderSpecific: endpoint.ProviderSpecific{},
+				},
+				{
+					DNSName:          "my-proxy.example.com",
+					Targets:          endpoint.Targets{"lb.example.com"},
+					RecordType:       endpoint.RecordTypeCNAME,
+					Labels:           endpoint.Labels{},
+					ProviderSpecific: endpoint.ProviderSpecific{},
+				},
+			},
+		},
+		{
+			title:              "fqdn-target-template with combine adds template endpoint alongside virtual-host endpoint",
+			proxyName:          "my-proxy",
+			svc:                makeIPSvc("my-proxy", "10.0.0.1"),
+			fqdnTargetTemplate: "{{.Name}}.example.com:lb.example.com",
+			combine:            true,
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:          "static.example.com",
+					Targets:          endpoint.Targets{"10.0.0.1"},
+					RecordType:       endpoint.RecordTypeA,
+					Labels:           endpoint.Labels{},
+					ProviderSpecific: endpoint.ProviderSpecific{},
+				},
+				{
+					DNSName:          "my-proxy.example.com",
+					Targets:          endpoint.Targets{"lb.example.com"},
+					RecordType:       endpoint.RecordTypeCNAME,
+					Labels:           endpoint.Labels{},
+					ProviderSpecific: endpoint.ProviderSpecific{},
+				},
+			},
+		},
+		{
+			title:          "fqdn-template without combine is ignored when virtual-host endpoints exist",
+			proxyName:      "my-proxy",
+			svc:            makeIPSvc("my-proxy", "10.0.0.1"),
+			fqdnTemplate:   "{{.Name}}.example.com",
+			targetTemplate: "lb.example.com",
+			combine:        false,
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:          "static.example.com",
+					Targets:          endpoint.Targets{"10.0.0.1"},
+					RecordType:       endpoint.RecordTypeA,
+					Labels:           endpoint.Labels{},
+					ProviderSpecific: endpoint.ProviderSpecific{},
+				},
+			},
+		},
+		{
+			title:              "fqdn-target-template without combine is ignored when virtual-host endpoints exist",
+			proxyName:          "my-proxy",
+			svc:                makeIPSvc("my-proxy", "10.0.0.1"),
+			fqdnTargetTemplate: "{{.Name}}.example.com:lb.example.com",
+			combine:            false,
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:          "static.example.com",
+					Targets:          endpoint.Targets{"10.0.0.1"},
+					RecordType:       endpoint.RecordTypeA,
+					Labels:           endpoint.Labels{},
+					ProviderSpecific: endpoint.ProviderSpecific{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			t.Parallel()
+
+			p := makeProxy(tt.proxyName)
+			proxyJSON, err := json.Marshal(p)
+			require.NoError(t, err)
+
+			proxyObj := unstructured.Unstructured{}
+			require.NoError(t, proxyObj.UnmarshalJSON(proxyJSON))
+
+			fakeDynamicClient := newGlooDynamicClient(&proxyObj)
+			fakeKubernetesClient := fakeKube.NewSimpleClientset(&tt.svc)
+
+			src, err := NewGlooSource(t.Context(), fakeDynamicClient, fakeKubernetesClient, &Config{
+				GlooNamespaces: []string{ns},
+				TemplateEngine: templatetest.MustEngine(t, tt.fqdnTemplate, tt.targetTemplate, tt.fqdnTargetTemplate, tt.combine),
+			})
+			require.NoError(t, err)
+
+			// Wait for the proxy to appear in the lister cache.
+			count := &unstructured.UnstructuredList{}
+			for len(count.Items) < 1 {
+				count, _ = fakeDynamicClient.Resource(proxyGVR).Namespace(ns).List(t.Context(), metav1.ListOptions{})
+			}
+
+			endpoints, err := src.Endpoints(t.Context())
+			assert.NoError(t, err)
+			testutils.ValidateEndpoints(t, endpoints, tt.expected)
+		})
+	}
+}

--- a/source/gloo_proxy_test.go
+++ b/source/gloo_proxy_test.go
@@ -47,7 +47,7 @@ var (
 			APIVersion: proxyGVR.GroupVersion().String(),
 			Kind:       "Proxy",
 		},
-		Metadata: metav1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "internal",
 			Namespace: defaultGlooNamespace,
 		},
@@ -88,8 +88,8 @@ var (
 	}
 	internalProxySvc = corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      internalProxy.Metadata.Name,
-			Namespace: internalProxy.Metadata.Namespace,
+			Name:      internalProxy.Name,
+			Namespace: internalProxy.Namespace,
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeLoadBalancer,
@@ -126,7 +126,7 @@ var (
 			APIVersion: proxyGVR.GroupVersion().String(),
 			Kind:       "Proxy",
 		},
-		Metadata: metav1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "external",
 			Namespace: defaultGlooNamespace,
 		},
@@ -167,8 +167,8 @@ var (
 	}
 	externalProxySvc = corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      externalProxy.Metadata.Name,
-			Namespace: externalProxy.Metadata.Namespace,
+			Name:      externalProxy.Name,
+			Namespace: externalProxy.Namespace,
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeLoadBalancer,
@@ -205,7 +205,7 @@ var (
 			APIVersion: proxyGVR.GroupVersion().String(),
 			Kind:       "Proxy",
 		},
-		Metadata: metav1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "internal-static",
 			Namespace: defaultGlooNamespace,
 		},
@@ -250,8 +250,8 @@ var (
 	}
 	proxyWithMetadataStaticSvc = corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      proxyWithMetadataStatic.Metadata.Name,
-			Namespace: proxyWithMetadataStatic.Metadata.Namespace,
+			Name:      proxyWithMetadataStatic.Name,
+			Namespace: proxyWithMetadataStatic.Namespace,
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeLoadBalancer,
@@ -288,7 +288,7 @@ var (
 			APIVersion: proxyGVR.GroupVersion().String(),
 			Kind:       "Proxy",
 		},
-		Metadata: metav1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "target-ann",
 			Namespace: defaultGlooNamespace,
 			Annotations: map[string]string{
@@ -332,8 +332,8 @@ var (
 	}
 	targetAnnotatedProxySvc = corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      targetAnnotatedProxy.Metadata.Name,
-			Namespace: targetAnnotatedProxy.Metadata.Namespace,
+			Name:      targetAnnotatedProxy.Name,
+			Namespace: targetAnnotatedProxy.Namespace,
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeLoadBalancer,
@@ -370,7 +370,7 @@ var (
 			APIVersion: proxyGVR.GroupVersion().String(),
 			Kind:       "Proxy",
 		},
-		Metadata: metav1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "gateway-ingress-annotated",
 			Namespace: defaultGlooNamespace,
 		},

--- a/source/traefik_proxy.go
+++ b/source/traefik_proxy.go
@@ -273,6 +273,7 @@ func (ts *traefikSource) ingressRouteTCPEndpoints() ([]*endpoint.Endpoint, error
 		if err != nil {
 			return nil, err
 		}
+		ingressRouteTCP.GetObjectKind().SetGroupVersionKind(unstructuredHost.GetObjectKind().GroupVersionKind())
 		ingressRouteTCPs = append(ingressRouteTCPs, ingressRouteTCP)
 	}
 
@@ -924,7 +925,10 @@ func (ts *traefikSource) endpointsFromFQDNTargetTemplate(obj traefikObject) ([]*
 // 3. Filters the converted objects based on the annotation filter.
 // 4. Generates endpoints for each filtered object using the generateEndpoints function.
 // Returns a list of generated endpoints or an error if any step fails.
-func extractEndpoints[T annotations.AnnotatedObject](
+func extractEndpoints[T interface {
+	annotations.AnnotatedObject
+	runtime.Object
+}](
 	informer cache.GenericLister,
 	namespace string,
 	convertFunc func(*unstructured.Unstructured) (T, error),
@@ -949,6 +953,7 @@ func extractEndpoints[T annotations.AnnotatedObject](
 		if err != nil {
 			return nil, err
 		}
+		typed.GetObjectKind().SetGroupVersionKind(unstructuredObj.GetObjectKind().GroupVersionKind())
 		typedObjs = append(typedObjs, typed)
 	}
 

--- a/source/traefik_proxy_fqdn_test.go
+++ b/source/traefik_proxy_fqdn_test.go
@@ -159,6 +159,47 @@ func TestTraefikFQDNTemplateIngressRoute(t *testing.T) {
 				},
 			},
 		},
+		{
+			title: "fqdn-template can reference .Kind",
+			ingressRoute: IngressRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: ingressRouteGVR.GroupVersion().String(),
+					Kind:       "IngressRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-app",
+					Namespace: defaultTraefikNamespace,
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "traefik",
+					},
+				},
+			},
+			fqdnTemplate:   "{{.Kind | toLower}}.{{.Name}}.example.com",
+			targetTemplate: "lb.example.com",
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("ingressroute.my-app.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+			},
+		},
+		{
+			title: "fqdn-target-template can reference .APIVersion",
+			ingressRoute: IngressRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: ingressRouteGVR.GroupVersion().String(),
+					Kind:       "IngressRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-app",
+					Namespace: defaultTraefikNamespace,
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "traefik",
+					},
+				},
+			},
+			fqdnTargetTemplate: `{{.Name}}.{{replace "/" "." .APIVersion}}.example.com:1.2.3.4`,
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("my-app.traefik.io.v1alpha1.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -292,6 +333,47 @@ func TestTraefikFQDNTemplateIngressRouteTCP(t *testing.T) {
 				},
 			},
 		},
+		{
+			title: "fqdn-template can reference .Kind",
+			ingressRouteTCP: IngressRouteTCP{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: ingressRouteTCPGVR.GroupVersion().String(),
+					Kind:       "IngressRouteTCP",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-tcp-app",
+					Namespace: defaultTraefikNamespace,
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "traefik",
+					},
+				},
+			},
+			fqdnTemplate:   "{{.Kind | toLower}}.{{.Name}}.example.com",
+			targetTemplate: "lb.example.com",
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("ingressroutetcp.my-tcp-app.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+			},
+		},
+		{
+			title: "fqdn-target-template can reference .APIVersion",
+			ingressRouteTCP: IngressRouteTCP{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: ingressRouteTCPGVR.GroupVersion().String(),
+					Kind:       "IngressRouteTCP",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-tcp-app",
+					Namespace: defaultTraefikNamespace,
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "traefik",
+					},
+				},
+			},
+			fqdnTargetTemplate: `{{.Name}}.{{replace "/" "." .APIVersion}}.example.com:1.2.3.4`,
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("my-tcp-app.traefik.io.v1alpha1.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -419,6 +501,47 @@ func TestTraefikFQDNTemplateIngressRouteUDP(t *testing.T) {
 					Labels:           endpoint.Labels{},
 					ProviderSpecific: endpoint.ProviderSpecific{},
 				},
+			},
+		},
+		{
+			title: "fqdn-template can reference .Kind",
+			ingressRouteUDP: IngressRouteUDP{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: ingressRouteUDPGVR.GroupVersion().String(),
+					Kind:       "IngressRouteUDP",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-udp-app",
+					Namespace: defaultTraefikNamespace,
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "traefik",
+					},
+				},
+			},
+			fqdnTemplate:   "{{.Kind | toLower}}.{{.Name}}.example.com",
+			targetTemplate: "lb.example.com",
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("ingressrouteudp.my-udp-app.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+			},
+		},
+		{
+			title: "fqdn-target-template can reference .APIVersion",
+			ingressRouteUDP: IngressRouteUDP{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: ingressRouteUDPGVR.GroupVersion().String(),
+					Kind:       "IngressRouteUDP",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-udp-app",
+					Namespace: defaultTraefikNamespace,
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "traefik",
+					},
+				},
+			},
+			fqdnTargetTemplate: `{{.Name}}.{{replace "/" "." .APIVersion}}.example.com:1.2.3.4`,
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("my-udp-app.traefik.io.v1alpha1.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 	}


### PR DESCRIPTION
## What does it do ?

 - gloo-proxy source now accepts cfg.TemplateEngine and applies the same two-step CombineWithEndpoints flow established by traefik-proxy and F5 sources
 - traefik add fqdn support for `.Kind` and `.APIVersion`

## Motivation

  - The gloo-proxy source had no way to derive DNS names from Proxy resource metadata (name, namespace, labels) without annotations — the same gap that existed in the
  traefik-proxy and F5 sources before PRs #6468/#6470
  - Users running Gloo with external IPAM (where the LoadBalancer IP is not yet populated) had no fallback mechanism to generate DNS records; templates fill that gap via
  --target-template or --fqdn-target-template

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
