### PR TITLE
fix(dnsimple): read back all supported record types and fix record lookup by type

### DIFF
--- a/provider/dnsimple/dnsimple.go
+++ b/provider/dnsimple/dnsimple.go
@@ -212,7 +212,7 @@ func (p *dnsimpleProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, e
 				return nil, err
 			}
 			for _, record := range records.Data {
-				if record.Type != endpoint.RecordTypeA && record.Type != endpoint.RecordTypeCNAME && record.Type != endpoint.RecordTypeTXT {
+				if record.Type != endpoint.RecordTypeA && record.Type != endpoint.RecordTypeAAAA && record.Type != endpoint.RecordTypeCNAME && record.Type != endpoint.RecordTypeTXT {
 					continue
 				}
 				// Apex records have an empty string for their name.

--- a/provider/dnsimple/dnsimple.go
+++ b/provider/dnsimple/dnsimple.go
@@ -212,7 +212,7 @@ func (p *dnsimpleProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, e
 				return nil, err
 			}
 			for _, record := range records.Data {
-				if record.Type != endpoint.RecordTypeA && record.Type != endpoint.RecordTypeAAAA && record.Type != endpoint.RecordTypeCNAME && record.Type != endpoint.RecordTypeTXT {
+				if !provider.SupportedRecordType(record.Type) {
 					continue
 				}
 				// Apex records have an empty string for their name.
@@ -300,7 +300,7 @@ func (p *dnsimpleProvider) submitChanges(ctx context.Context, changes []*dnsimpl
 					return err
 				}
 			case dnsimpleDelete:
-				recordID, err := p.GetRecordID(ctx, zone.Name, *recordAttributes.Name)
+				recordID, err := p.GetRecordID(ctx, zone.Name, *recordAttributes.Name, recordAttributes.Type)
 				if err != nil {
 					return err
 				}
@@ -309,7 +309,7 @@ func (p *dnsimpleProvider) submitChanges(ctx context.Context, changes []*dnsimpl
 					return err
 				}
 			case dnsimpleUpdate:
-				recordID, err := p.GetRecordID(ctx, zone.Name, *recordAttributes.Name)
+				recordID, err := p.GetRecordID(ctx, zone.Name, *recordAttributes.Name, recordAttributes.Type)
 				if err != nil {
 					return err
 				}
@@ -323,10 +323,13 @@ func (p *dnsimpleProvider) submitChanges(ctx context.Context, changes []*dnsimpl
 	return nil
 }
 
-// GetRecordID returns the record ID for a given record name and zone.
-func (p *dnsimpleProvider) GetRecordID(ctx context.Context, zone string, recordName string) (int64, error) {
+// GetRecordID returns the record ID for a given record name, type and zone.
+// The record type is required to disambiguate dual-stack hosts that have both
+// an A and an AAAA record sharing the same name, where matching on name alone
+// could return the wrong record.
+func (p *dnsimpleProvider) GetRecordID(ctx context.Context, zone string, recordName string, recordType string) (int64, error) {
 	page := 1
-	listOptions := &dnsimple.ZoneRecordListOptions{Name: &recordName}
+	listOptions := &dnsimple.ZoneRecordListOptions{Name: &recordName, Type: &recordType}
 	for {
 		listOptions.Page = &page
 		records, err := p.client.ListRecords(ctx, p.accountID, zone, listOptions)
@@ -335,7 +338,7 @@ func (p *dnsimpleProvider) GetRecordID(ctx context.Context, zone string, recordN
 		}
 
 		for _, record := range records.Data {
-			if record.Name == recordName {
+			if record.Name == recordName && record.Type == recordType {
 				return record.ID, nil
 			}
 		}

--- a/provider/dnsimple/dnsimple_test.go
+++ b/provider/dnsimple/dnsimple_test.go
@@ -178,12 +178,9 @@ func testDnsimpleProviderZones(t *testing.T) {
 	os.Unsetenv("DNSIMPLE_ZONES")
 }
 
-// testDnsimpleProviderRecords drives Records() through a table of cases with a
-// fresh mock per case, instead of relying on shared global mock state. It
-// covers the supported record types returned together, a dual-stack host where
-// an A and an AAAA record share the same name, the apex domain (empty record
-// name mapping to the zone name), and error propagation from both ListZones and
-// ListRecords.
+// testDnsimpleProviderRecords drives Records() through a table of cases, each
+// with a fresh mock, covering the supported record types, dual-stack hosts,
+// apex names, and error propagation from ListZones and ListRecords.
 func testDnsimpleProviderRecords(t *testing.T) {
 	zonesResponse := &dnsimple.ZonesResponse{
 		Response: dnsimple.Response{Pagination: &dnsimple.Pagination{TotalPages: 1}},
@@ -203,7 +200,7 @@ func testDnsimpleProviderRecords(t *testing.T) {
 		want    []*endpoint.Endpoint
 	}{
 		{
-			name: "all supported types returned together",
+			name: "all supported types including SRV and NS returned together",
 			setup: func(m *mockDnsimpleZoneServiceInterface) {
 				m.On("ListZones", t.Context(), "1", &dnsimple.ZoneListOptions{ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(zonesResponse, nil)
 				m.On("ListRecords", t.Context(), "1", "example.com", &dnsimple.ZoneRecordListOptions{ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(recordsResponse(
@@ -211,6 +208,8 @@ func testDnsimpleProviderRecords(t *testing.T) {
 					dnsimple.ZoneRecord{ID: 2, ZoneID: "example.com", Name: "aaaa", Content: "fd00::1", TTL: 3600, Type: "AAAA"},
 					dnsimple.ZoneRecord{ID: 3, ZoneID: "example.com", Name: "cname", Content: "target", TTL: 7200, Type: "CNAME"},
 					dnsimple.ZoneRecord{ID: 4, ZoneID: "example.com", Name: "txt", Content: "hello", TTL: 3600, Type: "TXT"},
+					dnsimple.ZoneRecord{ID: 5, ZoneID: "example.com", Name: "srv", Content: "1 10 5060 sip.example.com", TTL: 3600, Type: "SRV"},
+					dnsimple.ZoneRecord{ID: 6, ZoneID: "example.com", Name: "ns", Content: "ns1.example.com", TTL: 3600, Type: "NS"},
 				), nil)
 			},
 			want: []*endpoint.Endpoint{
@@ -218,6 +217,8 @@ func testDnsimpleProviderRecords(t *testing.T) {
 				endpoint.NewEndpointWithTTL("aaaa.example.com", endpoint.RecordTypeAAAA, 3600, "fd00::1"),
 				endpoint.NewEndpointWithTTL("cname.example.com", endpoint.RecordTypeCNAME, 7200, "target"),
 				endpoint.NewEndpointWithTTL("txt.example.com", endpoint.RecordTypeTXT, 3600, "hello"),
+				endpoint.NewEndpointWithTTL("srv.example.com", endpoint.RecordTypeSRV, 3600, "1 10 5060 sip.example.com"),
+				endpoint.NewEndpointWithTTL("ns.example.com", endpoint.RecordTypeNS, 3600, "ns1.example.com"),
 			},
 		},
 		{
@@ -295,12 +296,9 @@ func testDnsimpleProviderRecords(t *testing.T) {
 	}
 }
 
-// testDnsimpleProviderApplyChanges drives ApplyChanges through a table of cases
-// and verifies the exact DNSimple API calls made for each one. Unlike a bare
-// "no error returned" assertion, it calls AssertExpectations so a no-op
-// ApplyChanges would fail. The dual-stack cases in particular exercise
-// GetRecordID's name+type disambiguation: a host with both an A and an AAAA
-// record at the same name must resolve to the matching record ID per type.
+// testDnsimpleProviderApplyChanges drives ApplyChanges through a table of cases,
+// asserting the exact DNSimple API calls via AssertExpectations so a no-op would
+// fail. The dual-stack cases exercise GetRecordID's name+type disambiguation.
 func testDnsimpleProviderApplyChanges(t *testing.T) {
 	zonesResponse := &dnsimple.ZonesResponse{
 		Response: dnsimple.Response{Pagination: &dnsimple.Pagination{TotalPages: 1}},

--- a/provider/dnsimple/dnsimple_test.go
+++ b/provider/dnsimple/dnsimple_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
 )
@@ -177,13 +178,6 @@ func testDnsimpleProviderZones(t *testing.T) {
 	os.Unsetenv("DNSIMPLE_ZONES")
 }
 
-// wantEndpoint is the comparable shape we assert Records() produced for a case.
-type wantEndpoint struct {
-	dnsName    string
-	recordType string
-	target     string
-}
-
 // testDnsimpleProviderRecords drives Records() through a table of cases with a
 // fresh mock per case, instead of relying on shared global mock state. It
 // covers the supported record types returned together, a dual-stack host where
@@ -203,10 +197,10 @@ func testDnsimpleProviderRecords(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		setup      func(m *mockDnsimpleZoneServiceInterface)
-		wantErr    bool
-		wantRecord []wantEndpoint
+		name    string
+		setup   func(m *mockDnsimpleZoneServiceInterface)
+		wantErr bool
+		want    []*endpoint.Endpoint
 	}{
 		{
 			name: "all supported types returned together",
@@ -215,15 +209,15 @@ func testDnsimpleProviderRecords(t *testing.T) {
 				m.On("ListRecords", t.Context(), "1", "example.com", &dnsimple.ZoneRecordListOptions{ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(recordsResponse(
 					dnsimple.ZoneRecord{ID: 1, ZoneID: "example.com", Name: "a", Content: "127.0.0.1", TTL: 3600, Type: "A"},
 					dnsimple.ZoneRecord{ID: 2, ZoneID: "example.com", Name: "aaaa", Content: "fd00::1", TTL: 3600, Type: "AAAA"},
-					dnsimple.ZoneRecord{ID: 3, ZoneID: "example.com", Name: "cname", Content: "target", TTL: 3600, Type: "CNAME"},
+					dnsimple.ZoneRecord{ID: 3, ZoneID: "example.com", Name: "cname", Content: "target", TTL: 7200, Type: "CNAME"},
 					dnsimple.ZoneRecord{ID: 4, ZoneID: "example.com", Name: "txt", Content: "hello", TTL: 3600, Type: "TXT"},
 				), nil)
 			},
-			wantRecord: []wantEndpoint{
-				{"a.example.com", "A", "127.0.0.1"},
-				{"aaaa.example.com", "AAAA", "fd00::1"},
-				{"cname.example.com", "CNAME", "target"},
-				{"txt.example.com", "TXT", "hello"},
+			want: []*endpoint.Endpoint{
+				endpoint.NewEndpointWithTTL("a.example.com", endpoint.RecordTypeA, 3600, "127.0.0.1"),
+				endpoint.NewEndpointWithTTL("aaaa.example.com", endpoint.RecordTypeAAAA, 3600, "fd00::1"),
+				endpoint.NewEndpointWithTTL("cname.example.com", endpoint.RecordTypeCNAME, 7200, "target"),
+				endpoint.NewEndpointWithTTL("txt.example.com", endpoint.RecordTypeTXT, 3600, "hello"),
 			},
 		},
 		{
@@ -235,9 +229,9 @@ func testDnsimpleProviderRecords(t *testing.T) {
 					dnsimple.ZoneRecord{ID: 2, ZoneID: "example.com", Name: "www", Content: "fd00::1", TTL: 3600, Type: "AAAA"},
 				), nil)
 			},
-			wantRecord: []wantEndpoint{
-				{"www.example.com", "A", "127.0.0.1"},
-				{"www.example.com", "AAAA", "fd00::1"},
+			want: []*endpoint.Endpoint{
+				endpoint.NewEndpointWithTTL("www.example.com", endpoint.RecordTypeA, 3600, "127.0.0.1"),
+				endpoint.NewEndpointWithTTL("www.example.com", endpoint.RecordTypeAAAA, 3600, "fd00::1"),
 			},
 		},
 		{
@@ -248,8 +242,8 @@ func testDnsimpleProviderRecords(t *testing.T) {
 					dnsimple.ZoneRecord{ID: 1, ZoneID: "example.com", Name: "", Content: "127.0.0.1", TTL: 3600, Type: "A"},
 				), nil)
 			},
-			wantRecord: []wantEndpoint{
-				{"example.com", "A", "127.0.0.1"},
+			want: []*endpoint.Endpoint{
+				endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, 3600, "127.0.0.1"),
 			},
 		},
 		{
@@ -261,8 +255,8 @@ func testDnsimpleProviderRecords(t *testing.T) {
 					dnsimple.ZoneRecord{ID: 2, ZoneID: "example.com", Name: "soa", Content: "ns.example.com", TTL: 3600, Type: "SOA"},
 				), nil)
 			},
-			wantRecord: []wantEndpoint{
-				{"a.example.com", "A", "127.0.0.1"},
+			want: []*endpoint.Endpoint{
+				endpoint.NewEndpointWithTTL("a.example.com", endpoint.RecordTypeA, 3600, "127.0.0.1"),
 			},
 		},
 		{
@@ -295,13 +289,7 @@ func testDnsimpleProviderRecords(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-
-			got := make([]wantEndpoint, 0, len(result))
-			for _, ep := range result {
-				require.Len(t, ep.Targets, 1)
-				got = append(got, wantEndpoint{ep.DNSName, ep.RecordType, ep.Targets[0]})
-			}
-			assert.ElementsMatch(t, tt.wantRecord, got)
+			assert.True(t, testutils.SameEndpoints(result, tt.want), "expected %v, got %v", tt.want, result)
 			mockDNS.AssertExpectations(t)
 		})
 	}

--- a/provider/dnsimple/dnsimple_test.go
+++ b/provider/dnsimple/dnsimple_test.go
@@ -133,6 +133,7 @@ func TestDnsimpleServices(t *testing.T) {
 
 	for _, record := range records {
 		recordName := record.Name
+		recordType := record.Type
 		simpleRecord := dnsimple.ZoneRecordAttributes{
 			Name:    &recordName,
 			Type:    record.Type,
@@ -145,7 +146,7 @@ func TestDnsimpleServices(t *testing.T) {
 			Data:     []dnsimple.ZoneRecord{record},
 		}
 
-		mockDNS.On("ListRecords", t.Context(), "1", record.ZoneID, &dnsimple.ZoneRecordListOptions{Name: &recordName, ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(&dnsimpleRecordResponse, nil)
+		mockDNS.On("ListRecords", t.Context(), "1", record.ZoneID, &dnsimple.ZoneRecordListOptions{Name: &recordName, Type: &recordType, ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(&dnsimpleRecordResponse, nil)
 		mockDNS.On("CreateRecord", t.Context(), "1", record.ZoneID, simpleRecord).Return(&dnsimple.ZoneRecordResponse{}, nil)
 		mockDNS.On("DeleteRecord", t.Context(), "1", record.ZoneID, record.ID).Return(&dnsimple.ZoneRecordResponse{}, nil)
 		mockDNS.On("UpdateRecord", t.Context(), "1", record.ZoneID, record.ID, simpleRecord).Return(&dnsimple.ZoneRecordResponse{}, nil)
@@ -205,24 +206,113 @@ func testDnsimpleProviderRecords(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// ptr is a small helper for building the *string fields the DNSimple options use.
+func ptr[T any](v T) *T { return &v }
+
+// testDnsimpleProviderApplyChanges drives ApplyChanges through a table of cases
+// and verifies the exact DNSimple API calls made for each one. Unlike a bare
+// "no error returned" assertion, it calls AssertExpectations so a no-op
+// ApplyChanges would fail. The dual-stack cases in particular exercise
+// GetRecordID's name+type disambiguation: a host with both an A and an AAAA
+// record at the same name must resolve to the matching record ID per type.
 func testDnsimpleProviderApplyChanges(t *testing.T) {
-	changes := &plan.Changes{}
-	changes.Create = []*endpoint.Endpoint{
-		{DNSName: "example.example.com", Targets: endpoint.Targets{"target"}, RecordType: endpoint.RecordTypeCNAME},
-		{DNSName: "custom-ttl.example.com", RecordTTL: 60, Targets: endpoint.Targets{"target"}, RecordType: endpoint.RecordTypeCNAME},
-	}
-	changes.Delete = []*endpoint.Endpoint{
-		{DNSName: "example-beta.example.com", Targets: endpoint.Targets{"127.0.0.1"}, RecordType: endpoint.RecordTypeA},
-	}
-	changes.UpdateNew = []*endpoint.Endpoint{
-		{DNSName: "example.example.com", Targets: endpoint.Targets{"target"}, RecordType: endpoint.RecordTypeCNAME},
-		{DNSName: "example.com", Targets: endpoint.Targets{"127.0.0.1"}, RecordType: endpoint.RecordTypeA},
+	zonesResponse := &dnsimple.ZonesResponse{
+		Response: dnsimple.Response{Pagination: &dnsimple.Pagination{TotalPages: 1}},
+		Data:     []dnsimple.Zone{{ID: 1, AccountID: 12345, Name: "example.com"}},
 	}
 
-	mockProvider.accountID = "1"
-	err := mockProvider.ApplyChanges(t.Context(), changes)
-	if err != nil {
-		t.Errorf("Failed to apply changes: %v", err)
+	// listRecords builds the single-record response GetRecordID expects for a
+	// ListRecords(name, type) lookup.
+	listRecords := func(id int64, name, recordType string) *dnsimple.ZoneRecordsResponse {
+		return &dnsimple.ZoneRecordsResponse{
+			Response: dnsimple.Response{Pagination: &dnsimple.Pagination{TotalPages: 1}},
+			Data: []dnsimple.ZoneRecord{
+				{ID: id, ZoneID: "example.com", Name: name, Type: recordType},
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		changes *plan.Changes
+		setup   func(m *mockDnsimpleZoneServiceInterface)
+	}{
+		{
+			name: "create A and AAAA",
+			changes: &plan.Changes{Create: []*endpoint.Endpoint{
+				{DNSName: "www.example.com", Targets: endpoint.Targets{"127.0.0.1"}, RecordType: endpoint.RecordTypeA},
+				{DNSName: "www.example.com", Targets: endpoint.Targets{"fd00::1"}, RecordType: endpoint.RecordTypeAAAA},
+			}},
+			setup: func(m *mockDnsimpleZoneServiceInterface) {
+				m.On("CreateRecord", t.Context(), "1", "example.com", dnsimple.ZoneRecordAttributes{Name: ptr("www"), Type: "A", Content: "127.0.0.1", TTL: defaultTTL}).Return(&dnsimple.ZoneRecordResponse{}, nil).Once()
+				m.On("CreateRecord", t.Context(), "1", "example.com", dnsimple.ZoneRecordAttributes{Name: ptr("www"), Type: "AAAA", Content: "fd00::1", TTL: defaultTTL}).Return(&dnsimple.ZoneRecordResponse{}, nil).Once()
+			},
+		},
+		{
+			name: "create apex strips name to empty",
+			changes: &plan.Changes{Create: []*endpoint.Endpoint{
+				{DNSName: "example.com", Targets: endpoint.Targets{"127.0.0.1"}, RecordType: endpoint.RecordTypeA},
+			}},
+			setup: func(m *mockDnsimpleZoneServiceInterface) {
+				m.On("CreateRecord", t.Context(), "1", "example.com", dnsimple.ZoneRecordAttributes{Name: ptr(""), Type: "A", Content: "127.0.0.1", TTL: defaultTTL}).Return(&dnsimple.ZoneRecordResponse{}, nil).Once()
+			},
+		},
+		{
+			name: "create with custom ttl",
+			changes: &plan.Changes{Create: []*endpoint.Endpoint{
+				{DNSName: "ttl.example.com", RecordTTL: 60, Targets: endpoint.Targets{"target"}, RecordType: endpoint.RecordTypeCNAME},
+			}},
+			setup: func(m *mockDnsimpleZoneServiceInterface) {
+				m.On("CreateRecord", t.Context(), "1", "example.com", dnsimple.ZoneRecordAttributes{Name: ptr("ttl"), Type: "CNAME", Content: "target", TTL: 60}).Return(&dnsimple.ZoneRecordResponse{}, nil).Once()
+			},
+		},
+		{
+			name: "update looks up id by name and type",
+			changes: &plan.Changes{UpdateNew: []*endpoint.Endpoint{
+				{DNSName: "www.example.com", Targets: endpoint.Targets{"127.0.0.2"}, RecordType: endpoint.RecordTypeA},
+			}},
+			setup: func(m *mockDnsimpleZoneServiceInterface) {
+				m.On("ListRecords", t.Context(), "1", "example.com", &dnsimple.ZoneRecordListOptions{Name: ptr("www"), Type: ptr("A"), ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(listRecords(10, "www", "A"), nil).Once()
+				m.On("UpdateRecord", t.Context(), "1", "example.com", int64(10), dnsimple.ZoneRecordAttributes{Name: ptr("www"), Type: "A", Content: "127.0.0.2", TTL: defaultTTL}).Return(&dnsimple.ZoneRecordResponse{}, nil).Once()
+			},
+		},
+		{
+			name: "delete looks up id by name and type",
+			changes: &plan.Changes{Delete: []*endpoint.Endpoint{
+				{DNSName: "www.example.com", Targets: endpoint.Targets{"127.0.0.1"}, RecordType: endpoint.RecordTypeA},
+			}},
+			setup: func(m *mockDnsimpleZoneServiceInterface) {
+				m.On("ListRecords", t.Context(), "1", "example.com", &dnsimple.ZoneRecordListOptions{Name: ptr("www"), Type: ptr("A"), ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(listRecords(10, "www", "A"), nil).Once()
+				m.On("DeleteRecord", t.Context(), "1", "example.com", int64(10)).Return(&dnsimple.ZoneRecordResponse{}, nil).Once()
+			},
+		},
+		{
+			name: "dual-stack delete resolves the right id per type",
+			changes: &plan.Changes{Delete: []*endpoint.Endpoint{
+				{DNSName: "www.example.com", Targets: endpoint.Targets{"127.0.0.1"}, RecordType: endpoint.RecordTypeA},
+				{DNSName: "www.example.com", Targets: endpoint.Targets{"fd00::1"}, RecordType: endpoint.RecordTypeAAAA},
+			}},
+			setup: func(m *mockDnsimpleZoneServiceInterface) {
+				// Same name, different types: each lookup must be scoped by type
+				// and return that type's distinct record ID.
+				m.On("ListRecords", t.Context(), "1", "example.com", &dnsimple.ZoneRecordListOptions{Name: ptr("www"), Type: ptr("A"), ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(listRecords(11, "www", "A"), nil).Once()
+				m.On("ListRecords", t.Context(), "1", "example.com", &dnsimple.ZoneRecordListOptions{Name: ptr("www"), Type: ptr("AAAA"), ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(listRecords(12, "www", "AAAA"), nil).Once()
+				m.On("DeleteRecord", t.Context(), "1", "example.com", int64(11)).Return(&dnsimple.ZoneRecordResponse{}, nil).Once()
+				m.On("DeleteRecord", t.Context(), "1", "example.com", int64(12)).Return(&dnsimple.ZoneRecordResponse{}, nil).Once()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockDNS := &mockDnsimpleZoneServiceInterface{}
+			mockDNS.On("ListZones", t.Context(), "1", &dnsimple.ZoneListOptions{ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(zonesResponse, nil)
+			tt.setup(mockDNS)
+
+			p := dnsimpleProvider{client: mockDNS, accountID: "1"}
+			require.NoError(t, p.ApplyChanges(t.Context(), tt.changes))
+			mockDNS.AssertExpectations(t)
+		})
 	}
 }
 
@@ -290,11 +380,11 @@ func testDnsimpleGetRecordID(t *testing.T) {
 	var err error
 
 	mockProvider.accountID = "1"
-	result, err = mockProvider.GetRecordID(t.Context(), "example.com", "example")
+	result, err = mockProvider.GetRecordID(t.Context(), "example.com", "example", "CNAME")
 	assert.NoError(t, err)
 	assert.Equal(t, int64(2), result)
 
-	result, err = mockProvider.GetRecordID(t.Context(), "example.com", "example-beta")
+	result, err = mockProvider.GetRecordID(t.Context(), "example.com", "example-beta", "A")
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), result)
 }

--- a/provider/dnsimple/dnsimple_test.go
+++ b/provider/dnsimple/dnsimple_test.go
@@ -106,8 +106,18 @@ func TestDnsimpleServices(t *testing.T) {
 		Priority: 0,
 		Type:     "A",
 	}
+	fifthRecord := dnsimple.ZoneRecord{
+		ID:       5,
+		ZoneID:   "example.com",
+		ParentID: 0,
+		Name:     "example-ipv6",
+		Content:  "fd00::1",
+		TTL:      3600,
+		Priority: 0,
+		Type:     "AAAA",
+	}
 
-	records := []dnsimple.ZoneRecord{firstRecord, secondRecord, thirdRecord, fourthRecord}
+	records := []dnsimple.ZoneRecord{firstRecord, secondRecord, thirdRecord, fourthRecord, fifthRecord}
 	dnsimpleListRecordsResponse = dnsimple.ZoneRecordsResponse{
 		Response: dnsimple.Response{Pagination: &dnsimple.Pagination{}},
 		Data:     records,
@@ -179,6 +189,16 @@ func testDnsimpleProviderRecords(t *testing.T) {
 	result, err := mockProvider.Records(ctx)
 	assert.NoError(t, err)
 	assert.Len(t, result, len(dnsimpleListRecordsResponse.Data))
+
+	var foundAAAA bool
+	for _, ep := range result {
+		if ep.RecordType == endpoint.RecordTypeAAAA {
+			foundAAAA = true
+			assert.Equal(t, "example-ipv6.example.com", ep.DNSName)
+			assert.Equal(t, endpoint.Targets{"fd00::1"}, ep.Targets)
+		}
+	}
+	assert.True(t, foundAAAA, "AAAA records should be returned by Records")
 
 	mockProvider.accountID = "2"
 	_, err = mockProvider.Records(ctx)

--- a/provider/dnsimple/dnsimple_test.go
+++ b/provider/dnsimple/dnsimple_test.go
@@ -307,9 +307,6 @@ func testDnsimpleProviderRecords(t *testing.T) {
 	}
 }
 
-// ptr is a small helper for building the *string fields the DNSimple options use.
-func ptr[T any](v T) *T { return &v }
-
 // testDnsimpleProviderApplyChanges drives ApplyChanges through a table of cases
 // and verifies the exact DNSimple API calls made for each one. Unlike a bare
 // "no error returned" assertion, it calls AssertExpectations so a no-op
@@ -323,12 +320,12 @@ func testDnsimpleProviderApplyChanges(t *testing.T) {
 	}
 
 	// listRecords builds the single-record response GetRecordID expects for a
-	// ListRecords(name, type) lookup.
-	listRecords := func(id int64, name, recordType string) *dnsimple.ZoneRecordsResponse {
+	// ListRecords lookup of the "www" host scoped to the given type.
+	listRecords := func(id int64, recordType string) *dnsimple.ZoneRecordsResponse {
 		return &dnsimple.ZoneRecordsResponse{
 			Response: dnsimple.Response{Pagination: &dnsimple.Pagination{TotalPages: 1}},
 			Data: []dnsimple.ZoneRecord{
-				{ID: id, ZoneID: "example.com", Name: name, Type: recordType},
+				{ID: id, ZoneID: "example.com", Name: "www", Type: recordType},
 			},
 		}
 	}
@@ -345,8 +342,8 @@ func testDnsimpleProviderApplyChanges(t *testing.T) {
 				{DNSName: "www.example.com", Targets: endpoint.Targets{"fd00::1"}, RecordType: endpoint.RecordTypeAAAA},
 			}},
 			setup: func(m *mockDnsimpleZoneServiceInterface) {
-				m.On("CreateRecord", t.Context(), "1", "example.com", dnsimple.ZoneRecordAttributes{Name: ptr("www"), Type: "A", Content: "127.0.0.1", TTL: defaultTTL}).Return(&dnsimple.ZoneRecordResponse{}, nil).Once()
-				m.On("CreateRecord", t.Context(), "1", "example.com", dnsimple.ZoneRecordAttributes{Name: ptr("www"), Type: "AAAA", Content: "fd00::1", TTL: defaultTTL}).Return(&dnsimple.ZoneRecordResponse{}, nil).Once()
+				m.On("CreateRecord", t.Context(), "1", "example.com", dnsimple.ZoneRecordAttributes{Name: new("www"), Type: "A", Content: "127.0.0.1", TTL: defaultTTL}).Return(&dnsimple.ZoneRecordResponse{}, nil).Once()
+				m.On("CreateRecord", t.Context(), "1", "example.com", dnsimple.ZoneRecordAttributes{Name: new("www"), Type: "AAAA", Content: "fd00::1", TTL: defaultTTL}).Return(&dnsimple.ZoneRecordResponse{}, nil).Once()
 			},
 		},
 		{
@@ -355,7 +352,7 @@ func testDnsimpleProviderApplyChanges(t *testing.T) {
 				{DNSName: "example.com", Targets: endpoint.Targets{"127.0.0.1"}, RecordType: endpoint.RecordTypeA},
 			}},
 			setup: func(m *mockDnsimpleZoneServiceInterface) {
-				m.On("CreateRecord", t.Context(), "1", "example.com", dnsimple.ZoneRecordAttributes{Name: ptr(""), Type: "A", Content: "127.0.0.1", TTL: defaultTTL}).Return(&dnsimple.ZoneRecordResponse{}, nil).Once()
+				m.On("CreateRecord", t.Context(), "1", "example.com", dnsimple.ZoneRecordAttributes{Name: new(""), Type: "A", Content: "127.0.0.1", TTL: defaultTTL}).Return(&dnsimple.ZoneRecordResponse{}, nil).Once()
 			},
 		},
 		{
@@ -364,7 +361,7 @@ func testDnsimpleProviderApplyChanges(t *testing.T) {
 				{DNSName: "ttl.example.com", RecordTTL: 60, Targets: endpoint.Targets{"target"}, RecordType: endpoint.RecordTypeCNAME},
 			}},
 			setup: func(m *mockDnsimpleZoneServiceInterface) {
-				m.On("CreateRecord", t.Context(), "1", "example.com", dnsimple.ZoneRecordAttributes{Name: ptr("ttl"), Type: "CNAME", Content: "target", TTL: 60}).Return(&dnsimple.ZoneRecordResponse{}, nil).Once()
+				m.On("CreateRecord", t.Context(), "1", "example.com", dnsimple.ZoneRecordAttributes{Name: new("ttl"), Type: "CNAME", Content: "target", TTL: 60}).Return(&dnsimple.ZoneRecordResponse{}, nil).Once()
 			},
 		},
 		{
@@ -373,8 +370,8 @@ func testDnsimpleProviderApplyChanges(t *testing.T) {
 				{DNSName: "www.example.com", Targets: endpoint.Targets{"127.0.0.2"}, RecordType: endpoint.RecordTypeA},
 			}},
 			setup: func(m *mockDnsimpleZoneServiceInterface) {
-				m.On("ListRecords", t.Context(), "1", "example.com", &dnsimple.ZoneRecordListOptions{Name: ptr("www"), Type: ptr("A"), ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(listRecords(10, "www", "A"), nil).Once()
-				m.On("UpdateRecord", t.Context(), "1", "example.com", int64(10), dnsimple.ZoneRecordAttributes{Name: ptr("www"), Type: "A", Content: "127.0.0.2", TTL: defaultTTL}).Return(&dnsimple.ZoneRecordResponse{}, nil).Once()
+				m.On("ListRecords", t.Context(), "1", "example.com", &dnsimple.ZoneRecordListOptions{Name: new("www"), Type: new("A"), ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(listRecords(10, "A"), nil).Once()
+				m.On("UpdateRecord", t.Context(), "1", "example.com", int64(10), dnsimple.ZoneRecordAttributes{Name: new("www"), Type: "A", Content: "127.0.0.2", TTL: defaultTTL}).Return(&dnsimple.ZoneRecordResponse{}, nil).Once()
 			},
 		},
 		{
@@ -383,7 +380,7 @@ func testDnsimpleProviderApplyChanges(t *testing.T) {
 				{DNSName: "www.example.com", Targets: endpoint.Targets{"127.0.0.1"}, RecordType: endpoint.RecordTypeA},
 			}},
 			setup: func(m *mockDnsimpleZoneServiceInterface) {
-				m.On("ListRecords", t.Context(), "1", "example.com", &dnsimple.ZoneRecordListOptions{Name: ptr("www"), Type: ptr("A"), ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(listRecords(10, "www", "A"), nil).Once()
+				m.On("ListRecords", t.Context(), "1", "example.com", &dnsimple.ZoneRecordListOptions{Name: new("www"), Type: new("A"), ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(listRecords(10, "A"), nil).Once()
 				m.On("DeleteRecord", t.Context(), "1", "example.com", int64(10)).Return(&dnsimple.ZoneRecordResponse{}, nil).Once()
 			},
 		},
@@ -396,8 +393,8 @@ func testDnsimpleProviderApplyChanges(t *testing.T) {
 			setup: func(m *mockDnsimpleZoneServiceInterface) {
 				// Same name, different types: each lookup must be scoped by type
 				// and return that type's distinct record ID.
-				m.On("ListRecords", t.Context(), "1", "example.com", &dnsimple.ZoneRecordListOptions{Name: ptr("www"), Type: ptr("A"), ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(listRecords(11, "www", "A"), nil).Once()
-				m.On("ListRecords", t.Context(), "1", "example.com", &dnsimple.ZoneRecordListOptions{Name: ptr("www"), Type: ptr("AAAA"), ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(listRecords(12, "www", "AAAA"), nil).Once()
+				m.On("ListRecords", t.Context(), "1", "example.com", &dnsimple.ZoneRecordListOptions{Name: new("www"), Type: new("A"), ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(listRecords(11, "A"), nil).Once()
+				m.On("ListRecords", t.Context(), "1", "example.com", &dnsimple.ZoneRecordListOptions{Name: new("www"), Type: new("AAAA"), ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(listRecords(12, "AAAA"), nil).Once()
 				m.On("DeleteRecord", t.Context(), "1", "example.com", int64(11)).Return(&dnsimple.ZoneRecordResponse{}, nil).Once()
 				m.On("DeleteRecord", t.Context(), "1", "example.com", int64(12)).Return(&dnsimple.ZoneRecordResponse{}, nil).Once()
 			},

--- a/provider/dnsimple/dnsimple_test.go
+++ b/provider/dnsimple/dnsimple_test.go
@@ -34,7 +34,6 @@ import (
 
 var (
 	mockProvider                     dnsimpleProvider
-	dnsimpleListRecordsResponse      dnsimple.ZoneRecordsResponse
 	dnsimpleListZonesResponse        dnsimple.ZonesResponse
 	dnsimpleListZonesFromEnvResponse dnsimple.ZonesResponse
 )
@@ -118,18 +117,12 @@ func TestDnsimpleServices(t *testing.T) {
 	}
 
 	records := []dnsimple.ZoneRecord{firstRecord, secondRecord, thirdRecord, fourthRecord, fifthRecord}
-	dnsimpleListRecordsResponse = dnsimple.ZoneRecordsResponse{
-		Response: dnsimple.Response{Pagination: &dnsimple.Pagination{}},
-		Data:     records,
-	}
 
 	// Setup mock services
 	// Note: AnythingOfType doesn't work with interfaces https://github.com/stretchr/testify/issues/519
 	mockDNS := &mockDnsimpleZoneServiceInterface{}
 	mockDNS.On("ListZones", t.Context(), "1", &dnsimple.ZoneListOptions{ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(&dnsimpleListZonesResponse, nil)
 	mockDNS.On("ListZones", t.Context(), "2", &dnsimple.ZoneListOptions{ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(nil, fmt.Errorf("Account ID not found"))
-	mockDNS.On("ListRecords", t.Context(), "1", "example.com", &dnsimple.ZoneRecordListOptions{ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(&dnsimpleListRecordsResponse, nil)
-	mockDNS.On("ListRecords", t.Context(), "1", "example-beta.com", &dnsimple.ZoneRecordListOptions{ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(&dnsimple.ZoneRecordsResponse{Response: dnsimple.Response{Pagination: &dnsimple.Pagination{}}}, nil)
 
 	for _, record := range records {
 		recordName := record.Name
@@ -184,26 +177,134 @@ func testDnsimpleProviderZones(t *testing.T) {
 	os.Unsetenv("DNSIMPLE_ZONES")
 }
 
-func testDnsimpleProviderRecords(t *testing.T) {
-	ctx := t.Context()
-	mockProvider.accountID = "1"
-	result, err := mockProvider.Records(ctx)
-	assert.NoError(t, err)
-	assert.Len(t, result, len(dnsimpleListRecordsResponse.Data))
+// wantEndpoint is the comparable shape we assert Records() produced for a case.
+type wantEndpoint struct {
+	dnsName    string
+	recordType string
+	target     string
+}
 
-	var foundAAAA bool
-	for _, ep := range result {
-		if ep.RecordType == endpoint.RecordTypeAAAA {
-			foundAAAA = true
-			assert.Equal(t, "example-ipv6.example.com", ep.DNSName)
-			assert.Equal(t, endpoint.Targets{"fd00::1"}, ep.Targets)
+// testDnsimpleProviderRecords drives Records() through a table of cases with a
+// fresh mock per case, instead of relying on shared global mock state. It
+// covers the supported record types returned together, a dual-stack host where
+// an A and an AAAA record share the same name, the apex domain (empty record
+// name mapping to the zone name), and error propagation from both ListZones and
+// ListRecords.
+func testDnsimpleProviderRecords(t *testing.T) {
+	zonesResponse := &dnsimple.ZonesResponse{
+		Response: dnsimple.Response{Pagination: &dnsimple.Pagination{TotalPages: 1}},
+		Data:     []dnsimple.Zone{{ID: 1, AccountID: 12345, Name: "example.com"}},
+	}
+	recordsResponse := func(records ...dnsimple.ZoneRecord) *dnsimple.ZoneRecordsResponse {
+		return &dnsimple.ZoneRecordsResponse{
+			Response: dnsimple.Response{Pagination: &dnsimple.Pagination{TotalPages: 1}},
+			Data:     records,
 		}
 	}
-	assert.True(t, foundAAAA, "AAAA records should be returned by Records")
 
-	mockProvider.accountID = "2"
-	_, err = mockProvider.Records(ctx)
-	assert.Error(t, err)
+	tests := []struct {
+		name       string
+		setup      func(m *mockDnsimpleZoneServiceInterface)
+		wantErr    bool
+		wantRecord []wantEndpoint
+	}{
+		{
+			name: "all supported types returned together",
+			setup: func(m *mockDnsimpleZoneServiceInterface) {
+				m.On("ListZones", t.Context(), "1", &dnsimple.ZoneListOptions{ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(zonesResponse, nil)
+				m.On("ListRecords", t.Context(), "1", "example.com", &dnsimple.ZoneRecordListOptions{ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(recordsResponse(
+					dnsimple.ZoneRecord{ID: 1, ZoneID: "example.com", Name: "a", Content: "127.0.0.1", TTL: 3600, Type: "A"},
+					dnsimple.ZoneRecord{ID: 2, ZoneID: "example.com", Name: "aaaa", Content: "fd00::1", TTL: 3600, Type: "AAAA"},
+					dnsimple.ZoneRecord{ID: 3, ZoneID: "example.com", Name: "cname", Content: "target", TTL: 3600, Type: "CNAME"},
+					dnsimple.ZoneRecord{ID: 4, ZoneID: "example.com", Name: "txt", Content: "hello", TTL: 3600, Type: "TXT"},
+				), nil)
+			},
+			wantRecord: []wantEndpoint{
+				{"a.example.com", "A", "127.0.0.1"},
+				{"aaaa.example.com", "AAAA", "fd00::1"},
+				{"cname.example.com", "CNAME", "target"},
+				{"txt.example.com", "TXT", "hello"},
+			},
+		},
+		{
+			name: "dual-stack host returns both A and AAAA",
+			setup: func(m *mockDnsimpleZoneServiceInterface) {
+				m.On("ListZones", t.Context(), "1", &dnsimple.ZoneListOptions{ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(zonesResponse, nil)
+				m.On("ListRecords", t.Context(), "1", "example.com", &dnsimple.ZoneRecordListOptions{ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(recordsResponse(
+					dnsimple.ZoneRecord{ID: 1, ZoneID: "example.com", Name: "www", Content: "127.0.0.1", TTL: 3600, Type: "A"},
+					dnsimple.ZoneRecord{ID: 2, ZoneID: "example.com", Name: "www", Content: "fd00::1", TTL: 3600, Type: "AAAA"},
+				), nil)
+			},
+			wantRecord: []wantEndpoint{
+				{"www.example.com", "A", "127.0.0.1"},
+				{"www.example.com", "AAAA", "fd00::1"},
+			},
+		},
+		{
+			name: "apex domain maps empty name to the zone name",
+			setup: func(m *mockDnsimpleZoneServiceInterface) {
+				m.On("ListZones", t.Context(), "1", &dnsimple.ZoneListOptions{ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(zonesResponse, nil)
+				m.On("ListRecords", t.Context(), "1", "example.com", &dnsimple.ZoneRecordListOptions{ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(recordsResponse(
+					dnsimple.ZoneRecord{ID: 1, ZoneID: "example.com", Name: "", Content: "127.0.0.1", TTL: 3600, Type: "A"},
+				), nil)
+			},
+			wantRecord: []wantEndpoint{
+				{"example.com", "A", "127.0.0.1"},
+			},
+		},
+		{
+			name: "unsupported types are skipped",
+			setup: func(m *mockDnsimpleZoneServiceInterface) {
+				m.On("ListZones", t.Context(), "1", &dnsimple.ZoneListOptions{ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(zonesResponse, nil)
+				m.On("ListRecords", t.Context(), "1", "example.com", &dnsimple.ZoneRecordListOptions{ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(recordsResponse(
+					dnsimple.ZoneRecord{ID: 1, ZoneID: "example.com", Name: "a", Content: "127.0.0.1", TTL: 3600, Type: "A"},
+					dnsimple.ZoneRecord{ID: 2, ZoneID: "example.com", Name: "soa", Content: "ns.example.com", TTL: 3600, Type: "SOA"},
+				), nil)
+			},
+			wantRecord: []wantEndpoint{
+				{"a.example.com", "A", "127.0.0.1"},
+			},
+		},
+		{
+			name: "ListZones error is propagated",
+			setup: func(m *mockDnsimpleZoneServiceInterface) {
+				m.On("ListZones", t.Context(), "1", &dnsimple.ZoneListOptions{ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(nil, fmt.Errorf("zones boom"))
+			},
+			wantErr: true,
+		},
+		{
+			name: "ListRecords error is propagated",
+			setup: func(m *mockDnsimpleZoneServiceInterface) {
+				m.On("ListZones", t.Context(), "1", &dnsimple.ZoneListOptions{ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(zonesResponse, nil)
+				m.On("ListRecords", t.Context(), "1", "example.com", &dnsimple.ZoneRecordListOptions{ListOptions: dnsimple.ListOptions{Page: new(1)}}).Return(nil, fmt.Errorf("records boom"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockDNS := &mockDnsimpleZoneServiceInterface{}
+			tt.setup(mockDNS)
+			p := dnsimpleProvider{client: mockDNS, accountID: "1"}
+
+			result, err := p.Records(t.Context())
+			if tt.wantErr {
+				assert.Error(t, err)
+				mockDNS.AssertExpectations(t)
+				return
+			}
+			require.NoError(t, err)
+
+			got := make([]wantEndpoint, 0, len(result))
+			for _, ep := range result {
+				require.Len(t, ep.Targets, 1)
+				got = append(got, wantEndpoint{ep.DNSName, ep.RecordType, ep.Targets[0]})
+			}
+			assert.ElementsMatch(t, tt.wantRecord, got)
+			mockDNS.AssertExpectations(t)
+		})
+	}
 }
 
 // ptr is a small helper for building the *string fields the DNSimple options use.


### PR DESCRIPTION
### What this fixes

Fixes #6511

The DNSimple provider's read path in Records() only returned A, CNAME and TXT records, so existing AAAA records were invisible to ExternalDNS. Every reconcile the AAAA record looked missing, ExternalDNS tried to create it again, and DNSimple rejected it because it already existed. The create path never filtered by type, so create and read disagreed about what existed.

### The change

- Records() now uses provider.SupportedRecordType() instead of a hand-maintained type list, so the read path stays in sync with the shared helper. This also brings AAAA back (the original fix) and, as a side effect, widens the returned types to SRV and NS.
- GetRecordID now takes a record type and filters the DNSimple lookup by both name and type. Without this, once AAAA records became visible, a dual-stack host with an A and an AAAA record at the same name could resolve to the wrong record ID on delete or update. Both call sites in submitChanges pass the record type.

### Note on the widened scope (SRV / NS)

Switching to SupportedRecordType() means Records() can now return SRV and NS in addition to A, AAAA, CNAME and TXT. This is safe in practice: the controller filters by --managed-record-types (default A, AAAA, CNAME) before records reach the plan, so types that are not managed are never acted on. The same reasoning applies to AAAA, which is the primary fix here. Calling this out per the review discussion so the scope change is explicit. Thanks to u-kai for confirming the approach.

### Testing

go test -race ./provider/dnsimple/

- testDnsimpleProviderRecords is now table-driven with a fresh mock per case: all supported types together, a dual-stack host, the apex domain, unsupported types skipped, and ListZones/ListRecords error propagation.
- testDnsimpleProviderApplyChanges is now table-driven and asserts the exact DNSimple API calls per case via mock expectations (the old test only checked for a nil error and never called AssertExpectations). It covers create/update/delete per type, apex name stripping, custom TTL, and a dual-stack delete where the same name resolves to a different ID per type. I verified the dual-stack case catches the GetRecordID bug by reverting the fix and watching it fail.