### PR TITLE
feat(chart): add hostAliases value

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add value `.service.enabled` to enable the creation of the Kubernetes service.
 - Add value `replicaCount` to set the number of `external-dns` replicas (bounded to `0` or `1`, since external-dns does not support leader election). [#6503](https://github.com/kubernetes-sigs/external-dns/pull/6503) _@yugstar_
+- Add value `hostAliases` to inject entries into the `Pod`'s `/etc/hosts`, for reaching a provider or webhook by a hostname that cluster DNS cannot resolve. [#6588](https://github.com/kubernetes-sigs/external-dns/pull/6588) _@jetersen_
 
 ### Fixed
 

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -114,6 +114,7 @@ If `namespaced` is set to `true`, please ensure that `sources` only contains sup
 | fullnameOverride | string | `nil` | Override the full name of the chart. |
 | gatewayNamespace | string | `nil` | _Gateway API_ gateway namespace to watch. When `namespaced=true`, setting this value avoids creating any cluster-scoped RBAC (no ClusterRole/ClusterRoleBinding) for Gateway sources. |
 | global.imagePullSecrets | list | `[]` | Global image pull secrets. |
+| hostAliases | list | `[]` | [Host aliases](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/) to add to the `Pod` definition, injected into the pod's `/etc/hosts`. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the `external-dns` container. |
 | image.repository | string | `"registry.k8s.io/external-dns/external-dns"` | Image repository for the `external-dns` container. |
 | image.tag | string | `nil` | Image tag for the `external-dns` container, this will default to `.Chart.AppVersion` if not set. |

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -70,6 +70,10 @@ spec:
       dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.initContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}

--- a/charts/external-dns/tests/deployment-config_test.yaml
+++ b/charts/external-dns/tests/deployment-config_test.yaml
@@ -96,3 +96,24 @@ tests:
           # Rejected by the values schema (maximum: 1) in schema-validated paths,
           # or by the template guard when schema validation is skipped.
           errorPattern: "(replicaCount must be 0 or 1|/replicaCount': maximum: got 2, want 1)"
+
+  - it: should not render hostAliases by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.hostAliases
+
+  - it: should render hostAliases when specified via values
+    set:
+      hostAliases:
+        - ip: 192.0.2.10
+          hostnames:
+            - provider.example.com
+            - provider
+    asserts:
+      - equal:
+          path: spec.template.spec.hostAliases
+          value:
+            - ip: 192.0.2.10
+              hostnames:
+                - provider.example.com
+                - provider

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -134,6 +134,10 @@
         }
       }
     },
+    "hostAliases": {
+      "description": "[Host aliases](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/) to add to the `Pod` definition, injected into the pod's `/etc/hosts`.",
+      "type": "array"
+    },
     "image": {
       "type": "object",
       "properties": {

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -114,6 +114,9 @@ dnsPolicy:  # @schema type:[string, null]; default: null
 # -- (object) [DNS config](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config) for the pod, if not set the default will be used.
 dnsConfig:  # @schema type:[object, null]; default: null
 
+# -- [Host aliases](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/) to add to the `Pod` definition, injected into the pod's `/etc/hosts`.
+hostAliases: []
+
 # -- [Init containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) to add to the `Pod` definition.
 initContainers: []
 


### PR DESCRIPTION
## What does it do ?

Exposes the `Pod`'s `hostAliases` field as a chart value, rendered into the Deployment alongside the existing `dnsPolicy` and `dnsConfig`. Defaults to `[]`, so the rendered `Pod` is unchanged unless the value is set.

## Motivation

`external-dns` sometimes has to reach a provider or webhook by a hostname that cluster DNS cannot resolve.

The case I hit: a UniFi controller whose API serves a publicly-trusted certificate issued for its hostname, with no IP SAN — and no public CA will issue one for an RFC1918 address. That leaves two bad options. Addressing it by IP means disabling certificate verification and sending an API key over an unverified connection. Addressing it by hostname means depending on the very DNS records `external-dns` is responsible for publishing, which deadlocks on a fresh cluster.

`hostAliases` resolves this cleanly: the hostname is pinned in the pod's `/etc/hosts`, consulted before any resolver, so TLS verifies against the real certificate with no DNS dependency. The same applies to any on-premises provider or webhook reachable only via a hostname that isn't in cluster DNS.

The chart renders a fixed allowlist of pod fields, so there is currently no way to set this — `dnsConfig` cannot map a name to an address, and a post-renderer is the only workaround.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

`values.schema.json` and `README.md` were regenerated with `scripts/helm-tools.sh --schema` and `--docs`. `helm unittest` passes (83 tests, including two new cases covering the default and configured behaviour).