### PR TITLE
fix(istio): skip out-of-scope endpoints before merge warnings

### DIFF
--- a/source/istio_gateway.go
+++ b/source/istio_gateway.go
@@ -61,6 +61,7 @@ var IstioGatewayIngressSource = annotations.Ingress
 // +externaldns:source:provider-specific=true
 type gatewaySource struct {
 	namespace                string
+	domainFilter             endpoint.DomainFilterInterface
 	templateEngine           template.Engine
 	ignoreHostnameAnnotation bool
 	serviceInformer          coreinformers.ServiceInformer
@@ -121,6 +122,7 @@ func NewIstioGatewaySource(
 
 	return &gatewaySource{
 		namespace:                cfg.Namespace,
+		domainFilter:             cfg.DomainFilter,
 		templateEngine:           cfg.TemplateEngine,
 		ignoreHostnameAnnotation: cfg.IgnoreHostnameAnnotation,
 		serviceInformer:          serviceInformer,
@@ -179,7 +181,7 @@ func (sc *gatewaySource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, err
 		endpoints = append(endpoints, gwEndpoints...)
 	}
 
-	return endpoint.MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(filterEndpointsByDomain(endpoints, sc.domainFilter)), nil
 }
 
 // AddEventHandler adds an event handler that should be triggered if the watched Istio Gateway changes.

--- a/source/istio_gateway_test.go
+++ b/source/istio_gateway_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"testing"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -37,6 +38,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 	"sigs.k8s.io/external-dns/source/annotations"
 
 	"sigs.k8s.io/external-dns/endpoint"
@@ -124,6 +126,53 @@ func TestGateway(t *testing.T) {
 	suite.Run(t, new(GatewaySuite))
 	t.Run("endpointsFromGatewayConfig", testEndpointsFromGatewayConfig)
 	t.Run("Endpoints", testGatewayEndpoints)
+	t.Run("does not warn for out-of-scope cname conflicts", testGatewayEndpointsIgnoreOutOfScopeCNAMEConflicts)
+}
+
+func testGatewayEndpointsIgnoreOutOfScopeCNAMEConflicts(t *testing.T) {
+	t.Parallel()
+
+	hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+	fakeKubernetesClient := fake.NewClientset()
+	fakeIstioClient := istiofake.NewSimpleClientset()
+
+	for _, gw := range []fakeGatewayConfig{
+		{
+			namespace: "istio-system",
+			name:      "gateway-a",
+			annotations: map[string]string{
+				annotations.TargetKey: "lb-a.example.net",
+			},
+			dnsnames: [][]string{{"api-meet.example.com"}},
+		},
+		{
+			namespace: "istio-system",
+			name:      "gateway-b",
+			annotations: map[string]string{
+				annotations.TargetKey: "lb-b.example.net",
+			},
+			dnsnames: [][]string{{"api-meet.example.com"}},
+		},
+	} {
+		_, err := fakeIstioClient.NetworkingV1().Gateways(gw.namespace).Create(t.Context(), gw.Config(), metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	src, err := NewIstioGatewaySource(
+		t.Context(),
+		fakeKubernetesClient,
+		fakeIstioClient,
+		&Config{
+			DomainFilter:   endpoint.NewDomainFilter([]string{"managed.example.internal"}),
+			TemplateEngine: templatetest.MustEngine(t, "{{.FQDN}}", "", "", false),
+		},
+	)
+	require.NoError(t, err)
+
+	endpoints, err := src.Endpoints(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, endpoints)
+	logtest.TestHelperLogNotContains("Only one CNAME per name", hook, t)
 }
 
 func testEndpointsFromGatewayConfig(t *testing.T) {

--- a/source/istio_virtualservice.go
+++ b/source/istio_virtualservice.go
@@ -62,6 +62,7 @@ const IstioMeshGateway = "mesh"
 // +externaldns:source:provider-specific=true
 type virtualServiceSource struct {
 	namespace                string
+	domainFilter             endpoint.DomainFilterInterface
 	templateEngine           template.Engine
 	ignoreHostnameAnnotation bool
 	serviceInformer          coreinformers.ServiceInformer
@@ -129,6 +130,7 @@ func NewIstioVirtualServiceSource(
 
 	return &virtualServiceSource{
 		namespace:                cfg.Namespace,
+		domainFilter:             cfg.DomainFilter,
 		templateEngine:           cfg.TemplateEngine,
 		ignoreHostnameAnnotation: cfg.IgnoreHostnameAnnotation,
 		serviceInformer:          serviceInformer,
@@ -178,7 +180,7 @@ func (sc *virtualServiceSource) Endpoints(ctx context.Context) ([]*endpoint.Endp
 		endpoints = append(endpoints, gwEndpoints...)
 	}
 
-	return endpoint.MergeEndpoints(endpoints), nil
+	return endpoint.MergeEndpoints(filterEndpointsByDomain(endpoints, sc.domainFilter)), nil
 }
 
 // AddEventHandler adds an event handler that should be triggered if the watched Istio VirtualService changes.

--- a/source/istio_virtualservice_test.go
+++ b/source/istio_virtualservice_test.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"testing"
 
+	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -145,6 +147,53 @@ func TestVirtualService(t *testing.T) {
 	t.Run("virtualServiceBindsToGateway", testVirtualServiceBindsToGateway)
 	t.Run("endpointsFromVirtualServiceConfig", testEndpointsFromVirtualServiceConfig)
 	t.Run("Endpoints", testVirtualServiceEndpoints)
+	t.Run("does not warn for out-of-scope cname conflicts", testVirtualServiceEndpointsIgnoreOutOfScopeCNAMEConflicts)
+}
+
+func testVirtualServiceEndpointsIgnoreOutOfScopeCNAMEConflicts(t *testing.T) {
+	t.Parallel()
+
+	hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+	fakeKubernetesClient := fake.NewClientset()
+	fakeIstioClient := istiofake.NewSimpleClientset()
+
+	for _, vs := range []fakeVirtualServiceConfig{
+		{
+			namespace: "example",
+			name:      "service-a",
+			annotations: map[string]string{
+				annotations.TargetKey: "lb-a.example.net",
+			},
+			dnsnames: []string{"api-meet.example.com"},
+		},
+		{
+			namespace: "example",
+			name:      "service-b",
+			annotations: map[string]string{
+				annotations.TargetKey: "lb-b.example.net",
+			},
+			dnsnames: []string{"api-meet.example.com"},
+		},
+	} {
+		_, err := fakeIstioClient.NetworkingV1().VirtualServices(vs.namespace).Create(t.Context(), vs.Config(), metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	src, err := NewIstioVirtualServiceSource(
+		t.Context(),
+		fakeKubernetesClient,
+		fakeIstioClient,
+		&Config{
+			DomainFilter:   endpoint.NewDomainFilter([]string{"managed.example.internal"}),
+			TemplateEngine: templatetest.MustEngine(t, "{{ .Name }}", "", "", false),
+		},
+	)
+	require.NoError(t, err)
+
+	endpoints, err := src.Endpoints(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, endpoints)
+	logtest.TestHelperLogNotContains("Only one CNAME per name", hook, t)
 }
 
 func testVirtualServiceBindsToGateway(t *testing.T) {

--- a/source/source.go
+++ b/source/source.go
@@ -56,6 +56,20 @@ func matchLabelSelector(selector labels.Selector, srcAnnotations map[string]stri
 	return selector.Matches(labels.Set(srcAnnotations))
 }
 
+func filterEndpointsByDomain(endpoints []*endpoint.Endpoint, filter endpoint.DomainFilterInterface) []*endpoint.Endpoint {
+	if filter == nil {
+		return endpoints
+	}
+
+	filtered := make([]*endpoint.Endpoint, 0, len(endpoints))
+	for _, ep := range endpoints {
+		if filter.Match(ep.DNSName) {
+			filtered = append(filtered, ep)
+		}
+	}
+	return filtered
+}
+
 type eventHandlerFunc func()
 
 func (fn eventHandlerFunc) OnAdd(_ any, _ bool) { fn() }

--- a/source/store.go
+++ b/source/store.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/rest"
 	gateway "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
+	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	kubeclient "sigs.k8s.io/external-dns/pkg/client"
 	"sigs.k8s.io/external-dns/source/annotations"
@@ -59,6 +60,7 @@ var ErrSourceNotFound = errors.New("source not found")
 // type conversions and validation.
 type Config struct {
 	Namespace                      string
+	DomainFilter                   endpoint.DomainFilterInterface
 	AnnotationFilter               labels.Selector
 	LabelFilter                    labels.Selector
 	IngressClassNames              []string
@@ -136,6 +138,7 @@ func NewSourceConfig(cfg *externaldns.Config, opts ...OverrideConfigOption) (*Co
 	}
 	c := &Config{
 		Namespace:                      cfg.Namespace,
+		DomainFilter:                   endpoint.NewDomainFilterWithOptions(endpoint.WithDomainFilter(cfg.DomainFilter), endpoint.WithRegexDomainFilter(cfg.RegexDomainFilter)),
 		AnnotationFilter:               annotationSelector,
 		LabelFilter:                    labelSelector,
 		IngressClassNames:              cfg.IngressClassNames,


### PR DESCRIPTION
## What does it do ?

Filters Istio endpoints by the configured domain filter before `MergeEndpoints()`.
This stops bogus `Only one CNAME per name` warnings for hosts this instance will never manage. pretty noisy otherwise.

## Motivation

Real repro from the current bug report:

Run with `--source=istio-gateway`, `--source=istio-virtualservice`, `--domain-filter=managed.example.internal`.
Then create two Istio resources that both produce `api-meet.example.com` with different CNAME targets.
Today external-dns warns before domain filtering, even though that host is out of scope and not this controller lane.

Related:
- https://github.com/kubernetes-sigs/external-dns/issues/6529
- https://github.com/kubernetes-sigs/external-dns/pull/6174

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly
