### PR TITLE
fix: scope CNAME conflict warnings to domain-filter matches

### DIFF
--- a/controller/execute.go
+++ b/controller/execute.go
@@ -106,6 +106,7 @@ func execute(ctx context.Context) {
 		endpoint.WithRegexDomainFilter(cfg.RegexDomainFilter),
 		endpoint.WithRegexDomainExclude(cfg.RegexDomainExclude),
 	)
+	endpoint.SetCNAMEConflictDomainFilter(domainFilter)
 
 	prvdr, err := providerfactory.Select(ctx, cfg, domainFilter)
 	if err != nil {

--- a/endpoint/domain_filter.go
+++ b/endpoint/domain_filter.go
@@ -29,6 +29,23 @@ import (
 	"sigs.k8s.io/external-dns/internal/idna"
 )
 
+// CNAMEConflictDomainFilter limits CNAME conflict warnings to DNS names matched
+// by the configured domain filter. When unset or unconfigured, all conflicts warn.
+var CNAMEConflictDomainFilter DomainFilterInterface
+
+// SetCNAMEConflictDomainFilter configures which DNS names should emit CNAME
+// conflict warnings during endpoint merging.
+func SetCNAMEConflictDomainFilter(filter DomainFilterInterface) {
+	CNAMEConflictDomainFilter = filter
+}
+
+func shouldWarnCNAMEConflict(dnsName string) bool {
+	if CNAMEConflictDomainFilter == nil {
+		return true
+	}
+	return CNAMEConflictDomainFilter.Match(dnsName)
+}
+
 type MatchAllDomainFilters []DomainFilterInterface
 
 func (f MatchAllDomainFilters) Match(domain string) bool {

--- a/endpoint/utils.go
+++ b/endpoint/utils.go
@@ -163,7 +163,9 @@ func MergeEndpoints(endpoints []*Endpoint) []*Endpoint {
 			// This will be caught by the provider when it tries to create the record, but log a warning here to make it more obvious.
 			// TODO: add metric for CNAME conflicts
 			if first, ok := cnameTargets[cnameKey]; ok && first != ep.Targets[0] {
-				log.Warnf("Only one CNAME per name — %s CNAME %s and %s CNAME %s is invalid DNS. A resolver wouldn't know which canonical name to follow.", ep.DNSName, first, ep.DNSName, ep.Targets[0])
+				if shouldWarnCNAMEConflict(ep.DNSName) {
+					log.Warnf("Only one CNAME per name — %s CNAME %s and %s CNAME %s is invalid DNS. A resolver wouldn't know which canonical name to follow.", ep.DNSName, first, ep.DNSName, ep.Targets[0])
+				}
 			}
 			cnameTargets[cnameKey] = ep.Targets[0]
 		}

--- a/endpoint/utils_test.go
+++ b/endpoint/utils_test.go
@@ -560,6 +560,32 @@ func TestMergeEndpointsLogging(t *testing.T) {
 		logtest.TestHelperLogNotContains("Only one CNAME per name", hook, t)
 	})
 
+	t.Run("no warning for CNAME conflict outside domain filter", func(t *testing.T) {
+		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+		t.Cleanup(func() { SetCNAMEConflictDomainFilter(nil) })
+		SetCNAMEConflictDomainFilter(NewDomainFilter([]string{"managed.example.internal"}))
+
+		MergeEndpoints([]*Endpoint{
+			NewEndpoint("api-meet.example.com", RecordTypeCNAME, "a.elb.com"),
+			NewEndpoint("api-meet.example.com", RecordTypeCNAME, "b.elb.com"),
+		})
+
+		logtest.TestHelperLogNotContains("Only one CNAME per name", hook, t)
+	})
+
+	t.Run("warns on CNAME conflict inside domain filter", func(t *testing.T) {
+		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+		t.Cleanup(func() { SetCNAMEConflictDomainFilter(nil) })
+		SetCNAMEConflictDomainFilter(NewDomainFilter([]string{"example.com"}))
+
+		MergeEndpoints([]*Endpoint{
+			NewEndpoint("app.example.com", RecordTypeCNAME, "a.elb.com"),
+			NewEndpoint("app.example.com", RecordTypeCNAME, "b.elb.com"),
+		})
+
+		logtest.TestHelperLogContainsWithLogLevel("Only one CNAME per name", log.WarnLevel, hook, t)
+	})
+
 	t.Run("debug log for CNAME with no targets", func(t *testing.T) {
 		hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
 


### PR DESCRIPTION
## Summary

- Limit `MergeEndpoints` CNAME conflict warnings to DNS names matching the configured domain filter.
- Avoids noisy warnings for Istio hosts outside `--domain-filter` that external-dns will never manage.

Fixes #6529

## Test plan

- [x] `go test ./endpoint/ -run MergeEndpointsLogging`
- [ ] Deploy with Istio sources + domain filter; confirm out-of-filter CNAME conflicts no longer warn