### PR TITLE
feat(helm): add Helm OCI chart publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,19 @@ helm-lint:
 	scripts/helm-tools.sh --schema
 	scripts/helm-tools.sh --docs
 
+.PHONY: helm-chart-package
+#? helm-chart-package: Package the Helm chart into a versioned chart archive file
+helm-chart-package:
+	DEST_CHART_DIR=$(DEST_CHART_DIR) \
+	HELM_CHART_PUSH=$(HELM_CHART_PUSH) \
+	HELM_CHART_REPO=$(HELM_CHART_REPO) \
+	./scripts/helm-chart-package.sh
+
+.PHONY: helm-chart-push
+#? helm-chart-push: Package and push the Helm chart to an OCI registry
+helm-chart-push: HELM_CHART_PUSH=true
+helm-chart-push: helm-chart-package
+
 .PHONY: go-dependency
 #? go-dependency: Dependency maintenance
 go-dependency:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,6 +13,24 @@ steps:
       - PULL_BASE_REF=$_PULL_BASE_REF
     args:
       - release.staging
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260127-c1affcc8de'
+    entrypoint: bash
+    env:
+      - HELM_CHART_REPO=gcr.io/k8s-staging-external-dns/charts
+    args:
+      - -eu
+      - -c
+      - |
+        set -o pipefail
+
+        if [[ "$_PULL_BASE_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
+          echo "Detected SemVer tag ($_PULL_BASE_REF); pushing Helm chart."
+          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          gcloud auth configure-docker gcr.io --quiet
+          make helm-chart-push
+        else
+          echo "Skipping Helm chart push: $_PULL_BASE_REF is not a SemVer tag."
+        fi
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution

--- a/docs/release.md
+++ b/docs/release.md
@@ -60,6 +60,22 @@ You must be an official maintainer of the project to be able to do a release.
 - Create an issue to release the corresponding Helm chart via the chart release process (below) assigned to a chart maintainer
 - Once the PR is merged, all is done :-)
 
+## How to promote a Helm OCI chart
+
+The project Cloud Build publishes the Helm chart to the staging OCI registry on release tags. The chart is pushed to `gcr.io/k8s-staging-external-dns/charts/external-dns:<chart-version>`.
+
+Promotion to `registry.k8s.io` is handled by the same `kubernetes/k8s.io` promotion flow used for container images:
+
+- Find the digest for the staged chart after Cloud Build completes.
+- Open a PR against the [k8s.io repo](https://github.com/kubernetes/k8s.io) adding the digest and chart version under a `charts/external-dns` entry in `registry.k8s.io/images/k8s-staging-external-dns/images.yaml`.
+- Once the PR merges, the promoter copies the OCI chart from `gcr.io/k8s-staging-external-dns/charts/external-dns` to the production replicas served by `registry.k8s.io/external-dns/charts/external-dns`.
+
+After promotion, users can install the chart with:
+
+```sh
+helm install external-dns oci://registry.k8s.io/external-dns/charts/external-dns --version <chart-version>
+```
+
 ## How to release a new chart version
 
 The chart needs to be released in response to an ExternalDNS image release or on an as-needed basis; this should be triggered by an issue to release the chart.

--- a/scripts/helm-chart-package.sh
+++ b/scripts/helm-chart-package.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DEST_CHART_DIR=${DEST_CHART_DIR:-bin/}
+HELM=${HELM:-helm}
+HELM_CHART_REPO=${HELM_CHART_REPO:-gcr.io/k8s-staging-external-dns/charts}
+
+readonly chart_dir="charts/external-dns"
+readonly chart_file="${chart_dir}/Chart.yaml"
+
+chart_version=$(grep -E '^version: ' "${chart_file}" | cut -d' ' -f2)
+
+mkdir -p "${DEST_CHART_DIR}"
+${HELM} package "${chart_dir}" -d "${DEST_CHART_DIR}"
+
+if [ "${HELM_CHART_PUSH:-false}" = "true" ]; then
+  ${HELM} push "${DEST_CHART_DIR}/external-dns-${chart_version}.tgz" "oci://${HELM_CHART_REPO}"
+fi


### PR DESCRIPTION
## What does it do ?

This is yet another draft attempt to try to add Helm OCI chart publishing, resolving #4630. This is presented for discussion primarily.

## Motivation

Helm users are increasingly used to managing and consuming Charts via OCI, which offers a more standardized common way to access repositories than the bespoke Helm repositories of yore. There are however quite a [variety of different implementations across projects](https://github.com/kubernetes-sigs/metrics-server/issues/1527#issuecomment-4636897099). This draft is intended to offer a viable, for consideration of ideas, that distills out a solution based on what existing projects are doing, to help get thoughts flowing about what might be the right way to go. **This draft is presented for discussion.**

## Note

There is also https://github.com/kubernetes-sigs/metrics-server/pull/1817, which is another Helm OCI Chart I've tried drafting. See https://github.com/kubernetes-sigs/metrics-server/issues/1527 for more discussion in general.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
