### PR TITLE
feat(source): attach RefObject to all remaining sources

### DIFF
--- a/endpoint/utils.go
+++ b/endpoint/utils.go
@@ -96,6 +96,10 @@ func AttachRefObject(eps []*Endpoint, ref *events.ObjectReference) {
 // MergeEndpoints merges endpoints with the same key (DNSName + RecordType + SetIdentifier + RecordTTL)
 // by combining their targets. CNAME endpoints are not merged (per DNS spec) but are deduplicated.
 // This is useful when multiple resources (e.g., pods, nodes) contribute targets to the same DNS record.
+//
+// When several endpoints merge into one, only the first endpoint's metadata (TTL, ProviderSpecific,
+// RefObject, ...) is retained; the merged record keeps a single RefObject and therefore references
+// only the first contributing source object. "First" follows the input slice order.
 func MergeEndpoints(endpoints []*Endpoint) []*Endpoint {
 	if len(endpoints) == 0 {
 		return endpoints

--- a/source/ambassador_host.go
+++ b/source/ambassador_host.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/external-dns/source/types"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/events"
 	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/source/informers"
 )
@@ -176,6 +177,8 @@ func (sc *ambassadorHostSource) Endpoints(ctx context.Context) ([]*endpoint.Endp
 		if endpoint.HasNoEmptyEndpoints(hostEndpoints, types.AmbassadorHost, host) {
 			continue
 		}
+
+		endpoint.AttachRefObject(hostEndpoints, events.NewObjectReference(host, types.AmbassadorHost))
 
 		log.Debugf("Endpoints generated from Host: %s: %v", fullname, hostEndpoints)
 		endpoints = append(endpoints, hostEndpoints...)

--- a/source/ambassador_host_test.go
+++ b/source/ambassador_host_test.go
@@ -36,6 +36,7 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source/annotations"
+	"sigs.k8s.io/external-dns/source/types"
 )
 
 const defaultAmbassadorNamespace = "ambassador"
@@ -661,6 +662,64 @@ func createAmbassadorHost(host *ambassador.Host) (*unstructured.Unstructured, er
 	err := uc.scheme.Convert(host, obj, nil)
 
 	return obj, err
+}
+
+func TestProcessEndpoint_AmbassadorHost_RefObjectExist(t *testing.T) {
+	t.Parallel()
+
+	hostAnnotation := fmt.Sprintf("%s/%s", defaultAmbassadorNamespace, defaultAmbassadorServiceName)
+
+	fakeKubernetesClient := fakeKube.NewSimpleClientset()
+	ambassadorScheme := runtime.NewScheme()
+	ambassador.AddToScheme(ambassadorScheme)
+	fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(ambassadorScheme)
+
+	namespace := v1.NamespaceDefault
+
+	service := v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultAmbassadorServiceName,
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{{
+					IP: "1.1.1.1",
+				}},
+			},
+		},
+	}
+	_, err := fakeKubernetesClient.CoreV1().Services(defaultAmbassadorNamespace).Create(t.Context(), &service, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	host, err := createAmbassadorHost(&ambassador.Host{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "basic-host",
+			UID:  "ambassador-host-uid",
+			Annotations: map[string]string{
+				ambHostAnnotation: hostAnnotation,
+			},
+		},
+		Spec: &ambassador.HostSpec{
+			Hostname: "www.example.org",
+		},
+	})
+	assert.NoError(t, err)
+
+	_, err = fakeDynamicClient.Resource(ambHostGVR).Namespace(namespace).Create(t.Context(), host, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	source, err := NewAmbassadorHostSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
+		&Config{
+			Namespace:   namespace,
+			LabelFilter: labels.Everything(),
+		})
+	assert.NoError(t, err)
+	assert.NotNil(t, source)
+
+	endpoints, err := source.Endpoints(t.Context())
+	assert.NoError(t, err)
+
+	testutils.AssertEndpointsHaveRefObject(t, endpoints, types.AmbassadorHost, 1)
 }
 
 // TestParseAmbLoadBalancerService tests our parsing of Ambassador service info.

--- a/source/contour_httpproxy.go
+++ b/source/contour_httpproxy.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/external-dns/source/types"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/events"
 	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/source/informers"
 	"sigs.k8s.io/external-dns/source/template"
@@ -151,6 +152,8 @@ func (sc *httpProxySource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, e
 		if endpoint.HasNoEmptyEndpoints(hpEndpoints, types.ContourHTTPProxy, hp) {
 			continue
 		}
+
+		endpoint.AttachRefObject(hpEndpoints, events.NewObjectReference(hp, types.ContourHTTPProxy))
 
 		log.Debugf("Endpoints generated from HTTPProxy: %s/%s: %v", hp.Namespace, hp.Name, hpEndpoints)
 		endpoints = append(endpoints, hpEndpoints...)

--- a/source/contour_httpproxy_test.go
+++ b/source/contour_httpproxy_test.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source/annotations"
 	templatetest "sigs.k8s.io/external-dns/source/template/testutil"
+	sourcetypes "sigs.k8s.io/external-dns/source/types"
 )
 
 // This is a compile-time validation that httpProxySource is a Source.
@@ -1056,6 +1057,38 @@ func newTestHTTPProxySource(t *testing.T) (*httpProxySource, error) {
 	}
 
 	return irsrc, nil
