### PR TITLE
feat(registry/txt): warn when an applied ownership TXT is dropped

### DIFF
--- a/docs/registry/txt.md
+++ b/docs/registry/txt.md
@@ -7,8 +7,8 @@ It stores DNS record metadata in TXT records, using the same provider.
 >
 > - If you plan to manage apex domains with external-dns whilst using a txt registry, you should ensure when using `--txt-prefix` that you specify the record type substitution and that it ends in a period (**.**).
 >   The record should be created under the same domain as the apex record being managed, i.e. `--txt-prefix=someprefix-%{record_type}.`
-> - With `--regex-domain-filter`, the regex must also match the type-prefixed TXT names (e.g. `a-example.org`), or ownership is not tracked.
-> - The [CRD registry](crd.md) stores ownership in a `DNSRecord` resource and is not affected.
+> - `--regex-domain-filter` must also match the type-prefixed TXT names (e.g. `a-example.org`), or ownership is not tracked.
+> - The [CRD registry](crd.md) stores ownership in a `DNSRecord` resource and is unaffected.
 > - `--txt-prefix` and `--txt-suffix` contribute to the 63-byte maximum record length. To avoid errors, use them only if absolutely required and keep them as short as possible.
 
 ## Record Format Options

--- a/docs/registry/txt.md
+++ b/docs/registry/txt.md
@@ -7,6 +7,8 @@ It stores DNS record metadata in TXT records, using the same provider.
 >
 > - If you plan to manage apex domains with external-dns whilst using a txt registry, you should ensure when using `--txt-prefix` that you specify the record type substitution and that it ends in a period (**.**).
 >   The record should be created under the same domain as the apex record being managed, i.e. `--txt-prefix=someprefix-%{record_type}.`
+> - With `--regex-domain-filter`, make sure the regex also matches the type-prefixed ownership TXT names (e.g. `a-example.org`); otherwise they are filtered out and ownership is not tracked.
+> - The [CRD registry](crd.md) stores ownership in a `DNSRecord` resource instead and is not affected.
 > - `--txt-prefix` and `--txt-suffix` contribute to the 63-byte maximum record length. To avoid errors, use them only if absolutely required and keep them as short as possible.
 
 ## Record Format Options

--- a/docs/registry/txt.md
+++ b/docs/registry/txt.md
@@ -7,8 +7,8 @@ It stores DNS record metadata in TXT records, using the same provider.
 >
 > - If you plan to manage apex domains with external-dns whilst using a txt registry, you should ensure when using `--txt-prefix` that you specify the record type substitution and that it ends in a period (**.**).
 >   The record should be created under the same domain as the apex record being managed, i.e. `--txt-prefix=someprefix-%{record_type}.`
-> - With `--regex-domain-filter`, make sure the regex also matches the type-prefixed ownership TXT names (e.g. `a-example.org`); otherwise they are filtered out and ownership is not tracked.
-> - The [CRD registry](crd.md) stores ownership in a `DNSRecord` resource instead and is not affected.
+> - With `--regex-domain-filter`, the regex must also match the type-prefixed TXT names (e.g. `a-example.org`), or ownership is not tracked.
+> - The [CRD registry](crd.md) stores ownership in a `DNSRecord` resource and is not affected.
 > - `--txt-prefix` and `--txt-suffix` contribute to the 63-byte maximum record length. To avoid errors, use them only if absolutely required and keep them as short as possible.
 
 ## Record Format Options

--- a/registry/txt/registry.go
+++ b/registry/txt/registry.go
@@ -72,12 +72,10 @@ type TXTRegistry struct {
 	// obsoleteTXTWarned dedups the legacy "cname-" alias warning to once per record per process.
 	obsoleteTXTWarned sets.Set[string]
 
-	// dryRun disables drift detection: ApplyChanges is a provider no-op, so nothing is written.
-	dryRun bool
-
-	// appliedTXTs holds the ownership TXT names created in the previous ApplyChanges; the next
-	// Records() flags any still absent as drifted (the provider dropped it, typically out of zone).
-	appliedTXTs sets.Set[string]
+	// present{TXTNames,RecordKeys} snapshot the last Records() (lower-cased): TXT names present, and
+	// "name/TYPE" of non-TXT records present. AdjustEndpoints diffs the desired set to spot dropped TXTs.
+	presentTXTNames   sets.Set[string]
+	presentRecordKeys sets.Set[string]
 
 	// driftTXTWarned dedups the drift warning to once per name.
 	driftTXTWarned sets.Set[string]
@@ -127,15 +125,10 @@ func (im *existingTXTs) reset() {
 
 // New creates a TXTRegistry from the given configuration.
 func New(cfg *externaldns.Config, p provider.Provider) (registry.Registry, error) {
-	reg, err := newRegistry(p, cfg.TXTPrefix, cfg.TXTSuffix, cfg.TXTOwnerID,
+	return newRegistry(p, cfg.TXTPrefix, cfg.TXTSuffix, cfg.TXTOwnerID,
 		cfg.TXTCacheInterval, cfg.TXTWildcardReplacement,
 		cfg.ManagedDNSRecordTypes, cfg.ExcludeDNSRecordTypes,
 		cfg.TXTEncryptEnabled, []byte(cfg.TXTEncryptAESKey), cfg.TXTOwnerOld)
-	if err != nil {
-		return nil, err
-	}
-	reg.dryRun = cfg.DryRun
-	return reg, nil
 }
 
 // newRegistry returns a new TXTRegistry object. When newFormatOnly is true, it will only
@@ -181,7 +174,8 @@ func newRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID strin
 		oldOwnerID:          oldOwnerID,
 		existingTXTs:        newExistingTXTs(),
 		obsoleteTXTWarned:   sets.New[string](),
-		appliedTXTs:         sets.New[string](),
+		presentTXTNames:     sets.New[string](),
+		presentRecordKeys:   sets.New[string](),
 		driftTXTWarned:      sets.New[string](),
 	}, nil
 }
@@ -254,8 +248,12 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 		im.existingTXTs.add(record)
 	}
 
-	// Report ownership TXTs the provider dropped since the last ApplyChanges.
-	im.warnDriftedTXTs(txtRecordsSet)
+	// Snapshot provider state for the drift check AdjustEndpoints runs later this cycle.
+	im.presentTXTNames = lowerSet(txtRecordsSet)
+	im.presentRecordKeys = sets.New[string]()
+	for _, record := range endpoints {
+		im.presentRecordKeys.Insert(recordKeyLower(record.DNSName, record.RecordType))
+	}
 
 	for _, ep := range endpoints {
 		if ep.Labels == nil {
@@ -344,23 +342,44 @@ func (im *TXTRegistry) warnObsoleteAliasTXT(dnsName string) {
 		legacyName, dnsName, im.mapper.ToTXTName(dnsName, endpoint.RecordTypeA))
 }
 
-// warnDriftedTXTs reports ownership TXTs applied last cycle but now absent — silently dropped
-// by the provider, typically because the type prefix pushed them out of zone (apex
-// "example.com" → "a-example.com"). Skipped under --dry-run and on the first sync.
-func (im *TXTRegistry) warnDriftedTXTs(present sets.Set[string]) {
-	if im.dryRun || len(im.appliedTXTs) == 0 {
-		return
-	}
-	for _, txtName := range im.appliedTXTs.List() {
-		if present.Has(txtName) || im.driftTXTWarned.Has(txtName) {
+// warnDriftedTXTs warns for desired managed records present at the provider whose ownership TXT is
+// absent — silently dropped, typically because the type prefix pushed it out of zone (apex
+// "example.com" → "a-example.com"). Reads the last Records() snapshot, so provider-agnostic and
+// restart-safe. Deduped once per name.
+func (im *TXTRegistry) warnDriftedTXTs(desired []*endpoint.Endpoint) {
+	for _, ep := range desired {
+		if !plan.IsManagedRecord(ep.RecordType, im.managedRecordTypes, im.excludeRecordTypes) {
+			continue
+		}
+		// Record not yet at the provider: pending create, not drift.
+		if !im.presentRecordKeys.Has(recordKeyLower(ep.DNSName, ep.RecordType)) {
+			continue
+		}
+		txtName := strings.ToLower(im.mapper.ToTXTName(ep.DNSName, ep.RecordType))
+		if im.presentTXTNames.Has(txtName) || im.driftTXTWarned.Has(txtName) {
 			continue
 		}
 		im.driftTXTWarned.Insert(txtName)
-		log.Warnf("Ownership TXT %q was applied but is absent from the provider; it likely "+
-			"falls outside a managed zone and cannot track ownership. "+
+		log.Warnf("Ownership TXT for %q %s is missing though the record exists at the provider; "+
+			"it likely falls outside a managed zone and cannot track ownership. "+
 			"Set --txt-prefix=\"someprefix-%%{record_type}.\" to keep it in-zone, or use --registry=crd. "+
-			"See docs/registry/txt.md.", txtName)
+			"See docs/registry/txt.md.", ep.DNSName, ep.RecordType)
 	}
+}
+
+// recordKeyLower builds the lower-cased "name/TYPE" key matching desired records to present ones.
+func recordKeyLower(dnsName, recordType string) string {
+	return strings.ToLower(dnsName) + "/" + strings.ToUpper(recordType)
+}
+
+// lowerSet returns s with every element lower-cased, for case-insensitive name comparison
+// (providers commonly return lower-cased names).
+func lowerSet(s sets.Set[string]) sets.Set[string] {
+	out := sets.New[string]()
+	for _, v := range s.List() {
+		out.Insert(strings.ToLower(v))
+	}
+	return out
 }
 
 // generateTXTRecord generates TXT records in either both formats (old and new) or new format only,
@@ -451,24 +470,18 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 		ctx = context.WithValue(ctx, provider.RecordsContextKey, nil)
 	}
 
-	if err := im.provider.ApplyChanges(ctx, filteredChanges); err != nil {
-		return err
-	}
-
-	// Track the ownership TXTs just created so the next Records() can spot silent drops.
-	if !im.dryRun {
-		applied := sets.New[string]()
-		for _, r := range changes.Create {
-			applied.Insert(im.mapper.ToTXTName(r.DNSName, r.RecordType))
-		}
-		im.appliedTXTs = applied
-	}
-	return nil
+	return im.provider.ApplyChanges(ctx, filteredChanges)
 }
 
 // AdjustEndpoints modifies the endpoints as needed by the specific provider
 func (im *TXTRegistry) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
-	return im.provider.AdjustEndpoints(endpoints)
+	adjusted, err := im.provider.AdjustEndpoints(endpoints)
+	if err != nil {
+		return nil, err
+	}
+	// Runs every sync against the Records() snapshot to spot dropped ownership TXTs.
+	im.warnDriftedTXTs(adjusted)
+	return adjusted, nil
 }
 
 func (im *TXTRegistry) addToCache(ep *endpoint.Endpoint) {

--- a/registry/txt/registry.go
+++ b/registry/txt/registry.go
@@ -72,9 +72,13 @@ type TXTRegistry struct {
 	// obsoleteTXTWarned dedups the legacy "cname-" alias warning to once per record per process.
 	obsoleteTXTWarned sets.Set[string]
 
-	// last Records() snapshot (lower-cased): present TXT names, and "name/TYPE" of present records.
+	// Last Records() snapshot (lower-cased): present TXT names, and "name/TYPE" of present records.
 	presentTXTNames   sets.Set[string]
 	presentRecordKeys sets.Set[string]
+
+	// appliedTXTNames (lower-cased) are ownership TXTs this process pushed; the drift check warns
+	// only for these, so a record we never created is not misreported. Reset on restart.
+	appliedTXTNames sets.Set[string]
 
 	// driftTXTWarned dedups the drift warning, once per name.
 	driftTXTWarned sets.Set[string]
@@ -175,6 +179,7 @@ func newRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID strin
 		obsoleteTXTWarned:   sets.New[string](),
 		presentTXTNames:     sets.New[string](),
 		presentRecordKeys:   sets.New[string](),
+		appliedTXTNames:     sets.New[string](),
 		driftTXTWarned:      sets.New[string](),
 	}, nil
 }
@@ -216,6 +221,10 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 	labelMap := map[endpoint.EndpointKey]endpoint.Labels{}
 	txtRecordsSet := make(sets.Set[string], len(records))
 
+	// Reset the drift-check snapshot; presentTXTNames is filled below.
+	im.presentTXTNames = sets.New[string]()
+	im.presentRecordKeys = sets.New[string]()
+
 	for _, record := range records {
 		if record.RecordType != endpoint.RecordTypeTXT {
 			endpoints = append(endpoints, record)
@@ -244,12 +253,11 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 		}
 		labelMap[key] = labels
 		txtRecordsSet.Insert(record.DNSName)
+		im.presentTXTNames.Insert(strings.ToLower(record.DNSName))
 		im.existingTXTs.add(record)
 	}
 
-	// Snapshot provider state for the drift check in AdjustEndpoints.
-	im.presentTXTNames = lowerSet(txtRecordsSet)
-	im.presentRecordKeys = sets.New[string]()
+	// Snapshot present records for the drift check.
 	for _, record := range endpoints {
 		im.presentRecordKeys.Insert(recordKeyLower(record.DNSName, record.RecordType))
 	}
@@ -341,9 +349,9 @@ func (im *TXTRegistry) warnObsoleteAliasTXT(dnsName string) {
 		legacyName, dnsName, im.mapper.ToTXTName(dnsName, endpoint.RecordTypeA))
 }
 
