### PR TITLE
fix(registry/txt): create ownership TXT records before primary records

### DIFF
--- a/registry/txt/registry.go
+++ b/registry/txt/registry.go
@@ -363,18 +363,24 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 		Delete:    endpoint.FilterEndpointsByOwnerID(im.ownerID, changes.Delete),
 	}
 
+	createTXTRecords := make([]*endpoint.Endpoint, 0, 2*len(filteredChanges.Create))
 	for _, r := range filteredChanges.Create {
 		if r.Labels == nil {
 			r.Labels = make(map[string]string)
 		}
 		r.Labels[endpoint.OwnerLabelKey] = im.ownerID
 
-		filteredChanges.Create = append(filteredChanges.Create, im.generateTXTRecordWithFilter(r, im.existingTXTs.isAbsent)...)
+		createTXTRecords = append(createTXTRecords, im.generateTXTRecordWithFilter(r, im.existingTXTs.isAbsent)...)
 
 		if im.cacheInterval > 0 {
 			im.addToCache(r)
 		}
 	}
+	// Ownership TXT records are created before their corresponding primary records so that,
+	// if a provider only partially applies this batch, the failure mode is an orphan TXT
+	// record (harmless, retried next sync) rather than a primary record with no TXT owner
+	// (which the registry then treats as unowned and stops reconciling forever).
+	filteredChanges.Create = append(createTXTRecords, filteredChanges.Create...)
 
 	for _, r := range filteredChanges.Delete {
 		// when we delete TXT records for which value has changed (due to new label) this would still work because


### PR DESCRIPTION
## Problem

`TXTRegistry.ApplyChanges` builds the `Create` batch it hands to the provider by iterating over `filteredChanges.Create` and *appending* the generated TXT ownership record(s) for each endpoint to that same slice:

```go
for _, r := range filteredChanges.Create {
    ...
    filteredChanges.Create = append(filteredChanges.Create, im.generateTXTRecordWithFilter(r, im.existingTXTs.isAbsent)...)
    ...
}
```

The resulting batch order is always: **all primary records first, then all their TXT ownership records.**

## Why this matters

`registry.ApplyChanges` hands this ordered slice straight to `provider.ApplyChanges`. Providers that apply changes as a single atomic batch (e.g. AWS Route53's `ChangeResourceRecordSets`) are unaffected — either the whole batch lands or none of it does.

Providers that don't have atomic batch semantics are a different story. **Azure** in particular inserts records serially, one API call per record, in the order they appear in the slice. If such a batch partially fails partway through, the current ordering means the failure mode is:

- Primary record (e.g. an `A` record) gets created.
- Its corresponding TXT ownership record — being later in the slice — never gets created because the batch aborted before reaching it.

Once that happens, the registry has a primary record with no TXT owner record. On every subsequent reconciliation, `TXTRegistry` sees a record it doesn't recognize as owned and treats it as **unowned** — it will never touch, update, or clean up that record again. The record is permanently orphaned from ExternalDNS's perspective, and the only way out is a manual fix in the DNS zone.

## Fix

Collect the generated TXT ownership records into a separate slice and prepend them to `filteredChanges.Create`, instead of appending them in-place:

```go
createTXTRecords := make([]*endpoint.Endpoint, 0, len(filteredChanges.Create))
for _, r := range filteredChanges.Create {
    ...
    createTXTRecords = append(createTXTRecords, im.generateTXTRecordWithFilter(r, im.existingTXTs.isAbsent)...)
    ...
}
filteredChanges.Create = append(createTXTRecords, filteredChanges.Create...)
```

Now the batch order is: **all TXT ownership records first, then their primary records.** If a non-atomic provider like Azure only partially applies the batch, the worst case is now an orphan TXT record with no primary record — which is harmless (it doesn't affect DNS resolution) and gets picked up and either reused or cleaned up on the very next reconciliation.

This mirrors the ordering the `Delete` path already has: primary records are deleted before their TXT records (they appear first in that slice already, by the same append-while-ranging quirk), so a partial delete failure on a non-atomic provider similarly degrades to "an orphan, harmless TXT record left behind" rather than "a primary record silently losing its owner."

The general invariant this restores: **a TXT ownership record must always be created before, and deleted after, its corresponding primary record**, so that no window exists where a primary record can exist without a TXT owner.

## Scope / impact

This is a correctness fix for any provider without atomic multi-record apply semantics. It's a no-op for providers that apply the whole batch atomically (AWS, Google Cloud DNS, etc.), since order within the batch doesn't matter when it's all-or-nothing.

## Test plan

- `go test ./registry/...`
