### PR TITLE
feat(chart): add TXT registry option values

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+- Add values `.txtWildcardReplacement`, `.txtEncryptEnabled`, and `.txtEncryptAesKey` for TXT registry options.
 - Add value `.service.enabled` to enable the creation of the Kubernetes service.
 
 ### Fixed

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -190,6 +190,9 @@ If `namespaced` is set to `true`, please ensure that `sources` only contains sup
 | txtOwnerId | string | `nil` | Specify an identifier for this instance of _ExternalDNS_ when using a registry other than `noop`. |
 | txtPrefix | string | `nil` | Specify a prefix for the domain names of TXT records created for the `txt` registry. Mutually exclusive with `txtSuffix`. |
 | txtSuffix | string | `nil` | Specify a suffix for the domain names of TXT records created for the `txt` registry. Mutually exclusive with `txtPrefix`. |
+| txtWildcardReplacement | string | `nil` | Specify a replacement for the asterisk in TXT registry records for wildcard DNS records. |
+| txtEncryptEnabled | bool | `false` | If `true`, encrypt TXT registry records before storing them. |
+| txtEncryptAesKey | string | `nil` | Specify the 32-byte AES key for TXT registry record encryption. Required when `txtEncryptEnabled` is `true`. |
 
 ## Usage
 

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -108,6 +108,15 @@ spec:
             {{- else if .Values.txtSuffix }}
             - --txt-suffix={{ .Values.txtSuffix }}
             {{- end }}
+            {{- if .Values.txtWildcardReplacement }}
+            - --txt-wildcard-replacement={{ .Values.txtWildcardReplacement }}
+            {{- end }}
+            {{- if .Values.txtEncryptEnabled }}
+            - --txt-encrypt-enabled
+            {{- end }}
+            {{- if .Values.txtEncryptAesKey }}
+            - --txt-encrypt-aes-key={{ .Values.txtEncryptAesKey }}
+            {{- end }}
             {{- if .Values.namespaced }}
             - --namespace={{ default (include "external-dns.namespace" .) .Values.sourceNamespace }}
             {{- end }}

--- a/charts/external-dns/tests/deployment-flags_test.yaml
+++ b/charts/external-dns/tests/deployment-flags_test.yaml
@@ -56,6 +56,26 @@ tests:
           path: spec.template.spec.containers[?(@.name == "external-dns")].args
           content: "--txt-suffix=custom-suffix"
 
+  - it: should configure 'txtWildcardReplacement' when set
+    set:
+      txtWildcardReplacement: "wildcard"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "external-dns")].args
+          content: "--txt-wildcard-replacement=wildcard"
+
+  - it: should configure TXT record encryption flags when set
+    set:
+      txtEncryptEnabled: true
+      txtEncryptAesKey: "01234567890123456789012345678901"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "external-dns")].args
+          content: "--txt-encrypt-enabled"
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "external-dns")].args
+          content: "--txt-encrypt-aes-key=01234567890123456789012345678901"
+
   - it: should be able configure multiple sources
     set:
       sources:

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -908,6 +908,24 @@
         "string",
         "null"
       ]
+    },
+    "txtWildcardReplacement": {
+      "description": "Specify a replacement for the asterisk in TXT registry records for wildcard DNS records.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "txtEncryptEnabled": {
+      "description": "If `true`, encrypt TXT registry records before storing them.",
+      "type": "boolean"
+    },
+    "txtEncryptAesKey": {
+      "description": "Specify the 32-byte AES key for TXT registry record encryption. Required when `txtEncryptEnabled` is `true`.",
+      "type": [
+        "string",
+        "null"
+      ]
     }
   },
   "additionalProperties": true

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -244,6 +244,12 @@ txtPrefix:  # @schema type:[string, null]; default: null
 # -- (string) Specify a suffix for the domain names of TXT records created for the `txt` registry.
 # Mutually exclusive with `txtPrefix`.
 txtSuffix:  # @schema type:[string, null]; default: null
+# -- (string) Specify a replacement for the asterisk in TXT registry records for wildcard DNS records.
+txtWildcardReplacement:  # @schema type:[string, null]; default: null
+# -- If `true`, encrypt TXT registry records before storing them.
+txtEncryptEnabled: false
+# -- (string) Specify the 32-byte AES key for TXT registry record encryption. Required when `txtEncryptEnabled` is `true`.
+txtEncryptAesKey:  # @schema type:[string, null]; default: null
 
 # -- Limit possible target zones by domain suffixes.
 domainFilters: []


### PR DESCRIPTION
## What

Adds first-class Helm chart values for TXT registry wildcard replacement and TXT record encryption:

- `.txtWildcardReplacement`
- `.txtEncryptEnabled`
- `.txtEncryptAesKey`

The Deployment template now renders the matching ExternalDNS flags when those values are set.

## Why

ExternalDNS already supports `--txt-wildcard-replacement`, `--txt-encrypt-enabled`, and `--txt-encrypt-aes-key`, but the Helm chart only exposed the older TXT registry options (`txtOwnerId`, `txtPrefix`, and `txtSuffix`) as dedicated values. Users had to fall back to `extraArgs` or raw `env` entries for these supported TXT registry settings.

## Validation

- `git diff --check`
- Parsed `charts/external-dns/values.schema.json` as JSON
- Confirmed the binary flag names in `pkg/apis/externaldns/types.go`

Helm render/unit tests were not run locally because `helm` is not installed in this environment.
