### PR TITLE
fix(rfc2136): normalize CNAME trailing dots to stop sync churn

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -129,7 +129,9 @@ func (t Targets) Swap(i, j int) {
 	t[i], t[j] = t[j], t[i]
 }
 
-// Same compares two Targets and returns true if they are identical (case-insensitive)
+// Same compares two Targets and returns true if they are identical (case-insensitive).
+// Trailing dots are ignored so FQDN wire form (e.g. "foo.example.com.") matches the
+// relative form used by most sources (e.g. "foo.example.com").
 func (t Targets) Same(o Targets) bool {
 	if len(t) != len(o) {
 		return false
@@ -138,9 +140,11 @@ func (t Targets) Same(o Targets) bool {
 	sort.Stable(o)
 
 	for i, e := range t {
-		if !strings.EqualFold(e, o[i]) {
+		a := strings.TrimSuffix(e, ".")
+		b := strings.TrimSuffix(o[i], ".")
+		if !strings.EqualFold(a, b) {
 			// IPv6 can be shortened, so it should be parsed for equality checking
-			ipA, err := netip.ParseAddr(e)
+			ipA, err := netip.ParseAddr(a)
 			if err != nil {
 				log.WithFields(log.Fields{
 					"targets":           t,
@@ -148,7 +152,7 @@ func (t Targets) Same(o Targets) bool {
 				}).Debugf("Couldn't parse %s as an IP address: %v", e, err)
 			}
 
-			ipB, err := netip.ParseAddr(o[i])
+			ipB, err := netip.ParseAddr(b)
 			if err != nil {
 				log.WithFields(log.Fields{
 					"targets":           t,

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -115,6 +115,18 @@ func TestSameSuccess(t *testing.T) {
 			[]string{"::1", "1.1.1.1", "2600.com", "3.3.3.3"},
 			[]string{"2600.com", "::0001", "3.3.3.3", "1.1.1.1"},
 		},
+		{
+			[]string{"traefik.example.com"},
+			[]string{"traefik.example.com."},
+		},
+		{
+			[]string{"ns1.example.com.", "ns2.example.com"},
+			[]string{"ns2.example.com.", "ns1.example.com"},
+		},
+		{
+			[]string{"FOO.Example.COM."},
+			[]string{"foo.example.com"},
+		},
 	}
 
 	for _, d := range tests {

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -1063,6 +1063,41 @@ func TestPlan(t *testing.T) {
 	suite.Run(t, new(PlanTestSuite))
 }
 
+// TestPlanNoChurnCNAMETrailingDot ensures desired CNAME targets without a
+// trailing dot match current AXFR-style targets with a trailing dot, so the
+// plan does not delete/recreate every sync (kubernetes-sigs/external-dns#6199).
+func TestPlanNoChurnCNAMETrailingDot(t *testing.T) {
+	current := []*endpoint.Endpoint{
+		{
+			DNSName:    "myservice.example.com",
+			RecordType: endpoint.RecordTypeCNAME,
+			Targets:    endpoint.Targets{"traefik.example.com."},
+			RecordTTL:  3600,
+			Labels:     endpoint.Labels{endpoint.OwnerLabelKey: "default"},
+		},
+	}
+	desired := []*endpoint.Endpoint{
+		{
+			DNSName:    "myservice.example.com",
+			RecordType: endpoint.RecordTypeCNAME,
+			Targets:    endpoint.Targets{"traefik.example.com"},
+			RecordTTL:  3600,
+			Labels:     endpoint.Labels{endpoint.OwnerLabelKey: "default"},
+		},
+	}
+
+	p := &Plan{
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeCNAME},
+	}
+	changes := p.Calculate().Changes
+	assert.Empty(t, changes.Create)
+	assert.Empty(t, changes.UpdateNew)
+	assert.Empty(t, changes.UpdateOld)
+	assert.Empty(t, changes.Delete)
+}
+
 // validateEntries validates that the list of entries matches expected.
 func validateEntries(t *testing.T, entries, expected []*endpoint.Endpoint) {
 	if !testutils.SameEndpoints(entries, expected) {

--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -241,7 +241,14 @@ OuterLoop:
 
 		for idx, existingEndpoint := range eps {
 			if existingEndpoint.DNSName == strings.TrimSuffix(rrFqdn, ".") && existingEndpoint.RecordType == rrType {
-				eps[idx].Targets = append(eps[idx].Targets, rrValues...)
+				// Rebuild through NewEndpointWithTTL so merge-appended targets
+				// get the same trailing-dot normalization as the first RR.
+				eps[idx] = endpoint.NewEndpointWithTTL(
+					existingEndpoint.DNSName,
+					rrType,
+					existingEndpoint.RecordTTL,
+					append(existingEndpoint.Targets, rrValues...)...,
+				)
 				continue OuterLoop
 			}
 		}

--- a/provider/rfc2136/rfc2136_test.go
+++ b/provider/rfc2136/rfc2136_test.go
@@ -553,6 +553,44 @@ func TestRfc2136GetRecords(t *testing.T) {
 	assert.True(t, contains(recs, "v2.foo.com"))
 }
 
+// TestRfc2136RecordsNormalizesCNAMETrailingDot covers AXFR wire-form CNAME/NS
+// targets (trailing dots from miekg/dns) so they compare equal to CRD/Ingress
+// desired targets without remove/re-add churn each sync.
+func TestRfc2136RecordsNormalizesCNAMETrailingDot(t *testing.T) {
+	stub := newStub()
+	err := stub.setOutput([]string{
+		"myservice.example.com. 3600 CNAME traefik.example.com.",
+		"example.com. 3600 NS ns1.example.com.",
+		"example.com. 3600 NS ns2.example.com.",
+	})
+	require.NoError(t, err)
+
+	p, err := createRfc2136StubProvider(stub, "example.com")
+	require.NoError(t, err)
+
+	recs, err := p.Records(t.Context())
+	require.NoError(t, err)
+	require.Len(t, recs, 2)
+
+	byKey := map[string]*endpoint.Endpoint{}
+	for _, ep := range recs {
+		byKey[ep.DNSName+"/"+ep.RecordType] = ep
+	}
+
+	cname := byKey["myservice.example.com/CNAME"]
+	require.NotNil(t, cname)
+	assert.Equal(t, []string{"traefik.example.com"}, []string(cname.Targets))
+
+	ns := byKey["example.com/NS"]
+	require.NotNil(t, ns)
+	assert.True(t, ns.Targets.Same(endpoint.Targets{"ns1.example.com", "ns2.example.com"}),
+		"merged NS targets must be trailing-dot normalized: got %v", ns.Targets)
+
+	// Desired CRD-style target (no trailing dot) must match AXFR current state.
+	desired := endpoint.NewEndpointWithTTL("myservice.example.com", endpoint.RecordTypeCNAME, 3600, "traefik.example.com")
+	assert.True(t, desired.Targets.Same(cname.Targets))
+}
+
 // Make sure the test version of SendMessage raises an error
 // if a zone update ever contains records outside of its zone
 // as the TestRfc2136ApplyChanges tests all assume this

--- a/source/crd.go
+++ b/source/crd.go
@@ -150,8 +150,23 @@ func (cs *crdSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 				continue
 			}
 
-			ep.WithLabel(endpoint.ResourceLabelKey, fmt.Sprintf("crd/%s/%s", dnsEndpoint.Namespace, dnsEndpoint.Name))
-			crdEndpoints = append(crdEndpoints, ep)
+			// Normalize via NewEndpointWithTTL so CNAME/NS/PTR targets match
+			// provider AXFR form (trailing dots stripped), same as Ingress/Service.
+			normalized := endpoint.NewEndpointWithTTL(ep.DNSName, ep.RecordType, ep.RecordTTL, ep.Targets...)
+			if normalized == nil {
+				log.Debugf(
+					"Skipping endpoint with DNSName %s in DNSEndpoint %s/%s: failed normalization",
+					ep.DNSName, dnsEndpoint.Namespace, dnsEndpoint.Name,
+				)
+				continue
+			}
+			normalized.SetIdentifier = ep.SetIdentifier
+			normalized.ProviderSpecific = ep.ProviderSpecific
+			for k, v := range ep.Labels {
+				normalized.WithLabel(k, v)
+			}
+			normalized.WithLabel(endpoint.ResourceLabelKey, fmt.Sprintf("crd/%s/%s", dnsEndpoint.Namespace, dnsEndpoint.Name))
+			crdEndpoints = append(crdEndpoints, normalized)
 		}
 
 		endpoint.AttachRefObject(crdEndpoints, events.NewObjectReference(dnsEndpoint, types.CRD))

--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -713,6 +714,57 @@ func validateCRDResource(t *testing.T, fakeClient client.Client, namespace, name
 	require.NoError(t, err)
 	require.Equal(t, updated.Generation, updated.Status.ObservedGeneration,
 		"ObservedGeneration should be updated to match Generation after Endpoints() is called")
+}
+
+// TestCRDSourceNormalizesCNAMETrailingDot ensures DNSEndpoint CNAME targets are
+// normalized the same way as Ingress/Service (via NewEndpointWithTTL), so a
+// trailing-dot FQDN in the CRD matches AXFR wire form without sync churn.
+func TestCRDSourceNormalizesCNAMETrailingDot(t *testing.T) {
+	obj := &apiv1alpha1.DNSEndpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myservice",
+			Namespace: "default",
+		},
+		Spec: apiv1alpha1.DNSEndpointSpec{
+			Endpoints: []*endpoint.Endpoint{
+				{
+					DNSName:    "myservice.example.com",
+					Targets:    endpoint.Targets{"traefik.example.com."},
+					RecordType: endpoint.RecordTypeCNAME,
+					RecordTTL:  3600,
+				},
+				{
+					DNSName:    "other.example.com",
+					Targets:    endpoint.Targets{"backend.example.com"},
+					RecordType: endpoint.RecordTypeCNAME,
+					RecordTTL:  300,
+				},
+			},
+		},
+	}
+
+	fakeCache := newFakeCRDCache(t, nil, fakeCRDCacheFilter{}, obj)
+	cs, err := newCrdSource(t.Context(), fakeCache, fakeCache.Client, "", nil)
+	require.NoError(t, err)
+
+	got, err := cs.Endpoints(t.Context())
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	byName := map[string]*endpoint.Endpoint{}
+	for _, ep := range got {
+		byName[ep.DNSName] = ep
+	}
+
+	require.Contains(t, byName, "myservice.example.com")
+	assert.Equal(t, []string{"traefik.example.com"}, []string(byName["myservice.example.com"].Targets),
+		"trailing dot must be stripped so CRD desired state matches provider Records()")
+	assert.Equal(t, endpoint.RecordTypeCNAME, byName["myservice.example.com"].RecordType)
+	assert.Equal(t, endpoint.TTL(3600), byName["myservice.example.com"].RecordTTL)
+	require.Contains(t, byName["myservice.example.com"].Labels, endpoint.ResourceLabelKey)
+
+	require.Contains(t, byName, "other.example.com")
+	assert.Equal(t, []string{"backend.example.com"}, []string(byName["other.example.com"].Targets))
 }
 
 func TestDNSEndpointsWithSetResourceLabels(t *testing.T) {


### PR DESCRIPTION
## Summary

- Normalize DNSEndpoint CRD endpoints via `NewEndpointWithTTL` so CNAME/NS/PTR targets match Ingress/Service (trailing dots stripped).
- Harden `Targets.Same` to ignore trailing dots when comparing FQDN targets, preventing plan churn when current (AXFR) and desired (CRD) forms differ.
- Rebuild rfc2136 AXFR merge-appended targets through `NewEndpointWithTTL` so multi-RR names get the same normalization as the first RR.

Fixes asymmetric trailing-dot handling that caused RFC2136 CNAME records from DNSEndpoint CRDs (and their TXT ownership records) to be removed and re-added every sync cycle.

Related: https://github.com/kubernetes-sigs/external-dns/issues/6199

## Test plan

- [x] `go test ./endpoint/ -run 'TestSame|TestTargetsSame|TestNewEndpointWithTTL'`
- [x] `go test ./plan/ -run TestPlanNoChurnCNAMETrailingDot`
- [x] `go test ./provider/rfc2136/ -run 'TestRfc2136RecordsNormalizesCNAMETrailingDot|TestRfc2136GetRecords'`
- [x] `go test ./source/ -run 'TestCRDSourceNormalizesCNAMETrailingDot|TestCRDSource'`
- [ ] Deploy with `--provider=rfc2136 --rfc2136-tsig-axfr --source=crd` and a DNSEndpoint CNAME; confirm subsequent syncs make no remove/add for unchanged records

Made with [Cursor](https://cursor.com)