### PR TITLE
feat(gateway): decoupled DNS hostname from listener hostname via annotation-only

### DIFF
--- a/docs/sources/gateway-api.md
+++ b/docs/sources/gateway-api.md
@@ -186,13 +186,20 @@ spec:
 
 In this example, External DNS will create DNS records only for `company.private.example.com` based on the annotation, ignoring the `hostnames` field in the `HTTPRoute` spec. This prevents conflicts with existing CNAME records while enabling public resolution for specific endpoints.
 
-When using `annotation-only`, the annotation hostname does **not** need to match the listener hostname. ExternalDNS creates DNS records for the annotation hostname using the parent Gateway's IP address, even when the annotation hostname differs from the listener hostname. This enables migration patterns where the DNS hostname and the routing hostname are different, for example:
+When using `annotation-only`, the annotation hostname does **not** need to match the listener hostname.
+ExternalDNS creates DNS records for the annotation hostname using the parent Gateway's IP address,
+even when the annotation hostname differs from the listener hostname.
+This enables migration patterns where the DNS hostname and the routing hostname are different,
+for example:
 
 - A listener routes traffic on `mywebsite.example.com`
 - ExternalDNS creates a DNS record for `mywebsite.gtw.prod.example.com` (from the annotation, in a zone managed by RFC2136)
 - An external CNAME (`mywebsite.example.com → mywebsite.gtw.prod.example.com`) is managed by a different DNS provider
 
