### PR TITLE
docs(external-dns chart): fix typo in values README (Eample -> Example)

### DIFF
--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -207,7 +207,7 @@ extraArgs:
   - --zone-id-filter=/hostedzone/Z00003
 ```
 
-Eample map: (supported values for map are strings, list of strings, and boolean)
+Example map: (supported values for map are strings, list of strings, and boolean)
 
 ```yaml
 extraArgs:

--- a/charts/external-dns/README.md.gotmpl
+++ b/charts/external-dns/README.md.gotmpl
@@ -103,7 +103,7 @@ extraArgs:
   - --zone-id-filter=/hostedzone/Z00003
 ```
 
-Eample map: (supported values for map are strings, list of strings, and boolean)
+Example map: (supported values for map are strings, list of strings, and boolean)
 
 ```yaml
 extraArgs:


### PR DESCRIPTION
### Description

Fixes a small spelling error in the external-dns Helm chart values documentation: `Eample map:` → `Example map:`.

The change is made in the helm-docs source template `charts/external-dns/README.md.gotmpl` and mirrored into the generated `charts/external-dns/README.md`, so the two stay in sync and the helm-docs CI check passes.

Documentation-only; no chart behavior, values, or schema changes. I did not bump the chart version or add a CHANGELOG entry since this is a docs typo — happy to add either if the maintainers prefer.

```release-note
NONE
```