### PR TITLE
fix(transip): add trailing dot to NS record targets

### DIFF
--- a/provider/transip/transip.go
+++ b/provider/transip/transip.go
@@ -394,7 +394,7 @@ func dnsEntriesForEndpoint(ep *endpoint.Endpoint, zoneName string) []domain.DNSE
 	entries := []domain.DNSEntry{}
 	for _, target := range ep.Targets {
 		// external hostnames require a trailing dot in TransIP API
-		if ep.RecordType == "CNAME" {
+		if ep.RecordType == "CNAME" || ep.RecordType == "NS" {
 			target = provider.EnsureTrailingDot(target)
 		}
 

--- a/provider/transip/transip_test.go
+++ b/provider/transip/transip_test.go
@@ -171,6 +171,17 @@ func TestTransIPAddEndpointToEntries(t *testing.T) {
 		assert.Equal(t, "CNAME", result[0].Type)
 		assert.Equal(t, "foo.bar.", result[0].Content)
 	}
+
+	// NS targets need a trailing dot, like CNAME
+	ep.RecordType = "NS"
+	ep.Targets = []string{"ns0.example.com", "ns1.example.com."}
+	result = dnsEntriesForEndpoint(ep, zone.Name)
+	if assert.Len(t, result, 2) {
+		assert.Equal(t, "NS", result[0].Type)
+		assert.Equal(t, "ns0.example.com.", result[0].Content)
+		assert.Equal(t, "NS", result[1].Type)
+		assert.Equal(t, "ns1.example.com.", result[1].Content)
+	}
 }
 
 func TestZoneNameForDNSName(t *testing.T) {


### PR DESCRIPTION
The TransIP API requires hostname targets to be fully qualified with a trailing dot; without it the API appends the zone to the value and rejects external targets. The provider only applied EnsureTrailingDot to CNAME records, so NS delegations to external nameservers were rejected. Because a rejected entry returns an error that aborts the whole apply, this broke all DNS automation for the zone, not just the NS record.

Apply the same trailing-dot handling to NS targets as CNAME, and cover it with a test.

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] **Not applicable? This was a bug imo** Yes, I updated end user documentation accordingly

*I used Claude Code with Opus 4.8 to identify this bug and draft the diff. I have reviewed the code line-by-line myself. It felt like a change that's sensible enough to propose as PR directly without wasting anyone's time on an issue first.*
