### PR TITLE
docs: clarify release tag vs kustomize manifest lag

### DIFF
--- a/.github/ISSUE_TEMPLATE/create-release.md
+++ b/.github/ISSUE_TEMPLATE/create-release.md
@@ -18,7 +18,7 @@ Full process: [docs/release.md](https://github.com/kubernetes-sigs/external-dns/
 
 ### Release Execution (order matters)
 
-> **Chicken-and-egg:** the git tag must exist before the image is built/promoted; kustomize on that tag will still reference the *previous* image until the version-updater PR merges. See [git tags vs kustomize](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/release.md#git-tags-vs-kustomize-manifests-known-lag).
+> **Chicken-and-egg:** the git tag must exist before the image is built/promoted; See [git tags vs kustomize](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/release.md#git-tags-vs-kustomize-manifests-known-lag).
 
 - [ ] Create the GitHub release / git tag (`scripts/releaser.sh` or GitHub UI)
 - [ ] Confirm staging image built for this tag (`gcr.io/k8s-staging-external-dns/external-dns`)

--- a/.github/ISSUE_TEMPLATE/create-release.md
+++ b/.github/ISSUE_TEMPLATE/create-release.md
@@ -9,15 +9,24 @@ assignees: ''
 
 This Issue tracks the next `external-dns` release. Please follow the guideline below. If anything is missing or unclear, please add a comment to this issue so this can be improved after the release.
 
+Full process: [docs/release.md](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/release.md).
+
 ## Preparation Tasks
 
-- [ ] Release [steps](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/release.md#steps)
+- [ ] Confirm version bump type (patch/minor) per [versioning convention](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/release.md#versioning-convention)
+- [ ] Release [steps](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/release.md#steps) reviewed
 
-### Release Execution
+### Release Execution (order matters)
 
-- [ ] Branch out from the default branch and run scripts/version-updater.sh to update the image tag used in the kustomization.yaml and in documentation.
-- [ ] Create the PR with this version change.
-- [ ] Create an issue to release the corresponding Helm chart via the chart release process (below) assigned to a chart maintainer
+> **Chicken-and-egg:** the git tag must exist before the image is built/promoted; kustomize on that tag will still reference the *previous* image until the version-updater PR merges. See [git tags vs kustomize](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/release.md#git-tags-vs-kustomize-manifests-known-lag).
+
+- [ ] Create the GitHub release / git tag (`scripts/releaser.sh` or GitHub UI)
+- [ ] Confirm staging image built for this tag (`gcr.io/k8s-staging-external-dns/external-dns`)
+- [ ] Promote image via k8s.io PR (digest from `scripts/get-sha256.sh`) and wait for merge
+- [ ] Verify pull: `docker run registry.k8s.io/external-dns/external-dns:vX.Y.Z --version`
+- [ ] Run `scripts/version-updater.sh` on a branch from default; open PR for kustomize + docs image tags
+- [ ] Merge version-updater PR (manifests on `master` now match the release image)
+- [ ] Create an issue to release the Helm chart; assign a chart maintainer
 
 ### After Release Tasks
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -74,7 +74,7 @@ Consequences:
 
 So:
 
-- Do **not** treat the kustomize tree *on the git tag* as the source of truth for that version’s image.
+- Do **not** treat the kustomize tree _on the git tag_ as the source of truth for that version’s image.
 - Prefer the Helm chart, or the post-release version-updater commit on `master`, for install manifests that pin the new tag.
 
 ## How to release a new chart version

--- a/docs/release.md
+++ b/docs/release.md
@@ -49,16 +49,33 @@ You must be an official maintainer of the project to be able to do a release.
 
 ### Steps
 
-- Run `scripts/releaser.sh` to create a new GitHub release. Alternatively you can create a release in the GitHub UI making sure to click on the autogenerate release node feature.
-- The step above will trigger the Kubernetes based CI/CD system [Prow](https://prow.k8s.io/?repo=kubernetes-sigs%2Fexternal-dns). Verify that a new image was built and uploaded to `gcr.io/k8s-staging-external-dns/external-dns`.
-- Create a PR in the [k8s.io repo](https://github.com/kubernetes/k8s.io) by taking the current staging image using the sha256 digest. They can be obtained with `scripts/get-sha256.sh`. Once the PR is merged, the image will be live with the corresponding tag specified in the PR.
-  - See https://github.com/kubernetes/k8s.io/pull/8466 for reference
-- Verify that the image is pullable with the given tag
-  - `docker run registry.k8s.io/external-dns/external-dns:v0.x.0 --version`
-- Branch out from the default branch and run `scripts/version-updater.sh` to update the image tag used in the kustomization.yaml and in documentation.
-- Create the PR with this version change.
-- Create an issue to release the corresponding Helm chart via the chart release process (below) assigned to a chart maintainer
-- Once the PR is merged, all is done :-)
+1. Run `scripts/releaser.sh` to create a new GitHub release (and git tag). Alternatively create a release in the GitHub UI and use the autogenerate release notes feature.
+2. The step above triggers the Kubernetes CI/CD system [Prow](https://prow.k8s.io/?repo=kubernetes-sigs%2Fexternal-dns). Verify that a new image was built and uploaded to `gcr.io/k8s-staging-external-dns/external-dns`.
+3. Create a PR in the [k8s.io repo](https://github.com/kubernetes/k8s.io) promoting the staging image by **sha256 digest** (from `scripts/get-sha256.sh`). Once that PR merges, the image is available at `registry.k8s.io` under the release tag.
+   - See https://github.com/kubernetes/k8s.io/pull/8466 for reference
+4. Verify that the image is pullable with the given tag:
+   - `docker run registry.k8s.io/external-dns/external-dns:v0.x.0 --version`
+5. **Only after** the image is pullable: branch from the default branch and run `scripts/version-updater.sh` to update the image tag in `kustomize/` manifests and documentation.
+6. Open and merge the version-updater PR.
+7. Open an issue to release the corresponding Helm chart (chart process below), assigned to a chart maintainer.
+8. Once the version-updater PR is merged, the release is complete.
+
+### Git tags vs kustomize manifests (known lag)
+
+Image promotion and in-repo manifest updates **cannot** happen in a single commit on the release tag. CI needs the git tag first to build and promote the image; kustomize/docs must not advertise a tag until that image is live on `registry.k8s.io`.
+
+Consequences:
+
+| Source | Image tag in manifests |
+|--------|------------------------|
+| Git **release tag** (e.g. `v0.18.0`) | Still points at the **previous** release image until a follow-up commit lands |
+| **`master`** after the version-updater PR | Matches the new release image |
+| **Helm chart** `appVersion` after chart release | Matches the new release image |
+
+So:
+
+- Do **not** treat the kustomize tree *on the git tag* as the source of truth for that version’s image.
+- Prefer the Helm chart, or the post-release version-updater commit on `master`, for install manifests that pin the new tag.
 
 ## How to release a new chart version
 


### PR DESCRIPTION
## Description

Documents the known chicken-and-egg between **creating the release git tag** (required to build/promote the image) and the **post-release version-updater PR** that pins kustomize + docs to the new `registry.k8s.io` image tag.

Also expands `.github/ISSUE_TEMPLATE/create-release.md` so the checklist matches the real order (tag → staging → k8s.io promote → verify pull → version-updater → helm).

Refers to issue 5622.

## Why

Maintainers noted in issue 5622 that kustomize on the release tag intentionally lags the new image until promotion completes. This change makes that explicit for release owners and consumers.

## Checklist

- [x] Docs only
- [x] DCO Signed-off-by
