### PR TITLE
docs(webhook): add namecheap webhook provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ from the usage of any externally developed webhook.
 | Infomaniak            | https://github.com/M0NsTeRRR/external-dns-webhook-infomaniak         |
 | Mikrotik              | https://github.com/mirceanton/external-dns-provider-mikrotik         |
 | Myra Security         | https://github.com/Myra-Security-GmbH/external-dns-myrasec-webhook   |
+| Namecheap             | https://github.com/evandeaubl/external-dns-namecheap-webhook         |
 | NAVER Cloud Platform  | https://github.com/NaverCloudPlatform/external-dns-navercloud-webhook |
 | Netbird               | https://codeberg.org/ccbash-oss/external-dns-netbird-webhook         |
 | Netcup                | https://github.com/mrueg/external-dns-netcup-webhook                 |


### PR DESCRIPTION
## What does it do ?

Adds the Namecheap webhook provider to the known webhook provider list.

## Motivation

Enabling Namecheap DNS to be used with ExternalDNS.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
