### PR TITLE
test(crd): assert the generated CRDs are installable

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -37,6 +37,11 @@ curl $CURL_RETRY_OPTS -fLO "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/li
 chmod +x kubectl
 sudo mv kubectl /usr/local/bin/kubectl
 
+# Nothing else checks that generated CRDs are accepted by API Server.
+echo "Installing CRDs"
+kubectl apply -f config/crd/standard/
+kubectl wait --for=condition=established --timeout=60s -f config/crd/standard/
+
 # Install ko
 echo "Installing ko..."
 curl $CURL_RETRY_OPTS -o ko.tar.gz -sSfL "https://github.com/ko-build/ko/releases/download/v${KO_VERSION}/ko_${KO_VERSION}_linux_x86_64.tar.gz"


### PR DESCRIPTION
## What does it do ?

Applies `config/crd/standard/` to the kind cluster the e2e run already creates
and waits for `Established`. 

## Motivation

`controller-gen` does not check that what it emits can be installed, and
`generate-crd.sh` only checks that generation is up to date, so a CRD the API
server refuses would first surface as a failed apply on a user's cluster.

Matters once the schema grows `x-kubernetes-validations` rules (#6609).

Replaces the earlier unit-test approach per review — no new Go dependency.

Verified on kind (API server v1.34.0): both CRDs reach `Established`, and a
deliberately cost-blowing rule is rejected with `estimated rule cost exceeds
budget by factor of more than 100x`.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] No end user documentation needed: test-only change