+}
+
+func TestProcessEndpoint_ContourHTTPProxy_RefObjectExist(t *testing.T) {
+	fakeDynamicClient, s := newContourDynamicKubernetesClient()
+
+	httpProxy := (fakeHTTPProxy{
+		name:      "foo-httpproxy",
+		namespace: "default",
+		host:      "example.com",
+		loadBalancer: fakeLoadBalancerService{
+			ips: []string{"8.8.8.8"},
+		},
+	}).HTTPProxy()
+	httpProxy.UID = "contour-httpproxy-uid"
+
+	unstructuredHTTPProxy, err := convertHTTPProxyToUnstructured(httpProxy, s)
+	require.NoError(t, err)
+
+	_, err = fakeDynamicClient.Resource(projectcontour.HTTPProxyGVR).Namespace(httpProxy.Namespace).Create(t.Context(), unstructuredHTTPProxy, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	src, err := NewContourHTTPProxySource(
+		t.Context(),
+		fakeDynamicClient,
+		&Config{Namespace: "default"},
+	)
+	require.NoError(t, err)
+
+	endpoints, err := src.Endpoints(t.Context())
+	require.NoError(t, err)
+
+	testutils.AssertEndpointsHaveRefObject(t, endpoints, string(sourcetypes.ContourHTTPProxy), 1)
 }
 
 type fakeHTTPProxy struct {

--- a/source/f5_transportserver.go
+++ b/source/f5_transportserver.go
@@ -38,8 +38,10 @@ import (
 	"sigs.k8s.io/external-dns/source/informers"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/events"
 	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/source/template"
+	"sigs.k8s.io/external-dns/source/types"
 )
 
 var f5TransportServerGVR = schema.GroupVersionResource{
@@ -196,6 +198,8 @@ func (ts *f5TransportServerSource) endpointsFromTransportServers(transportServer
 			log.Warnf("F5 TransportServer %s/%s is missing a valid IP address, skipping endpoint creation.",
 				transportServer.Namespace, transportServer.Name)
 		}
+
+		endpoint.AttachRefObject(tsEndpoints, events.NewObjectReference(transportServer, types.F5TransportServer))
 
 		endpoints = append(endpoints, tsEndpoints...)
 	}

--- a/source/f5_transportserver_test.go
+++ b/source/f5_transportserver_test.go
@@ -29,7 +29,9 @@ import (
 	fakeKube "k8s.io/client-go/kubernetes/fake"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
 	"sigs.k8s.io/external-dns/source/annotations"
+	"sigs.k8s.io/external-dns/source/types"
 
 	f5 "github.com/F5Networks/k8s-bigip-ctlr/v2/config/apis/cis/v1"
 )
@@ -395,9 +397,62 @@ func TestF5TransportServerEndpoints(t *testing.T) {
 			endpoints, err := source.Endpoints(t.Context())
 			require.NoError(t, err)
 			assert.Len(t, endpoints, len(tc.expected))
-			assert.Equal(t, tc.expected, endpoints)
+			testutils.ValidateEndpoints(t, endpoints, tc.expected)
 		})
 	}
+}
+
+func TestProcessEndpoint_F5TransportServer_RefObjectExist(t *testing.T) {
+	t.Parallel()
+
+	transportServer := f5.TransportServer{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: f5TransportServerGVR.GroupVersion().String(),
+			Kind:       "TransportServer",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ts",
+			Namespace: defaultF5TransportServerNamespace,
+			UID:       "f5-ts-uid-1234",
+		},
+		Spec: f5.TransportServerSpec{
+			Host:                 "www.example.com",
+			VirtualServerAddress: "192.168.1.100",
+		},
+		Status: f5.CustomResourceStatus{
+			VSAddress: "192.168.1.200",
+			Status:    "OK",
+		},
+	}
+
+	fakeKubernetesClient := fakeKube.NewSimpleClientset()
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypes(f5TransportServerGVR.GroupVersion(), &f5.TransportServer{}, &f5.TransportServerList{})
+	fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(scheme)
+
+	tsUnstructured := unstructured.Unstructured{}
+	tsJSON, err := json.Marshal(transportServer)
+	require.NoError(t, err)
+	require.NoError(t, tsUnstructured.UnmarshalJSON(tsJSON))
+
+	_, err = fakeDynamicClient.Resource(f5TransportServerGVR).Namespace(defaultF5TransportServerNamespace).Create(t.Context(), &tsUnstructured, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	source, err := NewF5TransportServerSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
+		&Config{
+			Namespace: defaultF5TransportServerNamespace,
+		})
+	require.NoError(t, err)
+
+	count := &unstructured.UnstructuredList{}
+	for len(count.Items) < 1 {
+		count, _ = fakeDynamicClient.Resource(f5TransportServerGVR).Namespace(defaultF5TransportServerNamespace).List(t.Context(), metav1.ListOptions{})
+	}
+
+	endpoints, err := source.Endpoints(t.Context())
+	require.NoError(t, err)
+
+	testutils.AssertEndpointsHaveRefObject(t, endpoints, string(types.F5TransportServer), 1)
 }
 
 func TestF5TransportServerSource_InformerTransform(t *testing.T) {

--- a/source/f5_virtualserver.go
+++ b/source/f5_virtualserver.go
@@ -36,9 +36,11 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/events"
 	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/source/informers"
 	"sigs.k8s.io/external-dns/source/template"
+	"sigs.k8s.io/external-dns/source/types"
 )
 
 var f5VirtualServerGVR = schema.GroupVersionResource{
@@ -200,6 +202,8 @@ func (vs *f5VirtualServerSource) endpointsFromVirtualServers(virtualServers []*f
 			log.Warnf("F5 VirtualServer %s/%s is missing a valid IP address, skipping endpoint creation.",
 				virtualServer.Namespace, virtualServer.Name)
 		}
+
+		endpoint.AttachRefObject(vsEndpoints, events.NewObjectReference(virtualServer, types.F5VirtualServer))
 
 		endpoints = append(endpoints, vsEndpoints...)
 	}

--- a/source/f5_virtualserver_test.go
+++ b/source/f5_virtualserver_test.go
@@ -32,6 +32,7 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source/annotations"
+	"sigs.k8s.io/external-dns/source/types"
 
 	f5 "github.com/F5Networks/k8s-bigip-ctlr/v2/config/apis/cis/v1"
 )
@@ -642,6 +643,59 @@ func TestF5VirtualServerEndpoints(t *testing.T) {
 			testutils.ValidateEndpoints(t, endpoints, tc.expected)
 		})
 	}
+}
+
+func TestProcessEndpoint_F5VirtualServer_RefObjectExist(t *testing.T) {
+	t.Parallel()
+
+	virtualServer := f5.VirtualServer{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: f5VirtualServerGVR.GroupVersion().String(),
+			Kind:       "VirtualServer",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-vs",
+			Namespace: defaultF5VirtualServerNamespace,
+			UID:       "f5-vs-uid-1234",
+		},
+		Spec: f5.VirtualServerSpec{
+			Host:                 "www.example.com",
+			VirtualServerAddress: "192.168.1.100",
+		},
+		Status: f5.CustomResourceStatus{
+			VSAddress: "192.168.1.200",
+			Status:    "OK",
+		},
+	}
+
+	fakeKubernetesClient := fakeKube.NewClientset()
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypes(f5VirtualServerGVR.GroupVersion(), &f5.VirtualServer{}, &f5.VirtualServerList{})
+	fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(scheme)
+
+	vsUnstructured := unstructured.Unstructured{}
+	vsJSON, err := json.Marshal(virtualServer)
+	require.NoError(t, err)
+	require.NoError(t, vsUnstructured.UnmarshalJSON(vsJSON))
+
+	_, err = fakeDynamicClient.Resource(f5VirtualServerGVR).Namespace(defaultF5VirtualServerNamespace).Create(t.Context(), &vsUnstructured, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	source, err := NewF5VirtualServerSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
+		&Config{
+			Namespace: defaultF5VirtualServerNamespace,
+		})
+	require.NoError(t, err)
+
+	count := &unstructured.UnstructuredList{}
+	for len(count.Items) < 1 {
+		count, _ = fakeDynamicClient.Resource(f5VirtualServerGVR).Namespace(defaultF5VirtualServerNamespace).List(t.Context(), metav1.ListOptions{})
+	}
+
+	endpoints, err := source.Endpoints(t.Context())
+	require.NoError(t, err)
+
+	testutils.AssertEndpointsHaveRefObject(t, endpoints, string(types.F5VirtualServer), 1)
 }
 
 func TestF5VirtualServerSource_InformerTransform(t *testing.T) {

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -37,6 +37,7 @@ import (
 	informers_v1 "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/apis/v1"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/events"
 	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/source/informers"
 	"sigs.k8s.io/external-dns/source/template"
@@ -332,6 +333,8 @@ func (src *gatewayRouteSource) Endpoints(_ context.Context) ([]*endpoint.Endpoin
 			routeEndpoints = append(routeEndpoints, endpoint.EndpointsForHostname(host, targets, ttl, providerSpecific, setIdentifier, resource)...)
 		}
 		log.Debugf("Endpoints generated from %s %s/%s: %v", src.rtKind, meta.Namespace, meta.Name, routeEndpoints)
+
+		endpoint.AttachRefObject(routeEndpoints, events.NewObjectReference(rt.Object(), "gateway-"+kind))
 
 		endpoints = append(endpoints, routeEndpoints...)
 	}

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -36,6 +36,7 @@ import (
 	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 	"sigs.k8s.io/external-dns/source/annotations"
 	templatetest "sigs.k8s.io/external-dns/source/template/testutil"
+	"sigs.k8s.io/external-dns/source/types"
 )
 
 func mustGetLabelSelector(s string) labels.Selector {
@@ -1761,4 +1762,68 @@ func TestGatewayHTTPRouteSource_InformerTransform(t *testing.T) {
 		withRemovedManagedFields(),
 		withRemovedStatusConditions(),
 	)
+}
+
+func TestProcessEndpoint_GatewayHTTPRoute_RefObjectExist(t *testing.T) {
+	fromAll := v1.NamespacesFromAll
+	allowAllNamespaces := &v1.AllowedRoutes{
+		Namespaces: &v1.RouteNamespaces{From: &fromAll},
+	}
+	objectMeta := func(namespace, name string) metav1.ObjectMeta {
+		return metav1.ObjectMeta{Name: name, Namespace: namespace}
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	gwClient := gatewayfake.NewSimpleClientset()
+	gw := &v1.Gateway{
+		ObjectMeta: objectMeta("gateway-namespace", "gateway-name"),
+		Spec: v1.GatewaySpec{
+			Listeners: []v1.Listener{{
+				Protocol:      v1.HTTPProtocolType,
+				AllowedRoutes: allowAllNamespaces,
+			}},
+		},
+		Status: gatewayStatus("1.2.3.4"),
+	}
+	_, err := gwClient.GatewayV1().Gateways(gw.Namespace).Create(ctx, gw, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	rt := &v1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "route-namespace",
+			UID:       "httproute-uid",
+		},
+		Spec: v1.HTTPRouteSpec{
+			Hostnames: []v1.Hostname{"test.example.internal"},
+			CommonRouteSpec: v1.CommonRouteSpec{
+				ParentRefs: []v1.ParentReference{
+					gwParentRef("gateway-namespace", "gateway-name"),
+				},
+			},
+		},
+		Status: httpRouteStatus(gwParentRef("gateway-namespace", "gateway-name")),
+	}
+	_, err = gwClient.GatewayV1().HTTPRoutes(rt.Namespace).Create(ctx, rt, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	kubeClient := kubefake.NewClientset()
+	for _, ns := range []string{"gateway-namespace", "route-namespace"} {
+		_, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: objectMeta("", ns)}, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	clients := new(testutils.MockClientGenerator)
+	clients.On("GatewayClient").Return(gwClient, nil)
+	clients.On("KubeClient").Return(kubeClient, nil)
+
+	src, err := NewGatewayHTTPRouteSource(ctx, clients, &Config{})
+	require.NoError(t, err)
+
+	endpoints, err := src.Endpoints(ctx)
+	require.NoError(t, err)
+
+	testutils.AssertEndpointsHaveRefObject(t, endpoints, string(types.GatewayHttpRoute), 1)
 }

--- a/source/gloo_proxy.go
+++ b/source/gloo_proxy.go
@@ -40,9 +40,11 @@ import (
 	netinformers "k8s.io/client-go/informers/networking/v1"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/events"
 	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/source/informers"
 	"sigs.k8s.io/external-dns/source/template"
+	"sigs.k8s.io/external-dns/source/types"
 )
 
 var (
@@ -263,6 +265,9 @@ func (gs *glooSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, error)
 				return nil, err
 			}
 			log.Debugf("Gloo[%s]: Generate %d endpoint(s)", proxy.Name, len(proxyEndpoints))
+
+			endpoint.AttachRefObject(proxyEndpoints, events.NewObjectReference(unstructuredObj, types.GlooProxy))
+
 			endpoints = append(endpoints, proxyEndpoints...)
 		}
 	}

--- a/source/gloo_proxy_test.go
+++ b/source/gloo_proxy_test.go
@@ -33,6 +33,8 @@ import (
 	fakeKube "k8s.io/client-go/kubernetes/fake"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
+	"sigs.k8s.io/external-dns/source/types"
 )
 
 // This is a compile-time validation that glooSource is a Source.
@@ -551,7 +553,7 @@ func TestGlooSource(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, endpoints, 11)
 
-	assert.ElementsMatch(t, endpoints, []*endpoint.Endpoint{
+	testutils.ValidateEndpoints(t, endpoints, []*endpoint.Endpoint{
 		{
 			DNSName:          "a.test",
 			Targets:          []string{internalProxySvc.Status.LoadBalancer.Ingress[0].IP, internalProxySvc.Status.LoadBalancer.Ingress[1].IP, internalProxySvc.Status.LoadBalancer.Ingress[2].IP},
@@ -787,6 +789,76 @@ func TestTransformerInGlooSource(t *testing.T) {
 		assert.NotContains(t, obj.GetAnnotations(), corev1.LastAppliedConfigAnnotation)
 		assert.Contains(t, obj.GetAnnotations(), "user-annotation")
 	})
+}
+
+func TestProcessEndpoint_GlooProxy_RefObjectExist(t *testing.T) {
+	t.Parallel()
+
+	refProxy := proxy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: proxyGVR.GroupVersion().String(),
+			Kind:       "Proxy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ref-proxy",
+			Namespace: defaultGlooNamespace,
+			UID:       "gloo-proxy-uid",
+		},
+		Spec: proxySpec{
+			Listeners: []proxySpecListener{
+				{
+					HTTPListener: proxySpecHTTPListener{
+						VirtualHosts: []proxyVirtualHost{
+							{
+								Domains: []string{"a.test"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	refProxySvc := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      refProxy.Name,
+			Namespace: refProxy.Namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{IP: "203.0.113.1"},
+				},
+			},
+		},
+	}
+
+	fakeKubernetesClient := fakeKube.NewSimpleClientset()
+	fakeDynamicClient := newGlooDynamicClient()
+
+	refProxyUnstructured := unstructured.Unstructured{}
+	refProxyAsJSON, err := json.Marshal(refProxy)
+	assert.NoError(t, err)
+	assert.NoError(t, refProxyUnstructured.UnmarshalJSON(refProxyAsJSON))
+
+	_, err = fakeKubernetesClient.CoreV1().Services(refProxySvc.GetNamespace()).Create(t.Context(), &refProxySvc, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	_, err = fakeDynamicClient.Resource(proxyGVR).Namespace(defaultGlooNamespace).Create(t.Context(), &refProxyUnstructured, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	source, err := NewGlooSource(t.Context(), fakeDynamicClient, fakeKubernetesClient, &Config{
+		GlooNamespaces: []string{defaultGlooNamespace},
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, source)
+
+	endpoints, err := source.Endpoints(t.Context())
+	assert.NoError(t, err)
+
+	testutils.AssertEndpointsHaveRefObject(t, endpoints, types.GlooProxy, 1)
 }
 
 func newGlooDynamicClient(objs ...runtime.Object) *fakeDynamic.FakeDynamicClient {

--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/external-dns/source/types"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/events"
 	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/source/informers"
 	"sigs.k8s.io/external-dns/source/template"
@@ -173,6 +174,8 @@ func (sc *gatewaySource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, err
 		if endpoint.HasNoEmptyEndpoints(gwEndpoints, types.IstioGateway, gateway) {
 			continue
 		}
+
+		endpoint.AttachRefObject(gwEndpoints, events.NewObjectReference(gateway, types.IstioGateway))
 
 		log.Debugf("Endpoints generated from '%s/%s/%s': %q", strings.ToLower(gateway.Kind), gateway.Namespace, gateway.Name, gwEndpoints)
 		endpoints = append(endpoints, gwEndpoints...)

--- a/source/istio_gateway_test.go
+++ b/source/istio_gateway_test.go
@@ -41,6 +41,7 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	templatetest "sigs.k8s.io/external-dns/source/template/testutil"
+	sourcetypes "sigs.k8s.io/external-dns/source/types"
 )
 
 // This is a compile-time validation that gatewaySource is a Source.
@@ -2017,4 +2018,39 @@ func (c fakeGatewayConfig) Config() *networkingv1.Gateway {
 	gw.Spec.Servers = servers
 
 	return gw
+}
+
+func TestProcessEndpoint_IstioGateway_RefObjectExist(t *testing.T) {
+	fakeKubernetesClient := fake.NewClientset()
+	fakeIstioClient := istiofake.NewSimpleClientset()
+
+	svc := fakeIngressGatewayService{
+		ips:       []string{"8.8.8.8"},
+		namespace: "default",
+		name:      "gateway-service",
+	}.Service()
+	_, err := fakeKubernetesClient.CoreV1().Services(svc.Namespace).Create(t.Context(), svc, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	gwCfg := fakeGatewayConfig{
+		namespace: "default",
+		name:      "test-gateway",
+		dnsnames:  [][]string{{"foo.bar"}},
+	}.Config()
+	gwCfg.UID = types.UID("istio-gateway-uid")
+	_, err = fakeIstioClient.NetworkingV1().Gateways(gwCfg.Namespace).Create(t.Context(), gwCfg, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	src, err := NewIstioGatewaySource(
+		t.Context(),
+		fakeKubernetesClient,
+		fakeIstioClient,
+		&Config{},
+	)
+	require.NoError(t, err)
+
+	endpoints, err := src.Endpoints(t.Context())
+	require.NoError(t, err)
+
+	testutils.AssertEndpointsHaveRefObject(t, endpoints, string(sourcetypes.IstioGateway), 1)
 }

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/external-dns/source/types"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/events"
 	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/source/informers"
 	"sigs.k8s.io/external-dns/source/template"
@@ -172,6 +173,8 @@ func (sc *virtualServiceSource) Endpoints(ctx context.Context) ([]*endpoint.Endp
 		if endpoint.HasNoEmptyEndpoints(gwEndpoints, types.IstioVirtualService, vService) {
 			continue
 		}
+
+		endpoint.AttachRefObject(gwEndpoints, events.NewObjectReference(vService, types.IstioVirtualService))
 
 		log.Debugf("Endpoints generated from '%s/%s/%s': %q", strings.ToLower(vService.Kind), vService.Namespace, vService.Name, gwEndpoints)
 		endpoints = append(endpoints, gwEndpoints...)

--- a/source/istio_virtualservice_test.go
+++ b/source/istio_virtualservice_test.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source/annotations"
 	templatetest "sigs.k8s.io/external-dns/source/template/testutil"
+	sourcetypes "sigs.k8s.io/external-dns/source/types"
 )
 
 // This is a compile-time validation that istioVirtualServiceSource is a Source.
@@ -2176,6 +2177,52 @@ func (c fakeVirtualServiceConfig) Config() *networkingv1.VirtualService {
 		},
 		Spec: *vs.DeepCopy(),
 	}
+}
+
+func TestProcessEndpoint_IstioVirtualService_RefObjectExist(t *testing.T) {
+	const namespace = "default"
+
+	fakeKubernetesClient := fake.NewClientset()
+	fakeIstioClient := istiofake.NewSimpleClientset()
+
+	svc := fakeIngressGatewayService{
+		namespace: namespace,
+		name:      "ingressgateway",
+		ips:       []string{"8.8.8.8"},
+	}.Service()
+	_, err := fakeKubernetesClient.CoreV1().Services(svc.Namespace).Create(t.Context(), svc, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	gwCfg := fakeGatewayConfig{
+		name:      "fake-gateway",
+		namespace: namespace,
+		dnsnames:  [][]string{{"example.org"}},
+	}.Config()
+	_, err = fakeIstioClient.NetworkingV1().Gateways(gwCfg.Namespace).Create(t.Context(), gwCfg, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	vsCfg := fakeVirtualServiceConfig{
+		name:      "fake-virtualservice",
+		namespace: namespace,
+		gateways:  []string{"fake-gateway"},
+		dnsnames:  []string{"example.org"},
+	}.Config()
+	vsCfg.UID = types.UID("istio-virtualservice-uid")
+	_, err = fakeIstioClient.NetworkingV1().VirtualServices(vsCfg.Namespace).Create(t.Context(), vsCfg, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	src, err := NewIstioVirtualServiceSource(
+		t.Context(),
+		fakeKubernetesClient,
+		fakeIstioClient,
+		&Config{},
+	)
+	require.NoError(t, err)
+
+	endpoints, err := src.Endpoints(t.Context())
+	require.NoError(t, err)
+
+	testutils.AssertEndpointsHaveRefObject(t, endpoints, string(sourcetypes.IstioVirtualService), 1)
 }
 
 func TestVirtualServiceSourceGetGateway(t *testing.T) {

--- a/source/kong_tcpingress.go
+++ b/source/kong_tcpingress.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/external-dns/source/types"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/events"
 	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/source/informers"
 )
@@ -157,6 +158,8 @@ func (sc *kongTCPIngressSource) Endpoints(_ context.Context) ([]*endpoint.Endpoi
 		if endpoint.HasNoEmptyEndpoints(ingressEndpoints, types.KongTCPIngress, tcpIngress) {
 			continue
 		}
+
+		endpoint.AttachRefObject(ingressEndpoints, events.NewObjectReference(tcpIngress, types.KongTCPIngress))
 
 		log.Debugf("Endpoints generated from TCPIngress: %s: %v", fullname, ingressEndpoints)
 		endpoints = append(endpoints, ingressEndpoints...)

--- a/source/kong_tcpingress_test.go
+++ b/source/kong_tcpingress_test.go
@@ -33,6 +33,7 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source/annotations"
+	"sigs.k8s.io/external-dns/source/types"
 )
 
 // This is a compile-time validation that kongTCPIngressSource is a Source.
@@ -426,6 +427,69 @@ func TestKongTCPIngressEndpoints(t *testing.T) {
 			testutils.ValidateEndpoints(t, endpoints, ti.expected)
 		})
 	}
+}
+
+func TestProcessEndpoint_KongTCPIngress_RefObjectExist(t *testing.T) {
+	t.Parallel()
+
+	tcpProxy := TCPIngress{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: kongGroupdVersionResource.GroupVersion().String(),
+			Kind:       "TCPIngress",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tcp-ingress-annotation",
+			Namespace: defaultKongNamespace,
+			UID:       "kong-tcpingress-uid",
+			Annotations: map[string]string{
+				"external-dns.kubernetes.io/hostname": "a.example.com",
+				"kubernetes.io/ingress.class":         "kong",
+			},
+		},
+		Spec: tcpIngressSpec{
+			Rules: []tcpIngressRule{
+				{Port: 30000},
+			},
+		},
+		Status: tcpIngressStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{Hostname: "a691234567a314e71861a4303f06a3bd-1291189659.us-east-1.elb.amazonaws.com"},
+				},
+			},
+		},
+	}
+
+	fakeKubernetesClient := fakeKube.NewSimpleClientset()
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypes(kongGroupdVersionResource.GroupVersion(), &TCPIngress{}, &TCPIngressList{})
+	fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(scheme)
+
+	tcpi := unstructured.Unstructured{}
+	tcpIngressAsJSON, err := json.Marshal(tcpProxy)
+	assert.NoError(t, err)
+	assert.NoError(t, tcpi.UnmarshalJSON(tcpIngressAsJSON))
+
+	_, err = fakeDynamicClient.Resource(kongGroupdVersionResource).Namespace(defaultKongNamespace).Create(t.Context(), &tcpi, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	source, err := NewKongTCPIngressSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
+		&Config{
+			Namespace:        defaultKongNamespace,
+			AnnotationFilter: "kubernetes.io/ingress.class=kong",
+		})
+	assert.NoError(t, err)
+	assert.NotNil(t, source)
+
+	count := &unstructured.UnstructuredList{}
+	for len(count.Items) < 1 {
+		count, _ = fakeDynamicClient.Resource(kongGroupdVersionResource).Namespace(defaultKongNamespace).List(t.Context(), metav1.ListOptions{})
+	}
+
+	endpoints, err := source.Endpoints(t.Context())
+	assert.NoError(t, err)
+
+	testutils.AssertEndpointsHaveRefObject(t, endpoints, types.KongTCPIngress, 1)
 }
 
 func TestKongTCPIngressSource_InformerTransform(t *testing.T) {

--- a/source/openshift_route.go
+++ b/source/openshift_route.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/external-dns/source/types"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/events"
 	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/source/informers"
 	"sigs.k8s.io/external-dns/source/template"
@@ -143,6 +144,8 @@ func (ors *ocpRouteSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, e
 		if endpoint.HasNoEmptyEndpoints(orEndpoints, types.OpenShiftRoute, ocpRoute) {
 			continue
 		}
+
+		endpoint.AttachRefObject(orEndpoints, events.NewObjectReference(ocpRoute, types.OpenShiftRoute))
 
 		log.Debugf("Endpoints generated from OpenShift Route: %s/%s: %v", ocpRoute.Namespace, ocpRoute.Name, orEndpoints)
 		endpoints = append(endpoints, orEndpoints...)

--- a/source/openshift_route_test.go
+++ b/source/openshift_route_test.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source/annotations"
 	templatetest "sigs.k8s.io/external-dns/source/template/testutil"
+	"sigs.k8s.io/external-dns/source/types"
 )
 
 type OCPRouteSuite struct {
@@ -521,6 +522,51 @@ func testOcpRouteSourceEndpoints(t *testing.T) {
 			testutils.ValidateEndpoints(t, res, tc.expected)
 		})
 	}
+}
+
+func TestProcessEndpoint_OpenShiftRoute_RefObjectExist(t *testing.T) {
+	t.Parallel()
+
+	ocpRoute := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "route-with-target",
+			UID:       "openshift-route-uid",
+		},
+		Status: routev1.RouteStatus{
+			Ingress: []routev1.RouteIngress{
+				{
+					Host:                    "my-domain.com",
+					RouterCanonicalHostname: "apps.my-domain.com",
+					Conditions: []routev1.RouteIngressCondition{
+						{
+							Type:   routev1.RouteAdmitted,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientset()
+	_, err := fakeClient.RouteV1().Routes(ocpRoute.Namespace).Create(t.Context(), ocpRoute, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	source, err := NewOcpRouteSource(
+		t.Context(),
+		fakeClient,
+		&Config{
+			TemplateEngine: templatetest.MustEngine(t, "{{.Name}}", "", "", false),
+			LabelFilter:    labels.Everything(),
+		},
+	)
+	require.NoError(t, err)
+
+	endpoints, err := source.Endpoints(t.Context())
+	require.NoError(t, err)
+
+	testutils.AssertEndpointsHaveRefObject(t, endpoints, types.OpenShiftRoute, 1)
 }
 
 func TestOcpRouteSource_InformerTransform(t *testing.T) {

--- a/source/skipper_routegroup.go
+++ b/source/skipper_routegroup.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/external-dns/source/types"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/events"
 	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/source/template"
 )
@@ -270,9 +271,11 @@ func (sc *routeGroupSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, 
 			return nil, err
 		}
 
-		if endpoint.HasNoEmptyEndpoints(eps, types.OpenShiftRoute, rg) {
+		if endpoint.HasNoEmptyEndpoints(eps, types.SkipperRouteGroup, rg) {
 			continue
 		}
+
+		endpoint.AttachRefObject(eps, events.NewObjectReference(rg, types.SkipperRouteGroup))
 
 		log.Debugf("Endpoints generated from ingress: %s/%s: %v", rg.Namespace, rg.Name, eps)
 		endpoints = append(endpoints, eps...)

--- a/source/skipper_routegroup_test.go
+++ b/source/skipper_routegroup_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source/annotations"
 	templatetest "sigs.k8s.io/external-dns/source/template/testutil"
+	"sigs.k8s.io/external-dns/source/types"
 )
 
 func createTestRouteGroup(ns, name string, annotations map[string]string, hosts []string, destinations []routeGroupLoadBalancer) *routeGroup {
@@ -867,4 +868,43 @@ func TestResourceLabelIsSet(t *testing.T) {
 			t.Errorf("Failed to set resource label on ep %v", ep)
 		}
 	}
+}
+
+func TestProcessEndpoint_SkipperRouteGroup_RefObjectExist(t *testing.T) {
+	t.Parallel()
+
+	rg := &routeGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "namespace1",
+			Name:      "rg1",
+			UID:       "skipper-rg-uid-1234",
+		},
+		Spec: routeGroupSpec{
+			Hosts: []string{"rg1.k8s.example"},
+		},
+		Status: routeGroupStatus{
+			LoadBalancer: routeGroupLoadBalancerStatus{
+				RouteGroup: []routeGroupLoadBalancer{
+					{
+						Hostname: "lb.example.org",
+					},
+				},
+			},
+		},
+	}
+
+	source := &routeGroupSource{
+		cli: &fakeRouteGroupClient{
+			rg: &routeGroupList{
+				Items: []*routeGroup{rg},
+			},
+		},
+	}
+
+	endpoints, err := source.Endpoints(t.Context())
+	if err != nil {
+		t.Fatalf("Got unexpected error: %v", err)
+	}
+
+	testutils.AssertEndpointsHaveRefObject(t, endpoints, string(types.SkipperRouteGroup), 1)
 }

--- a/source/traefik_proxy.go
+++ b/source/traefik_proxy.go
@@ -35,11 +35,13 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/external-dns/source/template"
 	"sigs.k8s.io/external-dns/source/types"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/events"
 	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/source/informers"
 )
@@ -296,6 +298,8 @@ func (ts *traefikSource) ingressRouteTCPEndpoints() ([]*endpoint.Endpoint, error
 		if endpoint.HasNoEmptyEndpoints(ingressEndpoints, types.TraefikProxy, ingressRouteTCP) {
 			continue
 		}
+
+		endpoint.AttachRefObject(ingressEndpoints, events.NewObjectReference(ingressRouteTCP, types.TraefikProxy))
 
 		log.Debugf("Endpoints generated from IngressRouteTCP: %s: %v", fullname, ingressEndpoints)
 		endpoints = append(endpoints, ingressEndpoints...)
@@ -974,6 +978,12 @@ func extractEndpoints[T interface {
 		if len(ingressEndpoints) == 0 {
 			log.Debugf("No endpoints could be generated from Host %s", name)
 			continue
+		}
+
+		// All traefik route kinds map to the traefik-proxy source. The concrete
+		// CRD types satisfy client.Object; the assertion guards the generic T.
+		if obj, ok := any(item).(client.Object); ok {
+			endpoint.AttachRefObject(ingressEndpoints, events.NewObjectReference(obj, types.TraefikProxy))
 		}
 
 		log.Debugf("Endpoints generated from %s: %v", name, ingressEndpoints)

--- a/source/traefik_proxy_test.go
+++ b/source/traefik_proxy_test.go
@@ -38,6 +38,7 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source/annotations"
+	"sigs.k8s.io/external-dns/source/types"
 )
 
 // This is a compile-time validation that traefikSource is a Source.
@@ -1956,4 +1957,60 @@ func TestTraefikSource_InformerTransform(t *testing.T) {
 			)
 		})
 	}
+}
+
+func TestProcessEndpoint_TraefikProxy_RefObjectExist(t *testing.T) {
+	t.Parallel()
+
+	ingressRoute := IngressRoute{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: ingressRouteGVR.GroupVersion().String(),
+			Kind:       "IngressRoute",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ingressroute-annotation",
+			Namespace: defaultTraefikNamespace,
+			UID:       "traefik-ir-uid-1234",
+			Annotations: map[string]string{
+				"external-dns.kubernetes.io/hostname": "a.example.com",
+				"external-dns.kubernetes.io/target":   "target.domain.tld",
+				"kubernetes.io/ingress.class":         "traefik",
+			},
+		},
+	}
+
+	fakeKubernetesClient := fakeKube.NewSimpleClientset()
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypes(ingressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
+	scheme.AddKnownTypes(ingressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
+	scheme.AddKnownTypes(ingressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
+	scheme.AddKnownTypes(oldIngressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
+	scheme.AddKnownTypes(oldIngressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
+	scheme.AddKnownTypes(oldIngressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
+	fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(scheme)
+
+	ir := unstructured.Unstructured{}
+	ingressRouteAsJSON, err := json.Marshal(ingressRoute)
+	require.NoError(t, err)
+	require.NoError(t, ir.UnmarshalJSON(ingressRouteAsJSON))
+
+	_, err = fakeDynamicClient.Resource(ingressRouteGVR).Namespace(defaultTraefikNamespace).Create(t.Context(), &ir, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	source, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
+		&Config{
+			Namespace:        defaultTraefikNamespace,
+			AnnotationFilter: "kubernetes.io/ingress.class=traefik",
+		})
+	require.NoError(t, err)
+
+	count := &unstructured.UnstructuredList{}
+	for len(count.Items) < 1 {
+		count, _ = fakeDynamicClient.Resource(ingressRouteGVR).Namespace(defaultTraefikNamespace).List(t.Context(), metav1.ListOptions{})
+	}
+
+	endpoints, err := source.Endpoints(t.Context())
+	require.NoError(t, err)
+
+	testutils.AssertEndpointsHaveRefObject(t, endpoints, string(types.TraefikProxy), 1)
 }


### PR DESCRIPTION
## What does it do ?

Attaches a `RefObject` (via `events.NewObjectReference`) to the endpoints produced by the sources that were missing it: the gateway routes (`gateway-httproute`, `-grpcroute`, `-tlsroute`, `-tcproute`, `-udproute`), `istio-gateway`, `istio-virtualservice`, `contour-httpproxy`, `gloo-proxy`, `traefik-proxy`, `openshift-route`, `ambassador-host`, `kong-tcpingress`, `f5-virtualserver`, `f5-transportserver` and `skipper-routegroup`.

Until now only `ingress`, `service`, `node`, `pod`, `crd`, `fake` and `unstructured` set a `RefObject`, so endpoints from every other source carried no source identity.

## Motivation

The `RefObject` is the transient, never-persisted source identity already used for:

- the `source` label on source metrics (deduplicated / invalid-endpoint counters) — sources without a `RefObject` report `source="unknown"`;
- Kubernetes Event emission (`--emit-events`) — events can only reference resources that carry an object reference.

This makes that identity consistent across all sources. `connector` (endpoints decoded from a socket, no Kubernetes object) and `empty` (no endpoints) cannot reference an object and are left untagged.

## More

- A small bug is fixed along the way: `skipper-routegroup` passed `types.OpenShiftRoute` instead of `types.SkipperRouteGroup` to `HasNoEmptyEndpoints`.
- A `*_RefObjectExist` unit test is added for each newly tagged source.

- [x] Yes, I added unit tests
