### PR TITLE
fix(source): return errors for invalid label/annotation filters in NewSourceConfig

### DIFF
--- a/source/store.go
+++ b/source/store.go
@@ -129,11 +129,11 @@ func WithClientGenerator(gen ClientGenerator) OverrideConfigOption {
 func NewSourceConfig(cfg *externaldns.Config, opts ...OverrideConfigOption) (*Config, error) {
 	labelSelector, err := labels.Parse(cfg.LabelFilter)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("--label-filter %q: %w", cfg.LabelFilter, err)
 	}
 	annotationSelector, err := annotations.ParseFilter(cfg.AnnotationFilter)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("--annotation-filter %q: %w", cfg.AnnotationFilter, err)
 	}
 	tmpls, err := template.NewEngine(cfg.FQDNTemplate, cfg.TargetTemplate, cfg.FQDNTargetTemplate, cfg.CombineFQDNAndAnnotation)
 	if err != nil {

--- a/source/store.go
+++ b/source/store.go
@@ -127,9 +127,14 @@ func WithClientGenerator(gen ClientGenerator) OverrideConfigOption {
 }
 
 func NewSourceConfig(cfg *externaldns.Config, opts ...OverrideConfigOption) (*Config, error) {
-	// errors are explicitly ignored because the filters are already validated in validation.ValidateConfig
-	labelSelector, _ := labels.Parse(cfg.LabelFilter)
-	annotationSelector, _ := annotations.ParseFilter(cfg.AnnotationFilter)
+	labelSelector, err := labels.Parse(cfg.LabelFilter)
+	if err != nil {
+		return nil, err
+	}
+	annotationSelector, err := annotations.ParseFilter(cfg.AnnotationFilter)
+	if err != nil {
+		return nil, err
+	}
 	tmpls, err := template.NewEngine(cfg.FQDNTemplate, cfg.TargetTemplate, cfg.FQDNTargetTemplate, cfg.CombineFQDNAndAnnotation)
 	if err != nil {
 		return nil, err

--- a/source/store.go
+++ b/source/store.go
@@ -129,11 +129,11 @@ func WithClientGenerator(gen ClientGenerator) OverrideConfigOption {
 func NewSourceConfig(cfg *externaldns.Config, opts ...OverrideConfigOption) (*Config, error) {
 	labelSelector, err := labels.Parse(cfg.LabelFilter)
 	if err != nil {
-		return nil, fmt.Errorf("--label-filter %q: %w", cfg.LabelFilter, err)
+		return nil, fmt.Errorf("label filter: %w", err)
 	}
 	annotationSelector, err := annotations.ParseFilter(cfg.AnnotationFilter)
 	if err != nil {
-		return nil, fmt.Errorf("--annotation-filter %q: %w", cfg.AnnotationFilter, err)
+		return nil, fmt.Errorf("annotation filter: %w", err)
 	}
 	tmpls, err := template.NewEngine(cfg.FQDNTemplate, cfg.TargetTemplate, cfg.FQDNTargetTemplate, cfg.CombineFQDNAndAnnotation)
 	if err != nil {

--- a/source/store_test.go
+++ b/source/store_test.go
@@ -440,13 +440,13 @@ func TestNewSourceConfig(t *testing.T) {
 			name:        "invalid label filter",
 			cfg:         &externaldns.Config{LabelFilter: "#invalid-selector"},
 			wantErr:     true,
-			errContains: `--label-filter "#invalid-selector": unable to parse requirement`,
+			errContains: `Invalid value: "#invalid-selector"`,
 		},
 		{
 			name:        "invalid annotation filter",
 			cfg:         &externaldns.Config{AnnotationFilter: "kubernetes.io/gateway.name in (a b)"},
 			wantErr:     true,
-			errContains: `--annotation-filter "kubernetes.io/gateway.name in (a b)": couldn't parse the selector string`,
+			errContains: `couldn't parse the selector string`,
 		},
 	}
 

--- a/source/store_test.go
+++ b/source/store_test.go
@@ -440,13 +440,13 @@ func TestNewSourceConfig(t *testing.T) {
 			name:        "invalid label filter",
 			cfg:         &externaldns.Config{LabelFilter: "#invalid-selector"},
 			wantErr:     true,
-			errContains: `unable to parse requirement`,
+			errContains: `--label-filter "#invalid-selector": unable to parse requirement`,
 		},
 		{
 			name:        "invalid annotation filter",
 			cfg:         &externaldns.Config{AnnotationFilter: "kubernetes.io/gateway.name in (a b)"},
 			wantErr:     true,
-			errContains: `unable to parse requirement`,
+			errContains: `--annotation-filter "kubernetes.io/gateway.name in (a b)": couldn't parse the selector string`,
 		},
 	}
 

--- a/source/store_test.go
+++ b/source/store_test.go
@@ -436,6 +436,18 @@ func TestNewSourceConfig(t *testing.T) {
 			wantErr:     true,
 			errContains: `--fqdn-template[1]`,
 		},
+		{
+			name:        "invalid label filter",
+			cfg:         &externaldns.Config{LabelFilter: "#invalid-selector"},
+			wantErr:     true,
+			errContains: `unable to parse requirement`,
+		},
+		{
+			name:        "invalid annotation filter",
+			cfg:         &externaldns.Config{AnnotationFilter: "kubernetes.io/gateway.name in (a b)"},
+			wantErr:     true,
+			errContains: `unable to parse requirement`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What does it do ?

- source/store.go: NewSourceConfig now checks and returns the error from labels.Parse(cfg.LabelFilter) and annotations.ParseFilter(cfg.AnnotationFilter) instead of discarding them, removing the stale comment that justified ignoring them.

## Motivation

- NewSourceConfig silently discarded parse errors from --label-filter and --annotation-filter, relying entirely on validation.ValidateConfig having already run first to catch bad input.
- Changing the current behaviour of a source config only, we no longer accepting nil/incorrect annotations or labels on config level https://github.com/kubernetes-sigs/external-dns/pull/6545#issuecomment-4902057345 where an invalid filter would silently produce a nil/empty selector instead of failing (new behaviour). Does not affect runtime, as fail-fast validation happens at runtime https://github.com/kubernetes-sigs/external-dns/blob/master/pkg/apis/externaldns/validation/validation.go

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
