### PR TITLE
fix(provider/rfc2136): use independent counters for AXFR and update nameserver rotation

### DIFF
--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -73,9 +73,12 @@ type rfc2136Provider struct {
 	dryRun       bool
 	actions      rfc2136Actions
 
-	// Counter for load balancing, and error handling
-	counter int
-	mu      sync.Mutex // Mutex for thread-safe counter
+	// Counters for load balancing, and error handling.
+	// List (AXFR) and Send (update) paths rotate independently so that
+	// one operation advancing its counter does not skew the other.
+	listCounter int
+	sendCounter int
+	mu          sync.Mutex // Mutex for thread-safe counters
 
 	// Load balancing strategy "round-robin", "random", or "disabled"
 	loadBalancingStrategy string
@@ -161,7 +164,8 @@ func newProvider(hosts []string, port int, zoneNames []string, insecure bool, ke
 		tlsConfig:             tlsConfig,
 		loadBalancingStrategy: loadBalancingStrategy,
 		randGen:               rand.New(rand.NewSource(time.Now().UnixNano())),
-		counter:               0,
+		listCounter:           0,
+		sendCounter:           0,
 		lastErr:               nil,
 	}
 	if actions != nil {
@@ -295,7 +299,7 @@ func (r *rfc2136Provider) List() ([]dns.RR, error) {
 
 		var lastErr error
 		for i := 0; i < len(r.nameservers); i++ {
-			nameserver := r.getNextNameserver()
+			nameserver := r.getNextNameserverForList()
 			log.Debugf("Fetching records from nameserver: %s", nameserver)
 
 			env, err := r.actions.IncomeTransfer(m, nameserver)
@@ -495,7 +499,11 @@ func (r *rfc2136Provider) RemoveRecord(m *dns.Msg, ep *endpoint.Endpoint) error 
 	return nil
 }
 
-func (r *rfc2136Provider) getNextNameserver() string {
+// getNextNameserver picks the next nameserver to use according to the
+// configured load balancing strategy, advancing the given counter. List
+// (AXFR) and Send (update) callers each pass their own counter so that the
+// two paths rotate independently instead of skewing each other.
+func (r *rfc2136Provider) getNextNameserver(counter *int) string {
 	if len(r.nameservers) == 1 {
 		return r.nameservers[0]
 	}
@@ -504,7 +512,7 @@ func (r *rfc2136Provider) getNextNameserver() string {
 	defer r.mu.Unlock()
 
 	if r.lastErr != nil {
-		log.Warnf("Last operation failed for nameserver %s", r.nameservers[r.counter])
+		log.Warnf("Last operation failed for nameserver %s", r.nameservers[*counter])
 		log.Warnf("Last operation error message: %v", r.lastErr)
 	}
 
@@ -514,25 +522,33 @@ func (r *rfc2136Provider) getNextNameserver() string {
 		for {
 			nameserver = r.nameservers[r.randGen.Intn(len(r.nameservers))]
 			// Ensure that we don't get the same nameserver as the last one
-			if nameserver != r.nameservers[r.counter] {
+			if nameserver != r.nameservers[*counter] {
 				break
 			}
 		}
 	case "round-robin":
-		nameserver = r.nameservers[r.counter]
-		r.counter = (r.counter + 1) % len(r.nameservers)
+		nameserver = r.nameservers[*counter]
+		*counter = (*counter + 1) % len(r.nameservers)
 	default:
 		if r.lastErr != nil {
-			r.counter = (r.counter + 1) % len(r.nameservers)
-			nameserver = r.nameservers[r.counter]
+			*counter = (*counter + 1) % len(r.nameservers)
+			nameserver = r.nameservers[*counter]
 		} else {
-			nameserver = r.nameservers[r.counter]
+			nameserver = r.nameservers[*counter]
 		}
 	}
 
 	// Last error has been logged, reset it for the next operation
 	r.lastErr = nil
 	return nameserver
+}
+
+func (r *rfc2136Provider) getNextNameserverForList() string {
+	return r.getNextNameserver(&r.listCounter)
+}
+
+func (r *rfc2136Provider) getNextNameserverForSend() string {
+	return r.getNextNameserver(&r.sendCounter)
 }
 
 func (r *rfc2136Provider) SendMessage(msg *dns.Msg) error {
@@ -544,7 +560,7 @@ func (r *rfc2136Provider) SendMessage(msg *dns.Msg) error {
 
 	var lastErr error
 	for i := 0; i < len(r.nameservers); i++ {
-		nameserver := r.getNextNameserver()
+		nameserver := r.getNextNameserverForSend()
 		log.Debugf("Sending message to nameserver: %s", nameserver)
 
 		c, err := makeClient(r, nameserver)

--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -73,22 +73,33 @@ type rfc2136Provider struct {
 	dryRun       bool
 	actions      rfc2136Actions
 
-	// Counters for load balancing, and error handling.
-	// List (AXFR) and Send (update) paths rotate independently so that
-	// one operation advancing its counter does not skew the other.
+	// Counters and last-seen errors for load balancing. List (AXFR) and
+	// Send (update) paths rotate and fail over independently, so each
+	// tracks its own counter and last error instead of sharing state that
+	// would let one operation skew or mask failover for the other.
 	listCounter int
 	sendCounter int
-	mu          sync.Mutex // Mutex for thread-safe counters
+	listLastErr error
+	sendLastErr error
+	mu          sync.Mutex // Mutex for thread-safe counters and last errors
 
 	// Load balancing strategy "round-robin", "random", or "disabled"
 	loadBalancingStrategy string
 
 	// Random number generator for random load balancing
 	randGen *rand.Rand
-
-	// Last error encountered
-	lastErr error
 }
+
+// nameserverOp identifies which rotation - list (AXFR) or send (update) -
+// is requesting the next nameserver, so getNextNameserverFor can resolve
+// the right counter and last-error state internally instead of the caller
+// having to know which field to pass in.
+type nameserverOp int
+
+const (
+	nameserverOpList nameserverOp = iota
+	nameserverOpSend
+)
 
 // TLSConfig is comprised of the TLS-related fields necessary if we are using DNS over TLS
 type TLSConfig struct {
@@ -166,7 +177,8 @@ func newProvider(hosts []string, port int, zoneNames []string, insecure bool, ke
 		randGen:               rand.New(rand.NewSource(time.Now().UnixNano())),
 		listCounter:           0,
 		sendCounter:           0,
-		lastErr:               nil,
+		listLastErr:           nil,
+		sendLastErr:           nil,
 	}
 	if actions != nil {
 		r.actions = actions
@@ -299,13 +311,13 @@ func (r *rfc2136Provider) List() ([]dns.RR, error) {
 
 		var lastErr error
 		for i := 0; i < len(r.nameservers); i++ {
-			nameserver := r.getNextNameserverForList()
+			nameserver := r.getNextNameserverFor(nameserverOpList)
 			log.Debugf("Fetching records from nameserver: %s", nameserver)
 
 			env, err := r.actions.IncomeTransfer(m, nameserver)
 			if err != nil {
 				lastErr = fmt.Errorf("failed to fetch records via AXFR: %w", err)
-				r.lastErr = lastErr
+				r.listLastErr = lastErr
 				continue
 			}
 
@@ -327,7 +339,7 @@ func (r *rfc2136Provider) List() ([]dns.RR, error) {
 		}
 
 		if lastErr != nil {
-			r.lastErr = lastErr
+			r.listLastErr = lastErr
 			return nil, provider.NewSoftError(lastErr)
 		}
 	}
@@ -499,11 +511,12 @@ func (r *rfc2136Provider) RemoveRecord(m *dns.Msg, ep *endpoint.Endpoint) error 
 	return nil
 }
 
-// getNextNameserver picks the next nameserver to use according to the
-// configured load balancing strategy, advancing the given counter. List
-// (AXFR) and Send (update) callers each pass their own counter so that the
-// two paths rotate independently instead of skewing each other.
-func (r *rfc2136Provider) getNextNameserver(counter *int) string {
+// getNextNameserverFor picks the next nameserver to use for the given
+// operation according to the configured load balancing strategy. List
+// (AXFR) and Send (update) operations rotate and fail over independently,
+// so the caller states its intent via op rather than reaching into the
+// provider's internal counter/error fields itself.
+func (r *rfc2136Provider) getNextNameserverFor(op nameserverOp) string {
 	if len(r.nameservers) == 1 {
 		return r.nameservers[0]
 	}
@@ -511,9 +524,11 @@ func (r *rfc2136Provider) getNextNameserver(counter *int) string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if r.lastErr != nil {
+	counter, lastErr := r.rotationStateFor(op)
+
+	if *lastErr != nil {
 		log.Warnf("Last operation failed for nameserver %s", r.nameservers[*counter])
-		log.Warnf("Last operation error message: %v", r.lastErr)
+		log.Warnf("Last operation error message: %v", *lastErr)
 	}
 
 	var nameserver string
@@ -530,7 +545,7 @@ func (r *rfc2136Provider) getNextNameserver(counter *int) string {
 		nameserver = r.nameservers[*counter]
 		*counter = (*counter + 1) % len(r.nameservers)
 	default:
-		if r.lastErr != nil {
+		if *lastErr != nil {
 			*counter = (*counter + 1) % len(r.nameservers)
 			nameserver = r.nameservers[*counter]
 		} else {
@@ -539,16 +554,18 @@ func (r *rfc2136Provider) getNextNameserver(counter *int) string {
 	}
 
 	// Last error has been logged, reset it for the next operation
-	r.lastErr = nil
+	*lastErr = nil
 	return nameserver
 }
 
-func (r *rfc2136Provider) getNextNameserverForList() string {
-	return r.getNextNameserver(&r.listCounter)
-}
-
-func (r *rfc2136Provider) getNextNameserverForSend() string {
-	return r.getNextNameserver(&r.sendCounter)
+// rotationStateFor returns the counter and last-error slots that belong to
+// the given operation, keeping the per-operation field bookkeeping in one
+// place instead of spread across List() and SendMessage().
+func (r *rfc2136Provider) rotationStateFor(op nameserverOp) (*int, *error) {
+	if op == nameserverOpList {
+		return &r.listCounter, &r.listLastErr
+	}
+	return &r.sendCounter, &r.sendLastErr
 }
 
 func (r *rfc2136Provider) SendMessage(msg *dns.Msg) error {
@@ -560,13 +577,13 @@ func (r *rfc2136Provider) SendMessage(msg *dns.Msg) error {
 
 	var lastErr error
 	for i := 0; i < len(r.nameservers); i++ {
-		nameserver := r.getNextNameserverForSend()
+		nameserver := r.getNextNameserverFor(nameserverOpSend)
 		log.Debugf("Sending message to nameserver: %s", nameserver)
 
 		c, err := makeClient(r, nameserver)
 		if err != nil {
 			lastErr = fmt.Errorf("error setting up TLS: %w", err)
-			r.lastErr = lastErr
+			r.sendLastErr = lastErr
 			continue
 		}
 
@@ -575,7 +592,7 @@ func (r *rfc2136Provider) SendMessage(msg *dns.Msg) error {
 				keyName, handle, err := r.KeyData(nameserver)
 				if err != nil {
 					lastErr = err
-					r.lastErr = lastErr
+					r.sendLastErr = lastErr
 					continue
 				}
 				defer handle.Close()
@@ -595,18 +612,18 @@ func (r *rfc2136Provider) SendMessage(msg *dns.Msg) error {
 			if resp != nil && resp.Rcode != dns.RcodeSuccess {
 				log.Infof("error in dns.Client.Exchange: %s", err)
 				lastErr = err
-				r.lastErr = lastErr
+				r.sendLastErr = lastErr
 				continue
 			}
 			log.Warnf("warn in dns.Client.Exchange: %s", err)
 			lastErr = err
-			r.lastErr = lastErr
+			r.sendLastErr = lastErr
 			continue
 		}
 		if resp != nil && resp.Rcode != dns.RcodeSuccess {
 			log.Infof("Bad dns.Client.Exchange response: %s", resp)
 			lastErr = fmt.Errorf("bad return code: %s", dns.RcodeToString[resp.Rcode])
-			r.lastErr = lastErr
+			r.sendLastErr = lastErr
 			continue
 		}
 
@@ -614,7 +631,7 @@ func (r *rfc2136Provider) SendMessage(msg *dns.Msg) error {
 		return nil
 	}
 
-	r.lastErr = lastErr
+	r.sendLastErr = lastErr
 	return provider.NewSoftError(lastErr)
 }
 

--- a/provider/rfc2136/rfc2136_test.go
+++ b/provider/rfc2136/rfc2136_test.go
@@ -978,6 +978,32 @@ func TestRandomLoadBalancing(t *testing.T) {
 	assert.Greater(t, len(nameserverCounts), 1, "Expected multiple nameservers to be used in random strategy")
 }
 
+// TestGetNextNameserverListAndSendCountersAreIndependent guards against the
+// regression described in https://github.com/kubernetes-sigs/external-dns/issues/6562:
+// AXFR/list and update/send nameserver rotation shared a single counter, so a
+// read advancing it would deterministically skew the following write onto a
+// different nameserver.
+func TestGetNextNameserverListAndSendCountersAreIndependent(t *testing.T) {
+	r := &rfc2136Provider{
+		nameservers:           []string{"ns1:53", "ns2:53", "ns3:53"},
+		loadBalancingStrategy: "round-robin",
+	}
+
+	// Advance only the list counter, as repeated AXFR attempts within a
+	// single List() call would.
+	assert.Equal(t, "ns1:53", r.getNextNameserverForList())
+	assert.Equal(t, "ns2:53", r.getNextNameserverForList())
+
+	// Send rotation must be unaffected by List()'s advancement and still
+	// start from the first nameserver.
+	assert.Equal(t, "ns1:53", r.getNextNameserverForSend())
+	assert.Equal(t, "ns2:53", r.getNextNameserverForSend())
+
+	// Both counters keep rotating independently from here on.
+	assert.Equal(t, "ns3:53", r.getNextNameserverForList())
+	assert.Equal(t, "ns3:53", r.getNextNameserverForSend())
+}
+
 // TestRfc2136ApplyChangesWithMultipleChunks tests Updates with multiple chunks
 func TestRfc2136ApplyChangesWithMultipleChunks(t *testing.T) {
 	stub := newStub()

--- a/provider/rfc2136/rfc2136_test.go
+++ b/provider/rfc2136/rfc2136_test.go
@@ -18,6 +18,7 @@ package rfc2136
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -991,17 +992,38 @@ func TestGetNextNameserverListAndSendCountersAreIndependent(t *testing.T) {
 
 	// Advance only the list counter, as repeated AXFR attempts within a
 	// single List() call would.
-	assert.Equal(t, "ns1:53", r.getNextNameserverForList())
-	assert.Equal(t, "ns2:53", r.getNextNameserverForList())
+	assert.Equal(t, "ns1:53", r.getNextNameserverFor(nameserverOpList))
+	assert.Equal(t, "ns2:53", r.getNextNameserverFor(nameserverOpList))
 
 	// Send rotation must be unaffected by List()'s advancement and still
 	// start from the first nameserver.
-	assert.Equal(t, "ns1:53", r.getNextNameserverForSend())
-	assert.Equal(t, "ns2:53", r.getNextNameserverForSend())
+	assert.Equal(t, "ns1:53", r.getNextNameserverFor(nameserverOpSend))
+	assert.Equal(t, "ns2:53", r.getNextNameserverFor(nameserverOpSend))
 
 	// Both counters keep rotating independently from here on.
-	assert.Equal(t, "ns3:53", r.getNextNameserverForList())
-	assert.Equal(t, "ns3:53", r.getNextNameserverForSend())
+	assert.Equal(t, "ns3:53", r.getNextNameserverFor(nameserverOpList))
+	assert.Equal(t, "ns3:53", r.getNextNameserverFor(nameserverOpSend))
+}
+
+// TestGetNextNameserverListAndSendLastErrAreIndependent guards against the
+// same class of regression for the failover state: under the default
+// (failover) strategy, a List()/AXFR failure must not cause the following
+// Send()/update rotation to fail over too, and vice versa.
+func TestGetNextNameserverListAndSendLastErrAreIndependent(t *testing.T) {
+	r := &rfc2136Provider{
+		nameservers: []string{"ns1:53", "ns2:53", "ns3:53"},
+	}
+
+	// Simulate a failed AXFR attempt.
+	r.listLastErr = errors.New("boom")
+
+	// Send rotation must be unaffected by List()'s failure and must not
+	// fail over to the next nameserver.
+	assert.Equal(t, "ns1:53", r.getNextNameserverFor(nameserverOpSend))
+	assert.Equal(t, "ns1:53", r.getNextNameserverFor(nameserverOpSend))
+
+	// List rotation, however, must fail over since its own last error was set.
+	assert.Equal(t, "ns2:53", r.getNextNameserverFor(nameserverOpList))
 }
 
 // TestRfc2136ApplyChangesWithMultipleChunks tests Updates with multiple chunks


### PR DESCRIPTION
## What does it do ?

Splits the single `counter` field on `rfc2136Provider` into independent `listCounter` and `sendCounter` fields. `getNextNameserver()` now takes the counter to advance as a parameter, with `getNextNameserverForList()` and `getNextNameserverForSend()` wrappers used by `List()` and `SendMessage()` respectively, so AXFR reads and update writes rotate through the configured nameservers independently.

## Motivation

With multiple `--rfc2136-host` values and `--rfc2136-load-balancing-strategy=round-robin`, a typical reconcile calls `List()` followed by `SendMessage()`. Because both paths shared one counter, the `List()` call advanced it and the following write consistently landed on the next nameserver instead of rotating on its own schedule — round-robin didn't behave independently for reads and writes, skewing update distribution across nameservers. This does not cause a crash or data loss, and dry-run/no-op behavior is unaffected.

Fixes #6562

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly
