### PR TITLE
feat(chart): add extraManifests support to helm chart

### DIFF
--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -109,6 +109,7 @@ If `namespaced` is set to `true`, please ensure that `sources` only contains sup
 | excludeDomains | list | `[]` | Intentionally exclude domains from being managed. |
 | extraArgs | object | `{}` | Extra arguments to provide to _ExternalDNS_. An array or map can be used, with maps allowing for value overrides; maps also support slice values to use the same arg multiple times. |
 | extraContainers | list | `[]` | Extra containers to add to the `Deployment`. |
+| extraManifests | list | `[]` | Extra Kubernetes manifests to deploy alongside the chart, templates are allowed inside the manifests themselves. |
 | extraVolumeMounts | list | `[]` | Extra [volume mounts](https://kubernetes.io/docs/concepts/storage/volumes/) for the `external-dns` container. |
 | extraVolumes | list | `[]` | Extra [volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the `Pod`. |
 | fullnameOverride | string | `nil` | Override the full name of the chart. |

--- a/charts/external-dns/templates/extra-manifests.yaml
+++ b/charts/external-dns/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -100,6 +100,13 @@
       "description": "Extra containers to add to the `Deployment`.",
       "type": "array"
     },
+    "extraManifests": {
+      "description": "Extra Kubernetes manifests to deploy alongside the chart, templates are allowed inside the manifests themselves.",
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
     "extraVolumeMounts": {
       "description": "Extra [volume mounts](https://kubernetes.io/docs/concepts/storage/volumes/) for the `external-dns` container.",
       "type": "array"

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -330,6 +330,9 @@ provider:  # @schema type: [object, string]
 # An array or map can be used, with maps allowing for value overrides; maps also support slice values to use the same arg multiple times.
 extraArgs: {}  # @schema type: [array, null, object]; item: string; uniqueItems: true
 
+# -- Extra Kubernetes manifests to deploy alongside the chart, templates are allowed inside the manifests themselves.
+extraManifests: []  # @schema item: object
+
 secretConfiguration:
   # -- If `true`, create a `Secret` to store sensitive provider configuration (**DEPRECATED**).
   enabled: false


### PR DESCRIPTION
- Added extraManifests: [] to charts/external-dns/values.yaml with docs/schema annotations.
- Added charts/external-dns/templates/extra-manifests.yaml, which renders each entry (with tpl support) as a separate manifest.
- Updated README.md and values.schema.json to match (normally auto-generated by helm-docs/helm schema, which weren't installed locally, so I mirrored their output by hand and validated with helm lint).
- Verified rendering with a sample ConfigMap via helm template.
