### PR TITLE
test(source): fix flaky unstructured source test

### DIFF
--- a/source/unstructured_test.go
+++ b/source/unstructured_test.go
@@ -743,9 +743,16 @@ func TestNewUnstructuredFQDNSource_Errors(t *testing.T) {
 					}},
 				},
 			},
-			// Empty scheme: List always returns "no kind registered", so HasSynced() stays false.
-			// Pre-cancelled context: WaitForCacheSync sees a closed stopCh and returns immediately.
-			dynamicClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), nil),
+			// Pre-cancelled context: WaitForCacheSync sees a closed stopCh and returns
+			// immediately with a sync failure, before the informer can populate.
+			// The list kind is registered so a racing reflector LIST returns cleanly
+			// instead of panicking in a background goroutine (which would crash the binary).
+			dynamicClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+				runtime.NewScheme(),
+				map[schema.GroupVersionResource]string{
+					{Group: "kubevirt.io", Version: "v1", Resource: "virtualmachineinstances"}: "VirtualMachineInstanceList",
+				},
+			),
 			ctx: func() context.Context {
 				ctx, cancel := context.WithCancel(t.Context())
 				cancel()


### PR DESCRIPTION
## Description

Fixes an intermittent panic that crashes the entire `source` test package.

`TestNewUnstructuredFQDNSource_Errors/"WaitForDynamicCacheSync error propagates"`
built its fake dynamic client with an empty scheme and `nil` list kinds.
`NewUnstructuredFQDNSource` calls `informerFactory.Start(ctx.Done())` *before*
`WaitForDynamicCacheSync` returns, so a reflector goroutine can race the
pre-cancelled context and issue a `LIST` on `virtualmachineinstances`. With no
registered list kind the fake client panics:

```
panic: coding error: you must register resource to list kind for every resource
you're going to LIST when creating the client ... kubevirt.io/v1,
Resource=virtualmachineinstances out of map[]
```

Observed in CI on #6482: [run 1 failed](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_external-dns/6482/pull-external-dns-unit-test/2064836219946143744), [run 2 passed](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_external-dns/6482/pull-external-dns-unit-test/2064840122863456256) with no code change between them.

## Fix

Register the `VirtualMachineInstanceList` list kind on that fake dynamic client
so a racing `LIST` returns cleanly instead of panicking. The pre-cancelled
context still drives the asserted `"failed to sync"` error, so the test's intent
is unchanged.

## Verification

```
go test -race -run 'TestNewUnstructuredFQDNSource_Errors|TestAddEventHandler_Unstructured' -count=20 ./source/
ok  	sigs.k8s.io/external-dns/source	3.784s
```

## Checklist

- [x] Unit tests updated
- [x] `make test` passes
