### PR TITLE
fix(coredns): write PTR records without random prefix to etcd

### DIFF
--- a/docs/tutorials/coredns-etcd.md
+++ b/docs/tutorials/coredns-etcd.md
@@ -251,7 +251,132 @@ dig +short @coredns.default.svc.cluster.local aa.example.org AAAA
 ❯❯ 2001:db8::1
 ```
 
-### 6. Cleanup
+### 6. PTR records (reverse DNS) — optional
+
+Once forward DNS works, you can optionally enable reverse lookups (PTR records).
+ExternalDNS can write PTR records into the same etcd backend — mapping IP addresses back
+to hostnames (e.g. `172.18.0.2 → my-service`).
+
+Two things are different from the forward-zone setup:
+
+- ExternalDNS needs the `--managed-record-types=PTR` flag (default only manages A, CNAME, TXT).
+- The `--domain-filter` must match the reverse zone you want to manage (e.g. `18.172.in-addr.arpa`).
+
+> **CoreDNS limitation:** the etcd plugin stores exactly **one** PTR record per reverse-DNS
+> key. ExternalDNS writes at the exact reverse-DNS path (e.g.
+> `/skydns/arpa/in-addr/172/18/0/2`) without any random suffix, so multiple targets for
+> the same IP are not supported — the last target wins.
+
+#### Step 6a. Add the reverse zone to CoreDNS
+
+Edit `docs/snippets/tutorials/coredns/values-coredns.yaml` and add a **second** `etcd`
+plugin block for the reverse zone, right after the existing `example.org` block:
+
+```yaml
+      # existing block (forward zone)
+      - name: etcd
+        parameters: "example.org"
+        configBlock: |
+          stubzones
+          path /skydns
+          endpoint http://etcd.default.svc.cluster.local:2379
+          fallthrough
+      # ▼ NEW — reverse zone for PTR
+      - name: etcd
+        parameters: "18.172.in-addr.arpa"
+        configBlock: |
+          path /skydns
+          endpoint http://etcd.default.svc.cluster.local:2379
+```
+
+Upgrade CoreDNS and wait for rollout:
+
+```sh
+helm upgrade coredns coredns/coredns \
+  -f docs/snippets/tutorials/coredns/values-coredns.yaml \
+  -n default
+kubectl rollout status deploy/coredns
+```
+
+#### Step 6b. Reconfigure ExternalDNS for the reverse zone
+
+When running from source, add the two flags:
+
+```sh
+export ETCD_URLS="http://127.0.0.1:32379"
+
+go run main.go \
+    --provider=coredns \
+    --source=service \
+    --managed-record-types=PTR \
+    --domain-filter=18.172.in-addr.arpa \
+    --log-level=debug
+```
+
+When running via Helm, update the values (`domainFilters` and `managedRecordTypes`):
+
+```yaml
+domainFilters:
+  - 18.172.in-addr.arpa      # ← was: example.org
+
+managedRecordTypes:
+  - PTR                       # ← add PTR (default: A, CNAME, TXT)
+```
+
+```sh
+helm upgrade external-dns external-dns/external-dns \
+  -f docs/snippets/tutorials/coredns/values-extdns-coredns.yaml \
+  -n default
+```
+
+#### Step 6c. Create a PTR-enabled service
+
+Annotate a service with the reverse-DNS hostname (`<reversed-ip>.in-addr.arpa`).
+The IP in the annotation must match the service's load-balancer IP:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  annotations:
+    external-dns.kubernetes.io/hostname: 2.0.18.172.in-addr.arpa
+    cluster-name: "cluster1"
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 80
+  selector:
+    app: my-app
+```
+
+Patch the status IP so ExternalDNS picks it up:
+
+```sh
+kubectl apply -f - <<EOF
+<service manifest above>
+EOF
+
+kubectl patch svc my-service --type=merge \
+  -p '{"status":{"loadBalancer":{"ingress":[{"ip":"172.18.0.2"}]}}}' \
+  --subresource=status
+```
+
+#### Step 6d. Verify
+
+```sh
+# The etcd key sits at the exact reverse-DNS path — no random prefix
+kubectl exec -it etcd-0 -- etcdctl get /skydns/arpa/in-addr/172/18/0/2
+# /skydns/arpa/in-addr/172/18/0/2
+# {"host":"my-service","ttl":0}
+
+# Reverse DNS lookup via CoreDNS
+kubectl run --rm -it dnsutils --image=infoblox/dnstools --restart=Never -- \
+  dig +short @coredns.default.svc.cluster.local -x 172.18.0.2
+# my-service.
+```
+
+### 7. Cleanup
 
 ```sh
 kind delete cluster --name coredns-etcd

--- a/provider/coredns/coredns.go
+++ b/provider/coredns/coredns.go
@@ -53,7 +53,7 @@ const (
 var (
 	// avoids allocating a new slice on every call
 	// prevents unwanted deletion of etcd keys based on labels
-	skipLabels = []string{originalTextLabel, "prefix", "resource", endpoint.OwnerLabelKey}
+	skipLabels = []string{originalTextLabel, randomPrefixLabel, "resource", endpoint.OwnerLabelKey}
 )
 
 // coreDNSClient is an interface to work with CoreDNS service records in etcd

--- a/provider/coredns/coredns.go
+++ b/provider/coredns/coredns.go
@@ -221,11 +221,11 @@ func (c etcdClient) DeleteService(ctx context.Context, key string, exact bool) e
 		}
 		return err
 	}
-	if exact {
-		_, err := c.client.Delete(ctx, key)
-		return err
+	var delOpts []etcdcv3.OpOption
+	if !exact {
+		delOpts = append(delOpts, etcdcv3.WithPrefix())
 	}
-	_, err := c.client.Delete(ctx, key, etcdcv3.WithPrefix())
+	_, err := c.client.Delete(ctx, key, delOpts...)
 	return err
 }
 

--- a/provider/coredns/coredns.go
+++ b/provider/coredns/coredns.go
@@ -47,19 +47,20 @@ const (
 
 	randomPrefixLabel     = "prefix"
 	providerSpecificGroup = "coredns/group"
+	originalTextLabel     = "originalText"
 )
 
 var (
 	// avoids allocating a new slice on every call
 	// prevents unwanted deletion of etcd keys based on labels
-	skipLabels = []string{"originalText", "prefix", "resource", endpoint.OwnerLabelKey}
+	skipLabels = []string{originalTextLabel, "prefix", "resource", endpoint.OwnerLabelKey}
 )
 
 // coreDNSClient is an interface to work with CoreDNS service records in etcd
 type coreDNSClient interface {
 	GetServices(ctx context.Context, prefix string) ([]*Service, error)
 	SaveService(ctx context.Context, value *Service) error
-	DeleteService(ctx context.Context, key string) error
+	DeleteService(ctx context.Context, key string, exact bool) error
 }
 
 type coreDNSProvider struct {
@@ -188,13 +189,19 @@ func (c etcdClient) SaveService(ctx context.Context, service *Service) error {
 	return nil
 }
 
-// DeleteService deletes service record from etcd
-func (c etcdClient) DeleteService(ctx context.Context, key string) error {
+// DeleteService deletes service record from etcd.
+// If exact is true, only the single key is deleted. Otherwise all keys sharing
+// the key as a byte-prefix are removed (etcd WithPrefix semantics).
+func (c etcdClient) DeleteService(ctx context.Context, key string, exact bool) error {
 	ctx, cancel := context.WithTimeout(ctx, etcdTimeout)
 	defer cancel()
 
 	if c.strictlyOwned {
-		rs, err := c.client.Get(ctx, key, etcdcv3.WithPrefix())
+		var getOpts []etcdcv3.OpOption
+		if !exact {
+			getOpts = append(getOpts, etcdcv3.WithPrefix())
+		}
+		rs, err := c.client.Get(ctx, key, getOpts...)
 		if err != nil {
 			return err
 		}
@@ -213,10 +220,13 @@ func (c etcdClient) DeleteService(ctx context.Context, key string) error {
 			}
 		}
 		return err
-	} else {
-		_, err := c.client.Delete(ctx, key, etcdcv3.WithPrefix())
+	}
+	if exact {
+		_, err := c.client.Delete(ctx, key)
 		return err
 	}
+	_, err := c.client.Delete(ctx, key, etcdcv3.WithPrefix())
+	return err
 }
 
 func (c etcdClient) unmarshalService(n *mvccpb.KeyValue) (*Service, error) {
@@ -325,9 +335,13 @@ func (p coreDNSProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, err
 				ep.Targets = append(ep.Targets, service.Host)
 				log.Debugf("Extending ep (%s) with new service host (%s)", ep, service.Host)
 			} else {
+				recordType := guessRecordType(service.Host)
+				if isPTRDomain(dnsName) {
+					recordType = endpoint.RecordTypePTR
+				}
 				ep = endpoint.NewEndpointWithTTL(
 					dnsName,
-					guessRecordType(service.Host),
+					recordType,
 					endpoint.TTL(service.TTL),
 					service.Host,
 				)
@@ -339,7 +353,7 @@ func (p coreDNSProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, err
 			if p.strictlyOwned {
 				ep.Labels[endpoint.OwnerLabelKey] = service.Owner
 			}
-			ep.Labels["originalText"] = service.Text
+			ep.Labels[originalTextLabel] = service.Text
 			ep.Labels[randomPrefixLabel] = prefix
 			ep.Labels[service.Host] = prefix
 			result = append(result, ep)
@@ -421,6 +435,19 @@ func (p coreDNSProvider) createServicesForEndpoint(ctx context.Context, dnsName 
 	var services []*Service
 
 	for _, target := range ep.Targets {
+		if ep.RecordType == endpoint.RecordTypePTR {
+			// CoreDNS etcd plugin expects PTR records at the exact reverse-DNS
+			// path (e.g., /skydns/arpa/in-addr/172/26/0/2) without any unique suffix.
+			services = append(services, &Service{
+				Host:        target,
+				Text:        ep.Labels[originalTextLabel],
+				Key:         p.etcdKeyFor(dnsName),
+				TargetStrip: 0,
+				TTL:         uint32(ep.RecordTTL),
+			})
+			continue
+		}
+
 		prefix := ep.Labels[target]
 		if prefix == "" {
 			prefix = fmt.Sprintf("%08x", rand.Int31())
@@ -432,7 +459,7 @@ func (p coreDNSProvider) createServicesForEndpoint(ctx context.Context, dnsName 
 		}
 		service := Service{
 			Host:        target,
-			Text:        ep.Labels["originalText"],
+			Text:        ep.Labels[originalTextLabel],
 			Key:         p.etcdKeyFor(prefix + "." + dnsName),
 			TargetStrip: strings.Count(prefix, ".") + 1,
 			TTL:         uint32(ep.RecordTTL),
@@ -442,14 +469,21 @@ func (p coreDNSProvider) createServicesForEndpoint(ctx context.Context, dnsName 
 		ep.Labels[target] = prefix
 	}
 
-	// Clean outdated labels
+	// Clean outdated labels.
+	// For PTR records, all targets share the same etcd key (the exact
+	// reverse-DNS path). Stale labels are superseded by the in-place overwrite
+	// from the new target — issuing a delete would either be a no-op (save
+	// restores the key) or, worse, delete a sibling key that shares the same
+	// byte-prefix. So skip stale-label cleanup entirely for PTR records.
+	if ep.RecordType == endpoint.RecordTypePTR {
+		return services, nil
+	}
 	for label, labelPrefix := range ep.Labels {
 		if slices.Contains(skipLabels, label) {
 			continue
 		}
 		if !slices.Contains(ep.Targets, label) {
-			err := p.deleteByDnsName(ctx, labelPrefix+"."+dnsName)
-			if err != nil {
+			if err := p.deleteByDnsName(ctx, labelPrefix+"."+dnsName, false); err != nil {
 				return nil, err
 			}
 		}
@@ -459,19 +493,31 @@ func (p coreDNSProvider) createServicesForEndpoint(ctx context.Context, dnsName 
 
 // updateTXTRecords updates the TXT records in the provided services slice based on the given group of endpoints.
 func (p coreDNSProvider) updateTXTRecords(dnsName string, group []*endpoint.Endpoint, services []*Service) []*Service {
+	isPTR := isPTRDomain(dnsName)
 	index := 0
 	for _, ep := range group {
 		if ep.RecordType != endpoint.RecordTypeTXT {
 			continue
 		}
 		if index >= len(services) {
-			prefix := ep.Labels[randomPrefixLabel]
-			if prefix == "" {
-				prefix = fmt.Sprintf("%08x", rand.Int31())
+			var key string
+			var targetStrip int
+			if isPTR {
+				// PTR reverse zones must not have a random prefix — CoreDNS
+				// expects the key at the exact reverse-DNS path.
+				key = p.etcdKeyFor(dnsName)
+				targetStrip = 0
+			} else {
+				prefix := ep.Labels[randomPrefixLabel]
+				if prefix == "" {
+					prefix = fmt.Sprintf("%08x", rand.Int31())
+				}
+				key = p.etcdKeyFor(prefix + "." + dnsName)
+				targetStrip = strings.Count(prefix, ".") + 1
 			}
 			services = append(services, &Service{
-				Key:         p.etcdKeyFor(prefix + "." + dnsName),
-				TargetStrip: strings.Count(prefix, ".") + 1,
+				Key:         key,
+				TargetStrip: targetStrip,
 				TTL:         uint32(ep.RecordTTL),
 			})
 		}
@@ -491,7 +537,8 @@ func (p coreDNSProvider) deleteEndpoints(ctx context.Context, endpoints []*endpo
 		if ep.Labels[randomPrefixLabel] != "" {
 			dnsName = ep.Labels[randomPrefixLabel] + "." + dnsName
 		}
-		err := p.deleteByDnsName(ctx, dnsName)
+		exact := ep.RecordType == endpoint.RecordTypePTR || ep.RecordType == endpoint.RecordTypeTXT
+		err := p.deleteByDnsName(ctx, dnsName, exact)
 		if err != nil {
 			return err
 		}
@@ -499,13 +546,13 @@ func (p coreDNSProvider) deleteEndpoints(ctx context.Context, endpoints []*endpo
 	return nil
 }
 
-func (p coreDNSProvider) deleteByDnsName(ctx context.Context, dnsName string) error {
+func (p coreDNSProvider) deleteByDnsName(ctx context.Context, dnsName string, exact bool) error {
 	key := p.etcdKeyFor(dnsName)
-	log.Infof("Delete key %s", key)
+	log.Infof("Delete key %s (exact=%v)", key, exact)
 	if p.dryRun {
 		return nil
 	}
-	if err := p.client.DeleteService(ctx, key); err != nil {
+	if err := p.client.DeleteService(ctx, key, exact); err != nil {
 		return err
 	}
 	return nil
@@ -515,6 +562,10 @@ func (p coreDNSProvider) etcdKeyFor(dnsName string) string {
 	domains := strings.Split(dnsName, ".")
 	reverse(domains)
 	return p.coreDNSPrefix + strings.Join(domains, "/")
+}
+
+func isPTRDomain(dnsName string) bool {
+	return strings.HasSuffix(dnsName, ".in-addr.arpa") || strings.HasSuffix(dnsName, ".ip6.arpa")
 }
 
 func guessRecordType(target string) string {

--- a/provider/coredns/coredns.go
+++ b/provider/coredns/coredns.go
@@ -436,6 +436,10 @@ func (p coreDNSProvider) createServicesForEndpoint(ctx context.Context, dnsName 
 
 	for _, target := range ep.Targets {
 		if ep.RecordType == endpoint.RecordTypePTR {
+			if len(ep.Targets) > 1 {
+				log.Warnf("PTR %s has %d targets; CoreDNS etcd backend stores one target per reverse-DNS key, using %q and ignoring %v",
+					dnsName, len(ep.Targets), ep.Targets[0], ep.Targets[1:])
+			}
 			// CoreDNS etcd plugin expects PTR records at the exact reverse-DNS
 			// path (e.g., /skydns/arpa/in-addr/172/26/0/2) without any unique suffix.
 			services = append(services, &Service{

--- a/provider/coredns/coredns_test.go
+++ b/provider/coredns/coredns_test.go
@@ -41,10 +41,11 @@ import (
 const defaultCoreDNSPrefix = "/skydns/"
 
 type fakeETCDClient struct {
-	services map[string]Service
+	services    map[string]Service
+	deletedKeys []string
 }
 
-func (c fakeETCDClient) GetServices(_ context.Context, prefix string) ([]*Service, error) {
+func (c *fakeETCDClient) GetServices(_ context.Context, prefix string) ([]*Service, error) {
 	var result []*Service
 	for key, value := range c.services {
 		if strings.HasPrefix(key, prefix) {
@@ -56,13 +57,26 @@ func (c fakeETCDClient) GetServices(_ context.Context, prefix string) ([]*Servic
 	return result, nil
 }
 
-func (c fakeETCDClient) SaveService(_ context.Context, service *Service) error {
+func (c *fakeETCDClient) SaveService(_ context.Context, service *Service) error {
 	c.services[service.Key] = *service
 	return nil
 }
 
-func (c fakeETCDClient) DeleteService(_ context.Context, key string) error {
-	delete(c.services, key)
+// DeleteService mirrors real etcd DeleteService semantics:
+// exact=false uses WithPrefix (range delete of all keys byte-prefixed by key),
+// exact=true deletes only the single key.
+// Also records all keys passed to DeleteService for test assertions.
+func (c *fakeETCDClient) DeleteService(_ context.Context, key string, exact bool) error {
+	c.deletedKeys = append(c.deletedKeys, key)
+	if exact {
+		delete(c.services, key)
+		return nil
+	}
+	for k := range c.services {
+		if strings.HasPrefix(k, key) {
+			delete(c.services, k)
+		}
+	}
 	return nil
 }
 
@@ -171,10 +185,9 @@ func TestAServiceTranslation(t *testing.T) {
 	expectedDNSName := "example.com"
 	expectedRecordType := endpoint.RecordTypeA
 
-	client := fakeETCDClient{
-		map[string]Service{
-			"/skydns/com/example": {Host: expectedTarget},
-		},
+	client := &fakeETCDClient{services: map[string]Service{
+		"/skydns/com/example": {Host: expectedTarget},
+	},
 	}
 	provider := coreDNSProvider{
 		client:        client,
@@ -218,9 +231,7 @@ func TestGuessRecordType(t *testing.T) {
 // It asserts both record types survive an apply + read round-trip with the correct
 // type (A stays A, AAAA stays AAAA), and that a second reconcile is a no-op.
 func TestCoreDNSRoundTrip(t *testing.T) {
-	client := fakeETCDClient{
-		map[string]Service{},
-	}
+	client := &fakeETCDClient{services: map[string]Service{}}
 	coredns := coreDNSProvider{
 		client:        client,
 		coreDNSPrefix: defaultCoreDNSPrefix,
@@ -270,10 +281,9 @@ func TestCNAMEServiceTranslation(t *testing.T) {
 	expectedDNSName := "example.com"
 	expectedRecordType := endpoint.RecordTypeCNAME
 
-	client := fakeETCDClient{
-		map[string]Service{
-			"/skydns/com/example": {Host: expectedTarget},
-		},
+	client := &fakeETCDClient{services: map[string]Service{
+		"/skydns/com/example": {Host: expectedTarget},
+	},
 	}
 	provider := coreDNSProvider{
 		client:        client,
@@ -300,10 +310,9 @@ func TestTXTServiceTranslation(t *testing.T) {
 	expectedDNSName := "example.com"
 	expectedRecordType := endpoint.RecordTypeTXT
 
-	client := fakeETCDClient{
-		map[string]Service{
-			"/skydns/com/example": {Text: expectedTarget},
-		},
+	client := &fakeETCDClient{services: map[string]Service{
+		"/skydns/com/example": {Text: expectedTarget},
+	},
 	}
 	provider := coreDNSProvider{
 		client:        client,
@@ -332,10 +341,9 @@ func TestAWithTXTServiceTranslation(t *testing.T) {
 	}
 	expectedDNSName := "example.com"
 
-	client := fakeETCDClient{
-		map[string]Service{
-			"/skydns/com/example": {Host: "1.2.3.4", Text: "string"},
-		},
+	client := &fakeETCDClient{services: map[string]Service{
+		"/skydns/com/example": {Host: "1.2.3.4", Text: "string"},
+	},
 	}
 	provider := coreDNSProvider{
 		client:        client,
@@ -372,10 +380,9 @@ func TestCNAMEWithTXTServiceTranslation(t *testing.T) {
 	}
 	expectedDNSName := "example.com"
 
-	client := fakeETCDClient{
-		map[string]Service{
-			"/skydns/com/example": {Host: "example.net", Text: "string"},
-		},
+	client := &fakeETCDClient{services: map[string]Service{
+		"/skydns/com/example": {Host: "example.net", Text: "string"},
+	},
 	}
 	provider := coreDNSProvider{
 		client:        client,
@@ -405,10 +412,62 @@ func TestCNAMEWithTXTServiceTranslation(t *testing.T) {
 	}
 }
 
-func TestCoreDNSApplyChanges(t *testing.T) {
-	client := fakeETCDClient{
-		map[string]Service{},
+// Deleting a TXT ownership marker must NOT delete the sibling A record that
+// shares the same dnsName. TXT keys (e.g. /skydns/local/domain1) are byte-
+// prefixes of A keys (/skydns/local/domain1/<random>); WithPrefix delete on
+// the TXT key would range-delete the A key too.
+func TestDeleteTXTDoesNotOverDeleteARecord(t *testing.T) {
+	client := &fakeETCDClient{services: map[string]Service{}}
+	coredns := coreDNSProvider{client: client, coreDNSPrefix: defaultCoreDNSPrefix}
+
+	// Create A + TXT for domain1, and A for domain2
+	err := coredns.ApplyChanges(t.Context(), &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("domain1.local", endpoint.RecordTypeA, "5.5.5.5"),
+			endpoint.NewEndpoint("domain1.local", endpoint.RecordTypeTXT, "owner-marker"),
+			endpoint.NewEndpoint("domain2.local", endpoint.RecordTypeA, "6.6.6.6"),
+		},
+	})
+	require.NoError(t, err)
+
+	// Verify A record exists for domain1 before delete
+	foundBefore := false
+	for _, svc := range client.services {
+		if svc.Host == "5.5.5.5" {
+			foundBefore = true
+		}
 	}
+	require.True(t, foundBefore, "A record must exist before TXT delete")
+
+	// Delete ONLY the TXT for domain1 (not the A record)
+	err = coredns.ApplyChanges(t.Context(), &plan.Changes{
+		Delete: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("domain1.local", endpoint.RecordTypeTXT, "owner-marker"),
+		},
+	})
+	require.NoError(t, err)
+
+	// domain1's A record must survive
+	foundA := false
+	for _, svc := range client.services {
+		if svc.Host == "5.5.5.5" {
+			foundA = true
+		}
+	}
+	assert.True(t, foundA, "TXT delete must NOT delete sibling A record (WithPrefix over-delete)")
+
+	// domain2's A record must also survive
+	foundD2 := false
+	for _, svc := range client.services {
+		if svc.Host == "6.6.6.6" {
+			foundD2 = true
+		}
+	}
+	assert.True(t, foundD2, "domain2 A record must be unaffected")
+}
+
+func TestCoreDNSApplyChanges(t *testing.T) {
+	client := &fakeETCDClient{services: map[string]Service{}}
 	coredns := coreDNSProvider{
 		client:        client,
 		coreDNSPrefix: defaultCoreDNSPrefix,
@@ -489,9 +548,7 @@ func TestCoreDNSApplyChanges(t *testing.T) {
 }
 
 func TestCoreDNSApplyChanges_DomainDoNotMatch(t *testing.T) {
-	client := fakeETCDClient{
-		map[string]Service{},
-	}
+	client := &fakeETCDClient{services: map[string]Service{}}
 	coredns := coreDNSProvider{
 		client:        client,
 		coreDNSPrefix: defaultCoreDNSPrefix,
@@ -823,7 +880,7 @@ func TestDeleteService(t *testing.T) {
 				},
 			}
 
-			err := c.DeleteService(t.Context(), tt.key)
+			err := c.DeleteService(t.Context(), tt.key, false)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -962,7 +1019,7 @@ func TestDeleteServiceWithStrictlyOwned(t *testing.T) {
 				strictlyOwned: true,
 			}
 
-			err := c.DeleteService(t.Context(), tt.key)
+			err := c.DeleteService(t.Context(), tt.key, false)
 
 			require.NoError(t, err)
 			mockKV.AssertExpectations(t)
@@ -1370,9 +1427,7 @@ func TestCoreDNSProvider_updateTXTRecords_ClearsExtraText(t *testing.T) {
 }
 
 func TestApplyChangesAWithGroupServiceTranslation(t *testing.T) {
-	client := fakeETCDClient{
-		map[string]Service{},
-	}
+	client := &fakeETCDClient{services: map[string]Service{}}
 	coredns := coreDNSProvider{
 		client:        client,
 		coreDNSPrefix: defaultCoreDNSPrefix,
@@ -1397,14 +1452,13 @@ func TestApplyChangesAWithGroupServiceTranslation(t *testing.T) {
 
 // Prevents unwanted deletion of etcd keys https://github.com/kubernetes-sigs/external-dns/commit/83ea480c57fcc6beeaf8a6a3e8446cb87e07415d
 func TestApplyChangesPreventCleanupForKnownLabels(t *testing.T) {
-	client := fakeETCDClient{
-		map[string]Service{
-			"/skydns/local/domain1/test":         {Host: "10.0.0.0"},
-			"/skydns/local/domain1/originalText": {Host: "10.0.0.0"},
-			"/skydns/local/domain1/prefix":       {Host: "10.0.0.0"},
-			"/skydns/local/domain1/resource":     {Host: "10.0.0.0"},
-			"/skydns/local/domain1/owner":        {Host: "10.0.0.0"},
-		},
+	client := &fakeETCDClient{services: map[string]Service{
+		"/skydns/local/domain1/test":         {Host: "10.0.0.0"},
+		"/skydns/local/domain1/originalText": {Host: "10.0.0.0"},
+		"/skydns/local/domain1/prefix":       {Host: "10.0.0.0"},
+		"/skydns/local/domain1/resource":     {Host: "10.0.0.0"},
+		"/skydns/local/domain1/owner":        {Host: "10.0.0.0"},
+	},
 	}
 	coredns := coreDNSProvider{
 		client:        client,
@@ -1456,10 +1510,9 @@ func TestApplyChangesPreventCleanupForKnownLabels(t *testing.T) {
 }
 
 func TestRecordsAWithGroupServiceTranslation(t *testing.T) {
-	client := fakeETCDClient{
-		map[string]Service{
-			"/skydns/local/domain1": {Host: "5.5.5.5", Group: "test1"},
-		},
+	client := &fakeETCDClient{services: map[string]Service{
+		"/skydns/local/domain1": {Host: "5.5.5.5", Group: "test1"},
+	},
 	}
 	coredns := coreDNSProvider{
 		client:        client,
@@ -1475,11 +1528,10 @@ func TestRecordsAWithGroupServiceTranslation(t *testing.T) {
 }
 
 func TestRecordsIncludeLabelOwnerWithStrictlyOwned(t *testing.T) {
-	client := fakeETCDClient{
-		map[string]Service{
-			"/skydns/local/domain1": {Host: "5.5.5.5", Group: "test1", Owner: "owner"},
-			"/skydns/com/example":   {Text: "bla", Owner: "owner"},
-		},
+	client := &fakeETCDClient{services: map[string]Service{
+		"/skydns/local/domain1": {Host: "5.5.5.5", Group: "test1", Owner: "owner"},
+		"/skydns/com/example":   {Text: "bla", Owner: "owner"},
+	},
 	}
 	coredns := coreDNSProvider{
 		client:        client,
@@ -1494,11 +1546,10 @@ func TestRecordsIncludeLabelOwnerWithStrictlyOwned(t *testing.T) {
 }
 
 func TestRecordsIncludeOwnerASLabelWithoutStrictlyOwned(t *testing.T) {
-	client := fakeETCDClient{
-		map[string]Service{
-			"/skydns/local/domain1": {Host: "5.5.5.5", Group: "test1", Owner: "owner"},
-			"/skydns/com/example":   {Text: "bla", Owner: "owner"},
-		},
+	client := &fakeETCDClient{services: map[string]Service{
+		"/skydns/local/domain1": {Host: "5.5.5.5", Group: "test1", Owner: "owner"},
+		"/skydns/com/example":   {Text: "bla", Owner: "owner"},
+	},
 	}
 	coredns := coreDNSProvider{
 		client:        client,
@@ -1510,4 +1561,235 @@ func TestRecordsIncludeOwnerASLabelWithoutStrictlyOwned(t *testing.T) {
 	for _, ep := range endpoints {
 		assert.Empty(t, ep.Labels[endpoint.OwnerLabelKey])
 	}
+}
+
+func TestPTRRecords(t *testing.T) {
+	t.Run("ReadIPv4PTR", func(t *testing.T) {
+		expectedTarget := "coredns-etcd-worker"
+		expectedDNSName := "2.0.26.172.in-addr.arpa"
+
+		client := &fakeETCDClient{services: map[string]Service{
+			"/skydns/arpa/in-addr/172/26/0/2": {Host: expectedTarget},
+		},
+		}
+		provider := coreDNSProvider{
+			client:        client,
+			coreDNSPrefix: defaultCoreDNSPrefix,
+		}
+		endpoints, err := provider.Records(t.Context())
+		require.NoError(t, err)
+		require.Len(t, endpoints, 1)
+		assert.Equal(t, expectedDNSName, endpoints[0].DNSName)
+		assert.Equal(t, expectedTarget, endpoints[0].Targets[0])
+		assert.Equal(t, endpoint.RecordTypePTR, endpoints[0].RecordType)
+	})
+
+	t.Run("ReadIPv6PTR", func(t *testing.T) {
+		expectedTarget := "coredns-etcd-worker"
+		// IPv6 2001:db8::1 → 32 nibbles reversed
+		expectedDNSName := "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa"
+
+		client := &fakeETCDClient{services: map[string]Service{
+			"/skydns/arpa/ip6/2/0/0/1/0/d/b/8/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/1": {Host: expectedTarget},
+		},
+		}
+		provider := coreDNSProvider{
+			client:        client,
+			coreDNSPrefix: defaultCoreDNSPrefix,
+		}
+		endpoints, err := provider.Records(t.Context())
+		require.NoError(t, err)
+		require.Len(t, endpoints, 1)
+		assert.Equal(t, expectedDNSName, endpoints[0].DNSName)
+		assert.Equal(t, expectedTarget, endpoints[0].Targets[0])
+		assert.Equal(t, endpoint.RecordTypePTR, endpoints[0].RecordType)
+	})
+
+	t.Run("CreateAndDeletePTR", func(t *testing.T) {
+		client := &fakeETCDClient{services: map[string]Service{}}
+		coredns := coreDNSProvider{
+			client:        client,
+			coreDNSPrefix: defaultCoreDNSPrefix,
+		}
+
+		// Create PTR records
+		changes := &plan.Changes{
+			Create: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "coredns-etcd-worker"),
+				endpoint.NewEndpoint("3.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "coredns-etcd-control-plane"),
+			},
+		}
+		err := coredns.ApplyChanges(t.Context(), changes)
+		require.NoError(t, err)
+
+		// Verify keys are created WITHOUT random prefix
+		expectedServices := map[string][]*Service{
+			"/skydns/arpa/in-addr/172/26/0/2": {{Host: "coredns-etcd-worker", TargetStrip: 0}},
+			"/skydns/arpa/in-addr/172/26/0/3": {{Host: "coredns-etcd-control-plane", TargetStrip: 0}},
+		}
+		validateServices(client.services, expectedServices, t, 1)
+
+		// Delete PTR records
+		deleteChanges := &plan.Changes{
+			Delete: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "coredns-etcd-worker"),
+			},
+		}
+		err = applyServiceChanges(coredns, deleteChanges)
+		require.NoError(t, err)
+
+		// Only the second record should remain
+		expectedAfterDelete := map[string][]*Service{
+			"/skydns/arpa/in-addr/172/26/0/3": {{Host: "coredns-etcd-control-plane", TargetStrip: 0}},
+		}
+		validateServices(client.services, expectedAfterDelete, t, 2)
+	})
+
+	t.Run("UpdatePTRTargetOverwritesInPlace", func(t *testing.T) {
+		// Verifies that updating a PTR target overwrites the same key (no
+		// separate delete needed — PTR records share a single etcd key, so
+		// stale-label cleanup is skipped).
+		client := &fakeETCDClient{services: map[string]Service{}}
+		coredns := coreDNSProvider{
+			client:        client,
+			coreDNSPrefix: defaultCoreDNSPrefix,
+		}
+
+		// Step 1: Create a PTR record pointing to "old-host"
+		createChanges := &plan.Changes{
+			Create: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "old-host"),
+			},
+		}
+		require.NoError(t, coredns.ApplyChanges(t.Context(), createChanges))
+
+		key := "/skydns/arpa/in-addr/172/26/0/2"
+		require.Equal(t, "old-host", client.services[key].Host)
+
+		// Step 2: Update target to "new-host"
+		records, err := coredns.Records(t.Context())
+		require.NoError(t, err)
+		oldEP := records[0]
+
+		newEP := endpoint.NewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "new-host")
+		require.NoError(t, coredns.ApplyChanges(t.Context(), &plan.Changes{
+			UpdateNew: []*endpoint.Endpoint{newEP},
+			UpdateOld: []*endpoint.Endpoint{oldEP},
+		}))
+
+		// The key still exists with the new target (overwrite, not delete+create)
+		require.Contains(t, client.services, key)
+		assert.Equal(t, "new-host", client.services[key].Host)
+	})
+
+	t.Run("DeletePTRDoesNotOverDeleteNeighbors", func(t *testing.T) {
+		client := &fakeETCDClient{services: map[string]Service{}}
+		coredns := coreDNSProvider{client: client, coreDNSPrefix: defaultCoreDNSPrefix}
+
+		// Create PTR records for .0.2 and .0.20 (bare octet keys where .2 is
+		// a byte-prefix of .20)
+		require.NoError(t, coredns.ApplyChanges(t.Context(), &plan.Changes{
+			Create: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "host-2"),
+				endpoint.NewEndpoint("20.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "host-20"),
+			},
+		}))
+
+		key2 := "/skydns/arpa/in-addr/172/26/0/2"
+		key20 := "/skydns/arpa/in-addr/172/26/0/20"
+		require.Contains(t, client.services, key2)
+		require.Contains(t, client.services, key20)
+
+		// Delete ONLY .2
+		require.NoError(t, coredns.ApplyChanges(t.Context(), &plan.Changes{
+			Delete: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "host-2"),
+			},
+		}))
+
+		assert.NotContains(t, client.services, key2, "intended target must be deleted")
+		assert.Contains(t, client.services, key20,
+			"deleting .2 must NOT delete neighbour .20 — etcd WithPrefix over-delete")
+	})
+
+	t.Run("MultiTargetPTRUpdateDoesNotDeleteSurvivor", func(t *testing.T) {
+		// Scenario: PTR has targets [host-1, host-2], updated to [host-2].
+		// The stale-label cleanup must NOT delete the key that host-2 lives on.
+		client := &fakeETCDClient{services: map[string]Service{}}
+		coredns := coreDNSProvider{client: client, coreDNSPrefix: defaultCoreDNSPrefix}
+
+		// Simulate the "before" state: a PTR record at the key with host-1
+		key := "/skydns/arpa/in-addr/172/26/0/2"
+		client.services[key] = Service{
+			Host:        "host-1",
+			TargetStrip: 0,
+		}
+
+		// Read records to populate labels (simulates what the controller does)
+		records, err := coredns.Records(t.Context())
+		require.NoError(t, err)
+		require.Len(t, records, 1)
+		oldEP := records[0]
+		require.Equal(t, "host-1", oldEP.Targets[0])
+
+		// Update: change target from host-1 to host-2
+		newEP := endpoint.NewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "host-2")
+		updateChanges := &plan.Changes{
+			UpdateNew: []*endpoint.Endpoint{newEP},
+			UpdateOld: []*endpoint.Endpoint{oldEP},
+		}
+		require.NoError(t, coredns.ApplyChanges(t.Context(), updateChanges))
+
+		// host-2 should be at the key (the update should have taken effect)
+		require.Contains(t, client.services, key,
+			"PTR key must survive after updating target from host-1 to host-2")
+		assert.Equal(t, "host-2", client.services[key].Host)
+	})
+
+	t.Run("PTRStaleLabelCleanupSkippedWhenOtherTargetsRemain", func(t *testing.T) {
+		// Verifies that stale-label cleanup for PTR records does NOT delete the
+		// shared key when other targets still exist. Uses a delete-recording
+		// client to assert that deleteByDnsName is never called for PTR stale
+		// labels (PTR records are overwritten in-place, not deleted+recreated).
+		rec := &fakeETCDClient{services: map[string]Service{
+			"/skydns/arpa/in-addr/172/26/0/2": {Host: "host-1", TargetStrip: 0},
+		}}
+		coredns := coreDNSProvider{client: rec, coreDNSPrefix: defaultCoreDNSPrefix}
+
+		// Read records to get labels, then update target from host-1 → host-2
+		records, err := coredns.Records(t.Context())
+		require.NoError(t, err)
+		oldEP := records[0]
+
+		newEP := endpoint.NewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "host-2")
+		updateChanges := &plan.Changes{
+			UpdateNew: []*endpoint.Endpoint{newEP},
+			UpdateOld: []*endpoint.Endpoint{oldEP},
+		}
+		require.NoError(t, coredns.ApplyChanges(t.Context(), updateChanges))
+
+		// The delete should NOT have been called for the PTR dnsName
+		// (stale host-1 label should be cleaned up by overwrite, not by delete)
+		ptrKey := "/skydns/arpa/in-addr/172/26/0/2"
+		assert.NotContains(t, rec.deletedKeys, ptrKey,
+			"stale-label cleanup for PTR must not issue delete when new target will overwrite the same key")
+	})
+
+	t.Run("UpdateTXTRecordsForPTRDomain", func(t *testing.T) {
+		provider := coreDNSProvider{coreDNSPrefix: "/skydns/"}
+		dnsName := "3.0.18.172.in-addr.arpa"
+		group := []*endpoint.Endpoint{
+			{
+				RecordType: endpoint.RecordTypeTXT,
+				Targets:    endpoint.Targets{"txt-value"},
+				Labels:     map[string]string{randomPrefixLabel: ""},
+				RecordTTL:  60,
+			},
+		}
+		services := provider.updateTXTRecords(dnsName, group, []*Service{})
+		require.Len(t, services, 1)
+		assert.Equal(t, "/skydns/arpa/in-addr/172/18/0/3", services[0].Key)
+		assert.Equal(t, 0, services[0].TargetStrip)
+		assert.Equal(t, "txt-value", services[0].Text)
+	})
 }


### PR DESCRIPTION
## What does it do ?

Fixes CoreDNS ignoring PTR records created by ExternalDNS (Close: #6466).

The CoreDNS etcd plugin expects PTR records at the exact reverse-DNS path (e.g. `/skydns/arpa/in-addr/172/26/0/2`), but the coredns provider was writing them with a random unique suffix (`/skydns/arpa/in-addr/172/26/0/2/41d1e77d`), making them invisible to CoreDNS queries.

Additionally, `guessRecordType()` always returned CNAME for PTR targets (hostnames), causing the plan to perpetually delete and recreate the record on every sync cycle.

## ⚠️ Upgrade note

PTR records written by older versions of ExternalDNS used a random suffix (e.g. `/skydns/.../PTR/<hex>`). This version writes PTR records at the exact reverse-DNS key (e.g. `/skydns/.../PTR`) and **will not auto-clean** the stale suffixed keys.

After upgrading, operators should manually remove any leftover suffixed PTR keys from etcd:

```sh
# Find stale PTR keys (contain a hex suffix after the reverse-DNS path)
kubectl exec -it etcd-0 -- etcdctl get --prefix /skydns/arpa/ --keys-only | grep -E '/[0-9a-f]{8}$'

# Remove them
kubectl exec -it etcd-0 -- etcdctl del /skydns/arpa/in-addr/172/26/0/2/<hex-suffix>
```

## Motivation

<!-- What inspired you to submit this pull request? -->

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly