### PR TITLE
fix(source): defer empty hostname fallback after annotations

### DIFF
--- a/source/gateway.go
+++ b/source/gateway.go
@@ -546,11 +546,7 @@ func (c *gatewayRouteResolver) matchRouteToListener(rt gatewayRoute, rtHosts []s
 	return match
 }
 
-func (c *gatewayRouteResolver) hosts(rt gatewayRoute) ([]string, error) {
-	var hostnames []string
-	for _, name := range rt.Hostnames() {
-		hostnames = append(hostnames, string(name))
-	}
+func (c *gatewayRouteResolver) applyGatewayTemplate(hostnames []string, rt gatewayRoute) ([]string, error) {
 	// TODO: The combine-fqdn-annotation flag is similarly vague.
 	if c.src.templateEngine.IsConfigured() && (len(hostnames) == 0 || c.src.templateEngine.Combining()) {
 		hosts, err := c.src.templateEngine.ExecFQDN(rt.Object())
@@ -559,45 +555,48 @@ func (c *gatewayRouteResolver) hosts(rt gatewayRoute) ([]string, error) {
 		}
 		hostnames = append(hostnames, hosts...)
 	}
+	return hostnames, nil
+}
+
+func (c *gatewayRouteResolver) hosts(rt gatewayRoute) ([]string, error) {
+	var hostnames []string
+	for _, name := range rt.Hostnames() {
+		hostnames = append(hostnames, string(name))
+	}
 
 	hostNameAnnotation, hostNameAnnotationExists := rt.Metadata().Annotations[annotations.GatewayHostnameSourceKey]
-	if !hostNameAnnotationExists {
-		// This means that the route doesn't specify a hostname and should use any provided by
-		// attached Gateway Listeners. This is only useful for {HTTP,TLS}Routes, but it doesn't
-		// break {TCP,UDP}Routes.
-		if !c.src.ignoreHostnameAnnotation {
-			hostnames = append(hostnames, annotations.HostnamesFromAnnotations(rt.Metadata().Annotations)...)
+	if hostNameAnnotationExists {
+		switch strings.ToLower(hostNameAnnotation) {
+		case gatewayHostnameSourceAnnotationOnlyValue:
+			if c.src.ignoreHostnameAnnotation {
+				return []string{}, nil
+			}
+			return annotations.HostnamesFromAnnotations(rt.Metadata().Annotations), nil
+		case gatewayHostnameSourceDefinedHostsOnlyValue:
+			// Explicitly use only defined hostnames (route spec and optional template result)
+			return c.applyGatewayTemplate(hostnames, rt)
+		default:
+			// Invalid value provided: warn and fall back to default behavior (as if the annotation is absent)
+			log.Warnf("Invalid value for %q on %s/%s: %q. Falling back to default behavior.",
+				annotations.GatewayHostnameSourceKey, rt.Metadata().Namespace, rt.Metadata().Name, hostNameAnnotation)
 		}
-		// Only fall back to the attached listener hostname when nothing else supplied a name.
-		// Appending "" earlier would publish wildcard listener hostnames (e.g. *.example.com)
-		// even when an annotation already named the record.
-		if len(hostnames) == 0 {
-			hostnames = append(hostnames, "")
-		}
-		return hostnames, nil
 	}
 
-	switch strings.ToLower(hostNameAnnotation) {
-	case gatewayHostnameSourceAnnotationOnlyValue:
-		if c.src.ignoreHostnameAnnotation {
-			return []string{}, nil
-		}
-		return annotations.HostnamesFromAnnotations(rt.Metadata().Annotations), nil
-	case gatewayHostnameSourceDefinedHostsOnlyValue:
-		// Explicitly use only defined hostnames (route spec and optional template result)
-		return hostnames, nil
-	default:
-		// Invalid value provided: warn and fall back to default behavior (as if the annotation is absent)
-		log.Warnf("Invalid value for %q on %s/%s: %q. Falling back to default behavior.",
-			annotations.GatewayHostnameSourceKey, rt.Metadata().Namespace, rt.Metadata().Name, hostNameAnnotation)
-		if !c.src.ignoreHostnameAnnotation {
-			hostnames = append(hostnames, annotations.HostnamesFromAnnotations(rt.Metadata().Annotations)...)
-		}
-		if len(hostnames) == 0 {
-			hostnames = append(hostnames, "")
-		}
-		return hostnames, nil
+	// Default behavior: spec.hostnames → annotation → template → listener fallback.
+	if !c.src.ignoreHostnameAnnotation {
+		hostnames = append(hostnames, annotations.HostnamesFromAnnotations(rt.Metadata().Annotations)...)
 	}
+	hostnames, err := c.applyGatewayTemplate(hostnames, rt)
+	if err != nil {
+		return nil, err
+	}
+	// Only fall back to the attached listener hostname when nothing else supplied a name.
+	// Appending "" earlier would publish wildcard listener hostnames (e.g. *.example.com)
+	// even when an annotation already named the record.
+	if len(hostnames) == 0 {
+		hostnames = append(hostnames, "")
+	}
+	return hostnames, nil
 }
 
 func (c *gatewayRouteResolver) routeIsAllowed(ownerNamespace string, lis *v1.Listener, rt gatewayRoute) bool {

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -565,11 +565,14 @@ func (c *gatewayRouteResolver) hosts(rt gatewayRoute) ([]string, error) {
 		// This means that the route doesn't specify a hostname and should use any provided by
 		// attached Gateway Listeners. This is only useful for {HTTP,TLS}Routes, but it doesn't
 		// break {TCP,UDP}Routes.
-		if len(rt.Hostnames()) == 0 {
-			hostnames = append(hostnames, "")
-		}
 		if !c.src.ignoreHostnameAnnotation {
 			hostnames = append(hostnames, annotations.HostnamesFromAnnotations(rt.Metadata().Annotations)...)
+		}
+		// Only fall back to the attached listener hostname when nothing else supplied a name.
+		// Appending "" earlier would publish wildcard listener hostnames (e.g. *.example.com)
+		// even when an annotation already named the record.
+		if len(hostnames) == 0 {
+			hostnames = append(hostnames, "")
 		}
 		return hostnames, nil
 	}
@@ -587,11 +590,11 @@ func (c *gatewayRouteResolver) hosts(rt gatewayRoute) ([]string, error) {
 		// Invalid value provided: warn and fall back to default behavior (as if the annotation is absent)
 		log.Warnf("Invalid value for %q on %s/%s: %q. Falling back to default behavior.",
 			annotations.GatewayHostnameSourceKey, rt.Metadata().Namespace, rt.Metadata().Name, hostNameAnnotation)
-		if len(rt.Hostnames()) == 0 {
-			hostnames = append(hostnames, "")
-		}
 		if !c.src.ignoreHostnameAnnotation {
 			hostnames = append(hostnames, annotations.HostnamesFromAnnotations(rt.Metadata().Annotations)...)
+		}
+		if len(hostnames) == 0 {
+			hostnames = append(hostnames, "")
 		}
 		return hostnames, nil
 	}

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -958,6 +958,43 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			},
 		},
 		{
+			// Annotation hostnames must be collected before the FQDN template so a
+			// configured template does not run when the annotation already named the record.
+			title: "AnnotationBeforeFQDNTemplate",
+			config: &Config{
+				TemplateEngine: templatetest.MustEngine(t, "{{.Name}}.template.internal", "", "", false),
+			},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{{Protocol: v1.HTTPProtocolType}},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "annotated-route",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.HostnameKey: "service.example.com",
+					},
+				},
+				Spec: v1.HTTPRouteSpec{
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test"),
+						},
+					},
+					Hostnames: nil,
+				},
+				Status: httpRouteStatus(gwParentRef("default", "test")),
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("service.example.com", "1.2.3.4"),
+			},
+		},
+		{
 			title: "IgnoreHostnameAnnotation",
 			config: &Config{
 				IgnoreHostnameAnnotation: true,

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -920,6 +920,44 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			},
 		},
 		{
+			// Annotation-only route against a wildcard listener must publish the
+			// annotation hostname, not the listener's *.example.com (#6596).
+			title:      "AnnotationHostnameWithWildcardListener",
+			config:     &Config{},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{{
+						Protocol: v1.HTTPProtocolType,
+						Hostname: new(v1.Hostname("*.example.com")),
+					}},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "annotation-only",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.HostnameKey: "service5.example.com",
+					},
+				},
+				Spec: v1.HTTPRouteSpec{
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test"),
+						},
+					},
+					Hostnames: nil,
+				},
+				Status: httpRouteStatus(gwParentRef("default", "test")),
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("service5.example.com", "1.2.3.4"),
+			},
+		},
+		{
 			title: "IgnoreHostnameAnnotation",
 			config: &Config{
 				IgnoreHostnameAnnotation: true,

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 
@@ -1067,6 +1068,78 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				newTestEndpoint("fqdn-with-hostnames.internal", "1.2.3.4"),
 				newTestEndpoint("combine-fqdn-with-hostnames.internal", "1.2.3.4"),
 			},
+		},
+		{
+			// With --combine-fqdn-annotation, the template must still run and be appended
+			// even when an annotation already produced a hostname (unlike the default,
+			// non-combining behavior covered by AnnotationBeforeFQDNTemplate above).
+			title: "AnnotationWithCombineFQDNTemplate",
+			config: &Config{
+				TemplateEngine: templatetest.MustEngine(t, "combine-{{.Name}}.internal", "", "", true),
+			},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{{Protocol: v1.HTTPProtocolType}},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "annotated-combine",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.HostnameKey: "annotation.internal",
+					},
+				},
+				Spec: v1.HTTPRouteSpec{
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test"),
+						},
+					},
+					Hostnames: nil,
+				},
+				Status: httpRouteStatus(gwParentRef("default", "test")),
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("annotation.internal", "1.2.3.4"),
+				newTestEndpoint("combine-annotated-combine.internal", "1.2.3.4"),
+			},
+		},
+		{
+			// A template result that doesn't match any attached listener's hostname must
+			// produce no endpoint, not silently fall back to the listener's own hostname
+			// (gwMatchingHost's "" rtHost case is the fallback path; a non-empty, non-matching
+			// rtHost must never hit it).
+			title: "FQDNTemplateOutsideListenerDomain",
+			config: &Config{
+				TemplateEngine: templatetest.MustEngine(t, "{{.Name}}.other-domain.internal", "", "", false),
+			},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{{
+						Protocol: v1.HTTPProtocolType,
+						Hostname: ptr.To(v1.Hostname("gateway.example.com")),
+					}},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: objectMeta("default", "outside-domain"),
+				Spec: v1.HTTPRouteSpec{
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test"),
+						},
+					},
+				},
+				Status: httpRouteStatus(gwParentRef("default", "test")),
+			}},
+			endpoints: []*endpoint.Endpoint{},
 		},
 		{
 			title:      "TTL",

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kubefake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/utils/ptr"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 
@@ -1123,7 +1122,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				Spec: v1.GatewaySpec{
 					Listeners: []v1.Listener{{
 						Protocol: v1.HTTPProtocolType,
-						Hostname: ptr.To(v1.Hostname("gateway.example.com")),
+						Hostname: new(v1.Hostname("gateway.example.com")),
 					}},
 				},
 				Status: gatewayStatus("1.2.3.4"),

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 
@@ -1104,6 +1105,78 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 				newTestEndpoint("fqdn-with-hostnames.internal", "1.2.3.4"),
 				newTestEndpoint("combine-fqdn-with-hostnames.internal", "1.2.3.4"),
 			},
+		},
+		{
+			// With --combine-fqdn-annotation, the template must still run and be appended
+			// even when an annotation already produced a hostname (unlike the default,
+			// non-combining behavior covered by AnnotationBeforeFQDNTemplate above).
+			title: "AnnotationWithCombineFQDNTemplate",
+			config: &Config{
+				TemplateEngine: templatetest.MustEngine(t, "combine-{{.Name}}.internal", "", "", true),
+			},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{{Protocol: v1.HTTPProtocolType}},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "annotated-combine",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.HostnameKey: "annotation.internal",
+					},
+				},
+				Spec: v1.HTTPRouteSpec{
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test"),
+						},
+					},
+					Hostnames: nil,
+				},
+				Status: httpRouteStatus(gwParentRef("default", "test")),
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("annotation.internal", "1.2.3.4"),
+				newTestEndpoint("combine-annotated-combine.internal", "1.2.3.4"),
+			},
+		},
+		{
+			// A template result that doesn't match any attached listener's hostname must
+			// produce no endpoint, not silently fall back to the listener's own hostname
+			// (gwMatchingHost's "" rtHost case is the fallback path; a non-empty, non-matching
+			// rtHost must never hit it).
+			title: "FQDNTemplateOutsideListenerDomain",
+			config: &Config{
+				TemplateEngine: templatetest.MustEngine(t, "{{.Name}}.other-domain.internal", "", "", false),
+			},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{{
+						Protocol: v1.HTTPProtocolType,
+						Hostname: ptr.To(v1.Hostname("gateway.example.com")),
+					}},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: objectMeta("default", "outside-domain"),
+				Spec: v1.HTTPRouteSpec{
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test"),
+						},
+					},
+				},
+				Status: httpRouteStatus(gwParentRef("default", "test")),
+			}},
+			endpoints: []*endpoint.Endpoint{},
 		},
 		{
 			title:      "TTL",


### PR DESCRIPTION
## What does it do ?

Defer the empty-string listener fallback in `hosts()` until after template + annotation hostnames are collected, so it only applies when nothing else named the record. Same change on the invalid `GatewayHostnameSourceKey` fallback path.

Adds unit coverage for annotation-only HTTPRoute + wildcard listener (`AnnotationHostnameWithWildcardListener`).

## Motivation

Related to #6596

When a Gateway route has empty `spec.hostnames` but sets `external-dns.kubernetes.io/hostname`, `hosts()` used to append `""` before the annotation hostnames. Matching that empty string against a wildcard listener published the listener hostname (`*.example.com`) next to the annotation name.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] No end user documentation is needed

Validation:

- [x] Unit: `AnnotationHostnameWithWildcardListener` fails without the fix, passes with it
- [x] `go test ./source/ -run 'TestGatewayHTTPRouteSource|TestGatewayTCPRouteSourceEndpoints' -count=1`
- [ ] CI