### PR TITLE
test(registry/crd): expand unit test coverage

### DIFF
--- a/internal/testutils/discovery.go
+++ b/internal/testutils/discovery.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutils
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiv1alpha1 "sigs.k8s.io/external-dns/apis/v1alpha1"
+)
+
+// NewFakeExternalDNSDiscoveryServer starts an httptest.Server advertising the given resources
+// under externaldns.k8s.io — enough for crcache.New and the informer to start. Any other path
+// returns 500 so LIST fails and the cache never syncs, letting callers exercise sync-failure
+// paths without a real API server.
+func NewFakeExternalDNSDiscoveryServer(t *testing.T, resources ...metav1.APIResource) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		encode := func(v any) {
+			if err := json.NewEncoder(w).Encode(v); err != nil {
+				t.Errorf("fakeDiscoveryServer: json.Encode %s: %v", r.URL.Path, err)
+			}
+		}
+		switch r.URL.Path {
+		case "/api":
+			encode(metav1.APIVersions{
+				TypeMeta: metav1.TypeMeta{Kind: "APIVersions", APIVersion: "v1"},
+				Versions: []string{"v1"},
+			})
+		case "/apis":
+			encode(metav1.APIGroupList{
+				TypeMeta: metav1.TypeMeta{Kind: "APIGroupList", APIVersion: "v1"},
+				Groups: []metav1.APIGroup{{
+					Name:             apiv1alpha1.GroupVersion.Group,
+					Versions:         []metav1.GroupVersionForDiscovery{{GroupVersion: apiv1alpha1.GroupVersion.String(), Version: apiv1alpha1.GroupVersion.Version}},
+					PreferredVersion: metav1.GroupVersionForDiscovery{GroupVersion: apiv1alpha1.GroupVersion.String(), Version: apiv1alpha1.GroupVersion.Version},
+				}},
+			})
+		case "/apis/" + apiv1alpha1.GroupVersion.String():
+			encode(metav1.APIResourceList{
+				TypeMeta:     metav1.TypeMeta{Kind: "APIResourceList", APIVersion: "v1"},
+				GroupVersion: apiv1alpha1.GroupVersion.String(),
+				APIResources: resources,
+			})
+		default:
+			// Causes the informer's LIST to fail so the cache never syncs.
+			http.Error(w, `{"kind":"Status","apiVersion":"v1","status":"Failure","code":500}`, http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}

--- a/registry/crd/crd_test.go
+++ b/registry/crd/crd_test.go
@@ -19,24 +19,33 @@ package crd
 import (
 	"context"
 	"errors"
+	"fmt"
 	"maps"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	apiv1alpha1 "sigs.k8s.io/external-dns/apis/v1alpha1"
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
+	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
 	"sigs.k8s.io/external-dns/provider/inmemory"
@@ -88,11 +97,79 @@ func TestCRDRegistryImplementsRegistry(t *testing.T) {
 }
 
 func TestCRDRegistryConstructor(t *testing.T) {
-	_, err := NewCRDRegistry(nil, "", "", "", "", time.Second)
-	assert.Error(t, err, "expected an error when no ownerID is specified")
+	tests := []struct {
+		name            string
+		kubeConfig      func(t *testing.T) string
+		namespace       string
+		ownerID         string
+		timeout         time.Duration
+		wantErrContains string
+	}{
+		{
+			name:            "empty owner id",
+			wantErrContains: "owner id cannot be empty",
+		},
+		{
+			name:            "invalid kubeconfig",
+			kubeConfig:      func(_ *testing.T) string { return "/dev/null" },
+			namespace:       "default",
+			ownerID:         "owner",
+			timeout:         time.Second,
+			wantErrContains: "unable to build rest config",
+		},
+		{
+			name:            "bad TLS cert in kubeconfig",
+			kubeConfig:      func(t *testing.T) string { return newFakeAPIServerKubeconfig(t, true) },
+			namespace:       "default",
+			ownerID:         "owner",
+			timeout:         time.Second,
+			wantErrContains: "unable to load root certificates",
+		},
+		{
+			name:            "cache fails to sync",
+			kubeConfig:      func(t *testing.T) string { return newFakeAPIServerKubeconfig(t, false) },
+			namespace:       "default",
+			ownerID:         "owner",
+			timeout:         100 * time.Millisecond,
+			wantErrContains: "cache failed to sync",
+		},
+	}
 
-	_, err = NewCRDRegistry(nil, "/dev/null", "", "default", "ownerID", time.Second)
-	assert.Error(t, err, "expected an error when the kubeconfig is invalid")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var kubeConfig string
+			if tt.kubeConfig != nil {
+				kubeConfig = tt.kubeConfig(t)
+			}
+			r, err := NewCRDRegistry(nil, kubeConfig, "", tt.namespace, tt.ownerID, tt.timeout)
+			require.ErrorContains(t, err, tt.wantErrContains)
+			require.Nil(t, r)
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	r, err := New(&externaldns.Config{}, nil)
+	require.ErrorContains(t, err, "owner id cannot be empty")
+	require.Nil(t, r)
+}
+
+func TestGetDomainFilter(t *testing.T) {
+	reg, _ := newTestRegistry(t, &mockProvider{}, "owner")
+	assert.Equal(t, &endpoint.DomainFilter{}, reg.GetDomainFilter())
+}
+
+func TestOwnerID(t *testing.T) {
+	reg, _ := newTestRegistry(t, &mockProvider{}, "owner")
+	assert.Equal(t, "owner", reg.OwnerID())
+}
+
+func TestCRDRegistryAdjustEndpoints(t *testing.T) {
+	eps := []*endpoint.Endpoint{{DNSName: "foo.example.com", RecordType: "A"}}
+	reg, _ := newTestRegistry(t, &mockProvider{}, "owner")
+	got, err := reg.AdjustEndpoints(eps)
+	require.NoError(t, err)
+	assert.Equal(t, eps, got)
 }
 
 func TestCRDRegistryRecords(t *testing.T) {
@@ -143,6 +220,29 @@ func TestCRDRegistryRecords(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, endpoints, 1)
 	assert.Equal(t, "resource", endpoints[0].Labels[endpoint.ResourceLabelKey])
+}
+
+func TestCRDRegistryRecordsListError(t *testing.T) {
+	c := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithStatusSubresource(&apiv1alpha1.DNSRecord{}).
+		Build()
+	failReader := interceptor.NewClient(c, interceptor.Funcs{
+		List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+			return assert.AnError
+		},
+	})
+	reg := &CRDRegistry{
+		crReader:  failReader,
+		crWriter:  c,
+		namespace: "default",
+		provider:  &mockProvider{},
+		ownerID:   "owner",
+	}
+
+	endpoints, err := reg.Records(t.Context())
+	require.ErrorIs(t, err, assert.AnError)
+	assert.Equal(t, []*endpoint.Endpoint{}, endpoints)
 }
 
 func TestCRDRegistryApplyChanges(t *testing.T) {
@@ -238,6 +338,63 @@ func TestCRDRegistryApplyChanges(t *testing.T) {
 				assert.Equal(t, endpoint.NewTargets("127.0.0.2"), got.Spec.Endpoint.Targets)
 			},
 		},
+		{
+			name:       "Create refreshes spec when DNSRecord already exists",
+			changeType: "Create",
+			ep: &endpoint.Endpoint{
+				DNSName:    "to.be.refreshed.mytestdomain.io",
+				RecordType: "A",
+				Targets:    endpoint.NewTargets("2.2.2.2"),
+				Labels:     map[string]string{endpoint.OwnerLabelKey: "test"},
+			},
+			seedRecord: &apiv1alpha1.DNSRecord{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Labels:    map[string]string{apiv1alpha1.RecordOwnerLabel: "test"},
+				},
+				Spec: apiv1alpha1.DNSRecordSpec{Endpoint: endpoint.Endpoint{
+					DNSName:    "to.be.refreshed.mytestdomain.io",
+					RecordType: "A",
+					Targets:    endpoint.NewTargets("1.1.1.1"),
+				}},
+			},
+			assertFn: func(t *testing.T, c client.Client, name string) {
+				got := &apiv1alpha1.DNSRecord{}
+				err := c.Get(ctx, types.NamespacedName{Namespace: "default", Name: name}, got)
+				require.NoError(t, err)
+				assert.Equal(t, endpoint.NewTargets("2.2.2.2"), got.Spec.Endpoint.Targets)
+			},
+		},
+		{
+			name:       "Update returns no error when DNSRecord is missing",
+			changeType: "Update",
+			ep: &endpoint.Endpoint{
+				DNSName:    "noop.update.mytestdomain.io",
+				RecordType: "A",
+				Targets:    endpoint.NewTargets("127.0.0.1"),
+				Labels:     map[string]string{endpoint.OwnerLabelKey: "test"},
+			},
+			assertFn: func(t *testing.T, c client.Client, name string) {
+				got := &apiv1alpha1.DNSRecord{}
+				err := c.Get(ctx, types.NamespacedName{Namespace: "default", Name: name}, got)
+				assert.True(t, k8sErrors.IsNotFound(err))
+			},
+		},
+		{
+			name:       "Delete returns no error when DNSRecord is missing",
+			changeType: "Delete",
+			ep: &endpoint.Endpoint{
+				DNSName:    "noop.delete.mytestdomain.io",
+				RecordType: "A",
+				Targets:    endpoint.NewTargets("127.0.0.1"),
+				Labels:     map[string]string{endpoint.OwnerLabelKey: "test"},
+			},
+			assertFn: func(t *testing.T, c client.Client, name string) {
+				got := &apiv1alpha1.DNSRecord{}
+				err := c.Get(ctx, types.NamespacedName{Namespace: "default", Name: name}, got)
+				assert.True(t, k8sErrors.IsNotFound(err))
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -304,6 +461,10 @@ func TestRecordObjectName(t *testing.T) {
 		}
 	})
 
+	t.Run("falls back to 'record' prefix when DNSName has no valid chars", func(t *testing.T) {
+		assert.Equal(t, "record-6fbee3c6", recordObjectName(ep("...", "A", "")))
+	})
+
 	t.Run("distinct identities never collide", func(t *testing.T) {
 		// Cases that collapsed to the same name under the old dns-with-dashes scheme.
 		collisions := [][2]*endpoint.Endpoint{
@@ -318,12 +479,16 @@ func TestRecordObjectName(t *testing.T) {
 }
 
 type mockProvider struct {
-	records  []*endpoint.Endpoint
-	addLabel bool
-	applyErr error
+	records    []*endpoint.Endpoint
+	addLabel   bool
+	applyErr   error
+	recordsErr error
 }
 
 func (m *mockProvider) Records(_ context.Context) ([]*endpoint.Endpoint, error) {
+	if m.recordsErr != nil {
+		return nil, m.recordsErr
+	}
 	return m.records, nil
 }
 
@@ -446,4 +611,276 @@ func TestCRDApplyChangesProviderError(t *testing.T) {
 	endpoints, err := reg.Records(ctx)
 	require.NoError(t, err)
 	assert.Empty(t, endpoints, "failed record must be excluded from current state")
+}
+
+func TestCRDApplyChangesErrorPaths(t *testing.T) {
+	ctx := t.Context()
+
+	makeEp := func(dns string) *endpoint.Endpoint {
+		return &endpoint.Endpoint{
+			DNSName:    dns,
+			RecordType: "A",
+			Targets:    endpoint.NewTargets("127.0.0.1"),
+			Labels:     map[string]string{endpoint.OwnerLabelKey: "test"},
+		}
+	}
+	seedFor := func(e *endpoint.Endpoint) *apiv1alpha1.DNSRecord {
+		return &apiv1alpha1.DNSRecord{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      recordObjectName(e),
+				Namespace: "default",
+				Labels:    map[string]string{apiv1alpha1.RecordOwnerLabel: "test"},
+			},
+			Spec: apiv1alpha1.DNSRecordSpec{Endpoint: *e},
+		}
+	}
+
+	epCreate := makeEp("create.example.io")
+	epUpdate := makeEp("update.example.io")
+	epDelete := makeEp("delete.example.io")
+	epExist := makeEp("exists.example.io")
+
+	alreadyExists := func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error {
+		return k8sErrors.NewAlreadyExists(schema.GroupResource{Resource: "dnsrecords"}, "")
+	}
+	notFound := func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+		return k8sErrors.NewNotFound(schema.GroupResource{Resource: "dnsrecords"}, "")
+	}
+
+	tests := []struct {
+		name            string
+		changes         *plan.Changes
+		seeded          []client.Object
+		fns             interceptor.Funcs
+		provider        provider.Provider
+		wantErrContains string
+		wantErrIs       error
+		wantLogContains string
+	}{
+		{
+			name:     "Create write fails",
+			changes:  &plan.Changes{Create: []*endpoint.Endpoint{epCreate}},
+			provider: &mockProvider{},
+			fns: interceptor.Funcs{
+				Create: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error {
+					return assert.AnError
+				},
+			},
+			wantErrContains: "unable to create DNSRecord",
+			wantErrIs:       assert.AnError,
+		},
+		{
+			name: "Update get fails",
+			changes: &plan.Changes{
+				UpdateNew: []*endpoint.Endpoint{epUpdate},
+				UpdateOld: []*endpoint.Endpoint{epUpdate},
+			},
+			seeded:   []client.Object{seedFor(epUpdate)},
+			provider: &mockProvider{},
+			fns: interceptor.Funcs{
+				Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+					return assert.AnError
+				},
+			},
+			wantErrContains: "unable to get DNSRecord",
+			wantErrIs:       assert.AnError,
+		},
+		{
+			name: "Update write fails",
+			changes: &plan.Changes{
+				UpdateNew: []*endpoint.Endpoint{epUpdate},
+				UpdateOld: []*endpoint.Endpoint{epUpdate},
+			},
+			seeded:   []client.Object{seedFor(epUpdate)},
+			provider: &mockProvider{},
+			fns: interceptor.Funcs{
+				Update: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.UpdateOption) error {
+					return assert.AnError
+				},
+			},
+			wantErrContains: "unable to update DNSRecord",
+			wantErrIs:       assert.AnError,
+		},
+		{
+			name:     "Delete get fails",
+			changes:  &plan.Changes{Delete: []*endpoint.Endpoint{epDelete}},
+			seeded:   []client.Object{seedFor(epDelete)},
+			provider: &mockProvider{},
+			fns: interceptor.Funcs{
+				Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+					return assert.AnError
+				},
+			},
+			wantErrContains: "unable to get DNSRecord",
+			wantErrIs:       assert.AnError,
+		},
+		{
+			name:     "Delete write fails",
+			changes:  &plan.Changes{Delete: []*endpoint.Endpoint{epDelete}},
+			seeded:   []client.Object{seedFor(epDelete)},
+			provider: &mockProvider{},
+			fns: interceptor.Funcs{
+				Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+					return assert.AnError
+				},
+			},
+			wantErrContains: "unable to delete DNSRecord",
+			wantErrIs:       assert.AnError,
+		},
+		{
+			name:     "Delete ignores NotFound",
+			changes:  &plan.Changes{Delete: []*endpoint.Endpoint{epDelete}},
+			seeded:   []client.Object{seedFor(epDelete)},
+			provider: &mockProvider{},
+			fns: interceptor.Funcs{
+				Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+					return k8sErrors.NewNotFound(schema.GroupResource{Resource: "dnsrecords"}, "")
+				},
+			},
+		},
+		{
+			name:     "Create AlreadyExists then Update fails",
+			changes:  &plan.Changes{Create: []*endpoint.Endpoint{epExist}},
+			seeded:   []client.Object{seedFor(epExist)},
+			provider: &mockProvider{},
+			fns: interceptor.Funcs{
+				Update: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.UpdateOption) error {
+					return assert.AnError
+				},
+			},
+			wantErrContains: "unable to update DNSRecord",
+			wantErrIs:       assert.AnError,
+		},
+		{
+			name:     "Create AlreadyExists then Get fails",
+			changes:  &plan.Changes{Create: []*endpoint.Endpoint{epExist}},
+			seeded:   []client.Object{seedFor(epExist)},
+			provider: &mockProvider{},
+			fns: interceptor.Funcs{
+				Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+					return assert.AnError
+				},
+			},
+			wantErrContains: "unable to get DNSRecord",
+			wantErrIs:       assert.AnError,
+		},
+		{
+			name:     "Create AlreadyExists but record vanished",
+			changes:  &plan.Changes{Create: []*endpoint.Endpoint{epExist}},
+			provider: &mockProvider{},
+			fns: interceptor.Funcs{
+				Create: alreadyExists,
+				Get:    notFound,
+			},
+			wantErrContains: "reported as existing but was not found",
+		},
+		{
+			name:            "Provider Records error during label adjust",
+			changes:         &plan.Changes{Create: []*endpoint.Endpoint{epCreate}},
+			provider:        &mockProvider{recordsErr: assert.AnError},
+			wantErrContains: "unable to get records from provider",
+			wantErrIs:       assert.AnError,
+		},
+		{
+			name:     "Label merge Update fails",
+			changes:  &plan.Changes{Create: []*endpoint.Endpoint{epCreate}},
+			provider: &mockProvider{addLabel: true},
+			fns: interceptor.Funcs{
+				Update: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.UpdateOption) error {
+					return assert.AnError
+				},
+			},
+			wantErrContains: "unable to update DNSRecord",
+			wantErrIs:       assert.AnError,
+			wantLogContains: "update DNSRecord with modified labels from provider",
+		},
+		{
+			name:     "Status update error is logged not returned",
+			changes:  &plan.Changes{Create: []*endpoint.Endpoint{epCreate}},
+			provider: &mockProvider{},
+			fns: interceptor.Funcs{
+				SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+					return assert.AnError
+				},
+			},
+			wantLogContains: "unable to update status of DNSRecord",
+		},
+		{
+			// Uses Update instead of Create so the mock provider does not auto-populate
+			// a matching record, forcing the registry to hit the no-match branch.
+			name: "No provider record matches applied DNSRecord",
+			changes: &plan.Changes{
+				UpdateNew: []*endpoint.Endpoint{epUpdate},
+				UpdateOld: []*endpoint.Endpoint{epUpdate},
+			},
+			seeded:          []client.Object{seedFor(epUpdate)},
+			provider:        &mockProvider{},
+			wantLogContains: "no provider record matched DNSRecord",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
+			c := fake.NewClientBuilder().
+				WithScheme(newTestScheme(t)).
+				WithStatusSubresource(&apiv1alpha1.DNSRecord{}).
+				WithObjects(tt.seeded...).
+				Build()
+			wrapped := interceptor.NewClient(c, tt.fns)
+			reg := &CRDRegistry{
+				crReader:  wrapped,
+				crWriter:  wrapped,
+				namespace: "default",
+				provider:  tt.provider,
+				ownerID:   "test",
+			}
+			err := reg.ApplyChanges(ctx, tt.changes)
+			if tt.wantErrContains == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErrContains)
+				if tt.wantErrIs != nil {
+					require.ErrorIs(t, err, tt.wantErrIs)
+				}
+			}
+			if tt.wantLogContains != "" {
+				logtest.TestHelperLogContains(tt.wantLogContains, hook, t)
+			}
+		})
+	}
+}
+
+// newFakeAPIServerKubeconfig writes a minimal kubeconfig. When badTLS is true,
+// invalid CA data forces transport construction to fail; otherwise it points at
+// a fake discovery server with TLS verification disabled.
+func newFakeAPIServerKubeconfig(t *testing.T, badTLS bool) string {
+	t.Helper()
+	apiResource := metav1.APIResource{Name: "dnsrecords", Namespaced: true, Kind: "DNSRecord", Verbs: metav1.Verbs{"list", "watch"}}
+	server := "https://127.0.0.1:1"
+	tlsLine := "certificate-authority-data: bm90LWEtcGVtLWNlcnQ="
+	if !badTLS {
+		server = testutils.NewFakeExternalDNSDiscoveryServer(t, apiResource).URL
+		tlsLine = "insecure-skip-tls-verify: true"
+	}
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	content := fmt.Sprintf(`apiVersion: v1
+kind: Config
+clusters:
+- name: fake
+  cluster:
+    server: %s
+    %s
+contexts:
+- name: fake
+  context:
+    cluster: fake
+    user: fake
+current-context: fake
+users:
+- name: fake
+  user: {}
+`, server, tlsLine)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
 }

