### PR TITLE
fix(source): skip invalid endpoint hostnames

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -281,12 +281,39 @@ type Endpoint struct {
 }
 
 // NewEndpoint initialization method to be used to create an endpoint
+//
+// Deprecated: use [NewValidatedEndpoint] instead. It returns the reason the
+// endpoint cannot be created as an error, where this constructor only logs
+// it and returns nil.
 func NewEndpoint(dnsName, recordType string, targets ...string) *Endpoint {
 	return NewEndpointWithTTL(dnsName, recordType, TTL(0), targets...)
 }
 
 // NewEndpointWithTTL initialization method to be used to create an endpoint with a TTL struct
+//
+// Deprecated: use [NewValidatedEndpointWithTTL] instead. It returns the reason
+// the endpoint cannot be created as an error, where this constructor only
+// logs it and returns nil.
 func NewEndpointWithTTL(dnsName, recordType string, ttl TTL, targets ...string) *Endpoint {
+	ep, err := NewValidatedEndpointWithTTL(dnsName, recordType, ttl, targets...)
+	if err != nil {
+		log.Errorf("%v. Cannot create endpoint", err)
+		return nil
+	}
+	return ep
+}
+
+// NewValidatedEndpoint creates an endpoint, rejecting DNS names that cannot be
+// represented as a record name. The returned error names the offending label
+// when any dot-separated label of dnsName exceeds the 63 characters allowed by
+// RFC 1035 section 2.3.4.
+func NewValidatedEndpoint(dnsName, recordType string, targets ...string) (*Endpoint, error) {
+	return NewValidatedEndpointWithTTL(dnsName, recordType, TTL(0), targets...)
+}
+
+// NewValidatedEndpointWithTTL creates an endpoint with a TTL, rejecting DNS
+// names that cannot be represented as a record name; see [NewValidatedEndpoint].
+func NewValidatedEndpointWithTTL(dnsName, recordType string, ttl TTL, targets ...string) (*Endpoint, error) {
 	cleanTargets := make([]string, len(targets))
 	for idx, target := range targets {
 		// Only trim trailing dots for domain name record types, not for TXT or NAPTR records
@@ -302,8 +329,7 @@ func NewEndpointWithTTL(dnsName, recordType string, ttl TTL, targets ...string) 
 
 	for label := range strings.SplitSeq(dnsName, ".") {
 		if len(label) > 63 {
-			log.Errorf("label %s in %s is longer than 63 characters. Cannot create endpoint", label, dnsName)
-			return nil
+			return nil, fmt.Errorf("label %s in %s is longer than 63 characters", label, dnsName)
 		}
 	}
 
@@ -313,7 +339,7 @@ func NewEndpointWithTTL(dnsName, recordType string, ttl TTL, targets ...string) 
 		RecordType: recordType,
 		Labels:     NewLabels(),
 		RecordTTL:  ttl,
-	}
+	}, nil
 }
 
 // WithSetIdentifier applies the given set identifier to the endpoint.
@@ -525,7 +551,7 @@ func NewPTREndpoint(target string, ttl TTL, hostnames ...string) (*Endpoint, err
 		return nil, fmt.Errorf("failed to compute reverse address for %s: %w", target, err)
 	}
 	ptrName := strings.TrimSuffix(revAddr, ".")
-	return NewEndpointWithTTL(ptrName, RecordTypePTR, ttl, hostnames...), nil
+	return NewValidatedEndpointWithTTL(ptrName, RecordTypePTR, ttl, hostnames...)
 }
 
 // String returns a human-readable representation of the endpoint in zone-file style.

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -1805,6 +1806,81 @@ func TestNewEndpointWithTTLPreservesDotsInTXTRecords(t *testing.T) {
 	cnameEndpoint := NewEndpointWithTTL("example.com", RecordTypeCNAME, TTL(300), "target.example.com.")
 	require.NotNil(t, cnameEndpoint, "CNAME endpoint should be created")
 	assert.Equal(t, "target.example.com", cnameEndpoint.Targets[0], "CNAME record should have trailing dot trimmed")
+}
+
+// TestNewEndpointRejectsOverlongDNSLabels pins down what makes the constructor
+// return nil: the length of an individual DNS label, capped at 63 characters by
+// RFC 1035 section 2.3.4. The cap is applied to every dot-separated label
+// independently and never to the name as a whole, so a name may be arbitrarily
+// longer than 63 characters as long as each of its labels is not.
+func TestNewEndpointRejectsOverlongDNSLabels(t *testing.T) {
+	const maxLabelLength = 63
+
+	maxLabel := strings.Repeat("a", maxLabelLength)
+	overlongLabel := strings.Repeat("a", maxLabelLength+1)
+
+	// 25 labels of 8 characters, 224 characters in total. Far longer than the
+	// per-label cap, and still a valid name because no single label exceeds it.
+	longNameShortLabels := strings.TrimSuffix(strings.Repeat("shortlbl.", 25), ".")
+	require.Greater(t, len(longNameShortLabels), maxLabelLength,
+		"this name must exceed the per-label cap for the test case to prove anything")
+
+	tests := []struct {
+		name    string
+		dnsName string
+		wantNil bool
+	}{
+		{
+			name:    "label of exactly 63 characters is accepted",
+			dnsName: maxLabel + ".example.com",
+		},
+		{
+			name:    "same label one character longer is rejected",
+			dnsName: overlongLabel + ".example.com",
+			wantNil: true,
+		},
+		{
+			name:    "over-long label in the middle of the name is rejected",
+			dnsName: "example." + overlongLabel + ".com",
+			wantNil: true,
+		},
+		{
+			name:    "over-long label at the end of the name is rejected",
+			dnsName: "example.com." + overlongLabel,
+			wantNil: true,
+		},
+		{
+			name:    "over-long name with no dots at all is rejected",
+			dnsName: overlongLabel,
+			wantNil: true,
+		},
+		{
+			name:    "name much longer than 63 characters is accepted while every label is short",
+			dnsName: longNameShortLabels,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hook := logtest.LogsUnderTestWithLogLevel(log.ErrorLevel, t)
+
+			ep := NewEndpointWithTTL(tt.dnsName, RecordTypeA, TTL(300), "1.2.3.4")
+
+			if tt.wantNil {
+				require.Nil(t, ep, "a name with an over-long label must not produce an endpoint")
+				logtest.TestHelperLogContains("is longer than 63 characters", hook, t)
+				return
+			}
+
+			require.NotNil(t, ep, "a name whose labels all fit must produce an endpoint")
+			assert.Equal(t, tt.dnsName, ep.DNSName)
+			logtest.TestHelperLogNotContains("is longer than 63 characters", hook, t)
+		})
+	}
+
+	// NewEndpoint delegates to NewEndpointWithTTL, so it rejects the same names.
+	assert.Nil(t, NewEndpoint(overlongLabel+".example.com", RecordTypeA, "1.2.3.4"))
+	assert.NotNil(t, NewEndpoint(maxLabel+".example.com", RecordTypeA, "1.2.3.4"))
 }
 
 func TestGetAliasProperty(t *testing.T) {

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -1808,11 +1808,16 @@ func TestNewEndpointWithTTLPreservesDotsInTXTRecords(t *testing.T) {
 	assert.Equal(t, "target.example.com", cnameEndpoint.Targets[0], "CNAME record should have trailing dot trimmed")
 }
 
-// TestNewEndpointRejectsOverlongDNSLabels pins down what makes the constructor
-// return nil: the length of an individual DNS label, capped at 63 characters by
-// RFC 1035 section 2.3.4. The cap is applied to every dot-separated label
+// TestNewEndpointRejectsOverlongDNSLabels pins down what makes the constructors
+// reject a DNS name: the length of an individual label, capped at 63 characters
+// by RFC 1035 section 2.3.4. The cap is applied to every dot-separated label
 // independently and never to the name as a whole, so a name may be arbitrarily
 // longer than 63 characters as long as each of its labels is not.
+//
+// A rejection surfaces differently per constructor: NewValidatedEndpointWithTTL
+// returns it as an error, while the deprecated NewEndpointWithTTL logs it and
+// returns nil. Both are covered here so the deprecated wrapper keeps its
+// contract for third-party callers until it is removed.
 func TestNewEndpointRejectsOverlongDNSLabels(t *testing.T) {
 	const maxLabelLength = 63
 
@@ -1826,33 +1831,33 @@ func TestNewEndpointRejectsOverlongDNSLabels(t *testing.T) {
 		"this name must exceed the per-label cap for the test case to prove anything")
 
 	tests := []struct {
-		name    string
-		dnsName string
-		wantNil bool
+		name         string
+		dnsName      string
+		wantRejected bool
 	}{
 		{
 			name:    "label of exactly 63 characters is accepted",
 			dnsName: maxLabel + ".example.com",
 		},
 		{
-			name:    "same label one character longer is rejected",
-			dnsName: overlongLabel + ".example.com",
-			wantNil: true,
+			name:         "same label one character longer is rejected",
+			dnsName:      overlongLabel + ".example.com",
+			wantRejected: true,
 		},
 		{
-			name:    "over-long label in the middle of the name is rejected",
-			dnsName: "example." + overlongLabel + ".com",
-			wantNil: true,
+			name:         "over-long label in the middle of the name is rejected",
+			dnsName:      "example." + overlongLabel + ".com",
+			wantRejected: true,
 		},
 		{
-			name:    "over-long label at the end of the name is rejected",
-			dnsName: "example.com." + overlongLabel,
-			wantNil: true,
+			name:         "over-long label at the end of the name is rejected",
+			dnsName:      "example.com." + overlongLabel,
+			wantRejected: true,
 		},
 		{
-			name:    "over-long name with no dots at all is rejected",
-			dnsName: overlongLabel,
-			wantNil: true,
+			name:         "over-long name with no dots at all is rejected",
+			dnsName:      overlongLabel,
+			wantRejected: true,
 		},
 		{
 			name:    "name much longer than 63 characters is accepted while every label is short",
@@ -1864,21 +1869,37 @@ func TestNewEndpointRejectsOverlongDNSLabels(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			hook := logtest.LogsUnderTestWithLogLevel(log.ErrorLevel, t)
 
-			ep := NewEndpointWithTTL(tt.dnsName, RecordTypeA, TTL(300), "1.2.3.4")
+			validated, err := NewValidatedEndpointWithTTL(tt.dnsName, RecordTypeA, TTL(300), "1.2.3.4")
+			deprecated := NewEndpointWithTTL(tt.dnsName, RecordTypeA, TTL(300), "1.2.3.4")
 
-			if tt.wantNil {
-				require.Nil(t, ep, "a name with an over-long label must not produce an endpoint")
+			if tt.wantRejected {
+				require.Nil(t, validated, "a name with an over-long label must not produce an endpoint")
+				require.ErrorContains(t, err, "is longer than 63 characters",
+					"the error must name the reason the endpoint cannot be created")
+
+				require.Nil(t, deprecated, "the deprecated constructor must keep returning nil")
 				logtest.TestHelperLogContains("is longer than 63 characters", hook, t)
 				return
 			}
 
-			require.NotNil(t, ep, "a name whose labels all fit must produce an endpoint")
-			assert.Equal(t, tt.dnsName, ep.DNSName)
+			require.NoError(t, err)
+			require.NotNil(t, validated, "a name whose labels all fit must produce an endpoint")
+			assert.Equal(t, tt.dnsName, validated.DNSName)
+
+			require.NotNil(t, deprecated)
+			assert.Equal(t, validated, deprecated,
+				"both constructors must build the same endpoint for an accepted name")
 			logtest.TestHelperLogNotContains("is longer than 63 characters", hook, t)
 		})
 	}
 
-	// NewEndpoint delegates to NewEndpointWithTTL, so it rejects the same names.
+	// The TTL-less constructors delegate to the TTL variants, so they reject
+	// the same names.
+	_, err := NewValidatedEndpoint(overlongLabel+".example.com", RecordTypeA, "1.2.3.4")
+	assert.ErrorContains(t, err, "is longer than 63 characters")
+	ep, err := NewValidatedEndpoint(maxLabel+".example.com", RecordTypeA, "1.2.3.4")
+	assert.NoError(t, err)
+	assert.NotNil(t, ep)
 	assert.Nil(t, NewEndpoint(overlongLabel+".example.com", RecordTypeA, "1.2.3.4"))
 	assert.NotNil(t, NewEndpoint(maxLabel+".example.com", RecordTypeA, "1.2.3.4"))
 }

--- a/endpoint/utils.go
+++ b/endpoint/utils.go
@@ -139,7 +139,7 @@ func EndpointsForHostsAndTargets(hostnames, targets []string) []*Endpoint {
 	endpoints := make([]*Endpoint, 0, len(sortedHosts)*len(sortedTypes))
 	for _, hostname := range sortedHosts {
 		for _, recordType := range sortedTypes {
-			endpoints = append(endpoints, NewEndpoint(hostname, recordType, sortedTargets[recordType]...))
+			endpoints = AppendIfNotNil(endpoints, NewEndpoint(hostname, recordType, sortedTargets[recordType]...))
 		}
 	}
 	return endpoints

--- a/endpoint/utils.go
+++ b/endpoint/utils.go
@@ -58,22 +58,10 @@ func HasNoEmptyEndpoints(
 	return false
 }
 
-// AppendIfNotNil appends ep to endpoints, skipping it when ep is nil.
-//
-// NewEndpoint and NewEndpointWithTTL return nil for a DNS name that cannot be
-// represented, currently a label longer than the 63 characters allowed by
-// RFC 1035 section 2.3.4, and log the reason. Collecting that nil would panic
-// later in MergeEndpoints or in any caller that sets labels on the result, so
-// every site that appends a freshly constructed endpoint goes through here.
-func AppendIfNotNil(endpoints []*Endpoint, ep *Endpoint) []*Endpoint {
-	if ep == nil {
-		return endpoints
-	}
-	return append(endpoints, ep)
-}
-
 // EndpointsForHostname returns endpoint objects for each host-target combination,
 // grouping targets by their suitable DNS record type (A, AAAA, or CNAME).
+// A hostname the endpoint constructor rejects is skipped with a warning
+// rather than aborting the remaining record types.
 func EndpointsForHostname(hostname string, targets Targets, ttl TTL, providerSpecific ProviderSpecific, setIdentifier string, resource string) []*Endpoint {
 	byType := map[string]Targets{}
 	for _, t := range targets {
@@ -86,16 +74,17 @@ func EndpointsForHostname(hostname string, targets Targets, ttl TTL, providerSpe
 		if len(byType[rt]) == 0 {
 			continue
 		}
-		endpoints = AppendIfNotNil(endpoints, NewEndpointWithTTL(hostname, rt, ttl, byType[rt]...))
-	}
-
-	// add the shared metadata to every endpoint that was created
-	for _, ep := range endpoints {
+		ep, err := NewValidatedEndpointWithTTL(hostname, rt, ttl, byType[rt]...)
+		if err != nil {
+			log.Warnf("Skipping %s endpoint for hostname %q: %v", rt, hostname, err)
+			continue
+		}
 		ep.ProviderSpecific = providerSpecific
 		ep.SetIdentifier = setIdentifier
 		if resource != "" {
 			ep.Labels[ResourceLabelKey] = resource
 		}
+		endpoints = append(endpoints, ep)
 	}
 
 	return endpoints
@@ -139,7 +128,12 @@ func EndpointsForHostsAndTargets(hostnames, targets []string) []*Endpoint {
 	endpoints := make([]*Endpoint, 0, len(sortedHosts)*len(sortedTypes))
 	for _, hostname := range sortedHosts {
 		for _, recordType := range sortedTypes {
-			endpoints = AppendIfNotNil(endpoints, NewEndpoint(hostname, recordType, sortedTargets[recordType]...))
+			ep, err := NewValidatedEndpoint(hostname, recordType, sortedTargets[recordType]...)
+			if err != nil {
+				log.Warnf("Skipping %s endpoint for hostname %q: %v", recordType, hostname, err)
+				continue
+			}
+			endpoints = append(endpoints, ep)
 		}
 	}
 	return endpoints

--- a/endpoint/utils.go
+++ b/endpoint/utils.go
@@ -58,6 +58,20 @@ func HasNoEmptyEndpoints(
 	return false
 }
 
+// AppendIfNotNil appends ep to endpoints, skipping it when ep is nil.
+//
+// NewEndpoint and NewEndpointWithTTL return nil for a DNS name that cannot be
+// represented, currently a label longer than the 63 characters allowed by
+// RFC 1035 section 2.3.4, and log the reason. Collecting that nil would panic
+// later in MergeEndpoints or in any caller that sets labels on the result, so
+// every site that appends a freshly constructed endpoint goes through here.
+func AppendIfNotNil(endpoints []*Endpoint, ep *Endpoint) []*Endpoint {
+	if ep == nil {
+		return endpoints
+	}
+	return append(endpoints, ep)
+}
+
 // EndpointsForHostname returns endpoint objects for each host-target combination,
 // grouping targets by their suitable DNS record type (A, AAAA, or CNAME).
 func EndpointsForHostname(hostname string, targets Targets, ttl TTL, providerSpecific ProviderSpecific, setIdentifier string, resource string) []*Endpoint {
@@ -72,17 +86,18 @@ func EndpointsForHostname(hostname string, targets Targets, ttl TTL, providerSpe
 		if len(byType[rt]) == 0 {
 			continue
 		}
-		ep := NewEndpointWithTTL(hostname, rt, ttl, byType[rt]...)
-		if ep == nil {
-			continue
-		}
+		endpoints = AppendIfNotNil(endpoints, NewEndpointWithTTL(hostname, rt, ttl, byType[rt]...))
+	}
+
+	// add the shared metadata to every endpoint that was created
+	for _, ep := range endpoints {
 		ep.ProviderSpecific = providerSpecific
 		ep.SetIdentifier = setIdentifier
 		if resource != "" {
 			ep.Labels[ResourceLabelKey] = resource
 		}
-		endpoints = append(endpoints, ep)
 	}
+
 	return endpoints
 }
 

--- a/endpoint/utils_external_test.go
+++ b/endpoint/utils_external_test.go
@@ -204,3 +204,35 @@ func TestEndpointsForHostsAndTargets(t *testing.T) {
 		})
 	}
 }
+
+// TestEndpointsForHostsAndTargetsSkipsRejectedHostnames covers a hostname the
+// constructor refuses to build an endpoint for. It must be dropped rather than
+// collected as a nil element: callers dereference every element of the result,
+// so a leaked nil panics in MergeEndpoints and in the label loop of the
+// unstructured source rather than surfacing as a rejected hostname.
+func TestEndpointsForHostsAndTargetsSkipsRejectedHostnames(t *testing.T) {
+	// The two names differ only in the length of the first label, 64 characters
+	// against the 63 that RFC 1035 section 2.3.4 allows.
+	rejected := strings.Repeat("a", 64) + ".example.com"
+	accepted := strings.Repeat("a", 63) + ".example.com"
+
+	t.Run("hostname is dropped rather than collected as nil", func(t *testing.T) {
+		result := endpoint.EndpointsForHostsAndTargets([]string{rejected}, []string{"192.168.1.1"})
+		assert.Empty(t, result)
+		assert.NotContains(t, result, (*endpoint.Endpoint)(nil))
+	})
+
+	t.Run("remaining hostnames are still returned", func(t *testing.T) {
+		result := endpoint.EndpointsForHostsAndTargets([]string{rejected, accepted}, []string{"192.168.1.1"})
+		testutils.ValidateEndpoints(t, result, []*endpoint.Endpoint{
+			endpoint.NewEndpoint(accepted, endpoint.RecordTypeA, "192.168.1.1"),
+		})
+	})
+
+	t.Run("result is safe to merge", func(t *testing.T) {
+		result := endpoint.EndpointsForHostsAndTargets([]string{rejected}, []string{"192.168.1.1"})
+		assert.NotPanics(t, func() {
+			endpoint.MergeEndpoints(result)
+		})
+	})
+}

--- a/endpoint/utils_external_test.go
+++ b/endpoint/utils_external_test.go
@@ -21,49 +21,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/internal/testutils"
 )
-
-func TestAppendIfNotNil(t *testing.T) {
-	first := endpoint.NewEndpoint("first.example.com", endpoint.RecordTypeA, "192.168.1.1")
-	second := endpoint.NewEndpoint("second.example.com", endpoint.RecordTypeA, "192.168.1.2")
-	require.NotNil(t, first)
-	require.NotNil(t, second)
-
-	t.Run("appends an endpoint to a nil slice", func(t *testing.T) {
-		assert.Equal(t, []*endpoint.Endpoint{first}, endpoint.AppendIfNotNil(nil, first))
-	})
-
-	t.Run("appends an endpoint to a populated slice", func(t *testing.T) {
-		got := endpoint.AppendIfNotNil([]*endpoint.Endpoint{first}, second)
-		assert.Equal(t, []*endpoint.Endpoint{first, second}, got)
-	})
-
-	t.Run("drops a nil endpoint and leaves the slice untouched", func(t *testing.T) {
-		got := endpoint.AppendIfNotNil([]*endpoint.Endpoint{first}, nil)
-		assert.Equal(t, []*endpoint.Endpoint{first}, got)
-	})
-
-	t.Run("a nil endpoint leaves a nil slice nil rather than empty", func(t *testing.T) {
-		var endpoints []*endpoint.Endpoint
-
-		got := endpoint.AppendIfNotNil(endpoints, nil)
-
-		// Nil rather than merely empty: EndpointsForHostname hands its slice
-		// straight back to callers that compare it against []*Endpoint(nil),
-		// so the helper has to return the input rather than allocate.
-		assert.Nil(t, got)
-	})
-
-	t.Run("drops the endpoint a rejected DNS name produces", func(t *testing.T) {
-		rejected := endpoint.NewEndpoint(strings.Repeat("a", 64)+".example.com", endpoint.RecordTypeA, "192.168.1.1")
-		require.Nil(t, rejected, "an over-long label must be rejected for this case to prove anything")
-		assert.Empty(t, endpoint.AppendIfNotNil(nil, rejected))
-	})
-}
 
 func TestEndpointsForHostsAndTargets(t *testing.T) {
 	tests := []struct {
@@ -206,10 +167,10 @@ func TestEndpointsForHostsAndTargets(t *testing.T) {
 }
 
 // TestEndpointsForHostsAndTargetsSkipsRejectedHostnames covers a hostname the
-// constructor refuses to build an endpoint for. It must be dropped rather than
-// collected as a nil element: callers dereference every element of the result,
-// so a leaked nil panics in MergeEndpoints and in the label loop of the
-// unstructured source rather than surfacing as a rejected hostname.
+// validating constructor refuses to build an endpoint for. The rejection must
+// drop only that hostname: callers dereference every element of the result
+// (MergeEndpoints, the label loop of the unstructured source), so nothing
+// unbuildable may leak into it, and the remaining hostnames must survive.
 func TestEndpointsForHostsAndTargetsSkipsRejectedHostnames(t *testing.T) {
 	// The two names differ only in the length of the first label, 64 characters
 	// against the 63 that RFC 1035 section 2.3.4 allows.

--- a/endpoint/utils_external_test.go
+++ b/endpoint/utils_external_test.go
@@ -17,13 +17,53 @@ limitations under the License.
 package endpoint_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/internal/testutils"
 )
+
+func TestAppendIfNotNil(t *testing.T) {
+	first := endpoint.NewEndpoint("first.example.com", endpoint.RecordTypeA, "192.168.1.1")
+	second := endpoint.NewEndpoint("second.example.com", endpoint.RecordTypeA, "192.168.1.2")
+	require.NotNil(t, first)
+	require.NotNil(t, second)
+
+	t.Run("appends an endpoint to a nil slice", func(t *testing.T) {
+		assert.Equal(t, []*endpoint.Endpoint{first}, endpoint.AppendIfNotNil(nil, first))
+	})
+
+	t.Run("appends an endpoint to a populated slice", func(t *testing.T) {
+		got := endpoint.AppendIfNotNil([]*endpoint.Endpoint{first}, second)
+		assert.Equal(t, []*endpoint.Endpoint{first, second}, got)
+	})
+
+	t.Run("drops a nil endpoint and leaves the slice untouched", func(t *testing.T) {
+		got := endpoint.AppendIfNotNil([]*endpoint.Endpoint{first}, nil)
+		assert.Equal(t, []*endpoint.Endpoint{first}, got)
+	})
+
+	t.Run("a nil endpoint leaves a nil slice nil rather than empty", func(t *testing.T) {
+		var endpoints []*endpoint.Endpoint
+
+		got := endpoint.AppendIfNotNil(endpoints, nil)
+
+		// Nil rather than merely empty: EndpointsForHostname hands its slice
+		// straight back to callers that compare it against []*Endpoint(nil),
+		// so the helper has to return the input rather than allocate.
+		assert.Nil(t, got)
+	})
+
+	t.Run("drops the endpoint a rejected DNS name produces", func(t *testing.T) {
+		rejected := endpoint.NewEndpoint(strings.Repeat("a", 64)+".example.com", endpoint.RecordTypeA, "192.168.1.1")
+		require.Nil(t, rejected, "an over-long label must be rejected for this case to prove anything")
+		assert.Empty(t, endpoint.AppendIfNotNil(nil, rejected))
+	})
+}
 
 func TestEndpointsForHostsAndTargets(t *testing.T) {
 	tests := []struct {

--- a/endpoint/utils_test.go
+++ b/endpoint/utils_test.go
@@ -229,11 +229,10 @@ func TestEndpointsForHostname(t *testing.T) {
 	}
 }
 
-// TestEndpointsForHostnameSkipsRejectedHostname covers a hostname the constructor
-// refuses to build an endpoint for. Every record type shares the one hostname, so
-// a rejection drops all of them, and none may be collected as a nil element: the
-// metadata pass that follows the construction loop dereferences every element of
-// the slice, as does MergeEndpoints downstream.
+// TestEndpointsForHostnameSkipsRejectedHostname covers a hostname the validating
+// constructor refuses to build an endpoint for. Every record type shares the one
+// hostname, so a rejection drops all of them, and nothing unbuildable may reach
+// the result: MergeEndpoints downstream dereferences every element of the slice.
 func TestEndpointsForHostnameSkipsRejectedHostname(t *testing.T) {
 	// The two names differ only in the length of the first label, 64 characters
 	// against the 63 that RFC 1035 section 2.3.4 allows.

--- a/endpoint/utils_test.go
+++ b/endpoint/utils_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package endpoint
 
 import (
+	"strings"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -226,6 +227,61 @@ func TestEndpointsForHostname(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// TestEndpointsForHostnameSkipsRejectedHostname covers a hostname the constructor
+// refuses to build an endpoint for. Every record type shares the one hostname, so
+// a rejection drops all of them, and none may be collected as a nil element: the
+// metadata pass that follows the construction loop dereferences every element of
+// the slice, as does MergeEndpoints downstream.
+func TestEndpointsForHostnameSkipsRejectedHostname(t *testing.T) {
+	// The two names differ only in the length of the first label, 64 characters
+	// against the 63 that RFC 1035 section 2.3.4 allows.
+	rejected := strings.Repeat("a", 64) + ".example.com"
+	accepted := strings.Repeat("a", 63) + ".example.com"
+
+	// One target per record type, so the hostname yields an A, an AAAA and a
+	// CNAME endpoint and a leaked nil would appear once for each.
+	targets := Targets{"192.0.2.1", "2001:db8::1", "cname.example.com"}
+	providerSpecific := ProviderSpecific{{Name: "provider", Value: "value"}}
+
+	t.Run("hostname is dropped rather than collected as nil", func(t *testing.T) {
+		result := EndpointsForHostname(rejected, targets, TTL(300), providerSpecific, "identifier", "resource")
+
+		assert.Empty(t, result)
+		assert.NotContains(t, result, (*Endpoint)(nil))
+	})
+
+	t.Run("result is safe to merge", func(t *testing.T) {
+		result := EndpointsForHostname(rejected, targets, TTL(300), providerSpecific, "identifier", "resource")
+
+		assert.NotPanics(t, func() {
+			MergeEndpoints(result)
+		})
+	})
+
+	t.Run("an accepted hostname carries the metadata on every record type", func(t *testing.T) {
+		result := EndpointsForHostname(accepted, targets, TTL(300), providerSpecific, "identifier", "resource")
+
+		require.Len(t, result, 3, "one endpoint per record type present in the targets")
+		for _, ep := range result {
+			require.NotNil(t, ep)
+			assert.Equal(t, accepted, ep.DNSName)
+			assert.Equal(t, providerSpecific, ep.ProviderSpecific, "%s endpoint lost its provider-specific config", ep.RecordType)
+			assert.Equal(t, "identifier", ep.SetIdentifier, "%s endpoint lost its set identifier", ep.RecordType)
+			assert.Equal(t, "resource", ep.Labels[ResourceLabelKey], "%s endpoint lost its resource label", ep.RecordType)
+		}
+	})
+
+	t.Run("an empty resource leaves the resource label unset", func(t *testing.T) {
+		result := EndpointsForHostname(accepted, targets, TTL(300), providerSpecific, "identifier", "")
+
+		require.Len(t, result, 3)
+		for _, ep := range result {
+			assert.NotContains(t, ep.Labels, ResourceLabelKey, "%s endpoint gained a resource label", ep.RecordType)
+			assert.Equal(t, "identifier", ep.SetIdentifier, "%s endpoint lost its set identifier", ep.RecordType)
+		}
+	})
 }
 
 func TestAttachRefObject(t *testing.T) {

--- a/internal/testutils/endpoint.go
+++ b/internal/testutils/endpoint.go
@@ -203,9 +203,14 @@ func GenerateTestEndpointsWithDistribution(
 // NewEndpointWithRef builds an endpoint attached to a Kubernetes object reference.
 // The record type is inferred from target: A for IPv4, AAAA for IPv6, CNAME otherwise.
 // Kind and APIVersion are resolved from the client-go scheme, so TypeMeta need not be set on obj.
+// It panics when the endpoint constructor rejects dns, since a fixture with an
+// unrepresentable name is a bug in the test itself.
 func NewEndpointWithRef(dns, target string, obj ctrlclient.Object, source string) *endpoint.Endpoint {
-	return endpoint.NewEndpoint(dns, endpoint.SuitableType(target), target).
-		WithRefObject(events.NewObjectReference(obj, source))
+	ep, err := endpoint.NewValidatedEndpoint(dns, endpoint.SuitableType(target), target)
+	if err != nil {
+		panic(err)
+	}
+	return ep.WithRefObject(events.NewObjectReference(obj, source))
 }
 
 // RefSource returns an ObjectReference carrying only a source identity. Set it on an

--- a/provider/alibabacloud/alibaba_cloud.go
+++ b/provider/alibabacloud/alibaba_cloud.go
@@ -340,7 +340,11 @@ func (p *AlibabaCloudProvider) recordsForDNS() ([]*endpoint.Endpoint, error) {
 		for _, record := range recordList {
 			targets = append(targets, record.Value)
 		}
-		ep := endpoint.NewEndpointWithTTL(name, recordType, endpoint.TTL(ttl), targets...)
+		ep, err := endpoint.NewValidatedEndpointWithTTL(name, recordType, endpoint.TTL(ttl), targets...)
+		if err != nil {
+			log.Warnf("Skipping endpoint %s: %v", name, err)
+			continue
+		}
 		endpoints = append(endpoints, ep)
 	}
 	return endpoints, nil
@@ -836,7 +840,11 @@ func (p *AlibabaCloudProvider) privateZoneRecords() ([]*endpoint.Endpoint, error
 			for _, record := range recordList {
 				targets = append(targets, record.Value)
 			}
-			ep := endpoint.NewEndpointWithTTL(name, recordType, endpoint.TTL(ttl), targets...)
+			ep, err := endpoint.NewValidatedEndpointWithTTL(name, recordType, endpoint.TTL(ttl), targets...)
+			if err != nil {
+				log.Warnf("Skipping endpoint %s: %v", name, err)
+				continue
+			}
 			endpoints = append(endpoints, ep)
 		}
 	}

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -543,7 +543,11 @@ func (p *AWSProvider) records(ctx context.Context, zones map[string]*profiledZon
 						targets[idx] = *rr.Value
 					}
 
-					ep := endpoint.NewEndpointWithTTL(name, string(r.Type), ttl, targets...)
+					ep, err := endpoint.NewValidatedEndpointWithTTL(name, string(r.Type), ttl, targets...)
+					if err != nil {
+						log.Warnf("Skipping endpoint %s: %v", name, err)
+						continue
+					}
 					if r.Type == endpoint.RecordTypeCNAME {
 						ep = ep.WithAliasProperty(endpoint.AliasFalse)
 					}
@@ -555,8 +559,12 @@ func (p *AWSProvider) records(ctx context.Context, zones map[string]*profiledZon
 					if ttl == 0 {
 						ttl = defaultTTL
 					}
-					ep := endpoint.
-						NewEndpointWithTTL(name, string(r.Type), ttl, *r.AliasTarget.DNSName).
+					ep, err := endpoint.NewValidatedEndpointWithTTL(name, string(r.Type), ttl, *r.AliasTarget.DNSName)
+					if err != nil {
+						log.Warnf("Skipping endpoint %s: %v", name, err)
+						continue
+					}
+					ep = ep.
 						WithProviderSpecific(providerSpecificEvaluateTargetHealth, fmt.Sprintf("%t", r.AliasTarget.EvaluateTargetHealth)).
 						WithAliasProperty(endpoint.AliasTrue)
 					newEndpoints = append(newEndpoints, ep)

--- a/provider/azure/azure.go
+++ b/provider/azure/azure.go
@@ -169,7 +169,11 @@ func (p *AzureProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, erro
 				if recordSet.Properties.TTL != nil {
 					ttl = endpoint.TTL(*recordSet.Properties.TTL)
 				}
-				ep := endpoint.NewEndpointWithTTL(name, recordType, ttl, targets...)
+				ep, err := endpoint.NewValidatedEndpointWithTTL(name, recordType, ttl, targets...)
+				if err != nil {
+					log.Warnf("Skipping endpoint %s: %v", name, err)
+					continue
+				}
 				extractMetadataFromRecordSet(ep, recordSet)
 				log.Debugf(
 					"Found %s record for '%s' with target '%s'.",

--- a/provider/azure/azure_private_dns.go
+++ b/provider/azure/azure_private_dns.go
@@ -168,7 +168,11 @@ func (p *AzurePrivateDNSProvider) Records(ctx context.Context) ([]*endpoint.Endp
 					ttl = endpoint.TTL(*recordSet.Properties.TTL)
 				}
 
-				ep := endpoint.NewEndpointWithTTL(name, recordType, ttl, targets...)
+				ep, err := endpoint.NewValidatedEndpointWithTTL(name, recordType, ttl, targets...)
+				if err != nil {
+					log.Warnf("Skipping endpoint %s: %v", name, err)
+					continue
+				}
 				log.Debugf(
 					"Found %s record for '%s' with target '%s'.",
 					ep.RecordType,

--- a/provider/civo/civo.go
+++ b/provider/civo/civo.go
@@ -141,7 +141,12 @@ func (p *CivoProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 					name = zone.Name
 				}
 
-				endpoints = append(endpoints, endpoint.NewEndpointWithTTL(name, toUpper, endpoint.TTL(r.TTL), r.Value))
+				ep, err := endpoint.NewValidatedEndpointWithTTL(name, toUpper, endpoint.TTL(r.TTL), r.Value)
+				if err != nil {
+					log.Warnf("Skipping endpoint %s: %v", name, err)
+					continue
+				}
+				endpoints = append(endpoints, ep)
 			}
 		}
 	}

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -885,15 +885,16 @@ func (p *CloudFlareProvider) groupByNameAndTypeWithCustomHostnames(records DNSRe
 				targets[i] = endpointTargetFromCloudflareRecord(record)
 			}
 		}
-		e := endpoint.NewEndpointWithTTL(
+		e, err := endpoint.NewValidatedEndpointWithTTL(
 			records[0].Name,
 			string(records[0].Type),
 			endpoint.TTL(records[0].TTL),
 			targets...)
-		proxied := records[0].Proxied
-		if e == nil {
+		if err != nil {
+			log.Warnf("Skipping endpoint %s: %v", records[0].Name, err)
 			continue
 		}
+		proxied := records[0].Proxied
 		e = e.WithProviderSpecific(annotations.CloudflareProxiedKey, strconv.FormatBool(proxied))
 		// noop (customHostnames is empty) if custom hostnames feature is not in use
 		if customHostnames, ok := customHostnames[records[0].Name]; ok {

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -2174,8 +2174,9 @@ func TestCloudflareZoneRecordsFail(t *testing.T) {
 	}
 }
 
-// TestCloudflareLongRecordsErrorLog checks if the error is logged when a record name exceeds 63 characters
-// it's not likely to happen in practice, as the Cloudflare API should reject having it
+// TestCloudflareLongRecordsErrorLog checks that a record whose name has a label exceeding
+// 63 characters is skipped with a warning instead of failing the listing.
+// It's not likely to happen in practice, as the Cloudflare API should reject having it.
 func TestCloudflareLongRecordsErrorLog(t *testing.T) {
 	client := NewMockCloudFlareClientWithRecords(map[string][]dns.RecordResponse{
 		"001": {
@@ -2198,7 +2199,8 @@ func TestCloudflareLongRecordsErrorLog(t *testing.T) {
 	if err != nil {
 		t.Errorf("should not fail - too long record, %s", err)
 	}
-	logtest.TestHelperLogContains("s longer than 63 characters. Cannot create endpoint", hook, t)
+	logtest.TestHelperLogContains("Skipping endpoint", hook, t)
+	logtest.TestHelperLogContains("is longer than 63 characters", hook, t)
 }
 
 // check if the error is expected

--- a/provider/coredns/coredns.go
+++ b/provider/coredns/coredns.go
@@ -339,12 +339,16 @@ func (p coreDNSProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, err
 				if isPTRDomain(dnsName) {
 					recordType = endpoint.RecordTypePTR
 				}
-				ep = endpoint.NewEndpointWithTTL(
+				ep, err = endpoint.NewValidatedEndpointWithTTL(
 					dnsName,
 					recordType,
 					endpoint.TTL(service.TTL),
 					service.Host,
 				)
+				if err != nil {
+					log.Warnf("Skipping endpoint %s: %v", dnsName, err)
+					continue
+				}
 				if service.Group != "" {
 					ep.WithProviderSpecific(providerSpecificGroup, service.Group)
 				}
@@ -359,11 +363,15 @@ func (p coreDNSProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, err
 			result = append(result, ep)
 		}
 		if service.Text != "" {
-			ep := endpoint.NewEndpoint(
+			ep, err := endpoint.NewValidatedEndpoint(
 				dnsName,
 				endpoint.RecordTypeTXT,
 				service.Text,
 			)
+			if err != nil {
+				log.Warnf("Skipping endpoint %s: %v", dnsName, err)
+				continue
+			}
 			if p.strictlyOwned {
 				ep.Labels[endpoint.OwnerLabelKey] = service.Owner
 			}

--- a/provider/dnsimple/dnsimple.go
+++ b/provider/dnsimple/dnsimple.go
@@ -221,7 +221,12 @@ func (p *dnsimpleProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, e
 				if record.Name == "" {
 					dnsName = record.ZoneID
 				}
-				endpoints = append(endpoints, endpoint.NewEndpointWithTTL(dnsName, record.Type, endpoint.TTL(record.TTL), record.Content))
+				ep, err := endpoint.NewValidatedEndpointWithTTL(dnsName, record.Type, endpoint.TTL(record.TTL), record.Content)
+				if err != nil {
+					log.Warnf("Skipping endpoint %s: %v", dnsName, err)
+					continue
+				}
+				endpoints = append(endpoints, ep)
 			}
 			page++
 			if page > records.Pagination.TotalPages {

--- a/provider/exoscale/exoscale.go
+++ b/provider/exoscale/exoscale.go
@@ -327,7 +327,11 @@ func (ep *ExoscaleProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, 
 				fqdn = record.Name + "." + zoneName
 			}
 
-			e := endpoint.NewEndpointWithTTL(fqdn, string(record.Type), endpoint.TTL(record.Ttl), record.Content)
+			e, err := endpoint.NewValidatedEndpointWithTTL(fqdn, string(record.Type), endpoint.TTL(record.Ttl), record.Content)
+			if err != nil {
+				log.Warnf("Skipping endpoint %s: %v", fqdn, err)
+				continue
+			}
 			endpoints = append(endpoints, e)
 		}
 	}

--- a/provider/gandi/gandi.go
+++ b/provider/gandi/gandi.go
@@ -140,10 +140,13 @@ func (p *GandiProvider) Records(_ context.Context) ([]*endpoint.Endpoint, error)
 						"zone":   zone,
 					}).Debug("Returning endpoint record")
 
-					endpoints = append(
-						endpoints,
-						endpoint.NewEndpointWithTTL(name, r.RrsetType, endpoint.TTL(r.RrsetTTL), v),
-					)
+					ep, err := endpoint.NewValidatedEndpointWithTTL(name, r.RrsetType, endpoint.TTL(r.RrsetTTL), v)
+					if err != nil {
+						log.Warnf("Skipping endpoint %s: %v", name, err)
+						continue
+					}
+
+					endpoints = append(endpoints, ep)
 				}
 			}
 		}

--- a/provider/godaddy/godaddy.go
+++ b/provider/godaddy/godaddy.go
@@ -301,12 +301,16 @@ func (p *GDProvider) groupByNameAndType(zoneRecords []gdRecords) []*endpoint.End
 				recordName = strings.TrimPrefix(fmt.Sprintf("%s.%s", records[0].Name, zoneName), ".")
 			}
 
-			ep := endpoint.NewEndpointWithTTL(
+			ep, err := endpoint.NewValidatedEndpointWithTTL(
 				recordName,
 				records[0].Type,
 				endpoint.TTL(records[0].TTL),
 				targets...,
 			)
+			if err != nil {
+				log.Warnf("Skipping endpoint %s: %v", recordName, err)
+				continue
+			}
 
 			endpoints = append(endpoints, ep)
 		}

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -221,7 +221,12 @@ func (p *GoogleProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, err
 			if !p.SupportedRecordType(r.Type) {
 				continue
 			}
-			endpoints = append(endpoints, endpoint.NewEndpointWithTTL(r.Name, r.Type, endpoint.TTL(r.Ttl), r.Rrdatas...))
+			ep, err := endpoint.NewValidatedEndpointWithTTL(r.Name, r.Type, endpoint.TTL(r.Ttl), r.Rrdatas...)
+			if err != nil {
+				log.Warnf("Skipping endpoint %s: %v", r.Name, err)
+				continue
+			}
+			endpoints = append(endpoints, ep)
 		}
 
 		return nil

--- a/provider/inmemory/inmemory.go
+++ b/provider/inmemory/inmemory.go
@@ -211,7 +211,12 @@ func (im *InMemoryProvider) ApplyChanges(ctx context.Context, changes *plan.Chan
 func copyEndpoints(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint {
 	records := make([]*endpoint.Endpoint, 0, len(endpoints))
 	for _, ep := range endpoints {
-		newEp := endpoint.NewEndpointWithTTL(ep.DNSName, ep.RecordType, ep.RecordTTL, ep.Targets...).WithSetIdentifier(ep.SetIdentifier)
+		newEp, err := endpoint.NewValidatedEndpointWithTTL(ep.DNSName, ep.RecordType, ep.RecordTTL, ep.Targets...)
+		if err != nil {
+			log.Warnf("Skipping endpoint %s: %v", ep.DNSName, err)
+			continue
+		}
+		newEp = newEp.WithSetIdentifier(ep.SetIdentifier)
 		newEp.Labels = endpoint.NewLabels()
 		maps.Copy(newEp.Labels, ep.Labels)
 		newEp.ProviderSpecific = append(endpoint.ProviderSpecific(nil), ep.ProviderSpecific...)

--- a/provider/linode/linode.go
+++ b/provider/linode/linode.go
@@ -143,7 +143,12 @@ func (p *LinodeProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, err
 					name = zone.Domain
 				}
 
-				endpoints = append(endpoints, endpoint.NewEndpointWithTTL(name, string(r.Type), endpoint.TTL(r.TTLSec), r.Target))
+				ep, err := endpoint.NewValidatedEndpointWithTTL(name, string(r.Type), endpoint.TTL(r.TTLSec), r.Target)
+				if err != nil {
+					log.Warnf("Skipping endpoint %s: %v", name, err)
+					continue
+				}
+				endpoints = append(endpoints, ep)
 			}
 		}
 	}

--- a/provider/ns1/ns1.go
+++ b/provider/ns1/ns1.go
@@ -178,13 +178,17 @@ func (p *NS1Provider) Records(_ context.Context) ([]*endpoint.Endpoint, error) {
 
 		for _, record := range zoneData.Records {
 			if provider.SupportedRecordType(record.Type) {
-				endpoints = append(endpoints, endpoint.NewEndpointWithTTL(
+				ep, err := endpoint.NewValidatedEndpointWithTTL(
 					record.Domain,
 					record.Type,
 					endpoint.TTL(record.TTL),
 					record.ShortAns...,
-				),
 				)
+				if err != nil {
+					log.Warnf("Skipping endpoint %s: %v", record.Domain, err)
+					continue
+				}
+				endpoints = append(endpoints, ep)
 			}
 		}
 	}

--- a/provider/oci/oci.go
+++ b/provider/oci/oci.go
@@ -217,7 +217,11 @@ func mergeEndpointsMultiTargets(endpoints []*endpoint.Endpoint) []*endpoint.Endp
 			targets[i] = e.Targets[0]
 		}
 
-		e := endpoint.NewEndpointWithTTL(dnsName, recordType, recordTTL, targets...)
+		e, err := endpoint.NewValidatedEndpointWithTTL(dnsName, recordType, recordTTL, targets...)
+		if err != nil {
+			log.Warnf("Skipping endpoint %s: %v", dnsName, err)
+			continue
+		}
 		mergedEndpoints = append(mergedEndpoints, e)
 	}
 
@@ -299,14 +303,17 @@ func (p *OCIProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error)
 				if !provider.SupportedRecordType(*record.Rtype) {
 					continue
 				}
-				endpoints = append(endpoints,
-					endpoint.NewEndpointWithTTL(
-						*record.Domain,
-						*record.Rtype,
-						endpoint.TTL(*record.Ttl),
-						*record.Rdata,
-					),
+				ep, err := endpoint.NewValidatedEndpointWithTTL(
+					*record.Domain,
+					*record.Rtype,
+					endpoint.TTL(*record.Ttl),
+					*record.Rdata,
 				)
+				if err != nil {
+					log.Warnf("Skipping endpoint %s: %v", *record.Domain, err)
+					continue
+				}
+				endpoints = append(endpoints, ep)
 			}
 
 			if page = resp.OpcNextPage; resp.OpcNextPage == nil {

--- a/provider/ovh/ovh.go
+++ b/provider/ovh/ovh.go
@@ -510,12 +510,17 @@ func ovhGroupByNameAndType(records []ovhRecord) []*endpoint.Endpoint {
 		for _, record := range records {
 			targets = append(targets, record.Target)
 		}
-		ep := endpoint.NewEndpointWithTTL(
-			strings.TrimPrefix(records[0].SubDomain+"."+records[0].Zone, "."),
+		dnsName := strings.TrimPrefix(records[0].SubDomain+"."+records[0].Zone, ".")
+		ep, err := endpoint.NewValidatedEndpointWithTTL(
+			dnsName,
 			records[0].FieldType,
 			endpoint.TTL(records[0].TTL),
 			targets...,
 		)
+		if err != nil {
+			log.Warnf("Skipping endpoint %s: %v", dnsName, err)
+			continue
+		}
 		endpoints = append(endpoints, ep)
 	}
 

--- a/provider/pdns/pdns.go
+++ b/provider/pdns/pdns.go
@@ -345,7 +345,12 @@ func (p *PDNSProvider) convertRRSetToEndpoints(rr pgo.RRset) []*endpoint.Endpoin
 	if rrType == string(pgo.RRTypeALIAS) {
 		rrType = endpoint.RecordTypeCNAME
 	}
-	endpoints = append(endpoints, endpoint.NewEndpointWithTTL(pgo.StringValue(rr.Name), rrType, endpoint.TTL(pgo.Uint32Value(rr.TTL)), targets...))
+	ep, err := endpoint.NewValidatedEndpointWithTTL(pgo.StringValue(rr.Name), rrType, endpoint.TTL(pgo.Uint32Value(rr.TTL)), targets...)
+	if err != nil {
+		log.Warnf("Skipping endpoint %s: %v", pgo.StringValue(rr.Name), err)
+		return endpoints
+	}
+	endpoints = append(endpoints, ep)
 	return endpoints
 }
 

--- a/provider/pihole/client.go
+++ b/provider/pihole/client.go
@@ -161,7 +161,11 @@ func (p *piholeClient) listRecords(ctx context.Context, rtype string) ([]*endpoi
 			}
 		}
 
-		ep := endpoint.NewEndpointWithTTL(dnsName, rtype, ttl, target)
+		ep, err := endpoint.NewValidatedEndpointWithTTL(dnsName, rtype, ttl, target)
+		if err != nil {
+			log.Warnf("Skipping endpoint %s: %v", dnsName, err)
+			continue
+		}
 
 		if oldEp, ok := endpoints[dnsName]; ok {
 			ep.Targets = append(oldEp.Targets, target) // nolint: gocritic // appendAssign

--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -246,12 +246,16 @@ OuterLoop:
 			}
 		}
 
-		ep := endpoint.NewEndpointWithTTL(
+		ep, err := endpoint.NewValidatedEndpointWithTTL(
 			rrFqdn,
 			rrType,
 			rrTTL,
 			rrValues...,
 		)
+		if err != nil {
+			log.Warnf("Skipping endpoint %s: %v", rrFqdn, err)
+			continue
+		}
 
 		eps = append(eps, ep)
 	}

--- a/provider/scaleway/scaleway.go
+++ b/provider/scaleway/scaleway.go
@@ -178,7 +178,11 @@ func (p *ScalewayProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, e
 				existingEndpoint.Targets = append(existingEndpoint.Targets, record.Data)
 				log.Infof("Appending target %s to record %s, using TTL and priority of target %s", record.Data, fullRecordName, existingEndpoint.Targets[0])
 			} else {
-				ep := endpoint.NewEndpointWithTTL(fullRecordName, record.Type.String(), endpoint.TTL(record.TTL), record.Data)
+				ep, err := endpoint.NewValidatedEndpointWithTTL(fullRecordName, record.Type.String(), endpoint.TTL(record.TTL), record.Data)
+				if err != nil {
+					log.Warnf("Skipping endpoint %s: %v", fullRecordName, err)
+					continue
+				}
 				ep = ep.WithProviderSpecific(scalewayPriorityKey, fmt.Sprintf("%d", record.Priority))
 				endpoints[record.Type.String()+"/"+fullRecordName] = ep
 			}

--- a/registry/txt/registry.go
+++ b/registry/txt/registry.go
@@ -341,14 +341,16 @@ func (im *TXTRegistry) generateTXTRecordWithFilter(r *endpoint.Endpoint, filter 
 		r.Labels[endpoint.OwnerLabelKey] = im.ownerID
 	}
 
-	txtNew := endpoint.NewEndpoint(im.mapper.ToTXTName(r.DNSName, recordType), endpoint.RecordTypeTXT, r.Labels.Serialize(true, im.txtEncryptEnabled, im.txtEncryptAESKey))
-	if txtNew != nil {
-		txtNew.WithSetIdentifier(r.SetIdentifier)
-		txtNew.Labels[endpoint.OwnedRecordLabelKey] = r.DNSName
-		txtNew.ProviderSpecific = r.ProviderSpecific
-		if filter(txtNew) {
-			endpoints = append(endpoints, txtNew)
-		}
+	txtNew, err := endpoint.NewValidatedEndpoint(im.mapper.ToTXTName(r.DNSName, recordType), endpoint.RecordTypeTXT, r.Labels.Serialize(true, im.txtEncryptEnabled, im.txtEncryptAESKey))
+	if err != nil {
+		log.Warnf("Skipping ownership TXT record for %q: %v", r.DNSName, err)
+		return endpoints
+	}
+	txtNew.WithSetIdentifier(r.SetIdentifier)
+	txtNew.Labels[endpoint.OwnedRecordLabelKey] = r.DNSName
+	txtNew.ProviderSpecific = r.ProviderSpecific
+	if filter(txtNew) {
+		endpoints = append(endpoints, txtNew)
 	}
 	return endpoints
 }

--- a/source/compatibility.go
+++ b/source/compatibility.go
@@ -19,11 +19,24 @@ package source
 import (
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"sigs.k8s.io/external-dns/endpoint"
 )
+
+// appendValidatedEndpoint constructs an endpoint for the given hostname and
+// appends it, skipping hostnames the endpoint constructor rejects with a
+// warning.
+func appendValidatedEndpoint(endpoints []*endpoint.Endpoint, hostname, recordType, target string) []*endpoint.Endpoint {
+	ep, err := endpoint.NewValidatedEndpoint(hostname, recordType, target)
+	if err != nil {
+		log.Warnf("Skipping %s endpoint for hostname %q: %v", recordType, hostname, err)
+		return endpoints
+	}
+	return append(endpoints, ep)
+}
 
 const (
 	mateAnnotationKey     = "zalando.org/dnsname"
@@ -63,12 +76,10 @@ func legacyEndpointsFromMateService(svc *v1.Service) []*endpoint.Endpoint {
 	// Create a corresponding endpoint for each configured external entrypoint.
 	for _, lb := range svc.Status.LoadBalancer.Ingress {
 		if lb.IP != "" {
-			newEndpoint := endpoint.NewEndpoint(hostname, endpoint.RecordTypeA, lb.IP)
-			endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
+			endpoints = appendValidatedEndpoint(endpoints, hostname, endpoint.RecordTypeA, lb.IP)
 		}
 		if lb.Hostname != "" {
-			newEndpoint := endpoint.NewEndpoint(hostname, endpoint.RecordTypeCNAME, lb.Hostname)
-			endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
+			endpoints = appendValidatedEndpoint(endpoints, hostname, endpoint.RecordTypeCNAME, lb.Hostname)
 		}
 	}
 
@@ -97,12 +108,10 @@ func legacyEndpointsFromMoleculeService(svc *v1.Service) []*endpoint.Endpoint {
 		// Create a corresponding endpoint for each configured external entrypoint.
 		for _, lb := range svc.Status.LoadBalancer.Ingress {
 			if lb.IP != "" {
-				newEndpoint := endpoint.NewEndpoint(hostname, endpoint.RecordTypeA, lb.IP)
-				endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
+				endpoints = appendValidatedEndpoint(endpoints, hostname, endpoint.RecordTypeA, lb.IP)
 			}
 			if lb.Hostname != "" {
-				newEndpoint := endpoint.NewEndpoint(hostname, endpoint.RecordTypeCNAME, lb.Hostname)
-				endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
+				endpoints = appendValidatedEndpoint(endpoints, hostname, endpoint.RecordTypeCNAME, lb.Hostname)
 			}
 		}
 	}
@@ -164,12 +173,10 @@ func legacyEndpointsFromDNSControllerNodePortService(svc *v1.Service, sc *servic
 				recordType := endpoint.SuitableType(address.Address)
 				// IPv6 addresses are labeled as NodeInternalIP despite being usable externally as well.
 				if isExternal && (address.Type == v1.NodeExternalIP || (sc.exposeInternalIPv6 && address.Type == v1.NodeInternalIP && recordType == endpoint.RecordTypeAAAA)) {
-					newEndpoint := endpoint.NewEndpoint(hostname, recordType, address.Address)
-					endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
+					endpoints = appendValidatedEndpoint(endpoints, hostname, recordType, address.Address)
 				}
 				if isInternal && address.Type == v1.NodeInternalIP {
-					newEndpoint := endpoint.NewEndpoint(hostname, recordType, address.Address)
-					endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
+					endpoints = appendValidatedEndpoint(endpoints, hostname, recordType, address.Address)
 				}
 			}
 		}
@@ -202,12 +209,10 @@ func legacyEndpointsFromDNSControllerLoadBalancerService(svc *v1.Service) []*end
 		// Create a corresponding endpoint for each configured external entrypoint.
 		for _, lb := range svc.Status.LoadBalancer.Ingress {
 			if lb.IP != "" {
-				newEndpoint := endpoint.NewEndpoint(hostname, endpoint.RecordTypeA, lb.IP)
-				endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
+				endpoints = appendValidatedEndpoint(endpoints, hostname, endpoint.RecordTypeA, lb.IP)
 			}
 			if lb.Hostname != "" {
-				newEndpoint := endpoint.NewEndpoint(hostname, endpoint.RecordTypeCNAME, lb.Hostname)
-				endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
+				endpoints = appendValidatedEndpoint(endpoints, hostname, endpoint.RecordTypeCNAME, lb.Hostname)
 			}
 		}
 	}

--- a/source/compatibility.go
+++ b/source/compatibility.go
@@ -64,11 +64,11 @@ func legacyEndpointsFromMateService(svc *v1.Service) []*endpoint.Endpoint {
 	for _, lb := range svc.Status.LoadBalancer.Ingress {
 		if lb.IP != "" {
 			newEndpoint := endpoint.NewEndpoint(hostname, endpoint.RecordTypeA, lb.IP)
-			endpoints = appendEndpointIfValid(endpoints, newEndpoint)
+			endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
 		}
 		if lb.Hostname != "" {
 			newEndpoint := endpoint.NewEndpoint(hostname, endpoint.RecordTypeCNAME, lb.Hostname)
-			endpoints = appendEndpointIfValid(endpoints, newEndpoint)
+			endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
 		}
 	}
 
@@ -98,11 +98,11 @@ func legacyEndpointsFromMoleculeService(svc *v1.Service) []*endpoint.Endpoint {
 		for _, lb := range svc.Status.LoadBalancer.Ingress {
 			if lb.IP != "" {
 				newEndpoint := endpoint.NewEndpoint(hostname, endpoint.RecordTypeA, lb.IP)
-				endpoints = appendEndpointIfValid(endpoints, newEndpoint)
+				endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
 			}
 			if lb.Hostname != "" {
 				newEndpoint := endpoint.NewEndpoint(hostname, endpoint.RecordTypeCNAME, lb.Hostname)
-				endpoints = appendEndpointIfValid(endpoints, newEndpoint)
+				endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
 			}
 		}
 	}
@@ -165,11 +165,11 @@ func legacyEndpointsFromDNSControllerNodePortService(svc *v1.Service, sc *servic
 				// IPv6 addresses are labeled as NodeInternalIP despite being usable externally as well.
 				if isExternal && (address.Type == v1.NodeExternalIP || (sc.exposeInternalIPv6 && address.Type == v1.NodeInternalIP && recordType == endpoint.RecordTypeAAAA)) {
 					newEndpoint := endpoint.NewEndpoint(hostname, recordType, address.Address)
-					endpoints = appendEndpointIfValid(endpoints, newEndpoint)
+					endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
 				}
 				if isInternal && address.Type == v1.NodeInternalIP {
 					newEndpoint := endpoint.NewEndpoint(hostname, recordType, address.Address)
-					endpoints = appendEndpointIfValid(endpoints, newEndpoint)
+					endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
 				}
 			}
 		}
@@ -203,11 +203,11 @@ func legacyEndpointsFromDNSControllerLoadBalancerService(svc *v1.Service) []*end
 		for _, lb := range svc.Status.LoadBalancer.Ingress {
 			if lb.IP != "" {
 				newEndpoint := endpoint.NewEndpoint(hostname, endpoint.RecordTypeA, lb.IP)
-				endpoints = appendEndpointIfValid(endpoints, newEndpoint)
+				endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
 			}
 			if lb.Hostname != "" {
 				newEndpoint := endpoint.NewEndpoint(hostname, endpoint.RecordTypeCNAME, lb.Hostname)
-				endpoints = appendEndpointIfValid(endpoints, newEndpoint)
+				endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
 			}
 		}
 	}

--- a/source/compatibility.go
+++ b/source/compatibility.go
@@ -63,10 +63,12 @@ func legacyEndpointsFromMateService(svc *v1.Service) []*endpoint.Endpoint {
 	// Create a corresponding endpoint for each configured external entrypoint.
 	for _, lb := range svc.Status.LoadBalancer.Ingress {
 		if lb.IP != "" {
-			endpoints = append(endpoints, endpoint.NewEndpoint(hostname, endpoint.RecordTypeA, lb.IP))
+			newEndpoint := endpoint.NewEndpoint(hostname, endpoint.RecordTypeA, lb.IP)
+			endpoints = appendEndpointIfValid(endpoints, newEndpoint)
 		}
 		if lb.Hostname != "" {
-			endpoints = append(endpoints, endpoint.NewEndpoint(hostname, endpoint.RecordTypeCNAME, lb.Hostname))
+			newEndpoint := endpoint.NewEndpoint(hostname, endpoint.RecordTypeCNAME, lb.Hostname)
+			endpoints = appendEndpointIfValid(endpoints, newEndpoint)
 		}
 	}
 
@@ -95,10 +97,12 @@ func legacyEndpointsFromMoleculeService(svc *v1.Service) []*endpoint.Endpoint {
 		// Create a corresponding endpoint for each configured external entrypoint.
 		for _, lb := range svc.Status.LoadBalancer.Ingress {
 			if lb.IP != "" {
-				endpoints = append(endpoints, endpoint.NewEndpoint(hostname, endpoint.RecordTypeA, lb.IP))
+				newEndpoint := endpoint.NewEndpoint(hostname, endpoint.RecordTypeA, lb.IP)
+				endpoints = appendEndpointIfValid(endpoints, newEndpoint)
 			}
 			if lb.Hostname != "" {
-				endpoints = append(endpoints, endpoint.NewEndpoint(hostname, endpoint.RecordTypeCNAME, lb.Hostname))
+				newEndpoint := endpoint.NewEndpoint(hostname, endpoint.RecordTypeCNAME, lb.Hostname)
+				endpoints = appendEndpointIfValid(endpoints, newEndpoint)
 			}
 		}
 	}
@@ -160,10 +164,12 @@ func legacyEndpointsFromDNSControllerNodePortService(svc *v1.Service, sc *servic
 				recordType := endpoint.SuitableType(address.Address)
 				// IPv6 addresses are labeled as NodeInternalIP despite being usable externally as well.
 				if isExternal && (address.Type == v1.NodeExternalIP || (sc.exposeInternalIPv6 && address.Type == v1.NodeInternalIP && recordType == endpoint.RecordTypeAAAA)) {
-					endpoints = append(endpoints, endpoint.NewEndpoint(hostname, recordType, address.Address))
+					newEndpoint := endpoint.NewEndpoint(hostname, recordType, address.Address)
+					endpoints = appendEndpointIfValid(endpoints, newEndpoint)
 				}
 				if isInternal && address.Type == v1.NodeInternalIP {
-					endpoints = append(endpoints, endpoint.NewEndpoint(hostname, recordType, address.Address))
+					newEndpoint := endpoint.NewEndpoint(hostname, recordType, address.Address)
+					endpoints = appendEndpointIfValid(endpoints, newEndpoint)
 				}
 			}
 		}
@@ -196,10 +202,12 @@ func legacyEndpointsFromDNSControllerLoadBalancerService(svc *v1.Service) []*end
 		// Create a corresponding endpoint for each configured external entrypoint.
 		for _, lb := range svc.Status.LoadBalancer.Ingress {
 			if lb.IP != "" {
-				endpoints = append(endpoints, endpoint.NewEndpoint(hostname, endpoint.RecordTypeA, lb.IP))
+				newEndpoint := endpoint.NewEndpoint(hostname, endpoint.RecordTypeA, lb.IP)
+				endpoints = appendEndpointIfValid(endpoints, newEndpoint)
 			}
 			if lb.Hostname != "" {
-				endpoints = append(endpoints, endpoint.NewEndpoint(hostname, endpoint.RecordTypeCNAME, lb.Hostname))
+				newEndpoint := endpoint.NewEndpoint(hostname, endpoint.RecordTypeCNAME, lb.Hostname)
+				endpoints = appendEndpointIfValid(endpoints, newEndpoint)
 			}
 		}
 	}

--- a/source/endpoints.go
+++ b/source/endpoints.go
@@ -16,6 +16,8 @@ package source
 import (
 	"fmt"
 
+	log "github.com/sirupsen/logrus"
+
 	"k8s.io/apimachinery/pkg/labels"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 
@@ -55,4 +57,13 @@ func EndpointTargetsFromServices(svcInformer coreinformers.ServiceInformer, name
 		}
 	}
 	return endpoint.NewTargets(targets...), nil
+}
+
+// appendEndpointIfValid appends ep to endpoints, skipping it when ep is nil.
+func appendEndpointIfValid(endpoints []*endpoint.Endpoint, ep *endpoint.Endpoint) []*endpoint.Endpoint {
+	if ep == nil {
+		log.Debug("Skipping nil endpoint")
+		return endpoints
+	}
+	return append(endpoints, ep)
 }

--- a/source/endpoints.go
+++ b/source/endpoints.go
@@ -16,8 +16,6 @@ package source
 import (
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
-
 	"k8s.io/apimachinery/pkg/labels"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 
@@ -57,13 +55,4 @@ func EndpointTargetsFromServices(svcInformer coreinformers.ServiceInformer, name
 		}
 	}
 	return endpoint.NewTargets(targets...), nil
-}
-
-// appendEndpointIfValid appends ep to endpoints, skipping it when ep is nil.
-func appendEndpointIfValid(endpoints []*endpoint.Endpoint, ep *endpoint.Endpoint) []*endpoint.Endpoint {
-	if ep == nil {
-		log.Debug("Skipping nil endpoint")
-		return endpoints
-	}
-	return append(endpoints, ep)
 }

--- a/source/fake.go
+++ b/source/fake.go
@@ -97,9 +97,7 @@ func (sc *fakeSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, error)
 			if err != nil {
 				return nil, fmt.Errorf("generating %s endpoint: %w", recordType, err)
 			}
-			if ep != nil {
-				endpoints = append(endpoints, ep)
-			}
+			endpoints = endpoint.AppendIfNotNil(endpoints, ep)
 		}
 	}
 	return endpoint.MergeEndpoints(endpoints), nil

--- a/source/fake.go
+++ b/source/fake.go
@@ -97,7 +97,7 @@ func (sc *fakeSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, error)
 			if err != nil {
 				return nil, fmt.Errorf("generating %s endpoint: %w", recordType, err)
 			}
-			endpoints = endpoint.AppendIfNotNil(endpoints, ep)
+			endpoints = append(endpoints, ep)
 		}
 	}
 	return endpoint.MergeEndpoints(endpoints), nil
@@ -105,46 +105,45 @@ func (sc *fakeSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, error)
 
 func (sc *fakeSource) generateEndpointForType(recordType, dnsName string) (*endpoint.Endpoint, error) {
 	var ep *endpoint.Endpoint
+	var err error
 
 	switch recordType {
 	case endpoint.RecordTypeA:
-		ep = endpoint.NewEndpoint(sc.generateDNSName(4, dnsName), endpoint.RecordTypeA, generateTargets(len(sc.dnsNames), sc.generateIPv4Address)...)
+		ep, err = endpoint.NewValidatedEndpoint(sc.generateDNSName(4, dnsName), endpoint.RecordTypeA, generateTargets(len(sc.dnsNames), sc.generateIPv4Address)...)
 	case endpoint.RecordTypeAAAA:
-		ep = endpoint.NewEndpoint(sc.generateDNSName(4, dnsName), endpoint.RecordTypeAAAA, generateTargets(len(sc.dnsNames), sc.generateIPv6Address)...)
+		ep, err = endpoint.NewValidatedEndpoint(sc.generateDNSName(4, dnsName), endpoint.RecordTypeAAAA, generateTargets(len(sc.dnsNames), sc.generateIPv6Address)...)
 	case endpoint.RecordTypeCNAME:
-		ep = endpoint.NewEndpoint(sc.generateDNSName(4, dnsName), endpoint.RecordTypeCNAME, sc.generateDNSName(4, dnsName))
+		ep, err = endpoint.NewValidatedEndpoint(sc.generateDNSName(4, dnsName), endpoint.RecordTypeCNAME, sc.generateDNSName(4, dnsName))
 	case endpoint.RecordTypeTXT:
-		ep = endpoint.NewEndpoint(sc.generateDNSName(4, dnsName), endpoint.RecordTypeTXT, `"heritage=external-dns,external-dns/owner=fake"`)
+		ep, err = endpoint.NewValidatedEndpoint(sc.generateDNSName(4, dnsName), endpoint.RecordTypeTXT, `"heritage=external-dns,external-dns/owner=fake"`)
 	case endpoint.RecordTypeSRV:
 		// SRV target format: "priority weight port target." (target must end with a dot per RFC 2782)
 		name := sc.generateDNSName(4, dnsName)
-		ep = endpoint.NewEndpoint(fmt.Sprintf("_sip._udp.%s", dnsName), endpoint.RecordTypeSRV, fmt.Sprintf("10 20 5060 %s.", name))
+		ep, err = endpoint.NewValidatedEndpoint(fmt.Sprintf("_sip._udp.%s", dnsName), endpoint.RecordTypeSRV, fmt.Sprintf("10 20 5060 %s.", name))
 	case endpoint.RecordTypeNS:
-		ep = endpoint.NewEndpoint(dnsName, endpoint.RecordTypeNS, sc.generateDNSName(3, dnsName))
+		ep, err = endpoint.NewValidatedEndpoint(dnsName, endpoint.RecordTypeNS, sc.generateDNSName(3, dnsName))
 	case endpoint.RecordTypePTR:
 		name := sc.generateDNSName(4, dnsName)
-		var err error
 		ep, err = endpoint.NewPTREndpoint(sc.generateIPv4Address(), endpoint.TTL(0), name)
-		if err != nil {
-			return nil, err
-		}
 	case endpoint.RecordTypeMX:
-		ep = endpoint.NewEndpoint(dnsName, endpoint.RecordTypeMX, fmt.Sprintf("10 %s", sc.generateDNSName(4, dnsName)))
+		ep, err = endpoint.NewValidatedEndpoint(dnsName, endpoint.RecordTypeMX, fmt.Sprintf("10 %s", sc.generateDNSName(4, dnsName)))
 	case endpoint.RecordTypeNAPTR:
 		// NAPTR target format: "order preference flags service regexp replacement"
-		ep = endpoint.NewEndpoint(fmt.Sprintf("_sip._udp.%s", dnsName), endpoint.RecordTypeNAPTR, fmt.Sprintf(`100 10 "u" "E2U+sip" "!^.*$!sip:info@%s!" .`, dnsName))
+		ep, err = endpoint.NewValidatedEndpoint(fmt.Sprintf("_sip._udp.%s", dnsName), endpoint.RecordTypeNAPTR, fmt.Sprintf(`100 10 "u" "E2U+sip" "!^.*$!sip:info@%s!" .`, dnsName))
 	default:
 		return nil, fmt.Errorf("unsupported record type: %s", recordType)
 	}
-
-	if ep != nil {
-		pod := fakePod
-		pod.Name = fakePodName(ep.DNSName)
-		ep.SetIdentifier = types.Fake
-		ep.WithLabel(endpoint.ResourceLabelKey, fmt.Sprintf("%s/%s/%s", types.Fake, pod.Namespace, ep.DNSName))
-		ep.WithRefObject(events.NewObjectReference(&pod, types.Fake))
-		log.Debugf("fake source generated %s endpoint: %s -> %v", ep.RecordType, ep.DNSName, ep.Targets)
+	if err != nil {
+		return nil, err
 	}
+
+	pod := fakePod
+	pod.Name = fakePodName(ep.DNSName)
+	ep.SetIdentifier = types.Fake
+	ep.WithLabel(endpoint.ResourceLabelKey, fmt.Sprintf("%s/%s/%s", types.Fake, pod.Namespace, ep.DNSName))
+	ep.WithRefObject(events.NewObjectReference(&pod, types.Fake))
+	log.Debugf("fake source generated %s endpoint: %s -> %v", ep.RecordType, ep.DNSName, ep.Targets)
+
 	return ep, nil
 }
 

--- a/source/node.go
+++ b/source/node.go
@@ -183,15 +183,15 @@ func (ns *nodeSource) endpointsForDNSNames(node *v1.Node, dnsNames []string) ([]
 		log.Debugf("adding endpoint with %d targets", len(addrs))
 
 		for _, addr := range addrs {
-			newEndpoint := endpoint.NewEndpointWithTTL(dns, endpoint.SuitableType(addr), ttl, addr)
-			endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
+			ep, err := endpoint.NewValidatedEndpointWithTTL(dns, endpoint.SuitableType(addr), ttl, addr)
+			if err != nil {
+				log.Warnf("Skipping endpoint for node %s: %v", node.Name, err)
+				continue
+			}
+			ep.WithLabel(endpoint.ResourceLabelKey, resource)
+			log.Debugf("adding endpoint %s target %s", ep, addr)
+			endpoints = append(endpoints, ep)
 		}
-	}
-
-	// add shared resource labels
-	for _, ep := range endpoints {
-		ep.WithLabel(endpoint.ResourceLabelKey, resource)
-		log.Debugf("adding endpoint %s", ep)
 	}
 
 	return endpoint.MergeEndpoints(endpoints), nil

--- a/source/node.go
+++ b/source/node.go
@@ -166,7 +166,8 @@ func (ns *nodeSource) endpointsFromNodeTemplate(node *v1.Node) ([]*endpoint.Endp
 
 // endpointsForDNSNames creates endpoints for the given DNS names using the node's addresses.
 func (ns *nodeSource) endpointsForDNSNames(node *v1.Node, dnsNames []string) ([]*endpoint.Endpoint, error) {
-	ttl := annotations.TTLFromAnnotations(node.Annotations, fmt.Sprintf("node/%s", node.Name))
+	resource := fmt.Sprintf("node/%s", node.Name)
+	ttl := annotations.TTLFromAnnotations(node.Annotations, resource)
 
 	addrs := annotations.TargetsFromTargetAnnotation(node.Annotations)
 	if len(addrs) == 0 {
@@ -182,11 +183,15 @@ func (ns *nodeSource) endpointsForDNSNames(node *v1.Node, dnsNames []string) ([]
 		log.Debugf("adding endpoint with %d targets", len(addrs))
 
 		for _, addr := range addrs {
-			ep := endpoint.NewEndpointWithTTL(dns, endpoint.SuitableType(addr), ttl, addr)
-			ep.WithLabel(endpoint.ResourceLabelKey, fmt.Sprintf("node/%s", node.Name))
-			log.Debugf("adding endpoint %s target %s", ep, addr)
-			endpoints = append(endpoints, ep)
+			newEndpoint := endpoint.NewEndpointWithTTL(dns, endpoint.SuitableType(addr), ttl, addr)
+			endpoints = appendEndpointIfValid(endpoints, newEndpoint)
 		}
+	}
+
+	// add labels for resource
+	for _, ep := range endpoints {
+		ep.WithLabel(endpoint.ResourceLabelKey, resource)
+		log.Debugf("adding endpoint %s", ep)
 	}
 
 	return endpoint.MergeEndpoints(endpoints), nil

--- a/source/node.go
+++ b/source/node.go
@@ -184,11 +184,11 @@ func (ns *nodeSource) endpointsForDNSNames(node *v1.Node, dnsNames []string) ([]
 
 		for _, addr := range addrs {
 			newEndpoint := endpoint.NewEndpointWithTTL(dns, endpoint.SuitableType(addr), ttl, addr)
-			endpoints = appendEndpointIfValid(endpoints, newEndpoint)
+			endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
 		}
 	}
 
-	// add labels for resource
+	// add shared resource labels
 	for _, ep := range endpoints {
 		ep.WithLabel(endpoint.ResourceLabelKey, resource)
 		log.Debugf("adding endpoint %s", ep)

--- a/source/node_test.go
+++ b/source/node_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"maps"
 	"math/rand"
+	"strings"
 	"testing"
 	"time"
 
@@ -107,6 +108,26 @@ func testNodeSourceEndpoints(t *testing.T) {
 			nodeAddresses:      []v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}},
 			expected: []*endpoint.Endpoint{
 				{RecordType: "A", DNSName: "node1.example.org", Targets: endpoint.Targets{"1.2.3.4"}},
+			},
+		},
+		{
+			// Paired with the case below: the two names differ only in the
+			// length of the first label, 64 characters against 63.
+			title:              "node with a 64 character fqdn template label returns no endpoints",
+			fqdnTemplate:       strings.Repeat("n", 64) + ".example.org",
+			nodeName:           "node1",
+			exposeInternalIPv6: true,
+			nodeAddresses:      []v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}},
+			expected:           []*endpoint.Endpoint{},
+		},
+		{
+			title:              "node with a 63 character fqdn template label returns one endpoint",
+			fqdnTemplate:       strings.Repeat("n", 63) + ".example.org",
+			nodeName:           "node1",
+			exposeInternalIPv6: true,
+			nodeAddresses:      []v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}},
+			expected: []*endpoint.Endpoint{
+				{RecordType: "A", DNSName: strings.Repeat("n", 63) + ".example.org", Targets: endpoint.Targets{"1.2.3.4"}},
 			},
 		},
 		{

--- a/source/pod.go
+++ b/source/pod.go
@@ -152,7 +152,7 @@ func (ps *podSource) endpointsFromPodAnnotations(pod *v1.Pod) []*endpoint.Endpoi
 	var endpoints []*endpoint.Endpoint
 	for key, targets := range endpointMap {
 		newEndpoint := endpoint.NewEndpointWithTTL(key.DNSName, key.RecordType, key.RecordTTL, targets...)
-		endpoints = appendEndpointIfValid(endpoints, newEndpoint)
+		endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
 	}
 	return endpoints
 }
@@ -166,7 +166,7 @@ func (ps *podSource) endpointsFromPodTemplate(pod *v1.Pod) ([]*endpoint.Endpoint
 	var endpoints []*endpoint.Endpoint
 	for key, targets := range hostsMap {
 		newEndpoint := endpoint.NewEndpointWithTTL(key.DNSName, key.RecordType, key.RecordTTL, targets...)
-		endpoints = appendEndpointIfValid(endpoints, newEndpoint)
+		endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
 	}
 	return endpoints, nil
 }

--- a/source/pod.go
+++ b/source/pod.go
@@ -151,8 +151,12 @@ func (ps *podSource) endpointsFromPodAnnotations(pod *v1.Pod) []*endpoint.Endpoi
 
 	var endpoints []*endpoint.Endpoint
 	for key, targets := range endpointMap {
-		newEndpoint := endpoint.NewEndpointWithTTL(key.DNSName, key.RecordType, key.RecordTTL, targets...)
-		endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
+		ep, err := endpoint.NewValidatedEndpointWithTTL(key.DNSName, key.RecordType, key.RecordTTL, targets...)
+		if err != nil {
+			log.Warnf("Skipping endpoint for pod %s/%s: %v", pod.Namespace, pod.Name, err)
+			continue
+		}
+		endpoints = append(endpoints, ep)
 	}
 	return endpoints
 }
@@ -165,8 +169,12 @@ func (ps *podSource) endpointsFromPodTemplate(pod *v1.Pod) ([]*endpoint.Endpoint
 
 	var endpoints []*endpoint.Endpoint
 	for key, targets := range hostsMap {
-		newEndpoint := endpoint.NewEndpointWithTTL(key.DNSName, key.RecordType, key.RecordTTL, targets...)
-		endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
+		ep, err := endpoint.NewValidatedEndpointWithTTL(key.DNSName, key.RecordType, key.RecordTTL, targets...)
+		if err != nil {
+			log.Warnf("Skipping endpoint for pod %s/%s: %v", pod.Namespace, pod.Name, err)
+			continue
+		}
+		endpoints = append(endpoints, ep)
 	}
 	return endpoints, nil
 }

--- a/source/pod.go
+++ b/source/pod.go
@@ -151,7 +151,8 @@ func (ps *podSource) endpointsFromPodAnnotations(pod *v1.Pod) []*endpoint.Endpoi
 
 	var endpoints []*endpoint.Endpoint
 	for key, targets := range endpointMap {
-		endpoints = append(endpoints, endpoint.NewEndpointWithTTL(key.DNSName, key.RecordType, key.RecordTTL, targets...))
+		newEndpoint := endpoint.NewEndpointWithTTL(key.DNSName, key.RecordType, key.RecordTTL, targets...)
+		endpoints = appendEndpointIfValid(endpoints, newEndpoint)
 	}
 	return endpoints
 }
@@ -164,7 +165,8 @@ func (ps *podSource) endpointsFromPodTemplate(pod *v1.Pod) ([]*endpoint.Endpoint
 
 	var endpoints []*endpoint.Endpoint
 	for key, targets := range hostsMap {
-		endpoints = append(endpoints, endpoint.NewEndpointWithTTL(key.DNSName, key.RecordType, key.RecordTTL, targets...))
+		newEndpoint := endpoint.NewEndpointWithTTL(key.DNSName, key.RecordType, key.RecordTTL, targets...)
+		endpoints = appendEndpointIfValid(endpoints, newEndpoint)
 	}
 	return endpoints, nil
 }

--- a/source/pod_fqdn_test.go
+++ b/source/pod_fqdn_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package source
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -121,6 +122,10 @@ func TestPodFQDNTemplate(t *testing.T) {
 			expected: []*endpoint.Endpoint{
 				{DNSName: "pod." + podName + ".example.com", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{podIP}},
 			},
+		},
+		{
+			title:        "fqdn-template with an invalid label returns no endpoints",
+			fqdnTemplate: strings.Repeat("n", 64) + ".example.com",
 		},
 		{
 			title:              "fqdn-target-template can reference .APIVersion",

--- a/source/pod_test.go
+++ b/source/pod_test.go
@@ -19,6 +19,7 @@ package source
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -702,6 +703,58 @@ func TestPodSource(t *testing.T) {
 					},
 					Status: corev1.PodStatus{
 						PodIP: "10.0.1.1",
+					},
+				},
+			},
+		},
+		{
+			// Paired with the case below: the two annotations differ only in
+			// the length of the first label, 64 characters against 63.
+			"internal hostname with a 64 character label returns no endpoints",
+			"",
+			"",
+			false,
+			"",
+			[]*endpoint.Endpoint{},
+			false,
+			nil,
+			[]*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "invalid-hostname",
+						Namespace: "default",
+						Annotations: map[string]string{
+							annotations.InternalHostnameKey: strings.Repeat("h", 64) + ".example.com",
+						},
+					},
+					Status: corev1.PodStatus{
+						PodIP: "10.1.2.3",
+					},
+				},
+			},
+		},
+		{
+			"internal hostname with a 63 character label returns one endpoint",
+			"",
+			"",
+			false,
+			"",
+			[]*endpoint.Endpoint{
+				{DNSName: strings.Repeat("h", 63) + ".example.com", Targets: endpoint.Targets{"10.1.2.3"}, RecordType: endpoint.RecordTypeA},
+			},
+			false,
+			nil,
+			[]*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "valid-hostname",
+						Namespace: "default",
+						Annotations: map[string]string{
+							annotations.InternalHostnameKey: strings.Repeat("h", 63) + ".example.com",
+						},
+					},
+					Status: corev1.PodStatus{
+						PodIP: "10.1.2.3",
 					},
 				},
 			},

--- a/source/service.go
+++ b/source/service.go
@@ -459,12 +459,16 @@ func buildHeadlessEndpoints(svc *v1.Service, targetsByHeadlessDomainAndType map[
 			deduppedTargets.Insert(target)
 			targets = append(targets, target)
 		}
-		ep := endpoint.NewEndpointWithTTL(headlessKey.DNSName, headlessKey.RecordType, ttl, targets...)
-		if ep != nil {
-			ep.WithLabel(endpoint.ResourceLabelKey, fmt.Sprintf("service/%s/%s", svc.Namespace, svc.Name))
-			endpoints = append(endpoints, ep)
-		}
+		newEndpoint := endpoint.NewEndpointWithTTL(headlessKey.DNSName, headlessKey.RecordType, ttl, targets...)
+		endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
 	}
+
+	// add labels for resource
+	resource := fmt.Sprintf("service/%s/%s", svc.Namespace, svc.Name)
+	for _, ep := range endpoints {
+		ep.WithLabel(endpoint.ResourceLabelKey, resource)
+	}
+
 	return endpoints
 }
 
@@ -764,12 +768,15 @@ func (sc *serviceSource) extractNodePortEndpoints(svc *v1.Service, hostname stri
 
 			recordName := fmt.Sprintf("_%s._%s.%s", svc.Name, protocol, hostname)
 
-			ep := endpoint.NewEndpointWithTTL(recordName, endpoint.RecordTypeSRV, ttl, target)
-			if ep != nil {
-				ep.WithLabel(endpoint.ResourceLabelKey, fmt.Sprintf("service/%s/%s", svc.Namespace, svc.Name))
-				endpoints = append(endpoints, ep)
-			}
+			newEndpoint := endpoint.NewEndpointWithTTL(recordName, endpoint.RecordTypeSRV, ttl, target)
+			endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
 		}