-// warnDriftedTXTs warns for present managed records whose ownership TXT is absent — dropped by the
-// provider, typically pushed out of zone by the type prefix (apex "example.com" → "a-example.com").
-// Uses the last Records() snapshot: provider-agnostic, restart-safe, deduped once per name.
+// warnDriftedTXTs warns for managed records whose ownership TXT this process applied but the provider
+// no longer returns — typically pushed out of zone by the type prefix (apex "example.com" →
+// "a-example.com"). Scoped to appliedTXTNames and deduped once per name.
 func (im *TXTRegistry) warnDriftedTXTs(desired []*endpoint.Endpoint) {
 	for _, ep := range desired {
 		if !plan.IsManagedRecord(ep.RecordType, im.managedRecordTypes, im.excludeRecordTypes) {
@@ -354,12 +362,13 @@ func (im *TXTRegistry) warnDriftedTXTs(desired []*endpoint.Endpoint) {
 			continue
 		}
 		txtName := strings.ToLower(im.mapper.ToTXTName(ep.DNSName, ep.RecordType))
-		if im.presentTXTNames.Has(txtName) || im.driftTXTWarned.Has(txtName) {
+		// Only warn for a TXT we actually applied and that is now gone from the provider.
+		if !im.appliedTXTNames.Has(txtName) || im.presentTXTNames.Has(txtName) || im.driftTXTWarned.Has(txtName) {
 			continue
 		}
 		im.driftTXTWarned.Insert(txtName)
-		log.Warnf("Ownership TXT for %q %s is missing though the record exists at the provider; "+
-			"it likely falls outside a managed zone and cannot track ownership. "+
+		log.Warnf("Ownership TXT for %q %s was applied but is missing from the provider though the "+
+			"record exists; it likely falls outside a managed zone and cannot track ownership. "+
 			"Set --txt-prefix=\"someprefix-%%{record_type}.\" to keep it in-zone, or use --registry=crd. "+
 			"See docs/registry/txt.md.", ep.DNSName, ep.RecordType)
 	}
@@ -368,15 +377,6 @@ func (im *TXTRegistry) warnDriftedTXTs(desired []*endpoint.Endpoint) {
 // recordKeyLower builds the lower-cased "name/TYPE" key for matching records.
 func recordKeyLower(dnsName, recordType string) string {
 	return strings.ToLower(dnsName) + "/" + strings.ToUpper(recordType)
-}
-
-// lowerSet lower-cases every element for case-insensitive name comparison.
-func lowerSet(s sets.Set[string]) sets.Set[string] {
-	out := sets.New[string]()
-	for _, v := range s.List() {
-		out.Insert(strings.ToLower(v))
-	}
-	return out
 }
 
 // generateTXTRecord generates TXT records in either both formats (old and new) or new format only,
@@ -424,7 +424,12 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 		}
 		r.Labels[endpoint.OwnerLabelKey] = im.ownerID
 
-		filteredChanges.Create = append(filteredChanges.Create, im.generateTXTRecordWithFilter(r, im.existingTXTs.isAbsent)...)
+		txts := im.generateTXTRecordWithFilter(r, im.existingTXTs.isAbsent)
+		for _, txt := range txts {
+			// Arm the drift check: a later Records() missing this TXT means the provider dropped it.
+			im.appliedTXTNames.Insert(strings.ToLower(txt.DNSName))
+		}
+		filteredChanges.Create = append(filteredChanges.Create, txts...)
 
 		if im.cacheInterval > 0 {
 			im.addToCache(r)

--- a/registry/txt/registry.go
+++ b/registry/txt/registry.go
@@ -72,12 +72,11 @@ type TXTRegistry struct {
 	// obsoleteTXTWarned dedups the legacy "cname-" alias warning to once per record per process.
 	obsoleteTXTWarned sets.Set[string]
 
-	// present{TXTNames,RecordKeys} snapshot the last Records() (lower-cased): TXT names present, and
-	// "name/TYPE" of non-TXT records present. AdjustEndpoints diffs the desired set to spot dropped TXTs.
+	// last Records() snapshot (lower-cased): present TXT names, and "name/TYPE" of present records.
 	presentTXTNames   sets.Set[string]
 	presentRecordKeys sets.Set[string]
 
-	// driftTXTWarned dedups the drift warning to once per name.
+	// driftTXTWarned dedups the drift warning, once per name.
 	driftTXTWarned sets.Set[string]
 }
 
@@ -248,7 +247,7 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 		im.existingTXTs.add(record)
 	}
 
-	// Snapshot provider state for the drift check AdjustEndpoints runs later this cycle.
+	// Snapshot provider state for the drift check in AdjustEndpoints.
 	im.presentTXTNames = lowerSet(txtRecordsSet)
 	im.presentRecordKeys = sets.New[string]()
 	for _, record := range endpoints {
@@ -342,16 +341,15 @@ func (im *TXTRegistry) warnObsoleteAliasTXT(dnsName string) {
 		legacyName, dnsName, im.mapper.ToTXTName(dnsName, endpoint.RecordTypeA))
 }
 
-// warnDriftedTXTs warns for desired managed records present at the provider whose ownership TXT is
-// absent — silently dropped, typically because the type prefix pushed it out of zone (apex
-// "example.com" → "a-example.com"). Reads the last Records() snapshot, so provider-agnostic and
-// restart-safe. Deduped once per name.
+// warnDriftedTXTs warns for present managed records whose ownership TXT is absent — dropped by the
+// provider, typically pushed out of zone by the type prefix (apex "example.com" → "a-example.com").
+// Uses the last Records() snapshot: provider-agnostic, restart-safe, deduped once per name.
 func (im *TXTRegistry) warnDriftedTXTs(desired []*endpoint.Endpoint) {
 	for _, ep := range desired {
 		if !plan.IsManagedRecord(ep.RecordType, im.managedRecordTypes, im.excludeRecordTypes) {
 			continue
 		}
-		// Record not yet at the provider: pending create, not drift.
+		// Not yet at the provider: pending create, not drift.
 		if !im.presentRecordKeys.Has(recordKeyLower(ep.DNSName, ep.RecordType)) {
 			continue
 		}
@@ -367,13 +365,12 @@ func (im *TXTRegistry) warnDriftedTXTs(desired []*endpoint.Endpoint) {
 	}
 }
 
-// recordKeyLower builds the lower-cased "name/TYPE" key matching desired records to present ones.
+// recordKeyLower builds the lower-cased "name/TYPE" key for matching records.
 func recordKeyLower(dnsName, recordType string) string {
 	return strings.ToLower(dnsName) + "/" + strings.ToUpper(recordType)
 }
 
-// lowerSet returns s with every element lower-cased, for case-insensitive name comparison
-// (providers commonly return lower-cased names).
+// lowerSet lower-cases every element for case-insensitive name comparison.
 func lowerSet(s sets.Set[string]) sets.Set[string] {
 	out := sets.New[string]()
 	for _, v := range s.List() {
@@ -479,7 +476,7 @@ func (im *TXTRegistry) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpo
 	if err != nil {
 		return nil, err
 	}
-	// Runs every sync against the Records() snapshot to spot dropped ownership TXTs.
+	// Spot ownership TXTs dropped by the provider, using the Records() snapshot.
 	im.warnDriftedTXTs(adjusted)
 	return adjusted, nil
 }

--- a/registry/txt/registry.go
+++ b/registry/txt/registry.go
@@ -71,6 +71,16 @@ type TXTRegistry struct {
 
 	// obsoleteTXTWarned dedups the legacy "cname-" alias warning to once per record per process.
 	obsoleteTXTWarned sets.Set[string]
+
+	// dryRun disables drift detection: ApplyChanges is a provider no-op, so nothing is written.
+	dryRun bool
+
+	// appliedTXTs holds the ownership TXT names created in the previous ApplyChanges; the next
+	// Records() flags any still absent as drifted (the provider dropped it, typically out of zone).
+	appliedTXTs sets.Set[string]
+
+	// driftTXTWarned dedups the drift warning to once per name.
+	driftTXTWarned sets.Set[string]
 }
 
 // existingTXTs stores pre‑existing TXT records to avoid duplicate creation.
@@ -117,10 +127,15 @@ func (im *existingTXTs) reset() {
 
 // New creates a TXTRegistry from the given configuration.
 func New(cfg *externaldns.Config, p provider.Provider) (registry.Registry, error) {
-	return newRegistry(p, cfg.TXTPrefix, cfg.TXTSuffix, cfg.TXTOwnerID,
+	reg, err := newRegistry(p, cfg.TXTPrefix, cfg.TXTSuffix, cfg.TXTOwnerID,
 		cfg.TXTCacheInterval, cfg.TXTWildcardReplacement,
 		cfg.ManagedDNSRecordTypes, cfg.ExcludeDNSRecordTypes,
 		cfg.TXTEncryptEnabled, []byte(cfg.TXTEncryptAESKey), cfg.TXTOwnerOld)
+	if err != nil {
+		return nil, err
+	}
+	reg.dryRun = cfg.DryRun
+	return reg, nil
 }
 
 // newRegistry returns a new TXTRegistry object. When newFormatOnly is true, it will only
@@ -166,6 +181,8 @@ func newRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID strin
 		oldOwnerID:          oldOwnerID,
 		existingTXTs:        newExistingTXTs(),
 		obsoleteTXTWarned:   sets.New[string](),
+		appliedTXTs:         sets.New[string](),
+		driftTXTWarned:      sets.New[string](),
 	}, nil
 }
 
@@ -236,6 +253,9 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 		txtRecordsSet.Insert(record.DNSName)
 		im.existingTXTs.add(record)
 	}
+
+	// Report ownership TXTs the provider dropped since the last ApplyChanges.
+	im.warnDriftedTXTs(txtRecordsSet)
 
 	for _, ep := range endpoints {
 		if ep.Labels == nil {
@@ -322,6 +342,25 @@ func (im *TXTRegistry) warnObsoleteAliasTXT(dnsName string) {
 	im.obsoleteTXTWarned.Insert(legacyName)
 	log.Warnf("Obsolete legacy TXT record %q for A ALIAS %q can be removed; now using %q (see scripts/aws-cleanup-legacy-txt-records.py).",
 		legacyName, dnsName, im.mapper.ToTXTName(dnsName, endpoint.RecordTypeA))
+}
+
+// warnDriftedTXTs reports ownership TXTs applied last cycle but now absent — silently dropped
+// by the provider, typically because the type prefix pushed them out of zone (apex
+// "example.com" → "a-example.com"). Skipped under --dry-run and on the first sync.
+func (im *TXTRegistry) warnDriftedTXTs(present sets.Set[string]) {
+	if im.dryRun || len(im.appliedTXTs) == 0 {
+		return
+	}
+	for _, txtName := range im.appliedTXTs.List() {
+		if present.Has(txtName) || im.driftTXTWarned.Has(txtName) {
+			continue
+		}
+		im.driftTXTWarned.Insert(txtName)
+		log.Warnf("Ownership TXT %q was applied but is absent from the provider; it likely "+
+			"falls outside a managed zone and cannot track ownership. "+
+			"Set --txt-prefix=\"someprefix-%%{record_type}.\" to keep it in-zone, or use --registry=crd. "+
+			"See docs/registry/txt.md.", txtName)
+	}
 }
 
 // generateTXTRecord generates TXT records in either both formats (old and new) or new format only,
@@ -411,7 +450,20 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 	if im.cacheInterval > 0 {
 		ctx = context.WithValue(ctx, provider.RecordsContextKey, nil)
 	}
-	return im.provider.ApplyChanges(ctx, filteredChanges)
+
+	if err := im.provider.ApplyChanges(ctx, filteredChanges); err != nil {
+		return err
+	}
+
+	// Track the ownership TXTs just created so the next Records() can spot silent drops.
+	if !im.dryRun {
+		applied := sets.New[string]()
+		for _, r := range changes.Create {
+			applied.Insert(im.mapper.ToTXTName(r.DNSName, r.RecordType))
+		}
+		im.appliedTXTs = applied
+	}
+	return nil
 }
 
 // AdjustEndpoints modifies the endpoints as needed by the specific provider

--- a/registry/txt/registry_test.go
+++ b/registry/txt/registry_test.go
@@ -2321,33 +2321,49 @@ func (p *droppingProvider) ApplyChanges(_ context.Context, changes *plan.Changes
 }
 
 func TestDriftedTXTWarning(t *testing.T) {
-	warnMsg := "was applied but is absent from the provider"
+	warnMsg := "is missing though the record exists at the provider"
 
-	newReg := func(t *testing.T, p provider.Provider, dryRun bool) *TXTRegistry {
+	managed := []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME}
+	newReg := func(t *testing.T, p provider.Provider) *TXTRegistry {
 		t.Helper()
-		r, err := newRegistry(p, "", "", "owner", 0, "", []string{}, []string{}, false, nil, "")
+		r, err := newRegistry(p, "", "", "owner", 0, "", managed, []string{}, false, nil, "")
 		require.NoError(t, err)
-		r.dryRun = dryRun
 		return r
 	}
 
 	apex := func() *endpoint.Endpoint { return endpoint.NewEndpoint("example.org", endpoint.RecordTypeA, "1.2.3.4") }
 
-	t.Run("warns on next Records when the applied TXT was dropped", func(t *testing.T) {
-		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
-		p := &droppingProvider{drop: map[string]bool{"a-example.org": true}}
-		r := newReg(t, p, false)
-		ctx := context.Background()
-
-		// First sync: nothing applied yet, then apply the apex A whose TXT the provider drops.
+	// sync mimics one controller cycle: Records() snapshots the provider state, then
+	// AdjustEndpoints() runs the drift check against the desired set.
+	sync := func(t *testing.T, r *TXTRegistry, desired ...*endpoint.Endpoint) {
+		t.Helper()
+		ctx := t.Context()
 		_, err := r.Records(ctx)
 		require.NoError(t, err)
-		require.NoError(t, r.ApplyChanges(ctx, &plan.Changes{Create: []*endpoint.Endpoint{apex()}}))
-		logtest.TestHelperLogNotContains(warnMsg, hook, t) // first sync: no warn yet
-
-		// Next sync: a-example.org is still absent -> drift warning.
-		_, err = r.Records(ctx)
+		_, err = r.AdjustEndpoints(desired)
 		require.NoError(t, err)
+	}
+
+	t.Run("warns when the record exists but its ownership TXT was dropped", func(t *testing.T) {
+		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+		p := &droppingProvider{drop: map[string]bool{"a-example.org": true}}
+		r := newReg(t, p)
+
+		// Apply the apex A; the provider keeps the A but drops its out-of-zone ownership TXT.
+		require.NoError(t, r.ApplyChanges(t.Context(), &plan.Changes{Create: []*endpoint.Endpoint{apex()}}))
+
+		sync(t, r, apex())
+		logtest.TestHelperLogContains(warnMsg, hook, t)
+	})
+
+	t.Run("warns on the first sync after a restart", func(t *testing.T) {
+		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+		// A freshly started pod finds a pre-existing apex A with no ownership TXT; nothing is
+		// applied this session, yet the drift must still be reported.
+		p := &droppingProvider{records: []*endpoint.Endpoint{apex()}}
+		r := newReg(t, p)
+
+		sync(t, r, apex())
 		logtest.TestHelperLogContains(warnMsg, hook, t)
 	})
 
@@ -2355,48 +2371,40 @@ func TestDriftedTXTWarning(t *testing.T) {
 		// Flat providers (e.g. CoreDNS) store the sibling name, so no drift is observed.
 		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
 		p := &droppingProvider{drop: map[string]bool{}}
-		r := newReg(t, p, false)
-		ctx := context.Background()
+		r := newReg(t, p)
 
-		require.NoError(t, r.ApplyChanges(ctx, &plan.Changes{Create: []*endpoint.Endpoint{apex()}}))
-		_, err := r.Records(ctx)
-		require.NoError(t, err)
+		require.NoError(t, r.ApplyChanges(t.Context(), &plan.Changes{Create: []*endpoint.Endpoint{apex()}}))
+		sync(t, r, apex())
 		logtest.TestHelperLogNotContains(warnMsg, hook, t)
 	})
 
-	t.Run("does not warn under dry-run", func(t *testing.T) {
+	t.Run("does not warn for a record not yet at the provider", func(t *testing.T) {
+		// Pending create: neither the record nor its TXT exist yet, so this is not drift.
 		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
 		p := &droppingProvider{drop: map[string]bool{"a-example.org": true}}
-		r := newReg(t, p, true)
-		ctx := context.Background()
+		r := newReg(t, p)
 
-		require.NoError(t, r.ApplyChanges(ctx, &plan.Changes{Create: []*endpoint.Endpoint{apex()}}))
-		_, err := r.Records(ctx)
-		require.NoError(t, err)
+		sync(t, r, apex())
 		logtest.TestHelperLogNotContains(warnMsg, hook, t)
 	})
 
-	t.Run("does not warn on the first sync", func(t *testing.T) {
+	t.Run("matches record and TXT names case-insensitively", func(t *testing.T) {
 		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
-		p := &droppingProvider{drop: map[string]bool{"a-example.org": true}}
-		r := newReg(t, p, false)
+		// The provider returns a lower-cased name; the desired record uses mixed case.
+		p := &droppingProvider{records: []*endpoint.Endpoint{apex()}}
+		r := newReg(t, p)
 
-		// Records before anything is applied must stay silent.
-		_, err := r.Records(context.Background())
-		require.NoError(t, err)
-		logtest.TestHelperLogNotContains(warnMsg, hook, t)
+		sync(t, r, endpoint.NewEndpoint("Example.ORG", endpoint.RecordTypeA, "1.2.3.4"))
+		logtest.TestHelperLogContains(warnMsg, hook, t)
 	})
 
 	t.Run("warns once per name across cycles", func(t *testing.T) {
 		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
-		p := &droppingProvider{drop: map[string]bool{"a-example.org": true}}
-		r := newReg(t, p, false)
-		ctx := context.Background()
+		p := &droppingProvider{records: []*endpoint.Endpoint{apex()}}
+		r := newReg(t, p)
 
-		require.NoError(t, r.ApplyChanges(ctx, &plan.Changes{Create: []*endpoint.Endpoint{apex()}}))
-		_, _ = r.Records(ctx)
-		require.NoError(t, r.ApplyChanges(ctx, &plan.Changes{Create: []*endpoint.Endpoint{apex()}}))
-		_, _ = r.Records(ctx)
+		sync(t, r, apex())
+		sync(t, r, apex())
 
 		count := 0
 		for _, e := range hook.AllEntries() {

--- a/registry/txt/registry_test.go
+++ b/registry/txt/registry_test.go
@@ -2297,3 +2297,113 @@ func TestTXTRegistryAliasARecordDeleteLeavesLegacyCNAME(t *testing.T) {
 	assert.NotNil(t, findEndpoint(applied.Delete, "a-alias.test-zone.example.org", endpoint.RecordTypeTXT), "the new a- ownership TXT must be deleted")
 	assert.Nil(t, findEndpoint(applied.Delete, "cname-alias.test-zone.example.org", endpoint.RecordTypeTXT), "the legacy cname- TXT should be kept")
 }
+
+// droppingProvider omits any name in drop on read, simulating a provider that cannot place an
+// out-of-zone ownership TXT (e.g. apex "a-example.org").
+type droppingProvider struct {
+	provider.BaseProvider
+	records []*endpoint.Endpoint
+	drop    map[string]bool
+}
+
+func (p *droppingProvider) Records(_ context.Context) ([]*endpoint.Endpoint, error) {
+	return p.records, nil
+}
+
+func (p *droppingProvider) ApplyChanges(_ context.Context, changes *plan.Changes) error {
+	for _, ep := range changes.Create {
+		if p.drop[ep.DNSName] {
+			continue // silently dropped, like an out-of-zone TXT
+		}
+		p.records = append(p.records, ep)
+	}
+	return nil
+}
+
+func TestDriftedTXTWarning(t *testing.T) {
+	warnMsg := "was applied but is absent from the provider"
+
+	newReg := func(t *testing.T, p provider.Provider, dryRun bool) *TXTRegistry {
+		t.Helper()
+		r, err := newRegistry(p, "", "", "owner", 0, "", []string{}, []string{}, false, nil, "")
+		require.NoError(t, err)
+		r.dryRun = dryRun
+		return r
+	}
+
+	apex := func() *endpoint.Endpoint { return endpoint.NewEndpoint("example.org", endpoint.RecordTypeA, "1.2.3.4") }
+
+	t.Run("warns on next Records when the applied TXT was dropped", func(t *testing.T) {
+		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+		p := &droppingProvider{drop: map[string]bool{"a-example.org": true}}
+		r := newReg(t, p, false)
+		ctx := context.Background()
+
+		// First sync: nothing applied yet, then apply the apex A whose TXT the provider drops.
+		_, err := r.Records(ctx)
+		require.NoError(t, err)
+		require.NoError(t, r.ApplyChanges(ctx, &plan.Changes{Create: []*endpoint.Endpoint{apex()}}))
+		logtest.TestHelperLogNotContains(warnMsg, hook, t) // first sync: no warn yet
+
+		// Next sync: a-example.org is still absent -> drift warning.
+		_, err = r.Records(ctx)
+		require.NoError(t, err)
+		logtest.TestHelperLogContains(warnMsg, hook, t)
+	})
+
+	t.Run("does not warn when the provider keeps the TXT", func(t *testing.T) {
+		// Flat providers (e.g. CoreDNS) store the sibling name, so no drift is observed.
+		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+		p := &droppingProvider{drop: map[string]bool{}}
+		r := newReg(t, p, false)
+		ctx := context.Background()
+
+		require.NoError(t, r.ApplyChanges(ctx, &plan.Changes{Create: []*endpoint.Endpoint{apex()}}))
+		_, err := r.Records(ctx)
+		require.NoError(t, err)
+		logtest.TestHelperLogNotContains(warnMsg, hook, t)
+	})
+
+	t.Run("does not warn under dry-run", func(t *testing.T) {
+		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+		p := &droppingProvider{drop: map[string]bool{"a-example.org": true}}
+		r := newReg(t, p, true)
+		ctx := context.Background()
+
+		require.NoError(t, r.ApplyChanges(ctx, &plan.Changes{Create: []*endpoint.Endpoint{apex()}}))
+		_, err := r.Records(ctx)
+		require.NoError(t, err)
+		logtest.TestHelperLogNotContains(warnMsg, hook, t)
+	})
+
+	t.Run("does not warn on the first sync", func(t *testing.T) {
+		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+		p := &droppingProvider{drop: map[string]bool{"a-example.org": true}}
+		r := newReg(t, p, false)
+
+		// Records before anything is applied must stay silent.
+		_, err := r.Records(context.Background())
+		require.NoError(t, err)
+		logtest.TestHelperLogNotContains(warnMsg, hook, t)
+	})
+
+	t.Run("warns once per name across cycles", func(t *testing.T) {
+		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+		p := &droppingProvider{drop: map[string]bool{"a-example.org": true}}
+		r := newReg(t, p, false)
+		ctx := context.Background()
+
+		require.NoError(t, r.ApplyChanges(ctx, &plan.Changes{Create: []*endpoint.Endpoint{apex()}}))
+		_, _ = r.Records(ctx)
+		require.NoError(t, r.ApplyChanges(ctx, &plan.Changes{Create: []*endpoint.Endpoint{apex()}}))
+		_, _ = r.Records(ctx)
+
+		count := 0
+		for _, e := range hook.AllEntries() {
+			if strings.Contains(e.Message, warnMsg) {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count, "expected exactly one drift warning")
+	})
+}

--- a/registry/txt/registry_test.go
+++ b/registry/txt/registry_test.go
@@ -2321,7 +2321,7 @@ func (p *droppingProvider) ApplyChanges(_ context.Context, changes *plan.Changes
 }
 
 func TestDriftedTXTWarning(t *testing.T) {
-	warnMsg := "is missing though the record exists at the provider"
+	warnMsg := "was applied but is missing from the provider"
 
 	managed := []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME}
 	newReg := func(t *testing.T, p provider.Provider) *TXTRegistry {
@@ -2356,13 +2356,17 @@ func TestDriftedTXTWarning(t *testing.T) {
 		logtest.TestHelperLogContains(warnMsg, hook, t)
 	})
 
-	t.Run("warns on the first sync after a restart", func(t *testing.T) {
+	t.Run("does not warn until we re-apply the TXT after a restart", func(t *testing.T) {
 		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
-		// A freshly started pod finds a pre-existing apex A with no ownership TXT; nothing is
-		// applied this session, yet the drift must still be reported.
-		p := &droppingProvider{records: []*endpoint.Endpoint{apex()}}
+		// Pre-existing apex A, nothing applied yet: not attributed to us on the first sync.
+		p := &droppingProvider{records: []*endpoint.Endpoint{apex()}, drop: map[string]bool{"a-example.org": true}}
 		r := newReg(t, p)
 
+		sync(t, r, apex())
+		logtest.TestHelperLogNotContains(warnMsg, hook, t)
+
+		// Re-create the ownership TXT; the provider drops it again, now it is ours and reported.
+		require.NoError(t, r.ApplyChanges(t.Context(), &plan.Changes{Create: []*endpoint.Endpoint{apex()}}))
 		sync(t, r, apex())
 		logtest.TestHelperLogContains(warnMsg, hook, t)
 	})
@@ -2374,6 +2378,16 @@ func TestDriftedTXTWarning(t *testing.T) {
 		r := newReg(t, p)
 
 		require.NoError(t, r.ApplyChanges(t.Context(), &plan.Changes{Create: []*endpoint.Endpoint{apex()}}))
+		sync(t, r, apex())
+		logtest.TestHelperLogNotContains(warnMsg, hook, t)
+	})
+
+	t.Run("does not warn for a pre-existing record we never applied", func(t *testing.T) {
+		// Record present with no ownership TXT that we never created (manual/migration): not our drift.
+		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+		p := &droppingProvider{records: []*endpoint.Endpoint{apex()}}
+		r := newReg(t, p)
+
 		sync(t, r, apex())
 		logtest.TestHelperLogNotContains(warnMsg, hook, t)
 	})
@@ -2390,19 +2404,21 @@ func TestDriftedTXTWarning(t *testing.T) {
 
 	t.Run("matches record and TXT names case-insensitively", func(t *testing.T) {
 		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
-		// The provider returns a lower-cased name; the desired record uses mixed case.
-		p := &droppingProvider{records: []*endpoint.Endpoint{apex()}}
+		// Provider returns a lower-cased name; the desired record uses mixed case.
+		p := &droppingProvider{drop: map[string]bool{"a-example.org": true}}
 		r := newReg(t, p)
 
+		require.NoError(t, r.ApplyChanges(t.Context(), &plan.Changes{Create: []*endpoint.Endpoint{apex()}}))
 		sync(t, r, endpoint.NewEndpoint("Example.ORG", endpoint.RecordTypeA, "1.2.3.4"))
 		logtest.TestHelperLogContains(warnMsg, hook, t)
 	})
 
 	t.Run("warns once per name across cycles", func(t *testing.T) {
 		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
-		p := &droppingProvider{records: []*endpoint.Endpoint{apex()}}
+		p := &droppingProvider{drop: map[string]bool{"a-example.org": true}}
 		r := newReg(t, p)
 
+		require.NoError(t, r.ApplyChanges(t.Context(), &plan.Changes{Create: []*endpoint.Endpoint{apex()}}))
 		sync(t, r, apex())
 		sync(t, r, apex())
 


### PR DESCRIPTION
## What does it do ?

WARN when a record exists but its ownership TXT is missing (silently dropped). Diffs
desired vs provider state each sync: provider-agnostic, restart-safe, deduped per name.

## Motivation

Apex case: type prefix turns `example.com` into out-of-zone `a-example.com`, which zone
providers drop, breaking ownership. Today only logged at DEBUG. Non-breaking.

Related: #449

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly
