### PR TITLE
fix(txt-registry): copy owned record TTL to ownership TXT records

### DIFF
--- a/registry/txt/registry.go
+++ b/registry/txt/registry.go
@@ -341,7 +341,8 @@ func (im *TXTRegistry) generateTXTRecordWithFilter(r *endpoint.Endpoint, filter 
 		r.Labels[endpoint.OwnerLabelKey] = im.ownerID
 	}
 
-	txtNew := endpoint.NewEndpoint(im.mapper.ToTXTName(r.DNSName, recordType), endpoint.RecordTypeTXT, r.Labels.Serialize(true, im.txtEncryptEnabled, im.txtEncryptAESKey))
+	// Preserve the owned record TTL so ownership TXT records match provider/zone TTL expectations.
+	txtNew := endpoint.NewEndpointWithTTL(im.mapper.ToTXTName(r.DNSName, recordType), endpoint.RecordTypeTXT, r.RecordTTL, r.Labels.Serialize(true, im.txtEncryptEnabled, im.txtEncryptAESKey))
 	if txtNew != nil {
 		txtNew.WithSetIdentifier(r.SetIdentifier)
 		txtNew.Labels[endpoint.OwnedRecordLabelKey] = r.DNSName

--- a/registry/txt/registry_test.go
+++ b/registry/txt/registry_test.go
@@ -1528,6 +1528,28 @@ func TestGenerateTXT(t *testing.T) {
 	assert.Equal(t, expectedTXT, gotTXT)
 }
 
+func TestGenerateTXTCopiesRecordTTL(t *testing.T) {
+	record := newEndpointWithOwner("foo.test-zone.example.org", "new-foo.loadbalancer.com", endpoint.RecordTypeCNAME, "owner")
+	record.RecordTTL = 600
+	expectedTXT := []*endpoint.Endpoint{
+		{
+			DNSName:    "cname-foo.test-zone.example.org",
+			Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=owner\""},
+			RecordType: endpoint.RecordTypeTXT,
+			RecordTTL:  600,
+			Labels: map[string]string{
+				endpoint.OwnedRecordLabelKey: "foo.test-zone.example.org",
+			},
+		},
+	}
+	p := inmemory.NewInMemoryProvider()
+	err := p.CreateZone(testZone)
+	require.NoError(t, err)
+	r, _ := newRegistry(p, "", "", "owner", time.Hour, "", []string{}, []string{}, false, nil, "")
+	gotTXT := r.generateTXTRecord(record)
+	assert.Equal(t, expectedTXT, gotTXT)
+}
+
 func TestGenerateTXTWithMigration(t *testing.T) {
 	record := newEndpointWithOwner("foo.test-zone.example.org", "1.2.3.4", endpoint.RecordTypeA, "owner")
 	expectedTXTBeforeMigration := []*endpoint.Endpoint{


### PR DESCRIPTION
## Summary
- Ownership TXT records created by the TXT registry always used TTL 0 (`NewEndpoint`), so providers published them without the owned record's configured TTL (visible in OVH debug logs on kubernetes-sigs/external-dns#6088 where SRV had TTL 600 and the companion TXT had TTL 0).
- `generateTXTRecordWithFilter` now uses `NewEndpointWithTTL` with the owned endpoint's `RecordTTL`.
- Adds a unit test covering TTL propagation.

## Test plan
- [x] `go test ./registry/txt/ -run 'TestGenerateTXT|TestGenerateTXTCopiesRecordTTL|TestGenerateTXTForAAAA|TestGenerateTXTWithMigration'`
- [ ] Confirm with a provider that surfaces TTL in create logs (e.g. OVH) that ownership TXT TTL matches the owned record TTL
