### PR TITLE
fix(cloudflare): soft-fail proxied private target rejections

### DIFF
--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -65,6 +65,10 @@ const (
 	// Cloudflare tier limitations https://developers.cloudflare.com/dns/manage-dns-records/reference/record-attributes/#availability
 	freeZoneMaxCommentLength = 100
 	paidZoneMaxCommentLength = 500
+
+	// cloudflareProxiedTargetNotAllowedCode is returned when a proxied record points at a
+	// non-proxyable target (e.g. RFC1918 / ULA). One bad endpoint must not CrashLoop ExternalDNS.
+	cloudflareProxiedTargetNotAllowedCode = 9003
 )
 
 var changeActionNames = map[changeAction]string{
@@ -246,6 +250,13 @@ func convertCloudflareError(err error) error {
 		if apierr.StatusCode == http.StatusTooManyRequests || apierr.StatusCode >= http.StatusInternalServerError {
 			return provider.NewSoftError(err)
 		}
+		// Proxied-record config rejected by Cloudflare (private/non-routable target). Soft-fail
+		// so a single bad Gateway/HTTPRoute does not take down reconciliation for other records.
+		for _, e := range apierr.Errors {
+			if e.Code == cloudflareProxiedTargetNotAllowedCode {
+				return provider.NewSoftError(err)
+			}
+		}
 		// For other structured API errors (4xx), return the error unchanged
 		// Note: We must NOT call err.Error() on v5 cloudflare.Error types with nil internal fields
 		return err
@@ -266,7 +277,8 @@ func convertCloudflareError(err error) error {
 	if strings.Contains(errMsg, "rate limit") ||
 		strings.Contains(errMsg, "429") ||
 		strings.Contains(errMsg, "exceeded available rate limit retries") ||
-		strings.Contains(errMsg, "too many requests") {
+		strings.Contains(errMsg, "too many requests") ||
+		strings.Contains(errMsg, "not allowed for a proxied record") {
 		return provider.NewSoftError(err)
 	}
 
@@ -610,6 +622,8 @@ func (p *CloudFlareProvider) submitChanges(ctx context.Context, changes []*cloud
 		}
 	}
 
+	// Per-record failures (including Cloudflare rejecting a proxied private IP) mark the zone
+	// failed above; surface that as a soft error so the controller logs and continues.
 	if len(failedZones) > 0 {
 		return provider.NewSoftErrorf("failed to submit all changes for the following zones: %q", failedZones)
 	}

--- a/provider/cloudflare/cloudflare_batch_test.go
+++ b/provider/cloudflare/cloudflare_batch_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -31,6 +32,7 @@ import (
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
 )
 
 func (m *mockCloudFlareClient) BatchDNSRecords(_ context.Context, params dns.RecordBatchParams) (*dns.RecordBatchResponse, error) {
@@ -118,6 +120,12 @@ func (m *mockCloudFlareClient) BatchDNSRecords(_ context.Context, params dns.Rec
 		}
 		if record.Name == "newerror.bar.com" && firstErr == nil {
 			firstErr = fmt.Errorf("failed to create record")
+		}
+		if record.Name == "proxied-private.bar.com" && firstErr == nil {
+			firstErr = newCloudflareErrorWithCodes(http.StatusBadRequest, cloudflare.ErrorData{
+				Code:    cloudflareProxiedTargetNotAllowedCode,
+				Message: fmt.Sprintf("Target %s is not allowed for a proxied record.", record.Content),
+			})
 		}
 	}
 
@@ -226,6 +234,7 @@ func TestBatchFallbackIndividual(t *testing.T) {
 
 		err := p.ApplyChanges(t.Context(), changes)
 		require.Error(t, err, "should return error when individual fallback has failures")
+		assert.ErrorIs(t, err, provider.SoftError, "zone submit failures must be soft errors")
 		assert.Equal(t, 1, client.BatchDNSRecordsCalls, "batch path should be attempted before fallback")
 
 		// The batch should have failed (because of newerror.bar.com), then

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -50,6 +50,11 @@ import (
 // The v5 SDK's Error type panics when .Error() is called with nil Request/Response fields,
 // so this helper initializes them properly.
 func newCloudflareError(statusCode int) *cloudflare.Error {
+	return newCloudflareErrorWithCodes(statusCode)
+}
+
+// newCloudflareErrorWithCodes is like newCloudflareError but attaches API error codes/messages.
+func newCloudflareErrorWithCodes(statusCode int, errs ...cloudflare.ErrorData) *cloudflare.Error {
 	req := httptest.NewRequest(http.MethodGet, "https://api.cloudflare.com/client/v4/zones", nil)
 	resp := &http.Response{
 		StatusCode: statusCode,
@@ -60,6 +65,7 @@ func newCloudflareError(statusCode int) *cloudflare.Error {
 		StatusCode: statusCode,
 		Request:    req,
 		Response:   resp,
+		Errors:     errs,
 	}
 }
 
@@ -166,6 +172,12 @@ func (m *mockCloudFlareClient) CreateDNSRecord(_ context.Context, params dns.Rec
 
 	if record.Name == "newerror.bar.com" {
 		return nil, fmt.Errorf("failed to create record")
+	}
+	if record.Name == "proxied-private.bar.com" {
+		return nil, newCloudflareErrorWithCodes(http.StatusBadRequest, cloudflare.ErrorData{
+			Code:    cloudflareProxiedTargetNotAllowedCode,
+			Message: fmt.Sprintf("Target %s is not allowed for a proxied record.", record.Content),
+		})
 	}
 	return &record, nil
 }
@@ -1083,17 +1095,54 @@ func TestCloudflareDryRunApplyChanges(t *testing.T) {
 func TestCloudflareApplyChangesError(t *testing.T) {
 	changes := &plan.Changes{}
 	client := NewMockCloudFlareClient()
-	provider := &CloudFlareProvider{
+	p := &CloudFlareProvider{
 		Client: client,
 	}
 	changes.Create = []*endpoint.Endpoint{{
 		DNSName: "newerror.bar.com",
 		Targets: endpoint.Targets{"target"},
 	}}
-	err := provider.ApplyChanges(t.Context(), changes)
-	if err == nil {
-		t.Errorf("should fail, %s", err)
+	err := p.ApplyChanges(t.Context(), changes)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, provider.SoftError, "per-record create failures must soft-fail so reconciliation continues")
+}
+
+func TestCloudflareApplyChangesProxiedPrivateIPSoftError(t *testing.T) {
+	client := NewMockCloudFlareClient()
+	p := &CloudFlareProvider{Client: client}
+
+	// One bad proxied private-IP create must not hard-fail ApplyChanges (issue #5964).
+	err := p.ApplyChanges(t.Context(), &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			{
+				DNSName:    "proxied-private.bar.com",
+				Targets:    endpoint.Targets{"192.168.1.128"},
+				RecordType: endpoint.RecordTypeA,
+				ProviderSpecific: endpoint.ProviderSpecific{
+					{Name: annotations.CloudflareProxiedKey, Value: "true"},
+				},
+			},
+			{
+				DNSName:    "ok.bar.com",
+				Targets:    endpoint.Targets{"1.2.3.4"},
+				RecordType: endpoint.RecordTypeA,
+			},
+		},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, provider.SoftError)
+	assert.Contains(t, err.Error(), "failed to submit all changes")
+
+	// The valid record in the same zone should still have been attempted (batch may
+	// fall back to individual ops; at least one successful create for ok.bar.com).
+	var createdOK bool
+	for _, a := range client.Actions {
+		if a.Name == "Create" && a.RecordData.Name == "ok.bar.com" {
+			createdOK = true
+			break
+		}
 	}
+	assert.True(t, createdOK, "valid records should still be created when a proxied private IP fails")
 }
 
 func TestCloudflareGetRecordID(t *testing.T) {
@@ -2666,6 +2715,21 @@ func TestConvertCloudflareError(t *testing.T) {
 			inputError:      newCloudflareError(400),
 			expectSoftError: false,
 			description:     "Client error (400) should not be converted to soft error",
+		},
+		{
+			name: "Proxied private target API code 9003",
+			inputError: newCloudflareErrorWithCodes(http.StatusBadRequest, cloudflare.ErrorData{
+				Code:    cloudflareProxiedTargetNotAllowedCode,
+				Message: "Target 192.168.1.128 is not allowed for a proxied record.",
+			}),
+			expectSoftError: true,
+			description:     "Cloudflare rejecting a proxied private/non-routable target should be a soft error",
+		},
+		{
+			name:            "Proxied private target string error",
+			inputError:      errors.New(`POST "https://api.cloudflare.com/client/v4/zones/abc/dns_records": 400 Bad Request {"errors":[{"code":9003,"message":"Target 192.168.1.128 is not allowed for a proxied record."}]}`),
+			expectSoftError: true,
+			description:     "Wrapped/string form of proxied-target rejection should be a soft error",
 		},
 		{
 			name:            "Client error 401",


### PR DESCRIPTION
## Summary
- Soft-fail Cloudflare API error **9003** (Target … is not allowed for a proxied record) in convertCloudflareError, matching the existing rate-limit soft-error path.
- Also match the same message via string fallback when the SDK wraps/hides the structured error.
- Document that submitChanges already returns provider.SoftError for failed zones (since #5899); add regression tests so a single bad proxied private-IP create does not hard-fail ApplyChanges and other records in the zone still apply.
- Related: https://github.com/kubernetes-sigs/external-dns/issues/5964

## Test plan
- [x] go test ./provider/cloudflare/ -count=1
- [x] TestConvertCloudflareError covers code 9003 + string form as soft; generic 400 remains hard
- [x] TestCloudflareApplyChangesProxiedPrivateIPSoftError asserts SoftError + sibling record still created
- [x] TestCloudflareApplyChangesError / batch fallback assert SoftError on zone submit failure