### PR TITLE
docs(faq): scope the access annotation to the Service source

### DIFF
--- a/docs/annotations/annotations.md
+++ b/docs/annotations/annotations.md
@@ -41,6 +41,11 @@ If the value is `private`, use the Nodes' addresses of type `InternalIP`.
 If the annotation is not present and there is at least one address of type `ExternalIP`,
 behave as if the value were `public`, otherwise behave as if the value were `private`.
 
+This annotation is read only by the Service source. Every other source ignores it, including the
+Ingress source — see
+[the FAQ](../faq.md#how-do-i-specify-that-i-want-the-dns-record-to-point-to-either-the-nodes-public-or-private-ip-when-it-has-both)
+for the alternatives available there.
+
 ## external-dns.kubernetes.io/controller
 
 If this annotation exists and has a value other than `dns-controller` then the source ignores the resource.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -326,13 +326,26 @@ See the [Split Horizon DNS guide](advanced/split-horizon.md) for detailed exampl
 If your Nodes have both public and private IP addresses, you might want to write DNS records with one or the other.
 For example, you may want to write a DNS record in a private zone that resolves to your Nodes' private IPs so that traffic never leaves your private network.
 
-To accomplish this, set this annotation on your service: `external-dns.kubernetes.io/access=private`
+To accomplish this, set this annotation on your `Service` of type `NodePort`: `external-dns.kubernetes.io/access=private`
 Conversely, to force the public IP: `external-dns.kubernetes.io/access=public`
 
 If this annotation is not set, and the node has both public and private IP addresses, then the public IP will be used by default.
 
+This applies to the [Service source](sources/service.md) only, and only to `Service`s of type `NodePort`.
+Every other source ignores the annotation.
+
+In particular, the [Ingress source](sources/ingress.md) takes its targets from the `Ingress`'s
+`status.loadBalancer.ingress` entries, which are written by the ingress controller. ExternalDNS does not look at
+`Node` addresses there, so it has no public/private pair to choose between — if the status lists both a public
+and a private address, both are published. To control which addresses end up in DNS for an `Ingress`:
+
+- configure the ingress controller to publish the addresses you want in `status.loadBalancer.ingress`;
+- set `external-dns.kubernetes.io/target` on the `Ingress`, which overrides the status entirely; or
+- use `--target-net-filter` / `--exclude-target-net`, described below.
+
 Some loadbalancer implementations assign multiple IP addresses as external addresses. You can filter the generated targets by their networks
-using `--target-net-filter=10.0.0.0/8` or `--exclude-target-net=10.0.0.0/8`.
+using `--target-net-filter=10.0.0.0/8` or `--exclude-target-net=10.0.0.0/8`. These flags apply to every source,
+and an endpoint whose targets are all filtered out is dropped.
 
 ## Can external-dns manage(add/remove) records in a hosted zone which is setup in different AWS account?
 


### PR DESCRIPTION
## Description

`external-dns.kubernetes.io/access` is read in exactly one place — [`getAccessFromAnnotations`](https://github.com/kubernetes-sigs/external-dns/blob/master/source/source.go#L47), called only from `extractNodePortTargets` in `source/service.go`. Every other source ignores it silently.

The FAQ entry describing it is written source-agnostically, so it reads as though it applied to any source. This PR scopes it, and documents what the Ingress source does instead: it takes its targets from `status.loadBalancer.ingress`, which the ingress controller writes, so when both a public and a private address are published there, both end up in DNS.

Docs-only:

- scopes the FAQ entry to `Service` of type `NodePort`, and says other sources ignore the annotation;
- explains what the Ingress source does, and lists the three ways to control which addresses reach DNS for an `Ingress`;
- notes that `--target-net-filter`/`--exclude-target-net` are process-wide and that an endpoint whose targets are all filtered out is dropped;
- adds a pointer from the annotation reference to the FAQ.

No behaviour change is proposed here. Whether the Ingress source should honour `access` is a separate question — it would need a node informer and `nodes` RBAC in that source, and a definition of which nodes an arbitrary `Ingress` refers to. That belongs in a proposal rather than this PR.

Fixes #5266

Related: #3270, #1841 — the same report, in 2023 and 2020, both bot-closed without a docs fix.

## Checklist

- [x] Unit tests updated — n/a, docs-only
- [x] End user documentation updated
- [x] `mkdocs build --strict` passes locally
