### PR TITLE
feat(endpoint): support multiple RefObjects per endpoint and per event

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -266,10 +266,10 @@ type Endpoint struct {
 	// ProviderSpecific stores provider specific config
 	// +optional
 	ProviderSpecific ProviderSpecific `json:"providerSpecific,omitempty"`
-	// refObject stores reference object
-	// TODO: should be an array, as endpoints merged from multiple sources may have multiple ref objects
+	// refObjects stores the set of unique Kubernetes objects this endpoint was derived from.
+	// An endpoint merged from multiple sources will have more than one entry.
 	// +optional
-	refObject *ObjectRef `json:"-"`
+	refObjects []*ObjectRef `json:"-"`
 }
 
 // NewEndpoint initialization method to be used to create an endpoint
@@ -459,16 +459,34 @@ func (e *Endpoint) WithLabel(key, value string) *Endpoint {
 	return e
 }
 
-// WithRefObject sets the reference object for the Endpoint and returns the Endpoint.
-// This can be used to associate the Endpoint with a specific Kubernetes object.
+// WithRefObject adds obj to the endpoint's set of reference objects, deduplicating by Key().
+// Calling it multiple times with the same object is safe — it is added at most once.
 func (e *Endpoint) WithRefObject(obj *events.ObjectReference) *Endpoint {
-	e.refObject = obj
+	if obj == nil {
+		return e
+	}
+	key := obj.Key()
+	for _, existing := range e.refObjects {
+		if existing.Key() == key {
+			return e
+		}
+	}
+	e.refObjects = append(e.refObjects, obj)
 	return e
 }
 
-// RefObject returns the Kubernetes object reference associated with this endpoint.
+// RefObject returns the first Kubernetes object reference associated with this endpoint,
+// or nil if none have been set. Use RefObjects for the full set.
 func (e *Endpoint) RefObject() *events.ObjectReference {
-	return e.refObject
+	if len(e.refObjects) == 0 {
+		return nil
+	}
+	return e.refObjects[0]
+}
+
+// RefObjects returns all Kubernetes object references associated with this endpoint.
+func (e *Endpoint) RefObjects() []*events.ObjectReference {
+	return e.refObjects
 }
 
 // Key returns the EndpointKey of the Endpoint.

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -466,22 +466,13 @@ func (e *Endpoint) WithRefObject(obj *events.ObjectReference) *Endpoint {
 		return e
 	}
 	key := obj.Key()
