### PR TITLE
docs(proposal): generic target-from resource dereference

### DIFF
--- a/docs/proposal/007-target-from-resource.md
+++ b/docs/proposal/007-target-from-resource.md
@@ -1,0 +1,258 @@
+```yaml
+---
+title: "Generic target-from resource dereference annotation"
+version: v1alpha1
+authors: "@mloiseleur"
+creation-date: 2026-07-04
+status: draft
+---
+```
+
+# Generic `target-from` Resource Dereference Annotation
+
+## Table of Contents
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories](#user-stories)
+  - [API](#api)
+  - [Behavior](#behavior)
+  - [Security Considerations](#security-considerations)
+  - [Implementation Steps](#implementation-steps)
+  - [Migration and Deprecation](#migration-and-deprecation)
+  - [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+<!-- /toc -->
+
+## Summary
+
+ExternalDNS discovers a record's *target* (the IP/hostname it points at) from a fixed set of
+per-source locations: a `LoadBalancer` Service, an `Ingress` `status.loadBalancer`, node
+addresses, or a literal `target` annotation.
+
+A growing class of setups provisions the public entry point (load balancer, accelerator,
+gateway) as a **separate resource** from the one owning the hostnames — the address lives in
+that other resource's `status`. Today each such integration arrives as its own vendor-specific
+annotation with its own code path baked into the sources (`ingress` for Istio, a proposed
+`gateway` for Gateway API, a proposed `global-accelerator` for AWS), each coupling a source to a
+third-party CRD and its API version.
+
+This proposes one generic annotation, `external-dns.alpha.kubernetes.io/target-from`, that
+dereferences a named field on an arbitrary referenced resource and uses the resolved value(s) as
+the target. It replaces the per-product annotations with one mechanism and imports **no vendor
+CRDs** into the sources.
+
+## Motivation
+
+The same request recurs and keeps hitting the same wall — do not couple a generic source to a
+specific product's CRD:
+
+- [#6438](https://github.com/kubernetes-sigs/external-dns/pull/6438) — Istio → Gateway API
+  `Gateway` (`/hold`: "merging multiple products in a single source").
+- [#6190](https://github.com/kubernetes-sigs/external-dns/pull/6190) /
+  [#6166](https://github.com/kubernetes-sigs/external-dns/issues/6166) — Ingress/Istio → AWS
+  `GlobalAccelerator` (closed: "annotation hack … vendor-specific CRDs baked into the sources").
+- [#6457](https://github.com/kubernetes-sigs/external-dns/issues/6457) — Traefik `IngressRoute`
+  needing a manual `target`.
+- [#4687](https://github.com/kubernetes-sigs/external-dns/issues/4687) — confusion over where a
+  Gateway API record's target comes from.
+
+A maintainer sketched the resolution directly in the #6190 review:
+
+> `external-dns.alpha.kubernetes.io/target-from: "aga.k8s.aws/v1beta1/globalaccelerators/namespace/name#status.dnsName"`
+> A single generic "dereference this CRD field as my target" annotation. That would serve the
+> AWS GA use case, any future GA-like product from any cloud, and be maintainable without
+> touching core source code.
+
+This formalizes that: defines the grammar/behavior and specifies generic resolution (dynamic
+client + RESTMapper) so no source imports a third-party CRD. The pattern already exists — the
+Istio `ingress` annotation dereferences `Ingress.status.loadBalancer`; `target-from` generalizes
+that one hard-coded case to any resource and field.
+
+### Goals
+
+- One annotation to source a record's target from a field on another resource, addressed by
+  group/resource/name.
+- Resolve generically, without typed clients or compile-time knowledge of the referenced CRD.
+- Cover the in-flight use cases (Gateway API `Gateway`, AWS Global Accelerator, cross-namespace
+  shared LBs) with a single mechanism.
+- Preserve target precedence and record-type inference (IP → A/AAAA, hostname → CNAME).
+- Offer a deprecation path for the bespoke `ingress` and the proposed per-product annotations.
+
+### Non-Goals
+
+- **Not a templating engine.** Arbitrary transformation is served by the
+  [`unstructured` source](../sources/unstructured.md); `target-from` resolves a field path to a
+  scalar or list of scalars, nothing more.
+- **Not a replacement for `unstructured`.** `target-from` *augments* a primary source (which
+  still supplies hostnames/TTL/provider config); `unstructured` *is* the source.
+- **Not a new source type.** A cross-cutting annotation resolved by shared code, usable from
+  multiple existing sources.
+- **Not automatic RBAC.** Granting read access to referenced resources is the operator's job
+  (see [Security Considerations](#security-considerations)).
+
+## Proposal
+
+### User Stories
+
+- **Platform operator**: a central Gateway/LB/accelerator lives in a shared namespace. Service
+  teams annotate their Istio `Gateway`/`VirtualService`/`Ingress`/route with `target-from`
+  pointing at it; records follow that entry point automatically, teams never hard-code its
+  address, and records update when it changes.
+- **AWS user**: Ingress fronted by a `GlobalAccelerator` from the AWS LB Controller — point
+  `target-from` at `globalaccelerators.aga.k8s.aws/.../<name>#status.dnsName`, no external
+  controller copying the value into a `target` annotation.
+- **Maintainer**: stop accepting one vendor-CRD coupling per product; point new "point at product
+  X's address" requests at one documented, product-agnostic annotation.
+
+### API
+
+Key: `external-dns.alpha.kubernetes.io/target-from` (subject to `--annotation-prefix`).
+
+Value grammar (comma-separated for multiple references):
+
+```
+<resource>[.<group>]/[<namespace>/]<name>#<fieldPath>
+```
+
+- `<resource>` — plural lowercase RBAC name (`gateways`, `services`, `globalaccelerators`).
+- `<group>` — API group; omitted for core (`services`).
+- `<namespace>` — optional, defaults to the annotated resource's namespace; cross-namespace refs
+  are allowed and are the primary use case.
+- `<name>` — referenced object's name.
+- `<fieldPath>` — a [JSONPath](https://kubernetes.io/docs/reference/kubectl/jsonpath/) resolving
+  to a scalar (one target) or list of scalars (many); `[*]` selects across list elements.
+  Surrounding `{}` are optional.
+
+Parsing: `<group>` is everything after the first `.` in the first path segment; no dot means the
+core group (`services`, `endpoints`).
+
+The API **version** is omitted and resolved via discovery/RESTMapper to the preferred served
+version (like `kubectl`), so records don't silently break on a CRD's `v1beta1` → `v1` graduation
+(the exact fragility raised against #6190). Explicit-version override: see Alternatives.
+
+Examples:
+
+```yaml
+# Istio Gateway → Gateway API Gateway in a shared namespace
+external-dns.alpha.kubernetes.io/hostname: my-service.example.com
+external-dns.alpha.kubernetes.io/target-from: "gateways.gateway.networking.k8s.io/istio-ingress/central-gateway#status.addresses[*].value"
+# Ingress → AWS Global Accelerator (same namespace)
+external-dns.alpha.kubernetes.io/target-from: "globalaccelerators.aga.k8s.aws/my-accelerator#status.dnsName"
+# Any resource → shared LoadBalancer Service (IP and hostname)
+external-dns.alpha.kubernetes.io/target-from: "services/lb-ns/shared-lb#status.loadBalancer.ingress[*].hostname,services/lb-ns/shared-lb#status.loadBalancer.ingress[*].ip"
+```
+
+### Behavior
+
+**Scope** — `target-from` resolves *only* the record's targets. Hostnames, TTL, and
+provider-specific config still come from the primary resource. The feature is inert unless the
+annotation is present on a resource; no feature flag gates it, so upgrade blast radius is limited
+to resources that opt in.
+
+**Precedence** — unchanged, with `target-from` where the bespoke `ingress` lookup sits:
+
+1. Literal `target` annotation — highest, unchanged.
+2. `target-from` — resolve referenced field(s).
+3. Legacy Istio `ingress` — kept as an alias of `target-from` against
+   `ingresses.networking.k8s.io/<ref>#status.loadBalancer.ingress[*]` during deprecation.
+4. Source's native discovery (Service selector, LB status, node IPs) — unchanged.
+
+**Record type** — resolved values reuse `suitableType`: IPv4 → `A`, IPv6 → `AAAA`, else `CNAME`;
+mixed IP+hostname produces both, as multi-target LB status does today. Resolved targets then pass
+through existing target filters (`--exclude-target-net`, etc.) unchanged.
+
+**Resolution** — a shared resolver keys a dynamic client by the RESTMapper GVR, backed by a
+per-GVR informer, so referenced resources are watched/cached and their changes trigger a sync via
+the normal event path (no polling). Because cross-namespace references are the primary use case,
+these referenced-resource informers watch **all namespaces regardless of `--namespace`** (which
+scopes only the primary sources); the watch reads only the referenced GVRs, gated by RBAC. This
+requires `list`+`watch` (not just `get`) on those GVRs; with only `get` granted, resolution still
+works via direct reads but loses change-driven sync.
+
+**Empty / not-found / missing-field (critical)** — an unresolved reference (object not found,
+field absent, empty list) must **not** fall through to native discovery and must **not** delete
+records: the endpoint is **skipped for this sync with a warning**, prior state intact. Avoids the
+#6438 failure mode (stale/empty lookup silently deleting records) and aligns with its
+log-and-continue resilience fix.
+
+**Edge cases** — multiple refs: de-duplicated union. Non-scalar JSONPath result: config error,
+warn+skip. No RBAC access: warn+skip, never crash. Unknown GVR (CRD not installed / RESTMapper
+miss): warn+skip. Cluster-scoped resource: `<namespace>` must be omitted, supplying one is an
+error.
+
+### Security Considerations
+
+`target-from` lets a namespaced annotation cause ExternalDNS to read another resource, possibly
+cross-namespace.
+
+**RBAC is the boundary.** Resolution uses ExternalDNS's own ServiceAccount; it reads only what
+that account is granted (`get`/`list`/`watch` on the intended `resource.group`, per namespace).
+No grant → fail closed (warn, skip). No new default RBAC for arbitrary CRDs ships. RBAC is
+strictly finer-grained than any resource-name allowlist (it also scopes by namespace), so an
+operator who wants to constrain `target-from` scopes the ServiceAccount's Role accordingly.
+
+Only a resolved field *value* is used, as a DNS target string — a value a tenant could already
+set via the literal `target` annotation — so there is no privilege escalation and no exposure of
+resource content beyond that one field.
+
+**Caveat for cluster-wide deployments.** ExternalDNS is frequently run with a cluster-wide
+`ClusterRole` (sources need services/ingresses/gateways/routes across all namespaces when
+`--namespace` is empty). In that setup RBAC does not meaningfully constrain `target-from`. The
+residual risk is narrow (deref an unintended CRD field and surface it as a DNS record the tenant
+controls). A GVR allowlist flag (`--target-from-allowed-resources`) is deliberately left as a
+**future option** rather than shipped in v1alpha1; operators needing a hard guardrail today can
+run ExternalDNS with namespace-scoped RBAC. Open question for review: is the allowlist worth
+adding, or is RBAC sufficient?
+
+### Implementation Steps
+
+- Shared resolver: parse grammar, RESTMapper lookup, per-GVR dynamic informer, JSONPath eval
+  (`k8s.io/client-go/util/jsonpath`).
+- Add `TargetFromKey` to `source/annotations`; wire into `targetsFromX` in sources already
+  honoring `target`/`ingress` (Istio Gateway, Istio VirtualService, Ingress, Gateway API routes,
+  Service, CRD/DNSEndpoint). Start with Istio + Ingress to cover the open requests.
+- Alias the legacy Istio `ingress` annotation onto the resolver; keep the `ParseIngress` →
+  `ParseNamespacedName` generalization (staged in #6438).
+- Docs: new section in `docs/annotations/annotations.md`, cross-linked from `unstructured`.
+- Tests mirroring the Istio `ingress` coverage plus not-found / empty / RBAC-denied / unknown-GVR.
+
+### Migration and Deprecation
+
+- Additive; no existing behavior changes on upgrade.
+- Istio `ingress` becomes a documented alias, soft-deprecated (kept working, docs steer to
+  `target-from`).
+- The per-product annotations proposed in #6438 (`gateway`) and #6190 (`global-accelerator`) are
+  **not added**; documented as `target-from` recipes instead. #6438 can close keeping only its
+  two orthogonal bug fixes; #6190 stays closed.
+
+### Drawbacks
+
+- Dynamic client + per-GVR informer is more machinery than a typed lookup and adds watches.
+- JSONPath in an annotation is a small language users can get wrong; mitigated by warn-and-skip
+  errors and documented recipes.
+- Under cluster-wide RBAC a tenant could target an unintended resource; mitigated by
+  namespace-scoped RBAC, with a GVR allowlist flag as a possible future guardrail.
+- Version-by-discovery can shift if a CRD's preferred version changes; safer than baking in a
+  version, with the explicit-version override as escape hatch.
+
+## Alternatives
+
+- **`unstructured` source (exists).** Reads any CRD field via templates, but *replaces* the
+  primary source — you lose its native hostname/TTL/provider handling. `target-from` keeps the
+  primary source and only borrows the address; complementary, docs point to whichever fits.
+- **Per-product annotations (`ingress`, `gateway`, `global-accelerator`, …).** The status quo:
+  each couples a source to a vendor CRD/version, multiplies code paths, repeatedly rejected
+  (#6438, #6190). `target-from` is the generalization that removes the coupling.
+- **External controller copies the address into `target`.** No ExternalDNS change, but pushes an
+  extra controller onto every user; maintainers floated the generic annotation as the better
+  answer.
+- **Explicit-version grammar** (`<resource>.<group>/<version>/<ns>/<name>#<path>`, the #6190
+  form). More precise but reintroduces version-drift fragility; offered as an optional override
+  on the discovery-based default, not the default.
+- **Do nothing.** Each new "point at product X" request keeps arriving as a coupling PR that gets
+  held or closed, leaving users on manual `target` or the heavier `unstructured` source.

--- a/docs/proposal/007-target-from-resource.md
+++ b/docs/proposal/007-target-from-resource.md
@@ -115,7 +115,7 @@ Key: `external-dns.kubernetes.io/target-from` (subject to `--annotation-prefix`)
 
 Value grammar (comma-separated for multiple references):
 
-```
+```text
 <resource>[.<group>]/[<namespace>/]<name>#<fieldPath>
 ```
 
@@ -176,8 +176,8 @@ works via direct reads but loses change-driven sync.
 
 **Empty / not-found / missing-field (critical)** — an unresolved reference (object not found,
 field absent, empty list) must **not** fall through to native discovery and must **not** delete
-records: the endpoint is **skipped for this sync with a warning**, prior state intact. Avoids the
-#6438 failure mode (stale/empty lookup silently deleting records) and aligns with its
+records: the endpoint is **skipped for this sync with a warning**, prior state intact. Avoids
+the #6438 failure mode (stale/empty lookup silently deleting records) and aligns with its
 log-and-continue resilience fix.
 
 **Edge cases** — multiple refs: de-duplicated union. Non-scalar JSONPath result: config error,

--- a/docs/proposal/007-target-from-resource.md
+++ b/docs/proposal/007-target-from-resource.md
@@ -34,17 +34,16 @@ ExternalDNS discovers a record's *target* (the IP/hostname it points at) from a 
 per-source locations: a `LoadBalancer` Service, an `Ingress` `status.loadBalancer`, node
 addresses, or a literal `target` annotation.
 
-A growing class of setups provisions the public entry point (load balancer, accelerator,
-gateway) as a **separate resource** from the one owning the hostnames — the address lives in
-that other resource's `status`. Today each such integration arrives as its own vendor-specific
-annotation with its own code path baked into the sources (`ingress` for Istio, a proposed
-`gateway` for Gateway API, a proposed `global-accelerator` for AWS), each coupling a source to a
-third-party CRD and its API version.
+A growing class of setups provisions the public entry point (load balancer, accelerator, gateway)
+as a **separate resource** — the address lives in that other resource's `status`.
 
-This proposes one generic annotation, `external-dns.kubernetes.io/target-from`, that
-dereferences a named field on an arbitrary referenced resource and uses the resolved value(s) as
-the target. It replaces the per-product annotations with one mechanism and imports **no vendor
-CRDs** into the sources.
+Each such integration arrives today as its own vendor-specific annotation and code path (`ingress`
+for Istio, a proposed `gateway` for Gateway API, a proposed `global-accelerator` for AWS), coupling
+a source to a third-party CRD and its API version.
+
+This proposes one generic annotation, `external-dns.kubernetes.io/target-from`, that dereferences
+a field on an arbitrary referenced resource and uses the resolved value(s) as the target — one
+mechanism instead of the per-product annotations, and **no vendor CRDs** in the sources.
 
 ## Motivation
 
@@ -61,23 +60,21 @@ specific product's CRD:
 - [#4687](https://github.com/kubernetes-sigs/external-dns/issues/4687) — confusion over where a
   Gateway API record's target comes from.
 
-A maintainer sketched the resolution directly in the #6190 review:
+All of these need the same thing: one generic "dereference this CRD field as my target"
+annotation, serving any current or future product from any vendor without touching core source
+code.
 
-> `external-dns.alpha.kubernetes.io/target-from: "aga.k8s.aws/v1beta1/globalaccelerators/namespace/name#status.dnsName"`
-> A single generic "dereference this CRD field as my target" annotation. That would serve the
-> AWS GA use case, any future GA-like product from any cloud, and be maintainable without
-> touching core source code.
-
-This formalizes that: defines the grammar/behavior and specifies generic resolution (dynamic
-client + RESTMapper) so no source imports a third-party CRD. The pattern already exists — the
-Istio `ingress` annotation dereferences `Ingress.status.loadBalancer`; `target-from` generalizes
-that one hard-coded case to any resource and field.
+The pattern already exists — the Istio `ingress` annotation dereferences
+`Ingress.status.loadBalancer`; `target-from` generalizes that one hard-coded case to any resource
+and field, resolved via a dynamic client and the RESTMapper so no source imports a third-party CRD.
 
 ### Goals
 
 - One annotation to source a record's target from a field on another resource, addressed by
   group/resource/name.
 - Resolve generically, without typed clients or compile-time knowledge of the referenced CRD.
+- Reuse the existing Go template engine and `FuncMap` (`source/template`) rather than introducing
+  a second expression language.
 - Cover the in-flight use cases (Gateway API `Gateway`, AWS Global Accelerator, cross-namespace
   shared LBs) with a single mechanism.
 - Preserve target precedence and record-type inference (IP → A/AAAA, hostname → CNAME).
@@ -85,11 +82,10 @@ that one hard-coded case to any resource and field.
 
 ### Non-Goals
 
-- **Not a templating engine.** Arbitrary transformation is served by the
-  [`unstructured` source](../sources/unstructured.md); `target-from` resolves a field path to a
-  scalar or list of scalars, nothing more.
 - **Not a replacement for `unstructured`.** `target-from` *augments* a primary source (which
-  still supplies hostnames/TTL/provider config); `unstructured` *is* the source.
+  still supplies hostnames/TTL/provider config); the [`unstructured`
+  source](../sources/unstructured.md) *is* the source. The difference is scope, not syntax: both
+  use the same templates.
 - **Not a new source type.** A cross-cutting annotation resolved by shared code, usable from
   multiple existing sources.
 - **Not automatic RBAC.** Granting read access to referenced resources is the operator's job
@@ -100,23 +96,21 @@ that one hard-coded case to any resource and field.
 ### User Stories
 
 - **Platform operator**: a central Gateway/LB/accelerator lives in a shared namespace. Service
-  teams annotate their Istio `Gateway`/`VirtualService`/`Ingress`/route with `target-from`
-  pointing at it; records follow that entry point automatically, teams never hard-code its
-  address, and records update when it changes.
-- **AWS user**: Ingress fronted by a `GlobalAccelerator` from the AWS LB Controller — point
-  `target-from` at `globalaccelerators.aga.k8s.aws/.../<name>#status.dnsName`, no external
-  controller copying the value into a `target` annotation.
-- **Maintainer**: stop accepting one vendor-CRD coupling per product; point new "point at product
-  X's address" requests at one documented, product-agnostic annotation.
+  teams point `target-from` at it instead of hard-coding its address; records follow it when it
+  changes.
+- **AWS user**: Ingress fronted by a `GlobalAccelerator` from the AWS LB Controller, with no
+  external controller copying the value into a `target` annotation.
+- **Maintainer**: new "point at product X's address" requests become a documented recipe, not one
+  more vendor-CRD coupling.
 
 ### API
 
 Key: `external-dns.kubernetes.io/target-from` (subject to `--annotation-prefix`).
 
-Value grammar (comma-separated for multiple references):
+Value grammar (`;`-separated for multiple references):
 
 ```text
-<resource>[.<group>]/[<namespace>/]<name>#<fieldPath>
+<resource>[.<group>]/[<namespace>/]<name>#<template>
 ```
 
 - `<resource>` — plural lowercase RBAC name (`gateways`, `services`, `globalaccelerators`).
@@ -124,135 +118,158 @@ Value grammar (comma-separated for multiple references):
 - `<namespace>` — optional, defaults to the annotated resource's namespace; cross-namespace refs
   are allowed and are the primary use case.
 - `<name>` — referenced object's name.
-- `<fieldPath>` — a [JSONPath](https://kubernetes.io/docs/reference/kubectl/jsonpath/) resolving
-  to a scalar (one target) or list of scalars (many); `[*]` selects across list elements.
-  Surrounding `{}` are optional.
+- `<template>` — a Go template evaluated against the referenced object's `unstructured` content,
+  using the shared engine and `FuncMap` from `source/template` (`contains`, `trimPrefix`,
+  `trimSuffix`, `trim`, `toLower`, `replace`, `isIPv4`, `isIPv6`, `fromJson`). Its output is split
+  on `,`, trimmed and de-duplicated — the same convention `--fqdn-template` and `--target-template`
+  already use — so one template can yield one target or many. `hasKey` is excluded until its
+  signature is generalized (see [Implementation Steps](#implementation-steps)).
 
-Parsing: `<group>` is everything after the first `.` in the first path segment; no dot means the
-core group (`services`, `endpoints`).
+Parsing: references are separated by `;`; within a reference, the template is everything after the
+**first** `#`. `,` cannot separate references because it is the multi-value separator *inside* a
+template's output. The value is tokenized left to right, and a `;` inside a `{{ … }}` action does
+not terminate a reference. `<group>` is everything after the first `.` in the first path segment;
+no dot means the core group (`services`, `endpoints`).
 
 The API **version** is omitted and resolved via discovery/RESTMapper to the preferred served
-version (like `kubectl`), so records don't silently break on a CRD's `v1beta1` → `v1` graduation
-(the exact fragility raised against #6190). Explicit-version override: see Alternatives.
+version (like `kubectl`), so a CRD graduating `v1beta1` → `v1` does not silently break records.
+Explicit-version override: see [Alternatives](#alternatives).
 
 Examples:
 
 ```yaml
 # Istio Gateway → Gateway API Gateway in a shared namespace
 external-dns.kubernetes.io/hostname: my-service.example.com
-external-dns.kubernetes.io/target-from: "gateways.gateway.networking.k8s.io/istio-ingress/central-gateway#status.addresses[*].value"
+external-dns.kubernetes.io/target-from: "gateways.gateway.networking.k8s.io/istio-ingress/central-gateway#{{ range .status.addresses }}{{ .value }},{{ end }}"
 # Ingress → AWS Global Accelerator (same namespace)
-external-dns.kubernetes.io/target-from: "globalaccelerators.aga.k8s.aws/my-accelerator#status.dnsName"
-# Any resource → shared LoadBalancer Service (IP and hostname)
-external-dns.kubernetes.io/target-from: "services/lb-ns/shared-lb#status.loadBalancer.ingress[*].hostname,services/lb-ns/shared-lb#status.loadBalancer.ingress[*].ip"
+external-dns.kubernetes.io/target-from: "globalaccelerators.aga.k8s.aws/my-accelerator#{{ .status.dnsName }}"
+# Shared LoadBalancer Service — hostname and IP from a single reference, IPv4 only
+external-dns.kubernetes.io/target-from: "services/lb-ns/shared-lb#{{ range .status.loadBalancer.ingress }}{{ .hostname }},{{ if isIPv4 .ip }}{{ .ip }},{{ end }}{{ end }}"
 ```
 
 ### Behavior
 
 **Scope** — `target-from` resolves *only* the record's targets. Hostnames, TTL, and
 provider-specific config still come from the primary resource. The feature is inert unless the
-annotation is present on a resource; no feature flag gates it, so upgrade blast radius is limited
-to resources that opt in.
+annotation is present, so no feature flag gates it and the upgrade blast radius is limited to
+resources that opt in.
 
 **Precedence** — unchanged, with `target-from` where the bespoke `ingress` lookup sits:
 
 1. Literal `target` annotation — highest, unchanged.
 2. `target-from` — resolve referenced field(s).
 3. Legacy Istio `ingress` — kept as an alias of `target-from` against
-   `ingresses.networking.k8s.io/<ref>#status.loadBalancer.ingress[*]` during deprecation.
+   `ingresses.networking.k8s.io/<ref>#{{ range .status.loadBalancer.ingress }}{{ .hostname }},{{ .ip }},{{ end }}`
+   during deprecation.
 4. Source's native discovery (Service selector, LB status, node IPs) — unchanged.
 
-**Record type** — resolved values reuse `suitableType`: IPv4 → `A`, IPv6 → `AAAA`, else `CNAME`;
-mixed IP+hostname produces both, as multi-target LB status does today. Resolved targets then pass
-through existing target filters (`--exclude-target-net`, etc.) unchanged.
+**Record type** — resolved values reuse `endpoint.SuitableType`: IPv4 → `A`, IPv6 → `AAAA`, else
+`CNAME`; mixed IP+hostname produces both, as multi-target LB status does today. Resolved targets
+then pass through existing target filters (`--exclude-target-net`, etc.) unchanged.
 
 **Resolution** — a shared resolver keys a dynamic client by the RESTMapper GVR, backed by a
-per-GVR informer, so referenced resources are watched/cached and their changes trigger a sync via
-the normal event path (no polling). Because cross-namespace references are the primary use case,
-these referenced-resource informers watch **all namespaces regardless of `--namespace`** (which
-scopes only the primary sources); the watch reads only the referenced GVRs, gated by RBAC. This
-requires `list`+`watch` (not just `get`) on those GVRs; with only `get` granted, resolution still
-works via direct reads but loses change-driven sync.
+per-GVR informer, so referenced resources are watched and their changes trigger a sync via the
+normal event path (no polling). Because cross-namespace references are the primary use case, these
+informers watch **all namespaces regardless of `--namespace`** (which scopes only the primary
+sources), gated by RBAC. With only `get` granted instead of `list`+`watch`, resolution still works
+via direct reads but loses change-driven sync.
 
 **Empty / not-found / missing-field (critical)** — an unresolved reference (object not found,
 field absent, empty list) must **not** fall through to native discovery and must **not** delete
-records: the endpoint is **skipped for this sync with a warning**, prior state intact. Avoids
-the #6438 failure mode (stale/empty lookup silently deleting records) and aligns with its
-log-and-continue resilience fix.
+records: the endpoint is **skipped for this sync with a warning**, prior state intact. A stale or
+empty lookup silently deleting live records is the failure mode this rules out.
 
-**Edge cases** — multiple refs: de-duplicated union. Non-scalar JSONPath result: config error,
-warn+skip. No RBAC access: warn+skip, never crash. Unknown GVR (CRD not installed / RESTMapper
-miss): warn+skip. Cluster-scoped resource: `<namespace>` must be omitted, supplying one is an
-error.
+Templating needs care here: `text/template` resolves a missing map key to the zero value and
+renders `<no value>` rather than failing, which would turn "field absent" into "empty target"
+silently. Two guards, both with precedent in-tree:
+
+1. The target-from template is parsed with `Option("missingkey=error")` so an absent key is
+a hard template error
+2. An empty (or whitespace-only) render is treated as *unresolved*, not as *no targets* — the same "field may not yet be populated" skip the `unstructured` source already does (`source/unstructured_converter.go`).
+
+Neither path may reach the plan as a deletion.
+
+**Edge cases** — multiple refs: de-duplicated union. Template parse/exec error (bad syntax,
+missing key, non-scalar value rendered): config error, warn+skip. No RBAC access: warn+skip, never
+crash. Unknown GVR (CRD not installed / RESTMapper miss): warn+skip. Cluster-scoped resource:
+`<namespace>` must be omitted, supplying one is an error.
 
 ### Security Considerations
 
 `target-from` lets a namespaced annotation cause ExternalDNS to read another resource, possibly
-cross-namespace.
+cross-namespace. **RBAC is the boundary**: resolution uses ExternalDNS's own ServiceAccount and
+reads only what that account is granted, per namespace; no grant means fail closed (warn, skip).
 
-**RBAC is the boundary.** Resolution uses ExternalDNS's own ServiceAccount; it reads only what
-that account is granted (`get`/`list`/`watch` on the intended `resource.group`, per namespace).
-No grant → fail closed (warn, skip). No new default RBAC for arbitrary CRDs ships. RBAC is
-strictly finer-grained than any resource-name allowlist (it also scopes by namespace), so an
-operator who wants to constrain `target-from` scopes the ServiceAccount's Role accordingly.
+No new default RBAC for arbitrary CRDs ships. Only a resolved field *value* is used, as a DNS
+target string — a value a tenant could already set via the literal `target` annotation — so there
+is no privilege escalation and no exposure of resource content beyond that field.
 
-Only a resolved field *value* is used, as a DNS target string — a value a tenant could already
-set via the literal `target` annotation — so there is no privilege escalation and no exposure of
-resource content beyond that one field.
+The caveat is cluster-wide deployments, where a `ClusterRole` is common and RBAC therefore does
+not meaningfully constrain `target-from`.
 
-**Caveat for cluster-wide deployments.** ExternalDNS is frequently run with a cluster-wide
-`ClusterRole` (sources need services/ingresses/gateways/routes across all namespaces when
-`--namespace` is empty). In that setup RBAC does not meaningfully constrain `target-from`. The
-residual risk is narrow (deref an unintended CRD field and surface it as a DNS record the tenant
-controls). A GVR allowlist flag (`--target-from-allowed-resources`) is deliberately left as a
-**future option** rather than shipped in v1alpha1; operators needing a hard guardrail today can
-run ExternalDNS with namespace-scoped RBAC. Open question for review: is the allowlist worth
-adding, or is RBAC sufficient?
+Residual risk is narrow (deref an unintended CRD field and surface it as a DNS record the tenant
+controls), and operators wanting a hard guardrail today can run with namespace-scoped RBAC.
 
 ### Implementation Steps
 
-- Shared resolver: parse grammar, RESTMapper lookup, per-GVR dynamic informer, JSONPath eval
-  (`k8s.io/client-go/util/jsonpath`).
-- Add `TargetFromKey` to `source/annotations`; wire into `targetsFromX` in sources already
-  honoring `target`/`ingress` (Istio Gateway, Istio VirtualService, Ingress, Gateway API routes,
-  Service, CRD/DNSEndpoint). Start with Istio + Ingress to cover the open requests.
-- Alias the legacy Istio `ingress` annotation onto the resolver; keep the `ParseIngress` →
-  `ParseNamespacedName` generalization (staged in #6438).
-- Docs: new section in `docs/annotations/annotations.md`, cross-linked from `unstructured`.
-- Tests mirroring the Istio `ingress` coverage plus not-found / empty / RBAC-denied / unknown-GVR.
+- Shared resolver: parse grammar, RESTMapper lookup, per-GVR dynamic informer, template eval via
+  `source/template`. No new dependency, no new expression language.
+- One new `source/template` entry point executing against an `unstructured.Unstructured`'s content
+  map, reusing the existing `FuncMap` and `execTemplate`'s comma-split/dedupe. Scope
+  `Option("missingkey=error")` to the `target-from` template **only**: the existing templates rely
+  on today's lenient behavior, so setting it engine-wide would be a breaking change.
+- Generalize `hasKey` from `map[string]string` to a map of `any` before advertising it here; as
+  written it cannot be called against unstructured content.
+- Add `TargetFromKey` to `source/annotations`; wire into `targetsFromX` in sources already honoring
+  `target`/`ingress`, starting with Istio + Ingress to cover the open requests.
+- Alias the legacy Istio `ingress` annotation onto the resolver, generalizing its `ParseIngress`
+  helper into a `ParseNamespacedName` shared by both paths.
+- Docs in `docs/annotations/annotations.md`, cross-linked from `unstructured`. Tests mirroring the
+  Istio `ingress` coverage plus not-found / empty / RBAC-denied / unknown-GVR / missing key /
+  template parse error.
 
 ### Migration and Deprecation
 
 - Additive; no existing behavior changes on upgrade.
 - Istio `ingress` becomes a documented alias, soft-deprecated (kept working, docs steer to
   `target-from`).
-- The per-product annotations proposed in #6438 (`gateway`) and #6190 (`global-accelerator`) are
-  **not added**; documented as `target-from` recipes instead. #6438 can close keeping only its
-  two orthogonal bug fixes; #6190 stays closed.
+- The per-product annotations (`gateway`, `global-accelerator`) are **not added**; they are
+  documented as `target-from` recipes instead.
 
 ### Drawbacks
 
 - Dynamic client + per-GVR informer is more machinery than a typed lookup and adds watches.
-- JSONPath in an annotation is a small language users can get wrong; mitigated by warn-and-skip
-  errors and documented recipes.
-- Under cluster-wide RBAC a tenant could target an unintended resource; mitigated by
-  namespace-scoped RBAC, with a GVR allowlist flag as a possible future guardrail.
-- Version-by-discovery can shift if a CRD's preferred version changes; safer than baking in a
-  version, with the explicit-version override as escape hatch.
+- A Go template in an annotation is verbose next to a bare field path, and missing keys rendering
+  as `<no value>` is a sharp edge; both handled per [Behavior](#behavior), the latter must stay
+  covered by tests.
+- Under cluster-wide RBAC a tenant could target an unintended resource; see
+  [Security Considerations](#security-considerations).
+- Version-by-discovery can shift if a CRD's preferred version changes, with the explicit-version
+  override as escape hatch.
 
 ## Alternatives
 
 - **`unstructured` source (exists).** Reads any CRD field via templates, but *replaces* the
   primary source — you lose its native hostname/TTL/provider handling. `target-from` keeps the
-  primary source and only borrows the address; complementary, docs point to whichever fits.
+  primary source and only borrows the address; complementary, docs point to whichever fits, and
+  both are written in the same template syntax.
+- **JSONPath instead of Go templates** (`#status.addresses[*].value`). Terser for the common "one
+  field" case, and it errors natively on a missing field.
+
+  It would be a second expression language in a project already standardized on `text/template` —
+  `source/template` backs `--fqdn-template`, `--target-template`, `--fqdn-target-template` and
+  the `unstructured` source.
+
+  No JSONPath exists in the tree today. It also buys no capability: `[*]` maps onto `range`, multi-value output
+  is already handled by the engine's comma-split/dedupe, and templates add conditionals plus the
+  existing helpers. Two syntaxes for "read a field off a CRD" is the cost; terseness the only gain.
 - **Per-product annotations (`ingress`, `gateway`, `global-accelerator`, …).** The status quo:
   each couples a source to a vendor CRD/version, multiplies code paths, repeatedly rejected
   (#6438, #6190). `target-from` is the generalization that removes the coupling.
 - **External controller copies the address into `target`.** No ExternalDNS change, but pushes an
-  extra controller onto every user; maintainers floated the generic annotation as the better
-  answer.
-- **Explicit-version grammar** (`<resource>.<group>/<version>/<ns>/<name>#<path>`, the #6190
-  form). More precise but reintroduces version-drift fragility; offered as an optional override
-  on the discovery-based default, not the default.
+  extra controller, with its own RBAC and failure modes, onto every user who needs this.
+- **Explicit-version grammar** (`<resource>.<group>/<version>/<ns>/<name>#<template>`). More
+  precise, but pins a version that a CRD will eventually graduate past; offered as an optional
+  override on the discovery-based default, not the default.
 - **Do nothing.** Each new "point at product X" request keeps arriving as a coupling PR that gets
   held or closed, leaving users on manual `target` or the heavier `unstructured` source.

--- a/docs/proposal/007-target-from-resource.md
+++ b/docs/proposal/007-target-from-resource.md
@@ -41,7 +41,7 @@ annotation with its own code path baked into the sources (`ingress` for Istio, a
 `gateway` for Gateway API, a proposed `global-accelerator` for AWS), each coupling a source to a
 third-party CRD and its API version.
 
-This proposes one generic annotation, `external-dns.alpha.kubernetes.io/target-from`, that
+This proposes one generic annotation, `external-dns.kubernetes.io/target-from`, that
 dereferences a named field on an arbitrary referenced resource and uses the resolved value(s) as
 the target. It replaces the per-product annotations with one mechanism and imports **no vendor
 CRDs** into the sources.
@@ -111,7 +111,7 @@ that one hard-coded case to any resource and field.
 
 ### API
 
-Key: `external-dns.alpha.kubernetes.io/target-from` (subject to `--annotation-prefix`).
+Key: `external-dns.kubernetes.io/target-from` (subject to `--annotation-prefix`).
 
 Value grammar (comma-separated for multiple references):
 
@@ -139,12 +139,12 @@ Examples:
 
 ```yaml
 # Istio Gateway → Gateway API Gateway in a shared namespace
-external-dns.alpha.kubernetes.io/hostname: my-service.example.com
-external-dns.alpha.kubernetes.io/target-from: "gateways.gateway.networking.k8s.io/istio-ingress/central-gateway#status.addresses[*].value"
+external-dns.kubernetes.io/hostname: my-service.example.com
+external-dns.kubernetes.io/target-from: "gateways.gateway.networking.k8s.io/istio-ingress/central-gateway#status.addresses[*].value"
 # Ingress → AWS Global Accelerator (same namespace)
-external-dns.alpha.kubernetes.io/target-from: "globalaccelerators.aga.k8s.aws/my-accelerator#status.dnsName"
+external-dns.kubernetes.io/target-from: "globalaccelerators.aga.k8s.aws/my-accelerator#status.dnsName"
 # Any resource → shared LoadBalancer Service (IP and hostname)
-external-dns.alpha.kubernetes.io/target-from: "services/lb-ns/shared-lb#status.loadBalancer.ingress[*].hostname,services/lb-ns/shared-lb#status.loadBalancer.ingress[*].ip"
+external-dns.kubernetes.io/target-from: "services/lb-ns/shared-lb#status.loadBalancer.ingress[*].hostname,services/lb-ns/shared-lb#status.loadBalancer.ingress[*].ip"
 ```
 
 ### Behavior

--- a/docs/proposal/007-target-from-resource.md
+++ b/docs/proposal/007-target-from-resource.md
@@ -107,7 +107,7 @@ and field, resolved via a dynamic client and the RESTMapper so no source imports
 
 Key: `external-dns.kubernetes.io/target-from` (subject to `--annotation-prefix`).
 
-Value grammar (`;`-separated for multiple references):
+Value grammar — one reference per annotation:
 
 ```text
 <resource>[.<group>]/[<namespace>/]<name>#<template>
@@ -125,11 +125,16 @@ Value grammar (`;`-separated for multiple references):
   already use — so one template can yield one target or many. `hasKey` is excluded until its
   signature is generalized (see [Implementation Steps](#implementation-steps)).
 
-Parsing: references are separated by `;`; within a reference, the template is everything after the
-**first** `#`. `,` cannot separate references because it is the multi-value separator *inside* a
-template's output. The value is tokenized left to right, and a `;` inside a `{{ … }}` action does
-not terminate a reference. `<group>` is everything after the first `.` in the first path segment;
-no dot means the core group (`services`, `endpoints`).
+Parsing: the template is everything after the **first** `#`, taken verbatim.
+
+Nothing terminates it, so there is no escaping rule and its source text may contain any character — `;` and `#` included, in literal text or inside an action.
+`<group>` is everything after the first `.` in the first path segment; no dot means the core group (`services`, `endpoints`).
+
+One annotation therefore names exactly one object, while the template over that object can still
+yield many targets (see the third example below).
+
+The reference is static: parsed before the object is fetched, so it cannot be templated
+(`services/{{ .metadata.namespace }}/lb#…` is unsupported).
 
 The API **version** is omitted and resolved via discovery/RESTMapper to the preferred served
 version (like `kubectl`), so a CRD graduating `v1beta1` → `v1` does not silently break records.
@@ -189,10 +194,14 @@ a hard template error
 
 Neither path may reach the plan as a deletion.
 
-**Edge cases** — multiple refs: de-duplicated union. Template parse/exec error (bad syntax,
-missing key, non-scalar value rendered): config error, warn+skip. No RBAC access: warn+skip, never
-crash. Unknown GVR (CRD not installed / RESTMapper miss): warn+skip. Cluster-scoped resource:
-`<namespace>` must be omitted, supplying one is an error.
+**Edge cases**
+
+- Repeated targets from one template: de-duplicated.
+- Template parse/exec error (bad syntax, missing key, non-scalar value rendered): warn+skip.
+- No RBAC access: warn+skip.
+- Unknown GVR (CRD not installed / RESTMapper miss): warn+skip.
+- Cluster-scoped resource: `<namespace>` must be omitted, warn+skip.
+- Value with no `#`: warn+skip.
 
 ### Security Considerations
 


### PR DESCRIPTION
## What does it do ?

Adds proposal 007: a generic `external-dns.kubernetes.io/target-from` annotation resolving a record's target from a field on another resource (dynamic client + RESTMapper, no vendor CRDs in sources). 

Replaces per-product source-to-CRD coupling.

## Motivation

Recurring, repeatedly-held/closed requests to couple sources to product CRDs: #6438 (Istio→Gateway API), #6190 / #6166 (→AWS Global Accelerator), #6457, #4687. 

Formalizes the generic annotation @ivankatliarchuk sketched in #6190.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, this is end user documentation