--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -18,11 +18,8 @@ package source
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math/rand"
-	"net/http"
-	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -909,8 +906,11 @@ func TestNewCRDSource(t *testing.T) {
 		{
 			// A fake discovery server lets crcache.New succeed; returning 500 for
 			// all LIST calls prevents the informer from ever syncing.
-			name:            "cache fails to sync: context deadline exceeded",
-			makeRestCfg:     func(t *testing.T) *rest.Config { return &rest.Config{Host: newFakeDiscoveryServer(t).URL} },
+			name: "cache fails to sync: context deadline exceeded",
+			makeRestCfg: func(t *testing.T) *rest.Config {
+				apiResource := metav1.APIResource{Name: "dnsendpoints", Namespaced: true, Kind: "DNSEndpoint", Verbs: metav1.Verbs{"list", "watch"}}
+				return &rest.Config{Host: testutils.NewFakeExternalDNSDiscoveryServer(t, apiResource).URL}
+			},
 			ctxTimeout:      3 * time.Second,
 			wantErrContains: "cache failed to sync",
 		},
@@ -928,53 +928,6 @@ func TestNewCRDSource(t *testing.T) {
 			require.ErrorContains(t, err, tc.wantErrContains)
 		})
 	}
-}
-
-// newFakeDiscoveryServer starts an httptest.Server that serves just enough of
-// the Kubernetes discovery API for crcache.New + client.New to succeed and the
-// DNSEndpoint informer to be registered.
-func newFakeDiscoveryServer(t *testing.T) *httptest.Server {
-	t.Helper()
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		encode := func(v any) {
-			if err := json.NewEncoder(w).Encode(v); err != nil {
-				t.Errorf("fakeDiscoveryServer: json.Encode %s: %v", r.URL.Path, err)
-			}
-		}
-		switch r.URL.Path {
-		case "/api":
-			encode(metav1.APIVersions{
-				TypeMeta: metav1.TypeMeta{Kind: "APIVersions", APIVersion: "v1"},
-				Versions: []string{"v1"},
-			})
-		case "/apis":
-			encode(metav1.APIGroupList{
-				TypeMeta: metav1.TypeMeta{Kind: "APIGroupList", APIVersion: "v1"},
-				Groups: []metav1.APIGroup{{
-					Name:             "externaldns.k8s.io",
-					Versions:         []metav1.GroupVersionForDiscovery{{GroupVersion: "externaldns.k8s.io/v1alpha1", Version: "v1alpha1"}},
-					PreferredVersion: metav1.GroupVersionForDiscovery{GroupVersion: "externaldns.k8s.io/v1alpha1", Version: "v1alpha1"},
-				}},
-			})
-		case "/apis/externaldns.k8s.io/v1alpha1":
-			encode(metav1.APIResourceList{
-				TypeMeta:     metav1.TypeMeta{Kind: "APIResourceList", APIVersion: "v1"},
-				GroupVersion: "externaldns.k8s.io/v1alpha1",
-				APIResources: []metav1.APIResource{{
-					Name:       "dnsendpoints",
-					Namespaced: true,
-					Kind:       "DNSEndpoint",
-					Verbs:      metav1.Verbs{"list", "watch"},
-				}},
-			})
-		default:
-			// Causes the informer's LIST to fail so the cache never syncs.
-			http.Error(w, `{"kind":"Status","apiVersion":"v1","status":"Failure","code":500}`, http.StatusInternalServerError)
-		}
-	}))
-	t.Cleanup(srv.Close)
-	return srv
 }
 
 // startSyncFakeCache is a minimal crcache.Cache stub for TestStartAndSync.


### PR DESCRIPTION
## What does it do ?

Adds unit tests for `registry/crd`, raising coverage of the constructor, `Records`, `ApplyChanges`, `recordObjectName`, and `adjustLabelsFromProvider` error paths.

Also extracts `NewFakeExternalDNSDiscoveryServer` into `internal/testutils` and reuses it from `source/crd_test.go`, which already had the same fake discovery server [implemented](https://github.com/kubernetes-sigs/external-dns/blob/master/source/crd_test.go#L933-L967).

## Motivation

Part of #5150, The CRD registry shipped with limited test coverage (54.2% of statements). These tests raise it to 92.2% and lock in current behavior so future changes are less likely to regress silently.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly
