### PR TITLE
docs(webhook): add NAVER Cloud Platform webhook provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ from the usage of any externally developed webhook.
 | Infomaniak            | https://github.com/M0NsTeRRR/external-dns-webhook-infomaniak         |
 | Mikrotik              | https://github.com/mirceanton/external-dns-provider-mikrotik         |
 | Myra Security         | https://github.com/Myra-Security-GmbH/external-dns-myrasec-webhook   |
+| NAVER Cloud Platform  | https://github.com/NaverCloudPlatform/external-dns-navercloud-webhook |
 | Netbird               | https://codeberg.org/ccbash-oss/external-dns-netbird-webhook         |
 | Netcup                | https://github.com/mrueg/external-dns-netcup-webhook                 |
 | Netic                 | https://github.com/neticdk/external-dns-tidydns-webhook              |


### PR DESCRIPTION
## What does it do ?

- Adds the NAVER Cloud Platform Global DNS webhook provider to the known webhook provider list.

## Motivation

The provider enables ExternalDNS to manage records in NAVER Cloud Platform Global DNS through the webhook protocol.

Provider repository: https://github.com/NaverCloudPlatform/external-dns-navercloud-webhook

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly
