### PR TITLE
feat(chart): add optional VerticalPodAutoscaler support

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add value `.service.enabled` to enable the creation of the Kubernetes service.
 - Add value `replicaCount` to set the number of `external-dns` replicas (bounded to `0` or `1`, since external-dns does not support leader election). [#6503](https://github.com/kubernetes-sigs/external-dns/pull/6503) _@yugstar_
+- Add `verticalPodAutoscaler` values to optionally create a `VerticalPodAutoscaler` resource for the `Deployment`.
 
 ### Fixed
 

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -191,6 +191,11 @@ If `namespaced` is set to `true`, please ensure that `sources` only contains sup
 | txtOwnerId | string | `nil` | Specify an identifier for this instance of _ExternalDNS_ when using a registry other than `noop`. |
 | txtPrefix | string | `nil` | Specify a prefix for the domain names of TXT records created for the `txt` registry. Mutually exclusive with `txtSuffix`. |
 | txtSuffix | string | `nil` | Specify a suffix for the domain names of TXT records created for the `txt` registry. Mutually exclusive with `txtPrefix`. |
+| verticalPodAutoscaler.additionalLabels | object | `{}` | Additional labels for the `VerticalPodAutoscaler`. |
+| verticalPodAutoscaler.annotations | object | `{}` | Annotations to add to the `VerticalPodAutoscaler`. |
+| verticalPodAutoscaler.enabled | bool | `false` | If `true`, create a `VerticalPodAutoscaler` resource for the `Deployment`. |
+| verticalPodAutoscaler.resourcePolicy | object | `{}` | [Resource policy](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/API.md#podresourcepolicy) for the `VerticalPodAutoscaler`, allows specifying constraints for individual containers. |
+| verticalPodAutoscaler.updatePolicy | object | `{"updateMode":"Auto"}` | [Update policy](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/API.md#podupdatepolicy) for the `VerticalPodAutoscaler`. |
 
 ## Usage
 

--- a/charts/external-dns/templates/verticalpodautoscaler.yaml
+++ b/charts/external-dns/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.verticalPodAutoscaler.enabled -}}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "external-dns.fullname" . }}
+  namespace: {{ include "external-dns.namespace" . }}
+  {{- with .Values.verticalPodAutoscaler.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "external-dns.labels" . | nindent 4 }}
+  {{- with .Values.verticalPodAutoscaler.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "external-dns.fullname" . }}
+  {{- with .Values.verticalPodAutoscaler.updatePolicy }}
+  updatePolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.verticalPodAutoscaler.resourcePolicy }}
+  resourcePolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/external-dns/tests/common-metadata_test.yaml
+++ b/charts/external-dns/tests/common-metadata_test.yaml
@@ -14,6 +14,8 @@ tests:
         mountPath: "/etc/kubernetes/"
       serviceMonitor:
         enabled: true
+      verticalPodAutoscaler:
+        enabled: true
     asserts:
       - exists:
           path: metadata.labels

--- a/charts/external-dns/tests/verticalpodautoscaler_test.yaml
+++ b/charts/external-dns/tests/verticalpodautoscaler_test.yaml
@@ -1,0 +1,60 @@
+suite: VerticalPodAutoscaler configuration
+templates:
+  - verticalpodautoscaler.yaml
+release:
+  namespace: default
+tests:
+  - it: should not create a VerticalPodAutoscaler by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a VerticalPodAutoscaler when enabled
+    set:
+      verticalPodAutoscaler:
+        enabled: true
+    asserts:
+      - isKind:
+          of: VerticalPodAutoscaler
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: apiVersion
+          value: autoscaling.k8s.io/v1
+      - equal:
+          path: spec.targetRef
+          value:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: RELEASE-NAME-external-dns
+      - equal:
+          path: spec.updatePolicy.updateMode
+          value: Auto
+
+  - it: should support additional labels, annotations, and a custom resource policy
+    set:
+      verticalPodAutoscaler:
+        enabled: true
+        additionalLabels:
+          foo: bar
+        annotations:
+          foo: bar
+        resourcePolicy:
+          containerPolicies:
+            - containerName: external-dns
+              minAllowed:
+                cpu: 10m
+                memory: 32Mi
+    asserts:
+      - equal:
+          path: metadata.labels.foo
+          value: bar
+      - equal:
+          path: metadata.annotations.foo
+          value: bar
+      - equal:
+          path: spec.resourcePolicy.containerPolicies[0].containerName
+          value: external-dns
+      - equal:
+          path: spec.resourcePolicy.containerPolicies[0].minAllowed.cpu
+          value: 10m

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -914,6 +914,37 @@
         "string",
         "null"
       ]
+    },
+    "verticalPodAutoscaler": {
+      "type": "object",
+      "properties": {
+        "additionalLabels": {
+          "description": "Additional labels for the `VerticalPodAutoscaler`.",
+          "type": "object"
+        },
+        "annotations": {
+          "description": "Annotations to add to the `VerticalPodAutoscaler`.",
+          "type": "object"
+        },
+        "enabled": {
+          "description": "If `true`, create a `VerticalPodAutoscaler` resource for the `Deployment`.",
+          "type": "boolean"
+        },
+        "resourcePolicy": {
+          "description": "[Resource policy](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/API.md#podresourcepolicy) for the `VerticalPodAutoscaler`, allows specifying constraints for individual containers.",
+          "type": "object"
+        },
+        "updatePolicy": {
+          "description": "[Update policy](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/API.md#podupdatepolicy) for the `VerticalPodAutoscaler`.",
+          "type": "object",
+          "properties": {
+            "updateMode": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": true
     }
   },
   "additionalProperties": true

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -203,6 +203,19 @@ serviceMonitor:
   # -- Provide target labels for the `ServiceMonitor`.
   targetLabels: []
 
+verticalPodAutoscaler:  # @schema additionalProperties: true
+  # -- If `true`, create a `VerticalPodAutoscaler` resource for the `Deployment`.
+  enabled: false
+  # -- Additional labels for the `VerticalPodAutoscaler`.
+  additionalLabels: {}
+  # -- Annotations to add to the `VerticalPodAutoscaler`.
+  annotations: {}
+  # -- [Update policy](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/API.md#podupdatepolicy) for the `VerticalPodAutoscaler`.
+  updatePolicy:
+    updateMode: Auto
+  # -- [Resource policy](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/API.md#podresourcepolicy) for the `VerticalPodAutoscaler`, allows specifying constraints for individual containers.
+  resourcePolicy: {}
+
 # -- Log level.
 logLevel: info  # @schema enum:[panic, debug, info, warning, error, fatal]; type:string; default: "info"
 


### PR DESCRIPTION
Adds optional VerticalPodAutoscaler (VPA) support to the external-dns Helm chart.

- New template templates/verticalpodautoscaler.yaml, rendered when verticalPodAutoscaler.enabled: true, creating a VerticalPodAutoscaler resource (autoscaling.k8s.io/v1) with targetRef pointing at the chart's Deployment.
- New verticalPodAutoscaler values section in values.yaml: enabled (defaults to false), updatePolicy (defaults to updateMode: Auto), resourcePolicy, additionalLabels, annotations.
- values.schema.json and README.md regenerated (helm schema / helm-docs) to reflect the new values.
- New unit test tests/verticalpodautoscaler_test.yaml (disabled by default, enabled case, custom labels/annotations/resourcePolicy).
- tests/common-metadata_test.yaml updated to also verify common labels on the new resource.
