### PR TITLE
test(source): assert RefObject via ValidateEndpoints opt-in

### DIFF
--- a/internal/testutils/endpoint.go
+++ b/internal/testutils/endpoint.go
@@ -278,13 +278,15 @@ func validateEndpoint(ep, expected *endpoint.Endpoint) []string {
 	}
 	// Opt-in: only checked when the expected endpoint declares a RefObject (see RefSource).
 	if expected.RefObject() != nil {
-		switch {
-		case ep.RefObject() == nil:
+		if ep.RefObject() == nil {
 			errs = append(errs, fmt.Sprintf("%s: RefObject expected, got nil", prefix))
-		case ep.RefObject().Source() != expected.RefObject().Source():
-			errs = append(errs, fmt.Sprintf("%s: RefObject.Source expected %q, got %q", prefix, expected.RefObject().Source(), ep.RefObject().Source()))
-		case ep.RefObject().UID() == "":
-			errs = append(errs, fmt.Sprintf("%s: RefObject.UID is empty", prefix))
+		} else {
+			if ep.RefObject().Source() != expected.RefObject().Source() {
+				errs = append(errs, fmt.Sprintf("%s: RefObject.Source expected %q, got %q", prefix, expected.RefObject().Source(), ep.RefObject().Source()))
+			}
+			if ep.RefObject().UID() == "" {
+				errs = append(errs, fmt.Sprintf("%s: RefObject.UID is empty", prefix))
+			}
 		}
 	}
 

--- a/internal/testutils/endpoint.go
+++ b/internal/testutils/endpoint.go
@@ -208,6 +208,13 @@ func NewEndpointWithRef(dns, target string, obj ctrlclient.Object, source string
 		WithRefObject(events.NewObjectReference(obj, source))
 }
 
+// RefSource returns an ObjectReference carrying only a source identity. Set it on an
+// expected endpoint via WithRefObject to opt into ValidateEndpoints' RefObject check,
+// which asserts the actual endpoint has a non-nil RefObject with this Source and a non-empty UID.
+func RefSource(source string) *events.ObjectReference {
+	return events.NewObjectReferenceFromParts("", "", "", "", "", source)
+}
+
 // AssertEndpointsHaveRefObject asserts that endpoints have the expected count
 // and each endpoint has a non-nil RefObject with the expected source type.
 func AssertEndpointsHaveRefObject(
@@ -268,6 +275,17 @@ func validateEndpoint(ep, expected *endpoint.Endpoint) []string {
 	}
 	if ep.SetIdentifier != expected.SetIdentifier {
 		errs = append(errs, fmt.Sprintf("%s: SetIdentifier expected %q, got %q", prefix, expected.SetIdentifier, ep.SetIdentifier))
+	}
+	// Opt-in: only checked when the expected endpoint declares a RefObject (see RefSource).
+	if expected.RefObject() != nil {
+		switch {
+		case ep.RefObject() == nil:
+			errs = append(errs, fmt.Sprintf("%s: RefObject expected, got nil", prefix))
+		case ep.RefObject().Source() != expected.RefObject().Source():
+			errs = append(errs, fmt.Sprintf("%s: RefObject.Source expected %q, got %q", prefix, expected.RefObject().Source(), ep.RefObject().Source()))
+		case ep.RefObject().UID() == "":
+			errs = append(errs, fmt.Sprintf("%s: RefObject.UID is empty", prefix))
+		}
 	}
 
 	return errs

--- a/source/ambassador_host_test.go
+++ b/source/ambassador_host_test.go
@@ -78,6 +78,7 @@ func TestAmbassadorHostSource(t *testing.T) {
 			host: ambassador.Host{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "basic-host",
+					UID:  "ambassador-host-uid",
 					Annotations: map[string]string{
 						ambHostAnnotation: hostAnnotation,
 					},
@@ -99,11 +100,11 @@ func TestAmbassadorHostSource(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				{
+				(&endpoint.Endpoint{
 					DNSName:    "www.example.org",
 					RecordType: endpoint.RecordTypeA,
 					Targets:    endpoint.Targets{"1.1.1.1"},
-				},
+				}).WithRefObject(testutils.RefSource(types.AmbassadorHost)),
 			},
 		}, {
 			title:         "Service with load balancer hostname",
@@ -662,64 +663,6 @@ func createAmbassadorHost(host *ambassador.Host) (*unstructured.Unstructured, er
 	err := uc.scheme.Convert(host, obj, nil)
 
 	return obj, err
-}
-
-func TestProcessEndpoint_AmbassadorHost_RefObjectExist(t *testing.T) {
-	t.Parallel()
-
-	hostAnnotation := fmt.Sprintf("%s/%s", defaultAmbassadorNamespace, defaultAmbassadorServiceName)
-
-	fakeKubernetesClient := fakeKube.NewSimpleClientset()
-	ambassadorScheme := runtime.NewScheme()
-	ambassador.AddToScheme(ambassadorScheme)
-	fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(ambassadorScheme)
-
-	namespace := v1.NamespaceDefault
-
-	service := v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: defaultAmbassadorServiceName,
-		},
-		Status: v1.ServiceStatus{
-			LoadBalancer: v1.LoadBalancerStatus{
-				Ingress: []v1.LoadBalancerIngress{{
-					IP: "1.1.1.1",
-				}},
-			},
-		},
-	}
-	_, err := fakeKubernetesClient.CoreV1().Services(defaultAmbassadorNamespace).Create(t.Context(), &service, metav1.CreateOptions{})
-	assert.NoError(t, err)
-
-	host, err := createAmbassadorHost(&ambassador.Host{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "basic-host",
-			UID:  "ambassador-host-uid",
-			Annotations: map[string]string{
-				ambHostAnnotation: hostAnnotation,
-			},
-		},
-		Spec: &ambassador.HostSpec{
-			Hostname: "www.example.org",
-		},
-	})
-	assert.NoError(t, err)
-
-	_, err = fakeDynamicClient.Resource(ambHostGVR).Namespace(namespace).Create(t.Context(), host, metav1.CreateOptions{})
-	assert.NoError(t, err)
-
-	source, err := NewAmbassadorHostSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
-		&Config{
-			Namespace:   namespace,
-			LabelFilter: labels.Everything(),
-		})
-	assert.NoError(t, err)
-	assert.NotNil(t, source)
-
-	endpoints, err := source.Endpoints(t.Context())
-	assert.NoError(t, err)
-
-	testutils.AssertEndpointsHaveRefObject(t, endpoints, types.AmbassadorHost, 1)
 }
 
 // TestParseAmbLoadBalancerService tests our parsing of Ambassador service info.

--- a/source/contour_httpproxy_test.go
+++ b/source/contour_httpproxy_test.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/source/annotations"
@@ -404,6 +405,7 @@ func testHTTPProxyEndpoints(t *testing.T) {
 				{
 					name:      "fake1",
 					namespace: namespace,
+					uid:       "contour-httpproxy-uid",
 					annotations: map[string]string{
 						"contour.heptio.com/ingress.class": "contour",
 					},
@@ -411,11 +413,11 @@ func testHTTPProxyEndpoints(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				{
+				(&endpoint.Endpoint{
 					DNSName:    "example.org",
 					RecordType: endpoint.RecordTypeA,
 					Targets:    endpoint.Targets{"8.8.8.8"},
-				},
+				}).WithRefObject(testutils.RefSource(string(sourcetypes.ContourHTTPProxy))),
 			},
 		},
 		{
@@ -1059,41 +1061,10 @@ func newTestHTTPProxySource(t *testing.T) (*httpProxySource, error) {
 	return irsrc, nil
 }
 
-func TestProcessEndpoint_ContourHTTPProxy_RefObjectExist(t *testing.T) {
-	fakeDynamicClient, s := newContourDynamicKubernetesClient()
-
-	httpProxy := (fakeHTTPProxy{
-		name:      "foo-httpproxy",
-		namespace: "default",
-		host:      "example.com",
-		loadBalancer: fakeLoadBalancerService{
-			ips: []string{"8.8.8.8"},
-		},
-	}).HTTPProxy()
-	httpProxy.UID = "contour-httpproxy-uid"
-
-	unstructuredHTTPProxy, err := convertHTTPProxyToUnstructured(httpProxy, s)
-	require.NoError(t, err)
-
-	_, err = fakeDynamicClient.Resource(projectcontour.HTTPProxyGVR).Namespace(httpProxy.Namespace).Create(t.Context(), unstructuredHTTPProxy, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	src, err := NewContourHTTPProxySource(
-		t.Context(),
-		fakeDynamicClient,
-		&Config{Namespace: "default"},
-	)
-	require.NoError(t, err)
-
-	endpoints, err := src.Endpoints(t.Context())
-	require.NoError(t, err)
-
-	testutils.AssertEndpointsHaveRefObject(t, endpoints, string(sourcetypes.ContourHTTPProxy), 1)
-}
-
 type fakeHTTPProxy struct {
 	namespace   string
 	name        string
+	uid         string
 	annotations map[string]string
 
 	host         string
@@ -1132,6 +1103,7 @@ func (ir fakeHTTPProxy) HTTPProxy() *projectcontour.HTTPProxy {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   ir.namespace,
 			Name:        ir.name,
+			UID:         k8stypes.UID(ir.uid),
 			Annotations: ir.annotations,
 		},
 		Spec: spec,

--- a/source/f5_transportserver_test.go
+++ b/source/f5_transportserver_test.go
@@ -58,6 +58,7 @@ func TestF5TransportServerEndpoints(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-vs",
 					Namespace: defaultF5TransportServerNamespace,
+					UID:       "f5-ts-uid-1234",
 					Annotations: map[string]string{
 						annotations.TargetKey: "192.168.1.150",
 					},
@@ -72,7 +73,7 @@ func TestF5TransportServerEndpoints(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				{
+				(&endpoint.Endpoint{
 					DNSName:    "www.example.com",
 					Targets:    []string{"192.168.1.150"},
 					RecordType: endpoint.RecordTypeA,
@@ -80,7 +81,7 @@ func TestF5TransportServerEndpoints(t *testing.T) {
 					Labels: endpoint.Labels{
 						"resource": "f5-transportserver/transportserver/test-vs",
 					},
-				},
+				}).WithRefObject(testutils.RefSource(string(types.F5TransportServer))),
 			},
 		},
 		{
@@ -400,59 +401,6 @@ func TestF5TransportServerEndpoints(t *testing.T) {
 			testutils.ValidateEndpoints(t, endpoints, tc.expected)
 		})
 	}
-}
-
-func TestProcessEndpoint_F5TransportServer_RefObjectExist(t *testing.T) {
-	t.Parallel()
-
-	transportServer := f5.TransportServer{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: f5TransportServerGVR.GroupVersion().String(),
-			Kind:       "TransportServer",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-ts",
-			Namespace: defaultF5TransportServerNamespace,
-			UID:       "f5-ts-uid-1234",
-		},
-		Spec: f5.TransportServerSpec{
-			Host:                 "www.example.com",
-			VirtualServerAddress: "192.168.1.100",
-		},
-		Status: f5.CustomResourceStatus{
-			VSAddress: "192.168.1.200",
-			Status:    "OK",
-		},
-	}
-
-	fakeKubernetesClient := fakeKube.NewSimpleClientset()
-	scheme := runtime.NewScheme()
-	scheme.AddKnownTypes(f5TransportServerGVR.GroupVersion(), &f5.TransportServer{}, &f5.TransportServerList{})
-	fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(scheme)
-
-	tsUnstructured := unstructured.Unstructured{}
-	tsJSON, err := json.Marshal(transportServer)
-	require.NoError(t, err)
-	require.NoError(t, tsUnstructured.UnmarshalJSON(tsJSON))
-
-	_, err = fakeDynamicClient.Resource(f5TransportServerGVR).Namespace(defaultF5TransportServerNamespace).Create(t.Context(), &tsUnstructured, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	source, err := NewF5TransportServerSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
-		&Config{
-			Namespace: defaultF5TransportServerNamespace,
-		})
-	require.NoError(t, err)
-
-	count := &unstructured.UnstructuredList{}
-	for len(count.Items) < 1 {
-		count, _ = fakeDynamicClient.Resource(f5TransportServerGVR).Namespace(defaultF5TransportServerNamespace).List(t.Context(), metav1.ListOptions{})
-	}
-
-	endpoints, err := source.Endpoints(t.Context())
-	require.NoError(t, err)
-
-	testutils.AssertEndpointsHaveRefObject(t, endpoints, string(types.F5TransportServer), 1)
 }
 
 func TestF5TransportServerSource_InformerTransform(t *testing.T) {

--- a/source/f5_virtualserver_test.go
+++ b/source/f5_virtualserver_test.go
@@ -58,6 +58,7 @@ func TestF5VirtualServerEndpoints(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-vs",
 					Namespace: defaultF5VirtualServerNamespace,
+					UID:       "f5-vs-uid-1234",
 					Annotations: map[string]string{
 						annotations.TargetKey: "192.168.1.150",
 					},
@@ -72,7 +73,7 @@ func TestF5VirtualServerEndpoints(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				{
+				(&endpoint.Endpoint{
 					DNSName:    "www.example.com",
 					Targets:    []string{"192.168.1.150"},
 					RecordType: endpoint.RecordTypeA,
@@ -80,7 +81,7 @@ func TestF5VirtualServerEndpoints(t *testing.T) {
 					Labels: endpoint.Labels{
 						"resource": "f5-virtualserver/virtualserver/test-vs",
 					},
-				},
+				}).WithRefObject(testutils.RefSource(string(types.F5VirtualServer))),
 			},
 		},
 		{
@@ -643,59 +644,6 @@ func TestF5VirtualServerEndpoints(t *testing.T) {
 			testutils.ValidateEndpoints(t, endpoints, tc.expected)
 		})
 	}
-}
-
-func TestProcessEndpoint_F5VirtualServer_RefObjectExist(t *testing.T) {
-	t.Parallel()
-
-	virtualServer := f5.VirtualServer{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: f5VirtualServerGVR.GroupVersion().String(),
-			Kind:       "VirtualServer",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vs",
-			Namespace: defaultF5VirtualServerNamespace,
-			UID:       "f5-vs-uid-1234",
-		},
-		Spec: f5.VirtualServerSpec{
-			Host:                 "www.example.com",
-			VirtualServerAddress: "192.168.1.100",
-		},
-		Status: f5.CustomResourceStatus{
-			VSAddress: "192.168.1.200",
-			Status:    "OK",
-		},
-	}
-
-	fakeKubernetesClient := fakeKube.NewClientset()
-	scheme := runtime.NewScheme()
-	scheme.AddKnownTypes(f5VirtualServerGVR.GroupVersion(), &f5.VirtualServer{}, &f5.VirtualServerList{})
-	fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(scheme)
-
-	vsUnstructured := unstructured.Unstructured{}
-	vsJSON, err := json.Marshal(virtualServer)
-	require.NoError(t, err)
-	require.NoError(t, vsUnstructured.UnmarshalJSON(vsJSON))
-
-	_, err = fakeDynamicClient.Resource(f5VirtualServerGVR).Namespace(defaultF5VirtualServerNamespace).Create(t.Context(), &vsUnstructured, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	source, err := NewF5VirtualServerSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
-		&Config{
-			Namespace: defaultF5VirtualServerNamespace,
-		})
-	require.NoError(t, err)
-
-	count := &unstructured.UnstructuredList{}
-	for len(count.Items) < 1 {
-		count, _ = fakeDynamicClient.Resource(f5VirtualServerGVR).Namespace(defaultF5VirtualServerNamespace).List(t.Context(), metav1.ListOptions{})
-	}
-
-	endpoints, err := source.Endpoints(t.Context())
-	require.NoError(t, err)
-
-	testutils.AssertEndpointsHaveRefObject(t, endpoints, string(types.F5VirtualServer), 1)
 }
 
 func TestF5VirtualServerSource_InformerTransform(t *testing.T) {

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -194,7 +194,11 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				},
 			},
 			routes: []*v1.HTTPRoute{{
-				ObjectMeta: objectMeta("route-namespace", "test"),
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "route-namespace",
+					UID:       "httproute-uid",
+				},
 				Spec: v1.HTTPRouteSpec{
 					Hostnames: hostnames("test.example.internal"),
 					CommonRouteSpec: v1.CommonRouteSpec{
@@ -210,7 +214,8 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				),
 			}},
 			endpoints: []*endpoint.Endpoint{
-				newTestEndpoint("test.example.internal", "1.2.3.4"),
+				newTestEndpoint("test.example.internal", "1.2.3.4").
+					WithRefObject(testutils.RefSource(string(types.GatewayHttpRoute))),
 			},
 			logExpectations: []string{
 				"Gateway gateway-namespace/not-gateway-name does not match gateway-name route-namespace/test",
@@ -1762,68 +1767,4 @@ func TestGatewayHTTPRouteSource_InformerTransform(t *testing.T) {
 		withRemovedManagedFields(),
 		withRemovedStatusConditions(),
 	)
-}
-
-func TestProcessEndpoint_GatewayHTTPRoute_RefObjectExist(t *testing.T) {
-	fromAll := v1.NamespacesFromAll
-	allowAllNamespaces := &v1.AllowedRoutes{
-		Namespaces: &v1.RouteNamespaces{From: &fromAll},
-	}
-	objectMeta := func(namespace, name string) metav1.ObjectMeta {
-		return metav1.ObjectMeta{Name: name, Namespace: namespace}
-	}
-
-	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
-	defer cancel()
-
-	gwClient := gatewayfake.NewSimpleClientset()
-	gw := &v1.Gateway{
-		ObjectMeta: objectMeta("gateway-namespace", "gateway-name"),
-		Spec: v1.GatewaySpec{
-			Listeners: []v1.Listener{{
-				Protocol:      v1.HTTPProtocolType,
-				AllowedRoutes: allowAllNamespaces,
-			}},
-		},
-		Status: gatewayStatus("1.2.3.4"),
-	}
-	_, err := gwClient.GatewayV1().Gateways(gw.Namespace).Create(ctx, gw, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	rt := &v1.HTTPRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "route-namespace",
-			UID:       "httproute-uid",
-		},
-		Spec: v1.HTTPRouteSpec{
-			Hostnames: []v1.Hostname{"test.example.internal"},
-			CommonRouteSpec: v1.CommonRouteSpec{
-				ParentRefs: []v1.ParentReference{
-					gwParentRef("gateway-namespace", "gateway-name"),
-				},
-			},
-		},
-		Status: httpRouteStatus(gwParentRef("gateway-namespace", "gateway-name")),
-	}
-	_, err = gwClient.GatewayV1().HTTPRoutes(rt.Namespace).Create(ctx, rt, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	kubeClient := kubefake.NewClientset()
-	for _, ns := range []string{"gateway-namespace", "route-namespace"} {
-		_, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: objectMeta("", ns)}, metav1.CreateOptions{})
-		require.NoError(t, err)
-	}
-
-	clients := new(testutils.MockClientGenerator)
-	clients.On("GatewayClient").Return(gwClient, nil)
-	clients.On("KubeClient").Return(kubeClient, nil)
-
-	src, err := NewGatewayHTTPRouteSource(ctx, clients, &Config{})
-	require.NoError(t, err)
-
-	endpoints, err := src.Endpoints(ctx)
-	require.NoError(t, err)
-
-	testutils.AssertEndpointsHaveRefObject(t, endpoints, string(types.GatewayHttpRoute), 1)
 }

