### PR TITLE
fix(oci): set useragent, record call limit

### DIFF
--- a/provider/oci/oci.go
+++ b/provider/oci/oci.go
@@ -114,7 +114,6 @@ func loadOCIConfig(path string) (*OCIConfig, error) {
 
 // newProvider initializes a new OCI DNS based Provider.
 func newProvider(cfg OCIConfig, domainFilter *endpoint.DomainFilter, zoneIDFilter provider.ZoneIDFilter, zoneScope string, dryRun bool) (*OCIProvider, error) {
-	var client ociDNSClient
 	var err error
 	var configProvider common.ConfigurationProvider
 	if cfg.Auth.UseInstancePrincipal && cfg.Auth.UseWorkloadIdentity {
@@ -149,10 +148,11 @@ func newProvider(cfg OCIConfig, domainFilter *endpoint.DomainFilter, zoneIDFilte
 		)
 	}
 
-	client, err = dns.NewDnsClientWithConfigurationProvider(configProvider)
+	client, err := dns.NewDnsClientWithConfigurationProvider(configProvider)
 	if err != nil {
 		return nil, fmt.Errorf("initializing OCI DNS API client: %w", err)
 	}
+	client.UserAgent = fmt.Sprintf("%s %s", client.UserAgent, externaldns.UserAgent())
 
 	return &OCIProvider{
 		client:       client,
@@ -287,9 +287,9 @@ func (p *OCIProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error)
 		var page *string
 		for {
 			resp, err := p.client.GetZoneRecords(ctx, dns.GetZoneRecordsRequest{
-				ZoneNameOrId:  zone.Id,
-				Page:          page,
-				CompartmentId: &p.cfg.CompartmentID,
+				ZoneNameOrId: zone.Id,
+				Page:         page,
+				Limit:        common.Int64(100),
 			})
 			if err != nil {
 				return nil, provider.NewSoftErrorf("getting records for zone %q: %w", *zone.Id, err)
@@ -357,7 +357,6 @@ func (p *OCIProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) e
 
 	for zoneID, ops := range opsByZone {
 		if _, err := p.client.PatchZoneRecords(ctx, dns.PatchZoneRecordsRequest{
-			CompartmentId:           &p.cfg.CompartmentID,
 			ZoneNameOrId:            &zoneID,
 			PatchZoneRecordsDetails: dns.PatchZoneRecordsDetails{Items: ops},
 		}); err != nil {

--- a/provider/oci/oci_test.go
+++ b/provider/oci/oci_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
 )
@@ -225,7 +226,7 @@ hKRtDhmSdWBo3tJK12RrAe4t7CUe8gMgTvU7ExlcA3xQkseFPx9K
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			_, err := newProvider(
+			provider, err := newProvider(
 				tc.config,
 				endpoint.NewDomainFilter([]string{"com"}),
 				provider.NewZoneIDFilter([]string{""}),
@@ -234,6 +235,10 @@ hKRtDhmSdWBo3tJK12RrAe4t7CUe8gMgTvU7ExlcA3xQkseFPx9K
 			)
 			if err == nil {
 				require.NoError(t, err)
+				client, ok := provider.client.(dns.DnsClient)
+				require.True(t, ok)
+				require.Contains(t, client.UserAgent, "Oracle-GoSDK/")
+				require.True(t, strings.HasSuffix(client.UserAgent, externaldns.UserAgent()))
 			} else {
 				// have to use prefix testing because the expected instance-principal error strings vary after a known prefix
 				require.Truef(t, strings.HasPrefix(err.Error(), tc.err.Error()), "observed: %s", err.Error())


### PR DESCRIPTION
## What does it do ?

This PR makes some minor changes to the OCI provider:
* Set HTTP user-agent to ExternalDNS
* When fetching records, fetch up to 100 records at a time instead of up to 50
* Remove the deprecated compartment id parameter from the two record operation calls

## Motivation

The user-agent change will help differentiate ExternalDNS calls from other generic Go SDK calls, and is a convention used by several of the other providers.

Specifying the limit on the GetZoneRecords call will halve the number of API calls required to fetch records, for zones with >50 of them.

## More

- [*] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [*] Yes, I added unit tests
- [*] Yes, I updated end user documentation accordingly