-The other supported value for this annotation is `defined-hosts-only`, which restricts hostname resolution to only those explicitly defined in the route spec (and optionally the FQDN template). This ignores annotation hostnames entirely, useful when you want to prevent annotation-based hostnames from creating DNS records.
+The other supported value for this annotation is `defined-hosts-only`, which restricts hostname resolution
+to only those explicitly defined in the route spec (and optionally the FQDN template).
+This ignores annotation hostnames entirely, useful when you want to prevent annotation-based
+hostnames from creating DNS records.
 
 For a complete list of supported annotations, see the
 [annotations documentation](../annotations/annotations.md#gateway-api-annotation-placement).

--- a/docs/sources/gateway-api.md
+++ b/docs/sources/gateway-api.md
@@ -186,6 +186,14 @@ spec:
 
 In this example, External DNS will create DNS records only for `company.private.example.com` based on the annotation, ignoring the `hostnames` field in the `HTTPRoute` spec. This prevents conflicts with existing CNAME records while enabling public resolution for specific endpoints.
 
+When using `annotation-only`, the annotation hostname does **not** need to match the listener hostname. ExternalDNS creates DNS records for the annotation hostname using the parent Gateway's IP address, even when the annotation hostname differs from the listener hostname. This enables migration patterns where the DNS hostname and the routing hostname are different, for example:
+
+- A listener routes traffic on `mywebsite.example.com`
+- ExternalDNS creates a DNS record for `mywebsite.gtw.prod.example.com` (from the annotation, in a zone managed by RFC2136)
+- An external CNAME (`mywebsite.example.com → mywebsite.gtw.prod.example.com`) is managed by a different DNS provider
+
+The other supported value for this annotation is `defined-hosts-only`, which restricts hostname resolution to only those explicitly defined in the route spec (and optionally the FQDN template). This ignores annotation hostnames entirely, useful when you want to prevent annotation-based hostnames from creating DNS records.
+
 For a complete list of supported annotations, see the
 [annotations documentation](../annotations/annotations.md#gateway-api-annotation-placement).
 

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -544,50 +544,59 @@ func (c *gatewayRouteResolver) hosts(rt gatewayRoute) ([]string, bool, error) {
 	for _, name := range rt.Hostnames() {
 		hostnames = append(hostnames, string(name))
 	}
-	// TODO: The combine-fqdn-annotation flag is similarly vague.
+
+	hostNameAnnotation, hostNameAnnotationExists := rt.Metadata().Annotations[annotations.GatewayHostnameSourceKey]
+	if hostNameAnnotationExists {
+		switch strings.ToLower(hostNameAnnotation) {
+		case gatewayHostnameSourceAnnotationOnlyValue:
+			if c.src.ignoreHostnameAnnotation {
+				return []string{}, true, nil
+			}
+			return annotations.HostnamesFromAnnotations(rt.Metadata().Annotations), true, nil
+		case gatewayHostnameSourceDefinedHostsOnlyValue:
+			// Explicitly use only defined hostnames (route spec and optional template result)
+			result, err := c.appendFQDNTemplate(hostnames, rt)
+			return result, false, err
+		default:
+			// Invalid value provided: warn and fall back to default behavior (as if the annotation is absent)
+			log.Warnf("Invalid value for %q on %s/%s: %q. Falling back to default behavior.",
+				annotations.GatewayHostnameSourceKey, rt.Metadata().Namespace, rt.Metadata().Name, hostNameAnnotation)
+		}
+	}
+
+	if !c.src.ignoreHostnameAnnotation {
+		// Skip empty values so an empty annotation does not gate the template below.
+		for _, hostname := range annotations.HostnamesFromAnnotations(rt.Metadata().Annotations) {
+			if hostname != "" {
+				hostnames = append(hostnames, hostname)
+			}
+		}
+	}
+	var err error
+	hostnames, err = c.appendFQDNTemplate(hostnames, rt)
+	if err != nil {
+		return nil, false, err
+	}
+	// The route named no hostname of its own, so fall back to the attached listeners' hostnames.
+	// Only useful for {HTTP,TLS}Routes, but it doesn't break {TCP,UDP}Routes.
+	if len(rt.Hostnames()) == 0 {
+		hostnames = append(hostnames, "")
+	}
+	return hostnames, false, nil
+}
+
+// appendFQDNTemplate appends the template-generated hostnames, unless another source already
+// supplied one and the template is not combining.
+// TODO: The combine-fqdn-annotation flag is similarly vague.
+func (c *gatewayRouteResolver) appendFQDNTemplate(hostnames []string, rt gatewayRoute) ([]string, error) {
 	if c.src.templateEngine.IsConfigured() && (len(hostnames) == 0 || c.src.templateEngine.Combining()) {
 		hosts, err := c.src.templateEngine.ExecFQDN(rt.Object())
 		if err != nil {
-			return nil, false, err
+			return nil, err
 		}
 		hostnames = append(hostnames, hosts...)
 	}
-
-	hostNameAnnotation, hostNameAnnotationExists := rt.Metadata().Annotations[annotations.GatewayHostnameSourceKey]
-	if !hostNameAnnotationExists {
-		// This means that the route doesn't specify a hostname and should use any provided by
-		// attached Gateway Listeners. This is only useful for {HTTP,TLS}Routes, but it doesn't
-		// break {TCP,UDP}Routes.
-		if len(rt.Hostnames()) == 0 {
-			hostnames = append(hostnames, "")
-		}
-		if !c.src.ignoreHostnameAnnotation {
-			hostnames = append(hostnames, annotations.HostnamesFromAnnotations(rt.Metadata().Annotations)...)
-		}
-		return hostnames, false, nil
-	}
-
-	switch strings.ToLower(hostNameAnnotation) {
-	case gatewayHostnameSourceAnnotationOnlyValue:
-		if c.src.ignoreHostnameAnnotation {
-			return []string{}, true, nil
-		}
-		return annotations.HostnamesFromAnnotations(rt.Metadata().Annotations), true, nil
-	case gatewayHostnameSourceDefinedHostsOnlyValue:
-		// Explicitly use only defined hostnames (route spec and optional template result)
-		return hostnames, false, nil
-	default:
-		// Invalid value provided: warn and fall back to default behavior (as if the annotation is absent)
-		log.Warnf("Invalid value for %q on %s/%s: %q. Falling back to default behavior.",
-			annotations.GatewayHostnameSourceKey, rt.Metadata().Namespace, rt.Metadata().Name, hostNameAnnotation)
-		if len(rt.Hostnames()) == 0 {
-			hostnames = append(hostnames, "")
-		}
-		if !c.src.ignoreHostnameAnnotation {
-			hostnames = append(hostnames, annotations.HostnamesFromAnnotations(rt.Metadata().Annotations)...)
-		}
-		return hostnames, false, nil
-	}
+	return hostnames, nil
 }
 
 func (c *gatewayRouteResolver) routeIsAllowed(ownerNamespace string, lis *v1.Listener, rt gatewayRoute) bool {

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -404,7 +404,7 @@ func newGatewayRouteResolver(src *gatewayRouteSource, gateways []*v1.Gateway, li
 }
 
 func (c *gatewayRouteResolver) resolve(rt gatewayRoute) (map[string]endpoint.Targets, error) {
-	rtHosts, err := c.hosts(rt)
+	rtHosts, annotationOnly, err := c.hosts(rt)
 	if err != nil {
 		return nil, err
 	}
@@ -422,7 +422,7 @@ func (c *gatewayRouteResolver) resolve(rt gatewayRoute) (map[string]endpoint.Tar
 		if !ok {
 			continue
 		}
-		c.matchRouteToParent(rt, rtHosts, parent, hostTargets)
+		c.matchRouteToParent(rt, rtHosts, parent, hostTargets, annotationOnly)
 	}
 	// If a Gateway has multiple matching Listeners for the same host, then we'll
 	// add its IPs to the target list multiple times and should dedupe them.
@@ -483,7 +483,7 @@ func (c *gatewayRouteResolver) resolveParentRef(rt gatewayRoute, routeParentRefs
 	}, true
 }
 
-func (c *gatewayRouteResolver) matchRouteToParent(rt gatewayRoute, rtHosts []string, parent *resolvedParent, hostTargets map[string]endpoint.Targets) {
+func (c *gatewayRouteResolver) matchRouteToParent(rt gatewayRoute, rtHosts []string, parent *resolvedParent, hostTargets map[string]endpoint.Targets, annotationOnly bool) {
 	meta := rt.Metadata()
 	match := false
 	var unattachedReason string
@@ -495,7 +495,7 @@ func (c *gatewayRouteResolver) matchRouteToParent(rt gatewayRoute, rtHosts []str
 			}
 			continue
 		}
-		if c.matchRouteToListener(rt, rtHosts, parent, &section.listener, hostTargets) {
+		if c.matchRouteToListener(rt, rtHosts, parent, &section.listener, hostTargets, annotationOnly) {
 			match = true
 		}
 	}
@@ -509,7 +509,7 @@ func (c *gatewayRouteResolver) matchRouteToParent(rt gatewayRoute, rtHosts []str
 	log.Debugf("%s %s/%s section %q does not match %s %s/%s hostnames %q", parent.kind, parent.namespace, parent.ref.Name, parent.section, c.src.rtKind, meta.Namespace, meta.Name, rtHosts)
 }
 
-func (c *gatewayRouteResolver) matchRouteToListener(rt gatewayRoute, rtHosts []string, parent *resolvedParent, lis *v1.Listener, hostTargets map[string]endpoint.Targets) bool {
+func (c *gatewayRouteResolver) matchRouteToListener(rt gatewayRoute, rtHosts []string, parent *resolvedParent, lis *v1.Listener, hostTargets map[string]endpoint.Targets, annotationOnly bool) bool {
 	if !gwProtocolMatches(rt.Protocol(), lis.Protocol) {
 		return false
 	}
@@ -530,15 +530,25 @@ func (c *gatewayRouteResolver) matchRouteToListener(rt gatewayRoute, rtHosts []s
 		if gwHost == "" && rtHost == "" {
 			continue
 		}
-		host, ok := gwMatchingHost(gwHost, rtHost)
-		if !ok {
-			continue
-		}
-		override := parent.obj.overrides
-		hostTargets[host] = append(hostTargets[host], override...)
-		if len(override) == 0 {
-			for _, addr := range parent.obj.gateway.Status.Addresses {
-				hostTargets[host] = append(hostTargets[host], addr.Value)
+		if !annotationOnly {
+			host, ok := gwMatchingHost(gwHost, rtHost)
+			if !ok {
+				continue
+			}
+			override := parent.obj.overrides
+			hostTargets[host] = append(hostTargets[host], override...)
+			if len(override) == 0 {
+				for _, addr := range parent.obj.gateway.Status.Addresses {
+					hostTargets[host] = append(hostTargets[host], addr.Value)
+				}
+			}
+		} else {
+			override := parent.obj.overrides
+			hostTargets[rtHost] = append(hostTargets[rtHost], override...)
+			if len(override) == 0 {
+				for _, addr := range parent.obj.gateway.Status.Addresses {
+					hostTargets[rtHost] = append(hostTargets[rtHost], addr.Value)
+				}
 			}
 		}
 		match = true
@@ -546,7 +556,7 @@ func (c *gatewayRouteResolver) matchRouteToListener(rt gatewayRoute, rtHosts []s
 	return match
 }
 
-func (c *gatewayRouteResolver) hosts(rt gatewayRoute) ([]string, error) {
+func (c *gatewayRouteResolver) hosts(rt gatewayRoute) ([]string, bool, error) {
 	var hostnames []string
 	for _, name := range rt.Hostnames() {
 		hostnames = append(hostnames, string(name))
@@ -555,7 +565,7 @@ func (c *gatewayRouteResolver) hosts(rt gatewayRoute) ([]string, error) {
 	if c.src.templateEngine.IsConfigured() && (len(hostnames) == 0 || c.src.templateEngine.Combining()) {
 		hosts, err := c.src.templateEngine.ExecFQDN(rt.Object())
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		hostnames = append(hostnames, hosts...)
 	}
@@ -571,18 +581,18 @@ func (c *gatewayRouteResolver) hosts(rt gatewayRoute) ([]string, error) {
 		if !c.src.ignoreHostnameAnnotation {
 			hostnames = append(hostnames, annotations.HostnamesFromAnnotations(rt.Metadata().Annotations)...)
 		}
-		return hostnames, nil
+		return hostnames, false, nil
 	}
 
 	switch strings.ToLower(hostNameAnnotation) {
 	case gatewayHostnameSourceAnnotationOnlyValue:
 		if c.src.ignoreHostnameAnnotation {
-			return []string{}, nil
+			return []string{}, true, nil
 		}
-		return annotations.HostnamesFromAnnotations(rt.Metadata().Annotations), nil
+		return annotations.HostnamesFromAnnotations(rt.Metadata().Annotations), true, nil
 	case gatewayHostnameSourceDefinedHostsOnlyValue:
 		// Explicitly use only defined hostnames (route spec and optional template result)
-		return hostnames, nil
+		return hostnames, false, nil
 	default:
 		// Invalid value provided: warn and fall back to default behavior (as if the annotation is absent)
 		log.Warnf("Invalid value for %q on %s/%s: %q. Falling back to default behavior.",
@@ -593,7 +603,7 @@ func (c *gatewayRouteResolver) hosts(rt gatewayRoute) ([]string, error) {
 		if !c.src.ignoreHostnameAnnotation {
 			hostnames = append(hostnames, annotations.HostnamesFromAnnotations(rt.Metadata().Annotations)...)
 		}
-		return hostnames, nil
+		return hostnames, false, nil
 	}
 }
 

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -387,7 +387,7 @@ func newGatewayRouteResolver(src *gatewayRouteSource, gateways []*v1.Gateway, li
 }
 
 func (c *gatewayRouteResolver) resolve(rt gatewayRoute) (map[string]endpoint.Targets, error) {
-	rtHosts, err := c.resolveHostnames(rt)
+	rtHosts, annotationOnly, err := c.hosts(rt)
 	if err != nil {
 		return nil, err
 	}
@@ -405,7 +405,7 @@ func (c *gatewayRouteResolver) resolve(rt gatewayRoute) (map[string]endpoint.Tar
 		if !ok {
 			continue
 		}
-		c.matchRouteToParent(rt, rtHosts, parent, hostTargets)
+		c.matchRouteToParent(rt, rtHosts, parent, hostTargets, annotationOnly)
 	}
 	// If a Gateway has multiple matching Listeners for the same host, then we'll
 	// add its IPs to the target list multiple times and should dedupe them.
@@ -466,7 +466,7 @@ func (c *gatewayRouteResolver) resolveParentRef(rt gatewayRoute, routeParentRefs
 	}, true
 }
 
-func (c *gatewayRouteResolver) matchRouteToParent(rt gatewayRoute, rtHosts []string, parent *resolvedParent, hostTargets map[string]endpoint.Targets) {
+func (c *gatewayRouteResolver) matchRouteToParent(rt gatewayRoute, rtHosts []string, parent *resolvedParent, hostTargets map[string]endpoint.Targets, annotationOnly bool) {
 	meta := rt.Metadata()
 	match := false
 	var unattachedReason string
@@ -478,7 +478,7 @@ func (c *gatewayRouteResolver) matchRouteToParent(rt gatewayRoute, rtHosts []str
 			}
 			continue
 		}
-		if c.matchRouteToListener(rt, rtHosts, parent, &section.listener, hostTargets) {
+		if c.matchRouteToListener(rt, rtHosts, parent, &section.listener, hostTargets, annotationOnly) {
 			match = true
 		}
 	}
@@ -492,7 +492,7 @@ func (c *gatewayRouteResolver) matchRouteToParent(rt gatewayRoute, rtHosts []str
 	log.Debugf("%s %s/%s section %q does not match %s %s/%s hostnames %q", parent.kind, parent.namespace, parent.ref.Name, parent.section, c.src.rtKind, meta.Namespace, meta.Name, rtHosts)
 }
 
-func (c *gatewayRouteResolver) matchRouteToListener(rt gatewayRoute, rtHosts []string, parent *resolvedParent, lis *v1.Listener, hostTargets map[string]endpoint.Targets) bool {
+func (c *gatewayRouteResolver) matchRouteToListener(rt gatewayRoute, rtHosts []string, parent *resolvedParent, lis *v1.Listener, hostTargets map[string]endpoint.Targets, annotationOnly bool) bool {
 	if !gwProtocolMatches(rt.Protocol(), lis.Protocol) {
 		return false
 	}
@@ -513,15 +513,25 @@ func (c *gatewayRouteResolver) matchRouteToListener(rt gatewayRoute, rtHosts []s
 		if gwHost == "" && rtHost == "" {
 			continue
 		}
-		host, ok := gwMatchingHost(gwHost, rtHost)
-		if !ok {
-			continue
-		}
-		override := parent.obj.overrides
-		hostTargets[host] = append(hostTargets[host], override...)
-		if len(override) == 0 {
-			for _, addr := range parent.obj.gateway.Status.Addresses {
-				hostTargets[host] = append(hostTargets[host], addr.Value)
+		if !annotationOnly {
+			host, ok := gwMatchingHost(gwHost, rtHost)
+			if !ok {
+				continue
+			}
+			override := parent.obj.overrides
+			hostTargets[host] = append(hostTargets[host], override...)
+			if len(override) == 0 {
+				for _, addr := range parent.obj.gateway.Status.Addresses {
+					hostTargets[host] = append(hostTargets[host], addr.Value)
+				}
+			}
+		} else {
+			override := parent.obj.overrides
+			hostTargets[rtHost] = append(hostTargets[rtHost], override...)
+			if len(override) == 0 {
+				for _, addr := range parent.obj.gateway.Status.Addresses {
+					hostTargets[rtHost] = append(hostTargets[rtHost], addr.Value)
+				}
 			}
 		}
 		match = true
@@ -529,64 +539,55 @@ func (c *gatewayRouteResolver) matchRouteToListener(rt gatewayRoute, rtHosts []s
 	return match
 }
 
-// appendFQDNTemplate appends the template-generated hostnames, unless another source already
-// supplied one and the template is not combining.
-// TODO: The combine-fqdn-annotation flag is similarly vague.
-func (c *gatewayRouteResolver) appendFQDNTemplate(hostnames []string, rt gatewayRoute) ([]string, error) {
-	if c.src.templateEngine.IsConfigured() && (len(hostnames) == 0 || c.src.templateEngine.Combining()) {
-		hosts, err := c.src.templateEngine.ExecFQDN(rt.Object())
-		if err != nil {
-			return nil, err
-		}
-		hostnames = append(hostnames, hosts...)
-	}
-	return hostnames, nil
-}
-
-// resolveHostnames returns a route's hostnames in the order documented for the gateway sources:
-// spec, annotation, FQDN template, listener fallback, subject to gateway-hostname-source.
-func (c *gatewayRouteResolver) resolveHostnames(rt gatewayRoute) ([]string, error) {
+func (c *gatewayRouteResolver) hosts(rt gatewayRoute) ([]string, bool, error) {
 	var hostnames []string
 	for _, name := range rt.Hostnames() {
 		hostnames = append(hostnames, string(name))
 	}
+	// TODO: The combine-fqdn-annotation flag is similarly vague.
+	if c.src.templateEngine.IsConfigured() && (len(hostnames) == 0 || c.src.templateEngine.Combining()) {
+		hosts, err := c.src.templateEngine.ExecFQDN(rt.Object())
+		if err != nil {
+			return nil, false, err
+		}
+		hostnames = append(hostnames, hosts...)
+	}
 
 	hostNameAnnotation, hostNameAnnotationExists := rt.Metadata().Annotations[annotations.GatewayHostnameSourceKey]
-	if hostNameAnnotationExists {
-		switch strings.ToLower(hostNameAnnotation) {
-		case gatewayHostnameSourceAnnotationOnlyValue:
-			if c.src.ignoreHostnameAnnotation {
-				return []string{}, nil
-			}
-			return annotations.HostnamesFromAnnotations(rt.Metadata().Annotations), nil
-		case gatewayHostnameSourceDefinedHostsOnlyValue:
-			// Explicitly use only defined hostnames (route spec and optional template result)
-			return c.appendFQDNTemplate(hostnames, rt)
-		default:
-			// Invalid value provided: warn and fall back to default behavior (as if the annotation is absent)
-			log.Warnf("Invalid value for %q on %s/%s: %q. Falling back to default behavior.",
-				annotations.GatewayHostnameSourceKey, rt.Metadata().Namespace, rt.Metadata().Name, hostNameAnnotation)
+	if !hostNameAnnotationExists {
+		// This means that the route doesn't specify a hostname and should use any provided by
+		// attached Gateway Listeners. This is only useful for {HTTP,TLS}Routes, but it doesn't
+		// break {TCP,UDP}Routes.
+		if len(rt.Hostnames()) == 0 {
+			hostnames = append(hostnames, "")
 		}
+		if !c.src.ignoreHostnameAnnotation {
+			hostnames = append(hostnames, annotations.HostnamesFromAnnotations(rt.Metadata().Annotations)...)
+		}
+		return hostnames, false, nil
 	}
 
-	if !c.src.ignoreHostnameAnnotation {
-		// Skip empty values so an empty annotation does not gate the template below.
-		for _, hostname := range annotations.HostnamesFromAnnotations(rt.Metadata().Annotations) {
-			if hostname != "" {
-				hostnames = append(hostnames, hostname)
-			}
+	switch strings.ToLower(hostNameAnnotation) {
+	case gatewayHostnameSourceAnnotationOnlyValue:
+		if c.src.ignoreHostnameAnnotation {
+			return []string{}, true, nil
 		}
+		return annotations.HostnamesFromAnnotations(rt.Metadata().Annotations), true, nil
+	case gatewayHostnameSourceDefinedHostsOnlyValue:
+		// Explicitly use only defined hostnames (route spec and optional template result)
+		return hostnames, false, nil
+	default:
+		// Invalid value provided: warn and fall back to default behavior (as if the annotation is absent)
+		log.Warnf("Invalid value for %q on %s/%s: %q. Falling back to default behavior.",
+			annotations.GatewayHostnameSourceKey, rt.Metadata().Namespace, rt.Metadata().Name, hostNameAnnotation)
+		if len(rt.Hostnames()) == 0 {
+			hostnames = append(hostnames, "")
+		}
+		if !c.src.ignoreHostnameAnnotation {
+			hostnames = append(hostnames, annotations.HostnamesFromAnnotations(rt.Metadata().Annotations)...)
+		}
+		return hostnames, false, nil
 	}
-	hostnames, err := c.appendFQDNTemplate(hostnames, rt)
-	if err != nil {
-		return nil, err
-	}
-	// The route named no hostname of its own, so fall back to the attached listeners' hostnames.
-	// Only useful for {HTTP,TLS}Routes, but it doesn't break {TCP,UDP}Routes.
-	if len(rt.Hostnames()) == 0 {
-		hostnames = append(hostnames, "")
-	}
-	return hostnames, nil
 }
 
 func (c *gatewayRouteResolver) routeIsAllowed(ownerNamespace string, lis *v1.Listener, rt gatewayRoute) bool {

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -1617,6 +1617,47 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			},
 		},
 		{
+			title: "OnlyAnnotationHostWithNonMatchingListenerHostname",
+			config: &Config{
+				GatewayNamespace: "gateway-namespace",
+			},
+			namespaces: namespaces("gateway-namespace", "route-namespace"),
+			gateways: []*v1.Gateway{
+				{
+					ObjectMeta: objectMeta("gateway-namespace", "test"),
+					Spec: v1.GatewaySpec{
+						Listeners: []v1.Listener{{
+							Hostname:      new(v1.Hostname("mywebsite.example.com")),
+							Protocol:      v1.HTTPProtocolType,
+							AllowedRoutes: allowAllNamespaces,
+						}},
+					},
+					Status: gatewayStatus("1.2.3.4"),
+				},
+			},
+			routes: []*v1.HTTPRoute{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "route-test",
+						Namespace:   "test",
+						Annotations: map[string]string{annotations.GatewayHostnameSourceKey: "annotation-only", annotations.HostnameKey: "mywebsite.gtw.prod.example.com"},
+					},
+					Spec: v1.HTTPRouteSpec{
+						Hostnames: hostnames("mywebsite.example.com"),
+						CommonRouteSpec: v1.CommonRouteSpec{
+							ParentRefs: []v1.ParentReference{
+								gwParentRef("gateway-namespace", "test"),
+							},
+						},
+					},
+					Status: httpRouteStatus(gwParentRef("gateway-namespace", "test")),
+				},
+			},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("mywebsite.gtw.prod.example.com", "1.2.3.4"),
+			},
+		},
+		{
 			title:      "InvalidSourceAnnotation",
 			config:     &Config{},
 			namespaces: namespaces("default"),

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -157,6 +157,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 		return v
 	}
 	hostnames := func(names ...v1.Hostname) []v1.Hostname { return names }
+	hostnamePtr := func(h v1.Hostname) *v1.Hostname { return &h }
 
 	tests := []struct {
 		title           string
@@ -1686,7 +1687,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 					ObjectMeta: objectMeta("gateway-namespace", "test"),
 					Spec: v1.GatewaySpec{
 						Listeners: []v1.Listener{{
-							Hostname:      new(v1.Hostname("mywebsite.example.com")),
+							Hostname:      hostnamePtr(v1.Hostname("mywebsite.example.com")),
 							Protocol:      v1.HTTPProtocolType,
 							AllowedRoutes: allowAllNamespaces,
 						}},

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -1697,11 +1697,9 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			},
 			routes: []*v1.HTTPRoute{
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        "route-test",
-						Namespace:   "test",
-						Annotations: map[string]string{annotations.GatewayHostnameSourceKey: "annotation-only", annotations.HostnameKey: "mywebsite.gtw.prod.example.com"},
-					},
+					Name:        "route-test",
+					Namespace:   "test",
+					Annotations: map[string]string{annotations.GatewayHostnameSourceKey: "annotation-only", annotations.HostnameKey: "mywebsite.gtw.prod.example.com"},
 					Spec: v1.HTTPRouteSpec{
 						Hostnames: hostnames("mywebsite.example.com"),
 						CommonRouteSpec: v1.CommonRouteSpec{

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -1676,6 +1676,47 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			},
 		},
 		{
+			title: "OnlyAnnotationHostWithNonMatchingListenerHostname",
+			config: &Config{
+				GatewayNamespace: "gateway-namespace",
+			},
+			namespaces: namespaces("gateway-namespace", "route-namespace"),
+			gateways: []*v1.Gateway{
+				{
+					ObjectMeta: objectMeta("gateway-namespace", "test"),
+					Spec: v1.GatewaySpec{
+						Listeners: []v1.Listener{{
+							Hostname:      new(v1.Hostname("mywebsite.example.com")),
+							Protocol:      v1.HTTPProtocolType,
+							AllowedRoutes: allowAllNamespaces,
+						}},
+					},
+					Status: gatewayStatus("1.2.3.4"),
+				},
+			},
+			routes: []*v1.HTTPRoute{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "route-test",
+						Namespace:   "test",
+						Annotations: map[string]string{annotations.GatewayHostnameSourceKey: "annotation-only", annotations.HostnameKey: "mywebsite.gtw.prod.example.com"},
+					},
+					Spec: v1.HTTPRouteSpec{
+						Hostnames: hostnames("mywebsite.example.com"),
+						CommonRouteSpec: v1.CommonRouteSpec{
+							ParentRefs: []v1.ParentReference{
+								gwParentRef("gateway-namespace", "test"),
+							},
+						},
+					},
+					Status: httpRouteStatus(gwParentRef("gateway-namespace", "test")),
+				},
+			},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("mywebsite.gtw.prod.example.com", "1.2.3.4"),
+			},
+		},
+		{
 			title:      "InvalidSourceAnnotation",
 			config:     &Config{},
 			namespaces: namespaces("default"),


### PR DESCRIPTION
## What does it do ?

When external-dns.kubernetes.io/gateway-hostname-source: annotation-only is set on a Route, ExternalDNS now creates DNS records from the annotation hostname (external-dns.kubernetes.io/hostname) using the parent Gateway's IP address, without requiring the annotation hostname to match the listener hostname.
Previously, matchRouteToListener required gwMatchingHost(listenerHostname, routeHostname) to return true before any endpoints were generated. When the annotation hostname differed from the listener hostname, the route was silently skipped, the gateway-hostname-source: annotation-only annotation was never effectively evaluated.

## Motivation

Fixes #6594
The Ingress source already supports decoupling DNS hostname from routing hostname via external-dns.kubernetes.io/ingress-hostname-source: annotation-only, which creates a DNS record for any hostname in the annotation regardless of the Ingress spec host. The Gateway API source lacked this capability, making the following migration pattern impossible:
1. Listener routes traffic on mywebsite.example.com
2. ExternalDNS creates a DNS record for mywebsite.gtw.prod.example.com (in a zone managed by RFC2136)
3. An external CNAME (mywebsite.example.com → mywebsite.gtw.prod.example.com) is managed by a different DNS provider
This pattern is common during Ingress → Gateway API migrations where the DNS zone managed by external-dns doesn't cover the routing hostname's parent zone, or where a CNAME chain exists between an externally-managed hostname and the RFC2136 zone.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

The existing docs/sources/gateway-api.md already documents the gateway-hostname-source annotation. The behavior change (bypassing listener hostname matching in annotation-only mode) could be noted there. Let me know if you'd like me to update it.
