### PR TITLE
docs(rfc2136): fix duplicated word in tutorial

### DIFF
--- a/docs/tutorials/rfc2136.md
+++ b/docs/tutorials/rfc2136.md
@@ -355,7 +355,7 @@ spec:
 
 This will set the DNS record's TTL to 60 seconds.
 
-A default TTL for all records can be set using the the flag with a time in seconds, minutes or hours, such as `--rfc2136-min-ttl=60s`
+A default TTL for all records can be set using the flag with a time in seconds, minutes or hours, such as `--rfc2136-min-ttl=60s`
 
 There are other annotation that can affect the generation of DNS records, but these are beyond the scope of this
 tutorial and are covered in the main documentation.


### PR DESCRIPTION
The rfc2136 tutorial read "can be set using the the flag" — removed the duplicated "the".
