### PR TITLE
fix(provider/cloudflare): trim surrounding whitespace from API token

### DIFF
--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -21,6 +21,7 @@ API Token will be preferred for authentication if `CF_API_TOKEN` environment var
 Otherwise `CF_API_KEY` and `CF_API_EMAIL` should be set to run ExternalDNS with Cloudflare.
 You may provide the Cloudflare API token through a file by setting the
 `CF_API_TOKEN="file:/path/to/token"`.
+Surrounding whitespace is trimmed from the token before use.
 
 Note. The `CF_API_KEY` and `CF_API_EMAIL` should not be present, if you are using a `CF_API_TOKEN`.
 

--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -21,7 +21,12 @@ API Token will be preferred for authentication if `CF_API_TOKEN` environment var
 Otherwise `CF_API_KEY` and `CF_API_EMAIL` should be set to run ExternalDNS with Cloudflare.
 You may provide the Cloudflare API token through a file by setting the
 `CF_API_TOKEN="file:/path/to/token"`.
-Surrounding whitespace is trimmed from the token before use.
+Surrounding whitespace is trimmed from the token before use. This is a fallback safeguard only — the token should be supplied already in the correct format.
+When generating a token for a Kubernetes Secret, use `echo -n` (not `echo`) or `printf` so no trailing newline is written, e.g.:
+
+```shell
+printf '%s' "$CF_API_TOKEN" | kubectl create secret generic cloudflare-api-key --from-file=apiKey=/dev/stdin
+```
 
 Note. The `CF_API_KEY` and `CF_API_EMAIL` should not be present, if you are using a `CF_API_TOKEN`.
 

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -273,18 +273,20 @@ func convertCloudflareError(err error) error {
 	return err
 }
 
-// resolveCloudFlareToken returns the CloudFlare API token from the given value,
+// resolveAPIToken returns the Cloudflare API token from the given value,
 // reading it from a file when prefixed with "file:". Surrounding whitespace is
-// trimmed
-func resolveCloudFlareToken(token string) (string, error) {
-	if path, ok := strings.CutPrefix(token, "file:"); ok {
-		tokenBytes, err := os.ReadFile(path)
-		if err != nil {
-			return "", fmt.Errorf("failed to read %s from file: %w", cfAPITokenEnvKey, err)
-		}
-		token = string(tokenBytes)
+// trimmed.
+func resolveAPIToken(input string) (string, error) {
+	path, ok := strings.CutPrefix(input, "file:")
+	if !ok {
+		return strings.TrimSpace(input), nil
 	}
-	return strings.TrimSpace(token), nil
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read %s from file: %w", cfAPITokenEnvKey, err)
+	}
+	return strings.TrimSpace(string(data)), nil
 }
 
 // newProvider initializes a new CloudFlare DNS based Provider.
@@ -302,7 +304,7 @@ func newProvider(
 	var client *cloudflare.Client
 
 	if token := os.Getenv(cfAPITokenEnvKey); token != "" {
-		resolved, err := resolveCloudFlareToken(token)
+		resolved, err := resolveAPIToken(token)
 		if err != nil {
 			return nil, err
 		}

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -273,6 +273,20 @@ func convertCloudflareError(err error) error {
 	return err
 }
 
+// resolveCloudFlareToken returns the CloudFlare API token from the given value,
+// reading it from a file when prefixed with "file:". Surrounding whitespace is
+// trimmed
+func resolveCloudFlareToken(token string) (string, error) {
+	if path, ok := strings.CutPrefix(token, "file:"); ok {
+		tokenBytes, err := os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("failed to read %s from file: %w", cfAPITokenEnvKey, err)
+		}
+		token = string(tokenBytes)
+	}
+	return strings.TrimSpace(token), nil
+}
+
 // newProvider initializes a new CloudFlare DNS based Provider.
 func newProvider(
 	domainFilter *endpoint.DomainFilter,
@@ -287,17 +301,13 @@ func newProvider(
 
 	var client *cloudflare.Client
 
-	token := os.Getenv(cfAPITokenEnvKey)
-	if token != "" {
-		if trimmed, ok := strings.CutPrefix(token, "file:"); ok {
-			tokenBytes, err := os.ReadFile(trimmed)
-			if err != nil {
-				return nil, fmt.Errorf("failed to read %s from file: %w", cfAPITokenEnvKey, err)
-			}
-			token = strings.TrimSpace(string(tokenBytes))
+	if token := os.Getenv(cfAPITokenEnvKey); token != "" {
+		resolved, err := resolveCloudFlareToken(token)
+		if err != nil {
+			return nil, err
 		}
 		client = cloudflare.NewClient(
-			option.WithAPIToken(token),
+			option.WithAPIToken(resolved),
 		)
 	} else {
 		apiKey := os.Getenv(cfAPIKeyEnvKey)

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -984,6 +985,56 @@ func TestCloudflareProvider(t *testing.T) {
 			}
 		})
 
+	}
+}
+
+func TestResolveCloudFlareToken(t *testing.T) {
+	tokenFile := filepath.Join(t.TempDir(), "cf_api_token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("abc123def\n"), 0o600))
+
+	testCases := []struct {
+		Name       string
+		Token      string
+		Expected   string
+		ShouldFail bool
+	}{
+		{
+			Name:     "plain token",
+			Token:    "abc123def",
+			Expected: "abc123def",
+		},
+		{
+			Name:     "token with trailing newline",
+			Token:    "abc123def\n",
+			Expected: "abc123def",
+		},
+		{
+			Name:     "token with surrounding whitespace",
+			Token:    "  abc123def\r\n",
+			Expected: "abc123def",
+		},
+		{
+			Name:     "token from file is trimmed",
+			Token:    "file:" + tokenFile,
+			Expected: "abc123def",
+		},
+		{
+			Name:       "missing file",
+			Token:      "file:/does/not/exist",
+			ShouldFail: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			resolved, err := resolveCloudFlareToken(tc.Token)
+			if tc.ShouldFail {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.Expected, resolved)
+		})
 	}
 }
 

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -988,7 +988,7 @@ func TestCloudflareProvider(t *testing.T) {
 	}
 }
 
-func TestResolveCloudFlareToken(t *testing.T) {
+func TestResolveAPIToken(t *testing.T) {
 	tokenFile := filepath.Join(t.TempDir(), "cf_api_token")
 	require.NoError(t, os.WriteFile(tokenFile, []byte("abc123def\n"), 0o600))
 
@@ -1027,7 +1027,7 @@ func TestResolveCloudFlareToken(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			resolved, err := resolveCloudFlareToken(tc.Token)
+			resolved, err := resolveAPIToken(tc.Token)
 			if tc.ShouldFail {
 				require.Error(t, err)
 				return


### PR DESCRIPTION
## What does it do ?

Resolves the Cloudflare API token through a single helper for both supported
sources (the inline `CF_API_TOKEN` value and the `file:` variant) that trims
surrounding whitespace, so a trailing newline no longer breaks authentication.

Covered by unit tests and documented in the Cloudflare tutorial.

## Motivation

When `CF_API_TOKEN` is provided directly — the common case when the value is
wired from a Kubernetes secret via an env var — a trailing newline was passed
to the Cloudflare client verbatim, producing an invalid HTTP Authorization
header and crash-looping the controller:

```
level=fatal msg="Failed to do run once: HTTP request failed: Get \"https://api.cloudflare.com/client/v4/zones?per_page=50\": net/http: invalid header field value for \"Authorization\""
```

The `file:` code path already trimmed the token with `strings.TrimSpace`, so the
behaviour was inconsistent depending on how the token was supplied. A trailing
newline is very easy to introduce (e.g. `echo` instead of `echo -n` when
building the secret). Trimming is a fallback safeguard only — the tutorial now
also documents how to create the secret without a trailing newline in the first
place.

Fixes #5400

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

```release-note
Cloudflare: trim surrounding whitespace from the API token, so a trailing newline (e.g. from a Kubernetes secret) no longer breaks authentication.
```
