### PR TITLE
fix(rfc2136): add GSS-TSIG authentication to AXFR zone transfers

### DIFF
--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -261,20 +261,59 @@ OuterLoop:
 
 func (r *rfc2136Provider) IncomeTransfer(m *dns.Msg, nameserver string) (chan *dns.Envelope, error) {
 	t := new(dns.Transfer)
-	if !r.insecure && !r.gssTsig {
-		t.TsigSecret = map[string]string{r.tsigKeyName: r.tsigSecret}
+	var gssCleanup func()
+	if !r.insecure {
+		if r.gssTsig {
+			keyName, handle, err := r.KeyData(nameserver)
+			if err != nil {
+				return nil, fmt.Errorf("failed to negotiate GSS-TSIG: %w", err)
+			}
+			t.TsigProvider = handle
+			m.SetTsig(keyName, tsig.GSS, clockSkew, time.Now().Unix())
+			gssCleanup = func() {
+				handle.DeleteContext(keyName)
+				handle.Close()
+			}
+		} else {
+			t.TsigSecret = map[string]string{r.tsigKeyName: r.tsigSecret}
+		}
 	}
 
 	c, err := makeClient(r, nameserver)
 	if err != nil {
+		if gssCleanup != nil {
+			gssCleanup()
+		}
 		return nil, fmt.Errorf("error setting up TLS: %w", err)
 	}
 	conn, err := c.Dial(nameserver)
 	if err != nil {
+		if gssCleanup != nil {
+			gssCleanup()
+		}
 		return nil, fmt.Errorf("failed to connect for transfer: %w", err)
 	}
 	t.Conn = conn
-	return t.In(m, nameserver)
+	env, err := t.In(m, nameserver)
+	if err != nil {
+		if gssCleanup != nil {
+			gssCleanup()
+		}
+		return nil, err
+	}
+
+	if gssCleanup != nil {
+		wrapped := make(chan *dns.Envelope)
+		go func() {
+			defer gssCleanup()
+			defer close(wrapped)
+			for e := range env {
+				wrapped <- e
+			}
+		}()
+		return wrapped, nil
+	}
+	return env, nil
 }
 
 func (r *rfc2136Provider) List() ([]dns.RR, error) {
@@ -289,6 +328,7 @@ func (r *rfc2136Provider) List() ([]dns.RR, error) {
 
 		m := new(dns.Msg)
 		m.SetAxfr(dns.Fqdn(zone))
+		// GSS-TSIG signing is handled inside IncomeTransfer after key negotiation.
 		if !r.insecure && !r.gssTsig {
 			m.SetTsig(r.tsigKeyName, r.tsigSecretAlg, clockSkew, time.Now().Unix())
 		}

--- a/provider/rfc2136/rfc2136_test.go
+++ b/provider/rfc2136/rfc2136_test.go
@@ -553,6 +553,60 @@ func TestRfc2136GetRecords(t *testing.T) {
 	assert.True(t, contains(recs, "v2.foo.com"))
 }
 
+// gssTsigSpyStub wraps rfc2136Stub to capture the dns.Msg passed to IncomeTransfer,
+// so tests can verify that List() does not pre-set TSIG for the GSS-TSIG case.
+type gssTsigSpyStub struct {
+	rfc2136Stub
+	incomeTransferMsg *dns.Msg
+}
+
+func (r *gssTsigSpyStub) IncomeTransfer(m *dns.Msg, nameserver string) (chan *dns.Envelope, error) {
+	r.incomeTransferMsg = m
+	return r.rfc2136Stub.IncomeTransfer(m, nameserver)
+}
+
+func TestRfc2136GetRecordsGssTsig(t *testing.T) {
+	spy := &gssTsigSpyStub{}
+	err := spy.setOutput([]string{
+		"v1.foo.com 3600 A 1.2.3.4",
+		"v1.foo.com 3600 TXT \"heritage=external-dns,external-dns/owner=owner\"",
+	})
+	require.NoError(t, err)
+
+	tlsConfig := TLSConfig{}
+	p, err := newProvider([]string{""}, 0, []string{"foo.com"}, false, "", "", "", true, &endpoint.DomainFilter{}, false, 300*time.Second, true, "user", "pass", "REALM", 50, tlsConfig, "", spy)
+	require.NoError(t, err)
+
+	recs, err := p.Records(t.Context())
+	require.NoError(t, err)
+
+	assert.Len(t, recs, 2)
+	assert.True(t, contains(recs, "v1.foo.com"))
+
+	// List() must not pre-set TSIG when gssTsig is enabled;
+	// signing is deferred to the production IncomeTransfer method.
+	require.NotNil(t, spy.incomeTransferMsg)
+	assert.Nil(t, spy.incomeTransferMsg.IsTsig(), "List() must not set TSIG when gssTsig is enabled")
+}
+
+func TestRfc2136IncomeTransferGssTsigPath(t *testing.T) {
+	tlsConfig := TLSConfig{}
+	p, err := newProvider([]string{"127.0.0.1"}, 53, []string{"foo.com"}, false, "", "", "", true, &endpoint.DomainFilter{}, false, 300*time.Second, true, "user", "pass", "REALM", 50, tlsConfig, "", nil)
+	require.NoError(t, err)
+
+	rawProvider := p.(*rfc2136Provider)
+
+	m := new(dns.Msg)
+	m.SetAxfr(dns.Fqdn("foo.com"))
+
+	// Call IncomeTransfer directly to exercise the production GSS-TSIG path.
+	// Without a Kerberos server, negotiation fails; the error confirms
+	// the GSS-TSIG code path in IncomeTransfer was reached.
+	_, err = rawProvider.IncomeTransfer(m, "127.0.0.1:53")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to negotiate GSS-TSIG")
+}
+
 // Make sure the test version of SendMessage raises an error
 // if a zone update ever contains records outside of its zone
 // as the TestRfc2136ApplyChanges tests all assume this


### PR DESCRIPTION
## What does it do ?

Adds GSS-TSIG (Kerberos) authentication to AXFR zone transfers in the rfc2136 provider.

IncomeTransfer() previously skipped all TSIG authentication when gssTsig was enabled, causing AXFR requests to be sent unauthenticated. Servers requiring GSS-TSIG (e.g. Active Directory DNS) rejected these transfers, so Records() returned empty and the controller re-created all records every interval. This mirrors the GSS-TSIG setup already present in SendMessage() into IncomeTransfer(): negotiate Kerberos credentials via KeyData(), set TsigProvider on the dns.Transfer, and sign the AXFR message. The GSS context is cleaned up after the transfer channel is fully drained.



<!-- A brief description of the change being made with this pull request. -->

## Motivation

Users running --rfc2136-gss-tsig with --rfc2136-tsig-axfr against Active Directory DNS see the controller continuously re-applying all records every interval because AXFR zone transfers fail silently (unauthenticated). This makes --rfc2136-tsig-axfr unusable for GSS-TSIG deployments.

Fixes: #6450 

## More

- [X] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
