### PR TITLE
fix(source): parse gloo-proxy aggregateListener virtual hosts

### DIFF
--- a/source/gloo_proxy.go
+++ b/source/gloo_proxy.go
@@ -82,8 +82,25 @@ type proxySpec struct {
 }
 
 type proxySpecListener struct {
-	HTTPListener   proxySpecHTTPListener `json:"httpListener"`
-	MetadataStatic proxyMetadataStatic   `json:"metadataStatic"`
+	HTTPListener      proxySpecHTTPListener      `json:"httpListener"`
+	AggregateListener proxySpecAggregateListener `json:"aggregateListener"`
+	MetadataStatic    proxyMetadataStatic        `json:"metadataStatic"`
+}
+
+// proxySpecAggregateListener is used instead of HTTPListener when a Gateway
+// has isolateVirtualHostsBySslConfig enabled, which splits virtual hosts
+// into per-SSL-config filter chains that reference shared virtual hosts by name.
+type proxySpecAggregateListener struct {
+	HTTPFilterChains []proxyAggregateListenerHTTPFilterChain `json:"httpFilterChains,omitempty"`
+	HTTPResources    proxyAggregateListenerHTTPResources     `json:"httpResources"`
+}
+
+type proxyAggregateListenerHTTPFilterChain struct {
+	VirtualHostRefs []string `json:"virtualHostRefs,omitempty"`
+}
+
+type proxyAggregateListenerHTTPResources struct {
+	VirtualHosts map[string]proxyVirtualHost `json:"virtualHosts,omitempty"`
 }
 
 type proxyMetadataStatic struct {
@@ -275,7 +292,15 @@ func (gs *glooSource) generateEndpointsFromProxy(p *proxy, targets endpoint.Targ
 	resource := fmt.Sprintf("proxy/%s/%s", p.Namespace, p.Name)
 
 	for _, listener := range p.Spec.Listeners {
-		for _, virtualHost := range listener.HTTPListener.VirtualHosts {
+		virtualHosts := listener.HTTPListener.VirtualHosts
+		for _, chain := range listener.AggregateListener.HTTPFilterChains {
+			for _, ref := range chain.VirtualHostRefs {
+				if virtualHost, ok := listener.AggregateListener.HTTPResources.VirtualHosts[ref]; ok {
+					virtualHosts = append(virtualHosts, virtualHost)
+				}
+			}
+		}
+		for _, virtualHost := range virtualHosts {
 			ants, err := gs.annotationsFromProxySource(virtualHost)
 			if err != nil {
 				return nil, err

--- a/source/gloo_proxy_test.go
+++ b/source/gloo_proxy_test.go
@@ -429,6 +429,42 @@ var (
 			},
 		},
 	}
+	// Proxy using aggregateListener, produced by Gloo when a Gateway has
+	// isolateVirtualHostsBySslConfig: true.
+	aggregateListenerProxy = proxy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: proxyGVR.GroupVersion().String(),
+			Kind:       "Proxy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aggregate-listener",
+			Namespace: defaultGlooNamespace,
+			Annotations: map[string]string{
+				"external-dns.kubernetes.io/target": "203.3.45.9",
+			},
+		},
+		Spec: proxySpec{
+			Listeners: []proxySpecListener{
+				{
+					AggregateListener: proxySpecAggregateListener{
+						HTTPFilterChains: []proxyAggregateListenerHTTPFilterChain{
+							{
+								VirtualHostRefs: []string{"gloo-system.example-vs"},
+							},
+						},
+						HTTPResources: proxyAggregateListenerHTTPResources{
+							VirtualHosts: map[string]proxyVirtualHost{
+								"gloo-system.example-vs": {
+									Domains: []string{"l.test"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
 	gatewayIngressAnnotatedProxyIngress = networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      gatewayIngressAnnotatedProxy.Spec.Listeners[0].MetadataStatic.Source[0].ResourceRef.Name,
@@ -461,6 +497,7 @@ func TestGlooSource(t *testing.T) {
 	gatewayIngressAnnotatedProxyGatewayUnstructured := unstructured.Unstructured{}
 	proxyMetadataStaticUnstructured := unstructured.Unstructured{}
 	targetAnnotatedProxyUnstructured := unstructured.Unstructured{}
+	aggregateListenerProxyUnstructured := unstructured.Unstructured{}
 
 	internalProxySourceUnstructured := unstructured.Unstructured{}
 	externalProxySourceUnstructured := unstructured.Unstructured{}
@@ -485,6 +522,9 @@ func TestGlooSource(t *testing.T) {
 	targetAnnotatedProxyAsJSON, err := json.Marshal(targetAnnotatedProxy)
 	assert.NoError(t, err)
 
+	aggregateListenerProxyAsJSON, err := json.Marshal(aggregateListenerProxy)
+	assert.NoError(t, err)
+
 	internalProxySvcAsJSON, err := json.Marshal(internalProxySource)
 	assert.NoError(t, err)
 
@@ -503,6 +543,7 @@ func TestGlooSource(t *testing.T) {
 	assert.NoError(t, gatewayIngressAnnotatedProxyGatewayUnstructured.UnmarshalJSON(gatewayIngressAnnotatedProxyGatewayAsJSON))
 	assert.NoError(t, proxyMetadataStaticUnstructured.UnmarshalJSON(proxyMetadataStaticAsJSON))
 	assert.NoError(t, targetAnnotatedProxyUnstructured.UnmarshalJSON(targetAnnotatedProxyAsJSON))
+	assert.NoError(t, aggregateListenerProxyUnstructured.UnmarshalJSON(aggregateListenerProxyAsJSON))
 
 	assert.NoError(t, internalProxySourceUnstructured.UnmarshalJSON(internalProxySvcAsJSON))
 	assert.NoError(t, externalProxySourceUnstructured.UnmarshalJSON(externalProxySvcAsJSON))
@@ -532,6 +573,8 @@ func TestGlooSource(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = fakeDynamicClient.Resource(proxyGVR).Namespace(defaultGlooNamespace).Create(t.Context(), &gatewayIngressAnnotatedProxyUnstructured, metav1.CreateOptions{})
 	assert.NoError(t, err)
+	_, err = fakeDynamicClient.Resource(proxyGVR).Namespace(defaultGlooNamespace).Create(t.Context(), &aggregateListenerProxyUnstructured, metav1.CreateOptions{})
+	assert.NoError(t, err)
 
 	// Create proxy source
 	_, err = fakeDynamicClient.Resource(virtualServiceGVR).Namespace(internalProxySource.Namespace).Create(t.Context(), &internalProxySourceUnstructured, metav1.CreateOptions{})
@@ -555,7 +598,7 @@ func TestGlooSource(t *testing.T) {
 
 	endpoints, err := source.Endpoints(t.Context())
 	assert.NoError(t, err)
-	assert.Len(t, endpoints, 11)
+	assert.Len(t, endpoints, 12)
 
 	testutils.ValidateEndpoints(t, endpoints, []*endpoint.Endpoint{
 		(&endpoint.Endpoint{
@@ -668,6 +711,14 @@ func TestGlooSource(t *testing.T) {
 			RecordTTL:        0,
 			Labels:           endpoint.Labels{},
 			ProviderSpecific: endpoint.ProviderSpecific{}},
+		{
+			DNSName:          "l.test",
+			Targets:          []string{"203.3.45.9"},
+			RecordType:       endpoint.RecordTypeA,
+			RecordTTL:        0,
+			Labels:           endpoint.Labels{},
+			ProviderSpecific: endpoint.ProviderSpecific{},
+		},
 	})
 }
 


### PR DESCRIPTION
## What does it do ?

Adds parsing support for the Gloo Edge `Proxy` CR's `aggregateListener` listener shape in the `gloo-proxy` source, so virtual hosts referenced via `aggregateListener.httpFilterChains[].virtualHostRefs` (resolved against `aggregateListener.httpResources.virtualHosts`, a map) are included alongside the existing `httpListener.virtualHosts[]` parsing.

## Motivation

`source/gloo_proxy.go`'s `proxySpecListener` struct only defined an `HTTPListener` field. When a Gloo Edge `Gateway` has `isolateVirtualHostsBySslConfig: true` (Gloo Edge 1.22.0+), Gloo translates the `Proxy` CR to use `aggregateListener` instead of `httpListener` for that listener. Since the struct had no matching field, Go's JSON unmarshalling silently dropped that part of the object, `listener.HTTPListener.VirtualHosts` was empty, and `generateEndpointsFromProxy` produced zero endpoints for that listener — with no error or warning logged. DNS records silently stopped being created/updated for any `VirtualService` domain served by an `aggregateListener`-backed listener, even though the `Proxy` CR was valid and Envoy was serving the domain correctly.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

Fixes #6627

```release-note
fix(source): parse gloo-proxy aggregateListener virtual hosts
```