### PR TITLE
fix(source): scope CNAME conflict warnings to the configured domain filter

### DIFF
--- a/controller/execute.go
+++ b/controller/execute.go
@@ -100,12 +100,9 @@ func execute(ctx context.Context) {
 		log.Fatal(err) // nolint: gocritic // exitAfterDefer
 	}
 
-	domainFilter := endpoint.NewDomainFilterWithOptions(
-		endpoint.WithDomainFilter(cfg.DomainFilter),
-		endpoint.WithDomainExclude(cfg.DomainExclude),
-		endpoint.WithRegexDomainFilter(cfg.RegexDomainFilter),
-		endpoint.WithRegexDomainExclude(cfg.RegexDomainExclude),
-	)
+	// The domain filter is built once by source.NewSourceConfig and shared between
+	// the source wrappers (to scope conflict warnings) and the provider.
+	domainFilter := sCfg.DomainFilter
 
 	prvdr, err := providerfactory.Select(ctx, cfg, domainFilter)
 	if err != nil {

--- a/controller/execute_test.go
+++ b/controller/execute_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	provider "sigs.k8s.io/external-dns/provider/factory"
 	"sigs.k8s.io/external-dns/source"
@@ -286,12 +285,7 @@ func TestControllerRunCancelContextStopsLoop(t *testing.T) {
 	defer cancel()
 	src, err := wrappers.Build(ctx, sCfg)
 	require.NoError(t, err)
-	domainFilter := endpoint.NewDomainFilterWithOptions(
-		endpoint.WithDomainFilter(cfg.DomainFilter),
-		endpoint.WithDomainExclude(cfg.DomainExclude),
-		endpoint.WithRegexDomainFilter(cfg.RegexDomainFilter),
-		endpoint.WithRegexDomainExclude(cfg.RegexDomainExclude),
-	)
+	domainFilter := sCfg.DomainFilter
 	p, err := provider.Select(ctx, cfg, domainFilter)
 	require.NoError(t, err)
 	ctrl, err := buildController(ctx, cfg, sCfg, src, p, domainFilter)

--- a/docs/contributing/source-wrappers.md
+++ b/docs/contributing/source-wrappers.md
@@ -25,14 +25,15 @@ Wrappers solve these key challenges:
 
 ## Built In Wrappers
 
-|       Wrapper        | Purpose                                 | Use Case                                            |
-|:--------------------:|:----------------------------------------|:----------------------------------------------------|
-|    `MultiSource`     | Combine multiple sources.               | Aggregate `Ingress`, `Service`, etc.                |
-|    `DedupSource`     | Remove duplicate DNS records.           | Avoid duplicate records from sources.               |
-| `TargetFilterSource` | Include/exclude targets based on CIDRs. | Exclude internal IPs.                               |
-|    `NAT64Source`     | Add NAT64-prefixed AAAA records.        | Support IPv6 with NAT64.                            |
-|   `PostProcessor`    | Add records post-processing.            | Configure TTL, filter provider-specific properties. |
-|    `PTRSource`       | Generate PTR records from A/AAAA.       | Automatic reverse DNS entries.                      |
+|        Wrapper        | Purpose                                 | Use Case                                            |
+|:---------------------:|:----------------------------------------|:----------------------------------------------------|
+|     `MultiSource`     | Combine multiple sources.               | Aggregate `Ingress`, `Service`, etc.                |
+|     `DedupSource`     | Remove duplicate DNS records.           | Avoid duplicate records from sources.               |
+| `TargetFilterSource`  | Include/exclude targets based on CIDRs. | Exclude internal IPs.                               |
+|     `NAT64Source`     | Add NAT64-prefixed AAAA records.        | Support IPv6 with NAT64.                            |
+|    `PostProcessor`    | Add records post-processing.            | Configure TTL, filter provider-specific properties. |
+|     `PTRSource`       | Generate PTR records from A/AAAA.       | Automatic reverse DNS entries.                      |
+| `CNAMEConflictSource` | Warn about conflicting CNAME records.   | Surface invalid desired state for managed domains.  |
 
 ### Use Cases
 
@@ -57,7 +58,18 @@ Converts IPv4 targets to IPv6 using NAT64 prefixes.
 --nat64-prefix=64:ff9b::/96
 ```
 
-### 3.1 `PostProcessor`
+### 3.1 `CNAMEConflictSource`
+
+Warns when multiple CNAME endpoints share the same DNS name and set identifier but point at different targets, which is invalid DNS.
+Only DNS names matching the configured domain filter are warned about; conflicts on names this ExternalDNS instance will never manage (e.g. Istio or Ingress hosts used purely for in-cluster routing) are logged at debug level instead.
+
+📌 **Use case**: Surface conflicting CNAME desired state for managed domains without noise for out-of-scope hosts.
+
+```yaml
+--domain-filter=example.com
+```
+
+### 4.1 `PostProcessor`
 
 Applies post-processing to all endpoints after they are collected from sources.
 
@@ -120,6 +132,7 @@ source = NewNAT64Source(source, cfg.NAT64Networks)
 source = NewTargetFilterSource(source, targetFilter)
 source = NewPostProcessor(source, WithTTL(minTTL), WithPostProcessorPreferAlias(preferAlias))
 source = NewPTRSource(source, createPTR)
+source = NewCNAMEConflictSource(source, domainFilter)
 ```
 
 Each wrapper processes the output of the previous one.

--- a/endpoint/utils.go
+++ b/endpoint/utils.go
@@ -160,10 +160,12 @@ func MergeEndpoints(endpoints []*Endpoint) []*Endpoint {
 			}
 			key.Target = ep.Targets[0]
 			cnameKey := ep.DNSName + "/" + ep.SetIdentifier
-			// This will be caught by the provider when it tries to create the record, but log a warning here to make it more obvious.
-			// TODO: add metric for CNAME conflicts
+			// Log at debug level only: at this point the endpoints have not been filtered by the
+			// configured domain filter yet, so the conflict may concern a DNS name this instance
+			// will never manage. The user-facing warning for in-scope conflicts is emitted by the
+			// CNAME conflict source wrapper after all sources have been combined.
 			if first, ok := cnameTargets[cnameKey]; ok && first != ep.Targets[0] {
-				log.Warnf("Only one CNAME per name — %s CNAME %s and %s CNAME %s is invalid DNS. A resolver wouldn't know which canonical name to follow.", ep.DNSName, first, ep.DNSName, ep.Targets[0])
+				log.Debugf("Only one CNAME per name — %s CNAME %s and %s CNAME %s is invalid DNS. A resolver wouldn't know which canonical name to follow.", ep.DNSName, first, ep.DNSName, ep.Targets[0])
 			}
 			cnameTargets[cnameKey] = ep.Targets[0]
 		}

--- a/endpoint/utils_test.go
+++ b/endpoint/utils_test.go
@@ -525,15 +525,17 @@ func TestMergeEndpoints_RefObjects(t *testing.T) {
 }
 
 func TestMergeEndpointsLogging(t *testing.T) {
-	t.Run("warns on CNAME conflict", func(t *testing.T) {
-		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+	t.Run("logs CNAME conflict at debug level", func(t *testing.T) {
+		hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
 
 		MergeEndpoints([]*Endpoint{
 			NewEndpoint("example.com", RecordTypeCNAME, "a.elb.com"),
 			NewEndpoint("example.com", RecordTypeCNAME, "b.elb.com"),
 		})
 
-		logtest.TestHelperLogContainsWithLogLevel("Only one CNAME per name", log.WarnLevel, hook, t)
+		// the warn-level message for in-scope conflicts is emitted by the CNAME conflict
+		// source wrapper after domain filtering, not at merge time
+		logtest.TestHelperLogContainsWithLogLevel("Only one CNAME per name", log.DebugLevel, hook, t)
 		logtest.TestHelperLogContains("example.com CNAME a.elb.com", hook, t)
 		logtest.TestHelperLogContains("example.com CNAME b.elb.com", hook, t)
 	})

--- a/source/store.go
+++ b/source/store.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/rest"
 	gateway "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
+	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	kubeclient "sigs.k8s.io/external-dns/pkg/client"
 	"sigs.k8s.io/external-dns/source/annotations"
@@ -106,6 +107,7 @@ type Config struct {
 	PreferAlias                    bool
 	PTRSupported                   bool
 	CreatePTR                      bool
+	DomainFilter                   *endpoint.DomainFilter
 
 	sources []string
 
@@ -183,7 +185,13 @@ func NewSourceConfig(cfg *externaldns.Config, opts ...OverrideConfigOption) (*Co
 		PreferAlias:                    cfg.PreferAlias,
 		PTRSupported:                   cfg.IsPTRSupported(),
 		CreatePTR:                      cfg.CreatePTR,
-		sources:                        cfg.Sources,
+		DomainFilter: endpoint.NewDomainFilterWithOptions(
+			endpoint.WithDomainFilter(cfg.DomainFilter),
+			endpoint.WithDomainExclude(cfg.DomainExclude),
+			endpoint.WithRegexDomainFilter(cfg.RegexDomainFilter),
+			endpoint.WithRegexDomainExclude(cfg.RegexDomainExclude),
+		),
+		sources: cfg.Sources,
 	}
 	for _, opt := range opts {
 		opt(c)

--- a/source/store_test.go
+++ b/source/store_test.go
@@ -456,6 +456,28 @@ func TestNewSourceConfig(t *testing.T) {
 	}
 }
 
+func TestNewSourceConfigDomainFilter(t *testing.T) {
+	t.Run("propagates domain filter and exclusions", func(t *testing.T) {
+		cfg := &externaldns.Config{
+			DomainFilter:  []string{"example.com"},
+			DomainExclude: []string{"internal.example.com"},
+		}
+		got, err := NewSourceConfig(cfg)
+		require.NoError(t, err)
+		require.NotNil(t, got.DomainFilter)
+		assert.True(t, got.DomainFilter.Match("api.example.com"))
+		assert.False(t, got.DomainFilter.Match("api.internal.example.com"))
+		assert.False(t, got.DomainFilter.Match("api.other.com"))
+	})
+
+	t.Run("empty configuration matches all domains", func(t *testing.T) {
+		got, err := NewSourceConfig(&externaldns.Config{})
+		require.NoError(t, err)
+		require.NotNil(t, got.DomainFilter)
+		assert.True(t, got.DomainFilter.Match("api.example.com"))
+	})
+}
+
 func TestKubeAPIRateLimitPropagation(t *testing.T) {
 	t.Run("NewSourceConfig propagates QPS and burst", func(t *testing.T) {
 		cfg := &externaldns.Config{

--- a/source/wrappers/build.go
+++ b/source/wrappers/build.go
@@ -41,6 +41,7 @@ func Build(ctx context.Context, cfg *source.Config) (source.Source, error) {
 		WithPreferAlias(cfg.PreferAlias),
 		WithPTRSupported(cfg.PTRSupported),
 		WithCreatePTR(cfg.CreatePTR),
+		WithDomainFilter(cfg.DomainFilter),
 	)
 	return wrapSources(sources, opts)
 }

--- a/source/wrappers/build_test.go
+++ b/source/wrappers/build_test.go
@@ -70,6 +70,13 @@ func TestBuildWrappedSource(t *testing.T) {
 			}),
 		},
 		{
+			name: "fake source with domain filter",
+			cfg: stubConfig(t, &externaldns.Config{
+				Sources:      []string{types.Fake},
+				DomainFilter: []string{"example.com"},
+			}),
+		},
+		{
 			name: "fake source with exclude target nets",
 			cfg: stubConfig(t, &externaldns.Config{
 				Sources:           []string{types.Fake},

--- a/source/wrappers/cnameconflictsource.go
+++ b/source/wrappers/cnameconflictsource.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wrappers
+
+import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/source"
+)
+
+// cnameConflictSource is a Source that warns about conflicting CNAME endpoints, i.e.
+// endpoints sharing the same DNS name and set identifier but pointing at different
+// targets. Per the DNS spec only one CNAME is allowed per name, so such desired state
+// is invalid and the planner will resolve it by picking a single candidate.
+//
+// The warning is only emitted for DNS names that match the configured domain filter.
+// Names outside the domain filter are never managed by this ExternalDNS instance
+// (e.g. Istio or Ingress hosts used purely for in-cluster routing), so conflicts on
+// them are logged at debug level instead to avoid noise.
+//
+// Endpoints are returned unmodified.
+type cnameConflictSource struct {
+	source       source.Source
+	domainFilter endpoint.DomainFilterInterface
+}
+
+// NewCNAMEConflictSource creates a new cnameConflictSource wrapping the provided Source.
+// A nil domainFilter matches all domains.
+func NewCNAMEConflictSource(source source.Source, domainFilter endpoint.DomainFilterInterface) source.Source {
+	return &cnameConflictSource{source: source, domainFilter: domainFilter}
+}
+
+// Endpoints collects endpoints from its wrapped source and returns them unmodified,
+// warning about CNAME conflicts on DNS names matching the domain filter.
+func (s *cnameConflictSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	endpoints, err := s.source.Endpoints(ctx)
+	if err != nil {
+		return nil, err
+	}
+	s.warnOnCNAMEConflicts(endpoints)
+	return endpoints, nil
+}
+
+// warnOnCNAMEConflicts logs a warning for every CNAME endpoint whose DNS name and set
+// identifier were already claimed by a CNAME endpoint with a different target. Conflicts
+// on DNS names not matching the domain filter are logged at debug level only.
+func (s *cnameConflictSource) warnOnCNAMEConflicts(endpoints []*endpoint.Endpoint) {
+	cnameTargets := make(map[string]string) // DNSName+SetIdentifier -> first target seen
+	for _, ep := range endpoints {
+		if ep == nil || ep.RecordType != endpoint.RecordTypeCNAME || len(ep.Targets) == 0 {
+			continue
+		}
+		key := ep.DNSName + "/" + ep.SetIdentifier
+		first, seen := cnameTargets[key]
+		if !seen {
+			cnameTargets[key] = ep.Targets[0]
+			continue
+		}
+		if first == ep.Targets[0] {
+			continue
+		}
+		if s.domainFilter != nil && !s.domainFilter.Match(ep.DNSName) {
+			log.Debugf("Skipping CNAME conflict warning for %s: it does not match the domain filter", ep.DNSName)
+			continue
+		}
+		// This will be caught by the provider when it tries to create the record, but log a warning here to make it more obvious.
+		// TODO: add metric for CNAME conflicts
+		log.Warnf("Only one CNAME per name — %s CNAME %s and %s CNAME %s is invalid DNS. A resolver wouldn't know which canonical name to follow.", ep.DNSName, first, ep.DNSName, ep.Targets[0])
+	}
+}
+
+func (s *cnameConflictSource) AddEventHandler(ctx context.Context, handler func()) {
+	log.Debug("cnameConflictSource: adding event handler")
+	s.source.AddEventHandler(ctx, handler)
+}

--- a/source/wrappers/cnameconflictsource_test.go
+++ b/source/wrappers/cnameconflictsource_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wrappers
+
+import (
+	"errors"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
+	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
+	"sigs.k8s.io/external-dns/source"
+)
+
+// Validates that cnameConflictSource is a Source
+var _ source.Source = &cnameConflictSource{}
+
+func TestCNAMEConflictSourceEndpoints(t *testing.T) {
+	for _, tc := range []struct {
+		title           string
+		domainFilter    endpoint.DomainFilterInterface
+		endpoints       []*endpoint.Endpoint
+		wantWarnings    []string
+		unwantedRecords []string
+	}{
+		{
+			title:        "conflict matching the domain filter warns",
+			domainFilter: endpoint.NewDomainFilter([]string{"example.com"}),
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("api.example.com", endpoint.RecordTypeCNAME, "a.elb.com"),
+				endpoint.NewEndpoint("api.example.com", endpoint.RecordTypeCNAME, "b.elb.com"),
+			},
+			wantWarnings: []string{
+				"Only one CNAME per name",
+				"api.example.com CNAME a.elb.com",
+				"api.example.com CNAME b.elb.com",
+			},
+		},
+		{
+			title:        "conflict outside the domain filter does not warn",
+			domainFilter: endpoint.NewDomainFilter([]string{"managed.example.internal"}),
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("api.example.com", endpoint.RecordTypeCNAME, "a.elb.com"),
+				endpoint.NewEndpoint("api.example.com", endpoint.RecordTypeCNAME, "b.elb.com"),
+			},
+			unwantedRecords: []string{"Only one CNAME per name"},
+		},
+		{
+			title:        "conflict warns when no domain filter is configured",
+			domainFilter: nil,
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("api.example.com", endpoint.RecordTypeCNAME, "a.elb.com"),
+				endpoint.NewEndpoint("api.example.com", endpoint.RecordTypeCNAME, "b.elb.com"),
+			},
+			wantWarnings: []string{"Only one CNAME per name"},
+		},
+		{
+			title:        "conflict warns with an empty domain filter",
+			domainFilter: endpoint.NewDomainFilterWithOptions(),
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("api.example.com", endpoint.RecordTypeCNAME, "a.elb.com"),
+				endpoint.NewEndpoint("api.example.com", endpoint.RecordTypeCNAME, "b.elb.com"),
+			},
+			wantWarnings: []string{"Only one CNAME per name"},
+		},
+		{
+			title:        "identical CNAMEs do not warn",
+			domainFilter: endpoint.NewDomainFilter([]string{"example.com"}),
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("api.example.com", endpoint.RecordTypeCNAME, "a.elb.com"),
+				endpoint.NewEndpoint("api.example.com", endpoint.RecordTypeCNAME, "a.elb.com"),
+			},
+			unwantedRecords: []string{"Only one CNAME per name"},
+		},
+		{
+			title:        "same DNS name with different set identifiers does not warn",
+			domainFilter: endpoint.NewDomainFilter([]string{"example.com"}),
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("api.example.com", endpoint.RecordTypeCNAME, "a.elb.com").WithSetIdentifier("weight-1"),
+				endpoint.NewEndpoint("api.example.com", endpoint.RecordTypeCNAME, "b.elb.com").WithSetIdentifier("weight-2"),
+			},
+			unwantedRecords: []string{"Only one CNAME per name"},
+		},
+		{
+			title:        "non-CNAME records with the same DNS name do not warn",
+			domainFilter: endpoint.NewDomainFilter([]string{"example.com"}),
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("api.example.com", endpoint.RecordTypeA, "1.1.1.1"),
+				endpoint.NewEndpoint("api.example.com", endpoint.RecordTypeA, "2.2.2.2"),
+			},
+			unwantedRecords: []string{"Only one CNAME per name"},
+		},
+		{
+			title:        "nil endpoints and CNAMEs without targets are skipped",
+			domainFilter: endpoint.NewDomainFilter([]string{"example.com"}),
+			endpoints: []*endpoint.Endpoint{
+				nil,
+				endpoint.NewEndpoint("api.example.com", endpoint.RecordTypeCNAME),
+				endpoint.NewEndpoint("api.example.com", endpoint.RecordTypeCNAME, "a.elb.com"),
+			},
+			unwantedRecords: []string{"Only one CNAME per name"},
+		},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
+
+			src := NewCNAMEConflictSource(testutils.NewMockSource(tc.endpoints...), tc.domainFilter)
+
+			endpoints, err := src.Endpoints(t.Context())
+			require.NoError(t, err)
+			assert.Equal(t, tc.endpoints, endpoints, "endpoints must be returned unmodified")
+
+			for _, msg := range tc.wantWarnings {
+				logtest.TestHelperLogContainsWithLogLevel(msg, log.WarnLevel, hook, t)
+			}
+			for _, msg := range tc.unwantedRecords {
+				logtest.TestHelperLogNotContains(msg, hook, t)
+			}
+		})
+	}
+}
+
+func TestCNAMEConflictSourceOutOfScopeConflictLoggedAtDebug(t *testing.T) {
+	hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
+
+	src := NewCNAMEConflictSource(
+		testutils.NewMockSource(
+			endpoint.NewEndpoint("api.example.com", endpoint.RecordTypeCNAME, "a.elb.com"),
+			endpoint.NewEndpoint("api.example.com", endpoint.RecordTypeCNAME, "b.elb.com"),
+		),
+		endpoint.NewDomainFilter([]string{"managed.example.internal"}),
+	)
+
+	_, err := src.Endpoints(t.Context())
+	require.NoError(t, err)
+
+	logtest.TestHelperLogContainsWithLogLevel("Skipping CNAME conflict warning for api.example.com", log.DebugLevel, hook, t)
+}
+
+func TestCNAMEConflictSourceEndpointsPropagatesError(t *testing.T) {
+	mockSource := new(testutils.MockSource)
+	mockSource.On("Endpoints").Return(nil, errors.New("inner source failed"))
+
+	src := NewCNAMEConflictSource(mockSource, nil)
+
+	endpoints, err := src.Endpoints(t.Context())
+	assert.Nil(t, endpoints)
+	require.EqualError(t, err, "inner source failed")
+}
+
+func TestCNAMEConflictSourceAddEventHandler(t *testing.T) {
+	mockSource := new(testutils.MockSource)
+	mockSource.On("AddEventHandler", mock.Anything).Return()
+
+	src := NewCNAMEConflictSource(mockSource, nil)
+	src.AddEventHandler(t.Context(), func() {})
+
+	mockSource.AssertExpectations(t)
+}

--- a/source/wrappers/types.go
+++ b/source/wrappers/types.go
@@ -34,9 +34,10 @@ type Config struct {
 	excludeTargetNets   []string
 	minTTL              time.Duration
 	preferAlias         bool
-	ptrSupported        bool             // PTR is in --managed-record-types
-	createPTR           bool             // --create-ptr default for all A/AAAA records
-	sourceWrappers      sets.Set[string] // set of source wrappers, e.g. "targetfilter", "nat64"
+	ptrSupported        bool                           // PTR is in --managed-record-types
+	createPTR           bool                           // --create-ptr default for all A/AAAA records
+	domainFilter        endpoint.DomainFilterInterface // --domain-filter and related flags
+	sourceWrappers      sets.Set[string]               // set of source wrappers, e.g. "targetfilter", "nat64"
 }
 
 func NewConfig(opts ...Option) *Config {
@@ -118,6 +119,15 @@ func WithCreatePTR(enabled bool) Option {
 	}
 }
 
+// WithDomainFilter sets the domain filter used to scope warnings about
+// conflicting endpoints to DNS names this ExternalDNS instance manages.
+// A nil filter matches all domains.
+func WithDomainFilter(filter endpoint.DomainFilterInterface) Option {
+	return func(o *Config) {
+		o.domainFilter = filter
+	}
+}
+
 // addSourceWrapper registers a source wrapper by name in the Config.
 // It initializes the sourceWrappers map if it is nil.
 func (o *Config) addSourceWrapper(name string) {
@@ -164,5 +174,7 @@ func wrapSources(
 	combinedSource = NewPostProcessor(combinedSource, WithTTL(opts.minTTL), WithPostProcessorPreferAlias(opts.preferAlias),
 		WithPostProcessorProvider(opts.provider))
 	opts.addSourceWrapper("post-processor")
+	combinedSource = NewCNAMEConflictSource(combinedSource, opts.domainFilter)
+	opts.addSourceWrapper("cname-conflict")
 	return combinedSource, nil
 }

--- a/source/wrappers/types_test.go
+++ b/source/wrappers/types_test.go
@@ -57,6 +57,7 @@ func TestWrapSources(t *testing.T) {
 			cfg:  NewConfig(),
 			asserts: func(t *testing.T, cfg *Config) {
 				assert.True(t, cfg.isSourceWrapperInstrumented("dedup"))
+				assert.True(t, cfg.isSourceWrapperInstrumented("cname-conflict"))
 				assert.False(t, cfg.isSourceWrapperInstrumented("nat64"))
 				assert.False(t, cfg.isSourceWrapperInstrumented("target-filter"))
 				assert.False(t, cfg.isSourceWrapperInstrumented("ptr"))
@@ -180,6 +181,14 @@ func TestWithMinTTL(t *testing.T) {
 	opt := WithMinTTL(300 * time.Second)
 	opt(cfg)
 	assert.Equal(t, 300*time.Second, cfg.minTTL)
+}
+
+func TestWithDomainFilter(t *testing.T) {
+	cfg := &Config{}
+	filter := endpoint.NewDomainFilter([]string{"example.com"})
+	opt := WithDomainFilter(filter)
+	opt(cfg)
+	assert.Equal(t, filter, cfg.domainFilter)
 }
 
 func TestAddSourceWrapperAndIsSourceWrapperInstrumented(t *testing.T) {


### PR DESCRIPTION
## What does it do ?

Stops the `Only one CNAME per name` warning from firing for DNS names that are outside the configured `--domain-filter` (and related `--exclude-domains` / `--regex-domain-filter` / `--regex-domain-exclusion` flags), while keeping the exact same warn-level message for names this instance actually manages.

Since #6174, sources call `endpoint.MergeEndpoints()`, which emitted the warning before the planner applies the domain filter — so hosts that exist purely for in-cluster routing (Istio Gateways/VirtualServices, Ingress hosts used by a CDN, ...) produced a misleading warning every sync interval even though ExternalDNS will never manage them.

Following the reviewer guidance on #6551 (fix it generically for all sources, gate the warning instead of pre-filtering endpoints, and use the source-wrapper pattern like `nat64source`), this PR:

- adds a new `CNAMEConflictSource` wrapper (`source/wrappers/cnameconflictsource.go`) installed at the end of the standard wrapper pipeline. It detects CNAME endpoints sharing the same DNS name + set identifier with different targets and warns only when the name matches the domain filter; out-of-scope conflicts are logged at debug level. Endpoints are returned unmodified — conflicting records are still resolved by the planner's conflict resolver, exactly as before.
- demotes the merge-time log in `endpoint.MergeEndpoints()` to debug level (same message text, still useful to trace which source produced a conflict). Because the wrapper runs on the combined output of all sources, conflicts *across* sources (e.g. `istio-gateway` vs `istio-virtualservice`, the exact repro in the issue) are now detected too, which the per-source merge could miss.
- builds the `DomainFilter` once in `source.NewSourceConfig()` and shares it between the wrapper pipeline and the provider (`controller/execute.go` previously constructed it separately).

Behavior summary:

| Scenario | Before | After |
|---|---|---|
| CNAME conflict, name matches domain filter | warn (per source) | warn (combined sources, same message) |
| CNAME conflict, name outside domain filter | warn | debug |
| No domain filter configured | warn | warn |
| Conflict across two sources | not detected | warn/debug per filter |

Fixes #6529

## Motivation

Users running `--source=istio-gateway --source=istio-virtualservice` (or plain Ingress, see the issue comments) with a `--domain-filter` get warnings every minute about "invalid DNS" for hosts that are intentionally not managed by ExternalDNS. The warning is legitimate signal for in-scope conflicts — per the maintainer feedback on #6551 it must not simply be hidden — but for out-of-scope names it is pure noise that looks like a real DNS problem.

Previous attempts #6546 and #6551 were closed after review feedback; this implements the design suggested there: keep the warning, gate it by the domain filter, apply it once for all sources via a wrapper.

Note on scope: the warning is gated by the `--domain-filter` family of flags only. Provider zone filters (e.g. `--zone-id-filter`) are not consulted, because zones are only known to the provider at plan time; if reviewers prefer gating on the registry/provider filter as well, the detection could instead move to `plan.Calculate()` — happy to adjust.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

This change was developed with AI assistance (Claude Code); I have reviewed and tested it.
