### PR TITLE
feat(source): migrate contour, f5, kong, traefik sources to indexer-based filtering

### DIFF
--- a/source/contour_httpproxy.go
+++ b/source/contour_httpproxy.go
@@ -75,6 +75,7 @@ func NewContourHTTPProxySource(
 	informers.MustAddIndexers(httpProxyInformer.Informer(), informers.IndexerWithOptions[*unstructured.Unstructured](
 		informers.IndexSelectorWithAnnotationFilter(cfg.AnnotationFilter),
 		informers.IndexSelectorWithLabelSelector(cfg.LabelFilter),
+		informers.IndexSelectorWithConditions(annotations.IsControllerMatch[*unstructured.Unstructured]),
 	))
 
 	// Add default resource event handlers to properly initialize informer.

--- a/source/contour_httpproxy.go
+++ b/source/contour_httpproxy.go
@@ -115,19 +115,12 @@ func (sc *httpProxySource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, e
 		httpProxies = append(httpProxies, hpConverted)
 	}
 
-	endpoints := []*endpoint.Endpoint{}
+	var endpoints []*endpoint.Endpoint
 
 	for _, hp := range httpProxies {
-		if annotations.IsControllerMismatch(hp, types.ContourHTTPProxy) {
-			continue
-		}
-
-		hpEndpoints := sc.endpointsFromHTTPProxy(hp)
-
 		// apply template if fqdn is missing on HTTPProxy
-		var err error
-		hpEndpoints, err = sc.templateEngine.CombineWithEndpoints(
-			hpEndpoints,
+		hpEndpoints, err := sc.templateEngine.CombineWithEndpoints(
+			sc.endpointsFromHTTPProxy(hp),
 			func() ([]*endpoint.Endpoint, error) { return sc.endpointsFromTemplate(hp) },
 		)
 		if err != nil {

--- a/source/contour_httpproxy.go
+++ b/source/contour_httpproxy.go
@@ -18,13 +18,11 @@ package source
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	kubeinformers "k8s.io/client-go/informers"
@@ -51,10 +49,6 @@ import (
 // +externaldns:source:fqdn-template=true
 // +externaldns:source:provider-specific=true
 type httpProxySource struct {
-	dynamicKubeClient        dynamic.Interface
-	namespace                string
-	annotationFilter         labels.Selector
-	labelSelector            labels.Selector
 	templateEngine           template.Engine
 	ignoreHostnameAnnotation bool
 	httpProxyInformer        kubeinformers.GenericInformer
@@ -78,6 +72,11 @@ func NewContourHTTPProxySource(
 		informers.TransformRemoveStatusConditions(),
 	))
 
+	informers.MustAddIndexers(httpProxyInformer.Informer(), informers.IndexerWithOptions[*unstructured.Unstructured](
+		informers.IndexSelectorWithAnnotationFilter(cfg.AnnotationFilter),
+		informers.IndexSelectorWithLabelSelector(cfg.LabelFilter),
+	))
+
 	// Add default resource event handlers to properly initialize informer.
 	informers.MustAddEventHandler(httpProxyInformer.Informer(), informers.DefaultEventHandler())
 
@@ -94,10 +93,6 @@ func NewContourHTTPProxySource(
 	}
 
 	return &httpProxySource{
-		dynamicKubeClient:        dynamicKubeClient,
-		namespace:                cfg.Namespace,
-		annotationFilter:         cfg.AnnotationFilter,
-		labelSelector:            cfg.LabelFilter,
 		templateEngine:           cfg.TemplateEngine,
 		ignoreHostnameAnnotation: cfg.IgnoreHostnameAnnotation,
 		httpProxyInformer:        httpProxyInformer,
@@ -108,27 +103,16 @@ func NewContourHTTPProxySource(
 // Endpoints returns endpoint objects for each host-target combination that should be processed.
 // Retrieves all HTTPProxy resources in the source's namespace(s).
 func (sc *httpProxySource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, error) {
-	hps, err := sc.httpProxyInformer.Lister().ByNamespace(sc.namespace).List(sc.labelSelector)
-	if err != nil {
-		return nil, err
-	}
+	hps := informers.ListIndexed[*unstructured.Unstructured](sc.httpProxyInformer.Informer().GetIndexer())
 
 	var httpProxies []*projectcontour.HTTPProxy
 	for _, hp := range hps {
-		unstructuredHP, ok := hp.(*unstructured.Unstructured)
-		if !ok {
-			return nil, errors.New("could not convert")
-		}
-
 		hpConverted := &projectcontour.HTTPProxy{}
-		err := sc.unstructuredConverter.scheme.Convert(unstructuredHP, hpConverted, nil)
-		if err != nil {
+		if err := sc.unstructuredConverter.scheme.Convert(hp, hpConverted, nil); err != nil {
 			return nil, fmt.Errorf("failed to convert to HTTPProxy: %w", err)
 		}
 		httpProxies = append(httpProxies, hpConverted)
 	}
-
-	httpProxies = annotations.Filter(httpProxies, sc.annotationFilter)
 
 	endpoints := []*endpoint.Endpoint{}
 
@@ -140,6 +124,7 @@ func (sc *httpProxySource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, e
 		hpEndpoints := sc.endpointsFromHTTPProxy(hp)
 
 		// apply template if fqdn is missing on HTTPProxy
+		var err error
 		hpEndpoints, err = sc.templateEngine.CombineWithEndpoints(
 			hpEndpoints,
 			func() ([]*endpoint.Endpoint, error) { return sc.endpointsFromTemplate(hp) },

--- a/source/contour_httpproxy_test.go
+++ b/source/contour_httpproxy_test.go
@@ -1207,3 +1207,123 @@ func TestContourHTTPProxySource_InformerTransform(t *testing.T) {
 		withRemovedStatusConditions(),
 	)
 }
+
+// TestContourHTTPProxyIndexer verifies that the httpproxy indexer correctly filters resources
+// by annotation filter and label selector at index time, so that only matching resources are
+// returned by Endpoints().
+func TestContourHTTPProxyIndexer(t *testing.T) {
+	t.Parallel()
+
+	makeEntity := func(namespace, name, fqdn, ip string, ann, lbls map[string]string) *projectcontour.HTTPProxy {
+		if ann == nil {
+			ann = map[string]string{}
+		}
+		if lbls == nil {
+			lbls = map[string]string{}
+		}
+		return &projectcontour.HTTPProxy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        name,
+				Namespace:   namespace,
+				Annotations: ann,
+				Labels:      lbls,
+			},
+			Spec: projectcontour.HTTPProxySpec{
+				VirtualHost: &projectcontour.VirtualHost{Fqdn: fqdn},
+			},
+			Status: projectcontour.HTTPProxyStatus{
+				LoadBalancer: v1.LoadBalancerStatus{
+					Ingress: []v1.LoadBalancerIngress{{IP: ip}},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name             string
+		annotationFilter string
+		labelFilter      string
+		proxies          []*projectcontour.HTTPProxy
+		expectedCount    int
+	}{
+		{
+			name:          "no filters returns all proxies",
+			expectedCount: 3,
+			proxies: []*projectcontour.HTTPProxy{
+				makeEntity("default", "hp1", "a.example.org", "1.2.3.1", nil, nil),
+				makeEntity("default", "hp2", "b.example.org", "1.2.3.2", nil, nil),
+				makeEntity("default", "hp3", "c.example.org", "1.2.3.3", nil, nil),
+			},
+		},
+		{
+			name:             "annotation filter includes matching proxies",
+			annotationFilter: "tier=frontend",
+			expectedCount:    2,
+			proxies: []*projectcontour.HTTPProxy{
+				makeEntity("default", "hp1", "a.example.org", "1.2.3.1", map[string]string{"tier": "frontend"}, nil),
+				makeEntity("default", "hp2", "b.example.org", "1.2.3.2", map[string]string{"tier": "frontend"}, nil),
+				makeEntity("default", "hp3", "c.example.org", "1.2.3.3", map[string]string{"tier": "backend"}, nil),
+			},
+		},
+		{
+			name:          "label filter includes matching proxies",
+			labelFilter:   "env=prod",
+			expectedCount: 1,
+			proxies: []*projectcontour.HTTPProxy{
+				makeEntity("default", "hp1", "a.example.org", "1.2.3.1", nil, map[string]string{"env": "prod"}),
+				makeEntity("default", "hp2", "b.example.org", "1.2.3.2", nil, map[string]string{"env": "staging"}),
+				makeEntity("default", "hp3", "c.example.org", "1.2.3.3", nil, nil),
+			},
+		},
+		{
+			name:             "annotation and label filter combined",
+			annotationFilter: "tier=frontend",
+			labelFilter:      "env=prod",
+			expectedCount:    1,
+			proxies: []*projectcontour.HTTPProxy{
+				makeEntity("default", "hp1", "a.example.org", "1.2.3.1", map[string]string{"tier": "frontend"}, map[string]string{"env": "prod"}),
+				makeEntity("default", "hp2", "b.example.org", "1.2.3.2", map[string]string{"tier": "frontend"}, map[string]string{"env": "staging"}),
+				makeEntity("default", "hp3", "c.example.org", "1.2.3.3", map[string]string{"tier": "backend"}, map[string]string{"env": "prod"}),
+			},
+		},
+		{
+			name:             "no matches returns empty",
+			annotationFilter: "tier=missing",
+			expectedCount:    0,
+			proxies: []*projectcontour.HTTPProxy{
+				makeEntity("default", "hp1", "a.example.org", "1.2.3.1", map[string]string{"tier": "frontend"}, nil),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fakeDynamicClient, scheme := newContourDynamicKubernetesClient()
+			for _, hp := range tt.proxies {
+				converted, err := convertHTTPProxyToUnstructured(hp, scheme)
+				require.NoError(t, err)
+				_, err = fakeDynamicClient.Resource(projectcontour.HTTPProxyGVR).Namespace(hp.Namespace).Create(t.Context(), converted, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+
+			labelSel := labels.Everything()
+			if tt.labelFilter != "" {
+				var err error
+				labelSel, err = labels.Parse(tt.labelFilter)
+				require.NoError(t, err)
+			}
+
+			src, err := NewContourHTTPProxySource(t.Context(), fakeDynamicClient, &Config{
+				AnnotationFilter: parseAnnotationFilterOrNil(tt.annotationFilter),
+				LabelFilter:      labelSel,
+			})
+			require.NoError(t, err)
+
+			endpoints, err := src.Endpoints(t.Context())
+			require.NoError(t, err)
+			assert.Len(t, endpoints, tt.expectedCount)
+		})
+	}
+}

--- a/source/contour_httpproxy_test.go
+++ b/source/contour_httpproxy_test.go
@@ -1247,12 +1247,12 @@ func TestContourHTTPProxyIndexer(t *testing.T) {
 		expectedCount    int
 	}{
 		{
-			name:          "no filters returns all proxies",
+			name:          "no filters returns all proxies across namespaces",
 			expectedCount: 3,
 			proxies: []*projectcontour.HTTPProxy{
 				makeEntity("default", "hp1", "a.example.org", "1.2.3.1", nil, nil),
-				makeEntity("default", "hp2", "b.example.org", "1.2.3.2", nil, nil),
-				makeEntity("default", "hp3", "c.example.org", "1.2.3.3", nil, nil),
+				makeEntity("staging", "hp2", "b.example.org", "1.2.3.2", nil, nil),
+				makeEntity("production", "hp3", "c.example.org", "1.2.3.3", nil, nil),
 			},
 		},
 		{
@@ -1261,8 +1261,8 @@ func TestContourHTTPProxyIndexer(t *testing.T) {
 			expectedCount:    2,
 			proxies: []*projectcontour.HTTPProxy{
 				makeEntity("default", "hp1", "a.example.org", "1.2.3.1", map[string]string{"tier": "frontend"}, nil),
-				makeEntity("default", "hp2", "b.example.org", "1.2.3.2", map[string]string{"tier": "frontend"}, nil),
-				makeEntity("default", "hp3", "c.example.org", "1.2.3.3", map[string]string{"tier": "backend"}, nil),
+				makeEntity("staging", "hp2", "b.example.org", "1.2.3.2", map[string]string{"tier": "frontend"}, nil),
+				makeEntity("production", "hp3", "c.example.org", "1.2.3.3", map[string]string{"tier": "backend"}, nil),
 			},
 		},
 		{
@@ -1271,8 +1271,8 @@ func TestContourHTTPProxyIndexer(t *testing.T) {
 			expectedCount: 1,
 			proxies: []*projectcontour.HTTPProxy{
 				makeEntity("default", "hp1", "a.example.org", "1.2.3.1", nil, map[string]string{"env": "prod"}),
-				makeEntity("default", "hp2", "b.example.org", "1.2.3.2", nil, map[string]string{"env": "staging"}),
-				makeEntity("default", "hp3", "c.example.org", "1.2.3.3", nil, nil),
+				makeEntity("staging", "hp2", "b.example.org", "1.2.3.2", nil, map[string]string{"env": "staging"}),
+				makeEntity("production", "hp3", "c.example.org", "1.2.3.3", nil, nil),
 			},
 		},
 		{
@@ -1282,8 +1282,8 @@ func TestContourHTTPProxyIndexer(t *testing.T) {
 			expectedCount:    1,
 			proxies: []*projectcontour.HTTPProxy{
 				makeEntity("default", "hp1", "a.example.org", "1.2.3.1", map[string]string{"tier": "frontend"}, map[string]string{"env": "prod"}),
-				makeEntity("default", "hp2", "b.example.org", "1.2.3.2", map[string]string{"tier": "frontend"}, map[string]string{"env": "staging"}),
-				makeEntity("default", "hp3", "c.example.org", "1.2.3.3", map[string]string{"tier": "backend"}, map[string]string{"env": "prod"}),
+				makeEntity("staging", "hp2", "b.example.org", "1.2.3.2", map[string]string{"tier": "frontend"}, map[string]string{"env": "staging"}),
+				makeEntity("production", "hp3", "c.example.org", "1.2.3.3", map[string]string{"tier": "backend"}, map[string]string{"env": "prod"}),
 			},
 		},
 		{

--- a/source/contour_httpproxy_test.go
+++ b/source/contour_httpproxy_test.go
@@ -1294,6 +1294,13 @@ func TestContourHTTPProxyIndexer(t *testing.T) {
 				makeEntity("default", "hp1", "a.example.org", "1.2.3.1", map[string]string{"tier": "frontend"}, nil),
 			},
 		},
+		{
+			name:          "controller mismatch is excluded",
+			expectedCount: 0,
+			proxies: []*projectcontour.HTTPProxy{
+				makeEntity("default", "hp1", "a.example.org", "1.2.3.1", map[string]string{annotations.ControllerKey: "other-controller"}, nil),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1308,16 +1315,9 @@ func TestContourHTTPProxyIndexer(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			labelSel := labels.Everything()
-			if tt.labelFilter != "" {
-				var err error
-				labelSel, err = labels.Parse(tt.labelFilter)
-				require.NoError(t, err)
-			}
-
 			src, err := NewContourHTTPProxySource(t.Context(), fakeDynamicClient, &Config{
 				AnnotationFilter: parseAnnotationFilterOrNil(tt.annotationFilter),
-				LabelFilter:      labelSel,
+				LabelFilter:      parseLabelSelectorOrEverything(t, tt.labelFilter),
 			})
 			require.NoError(t, err)
 

--- a/source/f5_transportserver.go
+++ b/source/f5_transportserver.go
@@ -59,7 +59,6 @@ var f5TransportServerGVR = schema.GroupVersionResource{
 // +externaldns:source:fqdn-template=true
 // +externaldns:source:provider-specific=false
 type f5TransportServerSource struct {
-	dynamicKubeClient       dynamic.Interface
 	transportServerInformer kubeinformers.GenericInformer
 	kubeClient              kubernetes.Interface
 	templateEngine          template.Engine
@@ -101,7 +100,6 @@ func NewF5TransportServerSource(
 	}
 
 	return &f5TransportServerSource{
-		dynamicKubeClient:       dynamicKubeClient,
 		transportServerInformer: transportServerInformer,
 		kubeClient:              kubeClient,
 		templateEngine:          cfg.TemplateEngine,

--- a/source/f5_transportserver.go
+++ b/source/f5_transportserver.go
@@ -18,7 +18,6 @@ package source
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -26,7 +25,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -64,9 +62,6 @@ type f5TransportServerSource struct {
 	dynamicKubeClient       dynamic.Interface
 	transportServerInformer kubeinformers.GenericInformer
 	kubeClient              kubernetes.Interface
-	annotationFilter        labels.Selector
-	labelSelector           labels.Selector
-	namespace               string
 	templateEngine          template.Engine
 	unstructuredConverter   *unstructuredConverter
 }
@@ -83,6 +78,11 @@ func NewF5TransportServerSource(
 	informers.MustSetTransform(transportServerInformer.Informer(), informers.TransformerWithOptions[*unstructured.Unstructured](
 		informers.TransformRemoveManagedFields(),
 		informers.TransformRemoveLastAppliedConfig(),
+	))
+
+	informers.MustAddIndexers(transportServerInformer.Informer(), informers.IndexerWithOptions[*unstructured.Unstructured](
+		informers.IndexSelectorWithAnnotationFilter(cfg.AnnotationFilter),
+		informers.IndexSelectorWithLabelSelector(cfg.LabelFilter),
 	))
 
 	informers.MustAddEventHandler(transportServerInformer.Informer(), informers.DefaultEventHandler())
@@ -103,9 +103,6 @@ func NewF5TransportServerSource(
 		dynamicKubeClient:       dynamicKubeClient,
 		transportServerInformer: transportServerInformer,
 		kubeClient:              kubeClient,
-		namespace:               cfg.Namespace,
-		annotationFilter:        cfg.AnnotationFilter,
-		labelSelector:           cfg.LabelFilter,
 		templateEngine:          cfg.TemplateEngine,
 		unstructuredConverter:   uc,
 	}, nil
@@ -114,21 +111,12 @@ func NewF5TransportServerSource(
 // Endpoints returns endpoint objects for each host-target combination that should be processed.
 // Retrieves all TransportServers in the source's namespace(s).
 func (ts *f5TransportServerSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, error) {
-	transportServerObjects, err := ts.transportServerInformer.Lister().ByNamespace(ts.namespace).List(ts.labelSelector)
-	if err != nil {
-		return nil, err
-	}
+	transportServerObjects := informers.ListIndexed[*unstructured.Unstructured](ts.transportServerInformer.Informer().GetIndexer())
 
 	var transportServers []*f5.TransportServer
 	for _, tsObj := range transportServerObjects {
-		unstructuredHost, ok := tsObj.(*unstructured.Unstructured)
-		if !ok {
-			return nil, errors.New("could not convert")
-		}
-
 		transportServer := &f5.TransportServer{}
-		err := ts.unstructuredConverter.scheme.Convert(unstructuredHost, transportServer, nil)
-		if err != nil {
+		if err := ts.unstructuredConverter.scheme.Convert(tsObj, transportServer, nil); err != nil {
 			return nil, err
 		}
 		transportServer.TypeMeta = metav1.TypeMeta{
@@ -137,8 +125,6 @@ func (ts *f5TransportServerSource) Endpoints(_ context.Context) ([]*endpoint.End
 		}
 		transportServers = append(transportServers, transportServer)
 	}
-
-	transportServers = annotations.Filter(transportServers, ts.annotationFilter)
 
 	endpoints, err := ts.endpointsFromTransportServers(transportServers)
 	if err != nil {

--- a/source/f5_transportserver.go
+++ b/source/f5_transportserver.go
@@ -83,6 +83,7 @@ func NewF5TransportServerSource(
 	informers.MustAddIndexers(transportServerInformer.Informer(), informers.IndexerWithOptions[*unstructured.Unstructured](
 		informers.IndexSelectorWithAnnotationFilter(cfg.AnnotationFilter),
 		informers.IndexSelectorWithLabelSelector(cfg.LabelFilter),
+		informers.IndexSelectorWithConditions(annotations.IsControllerMatch[*unstructured.Unstructured]),
 	))
 
 	informers.MustAddEventHandler(transportServerInformer.Informer(), informers.DefaultEventHandler())

--- a/source/f5_transportserver_test.go
+++ b/source/f5_transportserver_test.go
@@ -480,3 +480,132 @@ func TestF5TransportServerSource_InformerTransform(t *testing.T) {
 		withRemovedManagedFields(),
 	)
 }
+
+// TestF5TransportServerIndexer verifies that the TransportServer indexer correctly filters resources
+// by annotation filter and label selector at index time, so that only matching resources are
+// returned by Endpoints().
+func TestF5TransportServerIndexer(t *testing.T) {
+	t.Parallel()
+
+	makeEntity := func(name, vsAddress string, ann, lbls map[string]string) *f5.TransportServer {
+		if ann == nil {
+			ann = map[string]string{}
+		}
+		if lbls == nil {
+			lbls = map[string]string{}
+		}
+		return &f5.TransportServer{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: f5TransportServerGVR.GroupVersion().String(),
+				Kind:       "TransportServer",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        name,
+				Namespace:   defaultF5TransportServerNamespace,
+				Annotations: ann,
+				Labels:      lbls,
+			},
+			Spec: f5.TransportServerSpec{
+				Host: name + ".example.org",
+			},
+			Status: f5.CustomResourceStatus{
+				VSAddress: vsAddress,
+			},
+		}
+	}
+
+	tests := []struct {
+		name             string
+		annotationFilter string
+		labelFilter      string
+		servers          []*f5.TransportServer
+		expectedCount    int
+	}{
+		{
+			name:          "no filters returns all servers",
+			expectedCount: 3,
+			servers: []*f5.TransportServer{
+				makeEntity("ts1", "1.2.3.1", nil, nil),
+				makeEntity("ts2", "1.2.3.2", nil, nil),
+				makeEntity("ts3", "1.2.3.3", nil, nil),
+			},
+		},
+		{
+			name:             "annotation filter includes matching servers",
+			annotationFilter: "tier=frontend",
+			expectedCount:    2,
+			servers: []*f5.TransportServer{
+				makeEntity("ts1", "1.2.3.1", map[string]string{"tier": "frontend"}, nil),
+				makeEntity("ts2", "1.2.3.2", map[string]string{"tier": "frontend"}, nil),
+				makeEntity("ts3", "1.2.3.3", map[string]string{"tier": "backend"}, nil),
+			},
+		},
+		{
+			name:          "label filter includes matching servers",
+			labelFilter:   "env=prod",
+			expectedCount: 1,
+			servers: []*f5.TransportServer{
+				makeEntity("ts1", "1.2.3.1", nil, map[string]string{"env": "prod"}),
+				makeEntity("ts2", "1.2.3.2", nil, map[string]string{"env": "staging"}),
+				makeEntity("ts3", "1.2.3.3", nil, nil),
+			},
+		},
+		{
+			name:             "annotation and label filter combined",
+			annotationFilter: "tier=frontend",
+			labelFilter:      "env=prod",
+			expectedCount:    1,
+			servers: []*f5.TransportServer{
+				makeEntity("ts1", "1.2.3.1", map[string]string{"tier": "frontend"}, map[string]string{"env": "prod"}),
+				makeEntity("ts2", "1.2.3.2", map[string]string{"tier": "frontend"}, map[string]string{"env": "staging"}),
+				makeEntity("ts3", "1.2.3.3", map[string]string{"tier": "backend"}, map[string]string{"env": "prod"}),
+			},
+		},
+		{
+			name:             "no matches returns empty",
+			annotationFilter: "tier=missing",
+			expectedCount:    0,
+			servers: []*f5.TransportServer{
+				makeEntity("ts1", "1.2.3.1", map[string]string{"tier": "frontend"}, nil),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			uc, err := newTSUnstructuredConverter()
+			require.NoError(t, err)
+
+			fakeKubernetesClient := fakeKube.NewSimpleClientset()
+			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(uc.scheme)
+
+			for _, srv := range tt.servers {
+				data, err := json.Marshal(srv)
+				require.NoError(t, err)
+				obj := unstructured.Unstructured{}
+				require.NoError(t, obj.UnmarshalJSON(data))
+				_, err = fakeDynamicClient.Resource(f5TransportServerGVR).Namespace(defaultF5TransportServerNamespace).Create(t.Context(), &obj, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+
+			labelSel := labels.Everything()
+			if tt.labelFilter != "" {
+				labelSel, err = labels.Parse(tt.labelFilter)
+				require.NoError(t, err)
+			}
+
+			src, err := NewF5TransportServerSource(t.Context(), fakeDynamicClient, fakeKubernetesClient, &Config{
+				Namespace:        defaultF5TransportServerNamespace,
+				AnnotationFilter: parseAnnotationFilterOrNil(tt.annotationFilter),
+				LabelFilter:      labelSel,
+			})
+			require.NoError(t, err)
+
+			endpoints, err := src.Endpoints(t.Context())
+			require.NoError(t, err)
+			assert.Len(t, endpoints, tt.expectedCount)
+		})
+	}
+}

--- a/source/f5_transportserver_test.go
+++ b/source/f5_transportserver_test.go
@@ -569,14 +569,21 @@ func TestF5TransportServerIndexer(t *testing.T) {
 				makeEntity("ts1", "1.2.3.1", map[string]string{"tier": "frontend"}, nil),
 			},
 		},
+		{
+			name:          "controller mismatch is excluded",
+			expectedCount: 0,
+			servers: []*f5.TransportServer{
+				makeEntity("ts1", "1.2.3.1", map[string]string{annotations.ControllerKey: "other-controller"}, nil),
+			},
+		},
 	}
+
+	uc, err := newTSUnstructuredConverter()
+	require.NoError(t, err)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-
-			uc, err := newTSUnstructuredConverter()
-			require.NoError(t, err)
 
 			fakeKubernetesClient := fakeKube.NewSimpleClientset()
 			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(uc.scheme)
@@ -590,16 +597,10 @@ func TestF5TransportServerIndexer(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			labelSel := labels.Everything()
-			if tt.labelFilter != "" {
-				labelSel, err = labels.Parse(tt.labelFilter)
-				require.NoError(t, err)
-			}
-
 			src, err := NewF5TransportServerSource(t.Context(), fakeDynamicClient, fakeKubernetesClient, &Config{
 				Namespace:        defaultF5TransportServerNamespace,
 				AnnotationFilter: parseAnnotationFilterOrNil(tt.annotationFilter),
-				LabelFilter:      labelSel,
+				LabelFilter:      parseLabelSelectorOrEverything(t, tt.labelFilter),
 			})
 			require.NoError(t, err)
 

--- a/source/f5_virtualserver.go
+++ b/source/f5_virtualserver.go
@@ -58,7 +58,6 @@ var f5VirtualServerGVR = schema.GroupVersionResource{
 // +externaldns:source:fqdn-template=true
 // +externaldns:source:provider-specific=false
 type f5VirtualServerSource struct {
-	dynamicKubeClient     dynamic.Interface
 	virtualServerInformer kubeinformers.GenericInformer
 	kubeClient            kubernetes.Interface
 	templateEngine        template.Engine
@@ -100,7 +99,6 @@ func NewF5VirtualServerSource(
 	}
 
 	return &f5VirtualServerSource{
-		dynamicKubeClient:     dynamicKubeClient,
 		virtualServerInformer: virtualServerInformer,
 		kubeClient:            kubeClient,
 		templateEngine:        cfg.TemplateEngine,

--- a/source/f5_virtualserver.go
+++ b/source/f5_virtualserver.go
@@ -18,7 +18,6 @@ package source
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -26,7 +25,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -63,9 +61,6 @@ type f5VirtualServerSource struct {
 	dynamicKubeClient     dynamic.Interface
 	virtualServerInformer kubeinformers.GenericInformer
 	kubeClient            kubernetes.Interface
-	annotationFilter      labels.Selector
-	labelSelector         labels.Selector
-	namespace             string
 	templateEngine        template.Engine
 	unstructuredConverter *unstructuredConverter
 }
@@ -82,6 +77,11 @@ func NewF5VirtualServerSource(
 	informers.MustSetTransform(virtualServerInformer.Informer(), informers.TransformerWithOptions[*unstructured.Unstructured](
 		informers.TransformRemoveManagedFields(),
 		informers.TransformRemoveLastAppliedConfig(),
+	))
+
+	informers.MustAddIndexers(virtualServerInformer.Informer(), informers.IndexerWithOptions[*unstructured.Unstructured](
+		informers.IndexSelectorWithAnnotationFilter(cfg.AnnotationFilter),
+		informers.IndexSelectorWithLabelSelector(cfg.LabelFilter),
 	))
 
 	informers.MustAddEventHandler(virtualServerInformer.Informer(), informers.DefaultEventHandler())
@@ -102,9 +102,6 @@ func NewF5VirtualServerSource(
 		dynamicKubeClient:     dynamicKubeClient,
 		virtualServerInformer: virtualServerInformer,
 		kubeClient:            kubeClient,
-		namespace:             cfg.Namespace,
-		annotationFilter:      cfg.AnnotationFilter,
-		labelSelector:         cfg.LabelFilter,
 		templateEngine:        cfg.TemplateEngine,
 		unstructuredConverter: uc,
 	}, nil
@@ -113,21 +110,12 @@ func NewF5VirtualServerSource(
 // Endpoints returns endpoint objects for each host-target combination that should be processed.
 // Retrieves all VirtualServers in the source's namespace(s).
 func (vs *f5VirtualServerSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, error) {
-	virtualServerObjects, err := vs.virtualServerInformer.Lister().ByNamespace(vs.namespace).List(vs.labelSelector)
-	if err != nil {
-		return nil, err
-	}
+	virtualServerObjects := informers.ListIndexed[*unstructured.Unstructured](vs.virtualServerInformer.Informer().GetIndexer())
 
 	var virtualServers []*f5.VirtualServer
 	for _, vsObj := range virtualServerObjects {
-		unstructuredHost, ok := vsObj.(*unstructured.Unstructured)
-		if !ok {
-			return nil, errors.New("could not convert")
-		}
-
 		virtualServer := &f5.VirtualServer{}
-		err := vs.unstructuredConverter.scheme.Convert(unstructuredHost, virtualServer, nil)
-		if err != nil {
+		if err := vs.unstructuredConverter.scheme.Convert(vsObj, virtualServer, nil); err != nil {
 			return nil, err
 		}
 		virtualServer.TypeMeta = metav1.TypeMeta{
@@ -136,8 +124,6 @@ func (vs *f5VirtualServerSource) Endpoints(_ context.Context) ([]*endpoint.Endpo
 		}
 		virtualServers = append(virtualServers, virtualServer)
 	}
-
-	virtualServers = annotations.Filter(virtualServers, vs.annotationFilter)
 
 	endpoints, err := vs.endpointsFromVirtualServers(virtualServers)
 	if err != nil {

--- a/source/f5_virtualserver.go
+++ b/source/f5_virtualserver.go
@@ -82,6 +82,7 @@ func NewF5VirtualServerSource(
 	informers.MustAddIndexers(virtualServerInformer.Informer(), informers.IndexerWithOptions[*unstructured.Unstructured](
 		informers.IndexSelectorWithAnnotationFilter(cfg.AnnotationFilter),
 		informers.IndexSelectorWithLabelSelector(cfg.LabelFilter),
+		informers.IndexSelectorWithConditions(annotations.IsControllerMatch[*unstructured.Unstructured]),
 	))
 
 	informers.MustAddEventHandler(virtualServerInformer.Informer(), informers.DefaultEventHandler())

--- a/source/f5_virtualserver_test.go
+++ b/source/f5_virtualserver_test.go
@@ -813,14 +813,21 @@ func TestF5VirtualServerIndexer(t *testing.T) {
 				makeEntity("vs1", "1.2.3.1", map[string]string{"tier": "frontend"}, nil),
 			},
 		},
+		{
+			name:          "controller mismatch is excluded",
+			expectedCount: 0,
+			servers: []*f5.VirtualServer{
+				makeEntity("vs1", "1.2.3.1", map[string]string{annotations.ControllerKey: "other-controller"}, nil),
+			},
+		},
 	}
+
+	uc, err := newVSUnstructuredConverter()
+	require.NoError(t, err)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-
-			uc, err := newVSUnstructuredConverter()
-			require.NoError(t, err)
 
 			fakeKubernetesClient := fakeKube.NewSimpleClientset()
 			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(uc.scheme)
@@ -834,16 +841,10 @@ func TestF5VirtualServerIndexer(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			labelSel := labels.Everything()
-			if tt.labelFilter != "" {
-				labelSel, err = labels.Parse(tt.labelFilter)
-				require.NoError(t, err)
-			}
-
 			src, err := NewF5VirtualServerSource(t.Context(), fakeDynamicClient, fakeKubernetesClient, &Config{
 				Namespace:        defaultF5VirtualServerNamespace,
 				AnnotationFilter: parseAnnotationFilterOrNil(tt.annotationFilter),
-				LabelFilter:      labelSel,
+				LabelFilter:      parseLabelSelectorOrEverything(t, tt.labelFilter),
 			})
 			require.NoError(t, err)
 

--- a/source/f5_virtualserver_test.go
+++ b/source/f5_virtualserver_test.go
@@ -723,3 +723,133 @@ func TestF5VirtualServerSource_InformerTransform(t *testing.T) {
 		withRemovedManagedFields(),
 	)
 }
+
+// TestF5VirtualServerIndexer verifies that the VirtualServer indexer correctly filters resources
+// by annotation filter and label selector at index time, so that only matching resources are
+// returned by Endpoints().
+func TestF5VirtualServerIndexer(t *testing.T) {
+	t.Parallel()
+
+	makeEntity := func(name, vsAddress string, ann, lbls map[string]string) *f5.VirtualServer {
+		if ann == nil {
+			ann = map[string]string{}
+		}
+		if lbls == nil {
+			lbls = map[string]string{}
+		}
+		return &f5.VirtualServer{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: f5VirtualServerGVR.GroupVersion().String(),
+				Kind:       "VirtualServer",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        name,
+				Namespace:   defaultF5VirtualServerNamespace,
+				Annotations: ann,
+				Labels:      lbls,
+			},
+			Spec: f5.VirtualServerSpec{
+				Host:                 name + ".example.org",
+				VirtualServerAddress: vsAddress,
+			},
+			Status: f5.CustomResourceStatus{
+				VSAddress: vsAddress,
+			},
+		}
+	}
+
+	tests := []struct {
+		name             string
+		annotationFilter string
+		labelFilter      string
+		servers          []*f5.VirtualServer
+		expectedCount    int
+	}{
+		{
+			name:          "no filters returns all servers",
+			expectedCount: 3,
+			servers: []*f5.VirtualServer{
+				makeEntity("vs1", "1.2.3.1", nil, nil),
+				makeEntity("vs2", "1.2.3.2", nil, nil),
+				makeEntity("vs3", "1.2.3.3", nil, nil),
+			},
+		},
+		{
+			name:             "annotation filter includes matching servers",
+			annotationFilter: "tier=frontend",
+			expectedCount:    2,
+			servers: []*f5.VirtualServer{
+				makeEntity("vs1", "1.2.3.1", map[string]string{"tier": "frontend"}, nil),
+				makeEntity("vs2", "1.2.3.2", map[string]string{"tier": "frontend"}, nil),
+				makeEntity("vs3", "1.2.3.3", map[string]string{"tier": "backend"}, nil),
+			},
+		},
+		{
+			name:          "label filter includes matching servers",
+			labelFilter:   "env=prod",
+			expectedCount: 1,
+			servers: []*f5.VirtualServer{
+				makeEntity("vs1", "1.2.3.1", nil, map[string]string{"env": "prod"}),
+				makeEntity("vs2", "1.2.3.2", nil, map[string]string{"env": "staging"}),
+				makeEntity("vs3", "1.2.3.3", nil, nil),
+			},
+		},
+		{
+			name:             "annotation and label filter combined",
+			annotationFilter: "tier=frontend",
+			labelFilter:      "env=prod",
+			expectedCount:    1,
+			servers: []*f5.VirtualServer{
+				makeEntity("vs1", "1.2.3.1", map[string]string{"tier": "frontend"}, map[string]string{"env": "prod"}),
+				makeEntity("vs2", "1.2.3.2", map[string]string{"tier": "frontend"}, map[string]string{"env": "staging"}),
+				makeEntity("vs3", "1.2.3.3", map[string]string{"tier": "backend"}, map[string]string{"env": "prod"}),
+			},
+		},
+		{
+			name:             "no matches returns empty",
+			annotationFilter: "tier=missing",
+			expectedCount:    0,
+			servers: []*f5.VirtualServer{
+				makeEntity("vs1", "1.2.3.1", map[string]string{"tier": "frontend"}, nil),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			uc, err := newVSUnstructuredConverter()
+			require.NoError(t, err)
+
+			fakeKubernetesClient := fakeKube.NewSimpleClientset()
+			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(uc.scheme)
+
+			for _, srv := range tt.servers {
+				data, err := json.Marshal(srv)
+				require.NoError(t, err)
+				obj := unstructured.Unstructured{}
+				require.NoError(t, obj.UnmarshalJSON(data))
+				_, err = fakeDynamicClient.Resource(f5VirtualServerGVR).Namespace(defaultF5VirtualServerNamespace).Create(t.Context(), &obj, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+
+			labelSel := labels.Everything()
+			if tt.labelFilter != "" {
+				labelSel, err = labels.Parse(tt.labelFilter)
+				require.NoError(t, err)
+			}
+
+			src, err := NewF5VirtualServerSource(t.Context(), fakeDynamicClient, fakeKubernetesClient, &Config{
+				Namespace:        defaultF5VirtualServerNamespace,
+				AnnotationFilter: parseAnnotationFilterOrNil(tt.annotationFilter),
+				LabelFilter:      labelSel,
+			})
+			require.NoError(t, err)
+
+			endpoints, err := src.Endpoints(t.Context())
+			require.NoError(t, err)
+			assert.Len(t, endpoints, tt.expectedCount)
+		})
+	}
+}

--- a/source/fake_test.go
+++ b/source/fake_test.go
@@ -45,6 +45,18 @@ func parseAnnotationFilterOrNil(s string) labels.Selector {
 	return sel
 }
 
+// parseLabelSelectorOrEverything parses a label selector string for use in tests.
+// Returns labels.Everything() for empty input.
+func parseLabelSelectorOrEverything(t *testing.T, s string) labels.Selector {
+	t.Helper()
+	if s == "" {
+		return labels.Everything()
+	}
+	sel, err := labels.Parse(s)
+	require.NoError(t, err)
+	return sel
+}
+
 // Validate that fakeSource implements Source.
 var _ Source = &fakeSource{}
 

--- a/source/kong_tcpingress.go
+++ b/source/kong_tcpingress.go
@@ -18,14 +18,12 @@ package source
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -59,13 +57,10 @@ var kongGroupdVersionResource = schema.GroupVersionResource{
 // +externaldns:source:fqdn-template=false
 // +externaldns:source:provider-specific=true
 type kongTCPIngressSource struct {
-	annotationFilter         labels.Selector
-	labelSelector            labels.Selector
 	ignoreHostnameAnnotation bool
 	dynamicKubeClient        dynamic.Interface
 	kongTCPIngressInformer   kubeinformers.GenericInformer
 	kubeClient               kubernetes.Interface
-	namespace                string
 	unstructuredConverter    *unstructuredConverter
 }
 
@@ -85,6 +80,11 @@ func NewKongTCPIngressSource(
 		informers.TransformRemoveLastAppliedConfig(),
 	))
 
+	informers.MustAddIndexers(kongTCPIngressInformer.Informer(), informers.IndexerWithOptions[*unstructured.Unstructured](
+		informers.IndexSelectorWithAnnotationFilter(cfg.AnnotationFilter),
+		informers.IndexSelectorWithLabelSelector(cfg.LabelFilter),
+	))
+
 	// Add default resource event handlers to properly initialize informer.
 	informers.MustAddEventHandler(kongTCPIngressInformer.Informer(), informers.DefaultEventHandler())
 
@@ -101,13 +101,10 @@ func NewKongTCPIngressSource(
 	}
 
 	return &kongTCPIngressSource{
-		annotationFilter:         cfg.AnnotationFilter,
-		labelSelector:            cfg.LabelFilter,
 		ignoreHostnameAnnotation: cfg.IgnoreHostnameAnnotation,
 		dynamicKubeClient:        dynamicKubeClient,
 		kongTCPIngressInformer:   kongTCPIngressInformer,
 		kubeClient:               kubeClient,
-		namespace:                cfg.Namespace,
 		unstructuredConverter:    uc,
 	}, nil
 }
@@ -115,27 +112,16 @@ func NewKongTCPIngressSource(
 // Endpoints returns endpoint objects for each host-target combination that should be processed.
 // Retrieves all TCPIngresses in the source's namespace(s).
 func (sc *kongTCPIngressSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, error) {
-	tis, err := sc.kongTCPIngressInformer.Lister().ByNamespace(sc.namespace).List(sc.labelSelector)
-	if err != nil {
-		return nil, err
-	}
+	tis := informers.ListIndexed[*unstructured.Unstructured](sc.kongTCPIngressInformer.Informer().GetIndexer())
 
 	var tcpIngresses []*TCPIngress
-	for _, tcpIngressObj := range tis {
-		unstructuredHost, ok := tcpIngressObj.(*unstructured.Unstructured)
-		if !ok {
-			return nil, errors.New("could not convert")
-		}
-
+	for _, tiObj := range tis {
 		tcpIngress := &TCPIngress{}
-		err := sc.unstructuredConverter.scheme.Convert(unstructuredHost, tcpIngress, nil)
-		if err != nil {
+		if err := sc.unstructuredConverter.scheme.Convert(tiObj, tcpIngress, nil); err != nil {
 			return nil, err
 		}
 		tcpIngresses = append(tcpIngresses, tcpIngress)
 	}
-
-	tcpIngresses = annotations.Filter(tcpIngresses, sc.annotationFilter)
 
 	var endpoints []*endpoint.Endpoint
 	for _, tcpIngress := range tcpIngresses {

--- a/source/kong_tcpingress.go
+++ b/source/kong_tcpingress.go
@@ -83,6 +83,7 @@ func NewKongTCPIngressSource(
 	informers.MustAddIndexers(kongTCPIngressInformer.Informer(), informers.IndexerWithOptions[*unstructured.Unstructured](
 		informers.IndexSelectorWithAnnotationFilter(cfg.AnnotationFilter),
 		informers.IndexSelectorWithLabelSelector(cfg.LabelFilter),
+		informers.IndexSelectorWithConditions(annotations.IsControllerMatch[*unstructured.Unstructured]),
 	))
 
 	// Add default resource event handlers to properly initialize informer.

--- a/source/kong_tcpingress_test.go
+++ b/source/kong_tcpingress_test.go
@@ -521,3 +521,134 @@ func TestKongTCPIngressSource_InformerTransform(t *testing.T) {
 		withRemovedManagedFields(),
 	)
 }
+
+// TestKongTCPIngressIndexer verifies that the TCPIngress indexer correctly filters resources
+// by annotation filter and label selector at index time, so that only matching resources are
+// returned by Endpoints().
+func TestKongTCPIngressIndexer(t *testing.T) {
+	t.Parallel()
+
+	makeEntity := func(name string, ann, lbls map[string]string) *TCPIngress {
+		if ann == nil {
+			ann = map[string]string{}
+		}
+		if lbls == nil {
+			lbls = map[string]string{}
+		}
+		return &TCPIngress{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: kongGroupdVersionResource.GroupVersion().String(),
+				Kind:       "TCPIngress",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        name,
+				Namespace:   defaultKongNamespace,
+				Annotations: ann,
+				Labels:      lbls,
+			},
+			Spec: tcpIngressSpec{
+				Rules: []tcpIngressRule{{Host: name + ".example.org", Port: 80}},
+			},
+			Status: tcpIngressStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name             string
+		annotationFilter string
+		labelFilter      string
+		ingresses        []*TCPIngress
+		expectedCount    int
+	}{
+		{
+			name:          "no filters returns all ingresses",
+			expectedCount: 3,
+			ingresses: []*TCPIngress{
+				makeEntity("ti1", nil, nil),
+				makeEntity("ti2", nil, nil),
+				makeEntity("ti3", nil, nil),
+			},
+		},
+		{
+			name:             "annotation filter includes matching ingresses",
+			annotationFilter: "tier=frontend",
+			expectedCount:    2,
+			ingresses: []*TCPIngress{
+				makeEntity("ti1", map[string]string{"tier": "frontend"}, nil),
+				makeEntity("ti2", map[string]string{"tier": "frontend"}, nil),
+				makeEntity("ti3", map[string]string{"tier": "backend"}, nil),
+			},
+		},
+		{
+			name:          "label filter includes matching ingresses",
+			labelFilter:   "env=prod",
+			expectedCount: 1,
+			ingresses: []*TCPIngress{
+				makeEntity("ti1", nil, map[string]string{"env": "prod"}),
+				makeEntity("ti2", nil, map[string]string{"env": "staging"}),
+				makeEntity("ti3", nil, nil),
+			},
+		},
+		{
+			name:             "annotation and label filter combined",
+			annotationFilter: "tier=frontend",
+			labelFilter:      "env=prod",
+			expectedCount:    1,
+			ingresses: []*TCPIngress{
+				makeEntity("ti1", map[string]string{"tier": "frontend"}, map[string]string{"env": "prod"}),
+				makeEntity("ti2", map[string]string{"tier": "frontend"}, map[string]string{"env": "staging"}),
+				makeEntity("ti3", map[string]string{"tier": "backend"}, map[string]string{"env": "prod"}),
+			},
+		},
+		{
+			name:             "no matches returns empty",
+			annotationFilter: "tier=missing",
+			expectedCount:    0,
+			ingresses: []*TCPIngress{
+				makeEntity("ti1", map[string]string{"tier": "frontend"}, nil),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			uc, err := newKongUnstructuredConverter()
+			require.NoError(t, err)
+
+			fakeKubernetesClient := fakeKube.NewSimpleClientset()
+			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(uc.scheme)
+
+			for _, ing := range tt.ingresses {
+				data, err := json.Marshal(ing)
+				require.NoError(t, err)
+				obj := unstructured.Unstructured{}
+				require.NoError(t, obj.UnmarshalJSON(data))
+				_, err = fakeDynamicClient.Resource(kongGroupdVersionResource).Namespace(defaultKongNamespace).Create(t.Context(), &obj, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+
+			labelSel := labels.Everything()
+			if tt.labelFilter != "" {
+				labelSel, err = labels.Parse(tt.labelFilter)
+				require.NoError(t, err)
+			}
+
+			src, err := NewKongTCPIngressSource(t.Context(), fakeDynamicClient, fakeKubernetesClient, &Config{
+				Namespace:        defaultKongNamespace,
+				AnnotationFilter: parseAnnotationFilterOrNil(tt.annotationFilter),
+				LabelFilter:      labelSel,
+			})
+			require.NoError(t, err)
+
+			endpoints, err := src.Endpoints(t.Context())
+			require.NoError(t, err)
+			assert.Len(t, endpoints, tt.expectedCount)
+		})
+	}
+}

--- a/source/kong_tcpingress_test.go
+++ b/source/kong_tcpingress_test.go
@@ -612,14 +612,21 @@ func TestKongTCPIngressIndexer(t *testing.T) {
 				makeEntity("ti1", map[string]string{"tier": "frontend"}, nil),
 			},
 		},
+		{
+			name:          "controller mismatch is excluded",
+			expectedCount: 0,
+			ingresses: []*TCPIngress{
+				makeEntity("ti1", map[string]string{annotations.ControllerKey: "other-controller"}, nil),
+			},
+		},
 	}
+
+	uc, err := newKongUnstructuredConverter()
+	require.NoError(t, err)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-
-			uc, err := newKongUnstructuredConverter()
-			require.NoError(t, err)
 
 			fakeKubernetesClient := fakeKube.NewSimpleClientset()
 			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(uc.scheme)
@@ -633,16 +640,10 @@ func TestKongTCPIngressIndexer(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			labelSel := labels.Everything()
-			if tt.labelFilter != "" {
-				labelSel, err = labels.Parse(tt.labelFilter)
-				require.NoError(t, err)
-			}
-
 			src, err := NewKongTCPIngressSource(t.Context(), fakeDynamicClient, fakeKubernetesClient, &Config{
 				Namespace:        defaultKongNamespace,
 				AnnotationFilter: parseAnnotationFilterOrNil(tt.annotationFilter),
-				LabelFilter:      labelSel,
+				LabelFilter:      parseLabelSelectorOrEverything(t, tt.labelFilter),
 			})
 			require.NoError(t, err)
 

--- a/source/openshift_route.go
+++ b/source/openshift_route.go
@@ -27,7 +27,6 @@ import (
 	routeInformer "github.com/openshift/client-go/route/informers/externalversions/route/v1"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 
 	"sigs.k8s.io/external-dns/source/types"
 
@@ -53,13 +52,9 @@ import (
 // +externaldns:source:fqdn-template=true
 // +externaldns:source:provider-specific=true
 type ocpRouteSource struct {
-	client                   versioned.Interface
-	namespace                string
-	annotationFilter         labels.Selector
 	templateEngine           template.Engine
 	ignoreHostnameAnnotation bool
 	routeInformer            routeInformer.RouteInformer
-	labelSelector            labels.Selector
 	ocpRouterName            string
 }
 
@@ -79,6 +74,12 @@ func NewOcpRouteSource(
 		informers.TransformRemoveLastAppliedConfig(),
 	))
 
+	informers.MustAddIndexers(informer.Informer(), informers.IndexerWithOptions[*routev1.Route](
+		informers.IndexSelectorWithAnnotationFilter(cfg.AnnotationFilter),
+		informers.IndexSelectorWithLabelSelector(cfg.LabelFilter),
+		informers.IndexSelectorWithConditions(annotations.IsControllerMatch[*routev1.Route]),
+	))
+
 	// Add default resource event handlers to properly initialize informer.
 	informers.MustAddEventHandler(informer.Informer(), informers.DefaultEventHandler())
 
@@ -90,13 +91,9 @@ func NewOcpRouteSource(
 	}
 
 	return &ocpRouteSource{
-		client:                   ocpClient,
-		namespace:                cfg.Namespace,
-		annotationFilter:         cfg.AnnotationFilter,
 		templateEngine:           cfg.TemplateEngine,
 		ignoreHostnameAnnotation: cfg.IgnoreHostnameAnnotation,
 		routeInformer:            informer,
-		labelSelector:            cfg.LabelFilter,
 		ocpRouterName:            cfg.OCPRouterName,
 	}, nil
 }
@@ -113,25 +110,14 @@ func (ors *ocpRouteSource) AddEventHandler(_ context.Context, handler func()) {
 // Retrieves all OpenShift Route resources on all namespaces, unless an explicit namespace
 // is specified in ocpRouteSource.
 func (ors *ocpRouteSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, error) {
-	ocpRoutes, err := ors.routeInformer.Lister().Routes(ors.namespace).List(ors.labelSelector)
-	if err != nil {
-		return nil, err
-	}
+	ocpRoutes := informers.ListIndexed[*routev1.Route](ors.routeInformer.Informer().GetIndexer())
 
-	ocpRoutes = annotations.Filter(ocpRoutes, ors.annotationFilter)
-
-	endpoints := []*endpoint.Endpoint{}
+	var endpoints []*endpoint.Endpoint
 
 	for _, ocpRoute := range ocpRoutes {
-		if annotations.IsControllerMismatch(ocpRoute, types.OpenShiftRoute) {
-			continue
-		}
-
-		orEndpoints := ors.endpointsFromOcpRoute(ocpRoute, ors.ignoreHostnameAnnotation)
-
 		// apply template if host is missing on OpenShift Route
-		orEndpoints, err = ors.templateEngine.CombineWithEndpoints(
-			orEndpoints,
+		orEndpoints, err := ors.templateEngine.CombineWithEndpoints(
+			ors.endpointsFromOcpRoute(ocpRoute, ors.ignoreHostnameAnnotation),
 			func() ([]*endpoint.Endpoint, error) { return ors.endpointsFromTemplate(ocpRoute) },
 		)
 		if err != nil {

--- a/source/openshift_route_test.go
+++ b/source/openshift_route_test.go
@@ -525,6 +525,120 @@ func testOcpRouteSourceEndpoints(t *testing.T) {
 	}
 }
 
+func TestOcpRouteIndexer(t *testing.T) {
+	t.Parallel()
+
+	makeRoute := func(namespace, name, host, target string, ann, lbls map[string]string) *routev1.Route {
+		return &routev1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:   namespace,
+				Name:        name,
+				Annotations: ann,
+				Labels:      lbls,
+			},
+			Status: routev1.RouteStatus{
+				Ingress: []routev1.RouteIngress{
+					{
+						Host:                    host,
+						RouterCanonicalHostname: target,
+						Conditions: []routev1.RouteIngressCondition{
+							{Type: routev1.RouteAdmitted, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	for _, tc := range []struct {
+		name             string
+		annotationFilter string
+		labelFilter      string
+		routes           []*routev1.Route
+		wantCount        int
+	}{
+		{
+			name: "no filters — all namespaces included",
+			routes: []*routev1.Route{
+				makeRoute("default", "r1", "a.example.com", "apps.example.com", nil, nil),
+				makeRoute("staging", "r2", "b.example.com", "apps.example.com", nil, nil),
+				makeRoute("production", "r3", "c.example.com", "apps.example.com", nil, nil),
+			},
+			wantCount: 3,
+		},
+		{
+			name:             "annotation filter matches",
+			annotationFilter: "external-dns.kubernetes.io/managed=true",
+			routes: []*routev1.Route{
+				makeRoute("default", "r1", "a.example.com", "apps.example.com", map[string]string{"external-dns.kubernetes.io/managed": "true"}, nil),
+				makeRoute("staging", "r2", "b.example.com", "apps.example.com", nil, nil),
+			},
+			wantCount: 1,
+		},
+		{
+			name:        "label filter matches",
+			labelFilter: "tier=external",
+			routes: []*routev1.Route{
+				makeRoute("default", "r1", "a.example.com", "apps.example.com", nil, map[string]string{"tier": "external"}),
+				makeRoute("staging", "r2", "b.example.com", "apps.example.com", nil, map[string]string{"tier": "internal"}),
+			},
+			wantCount: 1,
+		},
+		{
+			name:             "annotation and label filter combined",
+			annotationFilter: "external-dns.kubernetes.io/managed=true",
+			labelFilter:      "tier=external",
+			routes: []*routev1.Route{
+				makeRoute("default", "r1", "a.example.com", "apps.example.com",
+					map[string]string{"external-dns.kubernetes.io/managed": "true"},
+					map[string]string{"tier": "external"}),
+				makeRoute("staging", "r2", "b.example.com", "apps.example.com",
+					map[string]string{"external-dns.kubernetes.io/managed": "true"},
+					map[string]string{"tier": "internal"}),
+			},
+			wantCount: 1,
+		},
+		{
+			name:             "no-match annotation filter",
+			annotationFilter: "external-dns.kubernetes.io/managed=true",
+			routes: []*routev1.Route{
+				makeRoute("default", "r1", "a.example.com", "apps.example.com", nil, nil),
+				makeRoute("production", "r2", "b.example.com", "apps.example.com", nil, nil),
+			},
+			wantCount: 0,
+		},
+		{
+			name: "controller mismatch is excluded",
+			routes: []*routev1.Route{
+				makeRoute("default", "r1", "a.example.com", "apps.example.com",
+					map[string]string{"external-dns.kubernetes.io/controller": "other-controller"},
+					nil),
+			},
+			wantCount: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fakeClient := fake.NewClientset()
+			for _, r := range tc.routes {
+				_, err := fakeClient.RouteV1().Routes(r.Namespace).Create(t.Context(), r, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+
+			src, err := NewOcpRouteSource(t.Context(), fakeClient, &Config{
+				AnnotationFilter: parseLabelSelectorOrEverything(t, tc.annotationFilter),
+				LabelFilter:      parseLabelSelectorOrEverything(t, tc.labelFilter),
+			})
+			require.NoError(t, err)
+
+			endpoints, err := src.Endpoints(t.Context())
+			require.NoError(t, err)
+			assert.Len(t, endpoints, tc.wantCount)
+		})
+	}
+}
+
 func TestOcpRouteSource_InformerTransform(t *testing.T) {
 	t.Parallel()
 

--- a/source/traefik_proxy.go
+++ b/source/traefik_proxy.go
@@ -18,7 +18,6 @@ package source
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -26,7 +25,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -62,6 +60,10 @@ var (
 		Version:  "v1alpha1",
 		Resource: "ingressrouteudps",
 	}
+	// TODO: traefik.containo.us CRDs were removed in Traefik v3 (released 2024).
+	// Traefik v2 active support ended 2025-04-29; security support ends 2026-02-01.
+	// Remove these GVRs and the --traefik-enable-legacy flag after 2026-02-01.
+	// See https://doc.traefik.io/traefik/deprecation/releases/
 	oldIngressRouteGVR = schema.GroupVersionResource{
 		Group:    "traefik.containo.us",
 		Version:  "v1alpha1",
@@ -95,9 +97,6 @@ var (
 type traefikSource struct {
 	dynamicKubeClient          dynamic.Interface
 	kubeClient                 kubernetes.Interface
-	annotationFilter           labels.Selector
-	labelSelector              labels.Selector
-	namespace                  string
 	ignoreHostnameAnnotation   bool
 	templateEngine             template.Engine
 	ingressRouteInformer       kubeinformers.GenericInformer
@@ -122,6 +121,10 @@ func NewTraefikSource(
 	var oldIngressRouteInformer, oldIngressRouteTcpInformer, oldIngressRouteUdpInformer kubeinformers.GenericInformer
 
 	// Add default resource event handlers to properly initialize informers.
+	indexerOpts := informers.IndexerWithOptions[*unstructured.Unstructured](
+		informers.IndexSelectorWithAnnotationFilter(cfg.AnnotationFilter),
+		informers.IndexSelectorWithLabelSelector(cfg.LabelFilter),
+	)
 	if !cfg.TraefikDisableNew {
 		ingressRouteInformer = informerFactory.ForResource(ingressRouteGVR)
 		ingressRouteTcpInformer = informerFactory.ForResource(ingressRouteTCPGVR)
@@ -138,6 +141,9 @@ func NewTraefikSource(
 			informers.TransformRemoveManagedFields(),
 			informers.TransformRemoveLastAppliedConfig(),
 		))
+		informers.MustAddIndexers(ingressRouteInformer.Informer(), indexerOpts)
+		informers.MustAddIndexers(ingressRouteTcpInformer.Informer(), indexerOpts)
+		informers.MustAddIndexers(ingressRouteUdpInformer.Informer(), indexerOpts)
 		informers.MustAddEventHandler(ingressRouteInformer.Informer(), informers.DefaultEventHandler())
 		informers.MustAddEventHandler(ingressRouteTcpInformer.Informer(), informers.DefaultEventHandler())
 		informers.MustAddEventHandler(ingressRouteUdpInformer.Informer(), informers.DefaultEventHandler())
@@ -158,6 +164,9 @@ func NewTraefikSource(
 			informers.TransformRemoveManagedFields(),
 			informers.TransformRemoveLastAppliedConfig(),
 		))
+		informers.MustAddIndexers(oldIngressRouteInformer.Informer(), indexerOpts)
+		informers.MustAddIndexers(oldIngressRouteTcpInformer.Informer(), indexerOpts)
+		informers.MustAddIndexers(oldIngressRouteUdpInformer.Informer(), indexerOpts)
 		informers.MustAddEventHandler(oldIngressRouteInformer.Informer(), informers.DefaultEventHandler())
 		informers.MustAddEventHandler(oldIngressRouteTcpInformer.Informer(), informers.DefaultEventHandler())
 		informers.MustAddEventHandler(oldIngressRouteUdpInformer.Informer(), informers.DefaultEventHandler())
@@ -176,8 +185,6 @@ func NewTraefikSource(
 	}
 
 	return &traefikSource{
-		annotationFilter:           cfg.AnnotationFilter,
-		labelSelector:              cfg.LabelFilter,
 		ignoreHostnameAnnotation:   cfg.IgnoreHostnameAnnotation,
 		templateEngine:             cfg.TemplateEngine,
 		dynamicKubeClient:          dynamicKubeClient,
@@ -188,7 +195,6 @@ func NewTraefikSource(
 		oldIngressRouteTcpInformer: oldIngressRouteTcpInformer,
 		oldIngressRouteUdpInformer: oldIngressRouteUdpInformer,
 		kubeClient:                 kubeClient,
-		namespace:                  cfg.Namespace,
 		unstructuredConverter:      uc,
 	}, nil
 }
@@ -245,14 +251,11 @@ func (ts *traefikSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, err
 // ingressRouteEndpoints extracts endpoints from all IngressRoute objects
 func (ts *traefikSource) ingressRouteEndpoints() ([]*endpoint.Endpoint, error) {
 	return extractEndpoints(
-		ts.ingressRouteInformer.Lister(),
-		ts.namespace,
+		ts.ingressRouteInformer.Informer().GetIndexer(),
 		func(u *unstructured.Unstructured) (*IngressRoute, error) {
 			typed := &IngressRoute{}
 			return typed, ts.unstructuredConverter.scheme.Convert(u, typed, nil)
 		},
-		ts.labelSelector,
-		ts.annotationFilter,
 		ts.endpointsFromIngressRoute,
 	)
 }
@@ -261,28 +264,17 @@ func (ts *traefikSource) ingressRouteEndpoints() ([]*endpoint.Endpoint, error) {
 func (ts *traefikSource) ingressRouteTCPEndpoints() ([]*endpoint.Endpoint, error) {
 	var endpoints []*endpoint.Endpoint
 
-	irs, err := ts.ingressRouteTcpInformer.Lister().ByNamespace(ts.namespace).List(ts.labelSelector)
-	if err != nil {
-		return nil, err
-	}
+	irs := informers.ListIndexed[*unstructured.Unstructured](ts.ingressRouteTcpInformer.Informer().GetIndexer())
 
 	var ingressRouteTCPs []*IngressRouteTCP
-	for _, ingressRouteTCPObj := range irs {
-		unstructuredHost, ok := ingressRouteTCPObj.(*unstructured.Unstructured)
-		if !ok {
-			return nil, errors.New("could not convert IngressRouteTCP object to unstructured")
-		}
-
+	for _, obj := range irs {
 		ingressRouteTCP := &IngressRouteTCP{}
-		err := ts.unstructuredConverter.scheme.Convert(unstructuredHost, ingressRouteTCP, nil)
-		if err != nil {
+		if err := ts.unstructuredConverter.scheme.Convert(obj, ingressRouteTCP, nil); err != nil {
 			return nil, err
 		}
-		ingressRouteTCP.GetObjectKind().SetGroupVersionKind(unstructuredHost.GetObjectKind().GroupVersionKind())
+		ingressRouteTCP.GetObjectKind().SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
 		ingressRouteTCPs = append(ingressRouteTCPs, ingressRouteTCP)
 	}
-
-	ingressRouteTCPs = annotations.Filter(ingressRouteTCPs, ts.annotationFilter)
 
 	for _, ingressRouteTCP := range ingressRouteTCPs {
 		var targets endpoint.Targets
@@ -311,14 +303,11 @@ func (ts *traefikSource) ingressRouteTCPEndpoints() ([]*endpoint.Endpoint, error
 // ingressRouteUDPEndpoints extracts endpoints from all IngressRouteUDP objects
 func (ts *traefikSource) ingressRouteUDPEndpoints() ([]*endpoint.Endpoint, error) {
 	return extractEndpoints(
-		ts.ingressRouteUdpInformer.Lister(),
-		ts.namespace,
+		ts.ingressRouteUdpInformer.Informer().GetIndexer(),
 		func(u *unstructured.Unstructured) (*IngressRouteUDP, error) {
 			typed := &IngressRouteUDP{}
 			return typed, ts.unstructuredConverter.scheme.Convert(u, typed, nil)
 		},
-		ts.labelSelector,
-		ts.annotationFilter,
 		ts.endpointsFromIngressRouteUDP,
 	)
 }
@@ -326,14 +315,11 @@ func (ts *traefikSource) ingressRouteUDPEndpoints() ([]*endpoint.Endpoint, error
 // oldIngressRouteEndpoints extracts endpoints from all IngressRoute objects
 func (ts *traefikSource) oldIngressRouteEndpoints() ([]*endpoint.Endpoint, error) {
 	return extractEndpoints(
-		ts.oldIngressRouteInformer.Lister(),
-		ts.namespace,
+		ts.oldIngressRouteInformer.Informer().GetIndexer(),
 		func(u *unstructured.Unstructured) (*IngressRoute, error) {
 			typed := &IngressRoute{}
 			return typed, ts.unstructuredConverter.scheme.Convert(u, typed, nil)
 		},
-		ts.labelSelector,
-		ts.annotationFilter,
 		ts.endpointsFromIngressRoute,
 	)
 }
@@ -341,14 +327,11 @@ func (ts *traefikSource) oldIngressRouteEndpoints() ([]*endpoint.Endpoint, error
 // oldIngressRouteTCPEndpoints extracts endpoints from all IngressRouteTCP objects
 func (ts *traefikSource) oldIngressRouteTCPEndpoints() ([]*endpoint.Endpoint, error) {
 	return extractEndpoints(
-		ts.oldIngressRouteTcpInformer.Lister(),
-		ts.namespace,
+		ts.oldIngressRouteTcpInformer.Informer().GetIndexer(),
 		func(u *unstructured.Unstructured) (*IngressRouteTCP, error) {
 			typed := &IngressRouteTCP{}
 			return typed, ts.unstructuredConverter.scheme.Convert(u, typed, nil)
 		},
-		ts.labelSelector,
-		ts.annotationFilter,
 		ts.endpointsFromIngressRouteTCP,
 	)
 }
@@ -356,14 +339,11 @@ func (ts *traefikSource) oldIngressRouteTCPEndpoints() ([]*endpoint.Endpoint, er
 // oldIngressRouteUDPEndpoints extracts endpoints from all IngressRouteUDP objects
 func (ts *traefikSource) oldIngressRouteUDPEndpoints() ([]*endpoint.Endpoint, error) {
 	return extractEndpoints(
-		ts.oldIngressRouteUdpInformer.Lister(),
-		ts.namespace,
+		ts.oldIngressRouteUdpInformer.Informer().GetIndexer(),
 		func(u *unstructured.Unstructured) (*IngressRouteUDP, error) {
 			typed := &IngressRouteUDP{}
 			return typed, ts.unstructuredConverter.scheme.Convert(u, typed, nil)
 		},
-		ts.labelSelector,
-		ts.annotationFilter,
 		ts.endpointsFromIngressRouteUDP,
 	)
 }
@@ -852,45 +832,31 @@ func (in *IngressRouteUDP) GetAnnotations() map[string]string {
 
 // extractEndpoints is a generic function that extracts endpoints from Kubernetes resources.
 // It performs the following steps:
-// 1. Lists all objects in the specified namespace using the provided informer.
+// 1. Lists all objects admitted by the indexer (annotation + label filters applied at index time).
 // 2. Converts the unstructured objects to the desired type using the convertFunc.
-// 3. Filters the converted objects based on the annotation filter.
-// 4. Generates endpoints for each filtered object using the generateEndpoints function.
+// 3. Generates endpoints for each object using the generateEndpoints function.
 // Returns a list of generated endpoints or an error if any step fails.
 func extractEndpoints[T interface {
 	annotations.AnnotatedObject
 	runtime.Object
 }](
-	informer cache.GenericLister,
-	namespace string,
+	indexer cache.Indexer,
 	convertFunc func(*unstructured.Unstructured) (T, error),
-	labelSelector labels.Selector,
-	annotationFilter labels.Selector,
 	generateEndpoints func(T, endpoint.Targets) ([]*endpoint.Endpoint, error),
 ) ([]*endpoint.Endpoint, error) {
 	var endpoints []*endpoint.Endpoint
 
-	objs, err := informer.ByNamespace(namespace).List(labelSelector)
-	if err != nil {
-		return nil, err
-	}
+	objs := informers.ListIndexed[*unstructured.Unstructured](indexer)
 
 	var typedObjs []T
 	for _, obj := range objs {
-		unstructuredObj, ok := obj.(*unstructured.Unstructured)
-		if !ok {
-			return nil, errors.New("failed to cast to unstructured.Unstructured")
-		}
-
-		typed, err := convertFunc(unstructuredObj)
+		typed, err := convertFunc(obj)
 		if err != nil {
 			return nil, err
 		}
-		typed.GetObjectKind().SetGroupVersionKind(unstructuredObj.GetObjectKind().GroupVersionKind())
+		typed.GetObjectKind().SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
 		typedObjs = append(typedObjs, typed)
 	}
-
-	typedObjs = annotations.Filter(typedObjs, annotationFilter)
 
 	for _, item := range typedObjs {
 		targets := annotations.TargetsFromTargetAnnotation(item.GetAnnotations())

--- a/source/traefik_proxy.go
+++ b/source/traefik_proxy.go
@@ -124,6 +124,7 @@ func NewTraefikSource(
 	indexerOpts := informers.IndexerWithOptions[*unstructured.Unstructured](
 		informers.IndexSelectorWithAnnotationFilter(cfg.AnnotationFilter),
 		informers.IndexSelectorWithLabelSelector(cfg.LabelFilter),
+		informers.IndexSelectorWithConditions(annotations.IsControllerMatch[*unstructured.Unstructured]),
 	)
 	if !cfg.TraefikDisableNew {
 		ingressRouteInformer = informerFactory.ForResource(ingressRouteGVR)
@@ -262,42 +263,14 @@ func (ts *traefikSource) ingressRouteEndpoints() ([]*endpoint.Endpoint, error) {
 
 // ingressRouteTCPEndpoints extracts endpoints from all IngressRouteTCP objects
 func (ts *traefikSource) ingressRouteTCPEndpoints() ([]*endpoint.Endpoint, error) {
-	var endpoints []*endpoint.Endpoint
-
-	irs := informers.ListIndexed[*unstructured.Unstructured](ts.ingressRouteTcpInformer.Informer().GetIndexer())
-
-	var ingressRouteTCPs []*IngressRouteTCP
-	for _, obj := range irs {
-		ingressRouteTCP := &IngressRouteTCP{}
-		if err := ts.unstructuredConverter.scheme.Convert(obj, ingressRouteTCP, nil); err != nil {
-			return nil, err
-		}
-		ingressRouteTCP.GetObjectKind().SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
-		ingressRouteTCPs = append(ingressRouteTCPs, ingressRouteTCP)
-	}
-
-	for _, ingressRouteTCP := range ingressRouteTCPs {
-		var targets endpoint.Targets
-
-		targets = append(targets, annotations.TargetsFromTargetAnnotation(ingressRouteTCP.Annotations)...)
-
-		fullname := fmt.Sprintf("%s/%s", ingressRouteTCP.Namespace, ingressRouteTCP.Name)
-
-		ingressEndpoints, err := ts.endpointsFromIngressRouteTCP(ingressRouteTCP, targets)
-		if err != nil {
-			return nil, err
-		}
-		if endpoint.HasNoEmptyEndpoints(ingressEndpoints, types.TraefikProxy, ingressRouteTCP) {
-			continue
-		}
-
-		endpoint.AttachRefObject(ingressEndpoints, events.NewObjectReference(ingressRouteTCP, types.TraefikProxy))
-
-		log.Debugf("Endpoints generated from IngressRouteTCP: %s: %v", fullname, ingressEndpoints)
-		endpoints = append(endpoints, ingressEndpoints...)
-	}
-
-	return endpoints, nil
+	return extractEndpoints(
+		ts.ingressRouteTcpInformer.Informer().GetIndexer(),
+		func(u *unstructured.Unstructured) (*IngressRouteTCP, error) {
+			typed := &IngressRouteTCP{}
+			return typed, ts.unstructuredConverter.scheme.Convert(u, typed, nil)
+		},
+		ts.endpointsFromIngressRouteTCP,
+	)
 }
 
 // ingressRouteUDPEndpoints extracts endpoints from all IngressRouteUDP objects
@@ -846,23 +819,17 @@ func extractEndpoints[T interface {
 ) ([]*endpoint.Endpoint, error) {
 	var endpoints []*endpoint.Endpoint
 
-	objs := informers.ListIndexed[*unstructured.Unstructured](indexer)
-
-	var typedObjs []T
-	for _, obj := range objs {
+	for _, obj := range informers.ListIndexed[*unstructured.Unstructured](indexer) {
 		typed, err := convertFunc(obj)
 		if err != nil {
 			return nil, err
 		}
 		typed.GetObjectKind().SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
-		typedObjs = append(typedObjs, typed)
-	}
 
-	for _, item := range typedObjs {
-		targets := annotations.TargetsFromTargetAnnotation(item.GetAnnotations())
+		targets := annotations.TargetsFromTargetAnnotation(typed.GetAnnotations())
+		name := getObjectFullName(typed)
 
-		name := getObjectFullName(item)
-		ingressEndpoints, err := generateEndpoints(item, targets)
+		ingressEndpoints, err := generateEndpoints(typed, targets)
 		if err != nil {
 			return nil, err
 		}
@@ -874,8 +841,8 @@ func extractEndpoints[T interface {
 
 		// All traefik route kinds map to the traefik-proxy source. The concrete
 		// CRD types satisfy client.Object; the assertion guards the generic T.
-		if obj, ok := any(item).(client.Object); ok {
-			endpoint.AttachRefObject(ingressEndpoints, events.NewObjectReference(obj, types.TraefikProxy))
+		if cObj, ok := any(typed).(client.Object); ok {
+			endpoint.AttachRefObject(ingressEndpoints, events.NewObjectReference(cObj, types.TraefikProxy))
 		}
 
 		log.Debugf("Endpoints generated from %s: %v", name, ingressEndpoints)
@@ -886,14 +853,8 @@ func extractEndpoints[T interface {
 }
 
 func getObjectFullName(obj any) string {
-	switch o := obj.(type) {
-	case *IngressRouteUDP:
-		return fmt.Sprintf("%s/%s", o.Namespace, o.Name)
-	case *IngressRoute:
-		return fmt.Sprintf("%s/%s", o.Namespace, o.Name)
-	case *IngressRouteTCP:
-		return fmt.Sprintf("%s/%s", o.Namespace, o.Name)
-	default:
-		return ""
+	if m, ok := obj.(metav1.Object); ok {
+		return m.GetNamespace() + "/" + m.GetName()
 	}
+	return ""
 }

--- a/source/traefik_proxy_test.go
+++ b/source/traefik_proxy_test.go
@@ -2024,3 +2024,254 @@ func TestTraefikSource_InformerTransform(t *testing.T) {
 		})
 	}
 }
+
+// newTraefikScheme builds a runtime.Scheme with all Traefik CRD types registered.
+func newTraefikScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	s.AddKnownTypes(ingressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
+	s.AddKnownTypes(ingressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
+	s.AddKnownTypes(ingressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
+	s.AddKnownTypes(oldIngressRouteGVR.GroupVersion(), &IngressRoute{}, &IngressRouteList{})
+	s.AddKnownTypes(oldIngressRouteTCPGVR.GroupVersion(), &IngressRouteTCP{}, &IngressRouteTCPList{})
+	s.AddKnownTypes(oldIngressRouteUDPGVR.GroupVersion(), &IngressRouteUDP{}, &IngressRouteUDPList{})
+	return s
+}
+
+// TestTraefikIndexer verifies that the indexer correctly filters IngressRoute, IngressRouteTCP,
+// and IngressRouteUDP resources (current traefik.io GVRs) by annotation and label at index time.
+func TestTraefikIndexer(t *testing.T) {
+	t.Parallel()
+
+	makeEntity := func(gvr schema.GroupVersionResource, kind, name string, ann, lbls map[string]string) *IngressRoute {
+		if ann == nil {
+			ann = map[string]string{}
+		}
+		if lbls == nil {
+			lbls = map[string]string{}
+		}
+		ann[annotations.TargetKey] = "1.2.3.4"
+		return &IngressRoute{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: gvr.GroupVersion().String(),
+				Kind:       kind,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        name,
+				Namespace:   defaultTraefikNamespace,
+				Annotations: ann,
+				Labels:      lbls,
+			},
+			Spec: traefikIngressRouteSpec{
+				Routes: []traefikRoute{{Match: fmt.Sprintf("Host(`%s.example.org`)", name)}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name             string
+		annotationFilter string
+		labelFilter      string
+		routes           []*IngressRoute
+		expectedCount    int
+	}{
+		{
+			name:          "no filters returns all routes",
+			expectedCount: 3,
+			routes: []*IngressRoute{
+				makeEntity(ingressRouteGVR, "IngressRoute", "ir1", nil, nil),
+				makeEntity(ingressRouteGVR, "IngressRoute", "ir2", nil, nil),
+				makeEntity(ingressRouteGVR, "IngressRoute", "ir3", nil, nil),
+			},
+		},
+		{
+			name:             "annotation filter includes matching routes",
+			annotationFilter: "tier=frontend",
+			expectedCount:    2,
+			routes: []*IngressRoute{
+				makeEntity(ingressRouteGVR, "IngressRoute", "ir1", map[string]string{"tier": "frontend"}, nil),
+				makeEntity(ingressRouteGVR, "IngressRoute", "ir2", map[string]string{"tier": "frontend"}, nil),
+				makeEntity(ingressRouteGVR, "IngressRoute", "ir3", map[string]string{"tier": "backend"}, nil),
+			},
+		},
+		{
+			name:          "label filter includes matching routes",
+			labelFilter:   "env=prod",
+			expectedCount: 1,
+			routes: []*IngressRoute{
+				makeEntity(ingressRouteGVR, "IngressRoute", "ir1", nil, map[string]string{"env": "prod"}),
+				makeEntity(ingressRouteGVR, "IngressRoute", "ir2", nil, map[string]string{"env": "staging"}),
+				makeEntity(ingressRouteGVR, "IngressRoute", "ir3", nil, nil),
+			},
+		},
+		{
+			name:             "annotation and label filter combined",
+			annotationFilter: "tier=frontend",
+			labelFilter:      "env=prod",
+			expectedCount:    1,
+			routes: []*IngressRoute{
+				makeEntity(ingressRouteGVR, "IngressRoute", "ir1", map[string]string{"tier": "frontend"}, map[string]string{"env": "prod"}),
+				makeEntity(ingressRouteGVR, "IngressRoute", "ir2", map[string]string{"tier": "frontend"}, map[string]string{"env": "staging"}),
+				makeEntity(ingressRouteGVR, "IngressRoute", "ir3", map[string]string{"tier": "backend"}, map[string]string{"env": "prod"}),
+			},
+		},
+		{
+			name:             "no matches returns empty",
+			annotationFilter: "tier=missing",
+			expectedCount:    0,
+			routes: []*IngressRoute{
+				makeEntity(ingressRouteGVR, "IngressRoute", "ir1", map[string]string{"tier": "frontend"}, nil),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fakeKubernetesClient := fakeKube.NewSimpleClientset()
+			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(newTraefikScheme())
+
+			for _, route := range tt.routes {
+				data, err := json.Marshal(route)
+				require.NoError(t, err)
+				obj := unstructured.Unstructured{}
+				require.NoError(t, obj.UnmarshalJSON(data))
+				_, err = fakeDynamicClient.Resource(ingressRouteGVR).Namespace(defaultTraefikNamespace).Create(t.Context(), &obj, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+
+			labelSel := labels.Everything()
+			if tt.labelFilter != "" {
+				var err error
+				labelSel, err = labels.Parse(tt.labelFilter)
+				require.NoError(t, err)
+			}
+
+			src, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient, &Config{
+				Namespace:        defaultTraefikNamespace,
+				AnnotationFilter: parseAnnotationFilterOrNil(tt.annotationFilter),
+				LabelFilter:      labelSel,
+			})
+			require.NoError(t, err)
+
+			endpoints, err := src.Endpoints(t.Context())
+			require.NoError(t, err)
+			assert.Len(t, endpoints, tt.expectedCount)
+		})
+	}
+}
+
+// TestTraefikLegacyIndexer verifies that the indexer correctly filters legacy IngressRoute resources
+// (traefik.containo.us GVRs, enabled via --traefik-enable-legacy) by annotation and label at index time.
+func TestTraefikLegacyIndexer(t *testing.T) {
+	t.Parallel()
+
+	makeEntity := func(name string, ann, lbls map[string]string) *IngressRoute {
+		if ann == nil {
+			ann = map[string]string{}
+		}
+		if lbls == nil {
+			lbls = map[string]string{}
+		}
+		ann[annotations.TargetKey] = "1.2.3.4"
+		return &IngressRoute{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: oldIngressRouteGVR.GroupVersion().String(),
+				Kind:       "IngressRoute",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        name,
+				Namespace:   defaultTraefikNamespace,
+				Annotations: ann,
+				Labels:      lbls,
+			},
+			Spec: traefikIngressRouteSpec{
+				Routes: []traefikRoute{{Match: fmt.Sprintf("Host(`%s.example.org`)", name)}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name             string
+		annotationFilter string
+		labelFilter      string
+		routes           []*IngressRoute
+		expectedCount    int
+	}{
+		{
+			name:          "no filters returns all legacy routes",
+			expectedCount: 3,
+			routes: []*IngressRoute{
+				makeEntity("ir1", nil, nil),
+				makeEntity("ir2", nil, nil),
+				makeEntity("ir3", nil, nil),
+			},
+		},
+		{
+			name:             "annotation filter on legacy routes",
+			annotationFilter: "tier=frontend",
+			expectedCount:    2,
+			routes: []*IngressRoute{
+				makeEntity("ir1", map[string]string{"tier": "frontend"}, nil),
+				makeEntity("ir2", map[string]string{"tier": "frontend"}, nil),
+				makeEntity("ir3", map[string]string{"tier": "backend"}, nil),
+			},
+		},
+		{
+			name:          "label filter on legacy routes",
+			labelFilter:   "env=prod",
+			expectedCount: 1,
+			routes: []*IngressRoute{
+				makeEntity("ir1", nil, map[string]string{"env": "prod"}),
+				makeEntity("ir2", nil, map[string]string{"env": "staging"}),
+				makeEntity("ir3", nil, nil),
+			},
+		},
+		{
+			name:             "no matches on legacy routes",
+			annotationFilter: "tier=missing",
+			expectedCount:    0,
+			routes: []*IngressRoute{
+				makeEntity("ir1", map[string]string{"tier": "frontend"}, nil),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fakeKubernetesClient := fakeKube.NewSimpleClientset()
+			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(newTraefikScheme())
+
+			for _, route := range tt.routes {
+				data, err := json.Marshal(route)
+				require.NoError(t, err)
+				obj := unstructured.Unstructured{}
+				require.NoError(t, obj.UnmarshalJSON(data))
+				_, err = fakeDynamicClient.Resource(oldIngressRouteGVR).Namespace(defaultTraefikNamespace).Create(t.Context(), &obj, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+
+			labelSel := labels.Everything()
+			if tt.labelFilter != "" {
+				var err error
+				labelSel, err = labels.Parse(tt.labelFilter)
+				require.NoError(t, err)
+			}
+
+			src, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient, &Config{
+				Namespace:           defaultTraefikNamespace,
+				AnnotationFilter:    parseAnnotationFilterOrNil(tt.annotationFilter),
+				LabelFilter:         labelSel,
+				TraefikDisableNew:   true,
+				TraefikEnableLegacy: true,
+			})
+			require.NoError(t, err)
+
+			endpoints, err := src.Endpoints(t.Context())
+			require.NoError(t, err)
+			assert.Len(t, endpoints, tt.expectedCount)
+		})
+	}
+}

--- a/source/traefik_proxy_test.go
+++ b/source/traefik_proxy_test.go
@@ -2131,12 +2131,13 @@ func TestTraefikIndexer(t *testing.T) {
 		},
 	}
 
+	traefikScheme := newTraefikScheme()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
 			fakeKubernetesClient := fakeKube.NewSimpleClientset()
-			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(newTraefikScheme())
+			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(traefikScheme)
 
 			for _, route := range tt.routes {
 				data, err := json.Marshal(route)
@@ -2255,12 +2256,13 @@ func TestTraefikLegacyIndexer(t *testing.T) {
 		},
 	}
 
+	traefikScheme := newTraefikScheme()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
 			fakeKubernetesClient := fakeKube.NewSimpleClientset()
-			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(newTraefikScheme())
+			fakeDynamicClient := fakeDynamic.NewSimpleDynamicClient(traefikScheme)
 
 			for _, route := range tt.routes {
 				data, err := json.Marshal(route)

--- a/source/traefik_proxy_test.go
+++ b/source/traefik_proxy_test.go
@@ -2122,6 +2122,13 @@ func TestTraefikIndexer(t *testing.T) {
 				makeEntity(ingressRouteGVR, "IngressRoute", "ir1", map[string]string{"tier": "frontend"}, nil),
 			},
 		},
+		{
+			name:          "controller mismatch is excluded",
+			expectedCount: 0,
+			routes: []*IngressRoute{
+				makeEntity(ingressRouteGVR, "IngressRoute", "ir1", map[string]string{annotations.ControllerKey: "other-controller"}, nil),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -2140,17 +2147,10 @@ func TestTraefikIndexer(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			labelSel := labels.Everything()
-			if tt.labelFilter != "" {
-				var err error
-				labelSel, err = labels.Parse(tt.labelFilter)
-				require.NoError(t, err)
-			}
-
 			src, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient, &Config{
 				Namespace:        defaultTraefikNamespace,
 				AnnotationFilter: parseAnnotationFilterOrNil(tt.annotationFilter),
-				LabelFilter:      labelSel,
+				LabelFilter:      parseLabelSelectorOrEverything(t, tt.labelFilter),
 			})
 			require.NoError(t, err)
 
@@ -2228,11 +2228,29 @@ func TestTraefikLegacyIndexer(t *testing.T) {
 			},
 		},
 		{
+			name:             "annotation and label filter combined",
+			annotationFilter: "tier=frontend",
+			labelFilter:      "env=prod",
+			expectedCount:    1,
+			routes: []*IngressRoute{
+				makeEntity("ir1", map[string]string{"tier": "frontend"}, map[string]string{"env": "prod"}),
+				makeEntity("ir2", map[string]string{"tier": "frontend"}, map[string]string{"env": "staging"}),
+				makeEntity("ir3", map[string]string{"tier": "backend"}, map[string]string{"env": "prod"}),
+			},
+		},
+		{
 			name:             "no matches on legacy routes",
 			annotationFilter: "tier=missing",
 			expectedCount:    0,
 			routes: []*IngressRoute{
 				makeEntity("ir1", map[string]string{"tier": "frontend"}, nil),
+			},
+		},
+		{
+			name:          "controller mismatch is excluded",
+			expectedCount: 0,
+			routes: []*IngressRoute{
+				makeEntity("ir1", map[string]string{annotations.ControllerKey: "other-controller"}, nil),
 			},
 		},
 	}
@@ -2253,17 +2271,10 @@ func TestTraefikLegacyIndexer(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			labelSel := labels.Everything()
-			if tt.labelFilter != "" {
-				var err error
-				labelSel, err = labels.Parse(tt.labelFilter)
-				require.NoError(t, err)
-			}
-
 			src, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient, &Config{
 				Namespace:           defaultTraefikNamespace,
 				AnnotationFilter:    parseAnnotationFilterOrNil(tt.annotationFilter),
-				LabelFilter:         labelSel,
+				LabelFilter:         parseLabelSelectorOrEverything(t, tt.labelFilter),
 				TraefikDisableNew:   true,
 				TraefikEnableLegacy: true,
 			})


### PR DESCRIPTION
## What does it do ?

  - contour-httpproxy, f5-transportserver, f5-virtualserver, kong-tcpingress: add  MustAddIndexers[*unstructured.Unstructured] in each constructor (annotation + label
  filter); replace Lister().ByNamespace().List() + annotations.Filter() calls in Endpoints() with informers.ListIndexed[...]; remove now-unused annotationFilter,  labelSelector, namespace (and dynamicKubeClient on contour) from each struct
  - traefik-proxy: same indexer wiring for all 6 conditional informers (3 current traefik.io, 3 legacy traefik.containo.us); update extractEndpoints generic helper signature from (cache.GenericLister, namespace, labelSelector, annotationFilter) → (cache.Indexer) — removes runtime filtering entirely from the helper; update ingressRouteTCPEndpoints inline accordingly
  - Traefik legacy TODO: annotate traefik.containo.us GVRs with EOL timeline — active support ended 2025-04-29, security support ends 2026-02-01; flag for removal after that date

## Motivation

  - Follow-up to #6538 which wired up label/annotation filters for these sources but kept runtime filtering via Lister().ByNamespace().List() + annotations.Filter()
  - Runtime filtering scans all objects on every Endpoints() call; indexer-based filtering bakes the criteria in at cache-population time, so Endpoints() only iterates objects that already match
  - Struct fields annotationFilter, labelSelector, namespace on each source were unnecessary after indexing — they existed only to carry filter state to query time

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
