### PR TITLE
docs(crd): clarify annotation-filter behavior for DNSEndpoint

### DIFF
--- a/docs/sources/crd.md
+++ b/docs/sources/crd.md
@@ -75,6 +75,32 @@ for e.g:
 build/external-dns --source crd --crd-source-apiversion externaldns.k8s.io/v1alpha1  --crd-source-kind DNSEndpoint --provider inmemory --once --dry-run
 ```
 
+As with every source, `--annotation-filter` is optional. If you set it, ExternalDNS applies it to `DNSEndpoint` objects too, so a `DNSEndpoint` must match the filter itself or the CRD source will ignore it.
+
+For example, with:
+
+```sh
+build/external-dns --source crd --crd-source-apiversion externaldns.k8s.io/v1alpha1 --crd-source-kind DNSEndpoint --provider inmemory --once --dry-run --annotation-filter=external-dns=public
+```
+
+the `DNSEndpoint` metadata must include a matching annotation:
+
+```yaml
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: examplednsrecord
+  annotations:
+    external-dns: public
+spec:
+  endpoints:
+  - dnsName: foo.bar.com
+    recordTTL: 180
+    recordType: A
+    targets:
+    - 192.168.99.216
+```
+
 ## Creating DNS Records
 
 Create the objects of CRD type by filling in the fields of CRD and DNS record would be created accordingly.


### PR DESCRIPTION
## What does it do ?

Clarifies in the CRD source docs that `--annotation-filter` also applies to `DNSEndpoint` objects.
It also adds a small example showing the matching annotation on the CRD itself.

## Motivation

Related to #3634.
This is pretty easy to trip on in real setups. If you run ExternalDNS with `--source=crd` and `--annotation-filter=external-dns=public`, a `DNSEndpoint` without that annotation just gets ignored. The code already does this on purpose, and the FAQ says the filter is global, but the CRD source page didnt say it.

Quick repro:
1. Run `external-dns --source=crd --annotation-filter=external-dns=public ...`
2. Create a `DNSEndpoint` without `metadata.annotations.external-dns=public`
3. It is ignored
4. Add the annotation, and it works

I also re-checked the current behavior in `source/crd.go` and with `go test ./source -run 'TestBuildCacheOptions|TestCRDSource'`.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly
