### PR TITLE
fix(rfc2136): clear stale AXFR errors after fallback

### DIFF
--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -304,6 +304,8 @@ func (r *rfc2136Provider) List() ([]dns.RR, error) {
 				r.lastErr = lastErr
 				continue
 			}
+			lastErr = nil
+			r.lastErr = nil
 
 			for e := range env {
 				if e.Error != nil {

--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -300,12 +300,10 @@ func (r *rfc2136Provider) List() ([]dns.RR, error) {
 
 			env, err := r.actions.IncomeTransfer(m, nameserver)
 			if err != nil {
-				lastErr = fmt.Errorf("failed to fetch records via AXFR: %w", err)
-				r.lastErr = lastErr
+				lastErr = r.setLastErr(fmt.Errorf("failed to fetch records via AXFR: %w", err))
 				continue
 			}
-			lastErr = nil
-			r.lastErr = nil
+			lastErr = r.setLastErr(nil)
 
 			for e := range env {
 				if e.Error != nil {
@@ -325,8 +323,7 @@ func (r *rfc2136Provider) List() ([]dns.RR, error) {
 		}
 
 		if lastErr != nil {
-			r.lastErr = lastErr
-			return nil, provider.NewSoftError(lastErr)
+			return nil, provider.NewSoftError(r.setLastErr(lastErr))
 		}
 	}
 
@@ -497,6 +494,15 @@ func (r *rfc2136Provider) RemoveRecord(m *dns.Msg, ep *endpoint.Endpoint) error 
 	return nil
 }
 
+// setLastErr keeps the provider-level error state in sync with the retry
+// loops in List and SendMessage; getNextNameserver reads it to decide
+// failover, so a nil must be recorded once an attempt succeeds. It returns
+// err unchanged so callers can chain it.
+func (r *rfc2136Provider) setLastErr(err error) error {
+	r.lastErr = err
+	return err
+}
+
 func (r *rfc2136Provider) getNextNameserver() string {
 	if len(r.nameservers) == 1 {
 		return r.nameservers[0]
@@ -551,8 +557,7 @@ func (r *rfc2136Provider) SendMessage(msg *dns.Msg) error {
 
 		c, err := makeClient(r, nameserver)
 		if err != nil {
-			lastErr = fmt.Errorf("error setting up TLS: %w", err)
-			r.lastErr = lastErr
+			lastErr = r.setLastErr(fmt.Errorf("error setting up TLS: %w", err))
 			continue
 		}
 
@@ -560,8 +565,7 @@ func (r *rfc2136Provider) SendMessage(msg *dns.Msg) error {
 			if r.gssTsig {
 				keyName, handle, err := r.KeyData(nameserver)
 				if err != nil {
-					lastErr = err
-					r.lastErr = lastErr
+					lastErr = r.setLastErr(err)
 					continue
 				}
 				defer handle.Close()
@@ -580,28 +584,24 @@ func (r *rfc2136Provider) SendMessage(msg *dns.Msg) error {
 		if err != nil {
 			if resp != nil && resp.Rcode != dns.RcodeSuccess {
 				log.Infof("error in dns.Client.Exchange: %s", err)
-				lastErr = err
-				r.lastErr = lastErr
+				lastErr = r.setLastErr(err)
 				continue
 			}
 			log.Warnf("warn in dns.Client.Exchange: %s", err)
-			lastErr = err
-			r.lastErr = lastErr
+			lastErr = r.setLastErr(err)
 			continue
 		}
 		if resp != nil && resp.Rcode != dns.RcodeSuccess {
 			log.Infof("Bad dns.Client.Exchange response: %s", resp)
-			lastErr = fmt.Errorf("bad return code: %s", dns.RcodeToString[resp.Rcode])
-			r.lastErr = lastErr
+			lastErr = r.setLastErr(fmt.Errorf("bad return code: %s", dns.RcodeToString[resp.Rcode]))
 			continue
 		}
 
 		log.Debugf("SendMessage.success")
-		return nil
+		return r.setLastErr(nil)
 	}
 
-	r.lastErr = lastErr
-	return provider.NewSoftError(lastErr)
+	return provider.NewSoftError(r.setLastErr(lastErr))
 }
 
 func chunkBy(slice []*endpoint.Endpoint, chunkSize int) [][]*endpoint.Endpoint {

--- a/provider/rfc2136/rfc2136_test.go
+++ b/provider/rfc2136/rfc2136_test.go
@@ -42,6 +42,7 @@ type rfc2136Stub struct {
 	output                []*dns.Envelope
 	updateMsgs            []*dns.Msg
 	createMsgs            []*dns.Msg
+	incomeTransferErrors  map[string]error
 	nameservers           []string
 	counter               int
 	randGen               *rand.Rand
@@ -148,7 +149,11 @@ func (r *rfc2136Stub) setOutput(output []string) error {
 	return nil
 }
 
-func (r *rfc2136Stub) IncomeTransfer(m *dns.Msg, _ string) (chan *dns.Envelope, error) {
+func (r *rfc2136Stub) IncomeTransfer(m *dns.Msg, nameserver string) (chan *dns.Envelope, error) {
+	if err, ok := r.incomeTransferErrors[nameserver]; ok {
+		return nil, err
+	}
+
 	outChan := make(chan *dns.Envelope)
 	go func() {
 		for _, e := range r.output {
@@ -551,6 +556,22 @@ func TestRfc2136GetRecords(t *testing.T) {
 	assert.True(t, contains(recs, "v1.foo.com"))
 	assert.True(t, contains(recs, "v2.bar.com"))
 	assert.True(t, contains(recs, "v2.foo.com"))
+}
+
+func TestRfc2136GetRecordsClearsErrorAfterSuccessfulFallback(t *testing.T) {
+	stub := newStub()
+	stub.incomeTransferErrors = map[string]error{
+		"rfc2136-host1:0": assert.AnError,
+	}
+	require.NoError(t, stub.setOutput([]string{"foo.com 3600 IN A 192.0.2.1"}))
+
+	p, err := createRfc2136StubProviderWithHosts(stub)
+	require.NoError(t, err)
+
+	recs, err := p.Records(t.Context())
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	assert.Equal(t, "foo.com", recs[0].DNSName)
 }
 
 // Make sure the test version of SendMessage raises an error

--- a/provider/rfc2136/rfc2136_test.go
+++ b/provider/rfc2136/rfc2136_test.go
@@ -20,11 +20,13 @@ import (
 	"crypto/tls"
 	"fmt"
 	"math/rand"
+	"net"
 	"os"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -572,6 +574,67 @@ func TestRfc2136GetRecordsClearsErrorAfterSuccessfulFallback(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
 	assert.Equal(t, "foo.com", recs[0].DNSName)
+}
+
+// runLocalDNSServer starts an in-process DNS server on a random local TCP
+// port and answers every query with the rcode returned by rcodeFn.
+func runLocalDNSServer(t *testing.T, rcodeFn func() int) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := &dns.Server{
+		Listener: l,
+		Handler: dns.HandlerFunc(func(w dns.ResponseWriter, m *dns.Msg) {
+			resp := new(dns.Msg)
+			resp.SetRcode(m, rcodeFn())
+			_ = w.WriteMsg(resp)
+		}),
+		// The default accept func rejects dynamic updates with NOTIMP
+		// before they ever reach the handler.
+		MsgAcceptFunc: func(dns.Header) dns.MsgAcceptAction { return dns.MsgAccept },
+	}
+	go func() { _ = srv.ActivateAndServe() }()
+	t.Cleanup(func() { _ = srv.Shutdown() })
+	return l.Addr().String()
+}
+
+// With a single nameserver getNextNameserver returns early and never resets
+// lastErr, so only SendMessage itself can clear it after a success.
+func TestRfc2136SendMessageClearsErrorAfterSuccess(t *testing.T) {
+	var rcode atomic.Int32
+	rcode.Store(int32(dns.RcodeServerFailure))
+	addr := runLocalDNSServer(t, func() int { return int(rcode.Load()) })
+
+	p := &rfc2136Provider{
+		nameservers: []string{addr},
+		insecure:    true,
+	}
+
+	m := new(dns.Msg)
+	m.SetUpdate("foo.com.")
+
+	require.Error(t, p.SendMessage(m))
+	require.Error(t, p.lastErr)
+
+	rcode.Store(int32(dns.RcodeSuccess))
+	require.NoError(t, p.SendMessage(m))
+	assert.NoError(t, p.lastErr)
+}
+
+func TestRfc2136SendMessageClearsErrorAfterSuccessfulFallback(t *testing.T) {
+	failAddr := runLocalDNSServer(t, func() int { return dns.RcodeServerFailure })
+	okAddr := runLocalDNSServer(t, func() int { return dns.RcodeSuccess })
+
+	p := &rfc2136Provider{
+		nameservers: []string{failAddr, okAddr},
+		insecure:    true,
+	}
+
+	m := new(dns.Msg)
+	m.SetUpdate("foo.com.")
+
+	require.NoError(t, p.SendMessage(m))
+	assert.NoError(t, p.lastErr)
 }
 
 // Make sure the test version of SendMessage raises an error


### PR DESCRIPTION
## What does it do ?

Clears both the local retry error and provider error state after a fallback RFC2136 nameserver accepts an AXFR transfer. This prevents a failed first attempt from turning a successful fallback into a stale `SoftError`.

A deterministic unit test now fails the first nameserver transfer and verifies that records from the next nameserver are returned without an error.

## Motivation

Fixes #6561.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] End-user documentation is not required because no configuration or public API changes

Validation:

- `go test ./provider/rfc2136 -run '^TestRfc2136GetRecordsClearsErrorAfterSuccessfulFallback$' -count=1`
- RFC2136 non-TLS package tests (16 tests)
- `golangci-lint 2.11.4 run --timeout=10m ./provider/rfc2136/...` (`0 issues`)