### PR TITLE
fix(aws): handle AAAA ALIAS records as AAAA

### DIFF
--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -557,6 +557,9 @@ Annotations which are specific to AWS.
 
 `external-dns.alpha.kubernetes.io/alias` if set to `true` on an ingress, it will create an ALIAS record when the target is an ALIAS as well. To make the target an alias, the ingress needs to be configured correctly as described in [the docs](./nginx-ingress.md#with-a-separate-tcp-load-balancer). In particular, the argument `--publish-service=default/nginx-ingress-controller` has to be set on the `nginx-ingress-controller` container. If one uses the `nginx-ingress` Helm chart, this flag can be set with the `controller.publishService.enabled` configuration option.
 
+An `AAAA` endpoint with `alias: true` becomes an `AAAA` ALIAS record, matching its
+record type. Dualstack endpoints create both the `A` and `AAAA` alias records.
+
 ### target-hosted-zone
 
 `external-dns.alpha.kubernetes.io/aws-target-hosted-zone` can optionally be set to the ID of a Route53 hosted zone. This will force external-dns to use the specified hosted zone when creating an ALIAS target.

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -371,8 +371,32 @@ func (p *AWSProvider) Records(ctx context.Context) (endpoints []*endpoint.Endpoi
 
 func (p *AWSProvider) records(ctx context.Context, zones map[string]*route53.HostedZone) ([]*endpoint.Endpoint, error) {
 	endpoints := make([]*endpoint.Endpoint, 0)
-	f := func(resp *route53.ListResourceRecordSetsOutput, lastPage bool) (shouldContinue bool) {
-		for _, r := range resp.ResourceRecordSets {
+
+	for _, z := range zones {
+		var recordSets []*route53.ResourceRecordSet
+		f := func(resp *route53.ListResourceRecordSetsOutput, lastPage bool) (shouldContinue bool) {
+			recordSets = append(recordSets, resp.ResourceRecordSets...)
+			return true
+		}
+
+		params := &route53.ListResourceRecordSetsInput{
+			HostedZoneId: z.Id,
+			MaxItems:     aws.String(route53PageSize),
+		}
+
+		if err := p.client.ListResourceRecordSetsPagesWithContext(ctx, params, f); err != nil {
+			return nil, errors.Wrapf(err, "failed to list resource records sets for zone %s", *z.Id)
+		}
+
+		// A alias keys; a matching AAAA alias is a dualstack pair (#4897).
+		aAliasKeys := make(map[string]bool)
+		for _, r := range recordSets {
+			if r.AliasTarget != nil && aws.StringValue(r.Type) == route53.RRTypeA {
+				aAliasKeys[aliasRecordKey(r)] = true
+			}
+		}
+
+		for _, r := range recordSets {
 			newEndpoints := make([]*endpoint.Endpoint, 0)
 
 			if !p.SupportedRecordType(aws.StringValue(r.Type)) {
@@ -398,8 +422,13 @@ func (p *AWSProvider) records(ctx context.Context, zones map[string]*route53.Hos
 				if ttl == 0 {
 					ttl = recordTTL
 				}
+				// Lone AAAA alias -> AAAA; else CNAME (#4897).
+				aliasType := endpoint.RecordTypeCNAME
+				if aws.StringValue(r.Type) == route53.RRTypeAaaa && !aAliasKeys[aliasRecordKey(r)] {
+					aliasType = endpoint.RecordTypeAAAA
+				}
 				ep := endpoint.
-					NewEndpointWithTTL(wildcardUnescape(aws.StringValue(r.Name)), endpoint.RecordTypeCNAME, ttl, aws.StringValue(r.AliasTarget.DNSName)).
+					NewEndpointWithTTL(wildcardUnescape(aws.StringValue(r.Name)), aliasType, ttl, aws.StringValue(r.AliasTarget.DNSName)).
 					WithProviderSpecific(providerSpecificEvaluateTargetHealth, fmt.Sprintf("%t", aws.BoolValue(r.AliasTarget.EvaluateTargetHealth))).
 					WithProviderSpecific(providerSpecificAlias, "true")
 				newEndpoints = append(newEndpoints, ep)
@@ -440,22 +469,14 @@ func (p *AWSProvider) records(ctx context.Context, zones map[string]*route53.Hos
 				endpoints = append(endpoints, ep)
 			}
 		}
-
-		return true
-	}
-
-	for _, z := range zones {
-		params := &route53.ListResourceRecordSetsInput{
-			HostedZoneId: z.Id,
-			MaxItems:     aws.String(route53PageSize),
-		}
-
-		if err := p.client.ListResourceRecordSetsPagesWithContext(ctx, params, f); err != nil {
-			return nil, errors.Wrapf(err, "failed to list resource records sets for zone %s", *z.Id)
-		}
 	}
 
 	return endpoints, nil
+}
+
+// aliasRecordKey keys an ALIAS record by name and set identifier.
+func aliasRecordKey(r *route53.ResourceRecordSet) string {
+	return aws.StringValue(r.Name) + "/" + aws.StringValue(r.SetIdentifier)
 }
 
 // CreateRecords creates a given set of DNS records in the given hosted zone.
@@ -743,7 +764,12 @@ func (p *AWSProvider) newChange(action string, ep *endpoint.Endpoint) (*Route53C
 		if val, ok := ep.Labels[endpoint.DualstackLabelKey]; ok {
 			dualstack = val == "true"
 		}
-		change.ResourceRecordSet.Type = aws.String(route53.RRTypeA)
+		// Keep AAAA alias as AAAA, not A (#4897).
+		aliasType := route53.RRTypeA
+		if ep.RecordType == endpoint.RecordTypeAAAA {
+			aliasType = route53.RRTypeAaaa
+		}
+		change.ResourceRecordSet.Type = aws.String(aliasType)
 		change.ResourceRecordSet.AliasTarget = &route53.AliasTarget{
 			DNSName:              aws.String(ep.Targets[0]),
 			HostedZoneId:         aws.String(cleanZoneID(targetHostedZone)),
@@ -1021,7 +1047,7 @@ func useAlias(ep *endpoint.Endpoint, preferCNAME bool) bool {
 // and (if so) returns the target hosted zone ID
 func isAWSAlias(ep *endpoint.Endpoint) string {
 	prop, exists := ep.GetProviderSpecificProperty(providerSpecificAlias)
-	if exists && prop.Value == "true" && ep.RecordType == endpoint.RecordTypeCNAME && len(ep.Targets) > 0 {
+	if exists && prop.Value == "true" && (ep.RecordType == endpoint.RecordTypeCNAME || ep.RecordType == endpoint.RecordTypeAAAA) && len(ep.Targets) > 0 {
 		// alias records can only point to canonical hosted zones (e.g. to ELBs) or other records in the same zone
 
 		if hostedZoneID, ok := ep.GetProviderSpecificProperty(providerSpecificTargetHostedZone); ok {

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -618,6 +618,116 @@ func TestAWSCreateRecords(t *testing.T) {
 	})
 }
 
+func TestAWSCreateAAAAAlias(t *testing.T) {
+	// AAAA alias created as AAAA; no collision with A alias (#4897).
+	provider, _ := newAWSProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), defaultEvaluateTargetHealth, false, nil)
+
+	records := []*endpoint.Endpoint{
+		endpoint.NewEndpoint("create-test-a-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificAlias, "true"),
+		endpoint.NewEndpoint("create-test-a-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificAlias, "true"),
+	}
+
+	require.NoError(t, provider.CreateRecords(context.Background(), records))
+
+	validateRecords(t, listAWSRecords(t, provider.client, "/hostedzone/zone-1.ext-dns-test-2.teapot.zalan.do."), []*route53.ResourceRecordSet{
+		{
+			Name: aws.String("create-test-a-alias.zone-1.ext-dns-test-2.teapot.zalan.do."),
+			Type: aws.String(route53.RRTypeA),
+			AliasTarget: &route53.AliasTarget{
+				DNSName:              aws.String("foo.eu-central-1.elb.amazonaws.com."),
+				EvaluateTargetHealth: aws.Bool(true),
+				HostedZoneId:         aws.String("Z215JYRZR1TBD5"),
+			},
+		},
+		{
+			Name: aws.String("create-test-a-alias.zone-1.ext-dns-test-2.teapot.zalan.do."),
+			Type: aws.String(route53.RRTypeAaaa),
+			AliasTarget: &route53.AliasTarget{
+				DNSName:              aws.String("foo.eu-central-1.elb.amazonaws.com."),
+				EvaluateTargetHealth: aws.Bool(true),
+				HostedZoneId:         aws.String("Z215JYRZR1TBD5"),
+			},
+		},
+	})
+}
+
+func TestAWSAAAAAliasRecords(t *testing.T) {
+	// Lone AAAA alias -> AAAA; AAAA sharing name+setID with an A alias = dualstack, stays CNAME (#4897).
+	provider, _ := newAWSProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), false, false, []*route53.ResourceRecordSet{
+		{
+			Name: aws.String("aaaa-alias.zone-1.ext-dns-test-2.teapot.zalan.do."),
+			Type: aws.String(route53.RRTypeAaaa),
+			AliasTarget: &route53.AliasTarget{
+				DNSName:              aws.String("foo.eu-central-1.elb.amazonaws.com."),
+				EvaluateTargetHealth: aws.Bool(false),
+				HostedZoneId:         aws.String("Z215JYRZR1TBD5"),
+			},
+		},
+		{
+			Name: aws.String("dualstack-alias.zone-1.ext-dns-test-2.teapot.zalan.do."),
+			Type: aws.String(route53.RRTypeA),
+			AliasTarget: &route53.AliasTarget{
+				DNSName:              aws.String("bar.eu-central-1.elb.amazonaws.com."),
+				EvaluateTargetHealth: aws.Bool(false),
+				HostedZoneId:         aws.String("Z215JYRZR1TBD5"),
+			},
+		},
+		{
+			Name: aws.String("dualstack-alias.zone-1.ext-dns-test-2.teapot.zalan.do."),
+			Type: aws.String(route53.RRTypeAaaa),
+			AliasTarget: &route53.AliasTarget{
+				DNSName:              aws.String("bar.eu-central-1.elb.amazonaws.com."),
+				EvaluateTargetHealth: aws.Bool(false),
+				HostedZoneId:         aws.String("Z215JYRZR1TBD5"),
+			},
+		},
+	})
+
+	records, err := provider.Records(context.Background())
+	require.NoError(t, err)
+
+	validateEndpoints(t, records, []*endpoint.Endpoint{
+		endpoint.NewEndpointWithTTL("aaaa-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false").WithProviderSpecific(providerSpecificAlias, "true"),
+		endpoint.NewEndpointWithTTL("dualstack-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL), "bar.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false").WithProviderSpecific(providerSpecificAlias, "true"),
+		endpoint.NewEndpointWithTTL("dualstack-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL), "bar.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false").WithProviderSpecific(providerSpecificAlias, "true"),
+	})
+}
+
+func TestAWSAAAAAliasRoundtrip(t *testing.T) {
+	// Write then read an AAAA alias -> same endpoint, no plan churn (#4897).
+	provider, _ := newAWSProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), false, false, nil)
+
+	source := endpoint.NewEndpointWithTTL("aaaa-roundtrip.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificAlias, "true").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false")
+
+	require.NoError(t, provider.CreateRecords(context.Background(), []*endpoint.Endpoint{source}))
+
+	records, err := provider.Records(context.Background())
+	require.NoError(t, err)
+
+	validateEndpoints(t, records, []*endpoint.Endpoint{source})
+}
+
+func TestAWSDeleteAAAAAlias(t *testing.T) {
+	// Delete AAAA alias removes the AAAA record, not an A record (#4897).
+	provider, _ := newAWSProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), false, false, []*route53.ResourceRecordSet{
+		{
+			Name: aws.String("aaaa-alias.zone-1.ext-dns-test-2.teapot.zalan.do."),
+			Type: aws.String(route53.RRTypeAaaa),
+			AliasTarget: &route53.AliasTarget{
+				DNSName:              aws.String("foo.eu-central-1.elb.amazonaws.com."),
+				EvaluateTargetHealth: aws.Bool(false),
+				HostedZoneId:         aws.String("Z215JYRZR1TBD5"),
+			},
+		},
+	})
+
+	toDelete := endpoint.NewEndpointWithTTL("aaaa-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificAlias, "true").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false")
+
+	require.NoError(t, provider.DeleteRecords(context.Background(), []*endpoint.Endpoint{toDelete}))
+
+	validateRecords(t, listAWSRecords(t, provider.client, "/hostedzone/zone-1.ext-dns-test-2.teapot.zalan.do."), []*route53.ResourceRecordSet{})
+}
+
 func TestAWSUpdateRecords(t *testing.T) {
 	provider, _ := newAWSProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), defaultEvaluateTargetHealth, false, []*route53.ResourceRecordSet{
 		{


### PR DESCRIPTION
## What does it do ?

AWS provider now writes an `AAAA` alias as `AAAA` (not `A`) and reads it back as `AAAA`. A dualstack `AAAA` alias (shares name + set identifier with an `A` alias) stays `CNAME`. AWS only.

## Motivation

Fixes #4897

## Checklist

- [x] Unit tests updated
- [x] End user documentation updated
