### PR TITLE
feat(chart): add replicaCount to allow scaling external-dns to 0 or 1

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [UNRELEASED]
 
 - Add value `.service.enabled` to enable the creation of the Kubernetes service.
+- Add value `replicaCount` to set the number of `external-dns` replicas (bounded to `0` or `1`, since external-dns does not support leader election). [#6503](https://github.com/kubernetes-sigs/external-dns/pull/6503) _@yugstar_
 
 ### Fixed
 

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -151,6 +151,7 @@ If `namespaced` is set to `true`, please ensure that `sources` only contains sup
 | rbac.create | bool | `true` | If `true`, create a `ClusterRole` & `ClusterRoleBinding` with access to the Kubernetes API. |
 | readinessProbe | object | See _values.yaml_ | [Readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the `external-dns` container. |
 | registry | string | `"txt"` | Specify the registry for storing ownership and labels. Valid values are `txt`, `aws-sd`, `dynamodb` & `noop`. |
+| replicaCount | int | `1` | Number of replicas of the `external-dns` `Deployment`. external-dns does not support leader election, so this must be `0` or `1` to avoid duplicate or conflicting DNS record updates. Set to `0` to scale the `Deployment` down. |
 | resources | object | `{}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the `external-dns` container. |
 | revisionHistoryLimit | int | `nil` | Specify the number of old `ReplicaSets` to retain to allow rollback of the `Deployment``. |
 | secretConfiguration.data | object | `{}` | `Secret` data. |

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -12,7 +12,11 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: 1
+  {{- /* values.schema.json bounds replicaCount to 0-1, but that is skipped by e.g. `helm template | kubectl apply`, so guard here too. */}}
+  {{- if gt (int .Values.replicaCount) 1 }}
+  {{- fail "replicaCount must be 0 or 1: external-dns does not support leader election" }}
+  {{- end }}
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       {{- include "external-dns.selectorLabels" . | nindent 6 }}

--- a/charts/external-dns/tests/deployment-config_test.yaml
+++ b/charts/external-dns/tests/deployment-config_test.yaml
@@ -79,3 +79,20 @@ tests:
       - equal:
           path: spec.replicas
           value: 1
+
+  - it: should allow scaling to 0 via replicaCount
+    set:
+      replicaCount: 0
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 0
+
+  - it: should reject replicaCount greater than 1
+    set:
+      replicaCount: 2
+    asserts:
+      - failedTemplate:
+          # Rejected by the values schema (maximum: 1) in schema-validated paths,
+          # or by the template guard when schema validation is skipped.
+          errorPattern: "(replicaCount must be 0 or 1|/replicaCount': maximum: got 2, want 1)"

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -608,6 +608,12 @@
         "noop"
       ]
     },
+    "replicaCount": {
+      "description": "Number of replicas of the `external-dns` `Deployment`. external-dns does not support leader election, so this must be `0` or `1` to avoid duplicate or conflicting DNS record updates. Set to `0` to scale the `Deployment` down.",
+      "type": "integer",
+      "maximum": 1,
+      "minimum": 0
+    },
     "resources": {
       "description": "[Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the `external-dns` container.",
       "type": "object",

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -64,6 +64,11 @@ rbac:  # @schema additionalProperties: true
   # -- Additional rules to add to the `ClusterRole`.
   additionalPermissions: []
 
+# -- Number of replicas of the `external-dns` `Deployment`. external-dns does not
+# support leader election, so this must be `0` or `1` to avoid duplicate or
+# conflicting DNS record updates. Set to `0` to scale the `Deployment` down.
+replicaCount: 1  # @schema minimum:0; maximum:1
+
 # -- Annotations to add to the `Deployment`.
 deploymentAnnotations: {}
 


### PR DESCRIPTION
## Description

Closes #6127.

The `Deployment` hardcoded `replicas: 1` with no value to override it, so operators couldn't scale external-dns to `0` (e.g. to temporarily pause it, or manage it via GitOps) without forking the chart.

This adds a `replicaCount` value wired into the Deployment.

**Bounded to 0 or 1 on purpose:** external-dns has no leader election, so running >1 replica produces duplicate/conflicting DNS record updates. The value is constrained in `values.schema.json` to `minimum: 0, maximum: 1` (via the `# @schema` annotation), which directly addresses the concern that led to the earlier #4784 being closed.

## Verification

- `--set replicaCount=0` and `=1` → accepted; `--set replicaCount=2` → rejected by schema (`maximum`).
- Default render unchanged (`replicas: 1`).
- Schema regenerated via `scripts/helm-tools.sh --schema`; README regenerated via helm-docs; `helm lint` passes.
- Per the chart convention, `Chart.yaml` is not bumped; entry added under `CHANGELOG.md` `[UNRELEASED]`.

Maintainer @ivankatliarchuk noted on the issue: *"Just submit a solution"*.
