### PR TITLE
fix(cloudflare): send SRV records as structured data

### DIFF
--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -41,7 +41,8 @@ significantly reducing the total number of requests made.
 
 The batch API is transactional — if a chunk fails, the entire chunk is rolled back by Cloudflare.
 In that case, ExternalDNS automatically retries each record change in the chunk individually.
-Record types that are not supported by the batch PUT operation (e.g. SRV, CAA) are always submitted individually rather than through the batch API.
+Record types that are not supported by the batch PUT operation (e.g. CAA) are always submitted individually rather than through the batch API.
+SRV records are submitted with Cloudflare's structured SRV data fields for both batch and individual operations.
 
 | Flag | Default | Description |
 | :--- | :------ | :---------- |
@@ -309,6 +310,28 @@ Check your [Cloudflare dashboard](https://www.cloudflare.com/a/dns/example.com) 
 Substitute the zone for the one created above if a different domain was used.
 
 This should show the external IP address of the service as the A record for your domain.
+
+## Managing SRV records
+
+Cloudflare requires SRV records to be sent as structured fields (`priority`, `weight`, `port`, and `target`).
+ExternalDNS accepts SRV targets in the standard form `<priority> <weight> <port> <target>` and converts them for Cloudflare.
+
+For example, the CRD source can manage an SRV record like this:
+
+```yaml
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: caldav
+spec:
+  endpoints:
+    - dnsName: _caldavs._tcp.example.com
+      recordType: SRV
+      targets:
+        - 0 1 443 caldav.example.com.
+```
+
+After synchronization, the Cloudflare SRV record contains priority `0`, weight `1`, port `443`, and target `caldav.example.com`.
 
 ## Cleanup
 

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -689,28 +689,28 @@ func (m *MXTarget) GetPriority() *uint16 {
 }
 
 // GetHost returns the host of the MX record target.
-func (m *MXTarget) GetHost() *string {
-	return &m.host
+func (m *MXTarget) GetHost() string {
+	return m.host
 }
 
 // GetPriority returns the priority of the SRV record target.
-func (s *SRVTarget) GetPriority() *uint16 {
-	return &s.priority
+func (s *SRVTarget) GetPriority() uint16 {
+	return s.priority
 }
 
 // GetWeight returns the weight of the SRV record target.
-func (s *SRVTarget) GetWeight() *uint16 {
-	return &s.weight
+func (s *SRVTarget) GetWeight() uint16 {
+	return s.weight
 }
 
 // GetPort returns the port of the SRV record target.
-func (s *SRVTarget) GetPort() *uint16 {
-	return &s.port
+func (s *SRVTarget) GetPort() uint16 {
+	return s.port
 }
 
 // GetHost returns the host of the SRV record target.
-func (s *SRVTarget) GetHost() *string {
-	return &s.host
+func (s *SRVTarget) GetHost() string {
+	return s.host
 }
 
 // ValidateIPRecord reports whether all targets are valid IP addresses of the given record type (A or AAAA).

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -93,6 +93,14 @@ type MXTarget struct {
 	host     string
 }
 
+// SRVTarget represents a single SRV record target, including its priority, weight, port, and host.
+type SRVTarget struct {
+	priority uint16
+	weight   uint16
+	port     uint16
+	host     string
+}
+
 // NewTargets is a convenience method to create a new Targets object from a vararg of strings.
 // Returns a new Targets slice with duplicates removed and elements sorted in order.
 func NewTargets(target ...string) Targets {
@@ -643,6 +651,38 @@ func NewMXRecord(target string) (*MXTarget, error) {
 	}, nil
 }
 
+// NewSRVRecord parses a string representation of an SRV record target (e.g., "10 5 5060 example.com.")
+// and returns an SRVTarget struct. Returns an error if the input is invalid.
+func NewSRVRecord(target string) (*SRVTarget, error) {
+	parts := strings.Fields(strings.TrimSpace(target))
+	if len(parts) != 4 {
+		return nil, fmt.Errorf("invalid SRV record target: %s. SRV records must have a priority, weight, port, and target host, e.g. '10 5 5060 example.com.'", target)
+	}
+	if !strings.HasSuffix(parts[3], ".") {
+		return nil, fmt.Errorf("invalid SRV record target: %s. Target host does not end with a dot", target)
+	}
+
+	priority, err := strconv.ParseUint(parts[0], 10, 16)
+	if err != nil {
+		return nil, fmt.Errorf("invalid SRV priority %q: %w", parts[0], err)
+	}
+	weight, err := strconv.ParseUint(parts[1], 10, 16)
+	if err != nil {
+		return nil, fmt.Errorf("invalid SRV weight %q: %w", parts[1], err)
+	}
+	port, err := strconv.ParseUint(parts[2], 10, 16)
+	if err != nil {
+		return nil, fmt.Errorf("invalid SRV port %q: %w", parts[2], err)
+	}
+
+	return &SRVTarget{
+		priority: uint16(priority),
+		weight:   uint16(weight),
+		port:     uint16(port),
+		host:     parts[3],
+	}, nil
+}
+
 // GetPriority returns the priority of the MX record target.
 func (m *MXTarget) GetPriority() *uint16 {
 	return &m.priority
@@ -651,6 +691,26 @@ func (m *MXTarget) GetPriority() *uint16 {
 // GetHost returns the host of the MX record target.
 func (m *MXTarget) GetHost() *string {
 	return &m.host
+}
+
+// GetPriority returns the priority of the SRV record target.
+func (s *SRVTarget) GetPriority() *uint16 {
+	return &s.priority
+}
+
+// GetWeight returns the weight of the SRV record target.
+func (s *SRVTarget) GetWeight() *uint16 {
+	return &s.weight
+}
+
+// GetPort returns the port of the SRV record target.
+func (s *SRVTarget) GetPort() *uint16 {
+	return &s.port
+}
+
+// GetHost returns the host of the SRV record target.
+func (s *SRVTarget) GetHost() *string {
+	return &s.host
 }
 
 // ValidateIPRecord reports whether all targets are valid IP addresses of the given record type (A or AAAA).
@@ -689,24 +749,10 @@ func (t Targets) ValidateMXRecord() bool {
 // ValidateSRVRecord reports whether all targets are valid SRV record values (priority weight port host).
 func (t Targets) ValidateSRVRecord() bool {
 	for _, target := range t {
-		// SRV records must have a priority, weight, a port value and a target e.g. "10 5 5060 example.com."
-		// as per https://www.rfc-editor.org/rfc/rfc2782.txt the target host has to end with a dot.
-		targetParts := strings.Fields(strings.TrimSpace(target))
-		if len(targetParts) != 4 {
-			log.Debugf("Invalid SRV record target: %s. SRV records must have a priority, weight, a port value and a target host, e.g. '10 5 5060 example.com.'", target)
+		_, err := NewSRVRecord(target)
+		if err != nil {
+			log.Debugf("Invalid SRV record target: %s. %v", target, err)
 			return false
-		}
-		if !strings.HasSuffix(targetParts[3], ".") {
-			log.Debugf("Invalid SRV record target: %s. Target host does not end with a dot.'", target)
-			return false
-		}
-
-		for _, part := range targetParts[:3] {
-			_, err := strconv.ParseUint(part, 10, 16)
-			if err != nil {
-				log.Debugf("Invalid SRV record target: %s. Invalid integer value in target.", target)
-				return false
-			}
 		}
 	}
 	return true

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -1144,6 +1144,72 @@ func TestMXTarget_Getters(t *testing.T) {
 	assert.Equal(t, "mail.example.com", *m.GetHost())
 }
 
+func TestNewSRVRecord(t *testing.T) {
+	tests := []struct {
+		description string
+		target      string
+		expected    *SRVTarget
+		expectError bool
+	}{
+		{
+			description: "Valid SRV record",
+			target:      "10 20 5060 service.example.com.",
+			expected:    &SRVTarget{priority: 10, weight: 20, port: 5060, host: "service.example.com."},
+		},
+		{
+			description: "Valid root target",
+			target:      "0 0 0 .",
+			expected:    &SRVTarget{priority: 0, weight: 0, port: 0, host: "."},
+		},
+		{
+			description: "Invalid SRV record with missing part",
+			target:      "10 20 5060",
+			expectError: true,
+		},
+		{
+			description: "Invalid SRV record with non-integer priority",
+			target:      "abc 20 5060 service.example.com.",
+			expectError: true,
+		},
+		{
+			description: "Invalid SRV record with non-integer weight",
+			target:      "10 abc 5060 service.example.com.",
+			expectError: true,
+		},
+		{
+			description: "Invalid SRV record with non-integer port",
+			target:      "10 20 abc service.example.com.",
+			expectError: true,
+		},
+		{
+			description: "Invalid SRV record with missing dot for target host",
+			target:      "10 20 5060 service.example.com",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			actual, err := NewSRVRecord(tt.target)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestSRVTarget_Getters(t *testing.T) {
+	s, err := NewSRVRecord("10 20 5060 service.example.com.")
+	require.NoError(t, err)
+	assert.Equal(t, uint16(10), *s.GetPriority())
+	assert.Equal(t, uint16(20), *s.GetWeight())
+	assert.Equal(t, uint16(5060), *s.GetPort())
+	assert.Equal(t, "service.example.com.", *s.GetHost())
+}
+
 func TestCheckEndpoint(t *testing.T) {
 	tests := []struct {
 		description string

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -1141,7 +1141,7 @@ func TestMXTarget_Getters(t *testing.T) {
 	m, err := NewMXRecord("10 mail.example.com")
 	require.NoError(t, err)
 	assert.Equal(t, uint16(10), *m.GetPriority())
-	assert.Equal(t, "mail.example.com", *m.GetHost())
+	assert.Equal(t, "mail.example.com", m.GetHost())
 }
 
 func TestNewSRVRecord(t *testing.T) {
@@ -1204,10 +1204,10 @@ func TestNewSRVRecord(t *testing.T) {
 func TestSRVTarget_Getters(t *testing.T) {
 	s, err := NewSRVRecord("10 20 5060 service.example.com.")
 	require.NoError(t, err)
-	assert.Equal(t, uint16(10), *s.GetPriority())
-	assert.Equal(t, uint16(20), *s.GetWeight())
-	assert.Equal(t, uint16(5060), *s.GetPort())
-	assert.Equal(t, "service.example.com.", *s.GetHost())
+	assert.Equal(t, uint16(10), s.GetPriority())
+	assert.Equal(t, uint16(20), s.GetWeight())
+	assert.Equal(t, uint16(5060), s.GetPort())
+	assert.Equal(t, "service.example.com.", s.GetHost())
 }
 
 func TestCheckEndpoint(t *testing.T) {

--- a/endpoint/fuzz_test.go
+++ b/endpoint/fuzz_test.go
@@ -60,7 +60,7 @@ func FuzzNewMXRecord(f *testing.F) {
 				t.Error("priority should not be nil on success")
 			}
 			h := mx.GetHost()
-			if h == nil || *h == "" {
+			if h == "" {
 				t.Error("host should not be empty on success")
 			}
 		}
@@ -97,13 +97,8 @@ func FuzzNewSRVRecord(f *testing.F) {
 		}
 		srv, err := NewSRVRecord(input)
 		if err == nil {
-			for _, value := range []*uint16{srv.GetPriority(), srv.GetWeight(), srv.GetPort()} {
-				if value == nil {
-					t.Error("numeric SRV fields should not be nil on success")
-				}
-			}
 			h := srv.GetHost()
-			if h == nil || *h == "" {
+			if h == "" {
 				t.Error("host should not be empty on success")
 			}
 		}

--- a/endpoint/fuzz_test.go
+++ b/endpoint/fuzz_test.go
@@ -83,6 +83,33 @@ func FuzzValidateSRVRecord(f *testing.F) {
 	})
 }
 
+func FuzzNewSRVRecord(f *testing.F) {
+	f.Add("10 5 5060 example.com.")
+	f.Add("0 0 0 .")
+	f.Add("")
+	f.Add("10 5 5060 example.com")
+	f.Add("notanum 5 5060 example.com.")
+	f.Add("10 5 99999 example.com.")
+
+	f.Fuzz(func(t *testing.T, input string) {
+		if len(input) > 1024 {
+			t.Skip()
+		}
+		srv, err := NewSRVRecord(input)
+		if err == nil {
+			for _, value := range []*uint16{srv.GetPriority(), srv.GetWeight(), srv.GetPort()} {
+				if value == nil {
+					t.Error("numeric SRV fields should not be nil on success")
+				}
+			}
+			h := srv.GetHost()
+			if h == nil || *h == "" {
+				t.Error("host should not be empty on success")
+			}
+		}
+	})
+}
+
 func FuzzSuitableType(f *testing.F) {
 	f.Add("1.2.3.4")
 	f.Add("::1")

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -748,7 +748,7 @@ func (p *CloudFlareProvider) newCloudFlareChange(action changeAction, ep *endpoi
 	}
 
 	var priority float64
-	if ep.RecordType == "MX" {
+	if ep.RecordType == endpoint.RecordTypeMX {
 		mxRecord, err := endpoint.NewMXRecord(target)
 		if err != nil {
 			return &cloudFlareChange{}, fmt.Errorf("failed to parse MX record target %q: %w", target, err)
@@ -757,8 +757,8 @@ func (p *CloudFlareProvider) newCloudFlareChange(action changeAction, ep *endpoi
 			target = *mxRecord.GetHost()
 		}
 	}
-	if ep.RecordType == "SRV" {
-		if _, err := parseSRVRecordTarget(target); err != nil {
+	if ep.RecordType == endpoint.RecordTypeSRV {
+		if _, err := endpoint.NewSRVRecord(target); err != nil {
 			return &cloudFlareChange{}, fmt.Errorf("failed to parse SRV record target %q: %w", target, err)
 		}
 	}

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -754,7 +754,7 @@ func (p *CloudFlareProvider) newCloudFlareChange(action changeAction, ep *endpoi
 			return &cloudFlareChange{}, fmt.Errorf("failed to parse MX record target %q: %w", target, err)
 		} else {
 			priority = float64(*mxRecord.GetPriority())
-			target = *mxRecord.GetHost()
+			target = mxRecord.GetHost()
 		}
 	}
 	if ep.RecordType == endpoint.RecordTypeSRV {

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -694,10 +694,37 @@ func (p *CloudFlareProvider) changesByZone(zones []zones.Zone, changeSet []*clou
 }
 
 func (p *CloudFlareProvider) getRecordID(records DNSRecordsMap, record dns.RecordResponse) string {
-	if zoneRecord, ok := records[DNSRecordIndex{Name: record.Name, Type: string(record.Type), Content: record.Content}]; ok {
+	if zoneRecord, ok := records[newDNSRecordIndex(record)]; ok {
 		return zoneRecord.ID
 	}
 	return ""
+}
+
+func endpointTargetFromCloudflareRecord(record dns.RecordResponse) string {
+	if record.Type != dns.RecordResponseTypeSRV {
+		return record.Content
+	}
+
+	switch data := record.Data.(type) {
+	case dns.SRVRecordData:
+		if data.Target != "" {
+			return fmt.Sprintf("%v %v %v %s", data.Priority, data.Weight, data.Port, externalDNSSRVTarget(data.Target))
+		}
+	case map[string]any:
+		priority, priorityOK := data["priority"].(float64)
+		weight, weightOK := data["weight"].(float64)
+		port, portOK := data["port"].(float64)
+		target, targetOK := data["target"].(string)
+		if priorityOK && weightOK && portOK && targetOK {
+			return fmt.Sprintf("%v %v %v %s", priority, weight, port, externalDNSSRVTarget(target))
+		}
+	}
+
+	if parsed, err := parseSRVRecordTarget(record.Content); err == nil {
+		return fmt.Sprintf("%v %v %v %s", parsed.priority, parsed.weight, parsed.port, externalDNSSRVTarget(parsed.target))
+	}
+
+	return record.Content
 }
 
 func (p *CloudFlareProvider) newCloudFlareChange(action changeAction, ep *endpoint.Endpoint, target string, current *endpoint.Endpoint) (*cloudFlareChange, error) {
@@ -745,6 +772,11 @@ func (p *CloudFlareProvider) newCloudFlareChange(action changeAction, ep *endpoi
 			target = *mxRecord.GetHost()
 		}
 	}
+	if ep.RecordType == "SRV" {
+		if _, err := parseSRVRecordTarget(target); err != nil {
+			return &cloudFlareChange{}, fmt.Errorf("failed to parse SRV record target %q: %w", target, err)
+		}
+	}
 
 	return &cloudFlareChange{
 		Action: action,
@@ -765,7 +797,7 @@ func (p *CloudFlareProvider) newCloudFlareChange(action changeAction, ep *endpoi
 }
 
 func newDNSRecordIndex(r dns.RecordResponse) DNSRecordIndex {
-	return DNSRecordIndex{Name: r.Name, Type: string(r.Type), Content: r.Content}
+	return DNSRecordIndex{Name: r.Name, Type: string(r.Type), Content: endpointTargetFromCloudflareRecord(r)}
 }
 
 // getDNSRecordsMap retrieves all DNS records for a given zone and returns them as a DNSRecordsMap.
@@ -853,7 +885,7 @@ func (p *CloudFlareProvider) groupByNameAndTypeWithCustomHostnames(records DNSRe
 			if records[i].Type == "MX" {
 				targets[i] = fmt.Sprintf("%v %v", record.Priority, record.Content)
 			} else {
-				targets[i] = record.Content
+				targets[i] = endpointTargetFromCloudflareRecord(record)
 			}
 		}
 		e := endpoint.NewEndpointWithTTL(

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -705,23 +705,8 @@ func endpointTargetFromCloudflareRecord(record dns.RecordResponse) string {
 		return record.Content
 	}
 
-	switch data := record.Data.(type) {
-	case dns.SRVRecordData:
-		if data.Target != "" {
-			return fmt.Sprintf("%v %v %v %s", data.Priority, data.Weight, data.Port, externalDNSSRVTarget(data.Target))
-		}
-	case map[string]any:
-		priority, priorityOK := data["priority"].(float64)
-		weight, weightOK := data["weight"].(float64)
-		port, portOK := data["port"].(float64)
-		target, targetOK := data["target"].(string)
-		if priorityOK && weightOK && portOK && targetOK {
-			return fmt.Sprintf("%v %v %v %s", priority, weight, port, externalDNSSRVTarget(target))
-		}
-	}
-
-	if parsed, err := parseSRVRecordTarget(record.Content); err == nil {
-		return fmt.Sprintf("%v %v %v %s", parsed.priority, parsed.weight, parsed.port, externalDNSSRVTarget(parsed.target))
+	if data, ok := record.Data.(dns.SRVRecordData); ok && data.Target != "" {
+		return fmt.Sprintf("%v %v %v %s", data.Priority, data.Weight, data.Port, externalDNSSRVTarget(data.Target))
 	}
 
 	return record.Content

--- a/provider/cloudflare/cloudflare_batch.go
+++ b/provider/cloudflare/cloudflare_batch.go
@@ -18,6 +18,9 @@ package cloudflare
 
 import (
 	"context"
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cloudflare/cloudflare-go/v7"
@@ -48,9 +51,9 @@ type batchCollections struct {
 	createChanges []*cloudFlareChange
 	updateChanges []*cloudFlareChange
 
-	// fallbackUpdates holds changes for record types whose batch-put param
-	// requires structured Data fields (e.g. SRV, CAA). These are submitted
-	// via individual UpdateDNSRecord calls instead of the batch API.
+	// fallbackUpdates holds changes for record types not supported by the
+	// typed batch-put union. These are submitted via individual UpdateDNSRecord
+	// calls instead of the batch API.
 	fallbackUpdates []*cloudFlareChange
 }
 
@@ -69,7 +72,18 @@ func (z zoneService) BatchDNSRecords(ctx context.Context, params dns.RecordBatch
 }
 
 // getUpdateDNSRecordParam returns the RecordUpdateParams for an individual update.
-func getUpdateDNSRecordParam(zoneID string, cfc cloudFlareChange) dns.RecordUpdateParams {
+func getUpdateDNSRecordParam(zoneID string, cfc cloudFlareChange) (dns.RecordUpdateParams, error) {
+	if cfc.ResourceRecord.Type == dns.RecordResponseTypeSRV {
+		body, err := buildSRVRecordParam(cfc.ResourceRecord)
+		if err != nil {
+			return dns.RecordUpdateParams{}, fmt.Errorf("failed to parse SRV record target %q for %s: %w", cfc.ResourceRecord.Content, cfc.ResourceRecord.Name, err)
+		}
+		return dns.RecordUpdateParams{
+			ZoneID: cloudflare.F(zoneID),
+			Body:   body,
+		}, nil
+	}
+
 	return dns.RecordUpdateParams{
 		ZoneID: cloudflare.F(zoneID),
 		Body: dns.RecordUpdateParamsBody{
@@ -82,11 +96,22 @@ func getUpdateDNSRecordParam(zoneID string, cfc cloudFlareChange) dns.RecordUpda
 			Comment:  cloudflare.F(cfc.ResourceRecord.Comment),
 			Tags:     cloudflare.F(cfc.ResourceRecord.Tags),
 		},
-	}
+	}, nil
 }
 
 // getCreateDNSRecordParam returns the RecordNewParams for an individual create.
-func getCreateDNSRecordParam(zoneID string, cfc *cloudFlareChange) dns.RecordNewParams {
+func getCreateDNSRecordParam(zoneID string, cfc *cloudFlareChange) (dns.RecordNewParams, error) {
+	if cfc.ResourceRecord.Type == dns.RecordResponseTypeSRV {
+		body, err := buildSRVRecordParam(cfc.ResourceRecord)
+		if err != nil {
+			return dns.RecordNewParams{}, fmt.Errorf("failed to parse SRV record target %q for %s: %w", cfc.ResourceRecord.Content, cfc.ResourceRecord.Name, err)
+		}
+		return dns.RecordNewParams{
+			ZoneID: cloudflare.F(zoneID),
+			Body:   body,
+		}, nil
+	}
+
 	return dns.RecordNewParams{
 		ZoneID: cloudflare.F(zoneID),
 		Body: dns.RecordNewParamsBody{
@@ -99,7 +124,7 @@ func getCreateDNSRecordParam(zoneID string, cfc *cloudFlareChange) dns.RecordNew
 			Comment:  cloudflare.F(cfc.ResourceRecord.Comment),
 			Tags:     cloudflare.F(cfc.ResourceRecord.Tags),
 		},
-	}
+	}, nil
 }
 
 // chunkBatchChanges splits DNS record batch operations into batchChunks,
@@ -156,8 +181,90 @@ func tagsFromResponse(tags any) []dns.RecordTagsParam {
 	return nil
 }
 
-// buildBatchPostParam constructs a RecordBatchParamsPost for creating a DNS record in a batch.
-func buildBatchPostParam(r dns.RecordResponse) dns.RecordBatchParamsPost {
+type srvRecordTarget struct {
+	priority float64
+	weight   float64
+	port     float64
+	target   string
+}
+
+func parseSRVRecordTarget(target string) (srvRecordTarget, error) {
+	parts := strings.Fields(strings.TrimSpace(target))
+	if len(parts) != 4 {
+		return srvRecordTarget{}, fmt.Errorf("SRV record target must have priority, weight, port, and target host")
+	}
+
+	priority, err := strconv.ParseUint(parts[0], 10, 16)
+	if err != nil {
+		return srvRecordTarget{}, fmt.Errorf("invalid SRV priority %q: %w", parts[0], err)
+	}
+	weight, err := strconv.ParseUint(parts[1], 10, 16)
+	if err != nil {
+		return srvRecordTarget{}, fmt.Errorf("invalid SRV weight %q: %w", parts[1], err)
+	}
+	port, err := strconv.ParseUint(parts[2], 10, 16)
+	if err != nil {
+		return srvRecordTarget{}, fmt.Errorf("invalid SRV port %q: %w", parts[2], err)
+	}
+
+	return srvRecordTarget{
+		priority: float64(priority),
+		weight:   float64(weight),
+		port:     float64(port),
+		target:   cloudflareSRVTarget(parts[3]),
+	}, nil
+}
+
+func cloudflareSRVTarget(target string) string {
+	if target == "." {
+		return target
+	}
+	return strings.TrimSuffix(target, ".")
+}
+
+func externalDNSSRVTarget(target string) string {
+	if target == "." || strings.HasSuffix(target, ".") {
+		return target
+	}
+	return target + "."
+}
+
+func srvRecordDataParam(target srvRecordTarget) dns.SRVRecordDataParam {
+	return dns.SRVRecordDataParam{
+		Priority: cloudflare.F(target.priority),
+		Weight:   cloudflare.F(target.weight),
+		Port:     cloudflare.F(target.port),
+		Target:   cloudflare.F(target.target),
+	}
+}
+
+func buildSRVRecordParam(r dns.RecordResponse) (dns.SRVRecordParam, error) {
+	target, err := parseSRVRecordTarget(r.Content)
+	if err != nil {
+		return dns.SRVRecordParam{}, err
+	}
+	return dns.SRVRecordParam{
+		Name:    cloudflare.F(r.Name),
+		TTL:     cloudflare.F(r.TTL),
+		Type:    cloudflare.F(dns.SRVRecordTypeSRV),
+		Data:    cloudflare.F(srvRecordDataParam(target)),
+		Proxied: cloudflare.F(r.Proxied),
+		Comment: cloudflare.F(r.Comment),
+		Tags:    cloudflare.F(tagsFromResponse(r.Tags)),
+	}, nil
+}
+
+// buildBatchPostParam constructs a typed batch-post parameter for creating a DNS record.
+func buildBatchPostParam(r dns.RecordResponse) (dns.RecordBatchParamsPostUnion, bool) {
+	if r.Type == dns.RecordResponseTypeSRV {
+		param, err := buildSRVRecordParam(r)
+		if err != nil {
+			log.Errorf("failed to parse SRV record target %q for %s: %v", r.Content, r.Name, err)
+			return nil, false
+		}
+		return param, true
+	}
+
 	return dns.RecordBatchParamsPost{
 		Name:     cloudflare.F(r.Name),
 		TTL:      cloudflare.F(r.TTL),
@@ -167,11 +274,11 @@ func buildBatchPostParam(r dns.RecordResponse) dns.RecordBatchParamsPost {
 		Priority: cloudflare.F(r.Priority),
 		Comment:  cloudflare.F(r.Comment),
 		Tags:     cloudflare.F[any](tagsFromResponse(r.Tags)),
-	}
+	}, true
 }
 
 // buildBatchPutParam constructs a BatchPutUnionParam for updating a DNS record in a batch.
-// Returns (nil, false) for record types that use structured Data fields (e.g. SRV, CAA),
+// Returns (nil, false) for record types not supported by the typed batch-put union,
 // which fall back to individual UpdateDNSRecord calls.
 func buildBatchPutParam(id string, r dns.RecordResponse) (dns.BatchPutUnionParam, bool) {
 	tags := tagsFromResponse(r.Tags)
@@ -256,8 +363,18 @@ func buildBatchPutParam(id string, r dns.RecordResponse) (dns.BatchPutUnionParam
 				Tags:    cloudflare.F(tags),
 			},
 		}, true
+	case dns.RecordResponseTypeSRV:
+		param, err := buildSRVRecordParam(r)
+		if err != nil {
+			log.Errorf("failed to parse SRV record target %q for %s: %v", r.Content, r.Name, err)
+			return nil, false
+		}
+		return dns.BatchPutSRVRecordParam{
+			ID:             cloudflare.F(id),
+			SRVRecordParam: param,
+		}, true
 	default:
-		// Record types that use structured Data fields (SRV, CAA, etc.) are not
+		// Record types that use structured Data fields (CAA, etc.) are not
 		// supported in the generic batch put and fall back to individual updates.
 		return nil, false
 	}
@@ -284,8 +401,10 @@ func (p *CloudFlareProvider) buildBatchCollections(
 
 		switch change.Action {
 		case cloudFlareCreate:
-			bc.batchPosts = append(bc.batchPosts, buildBatchPostParam(change.ResourceRecord))
-			bc.createChanges = append(bc.createChanges, change)
+			if postParam, ok := buildBatchPostParam(change.ResourceRecord); ok {
+				bc.batchPosts = append(bc.batchPosts, postParam)
+				bc.createChanges = append(bc.createChanges, change)
+			}
 
 		case cloudFlareDelete:
 			recordID := p.getRecordID(records, change.ResourceRecord)
@@ -360,7 +479,12 @@ func (p *CloudFlareProvider) submitDNSRecordChanges(
 			"zone":   zoneID,
 		}
 		recordID := p.getRecordID(records, change.ResourceRecord)
-		recordParam := getUpdateDNSRecordParam(zoneID, *change)
+		recordParam, err := getUpdateDNSRecordParam(zoneID, *change)
+		if err != nil {
+			failed = true
+			log.WithFields(logFields).Errorf("failed to build update record request: %v", err)
+			continue
+		}
 		if _, err := p.Client.UpdateDNSRecord(ctx, recordID, recordParam); err != nil {
 			failed = true
 			log.WithFields(logFields).Errorf("failed to update record: %v", err)
@@ -409,8 +533,11 @@ func (p *CloudFlareProvider) fallbackIndividualChanges(
 			var err error
 			switch change.Action {
 			case cloudFlareCreate:
-				params := getCreateDNSRecordParam(zoneID, change)
-				_, err = p.Client.CreateDNSRecord(ctx, params)
+				var params dns.RecordNewParams
+				params, err = getCreateDNSRecordParam(zoneID, change)
+				if err == nil {
+					_, err = p.Client.CreateDNSRecord(ctx, params)
+				}
 
 			case cloudFlareDelete:
 				recordID := p.getRecordID(records, change.ResourceRecord)
@@ -430,8 +557,11 @@ func (p *CloudFlareProvider) fallbackIndividualChanges(
 					log.WithFields(logFields).Info("fallback: record unexpectedly not found for update, will re-evaluate on next sync")
 					continue
 				}
-				params := getUpdateDNSRecordParam(zoneID, *change)
-				_, err = p.Client.UpdateDNSRecord(ctx, recordID, params)
+				var params dns.RecordUpdateParams
+				params, err = getUpdateDNSRecordParam(zoneID, *change)
+				if err == nil {
+					_, err = p.Client.UpdateDNSRecord(ctx, recordID, params)
+				}
 			}
 
 			if err != nil {

--- a/provider/cloudflare/cloudflare_batch.go
+++ b/provider/cloudflare/cloudflare_batch.go
@@ -198,10 +198,10 @@ func externalDNSSRVTarget(target string) string {
 
 func srvRecordDataParam(target *endpoint.SRVTarget) dns.SRVRecordDataParam {
 	return dns.SRVRecordDataParam{
-		Priority: cloudflare.F(float64(*target.GetPriority())),
-		Weight:   cloudflare.F(float64(*target.GetWeight())),
-		Port:     cloudflare.F(float64(*target.GetPort())),
-		Target:   cloudflare.F(cloudflareSRVTarget(*target.GetHost())),
+		Priority: cloudflare.F(float64(target.GetPriority())),
+		Weight:   cloudflare.F(float64(target.GetWeight())),
+		Port:     cloudflare.F(float64(target.GetPort())),
+		Target:   cloudflare.F(cloudflareSRVTarget(target.GetHost())),
 	}
 }
 

--- a/provider/cloudflare/cloudflare_batch.go
+++ b/provider/cloudflare/cloudflare_batch.go
@@ -19,13 +19,14 @@ package cloudflare
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/cloudflare/cloudflare-go/v7"
 	"github.com/cloudflare/cloudflare-go/v7/dns"
 	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 const (
@@ -181,40 +182,6 @@ func tagsFromResponse(tags any) []dns.RecordTagsParam {
 	return nil
 }
 
-type srvRecordTarget struct {
-	priority float64
-	weight   float64
-	port     float64
-	target   string
-}
-
-func parseSRVRecordTarget(target string) (srvRecordTarget, error) {
-	parts := strings.Fields(strings.TrimSpace(target))
-	if len(parts) != 4 {
-		return srvRecordTarget{}, fmt.Errorf("SRV record target must have priority, weight, port, and target host")
-	}
-
-	priority, err := strconv.ParseUint(parts[0], 10, 16)
-	if err != nil {
-		return srvRecordTarget{}, fmt.Errorf("invalid SRV priority %q: %w", parts[0], err)
-	}
-	weight, err := strconv.ParseUint(parts[1], 10, 16)
-	if err != nil {
-		return srvRecordTarget{}, fmt.Errorf("invalid SRV weight %q: %w", parts[1], err)
-	}
-	port, err := strconv.ParseUint(parts[2], 10, 16)
-	if err != nil {
-		return srvRecordTarget{}, fmt.Errorf("invalid SRV port %q: %w", parts[2], err)
-	}
-
-	return srvRecordTarget{
-		priority: float64(priority),
-		weight:   float64(weight),
-		port:     float64(port),
-		target:   cloudflareSRVTarget(parts[3]),
-	}, nil
-}
-
 func cloudflareSRVTarget(target string) string {
 	if target == "." {
 		return target
@@ -229,17 +196,17 @@ func externalDNSSRVTarget(target string) string {
 	return target + "."
 }
 
-func srvRecordDataParam(target srvRecordTarget) dns.SRVRecordDataParam {
+func srvRecordDataParam(target *endpoint.SRVTarget) dns.SRVRecordDataParam {
 	return dns.SRVRecordDataParam{
-		Priority: cloudflare.F(target.priority),
-		Weight:   cloudflare.F(target.weight),
-		Port:     cloudflare.F(target.port),
-		Target:   cloudflare.F(target.target),
+		Priority: cloudflare.F(float64(*target.GetPriority())),
+		Weight:   cloudflare.F(float64(*target.GetWeight())),
+		Port:     cloudflare.F(float64(*target.GetPort())),
+		Target:   cloudflare.F(cloudflareSRVTarget(*target.GetHost())),
 	}
 }
 
 func buildSRVRecordParam(r dns.RecordResponse) (dns.SRVRecordParam, error) {
-	target, err := parseSRVRecordTarget(r.Content)
+	target, err := endpoint.NewSRVRecord(r.Content)
 	if err != nil {
 		return dns.SRVRecordParam{}, err
 	}

--- a/provider/cloudflare/cloudflare_batch_test.go
+++ b/provider/cloudflare/cloudflare_batch_test.go
@@ -446,22 +446,24 @@ func TestTagsFromResponse(t *testing.T) {
 
 func TestSRVRecordTarget(t *testing.T) {
 	t.Run("parses SRV target", func(t *testing.T) {
-		target, err := parseSRVRecordTarget("0 1 443 caldav.fastmail.com.")
+		target, err := endpoint.NewSRVRecord("0 1 443 caldav.fastmail.com.")
 		require.NoError(t, err)
-		assert.InDelta(t, 0, target.priority, 0)
-		assert.InDelta(t, 1, target.weight, 0)
-		assert.InDelta(t, 443, target.port, 0)
-		assert.Equal(t, "caldav.fastmail.com", target.target)
+		data := srvRecordDataParam(target)
+		assert.InDelta(t, 0, data.Priority.Value, 0)
+		assert.InDelta(t, 1, data.Weight.Value, 0)
+		assert.InDelta(t, 443, data.Port.Value, 0)
+		assert.Equal(t, "caldav.fastmail.com", data.Target.Value)
 	})
 
 	t.Run("keeps root target", func(t *testing.T) {
-		target, err := parseSRVRecordTarget("0 0 0 .")
+		target, err := endpoint.NewSRVRecord("0 0 0 .")
 		require.NoError(t, err)
-		assert.Equal(t, ".", target.target)
+		data := srvRecordDataParam(target)
+		assert.Equal(t, ".", data.Target.Value)
 	})
 
 	t.Run("rejects malformed target", func(t *testing.T) {
-		_, err := parseSRVRecordTarget("0 1 443")
+		_, err := endpoint.NewSRVRecord("0 1 443")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "priority, weight, port, and target host")
 	})
@@ -707,7 +709,7 @@ func TestSubmitDNSRecordChanges_FallbackUpdates(t *testing.T) {
 			ID:      "srv-1",
 			Name:    "srv.bar.com",
 			Type:    dns.RecordResponseTypeSRV,
-			Content: "10 20 443 target.bar.com",
+			Content: "10 20 443 target.bar.com.",
 		}
 		client := NewMockCloudFlareClientWithRecords(map[string][]dns.RecordResponse{
 			"001": {srvRecord},
@@ -733,7 +735,7 @@ func TestSubmitDNSRecordChanges_FallbackUpdates(t *testing.T) {
 			ID:      "newerror-upd-srv",
 			Name:    "newerror-update-srv.bar.com",
 			Type:    dns.RecordResponseTypeSRV,
-			Content: "10 20 443 target.bar.com",
+			Content: "10 20 443 target.bar.com.",
 		}
 		client := NewMockCloudFlareClientWithRecords(map[string][]dns.RecordResponse{
 			"001": {srvRecord},

--- a/provider/cloudflare/cloudflare_batch_test.go
+++ b/provider/cloudflare/cloudflare_batch_test.go
@@ -93,19 +93,31 @@ func (m *mockCloudFlareClient) BatchDNSRecords(_ context.Context, params dns.Rec
 
 	// Process Posts (creates).
 	for _, postUnion := range params.Posts.Value {
-		post, ok := postUnion.(dns.RecordBatchParamsPost)
-		if !ok {
+		var record dns.RecordResponse
+		switch post := postUnion.(type) {
+		case dns.SRVRecordParam:
+			record = dns.RecordResponse{
+				ID:      generateDNSRecordID(string(post.Type.Value), post.Name.Value, srvContentFromParam(post.Data.Value)),
+				Name:    post.Name.Value,
+				TTL:     post.TTL.Value,
+				Proxied: post.Proxied.Value,
+				Type:    dns.RecordResponseType(post.Type.Value),
+				Content: srvContentFromParam(post.Data.Value),
+				Data:    srvDataFromParam(post.Data.Value),
+			}
+		case dns.RecordBatchParamsPost:
+			typeStr := string(post.Type.Value)
+			record = dns.RecordResponse{
+				ID:       generateDNSRecordID(typeStr, post.Name.Value, post.Content.Value),
+				Name:     post.Name.Value,
+				TTL:      dns.TTL(post.TTL.Value),
+				Proxied:  post.Proxied.Value,
+				Type:     dns.RecordResponseType(typeStr),
+				Content:  post.Content.Value,
+				Priority: post.Priority.Value,
+			}
+		default:
 			continue
-		}
-		typeStr := string(post.Type.Value)
-		record := dns.RecordResponse{
-			ID:       generateDNSRecordID(typeStr, post.Name.Value, post.Content.Value),
-			Name:     post.Name.Value,
-			TTL:      dns.TTL(post.TTL.Value),
-			Proxied:  post.Proxied.Value,
-			Type:     dns.RecordResponseType(typeStr),
-			Content:  post.Content.Value,
-			Priority: post.Priority.Value,
 		}
 		m.Actions = append(m.Actions, MockAction{
 			Name:       "Create",
@@ -191,6 +203,16 @@ func extractBatchPutData(put dns.BatchPutUnionParam) (string, dns.RecordResponse
 			Proxied: p.Proxied.Value,
 			Type:    dns.RecordResponseTypeNS,
 			Content: p.Content.Value,
+		}
+	case dns.BatchPutSRVRecordParam:
+		return p.ID.Value, dns.RecordResponse{
+			ID:      p.ID.Value,
+			Name:    p.Name.Value,
+			TTL:     p.TTL.Value,
+			Proxied: p.Proxied.Value,
+			Type:    dns.RecordResponseTypeSRV,
+			Content: srvContentFromParam(p.Data.Value),
+			Data:    srvDataFromParam(p.Data.Value),
 		}
 	default:
 		panic(fmt.Sprintf("extractBatchPutData: unexpected BatchPutUnionParam type %T", put))
@@ -422,6 +444,66 @@ func TestTagsFromResponse(t *testing.T) {
 	})
 }
 
+func TestSRVRecordTarget(t *testing.T) {
+	t.Run("parses SRV target", func(t *testing.T) {
+		target, err := parseSRVRecordTarget("0 1 443 caldav.fastmail.com.")
+		require.NoError(t, err)
+		assert.InDelta(t, 0, target.priority, 0)
+		assert.InDelta(t, 1, target.weight, 0)
+		assert.InDelta(t, 443, target.port, 0)
+		assert.Equal(t, "caldav.fastmail.com", target.target)
+	})
+
+	t.Run("keeps root target", func(t *testing.T) {
+		target, err := parseSRVRecordTarget("0 0 0 .")
+		require.NoError(t, err)
+		assert.Equal(t, ".", target.target)
+	})
+
+	t.Run("rejects malformed target", func(t *testing.T) {
+		_, err := parseSRVRecordTarget("0 1 443")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "priority, weight, port, and target host")
+	})
+}
+
+func TestBuildSRVRecordParam(t *testing.T) {
+	record := dns.RecordResponse{
+		Name:    "_caldavs._tcp.example.com",
+		TTL:     120,
+		Type:    dns.RecordResponseTypeSRV,
+		Content: "0 1 443 caldav.fastmail.com.",
+		Comment: "test-comment",
+	}
+
+	param, err := buildSRVRecordParam(record)
+	require.NoError(t, err)
+
+	assert.Equal(t, "_caldavs._tcp.example.com", param.Name.Value)
+	assert.Equal(t, dns.SRVRecordTypeSRV, param.Type.Value)
+	assert.InDelta(t, 0, param.Data.Value.Priority.Value, 0)
+	assert.InDelta(t, 1, param.Data.Value.Weight.Value, 0)
+	assert.InDelta(t, 443, param.Data.Value.Port.Value, 0)
+	assert.Equal(t, "caldav.fastmail.com", param.Data.Value.Target.Value)
+	assert.Equal(t, "test-comment", param.Comment.Value)
+}
+
+func TestBuildBatchPostParamSRV(t *testing.T) {
+	record := dns.RecordResponse{
+		Name:    "_caldavs._tcp.example.com",
+		TTL:     120,
+		Type:    dns.RecordResponseTypeSRV,
+		Content: "0 1 443 caldav.fastmail.com.",
+	}
+
+	param, ok := buildBatchPostParam(record)
+	require.True(t, ok)
+	srvParam, cast := param.(dns.SRVRecordParam)
+	require.True(t, cast)
+	assert.Equal(t, dns.SRVRecordTypeSRV, srvParam.Type.Value)
+	assert.Equal(t, "caldav.fastmail.com", srvParam.Data.Value.Target.Value)
+}
+
 func TestBuildBatchPutParam(t *testing.T) {
 	base := dns.RecordResponse{
 		Name:    "example.bar.com",
@@ -494,13 +576,20 @@ func TestBuildBatchPutParam(t *testing.T) {
 		assert.Equal(t, dns.NSRecordTypeNS, p.Type.Value)
 	})
 
-	t.Run("SRV record falls back (returns nil, false)", func(t *testing.T) {
+	t.Run("SRV record", func(t *testing.T) {
 		r := base
 		r.Type = dns.RecordResponseTypeSRV
-		r.Content = "10 20 443 target.bar.com"
+		r.Content = "10 20 443 target.bar.com."
 		param, ok := buildBatchPutParam("id-srv", r)
-		assert.False(t, ok)
-		assert.Nil(t, param)
+		require.True(t, ok)
+		p, cast := param.(dns.BatchPutSRVRecordParam)
+		require.True(t, cast)
+		assert.Equal(t, "id-srv", p.ID.Value)
+		assert.Equal(t, dns.SRVRecordTypeSRV, p.Type.Value)
+		assert.Equal(t, "target.bar.com", p.Data.Value.Target.Value)
+		assert.InDelta(t, 10, float64(p.Data.Value.Priority.Value), 0)
+		assert.InDelta(t, 20, float64(p.Data.Value.Weight.Value), 0)
+		assert.InDelta(t, 443, float64(p.Data.Value.Port.Value), 0)
 	})
 
 	t.Run("CAA record falls back (returns nil, false)", func(t *testing.T) {
@@ -534,12 +623,12 @@ func TestBuildBatchCollections_EdgeCases(t *testing.T) {
 		assert.Empty(t, bc.fallbackUpdates)
 	})
 
-	t.Run("SRV update goes to fallbackUpdates", func(t *testing.T) {
+	t.Run("SRV update goes to batchPuts", func(t *testing.T) {
 		srvRecord := dns.RecordResponse{
 			ID:      "srv-1",
 			Name:    "srv.bar.com",
 			Type:    dns.RecordResponseTypeSRV,
-			Content: "10 20 443 target.bar.com",
+			Content: "10 20 443 target.bar.com.",
 		}
 		records := DNSRecordsMap{
 			newDNSRecordIndex(srvRecord): srvRecord,
@@ -551,10 +640,9 @@ func TestBuildBatchCollections_EdgeCases(t *testing.T) {
 			},
 		}
 		bc := p.buildBatchCollections("zone1", changes, records)
-		assert.Empty(t, bc.batchPuts, "SRV should not be in batch puts")
-		assert.Empty(t, bc.updateChanges)
-		require.Len(t, bc.fallbackUpdates, 1)
-		assert.Equal(t, "srv.bar.com", bc.fallbackUpdates[0].ResourceRecord.Name)
+		require.Len(t, bc.batchPuts, 1)
+		require.Len(t, bc.updateChanges, 1)
+		assert.Empty(t, bc.fallbackUpdates)
 	})
 
 	t.Run("delete with missing record ID is skipped", func(t *testing.T) {

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -729,14 +729,15 @@ func TestCloudflareSetProxied(t *testing.T) {
 			var content string
 			var priority float64
 
-			if testCase.recordType == "MX" {
+			switch testCase.recordType {
+			case "MX":
 				targets = endpoint.Targets{"10 mx.example.com"}
 				content = "mx.example.com"
 				priority = 10
-			} else if testCase.recordType == "SRV" {
+			case "SRV":
 				targets = endpoint.Targets{"0 1 443 target.bar.com."}
 				content = "0 1 443 target.bar.com."
-			} else {
+			default:
 				targets = endpoint.Targets{"127.0.0.1"}
 				content = "127.0.0.1"
 			}
@@ -763,9 +764,10 @@ func TestCloudflareSetProxied(t *testing.T) {
 				TTL:     1,
 				Proxied: testCase.proxiable,
 			}
-			if testCase.recordType == "MX" {
+			switch testCase.recordType {
+			case "MX":
 				recordData.Priority = priority
-			} else if testCase.recordType == "SRV" {
+			case "SRV":
 				recordData.Data = dns.SRVRecordData{
 					Priority: 0,
 					Weight:   1,
@@ -2484,15 +2486,10 @@ func TestEndpointTargetFromCloudflareRecordSRV(t *testing.T) {
 		assert.Equal(t, "0 1 443 caldav.fastmail.com.", endpointTargetFromCloudflareRecord(record))
 	})
 
-	t.Run("normalizes map SRV data", func(t *testing.T) {
+	t.Run("falls back to content without typed SRV data", func(t *testing.T) {
 		record := dns.RecordResponse{
-			Type: dns.RecordResponseTypeSRV,
-			Data: map[string]any{
-				"priority": float64(10),
-				"weight":   float64(20),
-				"port":     float64(995),
-				"target":   "pop.fastmail.com",
-			},
+			Type:    dns.RecordResponseTypeSRV,
+			Content: "10 20 995 pop.fastmail.com.",
 		}
 
 		assert.Equal(t, "10 20 995 pop.fastmail.com.", endpointTargetFromCloudflareRecord(record))

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -141,18 +141,80 @@ func NewMockCloudFlareClientWithRecords(records map[string][]dns.RecordResponse)
 	return m
 }
 
-func (m *mockCloudFlareClient) CreateDNSRecord(_ context.Context, params dns.RecordNewParams) (*dns.RecordResponse, error) {
-	body := params.Body.(dns.RecordNewParamsBody)
+func srvContentFromParam(data dns.SRVRecordDataParam) string {
+	return fmt.Sprintf("%v %v %v %s",
+		data.Priority.Value,
+		data.Weight.Value,
+		data.Port.Value,
+		externalDNSSRVTarget(data.Target.Value),
+	)
+}
 
-	record := dns.RecordResponse{
-		ID:       generateDNSRecordID(body.Type.String(), body.Name.Value, body.Content.Value),
-		Name:     body.Name.Value,
-		TTL:      dns.TTL(body.TTL.Value),
-		Proxied:  body.Proxied.Value,
-		Type:     dns.RecordResponseType(body.Type.String()),
-		Content:  body.Content.Value,
-		Priority: body.Priority.Value,
+func srvDataFromParam(data dns.SRVRecordDataParam) dns.SRVRecordData {
+	return dns.SRVRecordData{
+		Priority: data.Priority.Value,
+		Weight:   data.Weight.Value,
+		Port:     data.Port.Value,
+		Target:   data.Target.Value,
 	}
+}
+
+func recordResponseFromNewBody(body dns.RecordNewParamsBodyUnion) dns.RecordResponse {
+	switch b := body.(type) {
+	case dns.SRVRecordParam:
+		return dns.RecordResponse{
+			ID:      generateDNSRecordID(string(b.Type.Value), b.Name.Value, srvContentFromParam(b.Data.Value)),
+			Name:    b.Name.Value,
+			TTL:     b.TTL.Value,
+			Proxied: b.Proxied.Value,
+			Type:    dns.RecordResponseType(b.Type.Value),
+			Content: srvContentFromParam(b.Data.Value),
+			Data:    srvDataFromParam(b.Data.Value),
+		}
+	case dns.RecordNewParamsBody:
+		return dns.RecordResponse{
+			ID:       generateDNSRecordID(b.Type.String(), b.Name.Value, b.Content.Value),
+			Name:     b.Name.Value,
+			TTL:      dns.TTL(b.TTL.Value),
+			Proxied:  b.Proxied.Value,
+			Type:     dns.RecordResponseType(b.Type.String()),
+			Content:  b.Content.Value,
+			Priority: b.Priority.Value,
+		}
+	default:
+		panic(fmt.Sprintf("recordResponseFromNewBody: unexpected body type %T", body))
+	}
+}
+
+func recordResponseFromUpdateBody(recordID string, body dns.RecordUpdateParamsBodyUnion) dns.RecordResponse {
+	switch b := body.(type) {
+	case dns.SRVRecordParam:
+		return dns.RecordResponse{
+			ID:      recordID,
+			Name:    b.Name.Value,
+			TTL:     b.TTL.Value,
+			Proxied: b.Proxied.Value,
+			Type:    dns.RecordResponseType(b.Type.Value),
+			Content: srvContentFromParam(b.Data.Value),
+			Data:    srvDataFromParam(b.Data.Value),
+		}
+	case dns.RecordUpdateParamsBody:
+		return dns.RecordResponse{
+			ID:       recordID,
+			Name:     b.Name.Value,
+			TTL:      dns.TTL(b.TTL.Value),
+			Proxied:  b.Proxied.Value,
+			Type:     dns.RecordResponseType(b.Type.String()),
+			Content:  b.Content.Value,
+			Priority: b.Priority.Value,
+		}
+	default:
+		panic(fmt.Sprintf("recordResponseFromUpdateBody: unexpected body type %T", body))
+	}
+}
+
+func (m *mockCloudFlareClient) CreateDNSRecord(_ context.Context, params dns.RecordNewParams) (*dns.RecordResponse, error) {
+	record := recordResponseFromNewBody(params.Body)
 
 	m.Actions = append(m.Actions, MockAction{
 		Name:       "Create",
@@ -191,17 +253,7 @@ func (m *mockCloudFlareClient) ListDNSRecords(ctx context.Context, params dns.Re
 
 func (m *mockCloudFlareClient) UpdateDNSRecord(_ context.Context, recordID string, params dns.RecordUpdateParams) (*dns.RecordResponse, error) {
 	zoneID := params.ZoneID.String()
-	body := params.Body.(dns.RecordUpdateParamsBody)
-
-	record := dns.RecordResponse{
-		ID:       recordID,
-		Name:     body.Name.Value,
-		TTL:      dns.TTL(body.TTL.Value),
-		Proxied:  body.Proxied.Value,
-		Type:     dns.RecordResponseType(body.Type.String()),
-		Content:  body.Content.Value,
-		Priority: body.Priority.Value,
-	}
+	record := recordResponseFromUpdateBody(recordID, params.Body)
 
 	m.Actions = append(m.Actions, MockAction{
 		Name:       "Update",
@@ -681,6 +733,9 @@ func TestCloudflareSetProxied(t *testing.T) {
 				targets = endpoint.Targets{"10 mx.example.com"}
 				content = "mx.example.com"
 				priority = 10
+			} else if testCase.recordType == "SRV" {
+				targets = endpoint.Targets{"0 1 443 target.bar.com."}
+				content = "0 1 443 target.bar.com."
 			} else {
 				targets = endpoint.Targets{"127.0.0.1"}
 				content = "127.0.0.1"
@@ -710,6 +765,13 @@ func TestCloudflareSetProxied(t *testing.T) {
 			}
 			if testCase.recordType == "MX" {
 				recordData.Priority = priority
+			} else if testCase.recordType == "SRV" {
+				recordData.Data = dns.SRVRecordData{
+					Priority: 0,
+					Weight:   1,
+					Port:     443,
+					Target:   "target.bar.com",
+				}
 			}
 			AssertActions(t, &CloudFlareProvider{}, endpoints, []MockAction{
 				{
@@ -1902,6 +1964,18 @@ func TestCloudFlareProvider_newCloudFlareChange(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("invalid SRV target returns an error", func(t *testing.T) {
+		ep := &endpoint.Endpoint{
+			DNSName:    "_caldavs._tcp.example.com",
+			RecordType: "SRV",
+			Targets:    []string{"caldav.fastmail.com."},
+		}
+
+		_, err := freeProvider.newCloudFlareChange(cloudFlareCreate, ep, ep.Targets[0], nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse SRV record target")
+	})
 }
 
 func TestCloudFlareProvider_submitChangesCNAME(t *testing.T) {
@@ -2393,6 +2467,50 @@ func TestCloudFlareProvider_SupportedAdditionalRecordTypes(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestEndpointTargetFromCloudflareRecordSRV(t *testing.T) {
+	t.Run("normalizes typed SRV data", func(t *testing.T) {
+		record := dns.RecordResponse{
+			Type: dns.RecordResponseTypeSRV,
+			Data: dns.SRVRecordData{
+				Priority: 0,
+				Weight:   1,
+				Port:     443,
+				Target:   "caldav.fastmail.com",
+			},
+		}
+
+		assert.Equal(t, "0 1 443 caldav.fastmail.com.", endpointTargetFromCloudflareRecord(record))
+	})
+
+	t.Run("normalizes map SRV data", func(t *testing.T) {
+		record := dns.RecordResponse{
+			Type: dns.RecordResponseTypeSRV,
+			Data: map[string]any{
+				"priority": float64(10),
+				"weight":   float64(20),
+				"port":     float64(995),
+				"target":   "pop.fastmail.com",
+			},
+		}
+
+		assert.Equal(t, "10 20 995 pop.fastmail.com.", endpointTargetFromCloudflareRecord(record))
+	})
+
+	t.Run("keeps service-unavailable root target", func(t *testing.T) {
+		record := dns.RecordResponse{
+			Type: dns.RecordResponseTypeSRV,
+			Data: dns.SRVRecordData{
+				Priority: 0,
+				Weight:   0,
+				Port:     0,
+				Target:   ".",
+			},
+		}
+
+		assert.Equal(t, "0 0 0 .", endpointTargetFromCloudflareRecord(record))
+	})
 }
 
 func TestCloudflareZoneChanges(t *testing.T) {
@@ -2890,7 +3008,8 @@ func TestGetUpdateDNSRecordParam(t *testing.T) {
 		},
 	}
 
-	params := getUpdateDNSRecordParam("zone-123", cfc)
+	params, err := getUpdateDNSRecordParam("zone-123", cfc)
+	require.NoError(t, err)
 	body := params.Body.(dns.RecordUpdateParamsBody)
 
 	assert.Equal(t, "zone-123", params.ZoneID.Value)
@@ -2901,6 +3020,72 @@ func TestGetUpdateDNSRecordParam(t *testing.T) {
 	assert.Equal(t, "1.2.3.4", body.Content.Value)
 	assert.InDelta(t, 10, float64(body.Priority.Value), 0)
 	assert.Equal(t, "test-comment", body.Comment.Value)
+}
+
+func TestGetDNSRecordParamsSRV(t *testing.T) {
+	cfc := cloudFlareChange{
+		ResourceRecord: dns.RecordResponse{
+			ID:      "1234",
+			Name:    "_caldavs._tcp.example.com",
+			Type:    dns.RecordResponseTypeSRV,
+			TTL:     120,
+			Content: "0 1 443 caldav.fastmail.com.",
+			Comment: "test-comment",
+		},
+	}
+
+	t.Run("create uses structured SRV data", func(t *testing.T) {
+		params, err := getCreateDNSRecordParam("zone-123", &cfc)
+		require.NoError(t, err)
+		body, ok := params.Body.(dns.SRVRecordParam)
+		require.True(t, ok)
+
+		assert.Equal(t, "zone-123", params.ZoneID.Value)
+		assert.Equal(t, "_caldavs._tcp.example.com", body.Name.Value)
+		assert.Equal(t, dns.SRVRecordTypeSRV, body.Type.Value)
+		assert.InDelta(t, 0, body.Data.Value.Priority.Value, 0)
+		assert.InDelta(t, 1, body.Data.Value.Weight.Value, 0)
+		assert.InDelta(t, 443, body.Data.Value.Port.Value, 0)
+		assert.Equal(t, "caldav.fastmail.com", body.Data.Value.Target.Value)
+		assert.Equal(t, "test-comment", body.Comment.Value)
+
+		bodyJSON, err := json.Marshal(params.Body)
+		require.NoError(t, err)
+		assert.Contains(t, string(bodyJSON), `"data"`)
+		assert.Contains(t, string(bodyJSON), `"target":"caldav.fastmail.com"`)
+		assert.NotContains(t, string(bodyJSON), `"content"`)
+	})
+
+	t.Run("update uses structured SRV data", func(t *testing.T) {
+		params, err := getUpdateDNSRecordParam("zone-123", cfc)
+		require.NoError(t, err)
+		body, ok := params.Body.(dns.SRVRecordParam)
+		require.True(t, ok)
+
+		assert.Equal(t, "zone-123", params.ZoneID.Value)
+		assert.Equal(t, "_caldavs._tcp.example.com", body.Name.Value)
+		assert.Equal(t, dns.SRVRecordTypeSRV, body.Type.Value)
+		assert.InDelta(t, 0, body.Data.Value.Priority.Value, 0)
+		assert.InDelta(t, 1, body.Data.Value.Weight.Value, 0)
+		assert.InDelta(t, 443, body.Data.Value.Port.Value, 0)
+		assert.Equal(t, "caldav.fastmail.com", body.Data.Value.Target.Value)
+		assert.Equal(t, "test-comment", body.Comment.Value)
+
+		bodyJSON, err := json.Marshal(params.Body)
+		require.NoError(t, err)
+		assert.Contains(t, string(bodyJSON), `"data"`)
+		assert.Contains(t, string(bodyJSON), `"target":"caldav.fastmail.com"`)
+		assert.NotContains(t, string(bodyJSON), `"content"`)
+	})
+
+	t.Run("malformed SRV create returns an error", func(t *testing.T) {
+		badChange := cfc
+		badChange.ResourceRecord.Content = "caldav.fastmail.com."
+
+		_, err := getCreateDNSRecordParam("zone-123", &badChange)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse SRV record target")
+	})
 }
 
 func TestZoneService(t *testing.T) {
@@ -2925,7 +3110,8 @@ func TestZoneService(t *testing.T) {
 
 	t.Run("CreateDNSRecord", func(t *testing.T) {
 		t.Parallel()
-		params := getCreateDNSRecordParam(zoneID, &cloudFlareChange{})
+		params, err := getCreateDNSRecordParam(zoneID, &cloudFlareChange{})
+		require.NoError(t, err)
 		record, err := client.CreateDNSRecord(ctx, params)
 		assert.Empty(t, record)
 		assert.ErrorIs(t, err, context.Canceled)
@@ -2933,8 +3119,9 @@ func TestZoneService(t *testing.T) {
 
 	t.Run("UpdateDNSRecord", func(t *testing.T) {
 		t.Parallel()
-		recordParam := getUpdateDNSRecordParam(zoneID, cloudFlareChange{})
-		_, err := client.UpdateDNSRecord(ctx, "1234", recordParam)
+		recordParam, err := getUpdateDNSRecordParam(zoneID, cloudFlareChange{})
+		require.NoError(t, err)
+		_, err = client.UpdateDNSRecord(ctx, "1234", recordParam)
 		assert.ErrorIs(t, err, context.Canceled)
 	})
 


### PR DESCRIPTION
## What does it do ?

Parse ExternalDNS SRV targets into priority, weight, port, and target components and build typed Cloudflare SRV record params for individual create/update as well as batch post/put operations. Normalize returned Cloudflare SRV data back into ExternalDNS target strings, preserve root targets, and reject malformed SRV targets before they can fall through to the generic content request body.

Add regression coverage for SRV parsing, Cloudflare request body generation, batch behavior, individual create/update serialization, and read-side normalization.
## Motivation

Cloudflare's DNS API does not accept SRV records encoded only as the flat ExternalDNS content string, such as "0 1 443 caldav.fastmail.com.". Single-record creates and fallback updates were submitting that content field, and batch creates/updates did not consistently use the SDK's typed SRV payloads, causing Cloudflare to reject SRV operations with missing weight, port, and target data fields.

## More

- [X] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Yes, I added unit tests
- [X] Yes, I updated end user documentation accordingly