### PR TITLE
provider: add credential source boundary

### DIFF
--- a/provider/civo/civo.go
+++ b/provider/civo/civo.go
@@ -19,7 +19,6 @@ package civo
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/civo/civogo"
@@ -29,6 +28,7 @@ import (
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
+	"sigs.k8s.io/external-dns/provider/credentials"
 )
 
 // CivoProvider is an implementation of Provider for Civo's DNS.
@@ -71,13 +71,17 @@ type CivoChangeDelete struct {
 }
 
 // New creates a Civo provider from the given configuration.
-func New(_ context.Context, cfg *externaldns.Config, domainFilter *endpoint.DomainFilter) (provider.Provider, error) {
-	return newProvider(domainFilter, cfg.DryRun)
+func New(ctx context.Context, cfg *externaldns.Config, domainFilter *endpoint.DomainFilter) (provider.Provider, error) {
+	return newProviderWithCredentialSource(domainFilter, cfg.DryRun, credentials.FromContext(ctx))
 }
 
 // newProvider initializes a new Civo DNS based Provider.
 func newProvider(domainFilter *endpoint.DomainFilter, dryRun bool) (*CivoProvider, error) {
-	token, ok := os.LookupEnv("CIVO_TOKEN")
+	return newProviderWithCredentialSource(domainFilter, dryRun, credentials.SystemSource())
+}
+
+func newProviderWithCredentialSource(domainFilter *endpoint.DomainFilter, dryRun bool, credentialSource credentials.Source) (*CivoProvider, error) {
+	token, ok := credentialSource.LookupEnv("CIVO_TOKEN")
 	if !ok {
 		return nil, fmt.Errorf("no token found")
 	}

--- a/provider/civo/civo_test.go
+++ b/provider/civo/civo_test.go
@@ -31,6 +31,7 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider/credentials"
 )
 
 func TestNewProvider(t *testing.T) {
@@ -39,6 +40,25 @@ func TestNewProvider(t *testing.T) {
 	require.NoError(t, err)
 
 	_ = os.Unsetenv("CIVO_TOKEN")
+}
+
+func TestNewProviderWithCredentialSource(t *testing.T) {
+	t.Setenv("CIVO_TOKEN", "global")
+
+	_, err := newProviderWithCredentialSource(
+		endpoint.NewDomainFilter([]string{"test.civo.com"}),
+		true,
+		credentials.NewMapSource(nil),
+	)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "no token found")
+
+	_, err = newProviderWithCredentialSource(
+		endpoint.NewDomainFilter([]string{"test.civo.com"}),
+		true,
+		credentials.NewMapSource(map[string]string{"CIVO_TOKEN": "pipeline"}),
+	)
+	require.NoError(t, err)
 }
 
 func TestNewCivoProviderNoToken(t *testing.T) {

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
+	"sigs.k8s.io/external-dns/provider/credentials"
 	"sigs.k8s.io/external-dns/source/annotations"
 )
 
@@ -283,11 +284,33 @@ func newProvider(
 	customHostnamesConfig CustomHostnamesConfig,
 	dnsRecordsConfig DNSRecordsConfig,
 ) (*CloudFlareProvider, error) {
+	return newProviderWithCredentialSource(
+		domainFilter,
+		zoneIDFilter,
+		proxiedByDefault,
+		dryRun,
+		regionalServicesConfig,
+		customHostnamesConfig,
+		dnsRecordsConfig,
+		credentials.SystemSource(),
+	)
+}
+
+func newProviderWithCredentialSource(
+	domainFilter *endpoint.DomainFilter,
+	zoneIDFilter provider.ZoneIDFilter,
+	proxiedByDefault bool,
+	dryRun bool,
+	regionalServicesConfig RegionalServicesConfig,
+	customHostnamesConfig CustomHostnamesConfig,
+	dnsRecordsConfig DNSRecordsConfig,
+	credentialSource credentials.Source,
+) (*CloudFlareProvider, error) {
 	// initialize via chosen auth method and returns new API object
 
 	var client *cloudflare.Client
 
-	token := os.Getenv(cfAPITokenEnvKey)
+	token := credentialSource.Getenv(cfAPITokenEnvKey)
 	if token != "" {
 		if trimmed, ok := strings.CutPrefix(token, "file:"); ok {
 			tokenBytes, err := os.ReadFile(trimmed)
@@ -300,8 +323,8 @@ func newProvider(
 			option.WithAPIToken(token),
 		)
 	} else {
-		apiKey := os.Getenv(cfAPIKeyEnvKey)
-		apiEmail := os.Getenv(cfAPIEmailEnvKey)
+		apiKey := credentialSource.Getenv(cfAPIKeyEnvKey)
+		apiEmail := credentialSource.Getenv(cfAPIEmailEnvKey)
 		if apiKey == "" || apiEmail == "" {
 			return nil, fmt.Errorf("cloudflare credentials are not configured: set either %s or both %s and %s environment variables", cfAPITokenEnvKey, cfAPIKeyEnvKey, cfAPIEmailEnvKey)
 		}
@@ -328,8 +351,8 @@ func newProvider(
 }
 
 // New creates a Cloudflare provider from the given configuration.
-func New(_ context.Context, cfg *externaldns.Config, domainFilter *endpoint.DomainFilter) (provider.Provider, error) {
-	return newProvider(
+func New(ctx context.Context, cfg *externaldns.Config, domainFilter *endpoint.DomainFilter) (provider.Provider, error) {
+	return newProviderWithCredentialSource(
 		domainFilter,
 		provider.NewZoneIDFilter(cfg.ZoneIDFilter),
 		cfg.CloudflareProxied,
@@ -349,6 +372,7 @@ func New(_ context.Context, cfg *externaldns.Config, domainFilter *endpoint.Doma
 			BatchChangeSize:     cfg.BatchChangeSize,
 			BatchChangeInterval: cfg.BatchChangeInterval,
 		},
+		credentials.FromContext(ctx),
 	)
 }
 

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -43,6 +43,7 @@ import (
 	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
+	"sigs.k8s.io/external-dns/provider/credentials"
 	"sigs.k8s.io/external-dns/source/annotations"
 )
 
@@ -985,6 +986,35 @@ func TestCloudflareProvider(t *testing.T) {
 		})
 
 	}
+}
+
+func TestCloudflareProviderWithCredentialSource(t *testing.T) {
+	t.Setenv(cfAPITokenEnvKey, "global")
+
+	_, err := newProviderWithCredentialSource(
+		endpoint.NewDomainFilter([]string{"bar.com"}),
+		provider.NewZoneIDFilter([]string{""}),
+		false,
+		true,
+		RegionalServicesConfig{Enabled: false},
+		CustomHostnamesConfig{Enabled: false},
+		DNSRecordsConfig{PerPage: 5000, Comment: ""},
+		credentials.NewMapSource(nil),
+	)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "cloudflare credentials are not configured")
+
+	_, err = newProviderWithCredentialSource(
+		endpoint.NewDomainFilter([]string{"bar.com"}),
+		provider.NewZoneIDFilter([]string{""}),
+		false,
+		true,
+		RegionalServicesConfig{Enabled: false},
+		CustomHostnamesConfig{Enabled: false},
+		DNSRecordsConfig{PerPage: 5000, Comment: ""},
+		credentials.NewMapSource(map[string]string{cfAPITokenEnvKey: "pipeline"}),
+	)
+	require.NoError(t, err)
 }
 
 func TestCloudflareApplyChanges(t *testing.T) {

--- a/provider/credentials/credentials.go
+++ b/provider/credentials/credentials.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package credentials
+
+import (
+	"context"
+	"maps"
+	"os"
+)
+
+// Source provides credential values to provider constructors.
+type Source interface {
+	LookupEnv(key string) (string, bool)
+	Getenv(key string) string
+}
+
+type sourceKey struct{}
+
+type systemSource struct{}
+
+// SystemSource returns a Source backed by the process environment.
+func SystemSource() Source {
+	return systemSource{}
+}
+
+func (systemSource) LookupEnv(key string) (string, bool) {
+	return os.LookupEnv(key)
+}
+
+func (systemSource) Getenv(key string) string {
+	return os.Getenv(key)
+}
+
+type mapSource map[string]string
+
+// NewMapSource returns a Source backed by the provided values.
+func NewMapSource(values map[string]string) Source {
+	copied := make(mapSource, len(values))
+	maps.Copy(copied, values)
+	return copied
+}
+
+func (s mapSource) LookupEnv(key string) (string, bool) {
+	value, ok := s[key]
+	return value, ok
+}
+
+func (s mapSource) Getenv(key string) string {
+	return s[key]
+}
+
+// NewContext returns a context that carries a provider credential source.
+func NewContext(ctx context.Context, source Source) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if source == nil {
+		source = SystemSource()
+	}
+	return context.WithValue(ctx, sourceKey{}, source)
+}
+
+// FromContext returns the credential source carried by ctx, or the process
+// environment source when no explicit source was attached.
+func FromContext(ctx context.Context) Source {
+	if ctx == nil {
+		return SystemSource()
+	}
+	source, ok := ctx.Value(sourceKey{}).(Source)
+	if !ok || source == nil {
+		return SystemSource()
+	}
+	return source
+}

--- a/provider/credentials/credentials_test.go
+++ b/provider/credentials/credentials_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package credentials
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapSource(t *testing.T) {
+	values := map[string]string{
+		"API_TOKEN": "pipeline-a",
+	}
+	source := NewMapSource(values)
+
+	values["API_TOKEN"] = "mutated"
+
+	value, ok := source.LookupEnv("API_TOKEN")
+	assert.True(t, ok)
+	assert.Equal(t, "pipeline-a", value)
+	assert.Equal(t, "pipeline-a", source.Getenv("API_TOKEN"))
+
+	_, ok = source.LookupEnv("MISSING")
+	assert.False(t, ok)
+	assert.Empty(t, source.Getenv("MISSING"))
+}
+
+func TestContextSource(t *testing.T) {
+	ctx := NewContext(t.Context(), NewMapSource(map[string]string{
+		"API_TOKEN": "pipeline-a",
+	}))
+
+	value, ok := FromContext(ctx).LookupEnv("API_TOKEN")
+	assert.True(t, ok)
+	assert.Equal(t, "pipeline-a", value)
+}
+
+func TestContextDefaultsToSystemSource(t *testing.T) {
+	t.Setenv("API_TOKEN", "system")
+
+	value, ok := FromContext(t.Context()).LookupEnv("API_TOKEN")
+	assert.True(t, ok)
+	assert.Equal(t, "system", value)
+}
+
+func TestNilContextDefaultsToSystemSource(t *testing.T) {
+	t.Setenv("API_TOKEN", "system")
+
+	value, ok := FromContext(nil).LookupEnv("API_TOKEN")
+	assert.True(t, ok)
+	assert.Equal(t, "system", value)
+
+	ctx := NewContext(nil, NewMapSource(map[string]string{
+		"API_TOKEN": "pipeline-a",
+	}))
+	value, ok = FromContext(ctx).LookupEnv("API_TOKEN")
+	assert.True(t, ok)
+	assert.Equal(t, "pipeline-a", value)
+}

--- a/provider/dnsimple/dnsimple.go
+++ b/provider/dnsimple/dnsimple.go
@@ -19,7 +19,6 @@ package dnsimple
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -31,6 +30,7 @@ import (
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
+	"sigs.k8s.io/external-dns/provider/credentials"
 )
 
 const (
@@ -84,12 +84,13 @@ func (z dnsimpleZoneService) UpdateRecord(ctx context.Context, accountID string,
 
 type dnsimpleProvider struct {
 	provider.BaseProvider
-	client       dnsimpleZoneServiceInterface
-	identity     dnsimpleIdentityService
-	accountID    string
-	domainFilter *endpoint.DomainFilter
-	zoneIDFilter provider.ZoneIDFilter
-	dryRun       bool
+	client           dnsimpleZoneServiceInterface
+	identity         dnsimpleIdentityService
+	accountID        string
+	domainFilter     *endpoint.DomainFilter
+	zoneIDFilter     provider.ZoneIDFilter
+	dryRun           bool
+	credentialSource credentials.Source
 }
 
 type dnsimpleChange struct {
@@ -98,13 +99,17 @@ type dnsimpleChange struct {
 }
 
 // New creates a DNSimple provider from the given configuration.
-func New(_ context.Context, cfg *externaldns.Config, domainFilter *endpoint.DomainFilter) (provider.Provider, error) {
-	return newProvider(domainFilter, provider.NewZoneIDFilter(cfg.ZoneIDFilter), cfg.DryRun)
+func New(ctx context.Context, cfg *externaldns.Config, domainFilter *endpoint.DomainFilter) (provider.Provider, error) {
+	return newProviderWithCredentialSource(domainFilter, provider.NewZoneIDFilter(cfg.ZoneIDFilter), cfg.DryRun, credentials.FromContext(ctx))
 }
 
 // newProvider initializes a new Dnsimple based provider
 func newProvider(domainFilter *endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, dryRun bool) (provider.Provider, error) {
-	oauthToken := os.Getenv("DNSIMPLE_OAUTH")
+	return newProviderWithCredentialSource(domainFilter, zoneIDFilter, dryRun, credentials.SystemSource())
+}
+
+func newProviderWithCredentialSource(domainFilter *endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, dryRun bool, credentialSource credentials.Source) (provider.Provider, error) {
+	oauthToken := credentialSource.Getenv("DNSIMPLE_OAUTH")
 	if len(oauthToken) == 0 {
 		return nil, fmt.Errorf("no dnsimple oauth token provided")
 	}
@@ -116,14 +121,15 @@ func newProvider(domainFilter *endpoint.DomainFilter, zoneIDFilter provider.Zone
 	client.SetUserAgent(externaldns.UserAgent())
 
 	provider := &dnsimpleProvider{
-		client:       dnsimpleZoneService{service: client.Zones},
-		identity:     dnsimpleIdentityService{service: client.Identity},
-		domainFilter: domainFilter,
-		zoneIDFilter: zoneIDFilter,
-		dryRun:       dryRun,
+		client:           dnsimpleZoneService{service: client.Zones},
+		identity:         dnsimpleIdentityService{service: client.Identity},
+		domainFilter:     domainFilter,
+		zoneIDFilter:     zoneIDFilter,
+		dryRun:           dryRun,
+		credentialSource: credentialSource,
 	}
 
-	provider.accountID = os.Getenv("DNSIMPLE_ACCOUNT_ID")
+	provider.accountID = credentialSource.Getenv("DNSIMPLE_ACCOUNT_ID")
 	if provider.accountID == "" {
 		whoamiResponse, err := provider.identity.Whoami(context.Background())
 		if err != nil {
@@ -132,6 +138,13 @@ func newProvider(domainFilter *endpoint.DomainFilter, zoneIDFilter provider.Zone
 		provider.accountID = int64ToString(whoamiResponse.Data.Account.ID)
 	}
 	return provider, nil
+}
+
+func (p *dnsimpleProvider) getCredentialSource() credentials.Source {
+	if p.credentialSource == nil {
+		return credentials.SystemSource()
+	}
+	return p.credentialSource
 }
 
 // GetAccountID returns the account ID given DNSimple credentials.
@@ -162,7 +175,7 @@ func (p *dnsimpleProvider) Zones(ctx context.Context) (map[string]dnsimple.Zone,
 	// This is useful for when the DNSIMPLE_OAUTH environment variable is a User API token and
 	// not an Account API token as the User API token will not have permissions to list Zones
 	// belong to another account which the User has access permissions for.
-	envZonesStr := os.Getenv("DNSIMPLE_ZONES")
+	envZonesStr := p.getCredentialSource().Getenv("DNSIMPLE_ZONES")
 	if envZonesStr != "" {
 		return ZonesFromZoneString(envZonesStr), nil
 	}

--- a/provider/dnsimple/dnsimple_test.go
+++ b/provider/dnsimple/dnsimple_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
+	"sigs.k8s.io/external-dns/provider/credentials"
 )
 
 var (
@@ -263,6 +264,48 @@ func TestNewProvider(t *testing.T) {
 	assert.Equal(t, "12345678", dnsimpleTypedProvider.accountID)
 	os.Unsetenv("DNSIMPLE_OAUTH")
 	os.Unsetenv("DNSIMPLE_ACCOUNT_ID")
+}
+
+func TestNewProviderWithCredentialSource(t *testing.T) {
+	t.Setenv("DNSIMPLE_OAUTH", "global")
+	t.Setenv("DNSIMPLE_ACCOUNT_ID", "global-account")
+
+	_, err := newProviderWithCredentialSource(
+		endpoint.NewDomainFilter([]string{"example.com"}),
+		provider.NewZoneIDFilter([]string{""}),
+		true,
+		credentials.NewMapSource(nil),
+	)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "no dnsimple oauth token provided")
+
+	providerTypedProvider, err := newProviderWithCredentialSource(
+		endpoint.NewDomainFilter([]string{"example.com"}),
+		provider.NewZoneIDFilter([]string{""}),
+		true,
+		credentials.NewMapSource(map[string]string{
+			"DNSIMPLE_OAUTH":      "pipeline",
+			"DNSIMPLE_ACCOUNT_ID": "12345678",
+		}),
+	)
+	require.NoError(t, err)
+
+	dnsimpleTypedProvider := providerTypedProvider.(*dnsimpleProvider)
+	assert.Equal(t, "12345678", dnsimpleTypedProvider.accountID)
+}
+
+func TestZonesWithCredentialSource(t *testing.T) {
+	t.Setenv("DNSIMPLE_ZONES", "global-example.com")
+
+	provider := dnsimpleProvider{
+		credentialSource: credentials.NewMapSource(map[string]string{
+			"DNSIMPLE_ZONES": "source-example.com",
+		}),
+	}
+
+	zones, err := provider.Zones(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "source-example.com", zones["0"].Name)
 }
 
 func testDnsimpleGetRecordID(t *testing.T) {

--- a/provider/factory/provider.go
+++ b/provider/factory/provider.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/external-dns/provider/civo"
 	"sigs.k8s.io/external-dns/provider/cloudflare"
 	"sigs.k8s.io/external-dns/provider/coredns"
+	"sigs.k8s.io/external-dns/provider/credentials"
 	"sigs.k8s.io/external-dns/provider/dnsimple"
 	"sigs.k8s.io/external-dns/provider/exoscale"
 	"sigs.k8s.io/external-dns/provider/gandi"
@@ -56,6 +57,24 @@ type ProviderConstructor func(
 
 // Select creates a provider based on the given configuration.
 func Select(
+	ctx context.Context,
+	cfg *externaldns.Config,
+	domainFilter *endpoint.DomainFilter) (provider.Provider, error) {
+	return selectProvider(ctx, cfg, domainFilter)
+}
+
+// SelectWithCredentialSource creates a provider using an explicit credential
+// source. A nil credential source falls back to the process environment.
+func SelectWithCredentialSource(
+	ctx context.Context,
+	cfg *externaldns.Config,
+	domainFilter *endpoint.DomainFilter,
+	credentialSource credentials.Source,
+) (provider.Provider, error) {
+	return selectProvider(credentials.NewContext(ctx, credentialSource), cfg, domainFilter)
+}
+
+func selectProvider(
 	ctx context.Context,
 	cfg *externaldns.Config,
 	domainFilter *endpoint.DomainFilter) (provider.Provider, error) {

--- a/provider/factory/provider_test.go
+++ b/provider/factory/provider_test.go
@@ -28,6 +28,7 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
+	"sigs.k8s.io/external-dns/provider/credentials"
 )
 
 func TestSelectProvider(t *testing.T) {
@@ -152,6 +153,32 @@ func TestKnownProviders(t *testing.T) {
 		})
 	}
 	assert.ElementsMatch(t, externaldns.ProviderNames, names)
+}
+
+func TestSelectWithCredentialSource(t *testing.T) {
+	t.Setenv("NS1_APIKEY", "global")
+
+	domainFilter := endpoint.NewDomainFilter([]string{"example.com"})
+	cfg := &externaldns.Config{
+		Provider: externaldns.ProviderNS1,
+	}
+
+	_, err := SelectWithCredentialSource(t.Context(), cfg, domainFilter, credentials.NewMapSource(nil))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "NS1_APIKEY environment variable is not set")
+
+	for _, token := range []string{"pipeline-a", "pipeline-b"} {
+		t.Run(token, func(t *testing.T) {
+			p, err := SelectWithCredentialSource(
+				t.Context(),
+				cfg,
+				domainFilter,
+				credentials.NewMapSource(map[string]string{"NS1_APIKEY": token}),
+			)
+			require.NoError(t, err)
+			require.NotNil(t, p)
+		})
+	}
 }
 
 func TestSelectProvider_Webhook(t *testing.T) {

--- a/provider/gandi/gandi.go
+++ b/provider/gandi/gandi.go
@@ -16,7 +16,6 @@ package gandi
 import (
 	"context"
 	"errors"
-	"os"
 	"strings"
 
 	"github.com/go-gandi/go-gandi"
@@ -28,6 +27,7 @@ import (
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
+	"sigs.k8s.io/external-dns/provider/credentials"
 )
 
 const (
@@ -53,15 +53,19 @@ type GandiProvider struct {
 }
 
 func newProvider(domainFilter *endpoint.DomainFilter, dryRun bool) (*GandiProvider, error) {
-	key, ok_key := os.LookupEnv("GANDI_KEY")
-	pat, ok_pat := os.LookupEnv("GANDI_PAT")
+	return newProviderWithCredentialSource(domainFilter, dryRun, credentials.SystemSource())
+}
+
+func newProviderWithCredentialSource(domainFilter *endpoint.DomainFilter, dryRun bool, credentialSource credentials.Source) (*GandiProvider, error) {
+	key, ok_key := credentialSource.LookupEnv("GANDI_KEY")
+	pat, ok_pat := credentialSource.LookupEnv("GANDI_PAT")
 	if !ok_key && !ok_pat {
 		return nil, errors.New("no environment variable GANDI_KEY or GANDI_PAT provided")
 	}
 	if ok_key {
 		log.Warning("Usage of GANDI_KEY (API Key) is deprecated. Please consider creating a Personal Access Token (PAT) instead, see https://api.gandi.net/docs/authentication/")
 	}
-	sharingID, _ := os.LookupEnv("GANDI_SHARING_ID")
+	sharingID, _ := credentialSource.LookupEnv("GANDI_SHARING_ID")
 
 	g := config.Config{
 		APIKey:              key,
@@ -85,8 +89,8 @@ func newProvider(domainFilter *endpoint.DomainFilter, dryRun bool) (*GandiProvid
 }
 
 // New creates a Gandi provider from the given configuration.
-func New(_ context.Context, cfg *externaldns.Config, domainFilter *endpoint.DomainFilter) (provider.Provider, error) {
-	return newProvider(domainFilter, cfg.DryRun)
+func New(ctx context.Context, cfg *externaldns.Config, domainFilter *endpoint.DomainFilter) (provider.Provider, error) {
+	return newProviderWithCredentialSource(domainFilter, cfg.DryRun, credentials.FromContext(ctx))
 }
 
 func (p *GandiProvider) Zones() ([]string, error) {

--- a/provider/gandi/gandi_test.go
+++ b/provider/gandi/gandi_test.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/internal/testutils"
 	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider/credentials"
 )
 
 type MockAction struct {
@@ -187,6 +188,26 @@ func TestNewProvider(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected to fail")
 	}
+}
+
+func TestNewProviderWithCredentialSource(t *testing.T) {
+	t.Setenv("GANDI_PAT", "global")
+
+	_, err := newProviderWithCredentialSource(
+		endpoint.NewDomainFilter([]string{"example.com"}),
+		true,
+		credentials.NewMapSource(nil),
+	)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "no environment variable GANDI_KEY or GANDI_PAT provided")
+
+	provider, err := newProviderWithCredentialSource(
+		endpoint.NewDomainFilter([]string{"example.com"}),
+		true,
+		credentials.NewMapSource(map[string]string{"GANDI_PAT": "pipeline"}),
+	)
+	assert.NoError(t, err)
+	assert.True(t, provider.DryRun)
 }
 
 func TestGandiProvider_RecordsReturnsCorrectEndpoints(t *testing.T) {

--- a/provider/linode/linode.go
+++ b/provider/linode/linode.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 
@@ -31,6 +30,7 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
+	"sigs.k8s.io/external-dns/provider/credentials"
 
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 )
@@ -79,13 +79,17 @@ type LinodeChangeDelete struct {
 }
 
 // New creates a Linode provider from the given configuration.
-func New(_ context.Context, cfg *externaldns.Config, domainFilter *endpoint.DomainFilter) (provider.Provider, error) {
-	return newProvider(domainFilter, cfg.DryRun)
+func New(ctx context.Context, cfg *externaldns.Config, domainFilter *endpoint.DomainFilter) (provider.Provider, error) {
+	return newProviderWithCredentialSource(domainFilter, cfg.DryRun, credentials.FromContext(ctx))
 }
 
 // newProvider initializes a new Linode DNS based Provider.
 func newProvider(domainFilter *endpoint.DomainFilter, dryRun bool) (*LinodeProvider, error) {
-	token, ok := os.LookupEnv("LINODE_TOKEN")
+	return newProviderWithCredentialSource(domainFilter, dryRun, credentials.SystemSource())
+}
+
+func newProviderWithCredentialSource(domainFilter *endpoint.DomainFilter, dryRun bool, credentialSource credentials.Source) (*LinodeProvider, error) {
+	token, ok := credentialSource.LookupEnv("LINODE_TOKEN")
 	if !ok {
 		return nil, fmt.Errorf("no token found")
 	}

--- a/provider/linode/linode_test.go
+++ b/provider/linode/linode_test.go
@@ -28,6 +28,7 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider/credentials"
 )
 
 type MockDomainClient struct {
@@ -151,6 +152,25 @@ func TestNewProvider(t *testing.T) {
 	_ = os.Unsetenv("LINODE_TOKEN")
 	_, err = newProvider(endpoint.NewDomainFilter([]string{"ext-dns-test.zalando.to."}), true)
 	require.Error(t, err)
+}
+
+func TestNewProviderWithCredentialSource(t *testing.T) {
+	t.Setenv("LINODE_TOKEN", "global")
+
+	_, err := newProviderWithCredentialSource(
+		endpoint.NewDomainFilter([]string{"ext-dns-test.zalando.to."}),
+		true,
+		credentials.NewMapSource(nil),
+	)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "no token found")
+
+	_, err = newProviderWithCredentialSource(
+		endpoint.NewDomainFilter([]string{"ext-dns-test.zalando.to."}),
+		true,
+		credentials.NewMapSource(map[string]string{"LINODE_TOKEN": "pipeline"}),
+	)
+	require.NoError(t, err)
 }
 
 func TestLinodeStripRecordName(t *testing.T) {

--- a/provider/ns1/ns1.go
+++ b/provider/ns1/ns1.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -33,6 +32,7 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
+	"sigs.k8s.io/external-dns/provider/credentials"
 )
 
 const (
@@ -106,8 +106,8 @@ type NS1Provider struct {
 }
 
 // New creates an NS1 provider from the given configuration.
-func New(_ context.Context, cfg *externaldns.Config, domainFilter *endpoint.DomainFilter) (provider.Provider, error) {
-	return newProvider(
+func New(ctx context.Context, cfg *externaldns.Config, domainFilter *endpoint.DomainFilter) (provider.Provider, error) {
+	return newProviderWithCredentialSource(
 		NS1Config{
 			DomainFilter:  domainFilter,
 			ZoneIDFilter:  provider.NewZoneIDFilter(cfg.ZoneIDFilter),
@@ -116,16 +116,21 @@ func New(_ context.Context, cfg *externaldns.Config, domainFilter *endpoint.Doma
 			DryRun:        cfg.DryRun,
 			MinTTLSeconds: cfg.NS1MinTTLSeconds,
 		},
+		credentials.FromContext(ctx),
 	)
 }
 
 // newProvider creates a new NS1 Provider
 func newProvider(config NS1Config) (*NS1Provider, error) {
-	return newNS1ProviderWithHTTPClient(config, http.DefaultClient)
+	return newProviderWithCredentialSource(config, credentials.SystemSource())
 }
 
-func newNS1ProviderWithHTTPClient(config NS1Config, client *http.Client) (*NS1Provider, error) {
-	token, ok := os.LookupEnv("NS1_APIKEY")
+func newProviderWithCredentialSource(config NS1Config, credentialSource credentials.Source) (*NS1Provider, error) {
+	return newNS1ProviderWithHTTPClient(config, http.DefaultClient, credentialSource)
+}
+
+func newNS1ProviderWithHTTPClient(config NS1Config, client *http.Client, credentialSource credentials.Source) (*NS1Provider, error) {
+	token, ok := credentialSource.LookupEnv("NS1_APIKEY")
 	if !ok {
 		return nil, fmt.Errorf("NS1_APIKEY environment variable is not set")
 	}


### PR DESCRIPTION
## What
- Add a provider credential source abstraction with system-env and map-backed implementations.
- Add `SelectWithCredentialSource` at the provider factory boundary so future per-pipeline config can construct providers without mutating process env.
- Migrate Cloudflare, DNSimple, NS1, Civo, Gandi, and Linode provider construction to read credentials from the injected source while keeping existing env-backed behavior for current callers.
- Add tests proving explicit sources do not fall back to global env and same-type providers can be constructed with distinct credentials.

## Why
Follow-up slice from #6512 for the multi-provider CRD design in #1961. This establishes the credential boundary needed before wiring `credentialsRef` into pipeline construction.

## Notes
This does not wire CRD `credentialsRef` yet. OCI workload identity, CoreDNS etcd env, and Scaleway SDK env handling are left as provider-specific follow-ups because they need different treatment than direct credential env reads.

## Validation
- `go test ./provider/credentials ./provider/factory ./provider/ns1 ./provider/civo ./provider/linode ./provider/gandi ./provider/cloudflare ./provider/dnsimple`
- `go test ./provider/...`
- `go test ./...`
- `PATH="$HOME/go/bin:$PATH" make lint`
