### PR TITLE
fix(source/crd): restore custom CRD apiVersion and kind support

### DIFF
--- a/source/crd.go
+++ b/source/crd.go
@@ -25,7 +25,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
+	toolscache "k8s.io/client-go/tools/cache"
 	crcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -55,9 +61,23 @@ type crdSource struct {
 	listOpts []client.ListOption
 }
 
+type legacyCRDSource struct {
+	crdClient        rest.Interface
+	namespace        string
+	crdResource      string
+	codec            runtime.ParameterCodec
+	annotationFilter labels.Selector
+	labelSelector    labels.Selector
+	informer         toolscache.SharedInformer
+}
+
 // NewCRDSource creates a new crdSource backed by a controller-runtime cache.
 // It builds the scheme, cache, and status-write client from restConfig and cfg.
 func NewCRDSource(ctx context.Context, restConfig *rest.Config, cfg *Config) (Source, error) {
+	if !usesBuiltInDNSEndpointCRD(cfg) {
+		return newLegacyCRDSource(restConfig, cfg)
+	}
+
 	opts, err := buildCacheOptions(cfg.Namespace, cfg.LabelFilter, cfg.AnnotationFilter)
 	if err != nil {
 		return nil, err
@@ -77,11 +97,38 @@ func NewCRDSource(ctx context.Context, restConfig *rest.Config, cfg *Config) (So
 	return newCrdSource(ctx, c, crWriter, cfg.Namespace, cfg.LabelFilter)
 }
 
+func usesBuiltInDNSEndpointCRD(cfg *Config) bool {
+	apiVersion := cfg.CRDSourceAPIVersion
+	if apiVersion == "" {
+		apiVersion = apiv1alpha1.GroupVersion.String()
+	}
+
+	kind := cfg.CRDSourceKind
+	if kind == "" {
+		kind = "DNSEndpoint"
+	}
+
+	return apiVersion == apiv1alpha1.GroupVersion.String() && kind == "DNSEndpoint"
+}
+
 func (cs *crdSource) AddEventHandler(_ context.Context, handler func()) {
 	log.Debug("crd: adding event handler")
 	// Right now there is no way to remove event handler from informer, see:
 	// https://github.com/kubernetes/kubernetes/issues/79610
 	_, _ = cs.informer.AddEventHandler(eventHandlerFunc(handler))
+}
+
+func (cs *legacyCRDSource) AddEventHandler(_ context.Context, handler func()) {
+	if cs.informer == nil {
+		return
+	}
+
+	log.Debug("crd: adding event handler for custom CRD")
+	informers.MustAddEventHandler(cs.informer, toolscache.ResourceEventHandlerFuncs{
+		AddFunc:    func(_ any) { handler() },
+		UpdateFunc: func(_, _ any) { handler() },
+		DeleteFunc: func(_ any) { handler() },
+	})
 }
 
 // Endpoints returns endpoint objects for all DNSEndpoint resources visible to
@@ -96,65 +143,7 @@ func (cs *crdSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 	endpoints := make([]*endpoint.Endpoint, 0, len(list.Items))
 	for i := range list.Items {
 		dnsEndpoint := &list.Items[i]
-		var crdEndpoints []*endpoint.Endpoint
-		for _, ep := range dnsEndpoint.Spec.Endpoints {
-			if ep == nil {
-				log.Debugf(
-					"Skipping nil endpoint in DNSEndpoint %s/%s at spec.endpoints",
-					dnsEndpoint.Namespace,
-					dnsEndpoint.Name,
-				)
-				continue
-			}
-
-			if (ep.RecordType == endpoint.RecordTypeCNAME || ep.RecordType == endpoint.RecordTypeA || ep.RecordType == endpoint.RecordTypeAAAA) && len(ep.Targets) < 1 {
-				log.Debugf("Endpoint %s with DNSName %s has an empty list of targets, allowing it to pass through for default-targets processing", dnsEndpoint.Name, ep.DNSName)
-			}
-			illegalTarget := false
-			for _, target := range ep.Targets {
-				switch ep.RecordType {
-				case endpoint.RecordTypeTXT, endpoint.RecordTypeMX:
-					continue // no format constraint on targets
-				case endpoint.RecordTypeCNAME:
-					continue // RFC 1035 §5.1: trailing dot denotes an absolute FQDN in zone file notation; both forms are valid
-				case endpoint.RecordTypeSRV:
-					// SRV targets are "<prio> <weight> <port> <host>"; RFC 2782
-					// requires the host to be an absolute FQDN and
-					// Endpoint.ValidateSRVRecord enforces the trailing dot.
-					// Reject-on-trailing-dot (the default branch below) would
-					// loop users between this warning and ValidateSRVRecord's
-					// "does not end with a dot" error (#6357).
-					continue
-				}
-
-				hasDot := strings.HasSuffix(target, ".")
-
-				switch ep.RecordType {
-				case endpoint.RecordTypeNAPTR:
-					illegalTarget = !hasDot
-				default:
-					illegalTarget = hasDot
-				}
-
-				if illegalTarget {
-					fixed := target + "."
-					if ep.RecordType != endpoint.RecordTypeNAPTR {
-						fixed = strings.TrimSuffix(target, ".")
-					}
-					log.Warnf("Endpoint %s/%s with DNSName %s has an illegal target %q for %s record — use %q not %q.",
-						dnsEndpoint.Namespace, dnsEndpoint.Name, ep.DNSName, target, ep.RecordType, fixed, target)
-					break
-				}
-			}
-			if illegalTarget {
-				continue
-			}
-
-			ep.WithLabel(endpoint.ResourceLabelKey, fmt.Sprintf("crd/%s/%s", dnsEndpoint.Namespace, dnsEndpoint.Name))
-			crdEndpoints = append(crdEndpoints, ep)
-		}
-
-		endpoint.AttachRefObject(crdEndpoints, events.NewObjectReference(dnsEndpoint, types.CRD))
+		crdEndpoints := endpointsFromDNSEndpoint(dnsEndpoint)
 		endpoints = append(endpoints, crdEndpoints...)
 
 		if dnsEndpoint.Status.ObservedGeneration == dnsEndpoint.Generation {
@@ -165,6 +154,36 @@ func (cs *crdSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 		if err := cs.crWriter.Status().Update(ctx, dnsEndpoint); err != nil {
 			log.Warnf("Could not update ObservedGeneration of [%s/%s/%s]: %v",
 				"dnsendpoint", dnsEndpoint.Namespace, dnsEndpoint.Name, err)
+		}
+	}
+
+	return endpoint.MergeEndpoints(endpoints), nil
+}
+
+func (cs *legacyCRDSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	result, err := cs.List(ctx, &metav1.ListOptions{LabelSelector: cs.labelSelector.String()})
+	if err != nil {
+		return nil, err
+	}
+
+	endpoints := make([]*endpoint.Endpoint, 0, len(result.Items))
+	for i := range result.Items {
+		dnsEndpoint := &result.Items[i]
+		if !matchLabelSelector(cs.annotationFilter, dnsEndpoint.Annotations) {
+			continue
+		}
+
+		crdEndpoints := endpointsFromDNSEndpoint(dnsEndpoint)
+		endpoints = append(endpoints, crdEndpoints...)
+
+		if dnsEndpoint.Status.ObservedGeneration == dnsEndpoint.Generation {
+			continue
+		}
+
+		dnsEndpoint.Status.ObservedGeneration = dnsEndpoint.Generation
+		if _, err := cs.UpdateStatus(ctx, dnsEndpoint); err != nil {
+			log.Warnf("Could not update ObservedGeneration of [%s/%s/%s]: %v",
+				cs.crdResource, dnsEndpoint.Namespace, dnsEndpoint.Name, err)
 		}
 	}
 
@@ -256,4 +275,184 @@ func buildCacheOptions(namespace string, labelFilter, annotationSelector labels.
 			&apiv1alpha1.DNSEndpoint{}: byObj,
 		},
 	}, nil
+}
+
+func endpointsFromDNSEndpoint(dnsEndpoint *apiv1alpha1.DNSEndpoint) []*endpoint.Endpoint {
+	var crdEndpoints []*endpoint.Endpoint
+
+	for _, ep := range dnsEndpoint.Spec.Endpoints {
+		if ep == nil {
+			log.Debugf(
+				"Skipping nil endpoint in DNSEndpoint %s/%s at spec.endpoints",
+				dnsEndpoint.Namespace,
+				dnsEndpoint.Name,
+			)
+			continue
+		}
+
+		if endpointHasIllegalCRDTarget(dnsEndpoint, ep) {
+			continue
+		}
+
+		ep.WithLabel(endpoint.ResourceLabelKey, fmt.Sprintf("crd/%s/%s", dnsEndpoint.Namespace, dnsEndpoint.Name))
+		crdEndpoints = append(crdEndpoints, ep)
+	}
+
+	endpoint.AttachRefObject(crdEndpoints, events.NewObjectReference(dnsEndpoint, types.CRD))
+	return crdEndpoints
+}
+
+func endpointHasIllegalCRDTarget(dnsEndpoint *apiv1alpha1.DNSEndpoint, ep *endpoint.Endpoint) bool {
+	if (ep.RecordType == endpoint.RecordTypeCNAME || ep.RecordType == endpoint.RecordTypeA || ep.RecordType == endpoint.RecordTypeAAAA) && len(ep.Targets) < 1 {
+		log.Debugf("Endpoint %s with DNSName %s has an empty list of targets, allowing it to pass through for default-targets processing", dnsEndpoint.Name, ep.DNSName)
+	}
+
+	for _, target := range ep.Targets {
+		switch ep.RecordType {
+		case endpoint.RecordTypeTXT, endpoint.RecordTypeMX:
+			continue // no format constraint on targets
+		case endpoint.RecordTypeCNAME:
+			continue // RFC 1035 §5.1: trailing dot denotes an absolute FQDN in zone file notation; both forms are valid
+		case endpoint.RecordTypeSRV:
+			// SRV targets are "<prio> <weight> <port> <host>"; RFC 2782
+			// requires the host to be an absolute FQDN and
+			// Endpoint.ValidateSRVRecord enforces the trailing dot.
+			// Reject-on-trailing-dot (the default branch below) would
+			// loop users between this warning and ValidateSRVRecord's
+			// "does not end with a dot" error (#6357).
+			continue
+		}
+
+		hasDot := strings.HasSuffix(target, ".")
+		illegalTarget := hasDot
+		if ep.RecordType == endpoint.RecordTypeNAPTR {
+			illegalTarget = !hasDot
+		}
+
+		if illegalTarget {
+			fixed := target + "."
+			if ep.RecordType != endpoint.RecordTypeNAPTR {
+				fixed = strings.TrimSuffix(target, ".")
+			}
+			log.Warnf("Endpoint %s/%s with DNSName %s has an illegal target %q for %s record — use %q not %q.",
+				dnsEndpoint.Namespace, dnsEndpoint.Name, ep.DNSName, target, ep.RecordType, fixed, target)
+			return true
+		}
+	}
+
+	return false
+}
+
+func newLegacyCRDSource(restConfig *rest.Config, cfg *Config) (Source, error) {
+	crdClient, scheme, resource, err := newLegacyCRDClient(restConfig, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	sourceCrd := &legacyCRDSource{
+		crdResource:      resource,
+		namespace:        cfg.Namespace,
+		annotationFilter: cfg.AnnotationFilter,
+		labelSelector:    cfg.LabelFilter,
+		crdClient:        crdClient,
+		codec:            runtime.NewParameterCodec(scheme),
+	}
+	if cfg.UpdateEvents {
+		// external-dns already runs its sync-handler periodically to cover missed events.
+		sourceCrd.informer = toolscache.NewSharedInformer(
+			&toolscache.ListWatch{
+				ListWithContextFunc: func(ctx context.Context, lo metav1.ListOptions) (runtime.Object, error) {
+					return sourceCrd.List(ctx, &lo)
+				},
+				WatchFuncWithContext: func(ctx context.Context, lo metav1.ListOptions) (watch.Interface, error) {
+					return sourceCrd.watch(ctx, &lo)
+				},
+			},
+			&apiv1alpha1.DNSEndpoint{},
+			0,
+		)
+		go sourceCrd.informer.Run(wait.NeverStop)
+	}
+
+	return sourceCrd, nil
+}
+
+func newLegacyCRDClient(restConfig *rest.Config, cfg *Config) (rest.Interface, *runtime.Scheme, string, error) {
+	groupVersion, err := schema.ParseGroupVersion(cfg.CRDSourceAPIVersion)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	apiResourceList, err := discoveryClient.ServerResourcesForGroupVersion(groupVersion.String())
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("error listing resources in GroupVersion %q: %w", groupVersion.String(), err)
+	}
+
+	var crdResource string
+	for _, apiResource := range apiResourceList.APIResources {
+		if apiResource.Kind == cfg.CRDSourceKind {
+			crdResource = apiResource.Name
+			break
+		}
+	}
+	if crdResource == "" {
+		return nil, nil, "", fmt.Errorf("unable to find Resource Kind %q in GroupVersion %q", cfg.CRDSourceKind, cfg.CRDSourceAPIVersion)
+	}
+
+	scheme := runtime.NewScheme()
+	if err := apiv1alpha1.AddToScheme(scheme); err != nil {
+		return nil, nil, "", err
+	}
+	scheme.AddKnownTypes(groupVersion, &apiv1alpha1.DNSEndpoint{}, &apiv1alpha1.DNSEndpointList{})
+	metav1.AddToGroupVersion(scheme, groupVersion)
+
+	config := rest.CopyConfig(restConfig)
+	config.GroupVersion = &groupVersion
+	config.APIPath = "/apis"
+	config.NegotiatedSerializer = serializer.WithoutConversionCodecFactory{
+		CodecFactory: serializer.NewCodecFactory(scheme),
+	}
+
+	crdClient, err := rest.UnversionedRESTClientFor(config)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	return crdClient, scheme, crdResource, nil
+}
+
+func (cs *legacyCRDSource) watch(ctx context.Context, opts *metav1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return cs.crdClient.Get().
+		Namespace(cs.namespace).
+		Resource(cs.crdResource).
+		VersionedParams(opts, cs.codec).
+		Watch(ctx)
+}
+
+func (cs *legacyCRDSource) List(ctx context.Context, opts *metav1.ListOptions) (*apiv1alpha1.DNSEndpointList, error) {
+	result := &apiv1alpha1.DNSEndpointList{}
+	return result, cs.crdClient.Get().
+		Namespace(cs.namespace).
+		Resource(cs.crdResource).
+		VersionedParams(opts, cs.codec).
+		Do(ctx).
+		Into(result)
+}
+
+func (cs *legacyCRDSource) UpdateStatus(ctx context.Context, dnsEndpoint *apiv1alpha1.DNSEndpoint) (*apiv1alpha1.DNSEndpoint, error) {
+	result := &apiv1alpha1.DNSEndpoint{}
+	return result, cs.crdClient.Put().
+		Namespace(dnsEndpoint.Namespace).
+		Resource(cs.crdResource).
+		Name(dnsEndpoint.Name).
+		SubResource("status").
+		Body(dnsEndpoint).
+		Do(ctx).
+		Into(result)
 }

--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -18,8 +18,12 @@ package source
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"math/rand"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -126,6 +130,128 @@ func TestBuildCacheOptions(t *testing.T) {
 
 func TestCRDSource(t *testing.T) {
 	t.Run("Endpoints", testCRDSourceEndpoints)
+}
+
+func TestNewCRDSource_CustomGVKUsesConfiguredResource(t *testing.T) {
+	t.Parallel()
+
+	var (
+		listCalled      atomic.Bool
+		statusUpdates   atomic.Int32
+		labelSelectorOK atomic.Bool
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/apis/externaldns.nginx.org/v1":
+			err := json.NewEncoder(w).Encode(&metav1.APIResourceList{
+				GroupVersion: "externaldns.nginx.org/v1",
+				APIResources: []metav1.APIResource{{
+					Name:       "dnsendpoints",
+					Kind:       "DNSEndpoint",
+					Namespaced: true,
+				}},
+			})
+			require.NoError(t, err)
+		case r.Method == http.MethodGet && r.URL.Path == "/apis/externaldns.nginx.org/v1/namespaces/team-a/dnsendpoints":
+			listCalled.Store(true)
+			labelSelectorOK.Store(r.URL.Query().Get("labelSelector") == "app=custom")
+
+			err := json.NewEncoder(w).Encode(&apiv1alpha1.DNSEndpointList{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "externaldns.nginx.org/v1",
+					Kind:       "DNSEndpointList",
+				},
+				Items: []apiv1alpha1.DNSEndpoint{
+					{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "externaldns.nginx.org/v1",
+							Kind:       "DNSEndpoint",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "custom-record",
+							Namespace:   "team-a",
+							Generation:  3,
+							Annotations: map[string]string{"external-dns": "public"},
+						},
+						Spec: apiv1alpha1.DNSEndpointSpec{
+							Endpoints: []*endpoint.Endpoint{{
+								DNSName:    "api.example.org",
+								Targets:    endpoint.Targets{"1.2.3.4"},
+								RecordType: endpoint.RecordTypeA,
+								RecordTTL:  180,
+							}},
+						},
+					},
+					{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "externaldns.nginx.org/v1",
+							Kind:       "DNSEndpoint",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "ignored-record",
+							Namespace:   "team-a",
+							Generation:  2,
+							Annotations: map[string]string{"external-dns": "private"},
+						},
+						Spec: apiv1alpha1.DNSEndpointSpec{
+							Endpoints: []*endpoint.Endpoint{{
+								DNSName:    "ignored.example.org",
+								Targets:    endpoint.Targets{"5.6.7.8"},
+								RecordType: endpoint.RecordTypeA,
+								RecordTTL:  180,
+							}},
+						},
+					},
+				},
+			})
+			require.NoError(t, err)
+		case r.Method == http.MethodPut && r.URL.Path == "/apis/externaldns.nginx.org/v1/namespaces/team-a/dnsendpoints/custom-record/status":
+			statusUpdates.Add(1)
+
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+
+			var updated apiv1alpha1.DNSEndpoint
+			err = json.Unmarshal(body, &updated)
+			require.NoError(t, err)
+			require.EqualValues(t, 3, updated.Status.ObservedGeneration)
+
+			err = json.NewEncoder(w).Encode(&updated)
+			require.NoError(t, err)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		Namespace:           "team-a",
+		AnnotationFilter:    labels.SelectorFromSet(labels.Set{"external-dns": "public"}),
+		LabelFilter:         labels.SelectorFromSet(labels.Set{"app": "custom"}),
+		CRDSourceAPIVersion: "externaldns.nginx.org/v1",
+		CRDSourceKind:       "DNSEndpoint",
+	}
+
+	src, err := NewCRDSource(t.Context(), &rest.Config{Host: server.URL}, cfg)
+	require.NoError(t, err)
+	require.IsType(t, &legacyCRDSource{}, src)
+
+	endpoints, err := src.Endpoints(t.Context())
+	require.NoError(t, err)
+	require.True(t, listCalled.Load(), "custom CRD list endpoint should be called")
+	require.True(t, labelSelectorOK.Load(), "label selector should be forwarded to the API server")
+	require.EqualValues(t, 1, statusUpdates.Load(), "only matching custom CRD should get a status update")
+
+	expected := []*endpoint.Endpoint{{
+		DNSName:    "api.example.org",
+		Targets:    endpoint.Targets{"1.2.3.4"},
+		RecordType: endpoint.RecordTypeA,
+		RecordTTL:  180,
+	}}
+	testutils.ValidateEndpoints(t, endpoints, expected)
 }
 
 // testCRDSourceEndpoints tests various scenarios of using CRD source.


### PR DESCRIPTION
## What does it do ?

Restores custom CRD support for `--crd-source-apiversion` and `--crd-source-kind`.

Built-in `externaldns.k8s.io/v1alpha1` still uses the controller-runtime cache path. Custom DNSEndpoint-style CRDs fall back to the legacy REST path again, so the documented behavior works again.

## Motivation

Fixes #6414. This regressed in #6312. The refactor kinda hardcoded the built-in CRD, so custom DNSEndpoint contracts got ignored even when the flags were set.

Repro:
- run external-dns with `--source=crd`
- set `--crd-source-apiversion=externaldns.nginx.org/v1`
- set `--crd-source-kind=DNSEndpoint`
- create a custom DNSEndpoint-style resource
- on `v0.21.0` nothing gets reconciled, with this patch it does

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly
