### PR TITLE
fix(coredns): return AAAA for IPv6 targets

### DIFF
--- a/provider/coredns/coredns.go
+++ b/provider/coredns/coredns.go
@@ -519,8 +519,11 @@ func (p coreDNSProvider) etcdKeyFor(dnsName string) string {
 }
 
 func guessRecordType(target string) string {
-	if net.ParseIP(target) != nil {
-		return endpoint.RecordTypeA
+	if ip := net.ParseIP(target); ip != nil {
+		if ip.To4() != nil {
+			return endpoint.RecordTypeA
+		}
+		return endpoint.RecordTypeAAAA
 	}
 	return endpoint.RecordTypeCNAME
 }

--- a/provider/coredns/coredns.go
+++ b/provider/coredns/coredns.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"net"
 	"os"
 	"slices"
 	"strings"
@@ -519,13 +518,7 @@ func (p coreDNSProvider) etcdKeyFor(dnsName string) string {
 }
 
 func guessRecordType(target string) string {
-	if ip := net.ParseIP(target); ip != nil {
-		if ip.To4() != nil {
-			return endpoint.RecordTypeA
-		}
-		return endpoint.RecordTypeAAAA
-	}
-	return endpoint.RecordTypeCNAME
+	return endpoint.SuitableType(target)
 }
 
 func reverse(slice []string) {

--- a/provider/coredns/coredns_test.go
+++ b/provider/coredns/coredns_test.go
@@ -196,6 +196,55 @@ func TestAServiceTranslation(t *testing.T) {
 	}
 }
 
+func TestAAAAServiceTranslation(t *testing.T) {
+	expectedTarget := "2001:db8::1"
+	expectedDNSName := "example.com"
+	expectedRecordType := endpoint.RecordTypeAAAA
+
+	client := fakeETCDClient{
+		map[string]Service{
+			"/skydns/com/example": {Host: expectedTarget},
+		},
+	}
+	provider := coreDNSProvider{
+		client:        client,
+		coreDNSPrefix: defaultCoreDNSPrefix,
+	}
+	endpoints, err := provider.Records(t.Context())
+	require.NoError(t, err)
+	if len(endpoints) != 1 {
+		t.Fatalf("got unexpected number of endpoints: %d", len(endpoints))
+	}
+	if endpoints[0].DNSName != expectedDNSName {
+		t.Errorf("got unexpected DNS name: %s != %s", endpoints[0].DNSName, expectedDNSName)
+	}
+	if endpoints[0].Targets[0] != expectedTarget {
+		t.Errorf("got unexpected DNS target: %s != %s", endpoints[0].Targets[0], expectedTarget)
+	}
+	if endpoints[0].RecordType != expectedRecordType {
+		t.Errorf("got unexpected DNS record type: %s != %s", endpoints[0].RecordType, expectedRecordType)
+	}
+}
+
+func TestGuessRecordType(t *testing.T) {
+	tests := []struct {
+		target   string
+		expected string
+	}{
+		{"1.2.3.4", endpoint.RecordTypeA},
+		{"2001:db8::1", endpoint.RecordTypeAAAA},
+		{"::1", endpoint.RecordTypeAAAA},
+		{"::ffff:1.2.3.4", endpoint.RecordTypeA}, // IPv4-mapped IPv6 has a valid To4()
+		{"other.example.com", endpoint.RecordTypeCNAME},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.target, func(t *testing.T) {
+			assert.Equal(t, tt.expected, guessRecordType(tt.target))
+		})
+	}
+}
+
 func TestCNAMEServiceTranslation(t *testing.T) {
 	expectedTarget := "example.net"
 	expectedDNSName := "example.com"

--- a/provider/coredns/coredns_test.go
+++ b/provider/coredns/coredns_test.go
@@ -196,36 +196,6 @@ func TestAServiceTranslation(t *testing.T) {
 	}
 }
 
-func TestAAAAServiceTranslation(t *testing.T) {
-	expectedTarget := "2001:db8::1"
-	expectedDNSName := "example.com"
-	expectedRecordType := endpoint.RecordTypeAAAA
-
-	client := fakeETCDClient{
-		map[string]Service{
-			"/skydns/com/example": {Host: expectedTarget},
-		},
-	}
-	provider := coreDNSProvider{
-		client:        client,
-		coreDNSPrefix: defaultCoreDNSPrefix,
-	}
-	endpoints, err := provider.Records(t.Context())
-	require.NoError(t, err)
-	if len(endpoints) != 1 {
-		t.Fatalf("got unexpected number of endpoints: %d", len(endpoints))
-	}
-	if endpoints[0].DNSName != expectedDNSName {
-		t.Errorf("got unexpected DNS name: %s != %s", endpoints[0].DNSName, expectedDNSName)
-	}
-	if endpoints[0].Targets[0] != expectedTarget {
-		t.Errorf("got unexpected DNS target: %s != %s", endpoints[0].Targets[0], expectedTarget)
-	}
-	if endpoints[0].RecordType != expectedRecordType {
-		t.Errorf("got unexpected DNS record type: %s != %s", endpoints[0].RecordType, expectedRecordType)
-	}
-}
-
 func TestGuessRecordType(t *testing.T) {
 	tests := []struct {
 		target   string

--- a/provider/coredns/coredns_test.go
+++ b/provider/coredns/coredns_test.go
@@ -215,9 +215,8 @@ func TestGuessRecordType(t *testing.T) {
 	}
 }
 
-// It asserts both record types survive an apply + read round-trip with the
-// correct type (A stays A, AAAA stays AAAA), and that a second reconcile is a
-// no-op.
+// It asserts both record types survive an apply + read round-trip with the correct
+// type (A stays A, AAAA stays AAAA), and that a second reconcile is a no-op.
 func TestCoreDNSRoundTrip(t *testing.T) {
 	client := fakeETCDClient{
 		map[string]Service{},

--- a/provider/coredns/coredns_test.go
+++ b/provider/coredns/coredns_test.go
@@ -97,7 +97,7 @@ func (m *MockEtcdKV) Delete(ctx context.Context, key string, opts ...etcdcv3.OpO
 }
 
 func TestETCDConfig(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name  string
 		input map[string]string
 		want  *etcdcv3.Config
@@ -243,6 +243,57 @@ func TestGuessRecordType(t *testing.T) {
 			assert.Equal(t, tt.expected, guessRecordType(tt.target))
 		})
 	}
+}
+
+// It asserts both record types survive an apply + read round-trip with the
+// correct type (A stays A, AAAA stays AAAA), and that a second reconcile is a
+// no-op.
+func TestCoreDNSRoundTrip(t *testing.T) {
+	client := fakeETCDClient{
+		map[string]Service{},
+	}
+	coredns := coreDNSProvider{
+		client:        client,
+		coreDNSPrefix: defaultCoreDNSPrefix,
+	}
+
+	desired := []*endpoint.Endpoint{
+		endpoint.NewEndpoint("a.example.org", endpoint.RecordTypeA, "172.18.0.2"),
+		endpoint.NewEndpoint("aa.example.org", endpoint.RecordTypeAAAA, "2001:db8::1"),
+	}
+
+	// Write the records (controller's ApplyChanges with the source's desired state).
+	err := coredns.ApplyChanges(t.Context(), &plan.Changes{Create: desired})
+	require.NoError(t, err)
+
+	// Read them back from etcd.
+	current, err := coredns.Records(t.Context())
+	require.NoError(t, err)
+	require.Len(t, current, 2)
+
+	byName := map[string]*endpoint.Endpoint{}
+	for _, ep := range current {
+		byName[ep.DNSName] = ep
+	}
+
+	require.Contains(t, byName, "a.example.org")
+	assert.Equal(t, endpoint.RecordTypeA, byName["a.example.org"].RecordType)
+	assert.Equal(t, "172.18.0.2", byName["a.example.org"].Targets[0])
+
+	require.Contains(t, byName, "aa.example.org")
+	assert.Equal(t, endpoint.RecordTypeAAAA, byName["aa.example.org"].RecordType, "IPv6 target must read back as AAAA, not A")
+	assert.Equal(t, "2001:db8::1", byName["aa.example.org"].Targets[0])
+
+	// Second reconcile: desired vs read-back state must produce no changes.
+	managed := []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME, endpoint.RecordTypeTXT}
+	changes := (&plan.Plan{
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: managed,
+	}).Calculate().Changes
+	assert.Empty(t, changes.Create, "no records to create on second sync")
+	assert.Empty(t, changes.UpdateNew, "no records to update on second sync (no churn)")
+	assert.Empty(t, changes.Delete, "no records to delete on second sync")
 }
 
 func TestCNAMEServiceTranslation(t *testing.T) {

--- a/provider/coredns/coredns_test.go
+++ b/provider/coredns/coredns_test.go
@@ -204,7 +204,7 @@ func TestGuessRecordType(t *testing.T) {
 		{"1.2.3.4", endpoint.RecordTypeA},
 		{"2001:db8::1", endpoint.RecordTypeAAAA},
 		{"::1", endpoint.RecordTypeAAAA},
-		{"::ffff:1.2.3.4", endpoint.RecordTypeA}, // IPv4-mapped IPv6 has a valid To4()
+		{"::ffff:1.2.3.4", endpoint.RecordTypeAAAA}, // IPv4-mapped IPv6 is typed AAAA, matching endpoint.SuitableType
 		{"other.example.com", endpoint.RecordTypeCNAME},
 	}
 


### PR DESCRIPTION
## What does it do ?

`guessRecordType` returned `A` for any parseable IP, so IPv6 service hosts
read back from etcd were typed `A` instead of `AAAA`. CoreDNS still serves
AAAA (it infers the address family from the stored IP), so resolution looks
fine — but external-dns's desired state (`AAAA`) never matched the read-back
state (`A`), so it deleted and recreated the etcd key on every reconcile.

## Motivation

Following docs/tutorials/coredns-etcd.md, an AAAA service (`2001:db8::1`)
resolves correctly but causes a perpetual create/delete loop in external-dns.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly
