### PR TITLE
fix(source): evaluate FQDN templates on typed objects like unstructured

### DIFF
--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -1001,6 +1001,43 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			},
 		},
 		{
+			// A JSON-style FQDN template (lower-case Spec keys, the shape the unstructured
+			// source expects) fails direct struct field lookup against a typed HTTPRoute's
+			// Go-named fields ("can't evaluate field hostnames in type v1.HTTPRouteSpec") and
+			// falls back to the unstructured representation instead, so the same shared
+			// --fqdn-template value works for both source kinds. Uses combine so the template
+			// runs even though the route already has Spec.Hostnames set, proving the fallback
+			// reads the real data (not just that it avoids erroring on an empty range). See #6593.
+			title: "FQDNTemplate with JSON-style Spec access on typed HTTPRoute",
+			config: &Config{
+				TemplateEngine: templatetest.MustEngine(t, "{{range .Spec.hostnames}}{{.}}.json.internal,{{end}}", "", "", true),
+			},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{{Protocol: v1.HTTPProtocolType}},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: objectMeta("default", "fqdn-json-style"),
+				Spec: v1.HTTPRouteSpec{
+					Hostnames: hostnames("fqdn-json-style.internal"),
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test"),
+						},
+					},
+				},
+				Status: httpRouteStatus(gwParentRef("default", "test")),
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("fqdn-json-style.internal", "1.2.3.4"),
+				newTestEndpoint("fqdn-json-style.internal.json.internal", "1.2.3.4"),
+			},
+		},
+		{
 			title: "CombineFQDN",
 			config: &Config{
 				TemplateEngine: templatetest.MustEngine(t, "combine-{{.Name}}.internal", "", "", true),

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -1001,13 +1001,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			},
 		},
 		{
-			// A JSON-style FQDN template (lower-case Spec keys, the shape the unstructured
-			// source expects) fails direct struct field lookup against a typed HTTPRoute's
-			// Go-named fields ("can't evaluate field hostnames in type v1.HTTPRouteSpec") and
-			// falls back to the unstructured representation instead, so the same shared
-			// --fqdn-template value works for both source kinds. Uses combine so the template
-			// runs even though the route already has Spec.Hostnames set, proving the fallback
-			// reads the real data (not just that it avoids erroring on an empty range). See #6593.
+			// combine so the template runs even though Spec.Hostnames is already set.
 			title: "FQDNTemplate with JSON-style Spec access on typed HTTPRoute",
 			config: &Config{
 				TemplateEngine: templatetest.MustEngine(t, "{{range .Spec.hostnames}}{{.}}.json.internal,{{end}}", "", "", true),

--- a/source/template/engine.go
+++ b/source/template/engine.go
@@ -274,8 +274,17 @@ func execTemplate(tmpl *template.Template, obj kubeObject) ([]string, error) {
 		if convErr != nil {
 			return nil, wrapTemplateErr(obj, err)
 		}
+		// Clone before setting the option: Option mutates the template in place,
+		// and tmpl is the shared, cached parse reused by every call. Left
+		// unguarded, a missing map key silently renders as "<no value>" instead
+		// of failing the retry, masking template typos that should be errors.
+		strict, cloneErr := tmpl.Clone()
+		if cloneErr != nil {
+			return nil, wrapTemplateErr(obj, err)
+		}
+		strict = strict.Option("missingkey=error")
 		buf.Reset()
-		if err2 := tmpl.Execute(&buf, data); err2 != nil {
+		if err2 := strict.Execute(&buf, data); err2 != nil {
 			return nil, fmt.Errorf("%w (unstructured retry also failed: %w)", wrapTemplateErr(obj, err), err2)
 		}
 	}

--- a/source/template/engine.go
+++ b/source/template/engine.go
@@ -269,8 +269,21 @@ func execTemplate(tmpl *template.Template, obj kubeObject) ([]string, error) {
 
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, obj); err != nil {
-		kind := obj.GetObjectKind().GroupVersionKind().Kind
-		return nil, fmt.Errorf("failed to apply template on %s %s/%s: %w", kind, obj.GetNamespace(), obj.GetName(), err)
+		// Unstructured source wraps objects so templates can use {{ .Spec.hostnames }}
+		// (Spec is a map with JSON keys). Typed sources expose Go field names
+		// (.Spec.Hostnames), so the same shared --fqdn-template fails on
+		// gateway-httproute when hostnames are empty/absent (#6593).
+		// Retry with the same shape unstructuredWrapper provides.
+		data, convErr := toTemplateData(obj)
+		if convErr != nil {
+			kind := obj.GetObjectKind().GroupVersionKind().Kind
+			return nil, fmt.Errorf("failed to apply template on %s %s/%s: %w", kind, obj.GetNamespace(), obj.GetName(), err)
+		}
+		buf.Reset()
+		if err2 := tmpl.Execute(&buf, data); err2 != nil {
+			kind := obj.GetObjectKind().GroupVersionKind().Kind
+			return nil, fmt.Errorf("failed to apply template on %s %s/%s: %w", kind, obj.GetNamespace(), obj.GetName(), err)
+		}
 	}
 	hosts := strings.Split(buf.String(), ",")
 	hostnames := make(sets.Set[string], len(hosts))
@@ -282,4 +295,47 @@ func execTemplate(tmpl *template.Template, obj kubeObject) ([]string, error) {
 		}
 	}
 	return sets.Sorted(hostnames), nil
+}
+
+// fqdnTemplateData mirrors source.unstructuredWrapper so typed objects can
+// evaluate the same --fqdn-template as the unstructured source.
+type fqdnTemplateData struct {
+	Name        string
+	Namespace   string
+	Kind        string
+	APIVersion  string
+	Labels      map[string]string
+	Annotations map[string]string
+	Metadata    map[string]any
+	Spec        map[string]any
+	Status      map[string]any
+	Object      map[string]any
+}
+
+// toTemplateData converts a Kubernetes object into the unstructured-style
+// template data shape (JSON keys under Spec/Status, plus Name/Namespace/...).
+func toTemplateData(obj kubeObject) (*fqdnTemplateData, error) {
+	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	data := &fqdnTemplateData{
+		Name:        obj.GetName(),
+		Namespace:   obj.GetNamespace(),
+		Kind:        obj.GetObjectKind().GroupVersionKind().Kind,
+		APIVersion:  obj.GetObjectKind().GroupVersionKind().GroupVersion().String(),
+		Labels:      obj.GetLabels(),
+		Annotations: obj.GetAnnotations(),
+		Object:      raw,
+	}
+	if metadata, ok := raw["metadata"].(map[string]any); ok {
+		data.Metadata = metadata
+	}
+	if spec, ok := raw["spec"].(map[string]any); ok {
+		data.Spec = spec
+	}
+	if status, ok := raw["status"].(map[string]any); ok {
+		data.Status = status
+	}
+	return data, nil
 }

--- a/source/template/engine.go
+++ b/source/template/engine.go
@@ -272,13 +272,11 @@ func execTemplate(tmpl *template.Template, obj kubeObject) ([]string, error) {
 		// Retry against the unstructured data shape, so JSON-keyed Spec paths work on typed objects too.
 		data, convErr := toTemplateData(obj)
 		if convErr != nil {
-			kind := obj.GetObjectKind().GroupVersionKind().Kind
-			return nil, fmt.Errorf("failed to apply template on %s %s/%s: %w", kind, obj.GetNamespace(), obj.GetName(), err)
+			return nil, wrapTemplateErr(obj, err)
 		}
 		buf.Reset()
 		if err2 := tmpl.Execute(&buf, data); err2 != nil {
-			kind := obj.GetObjectKind().GroupVersionKind().Kind
-			return nil, fmt.Errorf("failed to apply template on %s %s/%s: %w", kind, obj.GetNamespace(), obj.GetName(), err)
+			return nil, fmt.Errorf("%w (unstructured retry also failed: %w)", wrapTemplateErr(obj, err), err2)
 		}
 	}
 	hosts := strings.Split(buf.String(), ",")
@@ -291,6 +289,11 @@ func execTemplate(tmpl *template.Template, obj kubeObject) ([]string, error) {
 		}
 	}
 	return sets.Sorted(hostnames), nil
+}
+
+func wrapTemplateErr(obj kubeObject, err error) error {
+	kind := obj.GetObjectKind().GroupVersionKind().Kind
+	return fmt.Errorf("failed to apply template on %s %s/%s: %w", kind, obj.GetNamespace(), obj.GetName(), err)
 }
 
 // fqdnTemplateData mirrors source.unstructuredWrapper so typed objects can

--- a/source/template/engine.go
+++ b/source/template/engine.go
@@ -269,11 +269,7 @@ func execTemplate(tmpl *template.Template, obj kubeObject) ([]string, error) {
 
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, obj); err != nil {
-		// Unstructured source wraps objects so templates can use {{ .Spec.hostnames }}
-		// (Spec is a map with JSON keys). Typed sources expose Go field names
-		// (.Spec.Hostnames), so the same shared --fqdn-template fails on
-		// gateway-httproute when hostnames are empty/absent (#6593).
-		// Retry with the same shape unstructuredWrapper provides.
+		// Retry against the unstructured data shape, so JSON-keyed Spec paths work on typed objects too.
 		data, convErr := toTemplateData(obj)
 		if convErr != nil {
 			kind := obj.GetObjectKind().GroupVersionKind().Kind

--- a/source/template/engine_test.go
+++ b/source/template/engine_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"sigs.k8s.io/external-dns/endpoint"
@@ -424,6 +425,77 @@ func TestExecFQDNNilObject(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// Typed objects expose Go field names (.Spec.Hostnames) while the unstructured
+// source wraps maps so {{ .Spec.hostnames }} works (JSON keys). A shared
+// --fqdn-template must succeed on both; empty/absent hostnames on typed routes
+// previously failed with "can't evaluate field hostnames" (#6593).
+func TestExecFQDNJSONFieldNamesOnTypedObject(t *testing.T) {
+	tmpl := `{{ range .Spec.hostnames }}{{ . }},{{ end }}`
+	engine, err := NewEngine([]string{tmpl}, nil, nil, false)
+	require.NoError(t, err)
+
+	typed := &hostnamesObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "route",
+			Namespace: "default",
+		},
+		Spec: hostnamesSpec{
+			Hostnames: []string{"a.example.com", "b.example.com"},
+		},
+	}
+	got, err := engine.ExecFQDN(typed)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a.example.com", "b.example.com"}, got)
+
+	empty := &hostnamesObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "route",
+			Namespace: "default",
+		},
+	}
+	got, err = engine.ExecFQDN(empty)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+
+	unstructuredObj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "gateway.networking.k8s.io/v1",
+			"kind":       "HTTPRoute",
+			"metadata": map[string]any{
+				"name":      "route",
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"hostnames": []any{"a.example.com", "b.example.com"},
+			},
+		},
+	}
+	got, err = engine.ExecFQDN(unstructuredObj)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a.example.com", "b.example.com"}, got)
+}
+
+func TestExecFQDNJSONFieldNamesKeepsNameAccess(t *testing.T) {
+	// After a JSON-name retry, promoted Name must still work for templates
+	// that mix metav1 fields with JSON keys under Spec.
+	tmpl := `{{ .Name }}.{{ range .Spec.hostnames }}{{ . }}{{ end }}`
+	engine, err := NewEngine([]string{tmpl}, nil, nil, false)
+	require.NoError(t, err)
+
+	obj := &hostnamesObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "route",
+			Namespace: "default",
+		},
+		Spec: hostnamesSpec{
+			Hostnames: []string{"example.com"},
+		},
+	}
+	got, err := engine.ExecFQDN(obj)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"route.example.com"}, got)
+}
+
 func TestExecFQDNPopulatesEmptyKind(t *testing.T) {
 	// Test that Kind is populated when initially empty (simulates informer behavior)
 	engine, err := NewEngine([]string{"{{ .Kind }}.{{ .Name }}.example.com"}, nil, nil, false)
@@ -690,4 +762,25 @@ func (t *testObject) DeepCopyObject() runtime.Object {
 		TypeMeta:   t.TypeMeta,
 		ObjectMeta: *t.ObjectMeta.DeepCopy(),
 	}
+}
+
+type hostnamesSpec struct {
+	Hostnames []string `json:"hostnames"`
+}
+
+// hostnamesObject mimics a typed API object with JSON tag names that differ
+// from Go exported field names (same shape as Gateway API HTTPRouteSpec).
+type hostnamesObject struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+	Spec hostnamesSpec `json:"spec"`
+}
+
+func (h *hostnamesObject) DeepCopyObject() runtime.Object {
+	c := *h
+	c.ObjectMeta = *h.ObjectMeta.DeepCopy()
+	if h.Spec.Hostnames != nil {
+		c.Spec.Hostnames = append([]string(nil), h.Spec.Hostnames...)
+	}
+	return &c
 }

--- a/source/template/engine_test.go
+++ b/source/template/engine_test.go
@@ -425,10 +425,7 @@ func TestExecFQDNNilObject(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// Typed objects expose Go field names (.Spec.Hostnames) while the unstructured
-// source wraps maps so {{ .Spec.hostnames }} works (JSON keys). A shared
-// --fqdn-template must succeed on both; empty/absent hostnames on typed routes
-// previously failed with "can't evaluate field hostnames" (#6593).
+// A shared --fqdn-template using JSON-style Spec keys must succeed on typed objects too.
 func TestExecFQDNJSONFieldNamesOnTypedObject(t *testing.T) {
 	tmpl := `{{ range .Spec.hostnames }}{{ . }},{{ end }}`
 	engine, err := NewEngine([]string{tmpl}, nil, nil, false)

--- a/source/template/engine_test.go
+++ b/source/template/engine_test.go
@@ -782,13 +782,9 @@ func (h *hostnamesObject) DeepCopyObject() runtime.Object {
 	return &c
 }
 
-// TestExecFQDNFailsClosedOnUnknownField guards against the unstructured
-// retry (added so JSON-keyed Spec paths work on typed objects too) silently
-// swallowing template typos. text/template's default missingkey mode
-// renders a missing map key as "<no value>" instead of erroring, so without
-// an explicit strict mode the retry could turn a real mistake in
-// --fqdn-template into a wrong-but-valid hostname/target rather than a
-// startup-time-visible error. Reported by mloiseleur on #6611.
+// TestExecFQDNFailsClosedOnUnknownField guards the unstructured retry
+// against text/template's default missingkey mode, which renders a missing
+// map key as "<no value>" instead of erroring.
 func TestExecFQDNFailsClosedOnUnknownField(t *testing.T) {
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "ns"},

--- a/source/template/engine_test.go
+++ b/source/template/engine_test.go
@@ -781,3 +781,53 @@ func (h *hostnamesObject) DeepCopyObject() runtime.Object {
 	}
 	return &c
 }
+
+// TestExecFQDNFailsClosedOnUnknownField guards against the unstructured
+// retry (added so JSON-keyed Spec paths work on typed objects too) silently
+// swallowing template typos. text/template's default missingkey mode
+// renders a missing map key as "<no value>" instead of erroring, so without
+// an explicit strict mode the retry could turn a real mistake in
+// --fqdn-template into a wrong-but-valid hostname/target rather than a
+// startup-time-visible error. Reported by mloiseleur on #6611.
+func TestExecFQDNFailsClosedOnUnknownField(t *testing.T) {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "ns"},
+	}
+
+	t.Run("fqdn template", func(t *testing.T) {
+		engine, err := NewEngine([]string{"{{ .Spec.hostname }}.example.com"}, nil, nil, false)
+		require.NoError(t, err)
+
+		got, err := engine.ExecFQDN(svc)
+
+		require.Error(t, err, "unknown field must not render as %q", "<no value>")
+		assert.Contains(t, err.Error(), "can't evaluate field hostname")
+		assert.Empty(t, got)
+	})
+
+	t.Run("target template", func(t *testing.T) {
+		// Same hole on --target-template: the endpoint would otherwise get
+		// "<no value>" as its target, which SuitableType classifies as a CNAME.
+		engine, err := NewEngine([]string{"{{ .Name }}.example.com"}, []string{"{{ .Spec.address }}"}, nil, false)
+		require.NoError(t, err)
+
+		eps, err := engine.ApplyTemplates(nil, svc)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "can't evaluate field address")
+		assert.Empty(t, eps)
+	})
+
+	t.Run("fqdn-target template", func(t *testing.T) {
+		// endpointsFromFQDNTargetTemplate skips pairs with an empty host or
+		// target, but "<no value>" is non-empty, so that guard cannot catch this.
+		engine, err := NewEngine(nil, nil, []string{"{{ .Name }}.example.com:{{ .Spec.address }}"}, false)
+		require.NoError(t, err)
+
+		eps, err := engine.ApplyFQDNTargetTemplate(nil, svc)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "can't evaluate field address")
+		assert.Empty(t, eps)
+	})
+}

--- a/source/unstructured.go
+++ b/source/unstructured.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"unicode"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -213,13 +214,46 @@ func newUnstructuredWrapper(u *unstructured.Unstructured) *unstructuredWrapper {
 		w.Metadata = metadata
 	}
 	if spec, ok := u.Object["spec"].(map[string]any); ok {
-		w.Spec = spec
+		w.Spec = withTitleCaseAliases(spec)
 	}
 	if status, ok := u.Object["status"].(map[string]any); ok {
-		w.Status = status
+		w.Status = withTitleCaseAliases(status)
 	}
 
 	return w
+}
+
+// withTitleCaseAliases lets a template address a JSON-keyed map field
+// (spec.hostnames) by its Go field name too (Spec.Hostnames), since a map
+// key miss in text/template renders empty instead of erroring.
+func withTitleCaseAliases(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		if nested, ok := v.(map[string]any); ok {
+			v = withTitleCaseAliases(nested)
+		}
+		out[k] = v
+	}
+	for k := range m {
+		title := titleCaseKey(k)
+		if title == k {
+			continue
+		}
+		if _, collision := m[title]; collision {
+			continue
+		}
+		out[title] = out[k]
+	}
+	return out
+}
+
+func titleCaseKey(k string) string {
+	if k == "" {
+		return k
+	}
+	r := []rune(k)
+	r[0] = unicode.ToUpper(r[0])
+	return string(r)
 }
 
 // discoverResources parses and validates resource identifiers against the cluster.

--- a/source/unstructured.go
+++ b/source/unstructured.go
@@ -226,12 +226,15 @@ func newUnstructuredWrapper(u *unstructured.Unstructured) *unstructuredWrapper {
 // withTitleCaseAliases lets a template address a JSON-keyed map field
 // (spec.hostnames) by its Go field name too (Spec.Hostnames), since a map
 // key miss in text/template renders empty instead of erroring.
+//
+// Deliberately shallow: an earlier version recursed into nested map values
+// to alias their keys too, but that duplicated every key one level down, so
+// a template ranging or taking len() over nested data (spec.records) saw
+// twice as many entries as were actually declared. Nested JSON keys stay
+// reachable through their literal path (spec.endpoint.hostname) instead.
 func withTitleCaseAliases(m map[string]any) map[string]any {
 	out := make(map[string]any, len(m))
 	for k, v := range m {
-		if nested, ok := v.(map[string]any); ok {
-			v = withTitleCaseAliases(nested)
-		}
 		out[k] = v
 	}
 	for k := range m {
@@ -247,13 +250,42 @@ func withTitleCaseAliases(m map[string]any) map[string]any {
 	return out
 }
 
+// commonInitialisms are the field-name segments Kubernetes' code generator
+// spells fully upper-case in Go structs (DNSNames, not DnsNames; URL, not
+// Url), taken from the CRD/API-machinery-relevant subset of the initialisms
+// staticcheck/golint treat as standard Go convention.
+var commonInitialisms = map[string]bool{
+	"acl": true, "api": true, "arn": true, "ca": true, "cidr": true,
+	"cpu": true, "crd": true, "db": true, "dns": true, "http": true,
+	"https": true, "id": true, "ip": true, "json": true, "jwk": true,
+	"jwt": true, "os": true, "pem": true, "rbac": true, "sql": true,
+	"ssl": true, "tcp": true, "tls": true, "ttl": true, "udp": true,
+	"uid": true, "uuid": true, "uri": true, "url": true, "vm": true,
+	"xml": true, "yaml": true,
+}
+
+// titleCaseKey converts a lowerCamelCase JSON key into its Go-convention
+// exported field name: dnsNames -> DNSNames, url -> URL, hostname ->
+// Hostname. It upper-cases the leading word in full when that word is a
+// known initialism, matching how Kubernetes generates Go types from CRD
+// schemas; otherwise it capitalizes just the first letter, as before.
 func titleCaseKey(k string) string {
 	if k == "" {
 		return k
 	}
 	r := []rune(k)
-	r[0] = unicode.ToUpper(r[0])
-	return string(r)
+	if unicode.IsUpper(r[0]) {
+		return k
+	}
+	end := 0
+	for end < len(r) && !unicode.IsUpper(r[end]) {
+		end++
+	}
+	word := string(r[:end])
+	if commonInitialisms[strings.ToLower(word)] {
+		return strings.ToUpper(word) + string(r[end:])
+	}
+	return strings.ToUpper(word[:1]) + word[1:] + string(r[end:])
 }
 
 // discoverResources parses and validates resource identifiers against the cluster.

--- a/source/unstructured.go
+++ b/source/unstructured.go
@@ -19,6 +19,7 @@ package source
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"unicode"
 
@@ -234,9 +235,7 @@ func newUnstructuredWrapper(u *unstructured.Unstructured) *unstructuredWrapper {
 // reachable through their literal path (spec.endpoint.hostname) instead.
 func withTitleCaseAliases(m map[string]any) map[string]any {
 	out := make(map[string]any, len(m))
-	for k, v := range m {
-		out[k] = v
-	}
+	maps.Copy(out, m)
 	for k := range m {
 		title := titleCaseKey(k)
 		if title == k {

--- a/source/unstructured_fqdn_test.go
+++ b/source/unstructured_fqdn_test.go
@@ -1049,6 +1049,26 @@ func TestUnstructuredWrapper_Templating(t *testing.T) {
 			},
 			want: []string{"reviews.bookinfo.svc.cluster.local"},
 		},
+		{
+			name: "Spec field access matches JSON key casing regardless of template casing",
+			tmpl: `{{index .Spec.Hostnames 0}}`,
+			obj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "gateway.networking.k8s.io/v1",
+					"kind":       "HTTPRoute",
+					"metadata": map[string]any{
+						"name":      "reviews",
+						"namespace": "bookinfo",
+					},
+					"spec": map[string]any{
+						"hostnames": []any{
+							"reviews.bookinfo.example.com",
+						},
+					},
+				},
+			},
+			want: []string{"reviews.bookinfo.example.com"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1065,4 +1085,36 @@ func TestUnstructuredWrapper_Templating(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestWithTitleCaseAliases(t *testing.T) {
+	in := map[string]any{
+		"hostnames": []any{"a.example.com"},
+		"nested": map[string]any{
+			"innerField": "value",
+		},
+		"Already": "unchanged", // already title-cased; no collision to resolve
+	}
+
+	out := withTitleCaseAliases(in)
+
+	assert.Equal(t, in["hostnames"], out["hostnames"], "original lowercase key must still resolve")
+	assert.Equal(t, in["hostnames"], out["Hostnames"], "title-cased alias must resolve to the same value")
+	assert.Equal(t, "unchanged", out["Already"])
+
+	nested, ok := out["Nested"].(map[string]any)
+	require.True(t, ok, "nested maps must get aliased recursively")
+	assert.Equal(t, "value", nested["InnerField"])
+}
+
+func TestWithTitleCaseAliases_DoesNotClobberExistingKey(t *testing.T) {
+	in := map[string]any{
+		"hostnames": "lower",
+		"Hostnames": "already-title-cased",
+	}
+
+	out := withTitleCaseAliases(in)
+
+	assert.Equal(t, "lower", out["hostnames"])
+	assert.Equal(t, "already-title-cased", out["Hostnames"], "must not overwrite a key the original data already defines")
 }

--- a/source/unstructured_fqdn_test.go
+++ b/source/unstructured_fqdn_test.go
@@ -880,6 +880,93 @@ func TestUnstructuredFqdnTemplatingExamples(t *testing.T) {
 			},
 			expected: nil,
 		},
+		{
+			title: "title-cased Spec field resolves against a lowercase JSON key",
+			cfg: cfg{
+				resources:      []string{"proxyservices.v1beta1.proxyconfigs.acme.corp"},
+				fqdnTemplate:   `{{index .Spec.Hostnames 0}}`,
+				targetTemplate: `{{index .Spec.hosts 0}}`,
+			},
+			objects: []*unstructured.Unstructured{
+				{
+					Object: map[string]any{
+						"apiVersion": "proxyconfigs.acme.corp/v1beta1",
+						"kind":       "ProxyService",
+						"metadata": map[string]any{
+							"name":      "reviews",
+							"namespace": "default",
+						},
+						"spec": map[string]any{
+							"hostnames": []any{"reviews.bookinfo.example.com"},
+							"hosts":     []any{"promo.svc.local"},
+						},
+					},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("reviews.bookinfo.example.com", endpoint.RecordTypeCNAME, "promo.svc.local").
+					WithLabel(endpoint.ResourceLabelKey, "proxyservice/default/reviews"),
+			},
+		},
+		{
+			title: "title-cased alias does not clobber a key already present under that name",
+			cfg: cfg{
+				resources:      []string{"proxyservices.v1beta1.proxyconfigs.acme.corp"},
+				fqdnTemplate:   `{{index .Spec.Hostnames 0}}`,
+				targetTemplate: `{{index .Spec.hosts 0}}`,
+			},
+			objects: []*unstructured.Unstructured{
+				{
+					Object: map[string]any{
+						"apiVersion": "proxyconfigs.acme.corp/v1beta1",
+						"kind":       "ProxyService",
+						"metadata": map[string]any{
+							"name":      "reviews",
+							"namespace": "default",
+						},
+						"spec": map[string]any{
+							"hostnames": "ignored.example.com",
+							"Hostnames": []any{"real.example.com"},
+							"hosts":     []any{"promo.svc.local"},
+						},
+					},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("real.example.com", endpoint.RecordTypeCNAME, "promo.svc.local").
+					WithLabel(endpoint.ResourceLabelKey, "proxyservice/default/reviews"),
+			},
+		},
+		{
+			title: "title-cased alias resolves through a nested map",
+			cfg: cfg{
+				resources:      []string{"proxyservices.v1beta1.proxyconfigs.acme.corp"},
+				fqdnTemplate:   `{{.Spec.Endpoint.Hostname}}`,
+				targetTemplate: `{{index .Spec.hosts 0}}`,
+			},
+			objects: []*unstructured.Unstructured{
+				{
+					Object: map[string]any{
+						"apiVersion": "proxyconfigs.acme.corp/v1beta1",
+						"kind":       "ProxyService",
+						"metadata": map[string]any{
+							"name":      "reviews",
+							"namespace": "default",
+						},
+						"spec": map[string]any{
+							"endpoint": map[string]any{
+								"hostname": "reviews.nested.example.com",
+							},
+							"hosts": []any{"promo.svc.local"},
+						},
+					},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("reviews.nested.example.com", endpoint.RecordTypeCNAME, "promo.svc.local").
+					WithLabel(endpoint.ResourceLabelKey, "proxyservice/default/reviews"),
+			},
+		},
 	} {
 		t.Run(tt.title, func(t *testing.T) {
 			kubeClient, dynamicClient := setupUnstructuredTestClients(t, tt.cfg.resources, tt.objects)
@@ -1085,36 +1172,4 @@ func TestUnstructuredWrapper_Templating(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
-}
-
-func TestWithTitleCaseAliases(t *testing.T) {
-	in := map[string]any{
-		"hostnames": []any{"a.example.com"},
-		"nested": map[string]any{
-			"innerField": "value",
-		},
-		"Already": "unchanged", // already title-cased; no collision to resolve
-	}
-
-	out := withTitleCaseAliases(in)
-
-	assert.Equal(t, in["hostnames"], out["hostnames"], "original lowercase key must still resolve")
-	assert.Equal(t, in["hostnames"], out["Hostnames"], "title-cased alias must resolve to the same value")
-	assert.Equal(t, "unchanged", out["Already"])
-
-	nested, ok := out["Nested"].(map[string]any)
-	require.True(t, ok, "nested maps must get aliased recursively")
-	assert.Equal(t, "value", nested["InnerField"])
-}
-
-func TestWithTitleCaseAliases_DoesNotClobberExistingKey(t *testing.T) {
-	in := map[string]any{
-		"hostnames": "lower",
-		"Hostnames": "already-title-cased",
-	}
-
-	out := withTitleCaseAliases(in)
-
-	assert.Equal(t, "lower", out["hostnames"])
-	assert.Equal(t, "already-title-cased", out["Hostnames"], "must not overwrite a key the original data already defines")
 }

--- a/source/unstructured_fqdn_test.go
+++ b/source/unstructured_fqdn_test.go
@@ -1175,11 +1175,8 @@ func TestUnstructuredWrapper_Templating(t *testing.T) {
 }
 
 // TestUnstructuredWrapper_MapIterationIsNotAliasPolluted guards
-// withTitleCaseAliases against recursing into nested map values: an earlier
-// version aliased every key at every depth, so a template ranging or
-// len()-ing arbitrary nested data (not just the Spec/Status field names the
-// alias exists for) saw twice as many entries as were actually declared.
-// Reported by mloiseleur on #6611.
+// withTitleCaseAliases against recursing into nested maps, which used to
+// double every key one level down and break range/len over nested data.
 func TestUnstructuredWrapper_MapIterationIsNotAliasPolluted(t *testing.T) {
 	obj := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -1228,12 +1225,8 @@ func TestUnstructuredWrapper_MapIterationIsNotAliasPolluted(t *testing.T) {
 	})
 }
 
-// TestTitleCaseKey_KnownInitialisms guards the CRD field names mloiseleur
-// called out on #6611: a naive first-letter-only titlecase turns "url" into
-// "Url" and "dnsNames" into "DnsNames", neither of which matches the Go
-// field names Kubernetes' code generator actually produces (URL, DNSNames),
-// so templates written against real generated types (cert-manager's
-// CertificateSpec.DNSNames, for one) silently failed to match.
+// TestTitleCaseKey_KnownInitialisms covers CRD field names a naive
+// first-letter-only titlecase would miss, e.g. cert-manager's URL/DNSNames.
 func TestTitleCaseKey_KnownInitialisms(t *testing.T) {
 	cases := map[string]string{
 		"url":       "URL",

--- a/source/unstructured_fqdn_test.go
+++ b/source/unstructured_fqdn_test.go
@@ -938,10 +938,10 @@ func TestUnstructuredFqdnTemplatingExamples(t *testing.T) {
 			},
 		},
 		{
-			title: "title-cased alias resolves through a nested map",
+			title: "title-cased alias resolves the top-level Spec key; nested JSON keys stay literal",
 			cfg: cfg{
 				resources:      []string{"proxyservices.v1beta1.proxyconfigs.acme.corp"},
-				fqdnTemplate:   `{{.Spec.Endpoint.Hostname}}`,
+				fqdnTemplate:   `{{.Spec.Endpoint.hostname}}`,
 				targetTemplate: `{{index .Spec.hosts 0}}`,
 			},
 			objects: []*unstructured.Unstructured{
@@ -1171,5 +1171,78 @@ func TestUnstructuredWrapper_Templating(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
+	}
+}
+
+// TestUnstructuredWrapper_MapIterationIsNotAliasPolluted guards
+// withTitleCaseAliases against recursing into nested map values: an earlier
+// version aliased every key at every depth, so a template ranging or
+// len()-ing arbitrary nested data (not just the Spec/Status field names the
+// alias exists for) saw twice as many entries as were actually declared.
+// Reported by mloiseleur on #6611.
+func TestUnstructuredWrapper_MapIterationIsNotAliasPolluted(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "proxyconfigs.acme.corp/v1beta1",
+			"kind":       "ProxyService",
+			"metadata": map[string]any{
+				"name":      "reviews",
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"records": map[string]any{
+					"env":  "1.2.3.4",
+					"team": "5.6.7.8",
+				},
+			},
+		},
+	}
+
+	t.Run("range over a nested map yields each key once", func(t *testing.T) {
+		engine := templatetest.MustEngine(t, `{{range $k, $v := .Spec.records}}{{$k}}.example.com,{{end}}`, "", "", false)
+
+		got, err := engine.ExecFQDN(newUnstructuredWrapper(obj))
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"env.example.com", "team.example.com"}, got,
+			"aliases must not leak into map iteration")
+	})
+
+	t.Run("len of a nested map counts declared keys only", func(t *testing.T) {
+		engine := templatetest.MustEngine(t, `{{len .Spec.records}}.example.com`, "", "", false)
+
+		got, err := engine.ExecFQDN(newUnstructuredWrapper(obj))
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"2.example.com"}, got)
+	})
+
+	t.Run("the source object itself is not mutated", func(t *testing.T) {
+		// This one already holds on both sides; kept so a future fix that
+		// aliases in place instead of copying is caught.
+		newUnstructuredWrapper(obj)
+
+		spec, _ := obj.Object["spec"].(map[string]any)
+		records, _ := spec["records"].(map[string]any)
+		assert.Len(t, records, 2, "informer cache object must stay untouched")
+	})
+}
+
+// TestTitleCaseKey_KnownInitialisms guards the CRD field names mloiseleur
+// called out on #6611: a naive first-letter-only titlecase turns "url" into
+// "Url" and "dnsNames" into "DnsNames", neither of which matches the Go
+// field names Kubernetes' code generator actually produces (URL, DNSNames),
+// so templates written against real generated types (cert-manager's
+// CertificateSpec.DNSNames, for one) silently failed to match.
+func TestTitleCaseKey_KnownInitialisms(t *testing.T) {
+	cases := map[string]string{
+		"url":       "URL",
+		"dnsNames":  "DNSNames",
+		"hostname":  "Hostname",
+		"hostnames": "Hostnames",
+		"ipAddress": "IPAddress",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, titleCaseKey(in), "titleCaseKey(%q)", in)
 	}
 }


### PR DESCRIPTION
## What does it do?

On FQDN template execution failure, retry with an unstructured-style data shape (`Spec`/`Status` as JSON maps, plus Name/Namespace/...). Shared `--fqdn-template` values that use JSON keys under Spec (e.g. `{{ range .Spec.hostnames }}`) then work for typed gateway routes the same way they already work for the unstructured source.

## Motivation

#6593: the same `--fqdn-template` is used for unstructured and typed sources. Unstructured wraps objects so `Spec` is a map with JSON keys; typed `v1.HTTPRouteSpec` exposes Go field names, so `.Spec.hostnames` fails with `can't evaluate field hostnames in type v1.HTTPRouteSpec` (including when hostnames are empty/absent).

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

Validation:

- [x] `go test ./source/template/` (typed hostnames, empty hostnames, unstructured, Name+Spec mix)
- [x] Existing `TestExecFQDNExecutionError` still fails closed on real template errors
- [ ] CI

Fixes #6593