+	}
+
+	// add labels for resource
+	resource := fmt.Sprintf("service/%s/%s", svc.Namespace, svc.Name)
+	for _, ep := range endpoints {
+		ep.WithLabel(endpoint.ResourceLabelKey, resource)
 	}
 
 	return endpoints

--- a/source/service.go
+++ b/source/service.go
@@ -459,14 +459,13 @@ func buildHeadlessEndpoints(svc *v1.Service, targetsByHeadlessDomainAndType map[
 			deduppedTargets.Insert(target)
 			targets = append(targets, target)
 		}
-		newEndpoint := endpoint.NewEndpointWithTTL(headlessKey.DNSName, headlessKey.RecordType, ttl, targets...)
-		endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
-	}
-
-	// add labels for resource
-	resource := fmt.Sprintf("service/%s/%s", svc.Namespace, svc.Name)
-	for _, ep := range endpoints {
-		ep.WithLabel(endpoint.ResourceLabelKey, resource)
+		ep, err := endpoint.NewValidatedEndpointWithTTL(headlessKey.DNSName, headlessKey.RecordType, ttl, targets...)
+		if err != nil {
+			log.Warnf("Skipping endpoint for service %s/%s: %v", svc.Namespace, svc.Name, err)
+			continue
+		}
+		ep.WithLabel(endpoint.ResourceLabelKey, fmt.Sprintf("service/%s/%s", svc.Namespace, svc.Name))
+		endpoints = append(endpoints, ep)
 	}
 
 	return endpoints
