### PR TITLE
feat(registry/txt)!: use a- prefix for AWS A ALIAS ownership TXT records

### DIFF
--- a/docs/registry/txt.md
+++ b/docs/registry/txt.md
@@ -44,11 +44,12 @@ For the domain `www.ex.com` the expected result is
 
 ### AWS A ALIAS records
 
-AWS ALIAS records are materialized in Route 53 as `A`/`AAAA` records, and their ownership TXT now
-uses the matching `a-`/`aaaa-` prefix. Earlier versions used the `cname-` prefix (external-dns
-models an A ALIAS as a CNAME internally). The legacy `cname-` record is still recognized, so
-ownership survives the upgrade; the new `a-` record is created on the next reconciliation and the
-obsolete `cname-` record is left in place with a warning logged.
+[AWS ALIAS records](../tutorials/aws.md#alias) are materialized in Route 53 as `A`/`AAAA` records
+(see the [Route 53 documentation](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-choosing-alias-non-alias.html)),
+and their ownership TXT now uses the matching `a-`/`aaaa-` prefix. Earlier versions used the `cname-`
+prefix (external-dns models an A ALIAS as a CNAME internally). The legacy `cname-` record is still
+recognized, so ownership survives the upgrade; the new `a-` record is created on the next
+reconciliation and the obsolete `cname-` record is left in place with a warning logged.
 See [#2903](https://github.com/kubernetes-sigs/external-dns/issues/2903).
 
 ### Manually Cleanup Legacy TXT Records

--- a/docs/registry/txt.md
+++ b/docs/registry/txt.md
@@ -42,6 +42,15 @@ For the domain `www.ex.com` the expected result is
 | `www-.cname.ex.com.` |  `TXT`  |
 |    `www.ex.com.`     | `CNAME` |
 
+### AWS A ALIAS records
+
+AWS ALIAS records are materialized in Route 53 as `A`/`AAAA` records, and their ownership TXT now
+uses the matching `a-`/`aaaa-` prefix. Earlier versions used the `cname-` prefix (external-dns
+models an A ALIAS as a CNAME internally). The legacy `cname-` record is still recognized, so
+ownership survives the upgrade; the new `a-` record is created on the next reconciliation and the
+obsolete `cname-` record is left in place with a warning logged.
+See [#2903](https://github.com/kubernetes-sigs/external-dns/issues/2903).
+
 ### Manually Cleanup Legacy TXT Records
 
 > While deleting registry TXT records won't cause downtime, a well-thought-out migration and cleanup plan is crucial.
@@ -51,6 +60,10 @@ Occasionally, it may be necessary to remove outdated TXT records from your regis
 An example script for AWS can be found in [scripts/aws-cleanup-legacy-txt-records.py](../../scripts/aws-cleanup-legacy-txt-records.py) with instructions on how to run it.
 The script performs targeted deletion of TXT records that include `ResourceRecords` matching the `heritage=external-dns,external-dns/owner=default` or similar pattern.
 In the event of unintended deletion of all TXT records managed by `external-dns`, `external-dns` will initiate a full DNS record regeneration, along with`TXT` and `non-TXT` records. Just be aware, this operation's duration is directly proportional to the DNS estate size."
+
+To remove the obsolete `cname-` records left by the AWS A ALIAS migration, run the script with
+`--alias-cname-cleanup`. It only deletes a `cname-` record when the matching `a-` record exists, so
+genuine `CNAME` ownership records are preserved.
 
 ### For version `v0.16.0 & v0.16.1`
 

--- a/docs/registry/txt.md
+++ b/docs/registry/txt.md
@@ -44,12 +44,11 @@ For the domain `www.ex.com` the expected result is
 
 ### AWS A ALIAS records
 
-[AWS ALIAS records](../tutorials/aws.md#alias) are materialized in Route 53 as `A`/`AAAA` records
-(see the [Route 53 documentation](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-choosing-alias-non-alias.html)),
-and their ownership TXT now uses the matching `a-`/`aaaa-` prefix. Earlier versions used the `cname-`
-prefix (external-dns models an A ALIAS as a CNAME internally). The legacy `cname-` record is still
-recognized, so ownership survives the upgrade; the new `a-` record is created on the next
-reconciliation and the obsolete `cname-` record is left in place with a warning logged.
+[AWS ALIAS records](../tutorials/aws.md#alias) are stored in Route 53 as
+[`A`/`AAAA` records](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-choosing-alias-non-alias.html),
+so their ownership TXT uses the matching `a-`/`aaaa-` prefix. For `A` ALIAS records this replaces the
+legacy `cname-` prefix: the old `cname-` record is still recognized (ownership is preserved), the `a-`
+record is created on the next reconciliation, and the obsolete `cname-` is left in place with a warning.
 See [#2903](https://github.com/kubernetes-sigs/external-dns/issues/2903).
 
 ### Manually Cleanup Legacy TXT Records
@@ -63,8 +62,7 @@ The script performs targeted deletion of TXT records that include `ResourceRecor
 In the event of unintended deletion of all TXT records managed by `external-dns`, `external-dns` will initiate a full DNS record regeneration, along with`TXT` and `non-TXT` records. Just be aware, this operation's duration is directly proportional to the DNS estate size."
 
 To remove the obsolete `cname-` records left by the AWS A ALIAS migration, run the script with
-`--alias-cname-cleanup`. It only deletes a `cname-` record when the matching `a-` record exists, so
-genuine `CNAME` ownership records are preserved.
+`--alias-cname-cleanup`, which deletes a `cname-` record only when its `a-` counterpart exists.
 
 ### For version `v0.16.0 & v0.16.1`
 

--- a/docs/snippets/tutorials/aws-localstack/dnsendpoint-alias.yml
+++ b/docs/snippets/tutorials/aws-localstack/dnsendpoint-alias.yml
@@ -1,0 +1,19 @@
+# ref: docs/snippets/tutorials/aws-localstack/dnsendpoint-alias.yml
+# A ALIAS record: recordType CNAME with an ELB-style target makes the AWS
+# provider treat it as an ALIAS and store it as an A record in Route 53, so its
+# ownership TXT uses the "a-" prefix (see docs/registry/txt.md, issue #2903).
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: alias-example
+  namespace: default
+  annotations:
+    dns.why/type: aws-localstack-tutorial
+spec:
+  endpoints:
+    - dnsName: alias.example.com
+      recordTTL: 300
+      recordType: CNAME
+      targets:
+        - my-lb.eu-west-1.elb.amazonaws.com

--- a/docs/snippets/tutorials/aws-localstack/dnsendpoint-alias.yml
+++ b/docs/snippets/tutorials/aws-localstack/dnsendpoint-alias.yml
@@ -1,15 +1,10 @@
 # ref: docs/snippets/tutorials/aws-localstack/dnsendpoint-alias.yml
-# A ALIAS record: recordType CNAME with an ELB-style target makes the AWS
-# provider treat it as an ALIAS and store it as an A record in Route 53, so its
-# ownership TXT uses the "a-" prefix (see docs/registry/txt.md, issue #2903).
 ---
 apiVersion: externaldns.k8s.io/v1alpha1
 kind: DNSEndpoint
 metadata:
   name: alias-example
   namespace: default
-  annotations:
-    dns.why/type: aws-localstack-tutorial
 spec:
   endpoints:
     - dnsName: alias.example.com

--- a/docs/snippets/tutorials/aws-localstack/dnsendpoint-cname.yml
+++ b/docs/snippets/tutorials/aws-localstack/dnsendpoint-cname.yml
@@ -5,8 +5,6 @@ kind: DNSEndpoint
 metadata:
   name: cname-example
   namespace: default
-  annotations:
-    dns.why/type: aws-localstack-tutorial
 spec:
   endpoints:
     - dnsName: www.example.com

--- a/docs/snippets/tutorials/aws-localstack/dnsendpoint-multi.yml
+++ b/docs/snippets/tutorials/aws-localstack/dnsendpoint-multi.yml
@@ -5,8 +5,6 @@ kind: DNSEndpoint
 metadata:
   name: simple-example
   namespace: default
-  annotations:
-    dns.why/type: aws-localstack-tutorial
 spec:
   endpoints:
     - dnsName: dnsendpoint-a.example.com

--- a/docs/snippets/tutorials/aws-localstack/foo-app.yml
+++ b/docs/snippets/tutorials/aws-localstack/foo-app.yml
@@ -6,7 +6,6 @@ metadata:
   name: foo-app
   annotations:
     external-dns.kubernetes.io/hostname: foo-app.example.com
-    dns.why/type: aws-localstack-tutorial
 spec:
   type: ClusterIP
   clusterIP: None
@@ -21,8 +20,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: foo-app
-  annotations:
-    dns.why/type: aws-localstack-tutorial
 spec:
   replicas: 3
   selector:

--- a/docs/snippets/tutorials/aws-localstack/service-lb.yml
+++ b/docs/snippets/tutorials/aws-localstack/service-lb.yml
@@ -6,7 +6,6 @@ metadata:
   name: loadbalancer-service
   annotations:
     external-dns.kubernetes.io/hostname: my-loadbalancer.example.com
-    dns.why/type: aws-localstack-tutorial
   namespace: default
 spec:
   type: LoadBalancer

--- a/docs/tutorials/aws-localstack.md
+++ b/docs/tutorials/aws-localstack.md
@@ -291,6 +291,41 @@ docs/snippets/tutorials/aws-localstack/fetch-records.sh "www.example"
 ]
 ```
 
+### Example 3: A ALIAS Record
+
+A `CNAME` targeting an AWS canonical hostname (e.g. an ELB) becomes an `A`/`AAAA`
+[ALIAS](aws.md#alias) record in Route 53, so its ownership TXT uses the matching
+`a-`/`aaaa-` prefix (see [the TXT registry docs](../registry/txt.md#aws-a-alias-records)
+and [#2903](https://github.com/kubernetes-sigs/external-dns/issues/2903)).
+
+```yaml
+[[% include 'tutorials/aws-localstack/dnsendpoint-alias.yml' %]]
+```
+
+Apply and verify
+
+```sh
+kubectl apply -f docs/snippets/tutorials/aws-localstack/dnsendpoint-alias.yml
+docs/snippets/tutorials/aws-localstack/fetch-records.sh "alias"
+
+❯❯ [
+    {
+        "Name": "a-alias.example.com.",
+        "Type": "TXT",
+        "Value": [
+            "\"heritage=external-dns,external-dns/owner=aws-localstack,...\""
+        ],
+        "TTL": 300
+    },
+    { "Name": "aaaa-alias.example.com.", "Type": "TXT", "...": "..." },
+    { "Name": "alias.example.com.", "Type": "A" },
+    { "Name": "alias.example.com.", "Type": "AAAA" }
+]
+```
+
+The `A`/`AAAA` records show no `Value` because an ALIAS keeps its target in
+`AliasTarget`, not `ResourceRecords`.
+
 ### Example 4: TXT Records
 
 Create TXT records (useful for domain verification, SPF, DKIM, etc.)

--- a/registry/txt/registry.go
+++ b/registry/txt/registry.go
@@ -68,6 +68,9 @@ type TXTRegistry struct {
 	// existingTXTs is the TXT records that already exist in the zone so that
 	// ApplyChanges() can skip re-creating them. See the struct below for details.
 	existingTXTs *existingTXTs
+
+	// obsoleteTXTWarned dedups the legacy "cname-" alias warning to once per record per process.
+	obsoleteTXTWarned sets.Set[string]
 }
 
 // existingTXTs stores pre‑existing TXT records to avoid duplicate creation.
@@ -162,6 +165,7 @@ func newRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID strin
 		txtEncryptAESKey:    txtEncryptAESKey,
 		oldOwnerID:          oldOwnerID,
 		existingTXTs:        newExistingTXTs(),
+		obsoleteTXTWarned:   sets.New[string](),
 	}, nil
 }
 
@@ -249,12 +253,22 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 			SetIdentifier: ep.SetIdentifier,
 		}
 
+		labels, labelsExist := labelMap[key]
+
+		// A ALIAS records used the legacy "cname-" prefix. Fall back to it so ownership
+		// survives migration to "a-", and report the stale record once. See issue #2903.
 		if shouldUseCNAMEForTxtRecord(ep) {
-			key.RecordType = endpoint.RecordTypeCNAME
+			legacyKey := key
+			legacyKey.RecordType = endpoint.RecordTypeCNAME
+			if legacyLabels, ok := labelMap[legacyKey]; ok {
+				if !labelsExist {
+					labels, labelsExist = legacyLabels, true
+				}
+				im.warnObsoleteAliasTXT(dnsName)
+			}
 		}
 
 		// Handle both new and old registry format with the preference for the new one
-		labels, labelsExist := labelMap[key]
 		if !labelsExist && ep.RecordType != endpoint.RecordTypeAAAA {
 			key.RecordType = ""
 			labels, labelsExist = labelMap[key]
@@ -292,11 +306,22 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 	return endpoints, nil
 }
 
-// shouldUseCNAMEForTxtRecord checks if the endpoint is an alias A record converted from CNAME.
-// TXT ownership records use CNAME as the record type for such records.
+// shouldUseCNAMEForTxtRecord reports whether the endpoint is an A ALIAS record, which external-dns
+// models internally as a CNAME. Used to recognize the legacy "cname-" ownership TXT for migration.
 func shouldUseCNAMEForTxtRecord(ep *endpoint.Endpoint) bool {
 	aliasType := ep.GetAliasProperty()
 	return (aliasType == endpoint.AliasTrue || aliasType == endpoint.AliasA) && ep.RecordType == endpoint.RecordTypeA
+}
+
+// warnObsoleteAliasTXT logs, once per record, that a legacy "cname-" alias TXT can be removed.
+func (im *TXTRegistry) warnObsoleteAliasTXT(dnsName string) {
+	legacyName := im.mapper.ToTXTName(dnsName, endpoint.RecordTypeCNAME)
+	if im.obsoleteTXTWarned.Has(legacyName) {
+		return
+	}
+	im.obsoleteTXTWarned.Insert(legacyName)
+	log.Warnf("Obsolete legacy TXT record %q for A ALIAS %q can be removed; now using %q (see scripts/aws-cleanup-legacy-txt-records.py).",
+		legacyName, dnsName, im.mapper.ToTXTName(dnsName, endpoint.RecordTypeA))
 }
 
 // generateTXTRecord generates TXT records in either both formats (old and new) or new format only,
@@ -309,12 +334,8 @@ func (im *TXTRegistry) generateTXTRecord(r *endpoint.Endpoint) []*endpoint.Endpo
 func (im *TXTRegistry) generateTXTRecordWithFilter(r *endpoint.Endpoint, filter func(*endpoint.Endpoint) bool) []*endpoint.Endpoint {
 	endpoints := make([]*endpoint.Endpoint, 0)
 
-	// Always create new format record
+	// Key the TXT record on the endpoint's actual record type (e.g. "a-" for A ALIAS records).
 	recordType := r.RecordType
-
-	if shouldUseCNAMEForTxtRecord(r) {
-		recordType = endpoint.RecordTypeCNAME
-	}
 
 	if im.oldOwnerID != "" && r.Labels[endpoint.OwnerLabelKey] == im.oldOwnerID {
 		r.Labels[endpoint.OwnerLabelKey] = im.ownerID

--- a/registry/txt/registry.go
+++ b/registry/txt/registry.go
@@ -257,7 +257,7 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 
 		// A ALIAS records used the legacy "cname-" prefix. Fall back to it so ownership
 		// survives migration to "a-", and report the stale record once. See issue #2903.
-		if shouldUseCNAMEForTxtRecord(ep) {
+		if isAliasARecord(ep) {
 			legacyKey := key
 			legacyKey.RecordType = endpoint.RecordTypeCNAME
 			if legacyLabels, ok := labelMap[legacyKey]; ok {
@@ -306,9 +306,9 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 	return endpoints, nil
 }
 
-// shouldUseCNAMEForTxtRecord reports whether the endpoint is an A ALIAS record, which external-dns
-// models internally as a CNAME. Used to recognize the legacy "cname-" ownership TXT for migration.
-func shouldUseCNAMEForTxtRecord(ep *endpoint.Endpoint) bool {
+// isAliasARecord reports whether the endpoint is an A ALIAS record (used to recognize the legacy
+// "cname-" ownership TXT during migration to the "a-" prefix).
+func isAliasARecord(ep *endpoint.Endpoint) bool {
 	aliasType := ep.GetAliasProperty()
 	return (aliasType == endpoint.AliasTrue || aliasType == endpoint.AliasA) && ep.RecordType == endpoint.RecordTypeA
 }

--- a/registry/txt/registry_test.go
+++ b/registry/txt/registry_test.go
@@ -2195,89 +2195,105 @@ func TestRecreateRecordAfterDeletion(t *testing.T) {
 	assert.True(t, testutils.SameEndpoints(records, append(desired, txtRecord...)), "Expected records after reconciliation: %v, but got: %v", append(desired, txtRecord...), records)
 }
 
-// TestTXTRegistryAliasARecordUsesARecordTXTPrefixIssue2903 verifies an A ALIAS record (a CNAME
-// converted by the AWS provider) now gets an "a-" prefixed ownership TXT instead of "cname-" (#2903).
-func TestTXTRegistryAliasARecordUsesARecordTXTPrefixIssue2903(t *testing.T) {
+// TestTXTRegistryAliasARecordUsesARecordTXTPrefix verifies an A ALIAS record (a CNAME converted by
+// the AWS provider) gets an "a-" prefixed ownership TXT instead of "cname-".
+func TestTXTRegistryAliasARecordUsesARecordTXTPrefix(t *testing.T) {
 	p := inmemory.NewInMemoryProvider()
-	err := p.CreateZone(testZone)
-	require.NoError(t, err)
+	require.NoError(t, p.CreateZone(testZone))
 
 	r, err := newRegistry(p, "", "", "owner", time.Hour, "", []string{}, []string{}, false, nil, "")
 	require.NoError(t, err)
 
-	// Endpoint as produced by the AWS provider's AdjustEndpoints for a CNAME-to-ELB: RecordType
-	// has been rewritten to A and the alias provider-specific property is set to true.
+	// As produced by the AWS provider's AdjustEndpoints for a CNAME-to-ELB: type rewritten to A
+	// with the alias provider-specific property set.
 	aliasA := newEndpointWithOwner("alias.test-zone.example.org", "foo.eu-central-1.elb.amazonaws.com", endpoint.RecordTypeA, "").
 		WithAliasProperty(endpoint.AliasTrue)
 
 	var applied *plan.Changes
-	p.OnApplyChanges = func(_ context.Context, got *plan.Changes) {
-		applied = got
-	}
+	p.OnApplyChanges = func(_ context.Context, got *plan.Changes) { applied = got }
 
-	err = r.ApplyChanges(t.Context(), &plan.Changes{Create: []*endpoint.Endpoint{aliasA}})
-	require.NoError(t, err)
+	require.NoError(t, r.ApplyChanges(t.Context(), &plan.Changes{Create: []*endpoint.Endpoint{aliasA}}))
 	require.NotNil(t, applied)
 
-	var primary, txt *endpoint.Endpoint
-	for _, ep := range applied.Create {
-		switch ep.RecordType {
-		case endpoint.RecordTypeTXT:
-			txt = ep
-		case endpoint.RecordTypeA:
-			primary = ep
-		}
-	}
-	require.NotNil(t, primary, "expected an A record to be applied")
-	require.NotNil(t, txt, "expected a TXT ownership record to be applied")
-
-	assert.Equal(t, endpoint.RecordTypeA, primary.RecordType)
-
-	// The TXT ownership record now uses the "a-" prefix, matching the A record it describes.
-	assert.Equal(t, "a-alias.test-zone.example.org", txt.DNSName)
-	assert.NotEqual(t, "cname-alias.test-zone.example.org", txt.DNSName)
+	assert.NotNil(t, findEndpoint(applied.Create, "alias.test-zone.example.org", endpoint.RecordTypeA), "expected the A record to be applied")
+	assert.NotNil(t, findEndpoint(applied.Create, "a-alias.test-zone.example.org", endpoint.RecordTypeTXT), "expected an a- prefixed ownership TXT")
+	assert.Nil(t, findEndpoint(applied.Create, "cname-alias.test-zone.example.org", endpoint.RecordTypeTXT), "must not create a cname- TXT")
 }
 
-// TestTXTRegistryAliasARecordLegacyCNAMEMigrationIssue2903 verifies the migration: a zone with only
-// the legacy "cname-" ownership TXT keeps its ownership and gets the new "a-" record generated (#2903).
-func TestTXTRegistryAliasARecordLegacyCNAMEMigrationIssue2903(t *testing.T) {
-	p := inmemory.NewInMemoryProvider()
-	err := p.CreateZone(testZone)
-	require.NoError(t, err)
+// TestTXTRegistryAliasARecordForceUpdateOnMigration covers the "cname-" -> "a-" migration via Records():
+// ownership is preserved through the legacy "cname-" TXT, and force-update is armed only while the new
+// "a-" TXT is still missing — so it is created once, then no longer churns.
+func TestTXTRegistryAliasARecordForceUpdateOnMigration(t *testing.T) {
+	const dnsName = "alias.test-zone.example.org"
+	const owner = "\"heritage=external-dns,external-dns/owner=owner\""
 
-	// Seed the zone with an A ALIAS record and only its legacy "cname-" ownership TXT.
-	err = p.ApplyChanges(t.Context(), &plan.Changes{
+	for _, tt := range []struct {
+		name      string
+		withATXT  bool
+		wantForce bool
+	}{
+		{"legacy cname- only: force-update to create a-", false, true},
+		{"a- and cname- coexist: no churn", true, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			p := inmemory.NewInMemoryProvider()
+			require.NoError(t, p.CreateZone(testZone))
+
+			seed := []*endpoint.Endpoint{
+				newEndpointWithOwner(dnsName, "foo.eu-central-1.elb.amazonaws.com", endpoint.RecordTypeA, "owner").WithAliasProperty(endpoint.AliasTrue),
+				newTXTEndpointWithOwnedRecord("cname-alias.test-zone.example.org", owner, dnsName),
+			}
+			if tt.withATXT {
+				seed = append(seed, newTXTEndpointWithOwnedRecord("a-alias.test-zone.example.org", owner, dnsName))
+			}
+			require.NoError(t, p.ApplyChanges(t.Context(), &plan.Changes{Create: seed}))
+
+			r, err := newRegistry(p, "", "", "owner", time.Hour, "", []string{endpoint.RecordTypeA}, []string{}, false, nil, "")
+			require.NoError(t, err)
+
+			records, err := r.Records(t.Context())
+			require.NoError(t, err)
+
+			aliasEp := findEndpoint(records, dnsName, endpoint.RecordTypeA)
+			require.NotNil(t, aliasEp, "expected the A ALIAS record to be returned")
+			assert.Equal(t, "owner", aliasEp.Labels[endpoint.OwnerLabelKey], "ownership must be preserved via the legacy cname- TXT")
+
+			forceUpdate, _ := aliasEp.GetProviderSpecificProperty(providerSpecificForceUpdate)
+			assert.Equal(t, tt.wantForce, forceUpdate == "true")
+		})
+	}
+}
+
+// TestTXTRegistryAliasARecordDeleteLeavesLegacyCNAME verifies that deleting an A ALIAS removes only
+// the "a-" TXT; the obsolete "cname-" is left behind for the cleanup script.
+func TestTXTRegistryAliasARecordDeleteLeavesLegacyCNAME(t *testing.T) {
+	const dnsName = "alias.test-zone.example.org"
+	const owner = "\"heritage=external-dns,external-dns/owner=owner\""
+
+	p := inmemory.NewInMemoryProvider()
+	require.NoError(t, p.CreateZone(testZone))
+
+	aliasA := newEndpointWithOwner(dnsName, "foo.eu-central-1.elb.amazonaws.com", endpoint.RecordTypeA, "owner").
+		WithAliasProperty(endpoint.AliasTrue)
+
+	require.NoError(t, p.ApplyChanges(t.Context(), &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("alias.test-zone.example.org", "foo.eu-central-1.elb.amazonaws.com", endpoint.RecordTypeA, "owner").WithAliasProperty(endpoint.AliasTrue),
-			newTXTEndpointWithOwnedRecord("cname-alias.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", "alias.test-zone.example.org"),
+			aliasA,
+			newTXTEndpointWithOwnedRecord("a-alias.test-zone.example.org", owner, dnsName),
+			newTXTEndpointWithOwnedRecord("cname-alias.test-zone.example.org", owner, dnsName),
 		},
-	})
-	require.NoError(t, err)
+	}))
 
 	r, err := newRegistry(p, "", "", "owner", time.Hour, "", []string{endpoint.RecordTypeA}, []string{}, false, nil, "")
 	require.NoError(t, err)
 
-	records, err := r.Records(t.Context())
-	require.NoError(t, err)
+	var applied *plan.Changes
+	p.OnApplyChanges = func(_ context.Context, got *plan.Changes) { applied = got }
 
-	// The A ALIAS record is recognized as owned via the legacy "cname-" TXT record.
-	var aliasEp *endpoint.Endpoint
-	for _, ep := range records {
-		if ep.DNSName == "alias.test-zone.example.org" && ep.RecordType == endpoint.RecordTypeA {
-			aliasEp = ep
-		}
-	}
-	require.NotNil(t, aliasEp, "expected the A ALIAS record to be returned")
-	assert.Equal(t, "owner", aliasEp.Labels[endpoint.OwnerLabelKey], "ownership must be preserved during migration")
+	require.NoError(t, r.ApplyChanges(t.Context(), &plan.Changes{Delete: []*endpoint.Endpoint{aliasA}}))
+	require.NotNil(t, applied)
 
-	// The migration must mark the record for re-creation (force-update) so the planner emits an
-	// update for it; the AWS provider applies updates as upserts, creating the new "a-" TXT.
-	forceUpdate, _ := aliasEp.GetProviderSpecificProperty(providerSpecificForceUpdate)
-	assert.Equal(t, "true", forceUpdate, "expected force-update so the new a- TXT is created")
-
-	// The desired ownership TXT generated for the alias endpoint now uses the "a-" prefix, so the
-	// new-format record is what gets created on apply.
-	desired := r.generateTXTRecord(aliasEp)
-	require.Len(t, desired, 1)
-	assert.Equal(t, "a-alias.test-zone.example.org", desired[0].DNSName)
+	assert.NotNil(t, findEndpoint(applied.Delete, dnsName, endpoint.RecordTypeA), "the A ALIAS record itself must be deleted")
+	assert.NotNil(t, findEndpoint(applied.Delete, "a-alias.test-zone.example.org", endpoint.RecordTypeTXT), "the new a- ownership TXT must be deleted")
+	assert.Nil(t, findEndpoint(applied.Delete, "cname-alias.test-zone.example.org", endpoint.RecordTypeTXT), "the legacy cname- TXT should be kept")
 }

--- a/registry/txt/registry_test.go
+++ b/registry/txt/registry_test.go
@@ -1110,9 +1110,9 @@ func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 			newEndpointWithOwner("example", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "owner"),
 			newTXTEndpointWithOwnedRecord("cname-example", "\"heritage=external-dns,external-dns/owner=owner\"", "example"),
 			newEndpointWithOwner("new-alias.test-zone.example.org", "my-domain.com", endpoint.RecordTypeA, "owner").WithAliasProperty(endpoint.AliasTrue),
-			newTXTEndpointWithOwnedRecord("cname-new-alias.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", "new-alias.test-zone.example.org").WithAliasProperty(endpoint.AliasTrue),
+			newTXTEndpointWithOwnedRecord("a-new-alias.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", "new-alias.test-zone.example.org").WithAliasProperty(endpoint.AliasTrue),
 			newEndpointWithOwner("new-alias-a-only.test-zone.example.org", "my-domain.com", endpoint.RecordTypeA, "owner").WithAliasProperty(endpoint.AliasA),
-			newTXTEndpointWithOwnedRecord("cname-new-alias-a-only.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", "new-alias-a-only.test-zone.example.org").WithAliasProperty(endpoint.AliasA),
+			newTXTEndpointWithOwnedRecord("a-new-alias-a-only.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", "new-alias-a-only.test-zone.example.org").WithAliasProperty(endpoint.AliasA),
 		},
 		Delete: []*endpoint.Endpoint{
 			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
@@ -2193,4 +2193,91 @@ func TestRecreateRecordAfterDeletion(t *testing.T) {
 	records, err = p.Records(ctx)
 	assert.NoError(t, err)
 	assert.True(t, testutils.SameEndpoints(records, append(desired, txtRecord...)), "Expected records after reconciliation: %v, but got: %v", append(desired, txtRecord...), records)
+}
+
+// TestTXTRegistryAliasARecordUsesARecordTXTPrefixIssue2903 verifies an A ALIAS record (a CNAME
+// converted by the AWS provider) now gets an "a-" prefixed ownership TXT instead of "cname-" (#2903).
+func TestTXTRegistryAliasARecordUsesARecordTXTPrefixIssue2903(t *testing.T) {
+	p := inmemory.NewInMemoryProvider()
+	err := p.CreateZone(testZone)
+	require.NoError(t, err)
+
+	r, err := newRegistry(p, "", "", "owner", time.Hour, "", []string{}, []string{}, false, nil, "")
+	require.NoError(t, err)
+
+	// Endpoint as produced by the AWS provider's AdjustEndpoints for a CNAME-to-ELB: RecordType
+	// has been rewritten to A and the alias provider-specific property is set to true.
+	aliasA := newEndpointWithOwner("alias.test-zone.example.org", "foo.eu-central-1.elb.amazonaws.com", endpoint.RecordTypeA, "").
+		WithAliasProperty(endpoint.AliasTrue)
+
+	var applied *plan.Changes
+	p.OnApplyChanges = func(_ context.Context, got *plan.Changes) {
+		applied = got
+	}
+
+	err = r.ApplyChanges(t.Context(), &plan.Changes{Create: []*endpoint.Endpoint{aliasA}})
+	require.NoError(t, err)
+	require.NotNil(t, applied)
+
+	var primary, txt *endpoint.Endpoint
+	for _, ep := range applied.Create {
+		switch ep.RecordType {
+		case endpoint.RecordTypeTXT:
+			txt = ep
+		case endpoint.RecordTypeA:
+			primary = ep
+		}
+	}
+	require.NotNil(t, primary, "expected an A record to be applied")
+	require.NotNil(t, txt, "expected a TXT ownership record to be applied")
+
+	assert.Equal(t, endpoint.RecordTypeA, primary.RecordType)
+
+	// The TXT ownership record now uses the "a-" prefix, matching the A record it describes.
+	assert.Equal(t, "a-alias.test-zone.example.org", txt.DNSName)
+	assert.NotEqual(t, "cname-alias.test-zone.example.org", txt.DNSName)
+}
+
+// TestTXTRegistryAliasARecordLegacyCNAMEMigrationIssue2903 verifies the migration: a zone with only
+// the legacy "cname-" ownership TXT keeps its ownership and gets the new "a-" record generated (#2903).
+func TestTXTRegistryAliasARecordLegacyCNAMEMigrationIssue2903(t *testing.T) {
+	p := inmemory.NewInMemoryProvider()
+	err := p.CreateZone(testZone)
+	require.NoError(t, err)
+
+	// Seed the zone with an A ALIAS record and only its legacy "cname-" ownership TXT.
+	err = p.ApplyChanges(t.Context(), &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			newEndpointWithOwner("alias.test-zone.example.org", "foo.eu-central-1.elb.amazonaws.com", endpoint.RecordTypeA, "owner").WithAliasProperty(endpoint.AliasTrue),
+			newTXTEndpointWithOwnedRecord("cname-alias.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", "alias.test-zone.example.org"),
+		},
+	})
+	require.NoError(t, err)
+
+	r, err := newRegistry(p, "", "", "owner", time.Hour, "", []string{endpoint.RecordTypeA}, []string{}, false, nil, "")
+	require.NoError(t, err)
+
+	records, err := r.Records(t.Context())
+	require.NoError(t, err)
+
+	// The A ALIAS record is recognized as owned via the legacy "cname-" TXT record.
+	var aliasEp *endpoint.Endpoint
+	for _, ep := range records {
+		if ep.DNSName == "alias.test-zone.example.org" && ep.RecordType == endpoint.RecordTypeA {
+			aliasEp = ep
+		}
+	}
+	require.NotNil(t, aliasEp, "expected the A ALIAS record to be returned")
+	assert.Equal(t, "owner", aliasEp.Labels[endpoint.OwnerLabelKey], "ownership must be preserved during migration")
+
+	// The migration must mark the record for re-creation (force-update) so the planner emits an
+	// update for it; the AWS provider applies updates as upserts, creating the new "a-" TXT.
+	forceUpdate, _ := aliasEp.GetProviderSpecificProperty(providerSpecificForceUpdate)
+	assert.Equal(t, "true", forceUpdate, "expected force-update so the new a- TXT is created")
+
+	// The desired ownership TXT generated for the alias endpoint now uses the "a-" prefix, so the
+	// new-format record is what gets created on apply.
+	desired := r.generateTXTRecord(aliasEp)
+	require.Len(t, desired, 1)
+	assert.Equal(t, "a-alias.test-zone.example.org", desired[0].DNSName)
 }

--- a/registry/txt/utils_test.go
+++ b/registry/txt/utils_test.go
@@ -48,6 +48,16 @@ func newEndpointWithOwnerAndLabels(dnsName, target, recordType, ownerID string, 
 	return e
 }
 
+// findEndpoint returns the first endpoint matching dnsName and recordType, or nil.
+func findEndpoint(eps []*endpoint.Endpoint, dnsName, recordType string) *endpoint.Endpoint {
+	for _, ep := range eps {
+		if ep.DNSName == dnsName && ep.RecordType == recordType {
+			return ep
+		}
+	}
+	return nil
+}
+
 func newCNAMEEndpointWithOwnerResource(dnsName, target, ownerID, resource string) *endpoint.Endpoint {
 	e := endpoint.NewEndpoint(dnsName, endpoint.RecordTypeCNAME, target)
 	e.Labels[endpoint.OwnerLabelKey] = ownerID

--- a/scripts/aws-cleanup-legacy-txt-records.py
+++ b/scripts/aws-cleanup-legacy-txt-records.py
@@ -65,6 +65,17 @@ SESSION_ID=uuid.uuid4()
 def json_prettify(data):
     return json.dumps(data, indent=4, default=str)
 
+def value_matches(value: str, contain: str) -> bool:
+    """True if `contain` occurs in `value` ending at a token boundary (',' or '"'),
+    so 'owner=prod' does not also match 'owner=prod-2'."""
+    start = value.find(contain)
+    while start != -1:
+        end = start + len(contain)
+        if end == len(value) or value[end] in ',"':
+            return True
+        start = value.find(contain, start + 1)
+    return False
+
 class Record:
 
     def __init__(self, record):
@@ -79,10 +90,7 @@ class Record:
         self.resource_record = resource_record
 
     def is_for_deletion(self, contains):
-
-        if contains in self.resource_record:
-            return True
-        return False
+        return value_matches(self.resource_record, contains)
 
     def __str__(self):
         return f'record: name: {self.name}, type: {self.type}, records: {self.resource_record}'
@@ -135,7 +143,7 @@ def orphaned_alias_cname_records(all_txt: list[Record], contain: str) -> list[Re
     for r in all_txt:
         if "cname-" not in r.name:
             continue
-        if contain not in r.resource_record:
+        if not value_matches(r.resource_record, contain):
             continue
         # Only delete the legacy alias record when the migrated 'a-' record already exists.
         if alias_to_a_name(r.name) in names:

--- a/scripts/aws-cleanup-legacy-txt-records.py
+++ b/scripts/aws-cleanup-legacy-txt-records.py
@@ -99,8 +99,12 @@ class Config:
         # Target legacy "cname-" alias records, but only when their "a-" twin exists (#2903).
         self.alias_cname_cleanup = alias_cname_cleanup
 
-def list_all_txt_records(r53client, zone_id) -> list[Record]:
-    """Return every TXT record in the zone (handles pagination)."""
+def list_all_txt_records(r53client, zone_id, limit=None) -> list[Record]:
+    """Return TXT records in the zone (handles pagination).
+
+    Stops once `limit` records are collected; pass None to list the whole zone
+    (required by alias cleanup, which needs every 'a-' twin to be visible).
+    """
     all_txt = []
     params = {'HostedZoneId': zone_id, 'MaxItems': str(MAX_ITEMS)}
     dns_in_iteration = r53client.list_resource_record_sets(**params)
@@ -109,6 +113,8 @@ def list_all_txt_records(r53client, zone_id) -> list[Record]:
         for el in elements:
             if el['Type'] == 'TXT':
                 all_txt.append(Record(el))
+                if limit is not None and len(all_txt) >= limit:
+                    return all_txt
         if len(elements) == 0 or 'NextRecordName' not in dns_in_iteration:
             break
         dns_in_iteration = r53client.list_resource_record_sets(
@@ -145,11 +151,12 @@ def records(config: Config) -> None:
     r53client = boto3.client('route53', config=cfg)
     dns_records_to_cleanup = []
     try:
-        all_txt = list_all_txt_records(r53client, config.zone_id)
-
         if config.alias_cname_cleanup:
+            all_txt = list_all_txt_records(r53client, config.zone_id)
             candidates = orphaned_alias_cname_records(all_txt, config.contain)
         else:
+            # Default mode: stop early once enough deletion candidates are found.
+            all_txt = list_all_txt_records(r53client, config.zone_id, limit=config.total_items)
             candidates = [r for r in all_txt if r.is_for_deletion(config.contain)]
 
         for record in candidates:

--- a/scripts/aws-cleanup-legacy-txt-records.py
+++ b/scripts/aws-cleanup-legacy-txt-records.py
@@ -89,13 +89,52 @@ class Record:
 
 class Config:
 
-    def __init__(self, zone_id, contain, total_items, batch, run):
+    def __init__(self, zone_id, contain, total_items, batch, run, alias_cname_cleanup=False):
         self.zone_id = zone_id
         self.record_contain = contain
         self.total_items = total_items
         self.batch_size = batch
         self.run = run
         self.contain = contain
+        # Target legacy "cname-" alias records, but only when their "a-" twin exists (#2903).
+        self.alias_cname_cleanup = alias_cname_cleanup
+
+def list_all_txt_records(r53client, zone_id) -> list[Record]:
+    """Return every TXT record in the zone (handles pagination)."""
+    all_txt = []
+    params = {'HostedZoneId': zone_id, 'MaxItems': str(MAX_ITEMS)}
+    dns_in_iteration = r53client.list_resource_record_sets(**params)
+    elements = dns_in_iteration['ResourceRecordSets']
+    while True:
+        for el in elements:
+            if el['Type'] == 'TXT':
+                all_txt.append(Record(el))
+        if len(elements) == 0 or 'NextRecordName' not in dns_in_iteration:
+            break
+        dns_in_iteration = r53client.list_resource_record_sets(
+            HostedZoneId=zone_id,
+            StartRecordName=dns_in_iteration['NextRecordName'],
+            MaxItems=str(MAX_ITEMS),
+        )
+        elements = dns_in_iteration['ResourceRecordSets']
+    return all_txt
+
+def alias_to_a_name(name: str) -> str:
+    """Map a 'cname-' TXT name to its 'a-' twin. The '%{record_type}' affix template is unsupported."""
+    return name.replace("cname-", "a-", 1)
+
+def orphaned_alias_cname_records(all_txt: list[Record], contain: str) -> list[Record]:
+    names = {r.name for r in all_txt}
+    selected = []
+    for r in all_txt:
+        if "cname-" not in r.name:
+            continue
+        if contain not in r.resource_record:
+            continue
+        # Only delete the legacy alias record when the migrated 'a-' record already exists.
+        if alias_to_a_name(r.name) in names:
+            selected.append(r)
+    return selected
 
 def records(config: Config) -> None:
     print(f"calculate TXT records to cleanup for 'zone:{config.zone_id}' and 'max records:{config.total_items}'")
@@ -105,40 +144,19 @@ def records(config: Config) -> None:
     )
     r53client = boto3.client('route53', config=cfg)
     dns_records_to_cleanup = []
-    items = 0
     try:
-        params = {
-            'HostedZoneId': config.zone_id,
-            'MaxItems': str(MAX_ITEMS),
-        }
-        dns_in_iteration = r53client.list_resource_record_sets(**params)
-        elements = dns_in_iteration['ResourceRecordSets']
-        for el in elements:
-            if el['Type'] == 'TXT':
-                record = Record(el)
-                if record.is_for_deletion(config.contain):
-                    dns_records_to_cleanup.append(record)
-                    print("to cleanup >>", record)
-                    items += 1
-                    if items >= config.total_items:
-                        break
+        all_txt = list_all_txt_records(r53client, config.zone_id)
 
-        while len(elements) > 0 and 'NextRecordName' in dns_in_iteration.keys() and items < config.total_items:
-            dns_in_iteration = r53client.list_resource_record_sets(
-                HostedZoneId= config.zone_id,
-                StartRecordName= dns_in_iteration['NextRecordName'],
-                MaxItems= str(MAX_ITEMS),
-            )
-            elements = dns_in_iteration['ResourceRecordSets']
-            for el in elements:
-                if el['Type'] == 'TXT':
-                    record = Record(el)
-                    if record.is_for_deletion(config.contain):
-                        dns_records_to_cleanup.append(record)
-                        print("to cleanup >>", record)
-                        items += 1
-                        if items >= config.total_items:
-                            break
+        if config.alias_cname_cleanup:
+            candidates = orphaned_alias_cname_records(all_txt, config.contain)
+        else:
+            candidates = [r for r in all_txt if r.is_for_deletion(config.contain)]
+
+        for record in candidates:
+            dns_records_to_cleanup.append(record)
+            print("to cleanup >>", record)
+            if len(dns_records_to_cleanup) >= config.total_items:
+                break
 
         if len(dns_records_to_cleanup) > 0:
             delete_records(r53client, config, dns_records_to_cleanup)
@@ -195,6 +213,7 @@ if __name__ == "__main__":
     parser.add_argument("--record-match", type=str, required=True, help="Record to match specific value. Example 'external-dns/owner=default'")
     parser.add_argument("--total-items", type=int, required=False, default=10, help="Number of items to delete. Default to 10")
     parser.add_argument("--batch-delete-count", type=int, required=False, default=2, help="Number of items to delete in single DELETE batch. Default to 2")
+    parser.add_argument("--alias-cname-cleanup", action="store_true", help="Delete legacy 'cname-' alias TXT records only when their 'a-' counterpart exists (#2903).")
     parser.add_argument("--run", action="store_true", help="Execute the cleanup. The tool will do a dry-run if --run is not specified.")
 
     answer = input("Run this script at your own RISKS!!! Please enter 'yes' or 'no': ")
@@ -211,5 +230,6 @@ if __name__ == "__main__":
         total_items=args.total_items,
         batch=args.batch_delete_count,
         run=args.run,
+        alias_cname_cleanup=args.alias_cname_cleanup,
     )
     records(cfg)


### PR DESCRIPTION
## What does it do ?

AWS A ALIAS records (a CNAME the AWS provider converts to an A record) now get an
`a-` prefixed ownership TXT record instead of `cname-`, matching the record type.

The legacy `cname-` record is still recognized, so ownership survives the upgrade:
the `a-` record is created on the next sync and the obsolete `cname-` record is left
in place with a warning. 

This PR update `scripts/aws-cleanup-legacy-txt-records.py` so user can clean those records.
It deletes a `cname-` only when its `a-` twin exists, so real CNAME records are preserved.

Scope is AWS only — the sole in-tree provider that rewrites the record type to A and
returns A on read. pdns keeps aliases as CNAME and is unaffected.

## Motivation

The ownership TXT for an AWS A ALIAS used the `cname-` prefix even though the
record created in Route 53 is an A record. This contradicts the documented
per-type prefix (`a-` for A records) and has confused operators for a long time.

Fixes #2903

## More

- [x] Yes, this PR title follows Conventional Commits
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly
