### PR TITLE
refactor(registry/crd): build REST config from shared client package

### DIFF
--- a/registry/crd/crd.go
+++ b/registry/crd/crd.go
@@ -37,10 +37,10 @@ import (
 	apiv1alpha1 "sigs.k8s.io/external-dns/apis/v1alpha1"
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
+	kubeclient "sigs.k8s.io/external-dns/pkg/client"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
 	"sigs.k8s.io/external-dns/registry"
-	"sigs.k8s.io/external-dns/source"
 )
 
 // CRDRegistry implements registry interface with ownership implemented via associated custom resource records (DNSRecord)
@@ -75,15 +75,9 @@ func NewCRDRegistry(provider provider.Provider, kubeConfig, apiServerURL, namesp
 		namespace = "default"
 	}
 
-	// new Singleton because the user may want to store this registry on a
-	// remote (and shared) cluster between multiple external-dns instances
-	clientGenerator := &source.SingletonClientGenerator{
-		KubeConfig:     kubeConfig,
-		APIServerURL:   apiServerURL,
-		RequestTimeout: apiServerTimeout,
-	}
-
-	restConfig, err := clientGenerator.RESTConfig()
+	// Build the REST config from the shared client package: this registry may run
+	// against a remote, shared cluster, so it does not reuse the source clients.
+	restConfig, err := kubeclient.InstrumentedRESTConfig(kubeConfig, apiServerURL, apiServerTimeout, 0, 0)
 	if err != nil {
 		return nil, fmt.Errorf("unable to build rest config: %w", err)
 	}


### PR DESCRIPTION
## What does it do ?

Call `kubeclient.InstrumentedRESTConfig` directly in the CRD registry and drop the `source` import. 
Behavior unchanged — `RESTConfig()` already delegated to it.

## Motivation

Follow-up to this [review comment](https://github.com/kubernetes-sigs/external-dns/pull/5372#discussion_r3350886245) on PR #5372

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly
