### PR TITLE
fix(source): preserve Skipper custom token file

### DIFF
--- a/source/skipper_routegroup.go
+++ b/source/skipper_routegroup.go
@@ -85,12 +85,8 @@ type routeGroupClient struct {
 
 func newRouteGroupClient(token, tokenPath string, timeout time.Duration) *routeGroupClient {
 	const (
-		tokenFile  = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 		rootCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	)
-	if tokenPath != "" {
-		tokenPath = tokenFile
-	}
 
 	tr := &http.Transport{
 		DialContext: (&net.Dialer{

--- a/source/skipper_routegroup.go
+++ b/source/skipper_routegroup.go
@@ -106,7 +106,7 @@ func newRouteGroupClient(token, tokenPath string, timeout time.Duration) *routeG
 		},
 		quit:      make(chan struct{}),
 		tokenFile: tokenPath,
-		token:     token,
+		token:     strings.TrimSpace(token),
 	}
 
 	go func() {

--- a/source/skipper_routegroup.go
+++ b/source/skipper_routegroup.go
@@ -154,7 +154,7 @@ func (cli *routeGroupClient) updateToken() {
 	}
 
 	cli.mu.Lock()
-	cli.token = string(token)
+	cli.token = strings.TrimSpace(string(token))
 	cli.mu.Unlock()
 }
 

--- a/source/skipper_routegroup_test.go
+++ b/source/skipper_routegroup_test.go
@@ -286,7 +286,7 @@ func TestNewRouteGroupClientLoadsCustomTokenFile(t *testing.T) {
 	t.Parallel()
 
 	tokenFile := filepath.Join(t.TempDir(), "token")
-	require.NoError(t, os.WriteFile(tokenFile, []byte("custom-token"), 0o600))
+	require.NoError(t, os.WriteFile(tokenFile, []byte("custom-token\n"), 0o600))
 
 	client := newRouteGroupClient("initial-token", tokenFile, time.Second)
 	t.Cleanup(func() { close(client.quit) })
@@ -304,7 +304,7 @@ func TestRouteGroupClientReloadsCustomTokenFile(t *testing.T) {
 	client := newRouteGroupClient("initial-token", tokenFile, time.Second)
 	t.Cleanup(func() { close(client.quit) })
 
-	require.NoError(t, os.WriteFile(tokenFile, []byte("rotated-file-token"), 0o600))
+	require.NoError(t, os.WriteFile(tokenFile, []byte("rotated-file-token\r\n"), 0o600))
 	client.updateToken()
 
 	assert.Equal(t, "rotated-file-token", client.getToken())

--- a/source/skipper_routegroup_test.go
+++ b/source/skipper_routegroup_test.go
@@ -282,6 +282,34 @@ func TestRouteGroupDeepCopyObject(t *testing.T) {
 	assert.Equal(t, "changed", original.Annotations["key"])
 }
 
+func TestNewRouteGroupClientLoadsCustomTokenFile(t *testing.T) {
+	t.Parallel()
+
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("custom-token"), 0o600))
+
+	client := newRouteGroupClient("initial-token", tokenFile, time.Second)
+	t.Cleanup(func() { close(client.quit) })
+
+	assert.Equal(t, tokenFile, client.tokenFile)
+	assert.Equal(t, "custom-token", client.getToken())
+}
+
+func TestRouteGroupClientReloadsCustomTokenFile(t *testing.T) {
+	t.Parallel()
+
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("initial-file-token"), 0o600))
+
+	client := newRouteGroupClient("initial-token", tokenFile, time.Second)
+	t.Cleanup(func() { close(client.quit) })
+
+	require.NoError(t, os.WriteFile(tokenFile, []byte("rotated-file-token"), 0o600))
+	client.updateToken()
+
+	assert.Equal(t, "rotated-file-token", client.getToken())
+}
+
 func createTestRouteGroup(ns, name string, annotations map[string]string, hosts []string, destinations []routeGroupLoadBalancer) *routeGroup {
 	return &routeGroup{
 		ObjectMeta: metav1.ObjectMeta{

--- a/source/skipper_routegroup_test.go
+++ b/source/skipper_routegroup_test.go
@@ -282,32 +282,39 @@ func TestRouteGroupDeepCopyObject(t *testing.T) {
 	assert.Equal(t, "changed", original.Annotations["key"])
 }
 
-func TestNewRouteGroupClientLoadsCustomTokenFile(t *testing.T) {
+func TestRouteGroupClientToken(t *testing.T) {
 	t.Parallel()
 
-	tokenFile := filepath.Join(t.TempDir(), "token")
-	require.NoError(t, os.WriteFile(tokenFile, []byte("custom-token\n"), 0o600))
+	t.Run("trims direct token", func(t *testing.T) {
+		client := newRouteGroupClient(" direct-token\r\n", "", time.Second)
+		t.Cleanup(func() { close(client.quit) })
 
-	client := newRouteGroupClient("initial-token", tokenFile, time.Second)
-	t.Cleanup(func() { close(client.quit) })
+		assert.Equal(t, "direct-token", client.getToken())
+	})
 
-	assert.Equal(t, tokenFile, client.tokenFile)
-	assert.Equal(t, "custom-token", client.getToken())
-}
+	t.Run("loads custom token file", func(t *testing.T) {
+		tokenFile := filepath.Join(t.TempDir(), "token")
+		require.NoError(t, os.WriteFile(tokenFile, []byte("custom-token\n"), 0o600))
 
-func TestRouteGroupClientReloadsCustomTokenFile(t *testing.T) {
-	t.Parallel()
+		client := newRouteGroupClient("initial-token", tokenFile, time.Second)
+		t.Cleanup(func() { close(client.quit) })
 
-	tokenFile := filepath.Join(t.TempDir(), "token")
-	require.NoError(t, os.WriteFile(tokenFile, []byte("initial-file-token"), 0o600))
+		assert.Equal(t, tokenFile, client.tokenFile)
+		assert.Equal(t, "custom-token", client.getToken())
+	})
 
-	client := newRouteGroupClient("initial-token", tokenFile, time.Second)
-	t.Cleanup(func() { close(client.quit) })
+	t.Run("reloads custom token file", func(t *testing.T) {
+		tokenFile := filepath.Join(t.TempDir(), "token")
+		require.NoError(t, os.WriteFile(tokenFile, []byte("initial-file-token"), 0o600))
 
-	require.NoError(t, os.WriteFile(tokenFile, []byte("rotated-file-token\r\n"), 0o600))
-	client.updateToken()
+		client := newRouteGroupClient("initial-token", tokenFile, time.Second)
+		t.Cleanup(func() { close(client.quit) })
 
-	assert.Equal(t, "rotated-file-token", client.getToken())
+		require.NoError(t, os.WriteFile(tokenFile, []byte("rotated-file-token\r\n"), 0o600))
+		client.updateToken()
+
+		assert.Equal(t, "rotated-file-token", client.getToken())
+	})
 }
 
 func createTestRouteGroup(ns, name string, annotations map[string]string, hosts []string, destinations []routeGroupLoadBalancer) *routeGroup {


### PR DESCRIPTION
## Summary

- Preserve the exact custom bearer token file path for the Skipper RouteGroup source.
- Add regression coverage for initial token loading and token rotation.

## Context

This issue came up while working on [#6580](https://github.com/kubernetes-sigs/external-dns/pull/6580), which added focused Skipper RouteGroup source coverage. `newRouteGroupClient` replaced every non-empty token path with the in-cluster service-account path, so kubeconfigs using a custom `tokenFile` were ignored. That could select the wrong token and prevent configured token rotation from being loaded.

Fixes #6581

## Validation

- `make test`
- `go test -race ./source`
- `golangci-lint run --timeout=30m ./source`