--- a/source/gloo_proxy_test.go
+++ b/source/gloo_proxy_test.go
@@ -52,6 +52,7 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "internal",
 			Namespace: defaultGlooNamespace,
+			UID:       "gloo-proxy-uid",
 		},
 		Spec: proxySpec{
 			Listeners: []proxySpecListener{
@@ -554,14 +555,14 @@ func TestGlooSource(t *testing.T) {
 	assert.Len(t, endpoints, 11)
 
 	testutils.ValidateEndpoints(t, endpoints, []*endpoint.Endpoint{
-		{
+		(&endpoint.Endpoint{
 			DNSName:          "a.test",
 			Targets:          []string{internalProxySvc.Status.LoadBalancer.Ingress[0].IP, internalProxySvc.Status.LoadBalancer.Ingress[1].IP, internalProxySvc.Status.LoadBalancer.Ingress[2].IP},
 			RecordType:       endpoint.RecordTypeA,
 			RecordTTL:        0,
 			Labels:           endpoint.Labels{},
 			ProviderSpecific: endpoint.ProviderSpecific{},
-		},
+		}).WithRefObject(testutils.RefSource(types.GlooProxy)),
 		{
 			DNSName:          "b.test",
 			Targets:          []string{internalProxySvc.Status.LoadBalancer.Ingress[0].IP, internalProxySvc.Status.LoadBalancer.Ingress[1].IP, internalProxySvc.Status.LoadBalancer.Ingress[2].IP},
@@ -789,76 +790,6 @@ func TestTransformerInGlooSource(t *testing.T) {
 		assert.NotContains(t, obj.GetAnnotations(), corev1.LastAppliedConfigAnnotation)
 		assert.Contains(t, obj.GetAnnotations(), "user-annotation")
 	})
-}
-
-func TestProcessEndpoint_GlooProxy_RefObjectExist(t *testing.T) {
-	t.Parallel()
-
-	refProxy := proxy{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: proxyGVR.GroupVersion().String(),
-			Kind:       "Proxy",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ref-proxy",
-			Namespace: defaultGlooNamespace,
-			UID:       "gloo-proxy-uid",
-		},
-		Spec: proxySpec{
-			Listeners: []proxySpecListener{
-				{
-					HTTPListener: proxySpecHTTPListener{
-						VirtualHosts: []proxyVirtualHost{
-							{
-								Domains: []string{"a.test"},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	refProxySvc := corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      refProxy.Name,
-			Namespace: refProxy.Namespace,
-		},
-		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeLoadBalancer,
-		},
-		Status: corev1.ServiceStatus{
-			LoadBalancer: corev1.LoadBalancerStatus{
-				Ingress: []corev1.LoadBalancerIngress{
-					{IP: "203.0.113.1"},
-				},
-			},
-		},
-	}
-
-	fakeKubernetesClient := fakeKube.NewSimpleClientset()
-	fakeDynamicClient := newGlooDynamicClient()
-
-	refProxyUnstructured := unstructured.Unstructured{}
-	refProxyAsJSON, err := json.Marshal(refProxy)
-	assert.NoError(t, err)
-	assert.NoError(t, refProxyUnstructured.UnmarshalJSON(refProxyAsJSON))
-
-	_, err = fakeKubernetesClient.CoreV1().Services(refProxySvc.GetNamespace()).Create(t.Context(), &refProxySvc, metav1.CreateOptions{})
-	assert.NoError(t, err)
-
-	_, err = fakeDynamicClient.Resource(proxyGVR).Namespace(defaultGlooNamespace).Create(t.Context(), &refProxyUnstructured, metav1.CreateOptions{})
-	assert.NoError(t, err)
-
-	source, err := NewGlooSource(t.Context(), fakeDynamicClient, fakeKubernetesClient, &Config{
-		GlooNamespaces: []string{defaultGlooNamespace},
-	})
-	assert.NoError(t, err)
-	assert.NotNil(t, source)
-
-	endpoints, err := source.Endpoints(t.Context())
-	assert.NoError(t, err)
-
-	testutils.AssertEndpointsHaveRefObject(t, endpoints, types.GlooProxy, 1)
 }
 
 func newGlooDynamicClient(objs ...runtime.Object) *fakeDynamic.FakeDynamicClient {

--- a/source/istio_gateway_test.go
+++ b/source/istio_gateway_test.go
@@ -761,14 +761,15 @@ func testGatewayEndpoints(t *testing.T) {
 					name:     "fake1",
 					labels:   map[string]string{"app": "istio-gateway"},
 					dnsnames: [][]string{{"example.org"}},
+					uid:      "istio-gateway-uid",
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				{
+				(&endpoint.Endpoint{
 					DNSName:    "example.org",
 					RecordType: endpoint.RecordTypeA,
 					Targets:    endpoint.Targets{"8.8.8.8"},
-				},
+				}).WithRefObject(testutils.RefSource(string(sourcetypes.IstioGateway))),
 			},
 		},
 		{
@@ -1988,6 +1989,7 @@ type fakeGatewayConfig struct {
 	labels      map[string]string
 	dnsnames    [][]string
 	selector    map[string]string
+	uid         string
 }
 
 func (c fakeGatewayConfig) Config() *networkingv1.Gateway {
@@ -2001,6 +2003,7 @@ func (c fakeGatewayConfig) Config() *networkingv1.Gateway {
 			Namespace:   ns,
 			Annotations: c.annotations,
 			Labels:      c.labels,
+			UID:         types.UID(c.uid),
 		},
 		Spec: istionetworking.Gateway{
 			Servers:  nil,
@@ -2018,39 +2021,4 @@ func (c fakeGatewayConfig) Config() *networkingv1.Gateway {
 	gw.Spec.Servers = servers
 
 	return gw
-}
-
-func TestProcessEndpoint_IstioGateway_RefObjectExist(t *testing.T) {
-	fakeKubernetesClient := fake.NewClientset()
-	fakeIstioClient := istiofake.NewSimpleClientset()
-
-	svc := fakeIngressGatewayService{
-		ips:       []string{"8.8.8.8"},
-		namespace: "default",
-		name:      "gateway-service",
-	}.Service()
-	_, err := fakeKubernetesClient.CoreV1().Services(svc.Namespace).Create(t.Context(), svc, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	gwCfg := fakeGatewayConfig{
-		namespace: "default",
-		name:      "test-gateway",
-		dnsnames:  [][]string{{"foo.bar"}},
-	}.Config()
-	gwCfg.UID = types.UID("istio-gateway-uid")
-	_, err = fakeIstioClient.NetworkingV1().Gateways(gwCfg.Namespace).Create(t.Context(), gwCfg, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	src, err := NewIstioGatewaySource(
-		t.Context(),
-		fakeKubernetesClient,
-		fakeIstioClient,
-		&Config{},
-	)
-	require.NoError(t, err)
-
-	endpoints, err := src.Endpoints(t.Context())
-	require.NoError(t, err)
-
-	testutils.AssertEndpointsHaveRefObject(t, endpoints, string(sourcetypes.IstioGateway), 1)
 }

--- a/source/istio_virtualservice_test.go
+++ b/source/istio_virtualservice_test.go
@@ -869,11 +869,11 @@ func testVirtualServiceEndpoints(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				{
+				(&endpoint.Endpoint{
 					DNSName:    "example.org",
 					RecordType: endpoint.RecordTypeA,
 					Targets:    endpoint.Targets{"8.8.8.8"},
-				},
+				}).WithRefObject(testutils.RefSource(string(sourcetypes.IstioVirtualService))),
 			},
 		},
 		{
@@ -2044,7 +2044,9 @@ func testVirtualServiceEndpoints(t *testing.T) {
 				gateways = append(gateways, gwItem.Config())
 			}
 			for _, vsItem := range ti.vsConfigs {
-				virtualservices = append(virtualservices, vsItem.Config())
+				vs := vsItem.Config()
+				vs.UID = types.UID("istio-virtualservice-uid")
+				virtualservices = append(virtualservices, vs)
 			}
 
 			fakeKubernetesClient := fake.NewClientset()
@@ -2177,52 +2179,6 @@ func (c fakeVirtualServiceConfig) Config() *networkingv1.VirtualService {
 		},
 		Spec: *vs.DeepCopy(),
 	}
-}
-
-func TestProcessEndpoint_IstioVirtualService_RefObjectExist(t *testing.T) {
-	const namespace = "default"
-
-	fakeKubernetesClient := fake.NewClientset()
-	fakeIstioClient := istiofake.NewSimpleClientset()
-
-	svc := fakeIngressGatewayService{
-		namespace: namespace,
-		name:      "ingressgateway",
-		ips:       []string{"8.8.8.8"},
-	}.Service()
-	_, err := fakeKubernetesClient.CoreV1().Services(svc.Namespace).Create(t.Context(), svc, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	gwCfg := fakeGatewayConfig{
-		name:      "fake-gateway",
-		namespace: namespace,
-		dnsnames:  [][]string{{"example.org"}},
-	}.Config()
-	_, err = fakeIstioClient.NetworkingV1().Gateways(gwCfg.Namespace).Create(t.Context(), gwCfg, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	vsCfg := fakeVirtualServiceConfig{
-		name:      "fake-virtualservice",
-		namespace: namespace,
-		gateways:  []string{"fake-gateway"},
-		dnsnames:  []string{"example.org"},
-	}.Config()
-	vsCfg.UID = types.UID("istio-virtualservice-uid")
-	_, err = fakeIstioClient.NetworkingV1().VirtualServices(vsCfg.Namespace).Create(t.Context(), vsCfg, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	src, err := NewIstioVirtualServiceSource(
-		t.Context(),
-		fakeKubernetesClient,
-		fakeIstioClient,
-		&Config{},
-	)
-	require.NoError(t, err)
-
-	endpoints, err := src.Endpoints(t.Context())
-	require.NoError(t, err)
-
-	testutils.AssertEndpointsHaveRefObject(t, endpoints, string(sourcetypes.IstioVirtualService), 1)
 }
 
 func TestVirtualServiceSourceGetGateway(t *testing.T) {

--- a/source/kong_tcpingress_test.go
+++ b/source/kong_tcpingress_test.go
@@ -60,6 +60,7 @@ func TestKongTCPIngressEndpoints(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tcp-ingress-annotation",
 					Namespace: defaultKongNamespace,
+					UID:       "kong-tcpingress-uid",
 					Annotations: map[string]string{
 						"external-dns.kubernetes.io/hostname": "a.example.com",
 						"kubernetes.io/ingress.class":         "kong",
@@ -86,7 +87,7 @@ func TestKongTCPIngressEndpoints(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				{
+				(&endpoint.Endpoint{
 					DNSName:    "a.example.com",
 					Targets:    []string{"a691234567a314e71861a4303f06a3bd-1291189659.us-east-1.elb.amazonaws.com"},
 					RecordType: endpoint.RecordTypeCNAME,
@@ -95,7 +96,7 @@ func TestKongTCPIngressEndpoints(t *testing.T) {
 						"resource": "tcpingress/kong/tcp-ingress-annotation",
 					},
 					ProviderSpecific: endpoint.ProviderSpecific{},
-				},
+				}).WithRefObject(testutils.RefSource(types.KongTCPIngress)),
 			},
 		},
 		{
@@ -427,69 +428,6 @@ func TestKongTCPIngressEndpoints(t *testing.T) {
 			testutils.ValidateEndpoints(t, endpoints, ti.expected)
 		})
 	}
-}
-
-func TestProcessEndpoint_KongTCPIngress_RefObjectExist(t *testing.T) {
-	t.Parallel()
-
-	tcpProxy := TCPIngress{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: kongGroupdVersionResource.GroupVersion().String(),
-			Kind:       "TCPIngress",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "tcp-ingress-annotation",
-			Namespace: defaultKongNamespace,
-			UID:       "kong-tcpingress-uid",
-			Annotations: map[string]string{
-				"external-dns.kubernetes.io/hostname": "a.example.com",
-				"kubernetes.io/ingress.class":         "kong",
-			},
-		},
-		Spec: tcpIngressSpec{
-			Rules: []tcpIngressRule{
-				{Port: 30000},
-			},
-		},
-		Status: tcpIngressStatus{
-			LoadBalancer: corev1.LoadBalancerStatus{
-				Ingress: []corev1.LoadBalancerIngress{
-					{Hostname: "a691234567a314e71861a4303f06a3bd-1291189659.us-east-1.elb.amazonaws.com"},
-				},
-			},
-		},
-	}
-
-	fakeKubernetesClient := fakeKube.NewSimpleClientset()
-	scheme := runtime.NewScheme()
-	scheme.AddKnownTypes(kongGroupdVersionResource.GroupVersion(), &TCPIngress{}, &TCPIngressList{})
-	fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(scheme)
-
-	tcpi := unstructured.Unstructured{}
-	tcpIngressAsJSON, err := json.Marshal(tcpProxy)
-	assert.NoError(t, err)
-	assert.NoError(t, tcpi.UnmarshalJSON(tcpIngressAsJSON))
-
-	_, err = fakeDynamicClient.Resource(kongGroupdVersionResource).Namespace(defaultKongNamespace).Create(t.Context(), &tcpi, metav1.CreateOptions{})
-	assert.NoError(t, err)
-
-	source, err := NewKongTCPIngressSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
-		&Config{
-			Namespace:        defaultKongNamespace,
-			AnnotationFilter: "kubernetes.io/ingress.class=kong",
-		})
-	assert.NoError(t, err)
-	assert.NotNil(t, source)
-
-	count := &unstructured.UnstructuredList{}
-	for len(count.Items) < 1 {
-		count, _ = fakeDynamicClient.Resource(kongGroupdVersionResource).Namespace(defaultKongNamespace).List(t.Context(), metav1.ListOptions{})
-	}
-
-	endpoints, err := source.Endpoints(t.Context())
-	assert.NoError(t, err)
-
-	testutils.AssertEndpointsHaveRefObject(t, endpoints, types.KongTCPIngress, 1)
 }
 
 func TestKongTCPIngressSource_InformerTransform(t *testing.T) {

--- a/source/openshift_route_test.go
+++ b/source/openshift_route_test.go
@@ -117,6 +117,7 @@ func testOcpRouteSourceEndpoints(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Name:      "route-with-target",
+					UID:       "openshift-route-uid",
 				},
 				Status: routev1.RouteStatus{
 					Ingress: []routev1.RouteIngress{
@@ -134,13 +135,13 @@ func testOcpRouteSourceEndpoints(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				{
+				(&endpoint.Endpoint{
 					DNSName:    "my-domain.com",
 					RecordType: endpoint.RecordTypeCNAME,
 					Targets: []string{
 						"apps.my-domain.com",
 					},
-				},
+				}).WithRefObject(testutils.RefSource(types.OpenShiftRoute)),
 			},
 		},
 		{
@@ -522,51 +523,6 @@ func testOcpRouteSourceEndpoints(t *testing.T) {
 			testutils.ValidateEndpoints(t, res, tc.expected)
 		})
 	}
-}
-
-func TestProcessEndpoint_OpenShiftRoute_RefObjectExist(t *testing.T) {
-	t.Parallel()
-
-	ocpRoute := &routev1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "route-with-target",
-			UID:       "openshift-route-uid",
-		},
-		Status: routev1.RouteStatus{
-			Ingress: []routev1.RouteIngress{
-				{
-					Host:                    "my-domain.com",
-					RouterCanonicalHostname: "apps.my-domain.com",
-					Conditions: []routev1.RouteIngressCondition{
-						{
-							Type:   routev1.RouteAdmitted,
-							Status: corev1.ConditionTrue,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	fakeClient := fake.NewClientset()
-	_, err := fakeClient.RouteV1().Routes(ocpRoute.Namespace).Create(t.Context(), ocpRoute, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	source, err := NewOcpRouteSource(
-		t.Context(),
-		fakeClient,
-		&Config{
-			TemplateEngine: templatetest.MustEngine(t, "{{.Name}}", "", "", false),
-			LabelFilter:    labels.Everything(),
-		},
-	)
-	require.NoError(t, err)
-
-	endpoints, err := source.Endpoints(t.Context())
-	require.NoError(t, err)
-
-	testutils.AssertEndpointsHaveRefObject(t, endpoints, types.OpenShiftRoute, 1)
 }
 
 func TestOcpRouteSource_InformerTransform(t *testing.T) {

--- a/source/skipper_routegroup_test.go
+++ b/source/skipper_routegroup_test.go
@@ -352,27 +352,35 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 				cli: &fakeRouteGroupClient{
 					rg: &routeGroupList{
 						Items: []*routeGroup{
-							createTestRouteGroup(
-								"namespace1",
-								"rg1",
-								nil,
-								[]string{"rg1.k8s.example"},
-								[]routeGroupLoadBalancer{
-									{
-										Hostname: "lb.example.org",
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "namespace1",
+									Name:      "rg1",
+									UID:       "skipper-rg-uid-1234",
+								},
+								Spec: routeGroupSpec{
+									Hosts: []string{"rg1.k8s.example"},
+								},
+								Status: routeGroupStatus{
+									LoadBalancer: routeGroupLoadBalancerStatus{
+										RouteGroup: []routeGroupLoadBalancer{
+											{
+												Hostname: "lb.example.org",
+											},
+										},
 									},
 								},
-							),
+							},
 						},
 					},
 				},
 			},
 			want: []*endpoint.Endpoint{
-				{
+				(&endpoint.Endpoint{
 					DNSName:    "rg1.k8s.example",
 					RecordType: endpoint.RecordTypeCNAME,
 					Targets:    endpoint.Targets([]string{"lb.example.org"}),
-				},
+				}).WithRefObject(testutils.RefSource(string(types.SkipperRouteGroup))),
 			},
 		},
 		{
@@ -868,43 +876,4 @@ func TestResourceLabelIsSet(t *testing.T) {
 			t.Errorf("Failed to set resource label on ep %v", ep)
 		}
 	}
-}
-
-func TestProcessEndpoint_SkipperRouteGroup_RefObjectExist(t *testing.T) {
-	t.Parallel()
-
-	rg := &routeGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "namespace1",
-			Name:      "rg1",
-			UID:       "skipper-rg-uid-1234",
-		},
-		Spec: routeGroupSpec{
-			Hosts: []string{"rg1.k8s.example"},
-		},
-		Status: routeGroupStatus{
-			LoadBalancer: routeGroupLoadBalancerStatus{
-				RouteGroup: []routeGroupLoadBalancer{
-					{
-						Hostname: "lb.example.org",
-					},
-				},
-			},
-		},
-	}
-
-	source := &routeGroupSource{
-		cli: &fakeRouteGroupClient{
-			rg: &routeGroupList{
-				Items: []*routeGroup{rg},
-			},
-		},
-	}
-
-	endpoints, err := source.Endpoints(t.Context())
-	if err != nil {
-		t.Fatalf("Got unexpected error: %v", err)
-	}
-
-	testutils.AssertEndpointsHaveRefObject(t, endpoints, string(types.SkipperRouteGroup), 1)
 }

--- a/source/traefik_proxy_test.go
+++ b/source/traefik_proxy_test.go
@@ -65,6 +65,7 @@ func TestTraefikProxyIngressRouteEndpoints(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ingressroute-annotation",
 					Namespace: defaultTraefikNamespace,
+					UID:       "traefik-ir-uid-1234",
 					Annotations: map[string]string{
 						"external-dns.kubernetes.io/hostname": "a.example.com",
 						"external-dns.kubernetes.io/target":   "target.domain.tld",
@@ -73,7 +74,7 @@ func TestTraefikProxyIngressRouteEndpoints(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				{
+				(&endpoint.Endpoint{
 					DNSName:    "a.example.com",
 					Targets:    []string{"target.domain.tld"},
 					RecordType: endpoint.RecordTypeCNAME,
@@ -82,7 +83,7 @@ func TestTraefikProxyIngressRouteEndpoints(t *testing.T) {
 						"resource": "ingressroute/traefik/ingressroute-annotation",
 					},
 					ProviderSpecific: endpoint.ProviderSpecific{},
-				},
+				}).WithRefObject(testutils.RefSource(string(types.TraefikProxy))),
 			},
 		},
 		{
@@ -1957,60 +1958,4 @@ func TestTraefikSource_InformerTransform(t *testing.T) {
 			)
 		})
 	}
-}
-
-func TestProcessEndpoint_TraefikProxy_RefObjectExist(t *testing.T) {
-	t.Parallel()
-
-	ingressRoute := IngressRoute{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: ingressRouteGVR.GroupVersion().String(),
-			Kind:       "IngressRoute",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ingressroute-annotation",
-			Namespace: defaultTraefikNamespace,
-			UID:       "traefik-ir-uid-1234",
-			Annotations: map[string]string{
-				"external-dns.kubernetes.io/hostname": "a.example.com",
-				"external-dns.kubernetes.io/target":   "target.domain.tld",
-				"kubernetes.io/ingress.class":         "traefik",
-			},
-		},
-	}
-
-	fakeKubernetesClient := fakeKube.NewSimpleClientset()
-	scheme := runtime.NewScheme()
-	scheme.AddKnownTypes(ingressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
-	scheme.AddKnownTypes(ingressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
-	scheme.AddKnownTypes(ingressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
-	scheme.AddKnownTypes(oldIngressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
-	scheme.AddKnownTypes(oldIngressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
-	scheme.AddKnownTypes(oldIngressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
-	fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(scheme)
-
-	ir := unstructured.Unstructured{}
-	ingressRouteAsJSON, err := json.Marshal(ingressRoute)
-	require.NoError(t, err)
-	require.NoError(t, ir.UnmarshalJSON(ingressRouteAsJSON))
-
-	_, err = fakeDynamicClient.Resource(ingressRouteGVR).Namespace(defaultTraefikNamespace).Create(t.Context(), &ir, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	source, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
-		&Config{
-			Namespace:        defaultTraefikNamespace,
-			AnnotationFilter: "kubernetes.io/ingress.class=traefik",
-		})
-	require.NoError(t, err)
-
-	count := &unstructured.UnstructuredList{}
-	for len(count.Items) < 1 {
-		count, _ = fakeDynamicClient.Resource(ingressRouteGVR).Namespace(defaultTraefikNamespace).List(t.Context(), metav1.ListOptions{})
-	}
-
-	endpoints, err := source.Endpoints(t.Context())
-	require.NoError(t, err)
-
-	testutils.AssertEndpointsHaveRefObject(t, endpoints, string(types.TraefikProxy), 1)
 }


### PR DESCRIPTION
## What does it do ?

Follow-up to #6492. Replaces the 12 standalone `TestProcessEndpoint_*_RefObjectExist` tests with an opt-in RefObject check in `testutils.ValidateEndpoints`.

When an expected endpoint declares a `RefObject` (via the new `testutils.RefSource`), it asserts the actual endpoint carries a non-nil `RefObject` with the same `Source()` and a non-empty `UID()` — same idiom already used for `Labels` and `ProviderSpecific`.

## Motivation

The standalone tests duplicated client/scheme/create setup per source and carried untimed informer busy-wait loops.

- [x] Yes, I added unit tests
