### PR TITLE
test(e2e): retry downloads to survive transient network errors

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -9,9 +9,11 @@ KUBECTL_VERSION="1.35.0"
 
 echo "Starting end-to-end tests for external-dns with local provider..."
 
+CURL_RETRY_OPTS="--retry 5 --retry-all-errors"
+
 # Install kind
 echo "Installing kind..."
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v${KIND_VERSION}/kind-linux-amd64
+curl $CURL_RETRY_OPTS -fLo ./kind https://kind.sigs.k8s.io/dl/v${KIND_VERSION}/kind-linux-amd64
 chmod +x ./kind
 sudo mv ./kind /usr/local/bin/kind
 
@@ -31,13 +33,13 @@ trap cleanup EXIT
 
 # Install kubectl
 echo "Installing kubectl..."
-curl -LO "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+curl $CURL_RETRY_OPTS -fLO "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
 chmod +x kubectl
 sudo mv kubectl /usr/local/bin/kubectl
 
 # Install ko
 echo "Installing ko..."
-curl -sSfL "https://github.com/ko-build/ko/releases/download/v${KO_VERSION}/ko_${KO_VERSION}_linux_x86_64.tar.gz" > ko.tar.gz
+curl $CURL_RETRY_OPTS -sSfL "https://github.com/ko-build/ko/releases/download/v${KO_VERSION}/ko_${KO_VERSION}_linux_x86_64.tar.gz" > ko.tar.gz
 tar xzf ko.tar.gz ko
 chmod +x ./ko
 sudo mv ko /usr/local/bin/ko

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -39,7 +39,7 @@ sudo mv kubectl /usr/local/bin/kubectl
 
 # Install ko
 echo "Installing ko..."
-curl $CURL_RETRY_OPTS -sSfL "https://github.com/ko-build/ko/releases/download/v${KO_VERSION}/ko_${KO_VERSION}_linux_x86_64.tar.gz" > ko.tar.gz
+curl $CURL_RETRY_OPTS -o ko.tar.gz -sSfL "https://github.com/ko-build/ko/releases/download/v${KO_VERSION}/ko_${KO_VERSION}_linux_x86_64.tar.gz"
 tar xzf ko.tar.gz ko
 chmod +x ./ko
 sudo mv ko /usr/local/bin/ko

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -9,7 +9,7 @@ KUBECTL_VERSION="1.35.0"
 
 echo "Starting end-to-end tests for external-dns with local provider..."
 
-CURL_RETRY_OPTS="--retry 5 --retry-all-errors"
+CURL_RETRY_OPTS="--retry 5 --retry-all-errors --retry-max-time 60"
 
 # Install kind
 echo "Installing kind..."


### PR DESCRIPTION
## What does it do ?

Adds `--retry 5 --retry-all-errors` to the curl calls that download kind, kubectl, and ko in `scripts/e2e-test.sh`, plus `-f` so a bad HTTP status
also fails loudly instead of silently saving an error page as the binary.

<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->
The e2e CI job failed with `curl: (35) Recv failure: Connection reset by peer` while downloading kubectl
([run](https://github.com/kubernetes-sigs/external-dns/actions/runs/30682287027/job/91321572528)) — a transient network blip unrelated to the code under test. 
`--retry-all-errors` is needed (not just `--retry`/`--retry-connrefused`) since this class of error isn't in curl's default retryable-error set. 
Adding retries avoids wasted re-runs on similar flakes.


## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