-	for _, existing := range e.refObjects {
-		if existing.Key() == key {
-			return e
-		}
+	if slices.ContainsFunc(e.refObjects, func(r *events.ObjectReference) bool {
+		return r.Key() == key
+	}) {
+		return e
 	}
 	e.refObjects = append(e.refObjects, obj)
 	return e
-}
-
-// RefObject returns the first Kubernetes object reference associated with this endpoint,
-// or nil if none have been set. Use RefObjects for the full set.
-func (e *Endpoint) RefObject() *events.ObjectReference {
-	if len(e.refObjects) == 0 {
-		return nil
-	}
-	return e.refObjects[0]
 }
 
 // RefObjects returns all Kubernetes object references associated with this endpoint.

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -1569,12 +1569,52 @@ func TestCheckEndpoint_PTRValidationLog(t *testing.T) {
 }
 
 func TestEndpoint_WithRefObject(t *testing.T) {
-	ep := &Endpoint{}
-	ref := events.NewObjectReferenceFromParts("Service", "", "default", "my-service", "", "")
-	result := ep.WithRefObject(ref)
+	ref1 := events.NewObjectReferenceFromParts("Service", "v1", "default", "svc-a", "uid-1", "service")
+	ref2 := events.NewObjectReferenceFromParts("Service", "v1", "default", "svc-b", "uid-2", "service")
 
-	assert.Equal(t, ref, ep.RefObject(), "refObject should be set")
-	assert.Equal(t, ep, result, "should return the same Endpoint pointer")
+	tests := []struct {
+		name     string
+		add      []*events.ObjectReference
+		wantLen  int
+		wantRefs []*events.ObjectReference
+	}{
+		{
+			name:     "nil ref is a no-op",
+			add:      []*events.ObjectReference{nil},
+			wantLen:  0,
+			wantRefs: nil,
+		},
+		{
+			name:     "single ref is stored",
+			add:      []*events.ObjectReference{ref1},
+			wantLen:  1,
+			wantRefs: []*events.ObjectReference{ref1},
+		},
+		{
+			name:    "same ref added twice is deduplicated",
+			add:     []*events.ObjectReference{ref1, ref1},
+			wantLen: 1,
+			wantRefs: []*events.ObjectReference{ref1},
+		},
+		{
+			name:     "distinct refs are added in insertion order",
+			add:      []*events.ObjectReference{ref1, ref2},
+			wantLen:  2,
+			wantRefs: []*events.ObjectReference{ref1, ref2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := &Endpoint{}
+			for _, ref := range tt.add {
+				ep.WithRefObject(ref)
+			}
+			refs := ep.RefObjects()
+			require.Len(t, refs, tt.wantLen)
+			assert.Equal(t, tt.wantRefs, refs)
+		})
+	}
 }
 
 func TestTargets_UniqueOrdered(t *testing.T) {

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -1591,9 +1591,9 @@ func TestEndpoint_WithRefObject(t *testing.T) {
 			wantRefs: []*events.ObjectReference{ref1},
 		},
 		{
-			name:    "same ref added twice is deduplicated",
-			add:     []*events.ObjectReference{ref1, ref1},
-			wantLen: 1,
+			name:     "same ref added twice is deduplicated",
+			add:      []*events.ObjectReference{ref1, ref1},
+			wantLen:  1,
 			wantRefs: []*events.ObjectReference{ref1},
 		},
 		{

--- a/endpoint/utils.go
+++ b/endpoint/utils.go
@@ -97,9 +97,9 @@ func AttachRefObject(eps []*Endpoint, ref *events.ObjectReference) {
 // by combining their targets. CNAME endpoints are not merged (per DNS spec) but are deduplicated.
 // This is useful when multiple resources (e.g., pods, nodes) contribute targets to the same DNS record.
 //
-// When several endpoints merge into one, only the first endpoint's metadata (TTL, ProviderSpecific,
-// RefObject, ...) is retained; the merged record keeps a single RefObject and therefore references
-// only the first contributing source object. "First" follows the input slice order.
+// When several endpoints merge into one, the first endpoint's scalar metadata (TTL, ProviderSpecific,
+// Labels, ...) is retained. RefObjects from all contributing endpoints are accumulated, so the merged
+// record references every source object that contributed to it. "First" follows the input slice order.
 func MergeEndpoints(endpoints []*Endpoint) []*Endpoint {
 	if len(endpoints) == 0 {
 		return endpoints
@@ -132,6 +132,9 @@ func MergeEndpoints(endpoints []*Endpoint) []*Endpoint {
 		}
 		if existing, ok := endpointMap[key]; ok {
 			existing.Targets = append(existing.Targets, ep.Targets...)
+			for _, ref := range ep.refObjects {
+				existing.WithRefObject(ref)
+			}
 		} else {
 			endpointMap[key] = ep
 		}

--- a/endpoint/utils_test.go
+++ b/endpoint/utils_test.go
@@ -444,14 +444,14 @@ func TestMergeEndpoints_RefObjects(t *testing.T) {
 			},
 		},
 		{
-			name: "two endpoints merged and only single refObject preserved",
+			name: "two endpoints merged — both distinct refObjects collected",
 			input: func() []*Endpoint {
 				return []*Endpoint{
 					NewEndpoint("a.example.com", RecordTypeA, "1.1.1.1").WithRefObject(
 						events.NewObjectReference(&v1.Service{
 							ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default", UID: "123"},
 						}, "service")),
-					NewEndpoint("a.example.com", RecordTypeA, "1.1.1.1").WithRefObject(
+					NewEndpoint("a.example.com", RecordTypeA, "2.2.2.2").WithRefObject(
 						events.NewObjectReference(&v1.Service{
 							ObjectMeta: metav1.ObjectMeta{Name: "bar", Namespace: "ns", UID: "345"},
 						}, "service")),
@@ -459,10 +459,27 @@ func TestMergeEndpoints_RefObjects(t *testing.T) {
 			},
 			expected: func(t *testing.T, ep []*Endpoint) {
 				assert.Len(t, ep, 1)
-				assert.Equal(t, "service", ep[0].RefObject().Source())
-				assert.Equal(t, "foo", ep[0].RefObject().Name())
+				refs := ep[0].RefObjects()
+				assert.Len(t, refs, 2)
+				uids := []string{string(refs[0].UID()), string(refs[1].UID())}
+				assert.ElementsMatch(t, []string{"123", "345"}, uids)
+			},
+		},
+		{
+			name: "two endpoints merged with same ref — deduplication keeps one entry",
+			input: func() []*Endpoint {
+				ref := events.NewObjectReference(&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default", UID: "123"},
+				}, "service")
+				return []*Endpoint{
+					NewEndpoint("a.example.com", RecordTypeA, "1.1.1.1").WithRefObject(ref),
+					NewEndpoint("a.example.com", RecordTypeA, "2.2.2.2").WithRefObject(ref),
+				}
+			},
+			expected: func(t *testing.T, ep []*Endpoint) {
+				assert.Len(t, ep, 1)
+				assert.Len(t, ep[0].RefObjects(), 1)
 				assert.Equal(t, "123", string(ep[0].RefObject().UID()))
-				assert.NotEqual(t, "345", string(ep[0].RefObject().UID()))
 			},
 		},
 		{

--- a/endpoint/utils_test.go
+++ b/endpoint/utils_test.go
@@ -21,6 +21,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -237,7 +238,9 @@ func TestAttachRefObject(t *testing.T) {
 	AttachRefObject(eps, ref)
 
 	for _, ep := range eps {
-		assert.Same(t, ref, ep.RefObject())
+		refs := ep.RefObjects()
+		require.NotEmpty(t, refs)
+		assert.Same(t, ref, refs[0])
 	}
 }
 
@@ -438,9 +441,11 @@ func TestMergeEndpoints_RefObjects(t *testing.T) {
 			},
 			expected: func(t *testing.T, ep []*Endpoint) {
 				assert.Len(t, ep, 1)
-				assert.Equal(t, "service", ep[0].RefObject().Source())
-				assert.Equal(t, "foo", ep[0].RefObject().Name())
-				assert.Equal(t, "123", string(ep[0].RefObject().UID()))
+				refs := ep[0].RefObjects()
+				require.NotEmpty(t, refs)
+				assert.Equal(t, "service", refs[0].Source())
+				assert.Equal(t, "foo", refs[0].Name())
+				assert.Equal(t, "123", string(refs[0].UID()))
 			},
 		},
 		{
@@ -478,8 +483,9 @@ func TestMergeEndpoints_RefObjects(t *testing.T) {
 			},
 			expected: func(t *testing.T, ep []*Endpoint) {
 				assert.Len(t, ep, 1)
-				assert.Len(t, ep[0].RefObjects(), 1)
-				assert.Equal(t, "123", string(ep[0].RefObject().UID()))
+				refs := ep[0].RefObjects()
+				require.Len(t, refs, 1)
+				assert.Equal(t, "123", string(refs[0].UID()))
 			},
 		},
 		{
@@ -500,9 +506,11 @@ func TestMergeEndpoints_RefObjects(t *testing.T) {
 				assert.Len(t, ep, 2)
 				assert.NotEqual(t, ep[0], ep[1])
 				for _, el := range ep {
-					assert.Equal(t, "service", el.RefObject().Source())
-					assert.Contains(t, []string{"foo", "bar"}, el.RefObject().Name())
-					assert.Contains(t, []string{"123", "345"}, string(el.RefObject().UID()))
+					refs := el.RefObjects()
+					require.NotEmpty(t, refs)
+					assert.Equal(t, "service", refs[0].Source())
+					assert.Contains(t, []string{"foo", "bar"}, refs[0].Name())
+					assert.Contains(t, []string{"123", "345"}, string(refs[0].UID()))
 				}
 			},
 		},

--- a/endpoint/zz_generated.deepcopy.go
+++ b/endpoint/zz_generated.deepcopy.go
@@ -24,10 +24,15 @@ func (in *Endpoint) DeepCopyInto(out *Endpoint) {
 		*out = make(ProviderSpecific, len(*in))
 		copy(*out, *in)
 	}
-	if in.refObject != nil {
-		in, out := &in.refObject, &out.refObject
-		*out = new(ObjectRef)
-		**out = **in
+	if in.refObjects != nil {
+		in, out := &in.refObjects, &out.refObjects
+		*out = make([]*ObjectRef, len(*in))
+		for i, ref := range *in {
+			if ref != nil {
+				copied := *ref
+				(*out)[i] = &copied
+			}
+		}
 	}
 }
 

--- a/internal/testutils/endpoint.go
+++ b/internal/testutils/endpoint.go
@@ -218,9 +218,10 @@ func AssertEndpointsHaveRefObject(
 	t.Helper()
 	assert.Len(t, endpoints, expectedCount)
 	for _, ep := range endpoints {
-		assert.NotNil(t, ep.RefObject())
-		assert.NotEmpty(t, ep.RefObject().UID())
-		assert.Equal(t, expectedSource, ep.RefObject().Source())
+		refs := ep.RefObjects()
+		assert.NotEmpty(t, refs)
+		assert.NotEmpty(t, refs[0].UID())
+		assert.Equal(t, expectedSource, refs[0].Source())
 	}
 }
 

--- a/internal/testutils/endpoint.go
+++ b/internal/testutils/endpoint.go
@@ -278,14 +278,15 @@ func validateEndpoint(ep, expected *endpoint.Endpoint) []string {
 		errs = append(errs, fmt.Sprintf("%s: SetIdentifier expected %q, got %q", prefix, expected.SetIdentifier, ep.SetIdentifier))
 	}
 	// Opt-in: only checked when the expected endpoint declares a RefObject (see RefSource).
-	if expected.RefObject() != nil {
-		if ep.RefObject() == nil {
-			errs = append(errs, fmt.Sprintf("%s: RefObject expected, got nil", prefix))
+	if expRefs := expected.RefObjects(); len(expRefs) > 0 {
+		actRefs := ep.RefObjects()
+		if len(actRefs) == 0 {
+			errs = append(errs, fmt.Sprintf("%s: RefObject expected, got none", prefix))
 		} else {
-			if ep.RefObject().Source() != expected.RefObject().Source() {
-				errs = append(errs, fmt.Sprintf("%s: RefObject.Source expected %q, got %q", prefix, expected.RefObject().Source(), ep.RefObject().Source()))
+			if actRefs[0].Source() != expRefs[0].Source() {
+				errs = append(errs, fmt.Sprintf("%s: RefObject.Source expected %q, got %q", prefix, expRefs[0].Source(), actRefs[0].Source()))
 			}
-			if ep.RefObject().UID() == "" {
+			if actRefs[0].UID() == "" {
 				errs = append(errs, fmt.Sprintf("%s: RefObject.UID is empty", prefix))
 			}
 		}

--- a/pkg/events/controller.go
+++ b/pkg/events/controller.go
@@ -119,11 +119,9 @@ func (ec *Controller) Add(events ...Event) {
 			dropped++
 			continue
 		}
-		event := e.event()
-		if event == nil {
-			continue
+		for _, event := range e.events() {
+			ec.emit(event)
 		}
-		ec.emit(event)
 	}
 	if dropped > 0 {
 		log.Warnf("event queue is full, dropped %d events", dropped)

--- a/pkg/events/controller_test.go
+++ b/pkg/events/controller_test.go
@@ -161,44 +161,6 @@ func TestController_Queue_EmitEvents(t *testing.T) {
 	assert.Contains(t, item.Reason, RecordReady)
 }
 
-func TestController_Add(t *testing.T) {
-	for _, tt := range []struct {
-		title           string
-		maxQueuedEvents int
-		events          []Event
-		wantQueueLen    int
-		wantWarnLog     string
-	}{
-		{
-			title:           "queue full drops events and logs warning",
-			maxQueuedEvents: 0, // 0 >= 0 is always true, so queue is immediately "full"
-			events:          []Event{NewEvent(&ObjectReference{name: "test", namespace: "default"}, "msg", ActionCreate, RecordReady)},
-			wantQueueLen:    0,
-			wantWarnLog:     "event queue is full, dropped 1 events",
-		},
-		{
-			title:           "nil event is skipped",
-			maxQueuedEvents: maxQueuedEvents,
-			// NewEvent(nil, ...) returns a zero-value Event; its event() returns nil because ref.Name == "".
-			events:       []Event{NewEvent(nil, "msg", ActionCreate, RecordReady)},
-			wantQueueLen: 0,
-		},
-	} {
-		t.Run(tt.title, func(t *testing.T) {
-			hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
-			ctrl, err := NewEventController(fake.NewClientset().EventsV1(), &Config{emitEvents: sets.New(RecordReady)})
-			ctrl.maxQueuedEvents = tt.maxQueuedEvents
-			require.NoError(t, err)
-
-			ctrl.Add(tt.events...)
-			assert.Equal(t, tt.wantQueueLen, ctrl.queue.Len())
-			if tt.wantWarnLog != "" {
-				logtest.TestHelperLogContains(tt.wantWarnLog, hook, t)
-			}
-		})
-	}
-}
-
 func TestController_ProcessNextWorkItem(t *testing.T) {
 	t.Run("dryRun sets DryRunAll on create options", func(t *testing.T) {
 		var capturedDryRun []string
@@ -233,6 +195,43 @@ func TestController_ProcessNextWorkItem(t *testing.T) {
 			ctrl.processNextWorkItem(t.Context())
 		}
 		logtest.TestHelperLogContains("dropping event", hook, t)
+	})
+}
+
+func TestController_Add(t *testing.T) {
+	svcRef := NewObjectReference(&v1.Service{
+		TypeMeta:   metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "my-svc", Namespace: "default", UID: "uid-svc"},
+	}, "service")
+
+	crdRef := NewObjectReference(&v1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "my-crd", Namespace: "default", UID: "uid-crd"},
+	}, "crd")
+
+	ep := func(refs ...*ObjectReference) EndpointInfo {
+		return &mockEndpointInfo{
+			dnsName:    "example.com",
+			recordType: "A",
+			recordTTL:  300,
+			targets:    []string{"1.2.3.4"},
+			owner:      "owner",
+			refObjects: refs,
+		}
+	}
+
+	t.Run("single ref object enqueues one k8s event", func(t *testing.T) {
+		ctrl, err := NewEventController(fake.NewClientset().EventsV1(), &Config{emitEvents: sets.New(RecordReady)})
+		require.NoError(t, err)
+		ctrl.Add(NewEventFromEndpoint(ep(svcRef), ActionCreate, RecordReady))
+		assert.Equal(t, 1, ctrl.queue.Len())
+	})
+
+	t.Run("multiple ref objects enqueue one k8s event per ref", func(t *testing.T) {
+		ctrl, err := NewEventController(fake.NewClientset().EventsV1(), &Config{emitEvents: sets.New(RecordReady)})
+		require.NoError(t, err)
+		ctrl.Add(NewEventFromEndpoint(ep(svcRef, crdRef), ActionCreate, RecordReady))
+		assert.Equal(t, 2, ctrl.queue.Len())
 	})
 }
 

--- a/pkg/events/controller_test.go
+++ b/pkg/events/controller_test.go
@@ -161,43 +161,6 @@ func TestController_Queue_EmitEvents(t *testing.T) {
 	assert.Contains(t, item.Reason, RecordReady)
 }
 
-func TestController_ProcessNextWorkItem(t *testing.T) {
-	t.Run("dryRun sets DryRunAll on create options", func(t *testing.T) {
-		var capturedDryRun []string
-		kubeClient := fake.NewClientset()
-		kubeClient.PrependReactor("create", "events", func(action clienttesting.Action) (bool, runtime.Object, error) {
-			capturedDryRun = action.(clienttesting.CreateActionImpl).CreateOptions.DryRun
-			return true, nil, nil
-		})
-		ctrl, err := NewEventController(kubeClient.EventsV1(), &Config{dryRun: true})
-		require.NoError(t, err)
-		ctrl.queue.Add(&eventsv1.Event{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-event", Namespace: "default"},
-		})
-		ctrl.processNextWorkItem(t.Context())
-		assert.Equal(t, []string{metav1.DryRunAll}, capturedDryRun)
-	})
-
-	t.Run("drops event after max retries", func(t *testing.T) {
-		hook := logtest.LogsUnderTestWithLogLevel(log.ErrorLevel, t)
-		kubeClient := fake.NewClientset()
-		kubeClient.PrependReactor("create", "events", func(_ clienttesting.Action) (bool, runtime.Object, error) {
-			return true, nil, fmt.Errorf("persistent error")
-		})
-		ctrl, err := NewEventController(kubeClient.EventsV1(), &Config{emitEvents: sets.New(RecordReady)})
-		require.NoError(t, err)
-
-		ctrl.queue.Add(&eventsv1.Event{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-event", Namespace: "default"},
-		})
-		// First maxTriesPerEvent calls requeue; the final call exhausts retries and drops.
-		for range maxRetriesPerEvent + 1 {
-			ctrl.processNextWorkItem(t.Context())
-		}
-		logtest.TestHelperLogContains("dropping event", hook, t)
-	})
-}
-
 func TestController_Add(t *testing.T) {
 	svcRef := NewObjectReference(&v1.Service{
 		TypeMeta:   metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
@@ -232,6 +195,43 @@ func TestController_Add(t *testing.T) {
 		require.NoError(t, err)
 		ctrl.Add(NewEventFromEndpoint(ep(svcRef, crdRef), ActionCreate, RecordReady))
 		assert.Equal(t, 2, ctrl.queue.Len())
+	})
+}
+
+func TestController_ProcessNextWorkItem(t *testing.T) {
+	t.Run("dryRun sets DryRunAll on create options", func(t *testing.T) {
+		var capturedDryRun []string
+		kubeClient := fake.NewClientset()
+		kubeClient.PrependReactor("create", "events", func(action clienttesting.Action) (bool, runtime.Object, error) {
+			capturedDryRun = action.(clienttesting.CreateActionImpl).CreateOptions.DryRun
+			return true, nil, nil
+		})
+		ctrl, err := NewEventController(kubeClient.EventsV1(), &Config{dryRun: true})
+		require.NoError(t, err)
+		ctrl.queue.Add(&eventsv1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-event", Namespace: "default"},
+		})
+		ctrl.processNextWorkItem(t.Context())
+		assert.Equal(t, []string{metav1.DryRunAll}, capturedDryRun)
+	})
+
+	t.Run("drops event after max retries", func(t *testing.T) {
+		hook := logtest.LogsUnderTestWithLogLevel(log.ErrorLevel, t)
+		kubeClient := fake.NewClientset()
+		kubeClient.PrependReactor("create", "events", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+			return true, nil, fmt.Errorf("persistent error")
+		})
+		ctrl, err := NewEventController(kubeClient.EventsV1(), &Config{emitEvents: sets.New(RecordReady)})
+		require.NoError(t, err)
+
+		ctrl.queue.Add(&eventsv1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-event", Namespace: "default"},
+		})
+		// First maxTriesPerEvent calls requeue; the final call exhausts retries and drops.
+		for range maxRetriesPerEvent + 1 {
+			ctrl.processNextWorkItem(t.Context())
+		}
+		logtest.TestHelperLogContains("dropping event", hook, t)
 	})
 }
 

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -65,9 +65,8 @@ type (
 	ConfigOption func(*Config)
 
 	Event struct {
-		ref     ObjectReference
+		refs    []ObjectReference
 		message string
-		source  string
 		action  Action
 		eType   EventType
 		reason  Reason
@@ -96,6 +95,7 @@ type (
 		GetTargets() []string
 		GetOwner() string
 		RefObject() *ObjectReference
+		RefObjects() []*ObjectReference
 	}
 )
 
@@ -127,28 +127,40 @@ func NewEvent(obj *ObjectReference, msg string, a Action, r Reason) Event {
 		return Event{}
 	}
 	return Event{
-		ref:     *obj,
+		refs:    []ObjectReference{*obj},
 		message: msg,
 		eType:   EventTypeNormal,
 		action:  a,
 		reason:  r,
-		source:  obj.source,
 	}
 }
 
 // NewEventFromEndpoint creates an Event from an EndpointInfo with formatted message.
+// All ref objects on the endpoint are stored in the event; one Kubernetes event is
+// emitted per ref when the event is processed by the Controller.
 func NewEventFromEndpoint(ep EndpointInfo, a Action, r Reason) Event {
-	if ep == nil || ep.RefObject() == nil {
+	if ep == nil {
+		return Event{}
+	}
+	var refs []ObjectReference
+	for _, ref := range ep.RefObjects() {
+		if ref != nil {
+			refs = append(refs, *ref)
+		}
+	}
+	if len(refs) == 0 {
 		return Event{}
 	}
 	msg := fmt.Sprintf("(external-dns) record:%s,owner:%s,type:%s,ttl:%d,targets:%s",
 		ep.GetDNSName(), ep.GetOwner(), ep.GetRecordType(), ep.GetRecordTTL(),
 		strings.Join(ep.GetTargets(), ","))
-	return NewEvent(ep.RefObject(), msg, a, r)
-}
-
-func (e *Event) description() string {
-	return fmt.Sprintf("%s/%s/%s", e.ref.kind, e.ref.namespace, e.ref.name)
+	return Event{
+		refs:    refs,
+		message: msg,
+		eType:   EventTypeNormal,
+		action:  a,
+		reason:  r,
+	}
 }
 
 // Action returns the action associated with the event (e.g. Created, Updated, Deleted).
@@ -166,8 +178,19 @@ func (e *Event) EventType() EventType {
 	return e.eType
 }
 
-func (e *Event) event() *eventsv1.Event {
-	if e.ref.name == "" {
+// events returns one Kubernetes event per ref stored in the Event.
+func (e *Event) events() []*eventsv1.Event {
+	result := make([]*eventsv1.Event, 0, len(e.refs))
+	for _, ref := range e.refs {
+		if ev := e.eventForRef(ref); ev != nil {
+			result = append(result, ev)
+		}
+	}
+	return result
+}
+
+func (e *Event) eventForRef(ref ObjectReference) *eventsv1.Event {
+	if ref.name == "" {
 		log.Debug("skipping event for resources as the name is not generated yet")
 		return nil
 	}
@@ -181,30 +204,28 @@ func (e *Event) event() *eventsv1.Event {
 
 	// Events are namespaced resources. For cluster-scoped objects like Nodes,
 	// the namespace is empty, so we default to "default" namespace.
-	namespace := e.ref.namespace
+	namespace := ref.namespace
 	if namespace == "" {
 		namespace = "default"
 	}
 
 	event := &eventsv1.Event{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      sanitize(e.ref.name, timestamp.Time),
+			Name:      sanitize(ref.name, timestamp.Time),
 			Namespace: namespace,
 		},
 		EventTime:           timestamp,
-		ReportingInstance:   controllerName + "/source/" + e.ref.source,
+		ReportingInstance:   controllerName + "/source/" + ref.source,
 		ReportingController: controllerName,
 		Action:              string(e.action),
 		Reason:              string(e.reason),
 		Note:                message,
 		Type:                string(e.eType),
 	}
-	if e.ref.name != "" {
-		ref := e.ref.objectRef()
-		event.Regarding = *ref
-		if e.ref.uid != "" {
-			event.Related = ref
-		}
+	objRef := ref.objectRef()
+	event.Regarding = *objRef
+	if ref.uid != "" {
+		event.Related = objRef
 	}
 	return event
 }
@@ -265,9 +286,29 @@ func (c *Config) IsEnabled() bool {
 	return len(c.emitEvents) > 0
 }
 
+// description returns a human-readable summary of the reference.
+// Namespaced resources use "kind/namespace/name"; cluster-scoped resources omit the namespace: "kind/name".
+func (r *ObjectReference) description() string {
+	if r.namespace == "" {
+		return fmt.Sprintf("%s/%s", r.kind, r.name)
+	}
+	return fmt.Sprintf("%s/%s/%s", r.kind, r.namespace, r.name)
+}
+
+// Key returns a stable string that uniquely identifies this object reference
+// in the form "source/namespace/name".
+func (r *ObjectReference) Key() string {
+	return r.source + "/" + r.namespace + "/" + r.name
+}
+
 // Kind returns the Kubernetes kind of the referenced object (e.g. "Service", "Ingress").
 func (r *ObjectReference) Kind() string {
 	return r.kind
+}
+
+// Namespace returns the namespace of the referenced Kubernetes object.
+func (r *ObjectReference) Namespace() string {
+	return r.namespace
 }
 
 // Name returns the name of the referenced Kubernetes object.

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -94,7 +94,6 @@ type (
 		GetRecordTTL() int64
 		GetTargets() []string
 		GetOwner() string
-		RefObject() *ObjectReference
 		RefObjects() []*ObjectReference
 	}
 )

--- a/pkg/events/types_test.go
+++ b/pkg/events/types_test.go
@@ -274,17 +274,11 @@ type mockEndpointInfo struct {
 	refObjects []*ObjectReference
 }
 
-func (m *mockEndpointInfo) GetDNSName() string    { return m.dnsName }
-func (m *mockEndpointInfo) GetRecordType() string { return m.recordType }
-func (m *mockEndpointInfo) GetRecordTTL() int64   { return m.recordTTL }
-func (m *mockEndpointInfo) GetTargets() []string  { return m.targets }
-func (m *mockEndpointInfo) GetOwner() string      { return m.owner }
-func (m *mockEndpointInfo) RefObject() *ObjectReference {
-	if len(m.refObjects) == 0 {
-		return nil
-	}
-	return m.refObjects[0]
-}
+func (m *mockEndpointInfo) GetDNSName() string             { return m.dnsName }
+func (m *mockEndpointInfo) GetRecordType() string          { return m.recordType }
+func (m *mockEndpointInfo) GetRecordTTL() int64            { return m.recordTTL }
+func (m *mockEndpointInfo) GetTargets() []string           { return m.targets }
+func (m *mockEndpointInfo) GetOwner() string               { return m.owner }
 func (m *mockEndpointInfo) RefObjects() []*ObjectReference { return m.refObjects }
 
 func TestNewEventFromEndpoint(t *testing.T) {

--- a/pkg/events/types_test.go
+++ b/pkg/events/types_test.go
@@ -76,7 +76,7 @@ func TestSanitize(t *testing.T) {
 	}
 }
 
-func TestEvent_Reference(t *testing.T) {
+func TestObjectReference_Description(t *testing.T) {
 	tests := []struct {
 		kind      string
 		namespace string
@@ -85,19 +85,13 @@ func TestEvent_Reference(t *testing.T) {
 	}{
 		{"Pod", "default", "nginx", "Pod/default/nginx"},
 		{"Service", "prod", "api", "Service/prod/api"},
-		{"", "", "", "//"},
+		{"Node", "", "worker-1", "Node/worker-1"},
+		{"", "", "", "/"},
 	}
 
 	for _, tt := range tests {
-		ev := Event{
-			ref: ObjectReference{
-				kind:      tt.kind,
-				namespace: tt.namespace,
-				name:      tt.name,
-				source:    "fake-source",
-			},
-		}
-		require.Equal(t, tt.expected, ev.description())
+		ref := ObjectReference{kind: tt.kind, namespace: tt.namespace, name: tt.name}
+		require.Equal(t, tt.expected, ref.description())
 	}
 }
 
@@ -105,13 +99,13 @@ func TestEvent_NewEvents(t *testing.T) {
 	tests := []struct {
 		name    string
 		event   Event
-		asserts func(e *eventsv1.Event)
+		asserts func(evs []*eventsv1.Event)
 	}{
 		{
 			name:  "empty event",
 			event: NewEvent(nil, "", ActionCreate, RecordReady),
-			asserts: func(e *eventsv1.Event) {
-				require.Nil(t, e)
+			asserts: func(evs []*eventsv1.Event) {
+				require.Empty(t, evs)
 			},
 		},
 		{
@@ -126,8 +120,9 @@ func TestEvent_NewEvents(t *testing.T) {
 					Namespace: apiv1.NamespaceDefault,
 				},
 			}, "fake"), "", ActionCreate, RecordReady),
-			asserts: func(e *eventsv1.Event) {
-				require.NotNil(t, e)
+			asserts: func(evs []*eventsv1.Event) {
+				require.Len(t, evs, 1)
+				e := evs[0]
 				require.Contains(t, e.Name, "fake-pod.")
 				require.Equal(t, apiv1.NamespaceDefault, e.Namespace)
 				require.Nil(t, e.Related)
@@ -149,8 +144,9 @@ func TestEvent_NewEvents(t *testing.T) {
 					UID:       "9de3fc19-8aeb-4e76-865d-ada955403103",
 				},
 			}, "fake"), "", ActionCreate, RecordReady),
-			asserts: func(e *eventsv1.Event) {
-				require.NotNil(t, e)
+			asserts: func(evs []*eventsv1.Event) {
+				require.Len(t, evs, 1)
+				e := evs[0]
 				require.Contains(t, e.Name, "fake-pod.")
 				require.NotNil(t, e.Related)
 				require.NotNil(t, e.Regarding)
@@ -159,7 +155,7 @@ func TestEvent_NewEvents(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(_ *testing.T) {
-			tt.asserts(tt.event.event())
+			tt.asserts(tt.event.events())
 		})
 	}
 }
@@ -171,9 +167,10 @@ func TestEvent_Transpose(t *testing.T) {
 		name:      "nginx",
 	}, "test message", ActionCreate, RecordReady)
 
-	event := ev.event()
-	require.NotNil(t, event)
-	require.Contains(t, event.ObjectMeta.Name, ev.ref.name)
+	evs := ev.events()
+	require.Len(t, evs, 1)
+	event := evs[0]
+	require.Contains(t, event.ObjectMeta.Name, ev.refs[0].name)
 	require.Equal(t, "default", event.ObjectMeta.Namespace)
 	require.Equal(t, string(ActionCreate), event.Action)
 	require.Equal(t, string(RecordReady), event.Reason)
@@ -184,11 +181,12 @@ func TestEvent_Transpose(t *testing.T) {
 
 	longMsg := strings.Repeat("a", 2000)
 	ev.message = longMsg
-	event = ev.event()
-	require.Equal(t, longMsg[:1021]+"...", event.Note)
+	evs = ev.events()
+	require.Len(t, evs, 1)
+	require.Equal(t, longMsg[:1021]+"...", evs[0].Note)
 
-	ev.ref.name = ""
-	require.Nil(t, ev.event())
+	ev.refs[0].name = ""
+	require.Empty(t, ev.events())
 }
 
 func TestEvent_NameAndEventTimeConsistent(t *testing.T) {
@@ -200,8 +198,9 @@ func TestEvent_NameAndEventTimeConsistent(t *testing.T) {
 			kind: "Pod", namespace: "default", name: "nginx",
 		}, "msg", ActionCreate, RecordReady)
 
-		k8sEvent := ev.event()
-		require.NotNil(t, k8sEvent)
+		evs := ev.events()
+		require.Len(t, evs, 1)
+		k8sEvent := evs[0]
 
 		require.True(t, strings.HasSuffix(k8sEvent.Name, expectedSuffix),
 			"name %q must end with timestamp suffix %q", k8sEvent.Name, expectedSuffix)
@@ -272,15 +271,21 @@ type mockEndpointInfo struct {
 	recordTTL  int64
 	targets    []string
 	owner      string
-	refObject  *ObjectReference
+	refObjects []*ObjectReference
 }
 
-func (m *mockEndpointInfo) GetDNSName() string          { return m.dnsName }
-func (m *mockEndpointInfo) GetRecordType() string       { return m.recordType }
-func (m *mockEndpointInfo) GetRecordTTL() int64         { return m.recordTTL }
-func (m *mockEndpointInfo) GetTargets() []string        { return m.targets }
-func (m *mockEndpointInfo) GetOwner() string            { return m.owner }
-func (m *mockEndpointInfo) RefObject() *ObjectReference { return m.refObject }
+func (m *mockEndpointInfo) GetDNSName() string    { return m.dnsName }
+func (m *mockEndpointInfo) GetRecordType() string { return m.recordType }
+func (m *mockEndpointInfo) GetRecordTTL() int64   { return m.recordTTL }
+func (m *mockEndpointInfo) GetTargets() []string  { return m.targets }
+func (m *mockEndpointInfo) GetOwner() string      { return m.owner }
+func (m *mockEndpointInfo) RefObject() *ObjectReference {
+	if len(m.refObjects) == 0 {
+		return nil
+	}
+	return m.refObjects[0]
+}
+func (m *mockEndpointInfo) RefObjects() []*ObjectReference { return m.refObjects }
 
 func TestNewEventFromEndpoint(t *testing.T) {
 	tests := []struct {
@@ -300,14 +305,14 @@ func TestNewEventFromEndpoint(t *testing.T) {
 			},
 		},
 		{
-			name: "endpoint with nil RefObject returns empty event",
+			name: "endpoint with no RefObjects returns empty event",
 			ep: &mockEndpointInfo{
 				dnsName:    "example.com",
 				recordType: "A",
 				recordTTL:  300,
 				targets:    []string{"10.0.0.1"},
 				owner:      "default",
-				refObject:  nil,
+				refObjects: nil,
 			},
 			action: ActionCreate,
 			reason: RecordReady,
@@ -323,12 +328,12 @@ func TestNewEventFromEndpoint(t *testing.T) {
 				recordTTL:  300,
 				targets:    []string{"10.0.0.1", "10.0.0.2"},
 				owner:      "my-owner",
-				refObject: &ObjectReference{
+				refObjects: []*ObjectReference{{
 					kind:      "Service",
 					namespace: "default",
 					name:      "my-service",
 					source:    "service",
-				},
+				}},
 			},
 			action: ActionCreate,
 			reason: RecordReady,
@@ -336,9 +341,10 @@ func TestNewEventFromEndpoint(t *testing.T) {
 				require.Equal(t, ActionCreate, ev.action)
 				require.Equal(t, RecordReady, ev.reason)
 				require.Equal(t, EventTypeNormal, ev.eType)
-				require.Equal(t, "Service", ev.ref.kind)
-				require.Equal(t, "default", ev.ref.namespace)
-				require.Equal(t, "my-service", ev.ref.name)
+				require.Len(t, ev.refs, 1)
+				require.Equal(t, "Service", ev.refs[0].kind)
+				require.Equal(t, "default", ev.refs[0].namespace)
+				require.Equal(t, "my-service", ev.refs[0].name)
 				require.Contains(t, ev.message, "record:test.example.com")
 				require.Contains(t, ev.message, "owner:my-owner")
 				require.Contains(t, ev.message, "type:A")
@@ -355,12 +361,12 @@ func TestNewEventFromEndpoint(t *testing.T) {
 				recordTTL:  0,
 				targets:    []string{"target.example.com"},
 				owner:      "",
-				refObject: &ObjectReference{
+				refObjects: []*ObjectReference{{
 					kind:      "Ingress",
 					namespace: "prod",
 					name:      "my-ingress",
 					source:    "ingress",
-				},
+				}},
 			},
 			action: ActionDelete,
 			reason: RecordDeleted,
@@ -380,22 +386,45 @@ func TestNewEventFromEndpoint(t *testing.T) {
 				recordTTL:  60,
 				targets:    []string{"192.168.1.1"},
 				owner:      "default",
-				refObject: &ObjectReference{
+				refObjects: []*ObjectReference{{
 					kind:      "Node",
 					namespace: "", // cluster-scoped
 					name:      "node1",
 					source:    "node",
-				},
+				}},
 			},
 			action: ActionCreate,
 			reason: RecordReady,
 			asserts: func(t *testing.T, ev Event) {
 				require.Equal(t, ActionCreate, ev.action)
-				require.Empty(t, ev.ref.namespace)
+				require.Empty(t, ev.refs[0].namespace)
 
-				k8sEvent := ev.event()
-				require.NotNil(t, k8sEvent)
-				require.Equal(t, "default", k8sEvent.Namespace)
+				evs := ev.events()
+				require.Len(t, evs, 1)
+				require.Equal(t, "default", evs[0].Namespace)
+			},
+		},
+		{
+			name: "endpoint with multiple RefObjects emits one k8s event per ref",
+			ep: &mockEndpointInfo{
+				dnsName:    "shared.example.com",
+				recordType: "A",
+				recordTTL:  300,
+				targets:    []string{"1.2.3.4"},
+				owner:      "owner",
+				refObjects: []*ObjectReference{
+					{kind: "DNSEndpoint", namespace: "default", name: "shared-dns", source: "crd"},
+					{kind: "Service", namespace: "default", name: "shared-svc", source: "service"},
+				},
+			},
+			action: ActionCreate,
+			reason: RecordReady,
+			asserts: func(t *testing.T, ev Event) {
+				require.Len(t, ev.refs, 2)
+				evs := ev.events()
+				require.Len(t, evs, 2)
+				names := []string{evs[0].Regarding.Name, evs[1].Regarding.Name}
+				require.ElementsMatch(t, []string{"shared-dns", "shared-svc"}, names)
 			},
 		},
 	}
@@ -548,6 +577,35 @@ func TestEvent_Accessors(t *testing.T) {
 	assert.Equal(t, ActionDelete, ev.Action())
 	assert.Equal(t, RecordDeleted, ev.Reason())
 	assert.Equal(t, EventTypeNormal, ev.EventType())
+}
+
+func TestObjectReference_Key(t *testing.T) {
+	tests := []struct {
+		name     string
+		ref      *ObjectReference
+		expected string
+	}{
+		{
+			name:     "namespaced resource",
+			ref:      &ObjectReference{source: "service", namespace: "default", name: "svc"},
+			expected: "service/default/svc",
+		},
+		{
+			name:     "cluster-scoped resource has empty namespace segment",
+			ref:      &ObjectReference{source: "node", namespace: "", name: "node-1"},
+			expected: "node//node-1",
+		},
+		{
+			name:     "different sources with same namespace and name produce distinct keys",
+			ref:      &ObjectReference{source: "crd", namespace: "default", name: "my-dns"},
+			expected: "crd/default/my-dns",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.ref.Key())
+		})
+	}
 }
 
 func TestWithDryRun(t *testing.T) {

--- a/provider/webhook/webhook.go
+++ b/provider/webhook/webhook.go
@@ -270,12 +270,12 @@ func (p WebhookProvider) ApplyChanges(ctx context.Context, changes *plan.Changes
 func (p WebhookProvider) AdjustEndpoints(e []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
 	adjustEndpointsRequestsGauge.Gauge.Inc()
 
-	// refObject is not serialized to JSON (tagged json:"-"), so we must
-	// preserve it across the webhook round-trip to keep event emission working.
-	refObjects := make(map[endpoint.EndpointKey]*endpoint.ObjectRef, len(e))
+	// refObjects are not serialized to JSON (tagged json:"-"), so we must
+	// preserve them across the webhook round-trip to keep event emission working.
+	refObjects := make(map[endpoint.EndpointKey][]*endpoint.ObjectRef, len(e))
 	for _, ep := range e {
-		if ep.RefObject() != nil {
-			refObjects[ep.Key()] = ep.RefObject()
+		if refs := ep.RefObjects(); len(refs) > 0 {
+			refObjects[ep.Key()] = refs
 		}
 	}
 
@@ -331,7 +331,7 @@ func (p WebhookProvider) AdjustEndpoints(e []*endpoint.Endpoint) ([]*endpoint.En
 	}
 
 	for _, ep := range endpoints {
-		if ref, ok := refObjects[ep.Key()]; ok {
+		for _, ref := range refObjects[ep.Key()] {
 			ep.WithRefObject(ref)
 		}
 	}

--- a/provider/webhook/webhook_test.go
+++ b/provider/webhook/webhook_test.go
@@ -388,8 +388,9 @@ func TestAdjustEndpoints_PreservesRefObjects(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Len(t, adjusted, 1)
-		require.Len(t, adjusted[0].RefObjects(), 1)
-		assert.Equal(t, ref, adjusted[0].RefObject())
+		refs := adjusted[0].RefObjects()
+		require.NotEmpty(t, refs)
+		assert.Equal(t, ref, refs[0])
 	})
 
 	t.Run("multiple refObjects are all preserved across round-trip", func(t *testing.T) {

--- a/provider/webhook/webhook_test.go
+++ b/provider/webhook/webhook_test.go
@@ -356,44 +356,64 @@ func TestAdjustEndpoints(t *testing.T) {
 	}}, adjustedEndpoints)
 }
 
-func TestAdjustEndpoints_PreservesRefObject(t *testing.T) {
-	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/" {
-			w.Header().Set(webhookapi.ContentTypeHeader, webhookapi.MediaTypeFormatAndVersion)
-			w.Write([]byte(`{}`))
-			return
-		}
-		assert.Equal(t, webhookapi.UrlAdjustEndpoints, r.URL.Path)
-
-		var endpoints []*endpoint.Endpoint
-		defer r.Body.Close()
-		b, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = json.Unmarshal(b, &endpoints)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		j, _ := json.Marshal(endpoints)
-		w.Write(j)
-	}))
-	defer svr.Close()
-
-	p, err := newProvider(t.Context(), svr.URL, testReadTimeout, testWriteTimeout)
-	require.NoError(t, err)
-
-	ref := events.NewObjectReferenceFromParts("Service", "v1", "default", "my-svc", "", "")
-	endpoints := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("test.example.com", "A", "1.2.3.4").WithRefObject(ref),
+func TestAdjustEndpoints_PreservesRefObjects(t *testing.T) {
+	echoSvr := func(t *testing.T) *httptest.Server {
+		t.Helper()
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/" {
+				w.Header().Set(webhookapi.ContentTypeHeader, webhookapi.MediaTypeFormatAndVersion)
+				w.Write([]byte(`{}`))
+				return
+			}
+			var eps []*endpoint.Endpoint
+			defer r.Body.Close()
+			b, err := io.ReadAll(r.Body)
+			assert.NoError(t, err)
+			assert.NoError(t, json.Unmarshal(b, &eps))
+			j, _ := json.Marshal(eps)
+			w.Write(j)
+		}))
 	}
 
-	adjusted, err := p.AdjustEndpoints(endpoints)
-	require.NoError(t, err)
-	require.Len(t, adjusted, 1)
-	require.NotNil(t, adjusted[0].RefObject(), "refObject should be preserved across webhook round-trip")
-	assert.Equal(t, ref, adjusted[0].RefObject())
+	t.Run("single refObject is preserved across round-trip", func(t *testing.T) {
+		svr := echoSvr(t)
+		defer svr.Close()
+
+		p, err := newProvider(t.Context(), svr.URL, testReadTimeout, testWriteTimeout)
+		require.NoError(t, err)
+
+		ref := events.NewObjectReferenceFromParts("Service", "v1", "default", "my-svc", "uid-1", "service")
+		adjusted, err := p.AdjustEndpoints([]*endpoint.Endpoint{
+			endpoint.NewEndpoint("test.example.com", "A", "1.2.3.4").WithRefObject(ref),
+		})
+		require.NoError(t, err)
+		require.Len(t, adjusted, 1)
+		require.Len(t, adjusted[0].RefObjects(), 1)
+		assert.Equal(t, ref, adjusted[0].RefObject())
+	})
+
+	t.Run("multiple refObjects are all preserved across round-trip", func(t *testing.T) {
+		svr := echoSvr(t)
+		defer svr.Close()
+
+		p, err := newProvider(t.Context(), svr.URL, testReadTimeout, testWriteTimeout)
+		require.NoError(t, err)
+
+		ref1 := events.NewObjectReferenceFromParts("Service", "v1", "default", "svc-a", "uid-1", "service")
+		ref2 := events.NewObjectReferenceFromParts("Service", "v1", "default", "svc-b", "uid-2", "service")
+		adjusted, err := p.AdjustEndpoints([]*endpoint.Endpoint{
+			endpoint.NewEndpoint("test.example.com", "A", "1.2.3.4").
+				WithRefObject(ref1).
+				WithRefObject(ref2),
+		})
+		require.NoError(t, err)
+		require.Len(t, adjusted, 1)
+
+		refs := adjusted[0].RefObjects()
+		require.Len(t, refs, 2)
+		uids := []string{string(refs[0].UID()), string(refs[1].UID())}
+		assert.ElementsMatch(t, []string{"uid-1", "uid-2"}, uids)
+	})
 }
 
 func TestAdjustendpointsWithError(t *testing.T) {

--- a/source/fake_test.go
+++ b/source/fake_test.go
@@ -65,8 +65,9 @@ func TestFakeSource_RecordTypes(t *testing.T) {
 				ip := net.ParseIP(ep.Targets[0])
 				assert.NotNil(t, ip, "A record target %q is not a valid IP", ep.Targets[0])
 				assert.NotNil(t, ip.To4(), "A record target %q must be IPv4", ep.Targets[0])
-				require.NotNil(t, ep.RefObject())
-				assert.Equal(t, "Pod", ep.RefObject().Kind())
+				refs := ep.RefObjects()
+				require.NotEmpty(t, refs)
+				assert.Equal(t, "Pod", refs[0].Kind())
 			},
 		},
 		{

--- a/source/wrappers/dedupsource.go
+++ b/source/wrappers/dedupsource.go
@@ -23,7 +23,6 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/external-dns/endpoint"
-	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/source"
 )
 
@@ -48,7 +47,7 @@ func (ms *dedupSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, err
 	}
 
 	result := make([]*endpoint.Endpoint, 0, len(endpoints))
-	collected := make(sets.Set[string], len(endpoints))
+	byIdentifier := make(map[string]*endpoint.Endpoint, len(endpoints))
 
 	for _, ep := range endpoints {
 		if ep == nil {
@@ -68,13 +67,16 @@ func (ms *dedupSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, err
 
 		identifier := strings.Join([]string{ep.RecordType, ep.DNSName, ep.SetIdentifier, ep.Targets.String()}, "/")
 
-		if collected.Has(identifier) {
+		if existing, ok := byIdentifier[identifier]; ok {
+			for _, ref := range ep.RefObjects() {
+				existing.WithRefObject(ref)
+			}
 			log.Debugf("Removing duplicate endpoint %s", ep)
 			deduplicatedEndpoints.AddWithLabels(1, ep.RecordType, endpointSource(ep))
 			continue
 		}
 
-		collected.Insert(identifier)
+		byIdentifier[identifier] = ep
 		result = append(result, ep)
 	}
 

--- a/source/wrappers/dedupsource_test.go
+++ b/source/wrappers/dedupsource_test.go
@@ -484,10 +484,11 @@ func TestDedupSource_RefObjects(t *testing.T) {
 			},
 			expected: func(t *testing.T, ep []*endpoint.Endpoint) {
 				require.Len(t, ep, 1)
-				require.NotNil(t, ep[0].RefObject())
-				require.Equal(t, types.Service, ep[0].RefObject().Source())
-				require.Equal(t, "foo", ep[0].RefObject().Name())
-				require.Equal(t, "123", string(ep[0].RefObject().UID()))
+				refs := ep[0].RefObjects()
+				require.NotEmpty(t, refs)
+				require.Equal(t, types.Service, refs[0].Source())
+				require.Equal(t, "foo", refs[0].Name())
+				require.Equal(t, "123", string(refs[0].UID()))
 			},
 		},
 		{
@@ -507,7 +508,7 @@ func TestDedupSource_RefObjects(t *testing.T) {
 				refs := ep[0].RefObjects()
 				require.Len(t, refs, 2)
 				// First endpoint is the surviving one; its ref is first
-				require.Equal(t, "uid-first", string(ep[0].RefObject().UID()))
+				require.Equal(t, "uid-first", string(refs[0].UID()))
 				uids := []string{string(refs[0].UID()), string(refs[1].UID())}
 				require.ElementsMatch(t, []string{"uid-first", "uid-second"}, uids)
 			},
@@ -529,7 +530,7 @@ func TestDedupSource_RefObjects(t *testing.T) {
 				refs := ep[0].RefObjects()
 				require.Len(t, refs, 2)
 				// Service arrived first — still primary
-				require.Equal(t, types.Service, ep[0].RefObject().Source())
+				require.Equal(t, types.Service, refs[0].Source())
 				sources := []string{refs[0].Source(), refs[1].Source()}
 				require.ElementsMatch(t, []string{types.Service, types.Ingress}, sources)
 			},
@@ -551,7 +552,7 @@ func TestDedupSource_RefObjects(t *testing.T) {
 				refs := ep[0].RefObjects()
 				require.Len(t, refs, 2)
 				// Ingress arrived first — still primary
-				require.Equal(t, types.Ingress, ep[0].RefObject().Source())
+				require.Equal(t, types.Ingress, refs[0].Source())
 				sources := []string{refs[0].Source(), refs[1].Source()}
 				require.ElementsMatch(t, []string{types.Ingress, types.Service}, sources)
 			},
@@ -583,14 +584,16 @@ func TestDedupSource_RefObjects(t *testing.T) {
 				}
 
 				require.NotNil(t, svcEndpoint)
-				require.NotNil(t, svcEndpoint.RefObject())
-				require.Equal(t, types.Service, svcEndpoint.RefObject().Source())
-				require.Equal(t, "my-service", svcEndpoint.RefObject().Name())
+				svcRefs := svcEndpoint.RefObjects()
+				require.NotEmpty(t, svcRefs)
+				require.Equal(t, types.Service, svcRefs[0].Source())
+				require.Equal(t, "my-service", svcRefs[0].Name())
 
 				require.NotNil(t, ingEndpoint)
-				require.NotNil(t, ingEndpoint.RefObject())
-				require.Equal(t, types.Ingress, ingEndpoint.RefObject().Source())
-				require.Equal(t, "my-ingress", ingEndpoint.RefObject().Name())
+				ingRefs := ingEndpoint.RefObjects()
+				require.NotEmpty(t, ingRefs)
+				require.Equal(t, types.Ingress, ingRefs[0].Source())
+				require.Equal(t, "my-ingress", ingRefs[0].Name())
 			},
 		},
 		{
@@ -613,7 +616,7 @@ func TestDedupSource_RefObjects(t *testing.T) {
 				refs := ep[0].RefObjects()
 				require.Len(t, refs, 3)
 				// Service arrived first — still primary
-				require.Equal(t, types.Service, ep[0].RefObject().Source())
+				require.Equal(t, types.Service, refs[0].Source())
 				uids := []string{string(refs[0].UID()), string(refs[1].UID()), string(refs[2].UID())}
 				require.ElementsMatch(t, []string{"123", "345", "456"}, uids)
 			},
@@ -631,9 +634,10 @@ func TestDedupSource_RefObjects(t *testing.T) {
 			expected: func(t *testing.T, ep []*endpoint.Endpoint) {
 				require.Len(t, ep, 1)
 				// Duplicate has no refs — surviving endpoint keeps its single ref
-				require.Len(t, ep[0].RefObjects(), 1)
-				require.Equal(t, types.Service, ep[0].RefObject().Source())
-				require.Equal(t, "123", string(ep[0].RefObject().UID()))
+				refs := ep[0].RefObjects()
+				require.Len(t, refs, 1)
+				require.Equal(t, types.Service, refs[0].Source())
+				require.Equal(t, "123", string(refs[0].UID()))
 			},
 		},
 		{
@@ -649,9 +653,10 @@ func TestDedupSource_RefObjects(t *testing.T) {
 			expected: func(t *testing.T, ep []*endpoint.Endpoint) {
 				require.Len(t, ep, 1)
 				// First endpoint had no ref; the duplicate's ref is merged in
-				require.Len(t, ep[0].RefObjects(), 1)
-				require.Equal(t, types.Service, ep[0].RefObject().Source())
-				require.Equal(t, "345", string(ep[0].RefObject().UID()))
+				refs := ep[0].RefObjects()
+				require.Len(t, refs, 1)
+				require.Equal(t, types.Service, refs[0].Source())
+				require.Equal(t, "345", string(refs[0].UID()))
 			},
 		},
 	}

--- a/source/wrappers/dedupsource_test.go
+++ b/source/wrappers/dedupsource_test.go
@@ -491,7 +491,7 @@ func TestDedupSource_RefObjects(t *testing.T) {
 			},
 		},
 		{
-			name: "duplicate endpoints with same source type - first RefObject preserved",
+			name: "duplicate endpoints with same source type - both RefObjects collected",
 			input: func() []*endpoint.Endpoint {
 				return []*endpoint.Endpoint{
 					testutils.NewEndpointWithRef("example.com", "1.2.3.4", &v1.Service{
@@ -504,14 +504,16 @@ func TestDedupSource_RefObjects(t *testing.T) {
 			},
 			expected: func(t *testing.T, ep []*endpoint.Endpoint) {
 				require.Len(t, ep, 1)
-				require.NotNil(t, ep[0].RefObject())
-				require.Equal(t, types.Service, ep[0].RefObject().Source())
-				require.Equal(t, "first-svc", ep[0].RefObject().Name())
+				refs := ep[0].RefObjects()
+				require.Len(t, refs, 2)
+				// First endpoint is the surviving one; its ref is first
 				require.Equal(t, "uid-first", string(ep[0].RefObject().UID()))
+				uids := []string{string(refs[0].UID()), string(refs[1].UID())}
+				require.ElementsMatch(t, []string{"uid-first", "uid-second"}, uids)
 			},
 		},
 		{
-			name: "duplicate endpoints with different source types - first RefObject preserved",
+			name: "duplicate endpoints with different source types - both RefObjects collected",
 			input: func() []*endpoint.Endpoint {
 				return []*endpoint.Endpoint{
 					testutils.NewEndpointWithRef("example.com", "1.2.3.4", &v1.Service{
@@ -524,15 +526,16 @@ func TestDedupSource_RefObjects(t *testing.T) {
 			},
 			expected: func(t *testing.T, ep []*endpoint.Endpoint) {
 				require.Len(t, ep, 1)
-				require.NotNil(t, ep[0].RefObject())
-				// First endpoint (Service) wins, Ingress is discarded
+				refs := ep[0].RefObjects()
+				require.Len(t, refs, 2)
+				// Service arrived first — still primary
 				require.Equal(t, types.Service, ep[0].RefObject().Source())
-				require.Equal(t, "my-service", ep[0].RefObject().Name())
-				require.Equal(t, "svc-uid", string(ep[0].RefObject().UID()))
+				sources := []string{refs[0].Source(), refs[1].Source()}
+				require.ElementsMatch(t, []string{types.Service, types.Ingress}, sources)
 			},
 		},
 		{
-			name: "duplicate endpoints - Ingress first, Service second - Ingress RefObject preserved",
+			name: "duplicate endpoints - Ingress first, Service second - both RefObjects collected",
 			input: func() []*endpoint.Endpoint {
 				return []*endpoint.Endpoint{
 					testutils.NewEndpointWithRef("example.com", "1.2.3.4", &networkingv1.Ingress{
@@ -545,11 +548,12 @@ func TestDedupSource_RefObjects(t *testing.T) {
 			},
 			expected: func(t *testing.T, ep []*endpoint.Endpoint) {
 				require.Len(t, ep, 1)
-				require.NotNil(t, ep[0].RefObject())
-				// First endpoint (Ingress) wins, Service is discarded
+				refs := ep[0].RefObjects()
+				require.Len(t, refs, 2)
+				// Ingress arrived first — still primary
 				require.Equal(t, types.Ingress, ep[0].RefObject().Source())
-				require.Equal(t, "my-ingress", ep[0].RefObject().Name())
-				require.Equal(t, "ing-uid", string(ep[0].RefObject().UID()))
+				sources := []string{refs[0].Source(), refs[1].Source()}
+				require.ElementsMatch(t, []string{types.Ingress, types.Service}, sources)
 			},
 		},
 		{
@@ -590,7 +594,7 @@ func TestDedupSource_RefObjects(t *testing.T) {
 			},
 		},
 		{
-			name: "three duplicate endpoints from different sources - first RefObject preserved",
+			name: "three duplicate endpoints from different sources - all RefObjects collected",
 			input: func() []*endpoint.Endpoint {
 				return []*endpoint.Endpoint{
 					testutils.NewEndpointWithRef("example.com", "1.2.3.4", &v1.Service{
@@ -606,11 +610,12 @@ func TestDedupSource_RefObjects(t *testing.T) {
 			},
 			expected: func(t *testing.T, ep []*endpoint.Endpoint) {
 				require.Len(t, ep, 1)
-				require.NotNil(t, ep[0].RefObject())
-				// First endpoint (Service) wins
+				refs := ep[0].RefObjects()
+				require.Len(t, refs, 3)
+				// Service arrived first — still primary
 				require.Equal(t, types.Service, ep[0].RefObject().Source())
-				require.Equal(t, "my-service", ep[0].RefObject().Name())
-				require.Equal(t, "123", string(ep[0].RefObject().UID()))
+				uids := []string{string(refs[0].UID()), string(refs[1].UID()), string(refs[2].UID())}
+				require.ElementsMatch(t, []string{"123", "345", "456"}, uids)
 			},
 		},
 		{
@@ -625,13 +630,14 @@ func TestDedupSource_RefObjects(t *testing.T) {
 			},
 			expected: func(t *testing.T, ep []*endpoint.Endpoint) {
 				require.Len(t, ep, 1)
-				require.NotNil(t, ep[0].RefObject())
+				// Duplicate has no refs — surviving endpoint keeps its single ref
+				require.Len(t, ep[0].RefObjects(), 1)
 				require.Equal(t, types.Service, ep[0].RefObject().Source())
 				require.Equal(t, "123", string(ep[0].RefObject().UID()))
 			},
 		},
 		{
-			name: "duplicate endpoints with first having nil RefObject - nil preserved",
+			name: "duplicate endpoints with first having nil RefObject - second RefObject merged in",
 			input: func() []*endpoint.Endpoint {
 				return []*endpoint.Endpoint{
 					endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4"),
@@ -642,8 +648,10 @@ func TestDedupSource_RefObjects(t *testing.T) {
 			},
 			expected: func(t *testing.T, ep []*endpoint.Endpoint) {
 				require.Len(t, ep, 1)
-				// First endpoint (without RefObject) wins
-				require.Nil(t, ep[0].RefObject())
+				// First endpoint had no ref; the duplicate's ref is merged in
+				require.Len(t, ep[0].RefObjects(), 1)
+				require.Equal(t, types.Service, ep[0].RefObject().Source())
+				require.Equal(t, "345", string(ep[0].RefObject().UID()))
 			},
 		},
 	}

--- a/source/wrappers/metrics.go
+++ b/source/wrappers/metrics.go
@@ -47,8 +47,8 @@ var (
 // or "unknown" if the reference is not set. Sources that set RefObject will
 // populate this with their name (e.g. "ingress", "service").
 func endpointSource(ep *endpoint.Endpoint) string {
-	if ref := ep.RefObject(); ref != nil && ref.Source() != "" {
-		return ref.Source()
+	if refs := ep.RefObjects(); len(refs) > 0 && refs[0].Source() != "" {
+		return refs[0].Source()
 	}
 	return "unknown"
 }

--- a/tests/integration/scenarios/tests.yaml
+++ b/tests/integration/scenarios/tests.yaml
@@ -1,24 +1,25 @@
 # Integration Test Scenarios
 #
 # Schema Summary:
-# | Field                                  | Type     | Description                              |
-# |----------------------------------------|----------|------------------------------------------|
-# | name                                   | string   | Test scenario name                       |
-# | config.sources                         | []string | Sources to create: ingress, node, service |
-# | config.defaultTargets                  | []string | --default-targets flag values            |
-# | config.forceDefaultTargets             | bool     | --force-default-targets flag             |
-# | config.targetNetFilter                 | []string | --target-net-filter flag values          |
-# | config.serviceTypeFilter               | []string | --service-type-filter flag values        |
-# | resources                              | []object | K8s resources with optional dependencies |
-# | resources[].resource                   | object   | K8s resource (Ingress, Service, etc.)    |
-# | resources[].dependencies               | object   | Auto-generated dependent resources       |
-# | resources[].dependencies.pods.replicas | int      | Number of pods to generate               |
-# | expected                               | []object | Expected endpoints                       |
+# | Field                                        | Type     | Description                              |
+# |----------------------------------------------|----------|------------------------------------------|
+# | name                                         | string   | Test scenario name                       |
+# | config.sources                               | []string | Sources to create: ingress, node, service |
+# | config.defaultTargets                        | []string | --default-targets flag values            |
+# | config.forceDefaultTargets                   | bool     | --force-default-targets flag             |
+# | config.targetNetFilter                       | []string | --target-net-filter flag values          |
+# | config.serviceTypeFilter                     | []string | --service-type-filter flag values        |
+# | resources                                    | []object | K8s resources with optional dependencies |
+# | resources[].resource                         | object   | K8s resource (Ingress, Service, etc.)    |
+# | resources[].dependencies                     | object   | Auto-generated dependent resources       |
+# | resources[].dependencies.pods.replicas       | int      | Number of pods to generate               |
+# | expected                                     | []object | Expected endpoints                       |
+# | expected[].refObjects                        | []object | Optional: assert ref object attribution  |
+# | expected[].refObjects[].key                  | string   | ObjectReference.Key(): source/namespace/name      |
 
 # TODO:
 # 1. Support to Endpoint.ResourceLabelKey
-# 2. Support for Endpoint.RefObject
-# 3. Support for Endpoint.ProviderSpecific
+# 2. Support for Endpoint.ProviderSpecific
 
 scenarios:
   - name: node-with-external-ip
@@ -536,3 +537,118 @@ scenarios:
       - dnsName: svc.example.com
         targets: ["10.0.0.2"]
         recordType: A
+
+# RefObject scenarios
+  - name: crd-two-records-ref-objects
+    description: >
+      A DNSEndpoint with two spec.endpoints produces two DNS records. Both
+      endpoints are attributed to the same DNSEndpoint object via a shared
+      refObject. The key is "source/namespace/name".
+    config:
+      sources: ["crd"]
+    resources:
+      - resource:
+          apiVersion: externaldns.k8s.io/v1alpha1
+          kind: DNSEndpoint
+          metadata:
+            name: multi-dns
+            namespace: default
+          spec:
+            endpoints:
+              - dnsName: api.example.com
+                targets:
+                  - 1.2.3.4
+                recordType: A
+                recordTTL: 120
+              - dnsName: www.example.com
+                targets:
+                  - 5.6.7.8
+                recordType: A
+                recordTTL: 120
+    expected:
+      - dnsName: api.example.com
+        targets: ["1.2.3.4"]
+        recordType: A
+        recordTTL: 120
+        refObjects:
+          - key: crd/default/multi-dns
+      - dnsName: www.example.com
+        targets: ["5.6.7.8"]
+        recordType: A
+        recordTTL: 120
+        refObjects:
+          - key: crd/default/multi-dns
+
+  - name: service-one-record-ref-object
+    description: >
+      A LoadBalancer Service produces a single A record attributed to that
+      Service via a refObject.
+    config:
+      sources: ["service"]
+    resources:
+      - resource:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: my-svc
+            namespace: default
+            annotations:
+              external-dns.kubernetes.io/hostname: svc.example.com
+          spec:
+            type: LoadBalancer
+          status:
+            loadBalancer:
+              ingress:
+                - ip: 1.2.3.4
+    expected:
+      - dnsName: svc.example.com
+        targets: ["1.2.3.4"]
+        recordType: A
+        refObjects:
+          - key: service/default/my-svc
+
+  - name: crd-and-service-shared-endpoint-two-ref-objects
+    description: >
+      When a CRD and a Service both publish the same hostname and target, the
+      dedupSource retains one endpoint and merges the refObjects from both
+      sources into it. The surviving endpoint therefore has two refObjects —
+      one from the CRD DNSEndpoint and one from the Service. Sources are
+      processed in declaration order (crd first), so the CRD ref is primary.
+    config:
+      sources: ["crd", "service"]
+    resources:
+      - resource:
+          apiVersion: externaldns.k8s.io/v1alpha1
+          kind: DNSEndpoint
+          metadata:
+            name: shared-dns
+            namespace: default
+          spec:
+            endpoints:
+              - dnsName: shared.example.com
+                targets:
+                  - 1.2.3.4
+                recordType: A
+                recordTTL: 300
+      - resource:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: shared-svc
+            namespace: default
+            annotations:
+              external-dns.kubernetes.io/hostname: shared.example.com
+          spec:
+            type: LoadBalancer
+          status:
+            loadBalancer:
+              ingress:
+                - ip: 1.2.3.4
+    expected:
+      - dnsName: shared.example.com
+        targets: ["1.2.3.4"]
+        recordType: A
+        recordTTL: 300
+        refObjects:
+          - key: crd/default/shared-dns
+          - key: service/default/shared-svc

--- a/tests/integration/source_test.go
+++ b/tests/integration/source_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"sigs.k8s.io/external-dns/internal/testutils"
 	"sigs.k8s.io/external-dns/tests/integration/toolkit"
 )
 
@@ -80,7 +79,7 @@ func TestSourceIntegration(t *testing.T) {
 			// Get endpoints
 			endpoints, err := wrappedSource.Endpoints(ctx)
 			require.NoError(t, err)
-			testutils.ValidateEndpoints(t, endpoints, scenario.Expected)
+			toolkit.ValidateScenarioEndpoints(t, endpoints, scenario.Expected)
 		})
 	}
 }

--- a/tests/integration/toolkit/models.go
+++ b/tests/integration/toolkit/models.go
@@ -34,7 +34,7 @@ type TestScenarios struct {
 }
 
 // ExpectedRefObject describes an expected Kubernetes object reference on an endpoint.
-// Key is matched against ObjectReference.Key() (UID when set, else "kind/namespace/name").
+// Key is matched against ObjectReference.Key() ("source/namespace/name").
 type ExpectedRefObject struct {
 	Key string `json:"key"`
 }

--- a/tests/integration/toolkit/models.go
+++ b/tests/integration/toolkit/models.go
@@ -33,13 +33,50 @@ type TestScenarios struct {
 	Scenarios []Scenario `json:"scenarios"`
 }
 
+// ExpectedRefObject describes an expected Kubernetes object reference on an endpoint.
+// Key is matched against ObjectReference.Key() (UID when set, else "kind/namespace/name").
+type ExpectedRefObject struct {
+	Key string `json:"key"`
+}
+
+// ExpectedEndpoint mirrors the JSON-serialisable fields of endpoint.Endpoint and
+// adds an optional RefObjects list for asserting event-source attribution.
+type ExpectedEndpoint struct {
+	DNSName          string                    `json:"dnsName,omitempty"`
+	Targets          endpoint.Targets          `json:"targets,omitempty"`
+	RecordType       string                    `json:"recordType,omitempty"`
+	SetIdentifier    string                    `json:"setIdentifier,omitempty"`
+	RecordTTL        endpoint.TTL              `json:"recordTTL,omitempty"`
+	Labels           endpoint.Labels           `json:"labels,omitempty"`
+	ProviderSpecific endpoint.ProviderSpecific `json:"providerSpecific,omitempty"`
+	// RefObjects is optional. When non-empty, the test asserts that the actual
+	// endpoint has exactly this many ref objects and that each one matches the
+	// corresponding ExpectedRefObject (partial match: only non-empty fields checked).
+	RefObjects []ExpectedRefObject `json:"refObjects,omitempty"`
+}
+
+// ToEndpoint converts an ExpectedEndpoint to a plain *endpoint.Endpoint for use
+// with the standard field validation helpers.
+func (e *ExpectedEndpoint) ToEndpoint() *endpoint.Endpoint {
+	ep := &endpoint.Endpoint{
+		DNSName:          e.DNSName,
+		Targets:          e.Targets,
+		RecordType:       e.RecordType,
+		SetIdentifier:    e.SetIdentifier,
+		RecordTTL:        e.RecordTTL,
+		Labels:           e.Labels,
+		ProviderSpecific: e.ProviderSpecific,
+	}
+	return ep
+}
+
 // Scenario represents a single test scenario.
 type Scenario struct {
 	Name        string                     `json:"name"`
 	Description string                     `json:"description"`
 	Config      ScenarioConfig             `json:"config"`
 	Resources   []ResourceWithDependencies `json:"resources"`
-	Expected    []*endpoint.Endpoint       `json:"expected"`
+	Expected    []*ExpectedEndpoint        `json:"expected"`
 }
 
 // ResourceWithDependencies wraps a K8s resource with optional dependencies.

--- a/tests/integration/toolkit/validate.go
+++ b/tests/integration/toolkit/validate.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package toolkit
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
+)
+
+// ValidateScenarioEndpoints asserts that the actual endpoints match the expected
+// scenario endpoints. Standard fields (DNSName, Targets, RecordType, TTL, etc.)
+// are validated via the shared testutils helper. When an ExpectedEndpoint carries
+// a non-empty RefObjects list, the actual endpoint is additionally checked to have
+// exactly that many ref objects, with each one satisfying the partial match
+// (only non-empty fields in ExpectedRefObject are compared).
+func ValidateScenarioEndpoints(t *testing.T, got []*endpoint.Endpoint, expected []*ExpectedEndpoint) {
+	t.Helper()
+
+	plain := make([]*endpoint.Endpoint, len(expected))
+	for i, e := range expected {
+		plain[i] = e.ToEndpoint()
+	}
+	testutils.ValidateEndpoints(t, got, plain)
+
+	// After ValidateEndpoints has sorted both slices in-place, pair them up and
+	// check refObjects where the expected entry specifies them.
+	// We re-sort expected by the same key so the pairing is stable.
+	sortExpected(expected)
+
+	for i := range min(len(got), len(expected)) {
+		exp := expected[i]
+		if len(exp.RefObjects) == 0 {
+			continue
+		}
+		act := got[i]
+		actualRefs := act.RefObjects()
+		if len(actualRefs) != len(exp.RefObjects) {
+			t.Errorf("endpoint %q: expected %d refObjects, got %d",
+				exp.DNSName, len(exp.RefObjects), len(actualRefs))
+			continue
+		}
+		errs := matchRefObjects(exp.DNSName, actualRefs, exp.RefObjects)
+		for _, e := range errs {
+			t.Error(e)
+		}
+	}
+}
+
+// matchRefObjects checks that every ExpectedRefObject.Key is satisfied by some
+// actual ref's Key() (order-independent).
+func matchRefObjects(dnsName string, actual []*endpoint.ObjectRef, expected []ExpectedRefObject) []string {
+	used := make([]bool, len(actual))
+	var errs []string
+
+	for _, exp := range expected {
+		matched := false
+		for j, ref := range actual {
+			if used[j] {
+				continue
+			}
+			if ref.Key() == exp.Key {
+				used[j] = true
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			errs = append(errs, fmt.Sprintf(
+				"endpoint %q: no actual refObject has key %q",
+				dnsName, exp.Key,
+			))
+		}
+	}
+	return errs
+}
+
+// sortExpected sorts expected endpoints by the same key as testutils.ValidateEndpoints
+// so that the pairing with got[] is stable.
+func sortExpected(expected []*ExpectedEndpoint) {
+	slices.SortFunc(expected, compareExpected)
+}
+
+func compareExpected(a, b *ExpectedEndpoint) int {
+	if n := strings.Compare(a.DNSName, b.DNSName); n != 0 {
+		return n
+	}
+	if n := strings.Compare(a.RecordType, b.RecordType); n != 0 {
+		return n
+	}
+	return strings.Compare(a.Targets.String(), b.Targets.String())
+}


### PR DESCRIPTION
## What does it do ?

- Endpoint.refObject *ObjectRef promoted to refObjects []*ObjectRef
- MergeEndpoints now accumulates all RefObjects from every merged endpoint into the surviving one, so a multi-pod or multi-source record carries attribution for all contributors
- Integration test framework extended: ExpectedEndpoint replaces *endpoint.Endpoint in scenario expected lists, adding an optional refObjects [{key}] assertion; ValidateScenarioEndpoints validates both endpoint fields and ref attribution

## Motivation

At the moment, when multiple resources co-own the record, only single event emitted. This change added multi-ref object support to endpoints and events so DNS records track all contributing Kubernetes sources.

  - An endpoint derived from multiple sources (e.g. a CRD and a Service both publishing the same hostname) previously only retained a single RefObject, silently discarding all but the first contributing Kubernetes object
  - The dedup source dropped the second occurrence of an identical endpoint entirely, losing the source attribution of the dropped duplicate
  - Kubernetes events were emitted at most once per DNS record change, missing the objects that co-own the record
  - The Event struct similarly held only a single ObjectReference, preventing per-source event emission when multiple objects contributed

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
