### PR TITLE
test(source): add regression coverage for TCPRoute referencing a ListenerSet

### DIFF
--- a/source/gateway_listenerset_test.go
+++ b/source/gateway_listenerset_test.go
@@ -1562,11 +1562,7 @@ func TestGatewayListenerSetSource_InformerTransform(t *testing.T) {
 }
 
 // TestGatewayTCPRouteWithListenerSetParentRef adds TCPRoute+ListenerSet
-// coverage for the shared resolveParentRef/routeIsAllowed path, mirroring
-// the existing HTTPRoute+ListenerSet test. It does not reproduce the
-// failure reported in https://github.com/kubernetes-sigs/external-dns/issues/6557:
-// TCPRoute already resolves correctly here, so this test cannot serve as a
-// regression guard for that issue's actual root cause.
+// coverage for the shared resolveParentRef/routeIsAllowed path.
 func TestGatewayTCPRouteWithListenerSetParentRef(t *testing.T) {
 	t.Parallel()
 

--- a/source/gateway_listenerset_test.go
+++ b/source/gateway_listenerset_test.go
@@ -1561,10 +1561,12 @@ func TestGatewayListenerSetSource_InformerTransform(t *testing.T) {
 	)
 }
 
-// TestGatewayTCPRouteWithListenerSetParentRef guards against
-// https://github.com/kubernetes-sigs/external-dns/issues/6557, where a
-// TCPRoute referencing a ListenerSet failed to resolve even though the
-// equivalent HTTPRoute worked.
+// TestGatewayTCPRouteWithListenerSetParentRef adds TCPRoute+ListenerSet
+// coverage for the shared resolveParentRef/routeIsAllowed path, mirroring
+// the existing HTTPRoute+ListenerSet test. It does not reproduce the
+// failure reported in https://github.com/kubernetes-sigs/external-dns/issues/6557:
+// TCPRoute already resolves correctly here, so this test cannot serve as a
+// regression guard for that issue's actual root cause.
 func TestGatewayTCPRouteWithListenerSetParentRef(t *testing.T) {
 	t.Parallel()
 

--- a/source/gateway_listenerset_test.go
+++ b/source/gateway_listenerset_test.go
@@ -26,10 +26,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/internal/testutils"
+	"sigs.k8s.io/external-dns/source/annotations"
 )
 
 func lsParentRef(namespace, name string, options ...gwParentRefOption) v1.ParentReference {
@@ -1557,4 +1559,75 @@ func TestGatewayListenerSetSource_InformerTransform(t *testing.T) {
 		withRemovedLastAppliedConfigAnnotation(),
 		withRemovedManagedFields(),
 	)
+}
+
+// TestGatewayTCPRouteWithListenerSetParentRef guards against
+// https://github.com/kubernetes-sigs/external-dns/issues/6557, where a
+// TCPRoute referencing a ListenerSet failed to resolve even though the
+// equivalent HTTPRoute worked.
+func TestGatewayTCPRouteWithListenerSetParentRef(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	gwClient := gatewayfake.NewSimpleClientset()
+	kubeClient := kubefake.NewClientset()
+	clients := new(testutils.MockClientGenerator)
+	clients.On("GatewayClient").Return(gwClient, nil)
+	clients.On("KubeClient").Return(kubeClient, nil)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+	_, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	ips := []string{"10.64.0.1", "10.64.0.2"}
+	gw := &v1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-gateway", Namespace: "default"},
+		Spec: v1.GatewaySpec{
+			AllowedListeners: allowAllListenerSets(),
+			Listeners:        []v1.Listener{{Name: "base", Protocol: v1.TCPProtocolType, Port: 80}},
+		},
+		Status: gatewayStatus(ips...),
+	}
+	_, err = gwClient.GatewayV1().Gateways(gw.Namespace).Create(ctx, gw, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	fromAll := v1.NamespacesFromAll
+	ls := &v1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-listenerset", Namespace: "default"},
+		Spec: v1.ListenerSetSpec{
+			ParentRef: v1.ParentGatewayReference{Name: "my-gateway"},
+			Listeners: []v1.ListenerEntry{{
+				Name: "app", Port: 8080, Protocol: v1.TCPProtocolType,
+				AllowedRoutes: &v1.AllowedRoutes{Namespaces: &v1.RouteNamespaces{From: &fromAll}},
+			}},
+		},
+		Status: listenerSetAcceptedStatus("app"),
+	}
+	_, err = gwClient.GatewayV1().ListenerSets(ls.Namespace).Create(ctx, ls, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	rt := &v1alpha2.TCPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "my-route",
+			Namespace:   "default",
+			Annotations: map[string]string{annotations.HostnameKey: "app.example.com"},
+		},
+		Spec: v1alpha2.TCPRouteSpec{
+			CommonRouteSpec: v1.CommonRouteSpec{ParentRefs: []v1.ParentReference{lsParentRef("default", "my-listenerset")}},
+		},
+		Status: v1alpha2.TCPRouteStatus{RouteStatus: gwRouteStatus(lsParentRef("default", "my-listenerset"))},
+	}
+	_, err = gwClient.GatewayV1alpha2().TCPRoutes(rt.Namespace).Create(ctx, rt, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	src, err := NewGatewayTCPRouteSource(ctx, clients, &Config{GatewayListenerSets: true})
+	require.NoError(t, err)
+
+	endpoints, err := src.Endpoints(ctx)
+	require.NoError(t, err)
+	testutils.ValidateEndpoints(t, endpoints, []*endpoint.Endpoint{
+		newTestEndpoint("app.example.com", ips...),
+	})
 }


### PR DESCRIPTION
## What this does

Adds TCPRoute+ListenerSet coverage for the `gateway-tcproute` source.

`TestGatewayTCPRouteWithListenerSetParentRef` builds a `Gateway` -> `ListenerSet` -> `TCPRoute` (whose `parentRef` targets the ListenerSet) and asserts the `gateway-tcproute` source resolves the expected endpoint (`app.example.com`) when `--gateway-listener-sets` is enabled — mirroring the existing HTTPRoute + ListenerSet coverage in this file.

## Why

Issue #6557 reported that a `TCPRoute` referencing a `ListenerSet` failed to resolve while an equivalent `HTTPRoute` worked. `resolveParentRef`/`routeIsAllowed` in `source/gateway.go` already handle TCPRoute correctly on current `HEAD` (this test passes without any production-code change), but that path had zero TCPRoute-specific test coverage before this PR.

As pointed out in review, this test is **not** a regression guard for #6557: nothing here fails without a fix and passes with one, so it can't demonstrate the reported bug ever existed in this code path. The root cause remains unconfirmed — possibly `--gateway-listener-sets` not being enabled in the reporter's environment (it defaults to `false`), an informer cache-sync race, RBAC restricting list/watch on ListenerSet, or an interaction specific to running `--source=gateway-tcproute` and `--source=gateway-httproute` together that isn't exercised by a single-source unit test. This PR only adds missing coverage for the TCPRoute+ListenerSet path; it does not close or resolve #6557.

## Notes
- Test-only change; no functional code modified.
- `go test ./source/...` passes locally.

Relates to #6557
