### PR TITLE
test(source/ingress): two ingresses with same host, different IPs

### DIFF
--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -1672,6 +1672,56 @@ func TestIngressWithConfiguration(t *testing.T) {
 			},
 		},
 		{
+			title: "multiple ingresses with same hostname, different IPs from different ingressClasses are merged",
+			ingresses: []*networkv1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-service",
+						Namespace: "old-ns",
+					},
+					Spec: networkv1.IngressSpec{
+						IngressClassName: new("old-class"),
+						Rules: []networkv1.IngressRule{
+							{Host: "my-service.example.com"},
+						},
+					},
+					Status: networkv1.IngressStatus{
+						LoadBalancer: networkv1.IngressLoadBalancerStatus{
+							Ingress: []networkv1.IngressLoadBalancerIngress{
+								{IP: "10.0.0.1"},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-service",
+						Namespace: "new-ns",
+					},
+					Spec: networkv1.IngressSpec{
+						IngressClassName: new("new-class"),
+						Rules: []networkv1.IngressRule{
+							{Host: "my-service.example.com"},
+						},
+					},
+					Status: networkv1.IngressStatus{
+						LoadBalancer: networkv1.IngressLoadBalancerStatus{
+							Ingress: []networkv1.IngressLoadBalancerIngress{
+								{IP: "10.0.0.2"},
+							},
+						},
+					},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "my-service.example.com",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"10.0.0.1", "10.0.0.2"},
+				},
+			},
+		},
+		{
 			title: "ingress with when AWS ALB controller and NLB type generates two targets for CNAME",
 			ingresses: []*networkv1.Ingress{
 				{


### PR DESCRIPTION
## What does it do ?

- New test case asserting that two ingresses in different namespaces with different ingressClassName values and the same hostname have their IPs merged into a single A record with both targets

- Issue #6479 reports that v0.21.0 changed behavior for two ingresses sharing the same hostname with different IPs from different ingressClasses

- No existing test covered this specific scenario (two A-record ingresses, different namespaces/classes, same host)

- Documents the current v0.21.0 behavior (targets are merged) so it's explicit and won't silently regress

## Motivation

Closes https://github.com/kubernetes-sigs/external-dns/issues/6479

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
