### PR TITLE
feat(aws): add aws-hosted-zone-id annotation to pin records to a specific zone

### DIFF
--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -775,6 +775,18 @@ Note: The `A` and `AAAA` values are currently only supported by the AWS Route53 
 
 `external-dns.kubernetes.io/aws-target-hosted-zone` can optionally be set to the ID of a Route53 hosted zone. This will force external-dns to use the specified hosted zone when creating an ALIAS target.
 
+### hosted-zone-id
+
+`external-dns.alpha.kubernetes.io/aws-hosted-zone-id` pins a record to a specific Route53 hosted zone by ID, bypassing suffix-based zone selection. Use it when overlapping zones share the same name (e.g. a public and a private `a.my.com`) and you need each record to land in exactly one zone. If the pinned zone is not among the configured zones, the record is skipped rather than fanned out.
+
+```yaml
+metadata:
+  annotations:
+    external-dns.alpha.kubernetes.io/aws-hosted-zone-id: "Z1234567890ABC"
+```
+
+Not to be confused with [target-hosted-zone](#target-hosted-zone), which sets the ALIAS *target's* hosted zone ID and does not affect record placement.
+
 ### aws-zone-match-parent
 
 `aws-zone-match-parent` allows support subdomains within the same zone by using their parent domain, i.e --domain-filter=x.example.com would create a DNS entry for x.example.com (and subdomains thereof).

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -777,15 +777,13 @@ Note: The `A` and `AAAA` values are currently only supported by the AWS Route53 
 
 ### hosted-zone-id
 
-`external-dns.alpha.kubernetes.io/aws-hosted-zone-id` pins a record to a specific Route53 hosted zone by ID, bypassing suffix-based zone selection. Use it when overlapping zones share the same name (e.g. a public and a private `a.my.com`) and you need each record to land in exactly one zone. If the pinned zone is not among the configured zones, the record is skipped rather than fanned out.
+`external-dns.alpha.kubernetes.io/aws-hosted-zone-id` pins a record to a specific Route53 hosted zone by ID. Use when overlapping zones share the same name (e.g. public + private `a.my.com`). If the pinned zone is not configured, the record is skipped.
 
 ```yaml
 metadata:
   annotations:
     external-dns.alpha.kubernetes.io/aws-hosted-zone-id: "Z1234567890ABC"
 ```
-
-Not to be confused with [target-hosted-zone](#target-hosted-zone), which sets the ALIAS *target's* hosted zone ID and does not affect record placement.
 
 ### aws-zone-match-parent
 

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -51,6 +51,10 @@ const (
 	// Hence, if AWS ever decides to raise this limit, we will automatically reduce the pressure on rate limits
 	route53PageSize                  int32 = 300
 	providerSpecificTargetHostedZone       = "aws/target-hosted-zone"
+	// providerSpecificHostedZoneID pins the record to a specific hosted zone,
+	// bypassing suffix-based zone selection. Needed when overlapping public/private
+	// zones share the same name.
+	providerSpecificHostedZoneID = "aws/hosted-zone-id"
 	// providerSpecificEvaluateTargetHealth specifies whether an AWS ALIAS record
 	// has the EvaluateTargetHealth field set to true. Present iff the endpoint
 	// has a `endpoint.ProviderSpecificAlias` value of `true`.
@@ -234,9 +238,10 @@ type Route53API interface {
 // Route53Change wrapper to handle ownership relation throughout the provider implementation
 type Route53Change struct {
 	route53types.Change
-	OwnedRecord string
-	sizeBytes   int
-	sizeValues  int
+	OwnedRecord  string
+	hostedZoneID string
+	sizeBytes    int
+	sizeValues   int
 }
 
 type Route53Changes []*Route53Change
@@ -949,6 +954,9 @@ func (p *AWSProvider) newChange(action route53types.ChangeAction, ep *endpoint.E
 		},
 	}
 	change.ResourceRecordSet.Type = route53types.RRType(ep.RecordType)
+	if prop, ok := ep.GetProviderSpecificProperty(providerSpecificHostedZoneID); ok {
+		change.hostedZoneID = cleanZoneID(prop)
+	}
 	if targetHostedZone := isAWSAlias(ep); targetHostedZone != "" {
 		evalTargetHealth := p.evaluateTargetHealth
 		if prop, exists := ep.GetBoolProviderSpecificProperty(providerSpecificEvaluateTargetHealth); exists {
@@ -1296,6 +1304,13 @@ func changesByZone(zones map[string]*profiledZone, changeSet Route53Changes) map
 		hostname := provider.EnsureTrailingDot(*c.ResourceRecordSet.Name)
 
 		zones := suitableZones(hostname, zones)
+		if c.hostedZoneID != "" {
+			zones = filterZonesByID(zones, c.hostedZoneID)
+			if len(zones) == 0 {
+				log.Warnf("Skipping record %s: pinned hosted zone %s is not among the configured/suitable zones", *c.ResourceRecordSet.Name, c.hostedZoneID)
+				continue
+			}
+		}
 		if len(zones) == 0 {
 			log.Debugf("Skipping record %s because no hosted zone matching record DNS Name was detected", *c.ResourceRecordSet.Name)
 			continue
@@ -1356,6 +1371,16 @@ func suitableZones(hostname string, zones map[string]*profiledZone) []*profiledZ
 	}
 
 	return matchingZones
+}
+
+// filterZonesByID returns only the zone whose ID matches the given ID (bare or /hostedzone/-prefixed).
+func filterZonesByID(zones []*profiledZone, id string) []*profiledZone {
+	for _, z := range zones {
+		if cleanZoneID(*z.zone.Id) == id {
+			return []*profiledZone{z}
+		}
+	}
+	return nil
 }
 
 // useAlias determines if AWS ALIAS should be used.

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -1600,6 +1600,93 @@ func TestAWSChangesByZones(t *testing.T) {
 	})
 }
 
+func TestAWSChangesByZonesHostedZoneIDPin(t *testing.T) {
+	zones := map[string]*profiledZone{
+		"pub-a-my-com": {
+			profile: defaultAWSProfile,
+			zone: &route53types.HostedZone{
+				Id:     aws.String("pub-a-my-com"),
+				Name:   aws.String("a.my.com."),
+				Config: &route53types.HostedZoneConfig{PrivateZone: false},
+			},
+		},
+		"prv-a-my-com": {
+			profile: defaultAWSProfile,
+			zone: &route53types.HostedZone{
+				Id:     aws.String("prv-a-my-com"),
+				Name:   aws.String("a.my.com."),
+				Config: &route53types.HostedZoneConfig{PrivateZone: true},
+			},
+		},
+	}
+
+	changes := Route53Changes{
+		{
+			Change: route53types.Change{
+				Action: route53types.ChangeActionCreate,
+				ResourceRecordSet: &route53types.ResourceRecordSet{
+					Name: aws.String("foo.a.my.com"), TTL: aws.Int64(1),
+				},
+			},
+			hostedZoneID: "prv-a-my-com",
+		},
+		{
+			Change: route53types.Change{
+				Action: route53types.ChangeActionCreate,
+				ResourceRecordSet: &route53types.ResourceRecordSet{
+					Name: aws.String("bar.a.my.com"), TTL: aws.Int64(1),
+				},
+			},
+			hostedZoneID: "pub-a-my-com",
+		},
+		{
+			Change: route53types.Change{
+				Action: route53types.ChangeActionCreate,
+				ResourceRecordSet: &route53types.ResourceRecordSet{
+					Name: aws.String("baz.a.my.com"), TTL: aws.Int64(1),
+				},
+			},
+		},
+	}
+
+	got := changesByZone(zones, changes)
+
+	require.Len(t, got["prv-a-my-com"], 2, "private zone should receive its pinned record and the unpinned record")
+	require.Len(t, got["pub-a-my-com"], 2, "public zone should receive its pinned record and the unpinned record")
+
+	prvNames := []string{*got["prv-a-my-com"][0].ResourceRecordSet.Name, *got["prv-a-my-com"][1].ResourceRecordSet.Name}
+	pubNames := []string{*got["pub-a-my-com"][0].ResourceRecordSet.Name, *got["pub-a-my-com"][1].ResourceRecordSet.Name}
+	assert.Contains(t, prvNames, "foo.a.my.com")
+	assert.NotContains(t, prvNames, "bar.a.my.com")
+	assert.Contains(t, pubNames, "bar.a.my.com")
+	assert.NotContains(t, pubNames, "foo.a.my.com")
+}
+
+func TestAWSChangesByZonesHostedZoneIDUnknown(t *testing.T) {
+	zones := map[string]*profiledZone{
+		"pub-a-my-com": {
+			profile: defaultAWSProfile,
+			zone: &route53types.HostedZone{
+				Id:   aws.String("pub-a-my-com"),
+				Name: aws.String("a.my.com."),
+			},
+		},
+	}
+	changes := Route53Changes{
+		{
+			Change: route53types.Change{
+				Action: route53types.ChangeActionCreate,
+				ResourceRecordSet: &route53types.ResourceRecordSet{
+					Name: aws.String("foo.a.my.com"), TTL: aws.Int64(1),
+				},
+			},
+			hostedZoneID: "does-not-exist",
+		},
+	}
+	got := changesByZone(zones, changes)
+	assert.Empty(t, got, "record pinned to unknown zone must be dropped, not fan-out to other zones")
+}
+
 func TestAWSsubmitChanges(t *testing.T) {
 	provider, _ := newAWSProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), defaultEvaluateTargetHealth, false, false, nil)
 	const subnets = 16


### PR DESCRIPTION
## What does it do ?

Adds a new annotation `external-dns.alpha.kubernetes.io/aws-hosted-zone-id` that pins a record to a specific Route53 hosted zone, bypassing suffix-based zone selection. If the pinned zone is not among the configured zones, the record is skipped rather than fanned out.

Wiring: `newChange` reads the `aws/hosted-zone-id` provider-specific property and stores it on `Route53Change`. `changesByZone` filters `suitableZones` down to the pinned zone before dispatching. TXT ownership records inherit `ProviderSpecific` from their parent endpoint, so they follow the same zone automatically.

Semantics of the existing `aws-target-hosted-zone` annotation (which sets the ALIAS target's `HostedZoneId`) are unchanged.

## Motivation

Overlapping zones — a public and a private zone of the same name, or a subdomain zone nested in its parent — currently fan a single record into every matching zone. There is no way to say "only create this record in zone X". See #6558 for a concrete blocked use case (one deployment, public + private `a.my.com`, split by ingress annotation) and #3587 for the original bug report.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

Closes #6558
