### PR TITLE
feat(chart): add crds.install flag to gate DNSEndpoint CRD installation

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add value `.service.enabled` to enable the creation of the Kubernetes service.
 - Add value `replicaCount` to set the number of `external-dns` replicas (bounded to `0` or `1`, since external-dns does not support leader election). [#6503](https://github.com/kubernetes-sigs/external-dns/pull/6503) _@yugstar_
+- Add value `.crds.install` to control whether the `DNSEndpoint` `CustomResourceDefinition` is installed. Defaults to `true`; set to `false` on all but one release when running multiple `external-dns` releases (e.g. one per provider) in the same cluster to avoid the CRD being installed more than once. Note: because the CRD is now rendered from `templates/`, Helm may attempt to update it on upgrade and will delete it on uninstall unless it is marked with `helm.sh/resource-policy: keep`.
 
 ### Changed
 

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -98,6 +98,7 @@ If `namespaced` is set to `true`, please ensure that `sources` only contains sup
 | annotationPrefix | string | `nil` | Annotation prefix for external-dns annotations (useful for split horizon DNS with multiple instances). |
 | automountServiceAccountToken | bool | `true` | Set this to `false` to [opt out of API credential automounting](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting) for the `Pod`. |
 | commonLabels | object | `{}` | Labels to add to all chart resources. |
+| crds.install | bool | `true` | If `true`, install the `DNSEndpoint` `CustomResourceDefinition`. Set this to `false` on all but one release when running multiple `external-dns` releases (e.g. one per provider) in the same cluster, to avoid the CRD being installed more than once. |
 | deploymentAnnotations | object | `{}` | Annotations to add to the `Deployment`. |
 | deploymentStrategy | object | `{"type":"Recreate"}` | [Deployment Strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy). |
 | dnsConfig | object | `nil` | [DNS config](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config) for the pod, if not set the default will be used. |

--- a/charts/external-dns/templates/dnsendpoint-crd.yaml
+++ b/charts/external-dns/templates/dnsendpoint-crd.yaml
@@ -1,9 +1,12 @@
+{{- if .Values.crds.install -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/external-dns/pull/2007
   name: dnsendpoints.externaldns.k8s.io
+  labels:
+    {{- include "external-dns.labels" . | nindent 4 }}
 spec:
   group: externaldns.k8s.io
   names:
@@ -94,3 +97,4 @@ spec:
       storage: true
       subresources:
         status: {}
+{{- end }}

--- a/charts/external-dns/tests/crds_test.yaml
+++ b/charts/external-dns/tests/crds_test.yaml
@@ -1,0 +1,25 @@
+suite: CRD configuration
+set:
+  policy: upsert-only
+templates:
+  - dnsendpoint-crd.yaml
+release:
+  namespace: default
+tests:
+  - it: should install the DNSEndpoint CRD by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: CustomResourceDefinition
+      - equal:
+          path: metadata.name
+          value: dnsendpoints.externaldns.k8s.io
+
+  - it: should not install the CRD when crds.install is false
+    set:
+      crds:
+        install: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/external-dns/values.schema.json
+++ b/charts/external-dns/values.schema.json
@@ -31,6 +31,15 @@
       "description": "Labels to add to all chart resources.",
       "type": "object"
     },
+    "crds": {
+      "type": "object",
+      "properties": {
+        "install": {
+          "description": "If `true`, install the `DNSEndpoint` `CustomResourceDefinition`. Set this to `false` on all but one release when running multiple `external-dns` releases (e.g. one per provider) in the same cluster, to avoid the CRD being installed more than once.",
+          "type": "boolean"
+        }
+      }
+    },
     "deploymentAnnotations": {
       "description": "Annotations to add to the `Deployment`.",
       "type": "object"

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -64,6 +64,10 @@ rbac:  # @schema additionalProperties: true
   # -- Additional rules to add to the `ClusterRole`.
   additionalPermissions: []
 
+crds:
+  # -- If `true`, install the `DNSEndpoint` `CustomResourceDefinition`. Set this to `false` on all but one release when running multiple `external-dns` releases (e.g. one per provider) in the same cluster, to avoid the CRD being installed more than once.
+  install: true
+
 # -- Number of replicas of the `external-dns` `Deployment`. external-dns does not
 # support leader election, so this must be `0` or `1` to avoid duplicate or
 # conflicting DNS record updates. Set to `0` to scale the `Deployment` down.


### PR DESCRIPTION
## What does it do?

Adds a `.crds.install` value (default `true`) to the `external-dns` chart, gating installation of the `DNSEndpoint` CustomResourceDefinition. The CRD is moved from `crds/` into `templates/dnsendpoint-crd.yaml`, wrapped in `{{- if .Values.crds.install -}}`.

## Motivation

When running multiple `external-dns` releases of this chart in the same cluster (e.g. one release per DNS provider — a common pattern when different Ingress/Service subsets are delegated to different providers), every release installs its own copy of the `DNSEndpoint` CRD via the chart's bundled `crds/` directory. Since CRDs are cluster-scoped, this means the identical CRD object is emitted by more than one Helm release.

GitOps tools that aggregate multiple releases under one logical application (e.g. ArgoCD via Helmfile) then see the same resource (`CustomResourceDefinition/dnsendpoints.externaldns.k8s.io`) appear more than once within a single application's manifest set, which is treated as a comparison error rather than a warning, blocking sync/diff for the whole application.

Helm's `crds/` directory has no templating support by design, so there's no way to conditionally skip it today. Moving the CRD into `templates/` with a value-gated toggle lets users installing multiple releases set `crds.install: false` on all but one release, so the CRD is applied exactly once, while leaving default single-release behavior unchanged.

This follows the same pattern used by several other charts that support multi-release-per-cluster installs (e.g. cert-manager's `crds.enabled`), trading Helm's CRD-protection-on-uninstall guarantee (native `crds/` are never deleted/upgraded by Helm) for the ability to toggle installation — a tradeoff that only affects users who explicitly opt in by setting the value.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation (README regenerated via `helm-docs`, values.schema.json regenerated via `helm schema`)
- [x] Added a CHANGELOG.md entry under `## [UNRELEASED]` per `docs/contributing/chart.md`