@@ -768,15 +767,14 @@ func (sc *serviceSource) extractNodePortEndpoints(svc *v1.Service, hostname stri
 
 			recordName := fmt.Sprintf("_%s._%s.%s", svc.Name, protocol, hostname)
 
-			newEndpoint := endpoint.NewEndpointWithTTL(recordName, endpoint.RecordTypeSRV, ttl, target)
-			endpoints = endpoint.AppendIfNotNil(endpoints, newEndpoint)
+			ep, err := endpoint.NewValidatedEndpointWithTTL(recordName, endpoint.RecordTypeSRV, ttl, target)
+			if err != nil {
+				log.Warnf("Skipping SRV endpoint for service %s/%s: %v", svc.Namespace, svc.Name, err)
+				continue
+			}
+			ep.WithLabel(endpoint.ResourceLabelKey, fmt.Sprintf("service/%s/%s", svc.Namespace, svc.Name))
+			endpoints = append(endpoints, ep)
 		}
-	}
-
-	// add labels for resource
-	resource := fmt.Sprintf("service/%s/%s", svc.Namespace, svc.Name)
-	for _, ep := range endpoints {
-		ep.WithLabel(endpoint.ResourceLabelKey, resource)
 	}
 
 	return endpoints

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -628,6 +628,21 @@ func testServiceSourceEndpoints(t *testing.T) {
 			},
 		},
 		{
+			title:         "services with invalid legacy hostnames return no endpoints",
+			svcNamespace:  "testing",
+			svcName:       "foo",
+			svcType:       v1.ServiceTypeLoadBalancer,
+			compatibility: "mate",
+			labels:        map[string]string{},
+			annotations: map[string]string{
+				mateAnnotationKey: strings.Repeat("n", 64) + ".example.org",
+			},
+			externalIPs:        []string{},
+			lbs:                []string{"1.2.3.4"},
+			serviceTypesFilter: []string{},
+			expected:           []*endpoint.Endpoint{},
+		},
+		{
 			title:         "services annotated with legacy molecule annotations return an endpoint in compatibility mode",
 			svcNamespace:  "testing",
 			svcName:       "foo",

--- a/source/template/engine.go
+++ b/source/template/engine.go
@@ -171,8 +171,13 @@ func (e Engine) endpointsFromFQDNTargetTemplate(obj kubeObject) ([]*endpoint.End
 				pair, kind, obj.GetNamespace(), obj.GetName())
 			continue
 		}
-		newEndpoint := endpoint.NewEndpoint(host, endpoint.SuitableType(target), target)
-		eps = endpoint.AppendIfNotNil(eps, newEndpoint)
+		ep, err := endpoint.NewValidatedEndpoint(host, endpoint.SuitableType(target), target)
+		if err != nil {
+			log.Warnf("Skipping host:target pair %q from %s %s/%s: %v",
+				pair, kind, obj.GetNamespace(), obj.GetName(), err)
+			continue
+		}
+		eps = append(eps, ep)
 	}
 	return endpoint.MergeEndpoints(eps), nil
 }

--- a/source/template/engine.go
+++ b/source/template/engine.go
@@ -171,7 +171,8 @@ func (e Engine) endpointsFromFQDNTargetTemplate(obj kubeObject) ([]*endpoint.End
 				pair, kind, obj.GetNamespace(), obj.GetName())
 			continue
 		}
-		eps = append(eps, endpoint.NewEndpoint(host, endpoint.SuitableType(target), target))
+		newEndpoint := endpoint.NewEndpoint(host, endpoint.SuitableType(target), target)
+		eps = endpoint.AppendIfNotNil(eps, newEndpoint)
 	}
 	return endpoint.MergeEndpoints(eps), nil
 }

--- a/source/template/engine_test.go
+++ b/source/template/engine_test.go
@@ -18,6 +18,7 @@ package template
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -588,6 +589,42 @@ func TestCombineWithEndpoints(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestFQDNTargetTemplateSkipsRejectedHostnames covers a fqdn-target template
+// that renders a hostname the constructor refuses to build an endpoint for.
+// It must be dropped before MergeEndpoints, which dereferences every element
+// and so panics on a leaked nil instead of skipping the hostname.
+func TestFQDNTargetTemplateSkipsRejectedHostnames(t *testing.T) {
+	// The two names differ only in the length of the first label, 64 characters
+	// against the 63 that RFC 1035 section 2.3.4 allows.
+	rejected := strings.Repeat("a", 64) + ".example.com"
+	accepted := strings.Repeat("a", 63) + ".example.com"
+
+	obj := &testObject{ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"}}
+
+	t.Run("hostname is dropped rather than collected as nil", func(t *testing.T) {
+		e, err := NewEngine(nil, nil, []string{rejected + ":1.2.3.4"}, false)
+		require.NoError(t, err)
+
+		got, err := e.ApplyFQDNTargetTemplate(nil, obj)
+
+		require.NoError(t, err)
+		assert.Empty(t, got)
+		assert.NotContains(t, got, (*endpoint.Endpoint)(nil))
+	})
+
+	t.Run("remaining hostnames are still returned", func(t *testing.T) {
+		e, err := NewEngine(nil, nil, []string{rejected + ":1.2.3.4", accepted + ":1.2.3.4"}, false)
+		require.NoError(t, err)
+
+		got, err := e.ApplyFQDNTargetTemplate(nil, obj)
+
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, accepted, got[0].DNSName)
+		assert.Equal(t, endpoint.Targets{"1.2.3.4"}, got[0].Targets)
+	})
 }
 
 func TestNewEngine_DebugLogging(t *testing.T) {


### PR DESCRIPTION
## What does it do ?

`NewEndpoint` and `NewEndpointWithTTL` return nil for a DNS name they cannot represent, so correctness depends on every caller remembering a nil check that nothing enforces. This replaces that contract rather than patching the call sites one at a time.

- **New constructors:** `NewValidatedEndpoint` and `NewValidatedEndpointWithTTL` return the rejection as an error, in the shape `NewPTREndpoint` already used. `NewPTREndpoint` now delegates to them, closing a gap where it could return a nil endpoint with a nil error.
- **Old constructors deprecated, not changed:** both are exported and called by out-of-tree webhook providers, so they stay as wrappers with their exact contract preserved, log line byte for byte. The `Deprecated:` marker puts staticcheck's SA1019 behind the migration, so a call site a follow-up misses fails the lint run instead of relying on convention. Test files are unaffected, since `.golangci.yml` excludes staticcheck for `_test.go`.
- **Every non-test call site migrated,** handling the rejection where it happens: sources and the template engine warn with the offending hostname and skip that one record; the TXT registry skips an ownership record it cannot build; `internal/testutils` panics, since an unrepresentable fixture name is a bug in the test itself.

That covers the two crash paths this PR set out to fix:

- **The template paths:** `EndpointsForHostsAndTargets` (`endpoint/utils.go`) and `endpointsFromFQDNTargetTemplate` (`source/template/engine.go`) appended the constructor's return value unchecked. Both are reached from `--fqdn-template` and `--fqdn-target-template`.
- **Sites that dereferenced or collected the nil:** node endpoints, pod annotation and FQDN-template endpoints, and legacy compatibility-mode service endpoints (`source/node.go`, `source/pod.go`, `source/compatibility.go`).

It also fixes a latent crash of the same shape in the providers: 23 provider packages built endpoints from zone listings without a nil check, so a rejected name in a listing leaked a nil out of `Records()` and panicked downstream.

Adds regression coverage for invalid names arriving from annotations, fqdn templates, fqdn-target templates, and legacy compatibility annotations. Each new source test fails with a nil pointer dereference when its fix is reverted.

## Motivation

`NewEndpointWithTTL` returns nil when any dot-separated label of the DNS name is longer than 63 characters (`endpoint/endpoint.go`). That 63 is the DNS label limit from [RFC 1035 section 2.3.4](https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.4), not a Kubernetes limit, and it applies per label rather than to the name as a whole (which the same section caps separately at 255).

The affected paths either dereferenced that nil result or appended it for later processing, causing source reconciliation to panic in `WithLabel`, `AttachRefObject`, or `MergeEndpoints`. A single invalid name therefore took down the whole sync, when it should be logged and skipped so the remaining records still reconcile.

### How an over-long label reaches these paths

The DNS per-label limit is stricter than what Kubernetes itself enforces on the names these sources read, so the API server can hand external-dns a name that `NewEndpointWithTTL` rejects:

- **Node:** node names are validated as a DNS-1123 *subdomain* (`NameIsDNSSubdomain` -> `IsDNS1123Subdomain`), which caps the total name at 253 characters and applies a regex that places no bound on individual labels. A single-label node name longer than 63 characters is therefore accepted.
- **Pod:** the `external-dns.alpha.kubernetes.io/internal-hostname` and `external-dns.alpha.kubernetes.io/hostname` annotations are free-form and fully user-controlled.
- **Any source with a template:** `--fqdn-template` and `--fqdn-target-template` render object fields into a hostname, so the result is only as valid as the template and the values it interpolates.

The annotation path was already guarded inside `EndpointsForHostname`, which is why the template paths went unnoticed for so long: when a resource declares its own hostname the template is never executed at all, so only resources relying on a template could reach the crash.

### Why not a shared nil-skipping helper

An earlier revision of this branch collected the skip into one `endpoint.AppendIfNotNil` helper beside the constructors. Surfacing the rejection as an error made that helper unnecessary and it is gone from the final diff: a call site that gets an error handles it and moves on, so nothing needs to filter nils out of a slice afterwards.

That also undid a restructuring the helper had forced. Sites setting `ProviderSpecific` or a resource label between constructing and collecting an endpoint could not call a helper inline while the nil was still in the way, so they had collected first and applied the shared metadata in a second pass. With the error handled at the call site the nil is gone before those field accesses, and they set metadata directly again. The endpoints produced are unchanged.

Fixes #6589.

## Testing

- `make build`
- `go test -race ./...`
- `golangci-lint run ./endpoint/... ./source/...`

## More

- [x] Yes, this PR title follows Conventional Commits
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly
