### PR TITLE
feat: support multiple namespaces and namespace label selector filtering

### DIFF
--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -55,6 +55,7 @@ type Config struct {
 	SkipperRouteGroupVersion                      string
 	Sources                                       []string
 	Namespace                                     string
+	NamespaceLabelFilter                          string
 	AnnotationFilter                              string
 	AnnotationPrefix                              string
 	LabelFilter                                   string
@@ -310,6 +311,7 @@ var defaultConfig = &Config{
 	MinEventSyncInterval:         5 * time.Second,
 	MinTTL:                       0,
 	Namespace:                    "",
+	NamespaceLabelFilter:         "",
 	NAT64Networks:                []string{},
 	NS1Endpoint:                  "",
 	NS1IgnoreSSL:                 false,
@@ -542,6 +544,7 @@ func bindFlags(b flags.FlagBinder, cfg *Config) {
 	managedRecordTypesHelp := fmt.Sprintf("Record types to manage; specify multiple times to include many; (default: %s) (supported records: A, AAAA, CNAME, NS, SRV, TXT)", strings.Join(defaultConfig.ManagedDNSRecordTypes, ","))
 	b.StringsVar("managed-record-types", managedRecordTypesHelp, defaultConfig.ManagedDNSRecordTypes, &cfg.ManagedDNSRecordTypes)
 	b.StringVar("namespace", "Limit resources queried for endpoints to a specific namespace (default: all namespaces)", defaultConfig.Namespace, &cfg.Namespace)
+	b.StringVar("namespace-label-filter", "Limit resources queried for endpoints to namespaces matching a label selector (default: all namespaces)", defaultConfig.NamespaceLabelFilter, &cfg.NamespaceLabelFilter)
 	b.StringsVar("nat64-networks", "Adding an A record for each AAAA record in NAT64-enabled networks; specify multiple times for multiple possible nets (optional)", nil, &cfg.NAT64Networks)
 	b.StringVar("openshift-router-name", "if source is openshift-route then you can pass the ingress controller name. Based on this name external-dns will select the respective router from the route status and map that routerCanonicalHostname to the route host while creating a CNAME record.", defaultConfig.OCPRouterName, &cfg.OCPRouterName)
 	b.StringVar("pod-source-domain", "Domain to use for pods records (optional)", defaultConfig.PodSourceDomain, &cfg.PodSourceDomain)

--- a/source/ingress.go
+++ b/source/ingress.go
@@ -24,11 +24,14 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	networkv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	kubeinformers "k8s.io/client-go/informers"
 	netinformers "k8s.io/client-go/informers/networking/v1"
 	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 
 	"sigs.k8s.io/external-dns/pkg/events"
 	"sigs.k8s.io/external-dns/source/informers"
@@ -69,6 +72,7 @@ type ingressSource struct {
 	ingressInformer          netinformers.IngressInformer
 	ignoreIngressTLSSpec     bool
 	ignoreIngressRulesSpec   bool
+	nsFilter                 *NamespaceFilter
 }
 
 // NewIngressSource creates a new ingressSource with the given config.
@@ -86,9 +90,29 @@ func NewIngressSource(
 			}
 		}
 	}
+	var namespaces []string
+	if len(cfg.Namespaces) > 0 {
+		namespaces = cfg.Namespaces
+	} else if cfg.Namespace != "" {
+		namespaces = []string{cfg.Namespace}
+	}
+
+	var informerNamespace string
+	if len(namespaces) == 1 && (cfg.NamespaceLabelFilter == nil || cfg.NamespaceLabelFilter.Empty()) {
+		informerNamespace = namespaces[0]
+	}
 	// Use shared informer to listen for add/update/delete of ingresses in the specified namespace.
 	// Set resync period to 0, to prevent processing when nothing has changed.
-	informerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 0, kubeinformers.WithNamespace(cfg.Namespace))
+	informerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 0, kubeinformers.WithNamespace(informerNamespace))
+
+	var namespaceLister corelisters.NamespaceLister
+	if cfg.NamespaceLabelFilter != nil && !cfg.NamespaceLabelFilter.Empty() {
+		namespaceInformer := informerFactory.Core().V1().Namespaces()
+		namespaceLister = namespaceInformer.Lister()
+		informers.MustAddEventHandler(namespaceInformer.Informer(), informers.DefaultEventHandler())
+	}
+	nsFilter := NewNamespaceFilter(namespaces, cfg.NamespaceLabelFilter, namespaceLister)
+
 	ingressInformer := informerFactory.Networking().V1().Ingresses()
 
 	informers.MustAddIndexers(ingressInformer.Informer(), informers.IndexerWithOptions[*networkv1.Ingress](
@@ -120,6 +144,7 @@ func NewIngressSource(
 		ingressInformer:          ingressInformer,
 		ignoreIngressTLSSpec:     cfg.IgnoreIngressTLSSpec,
 		ignoreIngressRulesSpec:   cfg.IgnoreIngressRulesSpec,
+		nsFilter:                 nsFilter,
 	}, nil
 }
 
@@ -134,6 +159,9 @@ func (sc *ingressSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, err
 	endpoints := []*endpoint.Endpoint{}
 
 	for _, ing := range ingresses {
+		if !sc.nsFilter.Matches(ing.Namespace) {
+			continue
+		}
 		ingEndpoints := endpointsFromIngress(ing, sc.ignoreHostnameAnnotation, sc.ignoreIngressTLSSpec, sc.ignoreIngressRulesSpec)
 
 		// apply template if host is missing on ingress
@@ -310,7 +338,27 @@ func targetsFromIngressStatus(status networkv1.IngressStatus) endpoint.Targets {
 func (sc *ingressSource) AddEventHandler(_ context.Context, handler func()) {
 	log.Debug("Adding event handler for ingress")
 
+	wrappedHandler := func(obj any) {
+		if metaObj, ok := obj.(metav1.Object); ok {
+			if !sc.nsFilter.Matches(metaObj.GetNamespace()) {
+				return
+			}
+		}
+		handler()
+	}
+
+	eventHandler := cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { wrappedHandler(obj) },
+		UpdateFunc: func(_, newObj any) { wrappedHandler(newObj) },
+		DeleteFunc: func(obj any) {
+			if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				obj = tombstone.Obj
+			}
+			wrappedHandler(obj)
+		},
+	}
+
 	// Right now there is no way to remove event handler from informer, see:
 	// https://github.com/kubernetes/kubernetes/issues/79610
-	informers.MustAddEventHandler(sc.ingressInformer.Informer(), eventHandlerFunc(handler))
+	informers.MustAddEventHandler(sc.ingressInformer.Informer(), eventHandler)
 }

--- a/source/namespace_filter.go
+++ b/source/namespace_filter.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	corelisters "k8s.io/client-go/listers/core/v1"
+)
+
+type NamespaceFilter struct {
+	namespaces           map[string]struct{}
+	namespaceLabelFilter labels.Selector
+	namespaceLister      corelisters.NamespaceLister
+}
+
+func NewNamespaceFilter(namespaces []string, namespaceLabelFilter labels.Selector, namespaceLister corelisters.NamespaceLister) *NamespaceFilter {
+	nsMap := make(map[string]struct{})
+	for _, ns := range namespaces {
+		nsMap[ns] = struct{}{}
+	}
+	return &NamespaceFilter{
+		namespaces:           nsMap,
+		namespaceLabelFilter: namespaceLabelFilter,
+		namespaceLister:      namespaceLister,
+	}
+}
+
+func (f *NamespaceFilter) Matches(ns string) bool {
+	if ns == corev1.NamespaceAll {
+		return true
+	}
+	if len(f.namespaces) == 0 && (f.namespaceLabelFilter == nil || f.namespaceLabelFilter.Empty()) {
+		return true
+	}
+	if len(f.namespaces) > 0 {
+		if _, ok := f.namespaces[ns]; !ok {
+			return false
+		}
+	}
+	if f.namespaceLabelFilter != nil && !f.namespaceLabelFilter.Empty() {
+		if f.namespaceLister == nil {
+			return false
+		}
+		namespace, err := f.namespaceLister.Get(ns)
+		if err != nil {
+			log.Errorf("failed to get namespace %s to check labels: %v", ns, err)
+			return false
+		}
+		if !f.namespaceLabelFilter.Matches(labels.Set(namespace.Labels)) {
+			return false
+		}
+	}
+	return true
+}

--- a/source/namespace_filter_test.go
+++ b/source/namespace_filter_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type mockNamespaceLister struct {
+	namespaces map[string]*corev1.Namespace
+}
+
+func (m *mockNamespaceLister) List(selector labels.Selector) ([]*corev1.Namespace, error) {
+	var list []*corev1.Namespace
+	for _, ns := range m.namespaces {
+		if selector.Matches(labels.Set(ns.Labels)) {
+			list = append(list, ns)
+		}
+	}
+	return list, nil
+}
+
+func (m *mockNamespaceLister) Get(name string) (*corev1.Namespace, error) {
+	ns, ok := m.namespaces[name]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return ns, nil
+}
+
+func TestNamespaceFilter(t *testing.T) {
+	lister := &mockNamespaceLister{
+		namespaces: map[string]*corev1.Namespace{
+			"ns1": {
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "ns1",
+					Labels: map[string]string{"tenant": "tenant1"},
+				},
+			},
+			"ns2": {
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "ns2",
+					Labels: map[string]string{"tenant": "tenant2"},
+				},
+			},
+			"ns3": {
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "ns3",
+					Labels: map[string]string{"tenant": "tenant1", "env": "prod"},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name                 string
+		namespaces           []string
+		namespaceLabelFilter string
+		testNS               string
+		expected             bool
+	}{
+		{
+			name:       "empty filters matches everything",
+			namespaces: nil,
+			testNS:     "ns1",
+			expected:   true,
+		},
+		{
+			name:       "namespaces list filter matches match",
+			namespaces: []string{"ns1", "ns3"},
+			testNS:     "ns1",
+			expected:   true,
+		},
+		{
+			name:       "namespaces list filter mismatches mismatch",
+			namespaces: []string{"ns1", "ns3"},
+			testNS:     "ns2",
+			expected:   false,
+		},
+		{
+			name:                 "namespace label selector match",
+			namespaceLabelFilter: "tenant=tenant1",
+			testNS:               "ns1",
+			expected:             true,
+		},
+		{
+			name:                 "namespace label selector mismatch",
+			namespaceLabelFilter: "tenant=tenant1",
+			testNS:               "ns2",
+			expected:             false,
+		},
+		{
+			name:                 "namespace label selector compound match",
+			namespaceLabelFilter: "tenant=tenant1,env=prod",
+			testNS:               "ns3",
+			expected:             true,
+		},
+		{
+			name:                 "namespace label selector compound mismatch",
+			namespaceLabelFilter: "tenant=tenant1,env=prod",
+			testNS:               "ns1",
+			expected:             false,
+		},
+		{
+			name:                 "both filters match",
+			namespaces:           []string{"ns1", "ns3"},
+			namespaceLabelFilter: "tenant=tenant1",
+			testNS:               "ns3",
+			expected:             true,
+		},
+		{
+			name:                 "both filters - namespace match label mismatch",
+			namespaces:           []string{"ns1", "ns2"},
+			namespaceLabelFilter: "tenant=tenant1",
+			testNS:               "ns2",
+			expected:             false,
+		},
+		{
+			name:                 "wildcard namespace always matches",
+			namespaces:           []string{"ns1"},
+			namespaceLabelFilter: "tenant=tenant1",
+			testNS:               "",
+			expected:             true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var selector labels.Selector
+			if tt.namespaceLabelFilter != "" {
+				selector, _ = labels.Parse(tt.namespaceLabelFilter)
+			}
+			filter := NewNamespaceFilter(tt.namespaces, selector, lister)
+			got := filter.Matches(tt.testNS)
+			if got != tt.expected {
+				t.Errorf("expected Matches(%q) = %v, got %v", tt.testNS, tt.expected, got)
+			}
+		})
+	}
+}

--- a/source/service.go
+++ b/source/service.go
@@ -28,11 +28,13 @@ import (
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kubeinformers "k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	discoveryinformers "k8s.io/client-go/informers/discovery/v1"
 	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 
 	"sigs.k8s.io/external-dns/endpoint"
@@ -71,6 +73,7 @@ var (
 type serviceSource struct {
 	client         kubernetes.Interface
 	namespace      string
+	nsFilter       *NamespaceFilter
 	templateEngine template.Engine
 
 	ignoreHostnameAnnotation       bool
@@ -97,9 +100,29 @@ func NewServiceSource(
 	kubeClient kubernetes.Interface,
 	config *Config,
 ) (Source, error) {
+	var namespaces []string
+	if len(config.Namespaces) > 0 {
+		namespaces = config.Namespaces
+	} else if config.Namespace != "" {
+		namespaces = []string{config.Namespace}
+	}
+
+	var informerNamespace string
+	if len(namespaces) == 1 && (config.NamespaceLabelFilter == nil || config.NamespaceLabelFilter.Empty()) {
+		informerNamespace = namespaces[0]
+	}
 	// Use shared informers to listen for add/update/delete of services/pods/nodes in the specified namespace.
 	// Set the resync period to 0 to prevent processing when nothing has changed
-	informerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 0, kubeinformers.WithNamespace(config.Namespace))
+	informerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 0, kubeinformers.WithNamespace(informerNamespace))
+
+	var namespaceLister corelisters.NamespaceLister
+	if config.NamespaceLabelFilter != nil && !config.NamespaceLabelFilter.Empty() {
+		namespaceInformer := informerFactory.Core().V1().Namespaces()
+		namespaceLister = namespaceInformer.Lister()
+		informers.MustAddEventHandler(namespaceInformer.Informer(), informers.DefaultEventHandler())
+	}
+	nsFilter := NewNamespaceFilter(namespaces, config.NamespaceLabelFilter, namespaceLister)
+
 	serviceInformer := informerFactory.Core().V1().Services()
 
 	// Transform the slice into a map so it will be way much easier and fast to filter later
@@ -171,6 +194,7 @@ func NewServiceSource(
 	return &serviceSource{
 		client:                         kubeClient,
 		namespace:                      config.Namespace,
+		nsFilter:                       nsFilter,
 		compatibility:                  config.Compatibility,
 		templateEngine:                 config.TemplateEngine,
 		ignoreHostnameAnnotation:       config.IgnoreHostnameAnnotation,
@@ -196,6 +220,9 @@ func (sc *serviceSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, err
 	endpoints := make([]*endpoint.Endpoint, 0, len(services))
 
 	for _, svc := range services {
+		if !sc.nsFilter.Matches(svc.Namespace) {
+			continue
+		}
 		var err error
 
 		svcEndpoints := sc.endpoints(svc)
@@ -778,11 +805,31 @@ func (sc *serviceSource) extractNodePortEndpoints(svc *v1.Service, hostname stri
 func (sc *serviceSource) AddEventHandler(_ context.Context, handler func()) {
 	log.Debug("Adding event handler for service")
 
+	wrappedHandler := func(obj any) {
+		if metaObj, ok := obj.(metav1.Object); ok {
+			if !sc.nsFilter.Matches(metaObj.GetNamespace()) {
+				return
+			}
+		}
+		handler()
+	}
+
+	eventHandler := cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { wrappedHandler(obj) },
+		UpdateFunc: func(_, newObj any) { wrappedHandler(newObj) },
+		DeleteFunc: func(obj any) {
+			if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				obj = tombstone.Obj
+			}
+			wrappedHandler(obj)
+		},
+	}
+
 	// Right now there is no way to remove event handler from informer, see:
 	// https://github.com/kubernetes/kubernetes/issues/79610
-	informers.MustAddEventHandler(sc.serviceInformer.Informer(), eventHandlerFunc(handler))
+	informers.MustAddEventHandler(sc.serviceInformer.Informer(), eventHandler)
 	if sc.listenEndpointEvents && sc.serviceTypeFilter.isRequired(v1.ServiceTypeNodePort, v1.ServiceTypeClusterIP) {
-		informers.MustAddEventHandler(sc.endpointSlicesInformer.Informer(), eventHandlerFunc(handler))
+		informers.MustAddEventHandler(sc.endpointSlicesInformer.Informer(), eventHandler)
 	}
 }
 

--- a/source/store.go
+++ b/source/store.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -59,6 +60,8 @@ var ErrSourceNotFound = errors.New("source not found")
 // type conversions and validation.
 type Config struct {
 	Namespace                      string
+	Namespaces                     []string
+	NamespaceLabelFilter           labels.Selector
 	AnnotationFilter               labels.Selector
 	LabelFilter                    labels.Selector
 	IngressClassNames              []string
@@ -130,12 +133,27 @@ func NewSourceConfig(cfg *externaldns.Config, opts ...OverrideConfigOption) (*Co
 	// errors are explicitly ignored because the filters are already validated in validation.ValidateConfig
 	labelSelector, _ := labels.Parse(cfg.LabelFilter)
 	annotationSelector, _ := annotations.ParseFilter(cfg.AnnotationFilter)
+	namespaceLabelSelector, err := labels.Parse(cfg.NamespaceLabelFilter)
+	if err != nil {
+		return nil, fmt.Errorf("invalid namespace label filter: %w", err)
+	}
 	tmpls, err := template.NewEngine(cfg.FQDNTemplate, cfg.TargetTemplate, cfg.FQDNTargetTemplate, cfg.CombineFQDNAndAnnotation)
 	if err != nil {
 		return nil, err
 	}
+	var namespaces []string
+	if cfg.Namespace != "" {
+		for ns := range strings.SplitSeq(cfg.Namespace, ",") {
+			ns = strings.TrimSpace(ns)
+			if ns != "" {
+				namespaces = append(namespaces, ns)
+			}
+		}
+	}
 	c := &Config{
 		Namespace:                      cfg.Namespace,
+		Namespaces:                     namespaces,
+		NamespaceLabelFilter:           namespaceLabelSelector,
 		AnnotationFilter:               annotationSelector,
 		LabelFilter:                    labelSelector,
 		IngressClassNames:              cfg.IngressClassNames,


### PR DESCRIPTION
Resolves #3565

### Description
This PR introduces support for watching multiple namespaces and namespace label filtering for `Service` and `Ingress` sources. 

### Changes
* **Multiple Namespaces**: Allows `--namespace` to accept a comma-separated list of namespaces.
* **Namespace Label Filter**: Adds a new `--namespace-label-filter` flag to dynamically filter namespaces based on a label selector.
* **Dynamic Watch Scope**: Automatically adjusts the informer namespace watch scope.
* **Event Throttling**: Drops irrelevant namespace events to prevent unnecessary reconciliations.
* **Tests**: Full unit test coverage included.