### PR TITLE
refactor(validation): reduce cyclomatic complexity of ValidateConfig

### DIFF
--- a/pkg/apis/externaldns/validation/validation.go
+++ b/pkg/apis/externaldns/validation/validation.go
@@ -17,108 +17,122 @@ limitations under the License.
 package validation
 
 import (
-	"errors"
-	"fmt"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 )
 
+// Validator validates a Config, returning any problems as a field.ErrorList.
+type Validator interface {
+	Validate(cfg *externaldns.Config) field.ErrorList
+}
+
+// validatorFunc adapts a plain function to the Validator interface.
+type validatorFunc func(cfg *externaldns.Config) field.ErrorList
+
+func (f validatorFunc) Validate(cfg *externaldns.Config) field.ErrorList {
+	return f(cfg)
+}
+
 // ValidateConfig performs validation on the Config object
 func ValidateConfig(cfg *externaldns.Config) error {
-	// TODO: Should probably return field.ErrorList
-	validators := []func(*externaldns.Config) error{
-		preValidateConfig,
-		validateConfigForProvider,
-		validateHostnameConfig,
-		validateTXTRegistryConfig,
-		validateLabelSelectors,
-		validateAnnotationPrefix,
-		validateKubeAPILimits,
-		validatePTRConfig,
+	validators := []Validator{
+		validatorFunc(preValidateConfig),
+		validatorFunc(validateConfigForProvider),
+		validatorFunc(validateHostnameConfig),
+		validatorFunc(validateTXTRegistryConfig),
+		validatorFunc(validateLabelSelectors),
+		validatorFunc(validateAnnotationPrefix),
+		validatorFunc(validateKubeAPILimits),
+		validatorFunc(validatePTRConfig),
 	}
-	for _, validate := range validators {
-		if err := validate(cfg); err != nil {
-			return err
-		}
+
+	var errs field.ErrorList
+	for _, v := range validators {
+		errs = append(errs, v.Validate(cfg)...)
 	}
-	return nil
+	return errs.ToAggregate()
 }
 
 // validateHostnameConfig ensures an FQDN template is set when hostname annotations are ignored.
-func validateHostnameConfig(cfg *externaldns.Config) error {
+func validateHostnameConfig(cfg *externaldns.Config) field.ErrorList {
 	if cfg.IgnoreHostnameAnnotation && len(cfg.FQDNTemplate) == 0 {
-		return errors.New("FQDN Template must be set if ignoring annotations")
+		return field.ErrorList{field.Required(field.NewPath("fqdn-template"), "FQDN Template must be set if ignoring annotations")}
 	}
 	return nil
 }
 
 // validateTXTRegistryConfig ensures the TXT registry prefix and suffix are not set together.
-func validateTXTRegistryConfig(cfg *externaldns.Config) error {
+func validateTXTRegistryConfig(cfg *externaldns.Config) field.ErrorList {
 	if len(cfg.TXTPrefix) > 0 && len(cfg.TXTSuffix) > 0 {
-		return errors.New("txt-prefix and txt-suffix are mutual exclusive")
+		return field.ErrorList{field.Invalid(field.NewPath("txt-prefix"), cfg.TXTPrefix, "txt-prefix and txt-suffix are mutual exclusive")}
 	}
 	return nil
 }
 
 // validateLabelSelectors ensures the label and annotation filters are valid selectors.
-func validateLabelSelectors(cfg *externaldns.Config) error {
+func validateLabelSelectors(cfg *externaldns.Config) field.ErrorList {
+	var errs field.ErrorList
 	if _, err := labels.Parse(cfg.LabelFilter); err != nil {
-		return errors.New("--label-filter does not specify a valid label selector")
+		errs = append(errs, field.Invalid(field.NewPath("label-filter"), cfg.LabelFilter, "does not specify a valid label selector"))
 	}
 	if _, err := metav1.ParseToLabelSelector(cfg.AnnotationFilter); err != nil {
-		return errors.New("--annotation-filter does not specify a valid label selector")
+		errs = append(errs, field.Invalid(field.NewPath("annotation-filter"), cfg.AnnotationFilter, "does not specify a valid label selector"))
 	}
-	return nil
+	return errs
 }
 
 // validateAnnotationPrefix ensures the annotation prefix is set and ends with a slash.
-func validateAnnotationPrefix(cfg *externaldns.Config) error {
+func validateAnnotationPrefix(cfg *externaldns.Config) field.ErrorList {
+	path := field.NewPath("annotation-prefix")
 	if cfg.AnnotationPrefix == "" {
-		return errors.New("--annotation-prefix cannot be empty")
+		return field.ErrorList{field.Required(path, "--annotation-prefix cannot be empty")}
 	}
 	if !strings.HasSuffix(cfg.AnnotationPrefix, "/") {
-		return errors.New("--annotation-prefix must end with '/'")
+		return field.ErrorList{field.Invalid(path, cfg.AnnotationPrefix, "--annotation-prefix must end with '/'")}
 	}
 	return nil
 }
 
 // validateKubeAPILimits ensures the Kubernetes API QPS and burst limits are positive.
-func validateKubeAPILimits(cfg *externaldns.Config) error {
+func validateKubeAPILimits(cfg *externaldns.Config) field.ErrorList {
+	var errs field.ErrorList
 	if cfg.KubeAPIQPS <= 0 {
-		return errors.New("--kube-api-qps must be greater than 0")
+		errs = append(errs, field.Invalid(field.NewPath("kube-api-qps"), cfg.KubeAPIQPS, "must be greater than 0"))
 	}
 	if cfg.KubeAPIBurst <= 0 {
-		return errors.New("--kube-api-burst must be greater than 0")
+		errs = append(errs, field.Invalid(field.NewPath("kube-api-burst"), cfg.KubeAPIBurst, "must be greater than 0"))
 	}
-	return nil
+	return errs
 }
 
 // validatePTRConfig ensures PTR is a managed record type when PTR creation is enabled.
-func validatePTRConfig(cfg *externaldns.Config) error {
+func validatePTRConfig(cfg *externaldns.Config) field.ErrorList {
 	if cfg.CreatePTR && !cfg.IsPTRSupported() {
-		return errors.New("--create-ptr requires PTR in --managed-record-types")
+		return field.ErrorList{field.Invalid(field.NewPath("create-ptr"), cfg.CreatePTR, "--create-ptr requires PTR in --managed-record-types")}
 	}
 	return nil
 }
 
-func preValidateConfig(cfg *externaldns.Config) error {
+func preValidateConfig(cfg *externaldns.Config) field.ErrorList {
+	var errs field.ErrorList
 	if cfg.LogFormat != externaldns.LogFormatText && cfg.LogFormat != externaldns.LogFormatJSON {
-		return fmt.Errorf("unsupported log format: %s", cfg.LogFormat)
+		errs = append(errs, field.Invalid(field.NewPath("log-format"), cfg.LogFormat, "unsupported log format"))
 	}
 	if len(cfg.Sources) == 0 {
-		return errors.New("no sources specified")
+		errs = append(errs, field.Required(field.NewPath("source"), "no sources specified"))
 	}
 	if cfg.Provider == "" {
-		return errors.New("no provider specified")
+		errs = append(errs, field.Required(field.NewPath("provider"), "no provider specified"))
 	}
-	return nil
+	return errs
 }
 
-func validateConfigForProvider(cfg *externaldns.Config) error {
+func validateConfigForProvider(cfg *externaldns.Config) field.ErrorList {
 	switch cfg.Provider {
 	case externaldns.ProviderAzure:
 		return validateConfigForAzure(cfg)
@@ -129,27 +143,28 @@ func validateConfigForProvider(cfg *externaldns.Config) error {
 	}
 }
 
-func validateConfigForAzure(cfg *externaldns.Config) error {
+func validateConfigForAzure(cfg *externaldns.Config) field.ErrorList {
 	if cfg.AzureConfigFile == "" {
-		return errors.New("no Azure config file specified")
+		return field.ErrorList{field.Required(field.NewPath("azure-config-file"), "no Azure config file specified")}
 	}
 	return nil
 }
 
-func validateConfigForRfc2136(cfg *externaldns.Config) error {
+func validateConfigForRfc2136(cfg *externaldns.Config) field.ErrorList {
+	var errs field.ErrorList
 	if cfg.RFC2136MinTTL < 0 {
-		return errors.New("TTL specified for rfc2136 is negative")
+		errs = append(errs, field.Invalid(field.NewPath("rfc2136-min-ttl"), cfg.RFC2136MinTTL, "TTL specified for rfc2136 is negative"))
 	}
 	if cfg.RFC2136Insecure && cfg.RFC2136GSSTSIG {
-		return errors.New("--rfc2136-insecure and --rfc2136-gss-tsig are mutually exclusive arguments")
+		errs = append(errs, field.Invalid(field.NewPath("rfc2136-insecure"), cfg.RFC2136Insecure, "--rfc2136-insecure and --rfc2136-gss-tsig are mutually exclusive arguments"))
 	}
 	if cfg.RFC2136GSSTSIG {
 		if cfg.RFC2136KerberosPassword == "" || cfg.RFC2136KerberosUsername == "" || cfg.RFC2136KerberosRealm == "" {
-			return errors.New("--rfc2136-kerberos-realm, --rfc2136-kerberos-username, and --rfc2136-kerberos-password are required when specifying --rfc2136-gss-tsig option")
+			errs = append(errs, field.Required(field.NewPath("rfc2136-kerberos-realm"), "--rfc2136-kerberos-realm, --rfc2136-kerberos-username, and --rfc2136-kerberos-password are required when specifying --rfc2136-gss-tsig option"))
 		}
 	}
 	if cfg.RFC2136BatchChangeSize < 1 {
-		return errors.New("batch size specified for rfc2136 cannot be less than 1")
+		errs = append(errs, field.Invalid(field.NewPath("rfc2136-batch-change-size"), cfg.RFC2136BatchChangeSize, "batch size specified for rfc2136 cannot be less than 1"))
 	}
-	return nil
+	return errs
 }

--- a/pkg/apis/externaldns/validation/validation.go
+++ b/pkg/apis/externaldns/validation/validation.go
@@ -30,50 +30,78 @@ import (
 // ValidateConfig performs validation on the Config object
 func ValidateConfig(cfg *externaldns.Config) error {
 	// TODO: Should probably return field.ErrorList
-
-	if err := preValidateConfig(cfg); err != nil {
-		return err
+	validators := []func(*externaldns.Config) error{
+		preValidateConfig,
+		validateConfigForProvider,
+		validateHostnameConfig,
+		validateTXTRegistryConfig,
+		validateLabelSelectors,
+		validateAnnotationPrefix,
+		validateKubeAPILimits,
+		validatePTRConfig,
 	}
-
-	if err := validateConfigForProvider(cfg); err != nil {
-		return err
+	for _, validate := range validators {
+		if err := validate(cfg); err != nil {
+			return err
+		}
 	}
+	return nil
+}
 
+// validateHostnameConfig ensures an FQDN template is set when hostname annotations are ignored.
+func validateHostnameConfig(cfg *externaldns.Config) error {
 	if cfg.IgnoreHostnameAnnotation && len(cfg.FQDNTemplate) == 0 {
 		return errors.New("FQDN Template must be set if ignoring annotations")
 	}
+	return nil
+}
 
+// validateTXTRegistryConfig ensures the TXT registry prefix and suffix are not set together.
+func validateTXTRegistryConfig(cfg *externaldns.Config) error {
 	if len(cfg.TXTPrefix) > 0 && len(cfg.TXTSuffix) > 0 {
 		return errors.New("txt-prefix and txt-suffix are mutual exclusive")
 	}
+	return nil
+}
 
-	_, err := labels.Parse(cfg.LabelFilter)
-	if err != nil {
+// validateLabelSelectors ensures the label and annotation filters are valid selectors.
+func validateLabelSelectors(cfg *externaldns.Config) error {
+	if _, err := labels.Parse(cfg.LabelFilter); err != nil {
 		return errors.New("--label-filter does not specify a valid label selector")
 	}
-
 	if _, err := metav1.ParseToLabelSelector(cfg.AnnotationFilter); err != nil {
 		return errors.New("--annotation-filter does not specify a valid label selector")
 	}
+	return nil
+}
 
+// validateAnnotationPrefix ensures the annotation prefix is set and ends with a slash.
+func validateAnnotationPrefix(cfg *externaldns.Config) error {
 	if cfg.AnnotationPrefix == "" {
 		return errors.New("--annotation-prefix cannot be empty")
 	}
 	if !strings.HasSuffix(cfg.AnnotationPrefix, "/") {
 		return errors.New("--annotation-prefix must end with '/'")
 	}
+	return nil
+}
 
+// validateKubeAPILimits ensures the Kubernetes API QPS and burst limits are positive.
+func validateKubeAPILimits(cfg *externaldns.Config) error {
 	if cfg.KubeAPIQPS <= 0 {
 		return errors.New("--kube-api-qps must be greater than 0")
 	}
 	if cfg.KubeAPIBurst <= 0 {
 		return errors.New("--kube-api-burst must be greater than 0")
 	}
+	return nil
+}
 
+// validatePTRConfig ensures PTR is a managed record type when PTR creation is enabled.
+func validatePTRConfig(cfg *externaldns.Config) error {
 	if cfg.CreatePTR && !cfg.IsPTRSupported() {
 		return errors.New("--create-ptr requires PTR in --managed-record-types")
 	}
-
 	return nil
 }
 

--- a/pkg/apis/externaldns/validation/validation_test.go
+++ b/pkg/apis/externaldns/validation/validation_test.go
@@ -378,9 +378,9 @@ func TestValidateHostnameConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &externaldns.Config{IgnoreHostnameAnnotation: tt.ignoreAnnotation, FQDNTemplate: tt.fqdnTemplate}
 			if tt.wantErr {
-				require.Error(t, validateHostnameConfig(cfg))
+				require.NotEmpty(t, validateHostnameConfig(cfg))
 			} else {
-				require.NoError(t, validateHostnameConfig(cfg))
+				require.Empty(t, validateHostnameConfig(cfg))
 			}
 		})
 	}
@@ -402,9 +402,9 @@ func TestValidateTXTRegistryConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &externaldns.Config{TXTPrefix: tt.prefix, TXTSuffix: tt.suffix}
 			if tt.wantErr {
-				require.Error(t, validateTXTRegistryConfig(cfg))
+				require.NotEmpty(t, validateTXTRegistryConfig(cfg))
 			} else {
-				require.NoError(t, validateTXTRegistryConfig(cfg))
+				require.Empty(t, validateTXTRegistryConfig(cfg))
 			}
 		})
 	}
@@ -426,9 +426,9 @@ func TestValidateLabelSelectors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &externaldns.Config{LabelFilter: tt.labelFilter, AnnotationFilter: tt.annotationFilter}
 			if tt.wantErr {
-				require.Error(t, validateLabelSelectors(cfg))
+				require.NotEmpty(t, validateLabelSelectors(cfg))
 			} else {
-				require.NoError(t, validateLabelSelectors(cfg))
+				require.Empty(t, validateLabelSelectors(cfg))
 			}
 		})
 	}
@@ -448,9 +448,9 @@ func TestValidateAnnotationPrefix(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &externaldns.Config{AnnotationPrefix: tt.prefix}
 			if tt.wantErr {
-				require.Error(t, validateAnnotationPrefix(cfg))
+				require.NotEmpty(t, validateAnnotationPrefix(cfg))
 			} else {
-				require.NoError(t, validateAnnotationPrefix(cfg))
+				require.Empty(t, validateAnnotationPrefix(cfg))
 			}
 		})
 	}
@@ -473,9 +473,9 @@ func TestValidateKubeAPILimits(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &externaldns.Config{KubeAPIQPS: tt.qps, KubeAPIBurst: tt.burst}
 			if tt.wantErr {
-				require.Error(t, validateKubeAPILimits(cfg))
+				require.NotEmpty(t, validateKubeAPILimits(cfg))
 			} else {
-				require.NoError(t, validateKubeAPILimits(cfg))
+				require.Empty(t, validateKubeAPILimits(cfg))
 			}
 		})
 	}
@@ -485,17 +485,17 @@ func TestValidatePTRConfig(t *testing.T) {
 	t.Run("create-ptr disabled", func(t *testing.T) {
 		cfg := newValidConfig(t)
 		cfg.CreatePTR = false
-		require.NoError(t, validatePTRConfig(cfg))
+		require.Empty(t, validatePTRConfig(cfg))
 	})
 	t.Run("create-ptr without PTR managed", func(t *testing.T) {
 		cfg := newValidConfig(t)
 		cfg.CreatePTR = true
-		require.Error(t, validatePTRConfig(cfg))
+		require.NotEmpty(t, validatePTRConfig(cfg))
 	})
 	t.Run("create-ptr with PTR managed", func(t *testing.T) {
 		cfg := newValidConfig(t)
 		cfg.CreatePTR = true
 		cfg.ManagedDNSRecordTypes = append(cfg.ManagedDNSRecordTypes, "PTR")
-		require.NoError(t, validatePTRConfig(cfg))
+		require.Empty(t, validatePTRConfig(cfg))
 	})
 }

--- a/pkg/apis/externaldns/validation/validation_test.go
+++ b/pkg/apis/externaldns/validation/validation_test.go
@@ -362,3 +362,140 @@ func TestValidateCreatePTRWithPTRManagedPasses(t *testing.T) {
 	err := ValidateConfig(cfg)
 	assert.NoError(t, err)
 }
+
+func TestValidateHostnameConfig(t *testing.T) {
+	tests := []struct {
+		name             string
+		ignoreAnnotation bool
+		fqdnTemplate     []string
+		wantErr          bool
+	}{
+		{"not ignoring annotations", false, nil, false},
+		{"ignoring annotations with template", true, []string{"{{.Name}}"}, false},
+		{"ignoring annotations without template", true, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &externaldns.Config{IgnoreHostnameAnnotation: tt.ignoreAnnotation, FQDNTemplate: tt.fqdnTemplate}
+			if tt.wantErr {
+				require.Error(t, validateHostnameConfig(cfg))
+			} else {
+				require.NoError(t, validateHostnameConfig(cfg))
+			}
+		})
+	}
+}
+
+func TestValidateTXTRegistryConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		prefix  string
+		suffix  string
+		wantErr bool
+	}{
+		{"neither set", "", "", false},
+		{"prefix only", "pre-", "", false},
+		{"suffix only", "", "-suf", false},
+		{"both set", "pre-", "-suf", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &externaldns.Config{TXTPrefix: tt.prefix, TXTSuffix: tt.suffix}
+			if tt.wantErr {
+				require.Error(t, validateTXTRegistryConfig(cfg))
+			} else {
+				require.NoError(t, validateTXTRegistryConfig(cfg))
+			}
+		})
+	}
+}
+
+func TestValidateLabelSelectors(t *testing.T) {
+	tests := []struct {
+		name             string
+		labelFilter      string
+		annotationFilter string
+		wantErr          bool
+	}{
+		{"both empty", "", "", false},
+		{"valid label filter", "foo=bar", "", false},
+		{"invalid label filter", "#invalid-selector", "", true},
+		{"invalid annotation filter", "", "kubernetes.io/gateway.name in (a b)", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &externaldns.Config{LabelFilter: tt.labelFilter, AnnotationFilter: tt.annotationFilter}
+			if tt.wantErr {
+				require.Error(t, validateLabelSelectors(cfg))
+			} else {
+				require.NoError(t, validateLabelSelectors(cfg))
+			}
+		})
+	}
+}
+
+func TestValidateAnnotationPrefix(t *testing.T) {
+	tests := []struct {
+		name    string
+		prefix  string
+		wantErr bool
+	}{
+		{"valid", "external-dns.kubernetes.io/", false},
+		{"empty", "", true},
+		{"missing trailing slash", "custom.io", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &externaldns.Config{AnnotationPrefix: tt.prefix}
+			if tt.wantErr {
+				require.Error(t, validateAnnotationPrefix(cfg))
+			} else {
+				require.NoError(t, validateAnnotationPrefix(cfg))
+			}
+		})
+	}
+}
+
+func TestValidateKubeAPILimits(t *testing.T) {
+	tests := []struct {
+		name    string
+		qps     int
+		burst   int
+		wantErr bool
+	}{
+		{"valid", 5, 10, false},
+		{"zero qps", 0, 10, true},
+		{"negative qps", -1, 10, true},
+		{"zero burst", 5, 0, true},
+		{"negative burst", 5, -1, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &externaldns.Config{KubeAPIQPS: tt.qps, KubeAPIBurst: tt.burst}
+			if tt.wantErr {
+				require.Error(t, validateKubeAPILimits(cfg))
+			} else {
+				require.NoError(t, validateKubeAPILimits(cfg))
+			}
+		})
+	}
+}
+
+func TestValidatePTRConfig(t *testing.T) {
+	t.Run("create-ptr disabled", func(t *testing.T) {
+		cfg := newValidConfig(t)
+		cfg.CreatePTR = false
+		require.NoError(t, validatePTRConfig(cfg))
+	})
+	t.Run("create-ptr without PTR managed", func(t *testing.T) {
+		cfg := newValidConfig(t)
+		cfg.CreatePTR = true
+		require.Error(t, validatePTRConfig(cfg))
+	})
+	t.Run("create-ptr with PTR managed", func(t *testing.T) {
+		cfg := newValidConfig(t)
+		cfg.CreatePTR = true
+		cfg.ManagedDNSRecordTypes = append(cfg.ManagedDNSRecordTypes, "PTR")
+		require.NoError(t, validatePTRConfig(cfg))
+	})
+}


### PR DESCRIPTION
## What does it do ?

Decomposes `ValidateConfig` in `pkg/apis/externaldns/validation` into a slice of small, single-purpose validators run in order (`validateHostnameConfig`, `validateTXTRegistryConfig`, `validateLabelSelectors`, `validateAnnotationPrefix`, `validateKubeAPILimits`, `validatePTRConfig`). This drops `ValidateConfig` to a cyclomatic complexity of ~3 (`gocyclo`), below every other function in the file. Validation order and error messages are unchanged, and I added table-driven unit tests for each extracted validator.

## Motivation

Part of #5419. `ValidateConfig` is one of the functions listed there. The "slice function" approach the issue suggests keeps each check small and independently testable, and makes it easier to lower the `cyclop` threshold further as the remaining functions are addressed. I left `.golangci.yml`'s `max-complexity` untouched so this change can't regress CI on its own.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly — n/a, internal refactor with no user-facing change
