### PR TITLE
fix(alibabacloud): fix TXT record value comparison during record updates

### DIFF
--- a/provider/alibabacloud/alibaba_cloud.go
+++ b/provider/alibabacloud/alibaba_cloud.go
@@ -338,11 +338,7 @@ func (p *AlibabaCloudProvider) recordsForDNS() ([]*endpoint.Endpoint, error) {
 
 		var targets []string
 		for _, record := range recordList {
-			target := record.Value
-			if recordType == "TXT" {
-				target = p.unescapeTXTRecordValue(target)
-			}
-			targets = append(targets, target)
+			targets = append(targets, record.Value)
 		}
 		ep := endpoint.NewEndpointWithTTL(name, recordType, endpoint.TTL(ttl), targets...)
 		endpoints = append(endpoints, ep)
@@ -458,6 +454,8 @@ func (p *AlibabaCloudProvider) getDomainRecords(domainName string) ([]alidns.Rec
 			if !provider.SupportedRecordType(recordType) {
 				continue
 			}
+			// Use the same format as ExternalDNS
+			record.Value = wrapWithQuotes(recordType, record.Value)
 			// TODO filter Locked record
 			results = append(results, record)
 		}
@@ -493,14 +491,18 @@ func (p *AlibabaCloudProvider) applyChangesForDNS(changes *plan.Changes) error {
 	return nil
 }
 
-func (p *AlibabaCloudProvider) escapeTXTRecordValue(value string) string {
-	// For unsupported chars
-	return value
+func unwrapQuotes(recordType, target string) string {
+	if recordType == endpoint.RecordTypeTXT && strings.HasPrefix(target, `"heritage=`) {
+		return strings.Trim(target, `"`)
+	}
+	return target
 }
 
-func (p *AlibabaCloudProvider) unescapeTXTRecordValue(value string) string {
-	if strings.HasPrefix(value, "heritage=") {
-		return fmt.Sprintf("\"%s\"", strings.ReplaceAll(value, ";", ","))
+func wrapWithQuotes(recordType, value string) string {
+	if recordType == endpoint.RecordTypeTXT && strings.HasPrefix(value, "heritage=") {
+		// Alibaba Cloud returns TXT record values without quotes.
+		// Restore the quotes to match ExternalDNS's expected format.
+		return fmt.Sprintf("\"%s\"", value)
 	}
 	return value
 }
@@ -529,10 +531,6 @@ func (p *AlibabaCloudProvider) createRecord(endpoint *endpoint.Endpoint, target 
 	ttl := int(endpoint.RecordTTL)
 	if ttl != 0 {
 		request.TTL = requests.NewInteger(ttl)
-	}
-
-	if endpoint.RecordType == "TXT" {
-		target = p.escapeTXTRecordValue(target)
 	}
 
 	request.Value = target
@@ -603,12 +601,7 @@ func (p *AlibabaCloudProvider) deleteRecords(recordMap map[string][]alidns.Recor
 		records := recordMap[key]
 		found := false
 		for _, record := range records {
-			value := record.Value
-			if record.Type == "TXT" {
-				value = p.unescapeTXTRecordValue(value)
-			}
-
-			if slices.Contains(endpoint.Targets, value) {
+			if slices.Contains(endpoint.Targets, record.Value) {
 				p.deleteRecord(record.RecordId)
 				found = true
 			}
@@ -638,17 +631,7 @@ func (p *AlibabaCloudProvider) updateRecords(recordMap map[string][]alidns.Recor
 		key := p.getRecordKeyByEndpoint(endpoint)
 		records := recordMap[key]
 		for _, record := range records {
-			value := record.Value
-			if record.Type == "TXT" {
-				value = p.unescapeTXTRecordValue(value)
-			}
-			found := false
-			for _, target := range endpoint.Targets {
-				// Find matched record to delete
-				if value == target {
-					found = true
-				}
-			}
+			found := slices.Contains(endpoint.Targets, record.Value)
 			if found {
 				if !p.equals(record, endpoint) {
 					// Update record
@@ -659,16 +642,9 @@ func (p *AlibabaCloudProvider) updateRecords(recordMap map[string][]alidns.Recor
 			}
 		}
 		for _, target := range endpoint.Targets {
-			if endpoint.RecordType == "TXT" {
-				target = p.escapeTXTRecordValue(target)
-			}
-			found := false
-			for _, record := range records {
-				// Find matched record to delete
-				if record.Value == target {
-					found = true
-				}
-			}
+			found := slices.ContainsFunc(records, func(record alidns.Record) bool {
+				return record.Value == target
+			})
 			if !found {
 				p.createRecord(endpoint, target, hostedZoneDomains)
 			}
@@ -800,6 +776,8 @@ func (p *AlibabaCloudProvider) getPrivateZones() (map[string]*alibabaPrivateZone
 					continue
 				}
 
+				// Use the same format as ExternalDNS
+				record.Value = wrapWithQuotes(recordType, record.Value)
 				// TODO filter Locked
 				records = append(records, record)
 			}
@@ -856,11 +834,7 @@ func (p *AlibabaCloudProvider) privateZoneRecords() ([]*endpoint.Endpoint, error
 			}
 			var targets []string
 			for _, record := range recordList {
-				target := record.Value
-				if recordType == "TXT" {
-					target = p.unescapeTXTRecordValue(target)
-				}
-				targets = append(targets, target)
+				targets = append(targets, record.Value)
 			}
 			ep := endpoint.NewEndpointWithTTL(name, recordType, endpoint.TTL(ttl), targets...)
 			endpoints = append(endpoints, ep)
@@ -888,10 +862,6 @@ func (p *AlibabaCloudProvider) createPrivateZoneRecord(zones map[string]*alibaba
 	ttl := int(endpoint.RecordTTL)
 	if ttl != 0 {
 		request.Ttl = requests.NewInteger(ttl)
-	}
-
-	if endpoint.RecordType == "TXT" {
-		target = p.escapeTXTRecordValue(target)
 	}
 
 	request.Value = target
@@ -950,11 +920,7 @@ func (p *AlibabaCloudProvider) deletePrivateZoneRecords(zones map[string]*alibab
 		found := false
 		for _, record := range zone.records {
 			if rr == record.Rr && endpoint.RecordType == record.Type {
-				value := record.Value
-				if record.Type == "TXT" {
-					value = p.unescapeTXTRecordValue(value)
-				}
-				if slices.Contains(endpoint.Targets, value) {
+				if slices.Contains(endpoint.Targets, record.Value) {
 					p.deletePrivateZoneRecord(record.RecordId)
 					found = true
 				}
@@ -1036,11 +1002,7 @@ func (p *AlibabaCloudProvider) updatePrivateZoneRecords(zones map[string]*alibab
 			if record.Rr != rr || record.Type != endpoint.RecordType {
 				continue
 			}
-			value := record.Value
-			if record.Type == "TXT" {
-				value = p.unescapeTXTRecordValue(value)
-			}
-			found := slices.Contains(endpoint.Targets, value)
+			found := slices.Contains(endpoint.Targets, record.Value)
 			if found {
 				if !p.equalsPrivateZone(record, endpoint) {
 					// Update record
@@ -1051,20 +1013,9 @@ func (p *AlibabaCloudProvider) updatePrivateZoneRecords(zones map[string]*alibab
 			}
 		}
 		for _, target := range endpoint.Targets {
-			if endpoint.RecordType == "TXT" {
-				target = p.escapeTXTRecordValue(target)
-			}
-			found := false
-			for _, record := range zone.records {
-				if record.Rr != rr || record.Type != endpoint.RecordType {
-					continue
-				}
-				// Find matched record to delete
-				if record.Value == target {
-					found = true
-					break
-				}
-			}
+			found := slices.ContainsFunc(zone.records, func(record pvtz.Record) bool {
+				return record.Rr == rr && record.Type == endpoint.RecordType && record.Value == target
+			})
 			if !found {
 				p.createPrivateZoneRecord(zones, endpoint, target)
 			}

--- a/provider/alibabacloud/alibaba_cloud_test.go
+++ b/provider/alibabacloud/alibaba_cloud_test.go
@@ -404,13 +404,6 @@ func newTestAlibabaCloudProviderWithConfig(domainFilter *endpoint.DomainFilter, 
 	}
 }
 
-func unwrapQuotes(recordType, target string) string {
-	if recordType == endpoint.RecordTypeTXT && strings.HasPrefix(target, `"heritage=`) {
-		return strings.Trim(target, `"`)
-	}
-	return target
-}
-
 func getSubname(domain string, ep *endpoint.Endpoint) string {
 	name := strings.TrimSuffix(ep.DNSName, ".")
 	name = strings.TrimSuffix(name, strings.TrimSuffix(domain, "."))
@@ -512,45 +505,6 @@ func TestAlibabaCloudProvider_ApplyChanges_UndefinedZoneDomain(t *testing.T) {
 	assert.True(t, testutils.SameEndpoints(changedEndpoints, endpoints), "expected and actual endpoints don't match. %s:%s", changedEndpoints, endpoints)
 }
 
-func TestAlibabaCloudProvider_ApplyChanges_NonStandardTXTRecord(t *testing.T) {
-	domain := "container-service.top"
-	provider := newTestAlibabaCloudProviderWithConfig(
-		endpoint.NewDomainFilter([]string{domain}), false, map[string][]*endpoint.Endpoint{
-			domain: {
-				endpoint.NewEndpointWithTTL("abc."+domain, "A", 300, "1.2.3.4"),
-				endpoint.NewEndpointWithTTL("a-abc."+domain, "TXT", 300, "heritage=external-dns;external-dns/owner=default"),
-			},
-		},
-	)
-
-	defaultEndpoints := []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("abc."+domain, "A", 300, "1.2.3.4"),
-		endpoint.NewEndpointWithTTL("a-abc."+domain, "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
-	}
-
-	ctx := t.Context()
-	endpoints, err := provider.Records(ctx)
-	require.NoError(t, err, "Failed to get records: %v", err)
-	require.Len(t, endpoints, len(defaultEndpoints), "Incorrect number of records: %d", len(endpoints))
-	assert.True(t, testutils.SameEndpoints(defaultEndpoints, endpoints), "expected and actual endpoints don't match. %s:%s", defaultEndpoints, endpoints)
-
-	changes := plan.Changes{
-		Create: []*endpoint.Endpoint{
-			endpoint.NewEndpointWithTTL("new."+domain, "TXT", 300, "heritage=external-dns;external-dns/owner=default"),
-		},
-	}
-	changedEndpoints := append([]*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("new."+domain, "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
-	}, defaultEndpoints...)
-
-	err = provider.ApplyChanges(ctx, &changes)
-	require.NoError(t, err, "Failed to apply changes: %v", err)
-	endpoints, err = provider.Records(ctx)
-	require.NoError(t, err, "Failed to get records: %v", err)
-	require.Len(t, endpoints, len(changedEndpoints), "Incorrect number of records: %d", len(endpoints))
-	assert.True(t, testutils.SameEndpoints(changedEndpoints, endpoints), "expected and actual endpoints don't match. %s:%s", changedEndpoints, endpoints)
-}
-
 func TestAlibabaCloudProvider_PrivateZone_Records(t *testing.T) {
 	domain := "container-service.top"
 	defaultEndpoints := createDefaultEndpoints(domain)
@@ -593,45 +547,6 @@ func TestAlibabaCloudProvider_PrivateZone_ApplyChanges(t *testing.T) {
 		endpoint.NewEndpointWithTTL("a-abc.container-service.top", "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
 	}, changes.Create...)
 
-	require.Len(t, endpoints, len(changedEndpoints), "Incorrect number of records: %d", len(endpoints))
-	assert.True(t, testutils.SameEndpoints(changedEndpoints, endpoints), "expected and actual endpoints don't match. %s:%s", changedEndpoints, endpoints)
-}
-
-func TestAlibabaCloudProvider_PrivateZone_ApplyChanges_NonStandardTXTRecord(t *testing.T) {
-	domain := "container-service.top"
-	provider := newTestAlibabaCloudProviderWithConfig(
-		endpoint.NewDomainFilter([]string{domain}), true, map[string][]*endpoint.Endpoint{
-			domain: {
-				endpoint.NewEndpointWithTTL("abc."+domain, "A", 300, "1.2.3.4"),
-				endpoint.NewEndpointWithTTL("a-abc."+domain, "TXT", 300, "heritage=external-dns;external-dns/owner=default"),
-			},
-		},
-	)
-
-	defaultEndpoints := []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("abc."+domain, "A", 300, "1.2.3.4"),
-		endpoint.NewEndpointWithTTL("a-abc."+domain, "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
-	}
-
-	ctx := t.Context()
-	endpoints, err := provider.Records(ctx)
-	require.NoError(t, err, "Failed to get records: %v", err)
-	require.Len(t, endpoints, len(defaultEndpoints), "Incorrect number of records: %d", len(endpoints))
-	assert.True(t, testutils.SameEndpoints(defaultEndpoints, endpoints), "expected and actual endpoints don't match. %s:%s", defaultEndpoints, endpoints)
-
-	changes := plan.Changes{
-		Create: []*endpoint.Endpoint{
-			endpoint.NewEndpointWithTTL("new."+domain, "TXT", 300, "heritage=external-dns;external-dns/owner=default"),
-		},
-	}
-	changedEndpoints := append([]*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("new."+domain, "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
-	}, defaultEndpoints...)
-
-	err = provider.ApplyChanges(ctx, &changes)
-	require.NoError(t, err, "Failed to apply changes: %v", err)
-	endpoints, err = provider.Records(ctx)
-	require.NoError(t, err, "Failed to get records: %v", err)
 	require.Len(t, endpoints, len(changedEndpoints), "Incorrect number of records: %d", len(endpoints))
 	assert.True(t, testutils.SameEndpoints(changedEndpoints, endpoints), "expected and actual endpoints don't match. %s:%s", changedEndpoints, endpoints)
 }
@@ -705,27 +620,12 @@ func TestAlibabaCloudProvider_splitDNSName(t *testing.T) {
 }
 
 func TestAlibabaCloudProvider_TXTEndpoint(t *testing.T) {
-	p := newTestAlibabaCloudProvider(false)
 	const recordValue = "heritage=external-dns,external-dns/owner=default"
 	const endpointTarget = "\"heritage=external-dns,external-dns/owner=default\""
 
-	if p.escapeTXTRecordValue(endpointTarget) != endpointTarget {
-		t.Errorf("Failed to escapeTXTRecordValue: %s", p.escapeTXTRecordValue(endpointTarget))
-	}
-	if p.unescapeTXTRecordValue(recordValue) != endpointTarget {
-		t.Errorf("Failed to unescapeTXTRecordValue: %s", p.unescapeTXTRecordValue(recordValue))
-	}
-}
+	newTarget := wrapWithQuotes("TXT", recordValue)
+	assert.Equal(t, endpointTarget, newTarget, "Failed to wrapWithQuotes: %s", newTarget)
 
-func TestAlibabaCloudProvider_TXTEndpoint_PrivateZone(t *testing.T) {
-	p := newTestAlibabaCloudProvider(true)
-	const recordValue = "heritage=external-dns,external-dns/owner=default"
-	const endpointTarget = "\"heritage=external-dns,external-dns/owner=default\""
-
-	if p.escapeTXTRecordValue(endpointTarget) != endpointTarget {
-		t.Errorf("Failed to escapeTXTRecordValue: %s", p.escapeTXTRecordValue(endpointTarget))
-	}
-	if p.unescapeTXTRecordValue(recordValue) != endpointTarget {
-		t.Errorf("Failed to unescapeTXTRecordValue: %s", p.unescapeTXTRecordValue(recordValue))
-	}
+	newValue := unwrapQuotes("TXT", endpointTarget)
+	assert.Equal(t, recordValue, newValue, "Failed to unwrapQuotes: %s", newValue)
 }


### PR DESCRIPTION
## Description

### Problem
Alibaba Cloud DNS may return TXT record values without double quotes and with semicolon-separated metadata, for example: `heritage=external-dns;external-dns/owner=default`

However, ExternalDNS TXT endpoints store targets with double quotes and comma-separated metadata, for example: `"heritage=external-dns,external-dns/owner=default"`

Because of this format mismatch, existing TXT records could be treated as different from the desired endpoint targets, causing unnecessary delete/create behavior during DNS updates.

API response body
```
{
  "RequestId": "******",
  "HostId": "alidns.aliyuncs.com",
  "Code": "DomainRecordDuplicate",
  "Message": "The DNS record already exists.",
  "Recommend": "https://api.aliyun.com/troubleshoot?q=DomainRecordDuplicate&product=Alidns&requestId=xxx"
}
```

### Solution
Normalize Alibaba Cloud TXT record values immediately after they are returned by the API. This keeps the provider using a consistent TXT record representation internally and avoids the need for additional conversions during record comparison or updates.

### Changes

- Moved TXT record normalization to the record query func, so API responses are normalized as soon as they are read
- Removed all calls to `escapeTXTRecordValue()`, since no escaping is actually required
- Removed all calls to `unescapeTXTRecordValue()` from the update logic
- Renamed `escapeTXTRecordValue` and `unescapeTXTRecordValue` to `unwrapQuotes` and `wrapWithQuotes` , and removed the `;` → `,` conversion to more accurately reflect their actual behavior.
- Removed the `*_NonStandardTXTRecord` unit tests, since the `;` → `,` conversion is no longer supported or needed
- Code simplification: Replaced manual loop search with `slices.Contains()` and `slices.ContainsFunc` for improved readability
- Updated `TestAlibabaCloudProvider_TXTEndpoint` to match the new TXT record handling

