### PR TITLE
test(controller): poll for the first reconcile in TestRun instead of a fixed sleep

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -259,6 +259,11 @@ func TestRun(t *testing.T) {
 		ManagedRecordTypes: cfg.ManagedDNSRecordTypes,
 	}
 	ctrl.nextRunAt = time.Now().Add(-time.Millisecond)
+
+	// Reset the shared gauge so the wait below observes a real 0->1 transition
+	// from this run rather than leftover state from an earlier test.
+	verifiedRecords.Gauge.Reset()
+
 	ctx, cancel := context.WithCancel(t.Context())
 	stopped := make(chan struct{})
 	go func() {
@@ -266,16 +271,9 @@ func TestRun(t *testing.T) {
 		close(stopped)
 	}()
 
-	// Wait until the controller goroutine has run once and recorded the verified
-	// records, instead of sleeping a fixed interval. The timeout serves as a safety
-	// net while being large enough to accommodate slow CI environments.
-	deadline := time.Now().Add(15 * time.Second)
-	for testutil.ToFloat64(verifiedRecords.Gauge.With(prometheus.Labels{"record_type": "a"})) < 1 {
-		if time.Now().After(deadline) {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	require.Eventually(t, func() bool {
+		return testutil.ToFloat64(verifiedRecords.Gauge.With(prometheus.Labels{"record_type": "a"})) >= 1
+	}, 15*time.Second, 10*time.Millisecond)
 	cancel() // start shutdown
 	<-stopped
 

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -36,6 +36,8 @@ import (
 	registryfactory "sigs.k8s.io/external-dns/registry/factory"
 	"sigs.k8s.io/external-dns/registry/noop"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -263,7 +265,17 @@ func TestRun(t *testing.T) {
 		ctrl.Run(ctx)
 		close(stopped)
 	}()
-	time.Sleep(1500 * time.Millisecond)
+
+	// Wait until the controller goroutine has run once and recorded the verified
+	// records, instead of sleeping a fixed interval. The timeout serves as a safety
+	// net while being large enough to accommodate slow CI environments.
+	deadline := time.Now().Add(15 * time.Second)
+	for testutil.ToFloat64(verifiedRecords.Gauge.With(prometheus.Labels{"record_type": "a"})) < 1 {
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	cancel() // start shutdown
 	<-stopped
 


### PR DESCRIPTION
`TestRun` sleeps a fixed 1500ms before asserting that the controller goroutine has completed its first reconcile and set `verifiedRecords`. Under load that assertion can run before the reconcile finishes, and the sleep is paid on every run regardless.

This polls the gauge until the first reconcile is observed (15s safety-net deadline, 10ms tick), matching the existing `TestToggleRegistry` poll in this file. Same assertions, no behaviour change.

```
go test -race -run TestRun -count=50 ./controller/   # ok, ~1.3s (was ~75s of sleeping)
```
