### PR TITLE
docs(aws): correct hosted zone annotation prefix

### DIFF
--- a/docs/annotations/annotations.md
+++ b/docs/annotations/annotations.md
@@ -378,10 +378,10 @@ metadata:
   name: my-app
   namespace: default
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: app.example.com
-    external-dns.alpha.kubernetes.io/target: ipv4-only-target.example.com
+    external-dns.kubernetes.io/hostname: app.example.com
+    external-dns.kubernetes.io/target: ipv4-only-target.example.com
     # Create only an A (IPv4) alias record to avoid creating an AAAA alias record for an IPv4-only target.
-    external-dns.alpha.kubernetes.io/alias: "A"
+    external-dns.kubernetes.io/alias: "A"
 spec:
   type: LoadBalancer
   ports:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -172,13 +172,13 @@ remaining source on the next reconcile, with no manual record deletion required.
 Be aware that a source may produce a hostname from more than one place, so
 removing a single field is not always enough. An `ingress`, for example, emits a
 hostname from both `spec.rules[].host` and the
-`external-dns.alpha.kubernetes.io/hostname` annotation, and by default returns
+`external-dns.kubernetes.io/hostname` annotation, and by default returns
 the union of the two. Commenting out the annotation alone does not help if the
 host is still listed under `spec.rules`. To stop an Ingress from claiming
 `test1.example.com`, do one of:
 
 - remove `test1.example.com` from `spec.rules[].host`;
-- set `external-dns.alpha.kubernetes.io/ingress-hostname-source: annotation-only`
+- set `external-dns.kubernetes.io/ingress-hostname-source: annotation-only`
   so only the annotation is read (then remove the annotation), or
   `defined-hosts-only` so only `spec.rules` is read; or
 - delete the Ingress.

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -777,12 +777,12 @@ Note: The `A` and `AAAA` values are currently only supported by the AWS Route53 
 
 ### hosted-zone-id
 
-`external-dns.alpha.kubernetes.io/aws-hosted-zone-id` pins a record to a specific Route53 hosted zone by ID. Use when overlapping zones share the same name (e.g. public + private `a.my.com`). If the pinned zone is not configured, the record is skipped.
+`external-dns.kubernetes.io/aws-hosted-zone-id` pins a record to a specific Route53 hosted zone by ID. Use when overlapping zones share the same name (e.g. public + private `a.my.com`). If the pinned zone is not configured, the record is skipped.
 
 ```yaml
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/aws-hosted-zone-id: "Z1234567890ABC"
+    external-dns.kubernetes.io/aws-hosted-zone-id: "Z1234567890ABC"
 ```
 
 ### aws-zone-match-parent


### PR DESCRIPTION
## What does it do ?

Fixes the AWS hosted zone pin example. It now uses the default annotation prefix.

## Motivation

The old alpha key is ignored by default, so overlapping zones still get every matching record

Repro: copy the old snippet to a Service or Ingress with same-name Route53 zones

Related: #6558

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly