### PR TITLE
refactor(source): migrate AnnotationFilter from string to labels.Selector

### DIFF
--- a/source/ambassador_host.go
+++ b/source/ambassador_host.go
@@ -73,7 +73,7 @@ type ambassadorHostSource struct {
 	dynamicKubeClient      dynamic.Interface
 	kubeClient             kubernetes.Interface
 	namespace              string
-	annotationFilter       string
+	annotationFilter       labels.Selector
 	ambassadorHostInformer kubeinformers.GenericInformer
 	unstructuredConverter  *unstructuredConverter
 	labelSelector          labels.Selector
@@ -147,10 +147,7 @@ func (sc *ambassadorHostSource) Endpoints(ctx context.Context) ([]*endpoint.Endp
 	}
 
 	// Filter Ambassador Hosts
-	ambassadorHosts, err = annotations.Filter(ambassadorHosts, sc.annotationFilter)
-	if err != nil {
-		return nil, fmt.Errorf("failed to filter Ambassador Hosts by annotation: %w", err)
-	}
+	ambassadorHosts = annotations.Filter(ambassadorHosts, sc.annotationFilter)
 
 	var endpoints []*endpoint.Endpoint
 

--- a/source/ambassador_host_test.go
+++ b/source/ambassador_host_test.go
@@ -643,7 +643,7 @@ func TestAmbassadorHostSource(t *testing.T) {
 			source, err := NewAmbassadorHostSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
 					Namespace:        namespace,
-					AnnotationFilter: mustParseAnnotationFilter(ti.annotationFilter),
+					AnnotationFilter: parseAnnotationFilterOrNil(ti.annotationFilter),
 					LabelFilter:      ti.labelSelector,
 				})
 			assert.NoError(t, err)

--- a/source/ambassador_host_test.go
+++ b/source/ambassador_host_test.go
@@ -643,7 +643,7 @@ func TestAmbassadorHostSource(t *testing.T) {
 			source, err := NewAmbassadorHostSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
 					Namespace:        namespace,
-					AnnotationFilter: ti.annotationFilter,
+					AnnotationFilter: mustParseAnnotationFilter(ti.annotationFilter),
 					LabelFilter:      ti.labelSelector,
 				})
 			assert.NoError(t, err)

--- a/source/annotations/filter.go
+++ b/source/annotations/filter.go
@@ -14,8 +14,6 @@ limitations under the License.
 package annotations
 
 import (
-	"strings"
-
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -26,25 +24,18 @@ type AnnotatedObject interface {
 }
 
 // Filter filters a slice of objects by annotation selector.
-// Returns all items if annotationFilter is empty.
-func Filter[T AnnotatedObject](items []T, filter string) ([]T, error) {
-	if filter == "" || strings.TrimSpace(filter) == "" {
-		return items, nil
-	}
-	selector, err := ParseFilter(filter)
-	if err != nil {
-		return nil, err
-	}
-	if selector.Empty() {
-		return items, nil
+// Returns all items if filter is nil or empty.
+func Filter[T AnnotatedObject](items []T, filter labels.Selector) []T {
+	if filter == nil || filter.Empty() {
+		return items
 	}
 
 	filtered := make([]T, 0, len(items))
 	for _, item := range items {
-		if selector.Matches(labels.Set(item.GetAnnotations())) {
+		if filter.Matches(labels.Set(item.GetAnnotations())) {
 			filtered = append(filtered, item)
 		}
 	}
 	log.Debugf("filtered '%d' services out of '%d' with annotation filter '%s'", len(filtered), len(items), filter)
-	return filtered, nil
+	return filtered
 }

--- a/source/annotations/filter_test.go
+++ b/source/annotations/filter_test.go
@@ -18,7 +18,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/labels"
 
 	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 )
@@ -32,93 +33,70 @@ func (m mockObj) GetAnnotations() map[string]string {
 	return m.annotations
 }
 
+func mustParseAnnotationFilter(s string) labels.Selector {
+	sel, err := ParseFilter(s)
+	if err != nil {
+		panic(err)
+	}
+	return sel
+}
+
 func TestFilter(t *testing.T) {
 	tests := []struct {
-		name        string
-		items       []mockObj
-		filter      string
-		expected    []mockObj
-		expectError bool
+		name     string
+		items    []mockObj
+		filter   labels.Selector
+		expected []mockObj
 	}{
 		{
-			name: "Empty filter returns all",
+			name: "nil filter returns all",
 			items: []mockObj{
 				{annotations: map[string]string{"foo": "bar"}},
 				{annotations: map[string]string{"baz": "qux"}},
 			},
-			filter: "",
+			filter: nil,
 			expected: []mockObj{
 				{annotations: map[string]string{"foo": "bar"}},
 				{annotations: map[string]string{"baz": "qux"}},
 			},
 		},
 		{
-			name: "Matching items",
+			name: "empty selector returns all",
+			items: []mockObj{
+				{annotations: map[string]string{"foo": "bar"}},
+				{annotations: map[string]string{"baz": "qux"}},
+			},
+			filter: labels.Everything(),
+			expected: []mockObj{
+				{annotations: map[string]string{"foo": "bar"}},
+				{annotations: map[string]string{"baz": "qux"}},
+			},
+		},
+		{
+			name: "matching items",
 			items: []mockObj{
 				{annotations: map[string]string{"foo": "bar"}},
 				{annotations: map[string]string{"foo": "baz"}},
 			},
-			filter: "foo=bar",
+			filter: mustParseAnnotationFilter("foo=bar"),
 			expected: []mockObj{
 				{annotations: map[string]string{"foo": "bar"}},
 			},
 		},
 		{
-			name: "No matching items",
+			name: "no matching items",
 			items: []mockObj{
 				{annotations: map[string]string{"foo": "baz"}},
 			},
-			filter:   "foo=bar",
+			filter:   mustParseAnnotationFilter("foo=bar"),
 			expected: []mockObj{},
-		},
-		{
-			name: "Whitespace filter returns all",
-			items: []mockObj{
-				{annotations: map[string]string{"foo": "bar"}},
-				{annotations: map[string]string{"baz": "qux"}},
-			},
-			filter: "   ",
-			expected: []mockObj{
-				{annotations: map[string]string{"foo": "bar"}},
-				{annotations: map[string]string{"baz": "qux"}},
-			},
-		},
-		{
-			name: "empty filter returns all",
-			items: []mockObj{
-				{annotations: map[string]string{"foo": "bar"}},
-				{annotations: map[string]string{"baz": "qux"}},
-			},
-			filter: "",
-			expected: []mockObj{
-				{annotations: map[string]string{"foo": "bar"}},
-				{annotations: map[string]string{"baz": "qux"}},
-			},
-		},
-		{
-			name: "invalid filter returns error",
-			items: []mockObj{
-				{annotations: map[string]string{"foo": "bar"}},
-				{annotations: map[string]string{"baz": "qux"}},
-			},
-			filter: "=invalid",
-			expected: []mockObj{
-				{annotations: map[string]string{"foo": "bar"}},
-				{annotations: map[string]string{"baz": "qux"}},
-			},
-			expectError: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := Filter(tt.items, tt.filter)
-			if tt.expectError {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tt.expected, result)
-			}
+			result := Filter(tt.items, tt.filter)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
@@ -130,8 +108,7 @@ func TestFilter_LogOutput(t *testing.T) {
 		{annotations: map[string]string{"foo": "bar"}},
 		{annotations: map[string]string{"foo": "baz"}},
 	}
-	filter := "foo=bar"
-	_, _ = Filter(items, filter)
+	Filter(items, mustParseAnnotationFilter("foo=bar"))
 
 	logtest.TestHelperLogContains("filtered '1' services out of '2' with annotation filter 'foo=bar'", hook, t)
 }

--- a/source/contour_httpproxy.go
+++ b/source/contour_httpproxy.go
@@ -53,7 +53,7 @@ import (
 type httpProxySource struct {
 	dynamicKubeClient        dynamic.Interface
 	namespace                string
-	annotationFilter         string
+	annotationFilter         labels.Selector
 	templateEngine           template.Engine
 	ignoreHostnameAnnotation bool
 	httpProxyInformer        kubeinformers.GenericInformer
@@ -126,10 +126,7 @@ func (sc *httpProxySource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, e
 		httpProxies = append(httpProxies, hpConverted)
 	}
 
-	httpProxies, err = annotations.Filter(httpProxies, sc.annotationFilter)
-	if err != nil {
-		return nil, fmt.Errorf("failed to filter HTTPProxies: %w", err)
-	}
+	httpProxies = annotations.Filter(httpProxies, sc.annotationFilter)
 
 	endpoints := []*endpoint.Endpoint{}
 

--- a/source/contour_httpproxy_test.go
+++ b/source/contour_httpproxy_test.go
@@ -1024,7 +1024,7 @@ func testHTTPProxyEndpoints(t *testing.T) {
 				fakeDynamicClient,
 				&Config{
 					Namespace:                ti.targetNamespace,
-					AnnotationFilter:         mustParseAnnotationFilter(ti.annotationFilter),
+					AnnotationFilter:         parseAnnotationFilterOrNil(ti.annotationFilter),
 					TemplateEngine:           templatetest.MustEngine(t, ti.fqdnTemplate, "", "", ti.combineFQDNAndAnnotation),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 				},

--- a/source/contour_httpproxy_test.go
+++ b/source/contour_httpproxy_test.go
@@ -440,7 +440,7 @@ func testHTTPProxyEndpoints(t *testing.T) {
 			expected: []*endpoint.Endpoint{},
 		},
 		{
-			title:            "invalid annotation filter expression",
+			title:            "invalid annotation filter expression is silently ignored",
 			targetNamespace:  "",
 			annotationFilter: "contour.heptio.com/ingress.name in (a b)",
 			loadBalancer: fakeLoadBalancerService{
@@ -456,8 +456,13 @@ func testHTTPProxyEndpoints(t *testing.T) {
 					host: "example.org",
 				},
 			},
-			expected:    []*endpoint.Endpoint{},
-			expectError: true,
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeA,
+					Targets:    endpoint.Targets{"8.8.8.8"},
+				},
+			},
 		},
 		{
 			title:            "valid matching annotation filter label",
@@ -1019,7 +1024,7 @@ func testHTTPProxyEndpoints(t *testing.T) {
 				fakeDynamicClient,
 				&Config{
 					Namespace:                ti.targetNamespace,
-					AnnotationFilter:         ti.annotationFilter,
+					AnnotationFilter:         mustParseAnnotationFilter(ti.annotationFilter),
 					TemplateEngine:           templatetest.MustEngine(t, ti.fqdnTemplate, "", "", ti.combineFQDNAndAnnotation),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 				},

--- a/source/crd.go
+++ b/source/crd.go
@@ -32,7 +32,6 @@ import (
 	apiv1alpha1 "sigs.k8s.io/external-dns/apis/v1alpha1"
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/pkg/events"
-	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/source/informers"
 	"sigs.k8s.io/external-dns/source/types"
 )
@@ -59,11 +58,7 @@ type crdSource struct {
 // NewCRDSource creates a new crdSource backed by a controller-runtime cache.
 // It builds the scheme, cache, and status-write client from restConfig and cfg.
 func NewCRDSource(ctx context.Context, restConfig *rest.Config, cfg *Config) (Source, error) {
-	annotationSelector, err := annotations.ParseFilter(cfg.AnnotationFilter)
-	if err != nil {
-		return nil, err
-	}
-	opts, err := buildCacheOptions(cfg.Namespace, cfg.LabelFilter, annotationSelector)
+	opts, err := buildCacheOptions(cfg.Namespace, cfg.LabelFilter, cfg.AnnotationFilter)
 	if err != nil {
 		return nil, err
 	}

--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -881,18 +881,11 @@ func TestStartAndSync(t *testing.T) {
 // reached through newCrdSource (which uses fake caches and writers directly).
 func TestNewCRDSource(t *testing.T) {
 	tests := []struct {
-		name             string
-		annotationFilter string
-		makeRestCfg      func(t *testing.T) *rest.Config
-		ctxTimeout       time.Duration // 0 → use t.Context() as-is
-		wantErrContains  string
+		name            string
+		makeRestCfg     func(t *testing.T) *rest.Config
+		ctxTimeout      time.Duration // 0 → use t.Context() as-is
+		wantErrContains string
 	}{
-		{
-			name:             "annotation filter parse error",
-			annotationFilter: "!!!invalid",
-			makeRestCfg:      func(_ *testing.T) *rest.Config { return &rest.Config{Host: "http://ignored"} },
-			wantErrContains:  "couldn't parse the selector string",
-		},
 		{
 			// crcache.New and client.New share the same restConfig and the same
 			// HTTP-client construction path, so they can't be isolated: any config
@@ -924,7 +917,7 @@ func TestNewCRDSource(t *testing.T) {
 				ctx, cancel = context.WithTimeout(ctx, tc.ctxTimeout)
 				t.Cleanup(cancel)
 			}
-			_, err := NewCRDSource(ctx, tc.makeRestCfg(t), &Config{AnnotationFilter: tc.annotationFilter})
+			_, err := NewCRDSource(ctx, tc.makeRestCfg(t), &Config{})
 			require.ErrorContains(t, err, tc.wantErrContains)
 		})
 	}

--- a/source/f5_transportserver.go
+++ b/source/f5_transportserver.go
@@ -64,7 +64,7 @@ type f5TransportServerSource struct {
 	dynamicKubeClient       dynamic.Interface
 	transportServerInformer kubeinformers.GenericInformer
 	kubeClient              kubernetes.Interface
-	annotationFilter        string
+	annotationFilter        labels.Selector
 	namespace               string
 	templateEngine          template.Engine
 	unstructuredConverter   *unstructuredConverter
@@ -136,10 +136,7 @@ func (ts *f5TransportServerSource) Endpoints(_ context.Context) ([]*endpoint.End
 		transportServers = append(transportServers, transportServer)
 	}
 
-	transportServers, err = annotations.Filter(transportServers, ts.annotationFilter)
-	if err != nil {
-		return nil, fmt.Errorf("failed to filter TransportServers: %w", err)
-	}
+	transportServers = annotations.Filter(transportServers, ts.annotationFilter)
 
 	endpoints, err := ts.endpointsFromTransportServers(transportServers)
 	if err != nil {

--- a/source/f5_transportserver_test.go
+++ b/source/f5_transportserver_test.go
@@ -385,7 +385,7 @@ func TestF5TransportServerEndpoints(t *testing.T) {
 			source, err := NewF5TransportServerSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
 					Namespace:        defaultF5TransportServerNamespace,
-					AnnotationFilter: mustParseAnnotationFilter(tc.annotationFilter),
+					AnnotationFilter: parseAnnotationFilterOrNil(tc.annotationFilter),
 				})
 			require.NoError(t, err)
 			assert.NotNil(t, source)

--- a/source/f5_transportserver_test.go
+++ b/source/f5_transportserver_test.go
@@ -385,7 +385,7 @@ func TestF5TransportServerEndpoints(t *testing.T) {
 			source, err := NewF5TransportServerSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
 					Namespace:        defaultF5TransportServerNamespace,
-					AnnotationFilter: tc.annotationFilter,
+					AnnotationFilter: mustParseAnnotationFilter(tc.annotationFilter),
 				})
 			require.NoError(t, err)
 			assert.NotNil(t, source)

--- a/source/f5_virtualserver.go
+++ b/source/f5_virtualserver.go
@@ -63,7 +63,7 @@ type f5VirtualServerSource struct {
 	dynamicKubeClient     dynamic.Interface
 	virtualServerInformer kubeinformers.GenericInformer
 	kubeClient            kubernetes.Interface
-	annotationFilter      string
+	annotationFilter      labels.Selector
 	namespace             string
 	templateEngine        template.Engine
 	unstructuredConverter *unstructuredConverter
@@ -135,10 +135,7 @@ func (vs *f5VirtualServerSource) Endpoints(_ context.Context) ([]*endpoint.Endpo
 		virtualServers = append(virtualServers, virtualServer)
 	}
 
-	virtualServers, err = annotations.Filter(virtualServers, vs.annotationFilter)
-	if err != nil {
-		return nil, fmt.Errorf("failed to filter VirtualServers: %w", err)
-	}
+	virtualServers = annotations.Filter(virtualServers, vs.annotationFilter)
 
 	endpoints, err := vs.endpointsFromVirtualServers(virtualServers)
 	if err != nil {

--- a/source/f5_virtualserver_test.go
+++ b/source/f5_virtualserver_test.go
@@ -628,7 +628,7 @@ func TestF5VirtualServerEndpoints(t *testing.T) {
 			source, err := NewF5VirtualServerSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
 					Namespace:        defaultF5VirtualServerNamespace,
-					AnnotationFilter: mustParseAnnotationFilter(tc.annotationFilter),
+					AnnotationFilter: parseAnnotationFilterOrNil(tc.annotationFilter),
 				})
 			require.NoError(t, err)
 			assert.NotNil(t, source)

--- a/source/f5_virtualserver_test.go
+++ b/source/f5_virtualserver_test.go
@@ -628,7 +628,7 @@ func TestF5VirtualServerEndpoints(t *testing.T) {
 			source, err := NewF5VirtualServerSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
 					Namespace:        defaultF5VirtualServerNamespace,
-					AnnotationFilter: tc.annotationFilter,
+					AnnotationFilter: mustParseAnnotationFilter(tc.annotationFilter),
 				})
 			require.NoError(t, err)
 			assert.NotNil(t, source)

--- a/source/fake_test.go
+++ b/source/fake_test.go
@@ -24,10 +24,26 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/source/annotations"
 	templatetest "sigs.k8s.io/external-dns/source/template/testutil"
 )
+
+// mustParseAnnotationFilter parses an annotation filter string into a labels.Selector for use in tests.
+// Returns nil for empty or invalid input, matching the production behavior in NewSourceConfig
+// where invalid annotation filters are silently treated as no-op selectors.
+func mustParseAnnotationFilter(s string) labels.Selector {
+	if s == "" {
+		return nil
+	}
+	sel, err := annotations.ParseFilter(s)
+	if err != nil {
+		return nil
+	}
+	return sel
+}
 
 // Validate that fakeSource implements Source.
 var _ Source = &fakeSource{}

--- a/source/fake_test.go
+++ b/source/fake_test.go
@@ -31,10 +31,10 @@ import (
 	templatetest "sigs.k8s.io/external-dns/source/template/testutil"
 )
 
-// mustParseAnnotationFilter parses an annotation filter string into a labels.Selector for use in tests.
+// parseAnnotationFilterOrNil parses an annotation filter string into a labels.Selector for use in tests.
 // Returns nil for empty or invalid input, matching the production behavior in NewSourceConfig
 // where invalid annotation filters are silently treated as no-op selectors.
-func mustParseAnnotationFilter(s string) labels.Selector {
+func parseAnnotationFilterOrNil(s string) labels.Selector {
 	if s == "" {
 		return nil
 	}

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -158,7 +158,7 @@ func newGatewayRouteSource(
 	config *Config,
 	kind string,
 	newInformerFn newGatewayRouteInformerFunc) (Source, error) {
-	gwLabels, err := getLabelSelector(config.GatewayLabelFilter)
+	gwLabels, err := annotations.ParseFilter(config.GatewayLabelFilter)
 	if err != nil {
 		return nil, err
 	}

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -166,9 +166,9 @@ func newGatewayRouteSource(
 	if rtLabels == nil {
 		rtLabels = labels.Everything()
 	}
-	rtAnnotations, err := getLabelSelector(config.AnnotationFilter)
-	if err != nil {
-		return nil, err
+	rtAnnotations := config.AnnotationFilter
+	if rtAnnotations == nil {
+		rtAnnotations = labels.Everything()
 	}
 
 	client, err := clients.GatewayClient()

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -446,7 +446,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 		{
 			title: "RouteAnnotationFilter",
 			config: &Config{
-				AnnotationFilter: "foo=bar",
+				AnnotationFilter: mustParseAnnotationFilter("foo=bar"),
 			},
 			namespaces: namespaces("default"),
 			gateways: []*v1.Gateway{{

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -40,7 +40,7 @@ import (
 )
 
 func mustGetLabelSelector(s string) labels.Selector {
-	v, err := getLabelSelector(s)
+	v, err := annotations.ParseFilter(s)
 	if err != nil {
 		panic(err)
 	}
@@ -446,7 +446,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 		{
 			title: "RouteAnnotationFilter",
 			config: &Config{
-				AnnotationFilter: mustParseAnnotationFilter("foo=bar"),
+				AnnotationFilter: parseAnnotationFilterOrNil("foo=bar"),
 			},
 			namespaces: namespaces("default"),
 			gateways: []*v1.Gateway{{

--- a/source/gloo_proxy_test.go
+++ b/source/gloo_proxy_test.go
@@ -934,7 +934,7 @@ func TestGlooProxyIndexer(t *testing.T) {
 
 			src, err := NewGlooSource(t.Context(), dynClient, fakeKube.NewSimpleClientset(), &Config{
 				GlooNamespaces:   tt.glooNamespaces,
-				AnnotationFilter: mustParseAnnotationFilter(tt.annotationFilter),
+				AnnotationFilter: parseAnnotationFilterOrNil(tt.annotationFilter),
 				LabelFilter:      labelSel,
 			})
 			require.NoError(t, err)

--- a/source/gloo_proxy_test.go
+++ b/source/gloo_proxy_test.go
@@ -934,7 +934,7 @@ func TestGlooProxyIndexer(t *testing.T) {
 
 			src, err := NewGlooSource(t.Context(), dynClient, fakeKube.NewSimpleClientset(), &Config{
 				GlooNamespaces:   tt.glooNamespaces,
-				AnnotationFilter: tt.annotationFilter,
+				AnnotationFilter: mustParseAnnotationFilter(tt.annotationFilter),
 				LabelFilter:      labelSel,
 			})
 			require.NoError(t, err)

--- a/source/informers/indexers.go
+++ b/source/informers/indexers.go
@@ -21,8 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
-
-	"sigs.k8s.io/external-dns/source/annotations"
 )
 
 const (
@@ -39,16 +37,9 @@ type IndexSelectorOptions struct {
 	conditions      []func(metav1.Object) bool
 }
 
-func IndexSelectorWithAnnotationFilter(input string) func(options *IndexSelectorOptions) {
+func IndexSelectorWithAnnotationFilter(input labels.Selector) func(options *IndexSelectorOptions) {
 	return func(options *IndexSelectorOptions) {
-		if input == "" {
-			return
-		}
-		selector, err := annotations.ParseFilter(input)
-		if err != nil {
-			return
-		}
-		options.annotationFilter = selector
+		options.annotationFilter = input
 	}
 }
 

--- a/source/informers/indexers_test.go
+++ b/source/informers/indexers_test.go
@@ -29,8 +29,10 @@ import (
 )
 
 func TestIndexerWithOptions_FilterByAnnotation(t *testing.T) {
+	sel, err := annotations.ParseFilter("example-annotation")
+	require.NoError(t, err)
 	indexers := IndexerWithOptions[*unstructured.Unstructured](
-		IndexSelectorWithAnnotationFilter("example-annotation"),
+		IndexSelectorWithAnnotationFilter(sel),
 	)
 
 	obj := &unstructured.Unstructured{}
@@ -110,8 +112,10 @@ func TestIndexerWithOptions_EmptyOptions(t *testing.T) {
 }
 
 func TestIndexerWithOptions_AnnotationFilterNoMatch(t *testing.T) {
+	sel, err := annotations.ParseFilter("example-annotation=value")
+	require.NoError(t, err)
 	indexers := IndexerWithOptions[*unstructured.Unstructured](
-		IndexSelectorWithAnnotationFilter("example-annotation=value"),
+		IndexSelectorWithAnnotationFilter(sel),
 	)
 
 	obj := &unstructured.Unstructured{}
@@ -125,40 +129,20 @@ func TestIndexerWithOptions_AnnotationFilterNoMatch(t *testing.T) {
 }
 
 func TestIndexSelectorWithAnnotationFilter(t *testing.T) {
-	tests := []struct {
-		name           string
-		input          string
-		expectedFilter labels.Selector
-	}{
-		{
-			name:           "valid input",
-			input:          "key=value",
-			expectedFilter: func() labels.Selector { s, _ := annotations.ParseFilter("key=value"); return s }(),
-		},
-		{
-			name:           "empty input",
-			input:          "",
-			expectedFilter: nil,
-		},
-		{
-			name:           "key only filter",
-			input:          "app",
-			expectedFilter: func() labels.Selector { s, _ := annotations.ParseFilter("app"); return s }(),
-		},
-		{
-			name:           "poisoned input",
-			input:          "=app",
-			expectedFilter: nil,
-		},
-	}
+	sel, err := annotations.ParseFilter("key=value")
+	require.NoError(t, err)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			options := &IndexSelectorOptions{}
-			IndexSelectorWithAnnotationFilter(tt.input)(options)
-			assert.Equal(t, tt.expectedFilter, options.annotationFilter)
-		})
-	}
+	t.Run("stores selector in options", func(t *testing.T) {
+		options := &IndexSelectorOptions{}
+		IndexSelectorWithAnnotationFilter(sel)(options)
+		assert.Equal(t, sel, options.annotationFilter)
+	})
+
+	t.Run("nil selector stored as nil", func(t *testing.T) {
+		options := &IndexSelectorOptions{}
+		IndexSelectorWithAnnotationFilter(nil)(options)
+		assert.Nil(t, options.annotationFilter)
+	})
 }
 
 func TestIndexerWithOptions_LabelKey(t *testing.T) {
@@ -313,6 +297,9 @@ func TestListIndexed(t *testing.T) {
 }
 
 func TestIndexSelectorWithFunctions(t *testing.T) {
+	envProdSel, err := annotations.ParseFilter("env=prod")
+	require.NoError(t, err)
+
 	makePod := func(name, namespace string, labelsMap, annotationsMap map[string]string) *corev1.Pod {
 		p := &corev1.Pod{}
 		p.SetName(name)
@@ -385,7 +372,7 @@ func TestIndexSelectorWithFunctions(t *testing.T) {
 		{
 			name: "combined annotation and predicate both pass includes object",
 			indexers: IndexerWithOptions[*corev1.Pod](
-				IndexSelectorWithAnnotationFilter("env=prod"),
+				IndexSelectorWithAnnotationFilter(envProdSel),
 				IndexSelectorWithConditions(func(p *corev1.Pod) bool { return p.GetLabels()["app"] == "web" }),
 			),
 			obj:      makePod("p", "default", map[string]string{"app": "web"}, map[string]string{"env": "prod"}),
@@ -394,7 +381,7 @@ func TestIndexSelectorWithFunctions(t *testing.T) {
 		{
 			name: "combined annotation fails excludes object",
 			indexers: IndexerWithOptions[*corev1.Pod](
-				IndexSelectorWithAnnotationFilter("env=prod"),
+				IndexSelectorWithAnnotationFilter(envProdSel),
 				IndexSelectorWithConditions(func(p *corev1.Pod) bool { return p.GetLabels()["app"] == "web" }),
 			),
 			obj: makePod("p", "default", map[string]string{"app": "web"}, map[string]string{"env": "staging"}),
@@ -402,7 +389,7 @@ func TestIndexSelectorWithFunctions(t *testing.T) {
 		{
 			name: "combined predicate fails excludes object",
 			indexers: IndexerWithOptions[*corev1.Pod](
-				IndexSelectorWithAnnotationFilter("env=prod"),
+				IndexSelectorWithAnnotationFilter(envProdSel),
 				IndexSelectorWithConditions(func(p *corev1.Pod) bool { return p.GetLabels()["app"] == "web" }),
 			),
 			obj: makePod("p", "default", map[string]string{"app": "api"}, map[string]string{"env": "prod"}),

--- a/source/ingress.go
+++ b/source/ingress.go
@@ -78,13 +78,8 @@ func NewIngressSource(
 	cfg *Config) (Source, error) {
 	// ensure that ingress class is only set in either the ingressClassNames or
 	// annotationFilter but not both
-	if cfg.IngressClassNames != nil && cfg.AnnotationFilter != "" {
-		selector, err := getLabelSelector(cfg.AnnotationFilter)
-		if err != nil {
-			return nil, err
-		}
-
-		requirements, _ := selector.Requirements()
+	if cfg.IngressClassNames != nil && cfg.AnnotationFilter != nil && !cfg.AnnotationFilter.Empty() {
+		requirements, _ := cfg.AnnotationFilter.Requirements()
 		for _, requirement := range requirements {
 			if requirement.Key() == IngressClassAnnotationKey {
 				return nil, errors.New("--ingress-class is mutually exclusive with the kubernetes.io/ingress.class annotation filter")

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -125,7 +125,7 @@ func TestNewIngressSource(t *testing.T) {
 				t.Context(),
 				fake.NewClientset(),
 				&Config{
-					AnnotationFilter:  mustParseAnnotationFilter(ti.annotationFilter),
+					AnnotationFilter:  parseAnnotationFilterOrNil(ti.annotationFilter),
 					TemplateEngine:    templatetest.MustEngine(t, ti.fqdnTemplate, "", "", ti.combineFQDNAndAnnotation),
 					IngressClassNames: ti.ingressClassNames,
 				},
@@ -1424,7 +1424,7 @@ func testIngressEndpoints(t *testing.T) {
 				fakeClient,
 				&Config{
 					Namespace:                ti.targetNamespace,
-					AnnotationFilter:         mustParseAnnotationFilter(ti.annotationFilter),
+					AnnotationFilter:         parseAnnotationFilterOrNil(ti.annotationFilter),
 					TemplateEngine:           templatetest.MustEngine(t, ti.fqdnTemplate, "", "", ti.combineFQDNAndAnnotation),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 					IgnoreIngressTLSSpec:     ti.ignoreIngressTLSSpec,
@@ -2116,7 +2116,7 @@ func TestIngressIndexer(t *testing.T) {
 			}
 
 			src, err := NewIngressSource(t.Context(), client, &Config{
-				AnnotationFilter: mustParseAnnotationFilter(tt.annotationFilter),
+				AnnotationFilter: parseAnnotationFilterOrNil(tt.annotationFilter),
 				LabelFilter:      labelSel,
 				TemplateEngine:   templatetest.MustEngine(t, "", "", "", false),
 			})

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -125,7 +125,7 @@ func TestNewIngressSource(t *testing.T) {
 				t.Context(),
 				fake.NewClientset(),
 				&Config{
-					AnnotationFilter:  ti.annotationFilter,
+					AnnotationFilter:  mustParseAnnotationFilter(ti.annotationFilter),
 					TemplateEngine:    templatetest.MustEngine(t, ti.fqdnTemplate, "", "", ti.combineFQDNAndAnnotation),
 					IngressClassNames: ti.ingressClassNames,
 				},
@@ -1424,7 +1424,7 @@ func testIngressEndpoints(t *testing.T) {
 				fakeClient,
 				&Config{
 					Namespace:                ti.targetNamespace,
-					AnnotationFilter:         ti.annotationFilter,
+					AnnotationFilter:         mustParseAnnotationFilter(ti.annotationFilter),
 					TemplateEngine:           templatetest.MustEngine(t, ti.fqdnTemplate, "", "", ti.combineFQDNAndAnnotation),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 					IgnoreIngressTLSSpec:     ti.ignoreIngressTLSSpec,
@@ -1963,16 +1963,6 @@ func TestNewIngressSource_Errors(t *testing.T) {
 		wantErr string
 	}{
 		{
-			title: "getLabelSelector error propagates",
-			cfg: &Config{
-				IngressClassNames: []string{"nginx"},
-				AnnotationFilter:  "=invalid",
-				LabelFilter:       labels.Everything(),
-			},
-			ctx:     t.Context,
-			wantErr: "invalid",
-		},
-		{
 			title: "WaitForCacheSync error propagates",
 			cfg: &Config{
 				LabelFilter: labels.Everything(),
@@ -2126,7 +2116,7 @@ func TestIngressIndexer(t *testing.T) {
 			}
 
 			src, err := NewIngressSource(t.Context(), client, &Config{
-				AnnotationFilter: tt.annotationFilter,
+				AnnotationFilter: mustParseAnnotationFilter(tt.annotationFilter),
 				LabelFilter:      labelSel,
 				TemplateEngine:   templatetest.MustEngine(t, "", "", "", false),
 			})

--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -28,7 +28,6 @@ import (
 	networkingv1informer "istio.io/client-go/pkg/informers/externalversions/networking/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkv1 "k8s.io/api/networking/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	kubeinformers "k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	netinformers "k8s.io/client-go/informers/networking/v1"
@@ -62,7 +61,6 @@ var IstioGatewayIngressSource = annotations.Ingress
 // +externaldns:source:provider-specific=true
 type gatewaySource struct {
 	namespace                string
-	annotationFilter         labels.Selector
 	templateEngine           template.Engine
 	ignoreHostnameAnnotation bool
 	serviceInformer          coreinformers.ServiceInformer
@@ -123,7 +121,6 @@ func NewIstioGatewaySource(
 
 	return &gatewaySource{
 		namespace:                cfg.Namespace,
-		annotationFilter:         cfg.AnnotationFilter,
 		templateEngine:           cfg.TemplateEngine,
 		ignoreHostnameAnnotation: cfg.IgnoreHostnameAnnotation,
 		serviceInformer:          serviceInformer,

--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -28,6 +28,7 @@ import (
 	networkingv1informer "istio.io/client-go/pkg/informers/externalversions/networking/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	kubeinformers "k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	netinformers "k8s.io/client-go/informers/networking/v1"
@@ -61,7 +62,7 @@ var IstioGatewayIngressSource = annotations.Ingress
 // +externaldns:source:provider-specific=true
 type gatewaySource struct {
 	namespace                string
-	annotationFilter         string
+	annotationFilter         labels.Selector
 	templateEngine           template.Engine
 	ignoreHostnameAnnotation bool
 	serviceInformer          coreinformers.ServiceInformer

--- a/source/istio_gateway_fqdn_test.go
+++ b/source/istio_gateway_fqdn_test.go
@@ -58,7 +58,7 @@ func TestIstioGatewaySourceNewSourceWithFqdn(t *testing.T) {
 				istiofake.NewSimpleClientset(),
 				&Config{
 					Namespace:                "",
-					AnnotationFilter:         mustParseAnnotationFilter(tt.annotationFilter),
+					AnnotationFilter:         parseAnnotationFilterOrNil(tt.annotationFilter),
 					TemplateEngine:           templatetest.MustEngine(t, tt.fqdnTemplate, "", "", false),
 					IgnoreHostnameAnnotation: false,
 				},

--- a/source/istio_gateway_fqdn_test.go
+++ b/source/istio_gateway_fqdn_test.go
@@ -58,7 +58,7 @@ func TestIstioGatewaySourceNewSourceWithFqdn(t *testing.T) {
 				istiofake.NewSimpleClientset(),
 				&Config{
 					Namespace:                "",
-					AnnotationFilter:         tt.annotationFilter,
+					AnnotationFilter:         mustParseAnnotationFilter(tt.annotationFilter),
 					TemplateEngine:           templatetest.MustEngine(t, tt.fqdnTemplate, "", "", false),
 					IgnoreHostnameAnnotation: false,
 				},
@@ -565,7 +565,7 @@ func TestIstioGatewaySourceFqdnTemplatingExamples(t *testing.T) {
 				istioClient,
 				&Config{
 					Namespace:                "",
-					AnnotationFilter:         "",
+					AnnotationFilter:         nil,
 					TemplateEngine:           templatetest.MustEngine(t, tt.fqdnTemplate, "", "", !tt.combineFqdn),
 					IgnoreHostnameAnnotation: false,
 				},

--- a/source/istio_gateway_test.go
+++ b/source/istio_gateway_test.go
@@ -1499,7 +1499,7 @@ func testGatewayEndpoints(t *testing.T) {
 					Namespace:                targetNamespace,
 					TemplateEngine:           templatetest.MustEngine(t, ti.fqdnTemplate, "", "", ti.combineFQDNAndAnnotation),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
-					AnnotationFilter:         mustParseAnnotationFilter(ti.annotationFilter),
+					AnnotationFilter:         parseAnnotationFilterOrNil(ti.annotationFilter),
 					LabelFilter:              ti.labelFilter,
 				},
 			)

--- a/source/istio_gateway_test.go
+++ b/source/istio_gateway_test.go
@@ -1499,7 +1499,7 @@ func testGatewayEndpoints(t *testing.T) {
 					Namespace:                targetNamespace,
 					TemplateEngine:           templatetest.MustEngine(t, ti.fqdnTemplate, "", "", ti.combineFQDNAndAnnotation),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
-					AnnotationFilter:         ti.annotationFilter,
+					AnnotationFilter:         mustParseAnnotationFilter(ti.annotationFilter),
 					LabelFilter:              ti.labelFilter,
 				},
 			)

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -31,7 +31,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
 	kubeinformers "k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	netinformers "k8s.io/client-go/informers/networking/v1"
@@ -63,7 +62,6 @@ const IstioMeshGateway = "mesh"
 // +externaldns:source:provider-specific=true
 type virtualServiceSource struct {
 	namespace                string
-	annotationFilter         labels.Selector
 	templateEngine           template.Engine
 	ignoreHostnameAnnotation bool
 	serviceInformer          coreinformers.ServiceInformer
@@ -131,7 +129,6 @@ func NewIstioVirtualServiceSource(
 
 	return &virtualServiceSource{
 		namespace:                cfg.Namespace,
-		annotationFilter:         cfg.AnnotationFilter,
 		templateEngine:           cfg.TemplateEngine,
 		ignoreHostnameAnnotation: cfg.IgnoreHostnameAnnotation,
 		serviceInformer:          serviceInformer,

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	kubeinformers "k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	netinformers "k8s.io/client-go/informers/networking/v1"
@@ -62,7 +63,7 @@ const IstioMeshGateway = "mesh"
 // +externaldns:source:provider-specific=true
 type virtualServiceSource struct {
 	namespace                string
-	annotationFilter         string
+	annotationFilter         labels.Selector
 	templateEngine           template.Engine
 	ignoreHostnameAnnotation bool
 	serviceInformer          coreinformers.ServiceInformer

--- a/source/istio_virtualservice_fqdn_test.go
+++ b/source/istio_virtualservice_fqdn_test.go
@@ -57,7 +57,7 @@ func TestIstioVirtualServiceSourceNewSourceWithFqdn(t *testing.T) {
 				istiofake.NewSimpleClientset(),
 				&Config{
 					Namespace:                "",
-					AnnotationFilter:         "",
+					AnnotationFilter:         nil,
 					TemplateEngine:           templatetest.MustEngine(t, tt.fqdnTemplate, "", "", false),
 					IgnoreHostnameAnnotation: false,
 				},
@@ -732,7 +732,7 @@ func TestIstioVirtualServiceSourceFqdnTemplatingExamples(t *testing.T) {
 				istioClient,
 				&Config{
 					Namespace:                "",
-					AnnotationFilter:         "",
+					AnnotationFilter:         nil,
 					TemplateEngine:           templatetest.MustEngine(t, tt.fqdnTemplate, "", "", !tt.combineFqdn),
 					IgnoreHostnameAnnotation: false,
 				},

--- a/source/istio_virtualservice_test.go
+++ b/source/istio_virtualservice_test.go
@@ -2081,7 +2081,7 @@ func testVirtualServiceEndpoints(t *testing.T) {
 				fakeIstioClient,
 				&Config{
 					Namespace:                ti.targetNamespace,
-					AnnotationFilter:         ti.annotationFilter,
+					AnnotationFilter:         mustParseAnnotationFilter(ti.annotationFilter),
 					LabelFilter:              ti.labelFilter,
 					TemplateEngine:           templatetest.MustEngine(t, ti.fqdnTemplate, "", "", ti.combineFQDNAndAnnotation),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,

--- a/source/istio_virtualservice_test.go
+++ b/source/istio_virtualservice_test.go
@@ -2081,7 +2081,7 @@ func testVirtualServiceEndpoints(t *testing.T) {
 				fakeIstioClient,
 				&Config{
 					Namespace:                ti.targetNamespace,
-					AnnotationFilter:         mustParseAnnotationFilter(ti.annotationFilter),
+					AnnotationFilter:         parseAnnotationFilterOrNil(ti.annotationFilter),
 					LabelFilter:              ti.labelFilter,
 					TemplateEngine:           templatetest.MustEngine(t, ti.fqdnTemplate, "", "", ti.combineFQDNAndAnnotation),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,

--- a/source/kong_tcpingress.go
+++ b/source/kong_tcpingress.go
@@ -59,7 +59,7 @@ var kongGroupdVersionResource = schema.GroupVersionResource{
 // +externaldns:source:fqdn-template=false
 // +externaldns:source:provider-specific=true
 type kongTCPIngressSource struct {
-	annotationFilter         string
+	annotationFilter         labels.Selector
 	ignoreHostnameAnnotation bool
 	dynamicKubeClient        dynamic.Interface
 	kongTCPIngressInformer   kubeinformers.GenericInformer
@@ -133,10 +133,7 @@ func (sc *kongTCPIngressSource) Endpoints(_ context.Context) ([]*endpoint.Endpoi
 		tcpIngresses = append(tcpIngresses, tcpIngress)
 	}
 
-	tcpIngresses, err = annotations.Filter(tcpIngresses, sc.annotationFilter)
-	if err != nil {
-		return nil, fmt.Errorf("failed to filter TCPIngresses: %w", err)
-	}
+	tcpIngresses = annotations.Filter(tcpIngresses, sc.annotationFilter)
 
 	var endpoints []*endpoint.Endpoint
 	for _, tcpIngress := range tcpIngresses {

--- a/source/kong_tcpingress_test.go
+++ b/source/kong_tcpingress_test.go
@@ -412,7 +412,7 @@ func TestKongTCPIngressEndpoints(t *testing.T) {
 			source, err := NewKongTCPIngressSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
 					Namespace:                defaultKongNamespace,
-					AnnotationFilter:         "kubernetes.io/ingress.class=kong",
+					AnnotationFilter:         mustParseAnnotationFilter("kubernetes.io/ingress.class=kong"),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 				})
 			assert.NoError(t, err)

--- a/source/kong_tcpingress_test.go
+++ b/source/kong_tcpingress_test.go
@@ -412,7 +412,7 @@ func TestKongTCPIngressEndpoints(t *testing.T) {
 			source, err := NewKongTCPIngressSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
 					Namespace:                defaultKongNamespace,
-					AnnotationFilter:         mustParseAnnotationFilter("kubernetes.io/ingress.class=kong"),
+					AnnotationFilter:         parseAnnotationFilterOrNil("kubernetes.io/ingress.class=kong"),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 				})
 			assert.NoError(t, err)

--- a/source/node_test.go
+++ b/source/node_test.go
@@ -395,7 +395,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 				t.Context(),
 				kubeClient,
 				&Config{
-					AnnotationFilter:     tc.annotationFilter,
+					AnnotationFilter:     mustParseAnnotationFilter(tc.annotationFilter),
 					TemplateEngine:       templatetest.MustEngine(t, tc.fqdnTemplate, "", "", false),
 					LabelFilter:          labelSelector,
 					ExposeInternalIPv6:   tc.exposeInternalIPv6,
@@ -509,7 +509,7 @@ func testNodeEndpointsWithIPv6(t *testing.T) {
 			t.Context(),
 			kubeClient,
 			&Config{
-				AnnotationFilter:     tc.annotationFilter,
+				AnnotationFilter:     mustParseAnnotationFilter(tc.annotationFilter),
 				TemplateEngine:       templatetest.MustEngine(t, tc.fqdnTemplate, "", "", false),
 				LabelFilter:          labelSelector,
 				ExposeInternalIPv6:   tc.exposeInternalIPv6,
@@ -829,7 +829,7 @@ func TestNodeIndexer(t *testing.T) {
 			}
 
 			src, err := NewNodeSource(t.Context(), client, &Config{
-				AnnotationFilter: tt.annotationFilter,
+				AnnotationFilter: mustParseAnnotationFilter(tt.annotationFilter),
 				LabelFilter:      labelSel,
 				TemplateEngine:   templatetest.MustEngine(t, "", "", "", false),
 			})

--- a/source/node_test.go
+++ b/source/node_test.go
@@ -395,7 +395,7 @@ func testNodeSourceEndpoints(t *testing.T) {
 				t.Context(),
 				kubeClient,
 				&Config{
-					AnnotationFilter:     mustParseAnnotationFilter(tc.annotationFilter),
+					AnnotationFilter:     parseAnnotationFilterOrNil(tc.annotationFilter),
 					TemplateEngine:       templatetest.MustEngine(t, tc.fqdnTemplate, "", "", false),
 					LabelFilter:          labelSelector,
 					ExposeInternalIPv6:   tc.exposeInternalIPv6,
@@ -509,7 +509,7 @@ func testNodeEndpointsWithIPv6(t *testing.T) {
 			t.Context(),
 			kubeClient,
 			&Config{
-				AnnotationFilter:     mustParseAnnotationFilter(tc.annotationFilter),
+				AnnotationFilter:     parseAnnotationFilterOrNil(tc.annotationFilter),
 				TemplateEngine:       templatetest.MustEngine(t, tc.fqdnTemplate, "", "", false),
 				LabelFilter:          labelSelector,
 				ExposeInternalIPv6:   tc.exposeInternalIPv6,
@@ -829,7 +829,7 @@ func TestNodeIndexer(t *testing.T) {
 			}
 
 			src, err := NewNodeSource(t.Context(), client, &Config{
-				AnnotationFilter: mustParseAnnotationFilter(tt.annotationFilter),
+				AnnotationFilter: parseAnnotationFilterOrNil(tt.annotationFilter),
 				LabelFilter:      labelSel,
 				TemplateEngine:   templatetest.MustEngine(t, "", "", "", false),
 			})

--- a/source/openshift_route.go
+++ b/source/openshift_route.go
@@ -55,7 +55,7 @@ import (
 type ocpRouteSource struct {
 	client                   versioned.Interface
 	namespace                string
-	annotationFilter         string
+	annotationFilter         labels.Selector
 	templateEngine           template.Engine
 	ignoreHostnameAnnotation bool
 	routeInformer            routeInformer.RouteInformer
@@ -118,10 +118,7 @@ func (ors *ocpRouteSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, e
 		return nil, err
 	}
 
-	ocpRoutes, err = annotations.Filter(ocpRoutes, ors.annotationFilter)
-	if err != nil {
-		return nil, err
-	}
+	ocpRoutes = annotations.Filter(ocpRoutes, ors.annotationFilter)
 
 	endpoints := []*endpoint.Endpoint{}
 

--- a/source/openshift_route_fqdn_test.go
+++ b/source/openshift_route_fqdn_test.go
@@ -342,7 +342,7 @@ func TestOpenShiftFqdnTemplatingExamples(t *testing.T) {
 				kubeClient,
 				&Config{
 					Namespace:        "",
-					AnnotationFilter: "",
+					AnnotationFilter: nil,
 					TemplateEngine:   templatetest.MustEngine(t, tt.fqdnTemplate, "", "", !tt.combineFqdn),
 					LabelFilter:      labels.Everything(),
 					OCPRouterName:    "",

--- a/source/pod_indexer_test.go
+++ b/source/pod_indexer_test.go
@@ -223,7 +223,7 @@ func TestPodsWithAnnotationsAndLabels(t *testing.T) {
 				&Config{
 					Namespace:        tt.namespace,
 					TemplateEngine:   templatetest.MustEngine(t, "{{ .Name }}.tld.org", "", "", false),
-					AnnotationFilter: tt.annotationFilter,
+					AnnotationFilter: mustParseAnnotationFilter(tt.annotationFilter),
 					LabelFilter:      selector,
 				})
 			require.NoError(t, err)

--- a/source/pod_indexer_test.go
+++ b/source/pod_indexer_test.go
@@ -223,7 +223,7 @@ func TestPodsWithAnnotationsAndLabels(t *testing.T) {
 				&Config{
 					Namespace:        tt.namespace,
 					TemplateEngine:   templatetest.MustEngine(t, "{{ .Name }}.tld.org", "", "", false),
-					AnnotationFilter: mustParseAnnotationFilter(tt.annotationFilter),
+					AnnotationFilter: parseAnnotationFilterOrNil(tt.annotationFilter),
 					LabelFilter:      selector,
 				})
 			require.NoError(t, err)

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -1092,7 +1092,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			client, err := NewServiceSource(t.Context(), kubernetes,
 				&Config{
 					TemplateEngine:              templatetest.MustEngine(t, tc.fqdnTemplate, "", "", tc.combineFQDNAndAnnotation),
-					AnnotationFilter:            tc.annotationFilter,
+					AnnotationFilter:            mustParseAnnotationFilter(tc.annotationFilter),
 					ServiceTypeFilter:           tc.serviceTypesFilter,
 					Compatibility:               tc.compatibility,
 					Namespace:                   tc.targetNamespace,
@@ -1302,7 +1302,7 @@ func testMultipleServicesEndpoints(t *testing.T) {
 			client, err := NewServiceSource(t.Context(), kubernetes,
 				&Config{
 					TemplateEngine:           templatetest.MustEngine(t, tc.fqdnTemplate, "", "", tc.combineFQDNAndAnnotation),
-					AnnotationFilter:         tc.annotationFilter,
+					AnnotationFilter:         mustParseAnnotationFilter(tc.annotationFilter),
 					ServiceTypeFilter:        tc.serviceTypesFilter,
 					Compatibility:            tc.compatibility,
 					Namespace:                tc.targetNamespace,
@@ -1598,7 +1598,7 @@ func TestClusterIpServices(t *testing.T) {
 			client, _ := NewServiceSource(t.Context(), kubernetes,
 				&Config{
 					TemplateEngine:           templatetest.MustEngine(t, tc.fqdnTemplate, "", "", false),
-					AnnotationFilter:         tc.annotationFilter,
+					AnnotationFilter:         mustParseAnnotationFilter(tc.annotationFilter),
 					Compatibility:            tc.compatibility,
 					Namespace:                tc.targetNamespace,
 					PublishInternal:          true,
@@ -2455,7 +2455,7 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 			client, _ := NewServiceSource(t.Context(), kubernetes,
 				&Config{
 					TemplateEngine:           templatetest.MustEngine(t, tc.fqdnTemplate, "", "", false),
-					AnnotationFilter:         tc.annotationFilter,
+					AnnotationFilter:         mustParseAnnotationFilter(tc.annotationFilter),
 					Compatibility:            tc.compatibility,
 					Namespace:                tc.targetNamespace,
 					IgnoreHostnameAnnotation: tc.ignoreHostnameAnnotation,
@@ -6030,7 +6030,7 @@ func TestServiceIndexer(t *testing.T) {
 			}
 
 			src, err := NewServiceSource(t.Context(), client, &Config{
-				AnnotationFilter:  tt.annotationFilter,
+				AnnotationFilter:  mustParseAnnotationFilter(tt.annotationFilter),
 				LabelFilter:       labelSel,
 				ServiceTypeFilter: tt.serviceTypeFilter,
 			})

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -1092,7 +1092,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			client, err := NewServiceSource(t.Context(), kubernetes,
 				&Config{
 					TemplateEngine:              templatetest.MustEngine(t, tc.fqdnTemplate, "", "", tc.combineFQDNAndAnnotation),
-					AnnotationFilter:            mustParseAnnotationFilter(tc.annotationFilter),
+					AnnotationFilter:            parseAnnotationFilterOrNil(tc.annotationFilter),
 					ServiceTypeFilter:           tc.serviceTypesFilter,
 					Compatibility:               tc.compatibility,
 					Namespace:                   tc.targetNamespace,
@@ -1302,7 +1302,7 @@ func testMultipleServicesEndpoints(t *testing.T) {
 			client, err := NewServiceSource(t.Context(), kubernetes,
 				&Config{
 					TemplateEngine:           templatetest.MustEngine(t, tc.fqdnTemplate, "", "", tc.combineFQDNAndAnnotation),
-					AnnotationFilter:         mustParseAnnotationFilter(tc.annotationFilter),
+					AnnotationFilter:         parseAnnotationFilterOrNil(tc.annotationFilter),
 					ServiceTypeFilter:        tc.serviceTypesFilter,
 					Compatibility:            tc.compatibility,
 					Namespace:                tc.targetNamespace,
@@ -1598,7 +1598,7 @@ func TestClusterIpServices(t *testing.T) {
 			client, _ := NewServiceSource(t.Context(), kubernetes,
 				&Config{
 					TemplateEngine:           templatetest.MustEngine(t, tc.fqdnTemplate, "", "", false),
-					AnnotationFilter:         mustParseAnnotationFilter(tc.annotationFilter),
+					AnnotationFilter:         parseAnnotationFilterOrNil(tc.annotationFilter),
 					Compatibility:            tc.compatibility,
 					Namespace:                tc.targetNamespace,
 					PublishInternal:          true,
@@ -2455,7 +2455,7 @@ func TestServiceSourceNodePortServices(t *testing.T) {
 			client, _ := NewServiceSource(t.Context(), kubernetes,
 				&Config{
 					TemplateEngine:           templatetest.MustEngine(t, tc.fqdnTemplate, "", "", false),
-					AnnotationFilter:         mustParseAnnotationFilter(tc.annotationFilter),
+					AnnotationFilter:         parseAnnotationFilterOrNil(tc.annotationFilter),
 					Compatibility:            tc.compatibility,
 					Namespace:                tc.targetNamespace,
 					IgnoreHostnameAnnotation: tc.ignoreHostnameAnnotation,
@@ -6030,7 +6030,7 @@ func TestServiceIndexer(t *testing.T) {
 			}
 
 			src, err := NewServiceSource(t.Context(), client, &Config{
-				AnnotationFilter:  mustParseAnnotationFilter(tt.annotationFilter),
+				AnnotationFilter:  parseAnnotationFilterOrNil(tt.annotationFilter),
 				LabelFilter:       labelSel,
 				ServiceTypeFilter: tt.serviceTypeFilter,
 			})

--- a/source/skipper_routegroup.go
+++ b/source/skipper_routegroup.go
@@ -32,6 +32,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"sigs.k8s.io/external-dns/source/types"
@@ -63,7 +64,7 @@ type routeGroupSource struct {
 	apiServer                string
 	namespace                string
 	apiEndpoint              string
-	annotationFilter         string
+	annotationFilter         labels.Selector
 	templateEngine           template.Engine
 	ignoreHostnameAnnotation bool
 }
@@ -250,10 +251,7 @@ func (sc *routeGroupSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, 
 		return nil, err
 	}
 
-	filtered, err := annotations.Filter(rgList.Items, sc.annotationFilter)
-	if err != nil {
-		return nil, err
-	}
+	filtered := annotations.Filter(rgList.Items, sc.annotationFilter)
 
 	endpoints := []*endpoint.Endpoint{}
 	for _, rg := range filtered {

--- a/source/skipper_routegroup_test.go
+++ b/source/skipper_routegroup_test.go
@@ -626,7 +626,7 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 		{
 			name: "multiple routegroups with filter annotations should return only filtered endpoints",
 			source: &routeGroupSource{
-				annotationFilter: mustParseAnnotationFilter("kubernetes.io/ingress.class=skipper"),
+				annotationFilter: parseAnnotationFilterOrNil("kubernetes.io/ingress.class=skipper"),
 				cli: &fakeRouteGroupClient{
 					rg: &routeGroupList{
 						Items: []*routeGroup{
@@ -695,7 +695,7 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 		{
 			name: "multiple routegroups with set operation annotation filter should return only filtered endpoints",
 			source: &routeGroupSource{
-				annotationFilter: mustParseAnnotationFilter("kubernetes.io/ingress.class in (nginx, skipper)"),
+				annotationFilter: parseAnnotationFilterOrNil("kubernetes.io/ingress.class in (nginx, skipper)"),
 				cli: &fakeRouteGroupClient{
 					rg: &routeGroupList{
 						Items: []*routeGroup{

--- a/source/skipper_routegroup_test.go
+++ b/source/skipper_routegroup_test.go
@@ -626,7 +626,7 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 		{
 			name: "multiple routegroups with filter annotations should return only filtered endpoints",
 			source: &routeGroupSource{
-				annotationFilter: "kubernetes.io/ingress.class=skipper",
+				annotationFilter: mustParseAnnotationFilter("kubernetes.io/ingress.class=skipper"),
 				cli: &fakeRouteGroupClient{
 					rg: &routeGroupList{
 						Items: []*routeGroup{
@@ -695,7 +695,7 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 		{
 			name: "multiple routegroups with set operation annotation filter should return only filtered endpoints",
 			source: &routeGroupSource{
-				annotationFilter: "kubernetes.io/ingress.class in (nginx, skipper)",
+				annotationFilter: mustParseAnnotationFilter("kubernetes.io/ingress.class in (nginx, skipper)"),
 				cli: &fakeRouteGroupClient{
 					rg: &routeGroupList{
 						Items: []*routeGroup{

--- a/source/source.go
+++ b/source/source.go
@@ -52,14 +52,6 @@ func getEndpointsTypeFromAnnotations(annots map[string]string) string {
 	return annots[annotations.EndpointsTypeKey]
 }
 
-func getLabelSelector(annotationFilter string) (labels.Selector, error) {
-	labelSelector, err := metav1.ParseToLabelSelector(annotationFilter)
-	if err != nil {
-		return nil, err
-	}
-	return metav1.LabelSelectorAsSelector(labelSelector)
-}
-
 func matchLabelSelector(selector labels.Selector, srcAnnotations map[string]string) bool {
 	return selector.Matches(labels.Set(srcAnnotations))
 }

--- a/source/source_test.go
+++ b/source/source_test.go
@@ -40,39 +40,6 @@ func TestEventHandlerFunc(t *testing.T) {
 	}
 }
 
-func TestGetLabelSelector(t *testing.T) {
-	tests := []struct {
-		name             string
-		annotationFilter string
-		expectError      bool
-		expectedSelector string
-	}{
-		{
-			name:             "Valid label selector",
-			annotationFilter: "key1=value1,key2=value2",
-			expectedSelector: "key1=value1,key2=value2",
-		},
-		{
-			name:             "Invalid label selector",
-			annotationFilter: "key1==value1",
-			expectedSelector: "key1=value1",
-		},
-		{
-			name:             "Empty label selector",
-			annotationFilter: "",
-			expectedSelector: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			selector, err := getLabelSelector(tt.annotationFilter)
-			assert.NoError(t, err)
-			assert.Equal(t, tt.expectedSelector, selector.String())
-		})
-	}
-}
-
 func TestMatchLabelSelector(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/source/store.go
+++ b/source/store.go
@@ -34,6 +34,7 @@ import (
 
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	kubeclient "sigs.k8s.io/external-dns/pkg/client"
+	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/source/template"
 	"sigs.k8s.io/external-dns/source/types"
 )
@@ -48,7 +49,7 @@ var ErrSourceNotFound = errors.New("source not found")
 //
 // Common Configuration Fields:
 // - Namespace: Target namespace for source operations
-// - AnnotationFilter: Filter sources by annotation patterns
+// - AnnotationFilter: Filter sources by annotation selector
 // - LabelFilter: Filter sources by label selectors
 // - FQDNTemplate: Template for generating fully qualified domain names
 // - CombineFQDNAndAnnotation: Whether to combine FQDN template with annotations
@@ -58,7 +59,7 @@ var ErrSourceNotFound = errors.New("source not found")
 // type conversions and validation.
 type Config struct {
 	Namespace                      string
-	AnnotationFilter               string
+	AnnotationFilter               labels.Selector
 	LabelFilter                    labels.Selector
 	IngressClassNames              []string
 	TemplateEngine                 template.Engine
@@ -126,15 +127,16 @@ func WithClientGenerator(gen ClientGenerator) OverrideConfigOption {
 }
 
 func NewSourceConfig(cfg *externaldns.Config, opts ...OverrideConfigOption) (*Config, error) {
-	// error is explicitly ignored because the filter is already validated in validation.ValidateConfig
+	// errors are explicitly ignored because the filters are already validated in validation.ValidateConfig
 	labelSelector, _ := labels.Parse(cfg.LabelFilter)
+	annotationSelector, _ := annotations.ParseFilter(cfg.AnnotationFilter)
 	tmpls, err := template.NewEngine(cfg.FQDNTemplate, cfg.TargetTemplate, cfg.FQDNTargetTemplate, cfg.CombineFQDNAndAnnotation)
 	if err != nil {
 		return nil, err
 	}
 	c := &Config{
 		Namespace:                      cfg.Namespace,
-		AnnotationFilter:               cfg.AnnotationFilter,
+		AnnotationFilter:               annotationSelector,
 		LabelFilter:                    labelSelector,
 		IngressClassNames:              cfg.IngressClassNames,
 		IgnoreHostnameAnnotation:       cfg.IgnoreHostnameAnnotation,

--- a/source/traefik_proxy.go
+++ b/source/traefik_proxy.go
@@ -95,7 +95,7 @@ var (
 type traefikSource struct {
 	dynamicKubeClient          dynamic.Interface
 	kubeClient                 kubernetes.Interface
-	annotationFilter           string
+	annotationFilter           labels.Selector
 	namespace                  string
 	ignoreHostnameAnnotation   bool
 	templateEngine             template.Engine
@@ -279,10 +279,7 @@ func (ts *traefikSource) ingressRouteTCPEndpoints() ([]*endpoint.Endpoint, error
 		ingressRouteTCPs = append(ingressRouteTCPs, ingressRouteTCP)
 	}
 
-	ingressRouteTCPs, err = annotations.Filter(ingressRouteTCPs, ts.annotationFilter)
-	if err != nil {
-		return nil, fmt.Errorf("failed to filter IngressRouteTCP: %w", err)
-	}
+	ingressRouteTCPs = annotations.Filter(ingressRouteTCPs, ts.annotationFilter)
 
 	for _, ingressRouteTCP := range ingressRouteTCPs {
 		var targets endpoint.Targets
@@ -860,7 +857,7 @@ func extractEndpoints[T interface {
 	informer cache.GenericLister,
 	namespace string,
 	convertFunc func(*unstructured.Unstructured) (T, error),
-	annotationFilter string,
+	annotationFilter labels.Selector,
 	generateEndpoints func(T, endpoint.Targets) ([]*endpoint.Endpoint, error),
 ) ([]*endpoint.Endpoint, error) {
 	var endpoints []*endpoint.Endpoint
@@ -885,10 +882,7 @@ func extractEndpoints[T interface {
 		typedObjs = append(typedObjs, typed)
 	}
 
-	typedObjs, err = annotations.Filter(typedObjs, annotationFilter)
-	if err != nil {
-		return nil, err
-	}
+	typedObjs = annotations.Filter(typedObjs, annotationFilter)
 
 	for _, item := range typedObjs {
 		targets := annotations.TargetsFromTargetAnnotation(item.GetAnnotations())

--- a/source/traefik_proxy_fqdn_test.go
+++ b/source/traefik_proxy_fqdn_test.go
@@ -221,7 +221,7 @@ func TestTraefikFQDNTemplateIngressRoute(t *testing.T) {
 
 			src, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubeClient, &Config{
 				Namespace:        defaultTraefikNamespace,
-				AnnotationFilter: mustParseAnnotationFilter("kubernetes.io/ingress.class=traefik"),
+				AnnotationFilter: parseAnnotationFilterOrNil("kubernetes.io/ingress.class=traefik"),
 				TemplateEngine:   templatetest.MustEngine(t, tt.fqdnTemplate, tt.targetTemplate, tt.fqdnTargetTemplate, tt.combine),
 			})
 			require.NoError(t, err)
@@ -395,7 +395,7 @@ func TestTraefikFQDNTemplateIngressRouteTCP(t *testing.T) {
 
 			src, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubeClient, &Config{
 				Namespace:        defaultTraefikNamespace,
-				AnnotationFilter: mustParseAnnotationFilter("kubernetes.io/ingress.class=traefik"),
+				AnnotationFilter: parseAnnotationFilterOrNil("kubernetes.io/ingress.class=traefik"),
 				TemplateEngine:   templatetest.MustEngine(t, tt.fqdnTemplate, tt.targetTemplate, tt.fqdnTargetTemplate, tt.combine),
 			})
 			require.NoError(t, err)
@@ -565,7 +565,7 @@ func TestTraefikFQDNTemplateIngressRouteUDP(t *testing.T) {
 
 			src, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubeClient, &Config{
 				Namespace:        defaultTraefikNamespace,
-				AnnotationFilter: mustParseAnnotationFilter("kubernetes.io/ingress.class=traefik"),
+				AnnotationFilter: parseAnnotationFilterOrNil("kubernetes.io/ingress.class=traefik"),
 				TemplateEngine:   templatetest.MustEngine(t, tt.fqdnTemplate, tt.targetTemplate, tt.fqdnTargetTemplate, tt.combine),
 			})
 			require.NoError(t, err)

--- a/source/traefik_proxy_fqdn_test.go
+++ b/source/traefik_proxy_fqdn_test.go
@@ -221,7 +221,7 @@ func TestTraefikFQDNTemplateIngressRoute(t *testing.T) {
 
 			src, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubeClient, &Config{
 				Namespace:        defaultTraefikNamespace,
-				AnnotationFilter: "kubernetes.io/ingress.class=traefik",
+				AnnotationFilter: mustParseAnnotationFilter("kubernetes.io/ingress.class=traefik"),
 				TemplateEngine:   templatetest.MustEngine(t, tt.fqdnTemplate, tt.targetTemplate, tt.fqdnTargetTemplate, tt.combine),
 			})
 			require.NoError(t, err)
@@ -395,7 +395,7 @@ func TestTraefikFQDNTemplateIngressRouteTCP(t *testing.T) {
 
 			src, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubeClient, &Config{
 				Namespace:        defaultTraefikNamespace,
-				AnnotationFilter: "kubernetes.io/ingress.class=traefik",
+				AnnotationFilter: mustParseAnnotationFilter("kubernetes.io/ingress.class=traefik"),
 				TemplateEngine:   templatetest.MustEngine(t, tt.fqdnTemplate, tt.targetTemplate, tt.fqdnTargetTemplate, tt.combine),
 			})
 			require.NoError(t, err)
@@ -565,7 +565,7 @@ func TestTraefikFQDNTemplateIngressRouteUDP(t *testing.T) {
 
 			src, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubeClient, &Config{
 				Namespace:        defaultTraefikNamespace,
-				AnnotationFilter: "kubernetes.io/ingress.class=traefik",
+				AnnotationFilter: mustParseAnnotationFilter("kubernetes.io/ingress.class=traefik"),
 				TemplateEngine:   templatetest.MustEngine(t, tt.fqdnTemplate, tt.targetTemplate, tt.fqdnTargetTemplate, tt.combine),
 			})
 			require.NoError(t, err)

--- a/source/traefik_proxy_test.go
+++ b/source/traefik_proxy_test.go
@@ -395,7 +395,7 @@ func TestTraefikProxyIngressRouteEndpoints(t *testing.T) {
 			source, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
 					Namespace:                defaultTraefikNamespace,
-					AnnotationFilter:         "kubernetes.io/ingress.class=traefik",
+					AnnotationFilter:         mustParseAnnotationFilter("kubernetes.io/ingress.class=traefik"),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 				})
 			assert.NoError(t, err)
@@ -692,7 +692,7 @@ func TestTraefikProxyIngressRouteTCPEndpoints(t *testing.T) {
 			source, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
 					Namespace:                defaultTraefikNamespace,
-					AnnotationFilter:         "kubernetes.io/ingress.class=traefik",
+					AnnotationFilter:         mustParseAnnotationFilter("kubernetes.io/ingress.class=traefik"),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 				})
 			require.NoError(t, err)
@@ -837,7 +837,7 @@ func TestTraefikProxyIngressRouteUDPEndpoints(t *testing.T) {
 			source, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
 					Namespace:                defaultTraefikNamespace,
-					AnnotationFilter:         "kubernetes.io/ingress.class=traefik",
+					AnnotationFilter:         mustParseAnnotationFilter("kubernetes.io/ingress.class=traefik"),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 				})
 			assert.NoError(t, err)
@@ -1170,7 +1170,7 @@ func TestTraefikProxyOldIngressRouteEndpoints(t *testing.T) {
 			source, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
 					Namespace:                defaultTraefikNamespace,
-					AnnotationFilter:         "kubernetes.io/ingress.class=traefik",
+					AnnotationFilter:         mustParseAnnotationFilter("kubernetes.io/ingress.class=traefik"),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 					TraefikEnableLegacy:      true,
 				})
@@ -1468,7 +1468,7 @@ func TestTraefikProxyOldIngressRouteTCPEndpoints(t *testing.T) {
 			source, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
 					Namespace:                defaultTraefikNamespace,
-					AnnotationFilter:         "kubernetes.io/ingress.class=traefik",
+					AnnotationFilter:         mustParseAnnotationFilter("kubernetes.io/ingress.class=traefik"),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 					TraefikEnableLegacy:      true,
 				})
@@ -1614,7 +1614,7 @@ func TestTraefikProxyOldIngressRouteUDPEndpoints(t *testing.T) {
 			source, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
 					Namespace:                defaultTraefikNamespace,
-					AnnotationFilter:         "kubernetes.io/ingress.class=traefik",
+					AnnotationFilter:         mustParseAnnotationFilter("kubernetes.io/ingress.class=traefik"),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 					TraefikEnableLegacy:      true,
 				})
@@ -1781,7 +1781,7 @@ func TestTraefikAPIGroupFlags(t *testing.T) {
 			source, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
 					Namespace:                defaultTraefikNamespace,
-					AnnotationFilter:         "kubernetes.io/ingress.class=traefik",
+					AnnotationFilter:         mustParseAnnotationFilter("kubernetes.io/ingress.class=traefik"),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 					TraefikEnableLegacy:      ti.enableLegacy,
 					TraefikDisableNew:        ti.disableNew,

--- a/source/traefik_proxy_test.go
+++ b/source/traefik_proxy_test.go
@@ -395,7 +395,7 @@ func TestTraefikProxyIngressRouteEndpoints(t *testing.T) {
 			source, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
 					Namespace:                defaultTraefikNamespace,
-					AnnotationFilter:         mustParseAnnotationFilter("kubernetes.io/ingress.class=traefik"),
+					AnnotationFilter:         parseAnnotationFilterOrNil("kubernetes.io/ingress.class=traefik"),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 				})
 			assert.NoError(t, err)
@@ -692,7 +692,7 @@ func TestTraefikProxyIngressRouteTCPEndpoints(t *testing.T) {
 			source, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
 					Namespace:                defaultTraefikNamespace,
-					AnnotationFilter:         mustParseAnnotationFilter("kubernetes.io/ingress.class=traefik"),
+					AnnotationFilter:         parseAnnotationFilterOrNil("kubernetes.io/ingress.class=traefik"),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 				})
 			require.NoError(t, err)
@@ -837,7 +837,7 @@ func TestTraefikProxyIngressRouteUDPEndpoints(t *testing.T) {
 			source, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
 					Namespace:                defaultTraefikNamespace,
-					AnnotationFilter:         mustParseAnnotationFilter("kubernetes.io/ingress.class=traefik"),
+					AnnotationFilter:         parseAnnotationFilterOrNil("kubernetes.io/ingress.class=traefik"),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 				})
 			assert.NoError(t, err)
@@ -1170,7 +1170,7 @@ func TestTraefikProxyOldIngressRouteEndpoints(t *testing.T) {
 			source, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
 					Namespace:                defaultTraefikNamespace,
-					AnnotationFilter:         mustParseAnnotationFilter("kubernetes.io/ingress.class=traefik"),
+					AnnotationFilter:         parseAnnotationFilterOrNil("kubernetes.io/ingress.class=traefik"),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 					TraefikEnableLegacy:      true,
 				})
@@ -1468,7 +1468,7 @@ func TestTraefikProxyOldIngressRouteTCPEndpoints(t *testing.T) {
 			source, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
 					Namespace:                defaultTraefikNamespace,
-					AnnotationFilter:         mustParseAnnotationFilter("kubernetes.io/ingress.class=traefik"),
+					AnnotationFilter:         parseAnnotationFilterOrNil("kubernetes.io/ingress.class=traefik"),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 					TraefikEnableLegacy:      true,
 				})
@@ -1614,7 +1614,7 @@ func TestTraefikProxyOldIngressRouteUDPEndpoints(t *testing.T) {
 			source, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
 					Namespace:                defaultTraefikNamespace,
-					AnnotationFilter:         mustParseAnnotationFilter("kubernetes.io/ingress.class=traefik"),
+					AnnotationFilter:         parseAnnotationFilterOrNil("kubernetes.io/ingress.class=traefik"),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 					TraefikEnableLegacy:      true,
 				})
@@ -1781,7 +1781,7 @@ func TestTraefikAPIGroupFlags(t *testing.T) {
 			source, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
 					Namespace:                defaultTraefikNamespace,
-					AnnotationFilter:         mustParseAnnotationFilter("kubernetes.io/ingress.class=traefik"),
+					AnnotationFilter:         parseAnnotationFilterOrNil("kubernetes.io/ingress.class=traefik"),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 					TraefikEnableLegacy:      ti.enableLegacy,
 					TraefikDisableNew:        ti.disableNew,

--- a/source/unstructured_test.go
+++ b/source/unstructured_test.go
@@ -463,7 +463,7 @@ func TestUnstructured_DifferentScenarios(t *testing.T) {
 				dynamicClient,
 				kubeClient,
 				&Config{
-					AnnotationFilter:      tt.cfg.annotationFilter,
+					AnnotationFilter:      mustParseAnnotationFilter(tt.cfg.annotationFilter),
 					LabelFilter:           labelSelector,
 					UnstructuredResources: tt.cfg.resources,
 					TemplateEngine:        templatetest.MustEngine(t, "", "", "", tt.cfg.combine),

--- a/source/unstructured_test.go
+++ b/source/unstructured_test.go
@@ -463,7 +463,7 @@ func TestUnstructured_DifferentScenarios(t *testing.T) {
 				dynamicClient,
 				kubeClient,
 				&Config{
-					AnnotationFilter:      mustParseAnnotationFilter(tt.cfg.annotationFilter),
+					AnnotationFilter:      parseAnnotationFilterOrNil(tt.cfg.annotationFilter),
 					LabelFilter:           labelSelector,
 					UnstructuredResources: tt.cfg.resources,
 					TemplateEngine:        templatetest.MustEngine(t, "", "", "", tt.cfg.combine),


### PR DESCRIPTION
## What does it do ?

- source.Config.AnnotationFilter field type changed from string to labels.Selector; parsing now happens once in NewSourceConfig (error silently ignored, matching LabelFilter behavior and upstream validation contract)

## Motivation

- Aligns AnnotationFilter with LabelFilter, which is already a labels.Selector — both are user-supplied selector strings with the same lifecycle
- https://github.com/kubernetes-sigs/external-dns/pull/6445#discussion_r3275812036 and https://github.com/kubernetes-sigs/external-dns/pull/6445#discussion_r3275823968 validation is happening here https://github.com/kubernetes-sigs/external-dns/blob/0554ddf4d4cd4296a1fd16a04e7df9d81616b832/pkg/apis/externaldns/validation/validation.go#L62 for annotation filter aka during startup for user input

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
