### PR TITLE
fix(endpoint): make MergeEndpoints result order deterministic

### DIFF
--- a/endpoint/utils.go
+++ b/endpoint/utils.go
@@ -150,12 +150,18 @@ func EndpointsForHostsAndTargets(hostnames, targets []string) []*Endpoint {
 // When several endpoints merge into one, the first endpoint's scalar metadata (TTL, ProviderSpecific,
 // Labels, ...) is retained. RefObjects from all contributing endpoints are accumulated, so the merged
 // record references every source object that contributed to it. "First" follows the input slice order.
+//
+// The result preserves the order in which each key was first seen in the input. This keeps the output
+// deterministic across calls with the same input — callers such as the conflict resolver in package
+// plan break ties between competing candidates using slice order, so a map-iteration-order-dependent
+// result would make DNS record ownership flap non-deterministically between reconciliations.
 func MergeEndpoints(endpoints []*Endpoint) []*Endpoint {
 	if len(endpoints) == 0 {
 		return endpoints
 	}
 
 	endpointMap := make(map[EndpointKey]*Endpoint)
+	order := make([]EndpointKey, 0, len(endpoints))
 	singleTargets := make(map[string]string) // recordType/DNSName+SetIdentifier -> first target seen
 
 	for _, ep := range endpoints {
@@ -187,11 +193,13 @@ func MergeEndpoints(endpoints []*Endpoint) []*Endpoint {
 			}
 		} else {
 			endpointMap[key] = ep
+			order = append(order, key)
 		}
 	}
 
 	result := make([]*Endpoint, 0, len(endpointMap))
-	for _, ep := range endpointMap {
+	for _, key := range order {
+		ep := endpointMap[key]
 		slices.Sort(ep.Targets)
 		ep.Targets = slices.Compact(ep.Targets)
 		result = append(result, ep)

--- a/endpoint/utils.go
+++ b/endpoint/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package endpoint
 
 import (
+	"cmp"
 	"maps"
 	"net/netip"
 	"slices"
@@ -151,17 +152,16 @@ func EndpointsForHostsAndTargets(hostnames, targets []string) []*Endpoint {
 // Labels, ...) is retained. RefObjects from all contributing endpoints are accumulated, so the merged
 // record references every source object that contributed to it. "First" follows the input slice order.
 //
-// The result preserves the order in which each key was first seen in the input. This keeps the output
-// deterministic across calls with the same input — callers such as the conflict resolver in package
-// plan break ties between competing candidates using slice order, so a map-iteration-order-dependent
-// result would make DNS record ownership flap non-deterministically between reconciliations.
+// The result is sorted by key (DNSName, RecordType, SetIdentifier, RecordTTL, Target), so it is
+// deterministic regardless of the input's order — callers such as the conflict resolver in package
+// plan break ties between competing candidates using slice order, so an order that merely mirrored
+// the (possibly map-derived, and therefore already random) input order would not be a real fix.
 func MergeEndpoints(endpoints []*Endpoint) []*Endpoint {
 	if len(endpoints) == 0 {
 		return endpoints
 	}
 
 	endpointMap := make(map[EndpointKey]*Endpoint)
-	order := make([]EndpointKey, 0, len(endpoints))
 	singleTargets := make(map[string]string) // recordType/DNSName+SetIdentifier -> first target seen
 
 	for _, ep := range endpoints {
@@ -193,12 +193,13 @@ func MergeEndpoints(endpoints []*Endpoint) []*Endpoint {
 			}
 		} else {
 			endpointMap[key] = ep
-			order = append(order, key)
 		}
 	}
 
+	keys := slices.SortedFunc(maps.Keys(endpointMap), compareEndpointKeys)
+
 	result := make([]*Endpoint, 0, len(endpointMap))
-	for _, key := range order {
+	for _, key := range keys {
 		ep := endpointMap[key]
 		slices.Sort(ep.Targets)
 		ep.Targets = slices.Compact(ep.Targets)
@@ -206,4 +207,22 @@ func MergeEndpoints(endpoints []*Endpoint) []*Endpoint {
 	}
 
 	return result
+}
+
+// compareEndpointKeys orders EndpointKeys canonically (independent of any input/map order),
+// so callers that break ties using slice order get a stable, reproducible result.
+func compareEndpointKeys(a, b EndpointKey) int {
+	if c := cmp.Compare(a.DNSName, b.DNSName); c != 0 {
+		return c
+	}
+	if c := cmp.Compare(a.RecordType, b.RecordType); c != 0 {
+		return c
+	}
+	if c := cmp.Compare(a.SetIdentifier, b.SetIdentifier); c != 0 {
+		return c
+	}
+	if c := cmp.Compare(a.RecordTTL, b.RecordTTL); c != 0 {
+		return c
+	}
+	return cmp.Compare(a.Target, b.Target)
 }

--- a/endpoint/utils_test.go
+++ b/endpoint/utils_test.go
@@ -453,17 +453,29 @@ func TestMergeEndpoints(t *testing.T) {
 // endpoints (e.g. two Gateway API routes with different TTLs producing the same target for
 // the same hostname) using slice order, so a randomized result order made DNS record
 // ownership flap non-deterministically between reconciliations.
+//
+// Sources such as the Gateway API HTTPRoute lister are themselves backed by a Go map, so their
+// list order is not guaranteed stable across calls either. The result must therefore be sorted
+// canonically rather than merely preserve whatever order the input happened to arrive in — this
+// is checked below by feeding the same endpoint set in several different input orders and
+// asserting the result is identical every time.
 func TestMergeEndpointsOrderIsDeterministic(t *testing.T) {
-	input := []*Endpoint{
-		NewEndpointWithTTL("pad.example.com", RecordTypeA, 0, "1.2.3.4"),
-		NewEndpointWithTTL("pad.example.com", RecordTypeA, 300, "1.2.3.4"),
-		NewEndpointWithTTL("other.example.com", RecordTypeA, 60, "5.6.7.8"),
+	e1 := NewEndpointWithTTL("pad.example.com", RecordTypeA, 0, "1.2.3.4")
+	e2 := NewEndpointWithTTL("pad.example.com", RecordTypeA, 300, "1.2.3.4")
+	e3 := NewEndpointWithTTL("other.example.com", RecordTypeA, 60, "5.6.7.8")
+
+	orderings := [][]*Endpoint{
+		{e1, e2, e3},
+		{e3, e2, e1},
+		{e2, e1, e3},
 	}
 
-	want := MergeEndpoints(input)
-	for range 100 {
-		got := MergeEndpoints(input)
-		assert.Equal(t, want, got, "MergeEndpoints result order must be stable across calls with the same input")
+	want := MergeEndpoints(orderings[0])
+	for _, input := range orderings {
+		for range 100 {
+			got := MergeEndpoints(input)
+			assert.Equal(t, want, got, "MergeEndpoints result must not depend on input order")
+		}
 	}
 }
 

--- a/endpoint/utils_test.go
+++ b/endpoint/utils_test.go
@@ -447,6 +447,26 @@ func TestMergeEndpoints(t *testing.T) {
 	}
 }
 
+// TestMergeEndpointsOrderIsDeterministic guards against a regression where MergeEndpoints
+// built its result by ranging over a Go map, whose iteration order is randomized per call.
+// Callers such as plan.PerResource.ResolveCreate break ties between competing candidate
+// endpoints (e.g. two Gateway API routes with different TTLs producing the same target for
+// the same hostname) using slice order, so a randomized result order made DNS record
+// ownership flap non-deterministically between reconciliations.
+func TestMergeEndpointsOrderIsDeterministic(t *testing.T) {
+	input := []*Endpoint{
+		NewEndpointWithTTL("pad.example.com", RecordTypeA, 0, "1.2.3.4"),
+		NewEndpointWithTTL("pad.example.com", RecordTypeA, 300, "1.2.3.4"),
+		NewEndpointWithTTL("other.example.com", RecordTypeA, 60, "5.6.7.8"),
+	}
+
+	want := MergeEndpoints(input)
+	for range 100 {
+		got := MergeEndpoints(input)
+		assert.Equal(t, want, got, "MergeEndpoints result order must be stable across calls with the same input")
+	}
+}
+
 func TestMergeEndpoints_RefObjects(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## What does it do ?

Makes `endpoint.MergeEndpoints` return its results in a canonical, deterministic order (sorted by `DNSName`, `RecordType`, `SetIdentifier`, `RecordTTL`, then `Target`) instead of the order produced by ranging directly over a Go map.

## Motivation

`MergeEndpoints` built its result by iterating an `endpointMap` (a Go map), and Go randomizes map iteration order on every call. When a hostname has multiple candidate endpoints that don't merge into one (e.g. because their `RecordTTL` differs), the resulting slice order changed randomly between calls.

That order flows unmodified into `Source.Endpoints()` (e.g. `source/gateway.go` returns `endpoint.MergeEndpoints(endpoints)` directly) and from there into `plan.PerResource.ResolveCreate`, which breaks ties between competing candidates with equal targets using `slices.MinFunc` over `row.candidates` — a function that resolves ties to "the first" element in input order.

An earlier version of this PR fixed this by preserving first-seen input order instead of map order. That was pointed out in review as insufficient: the input to `MergeEndpoints` itself already comes from a map-backed source (e.g. a client-go Lister backed by `cache.Indexer`), so "first-seen order" just relays an already-random order downstream rather than producing a stable result. This version instead sorts the output canonically, so the result depends only on endpoint content, not on the order anything arrived in.

## Approach

`MergeEndpoints` now collects merged endpoints into a map as before, then builds the result by sorting the map's keys with `compareEndpointKeys` (comparing `DNSName`, `RecordType`, `SetIdentifier`, `RecordTTL`, `Target` in that order) and iterating in that order — the same pattern `EndpointsForHostsAndTargets` above it already uses via `sets.Sorted`. This preserves all existing merge semantics (target sort/dedup, CNAME/DNAME single-target handling, ref-object accumulation); only the result ordering changes.

## Validation

- `TestMergeEndpointsOrderIsDeterministic` in `endpoint/utils_test.go` feeds the same colliding endpoints (two same-hostname candidates that don't merge, differing TTL, plus one unrelated candidate) in several different input orderings and asserts the output is identical across all of them and across 100 repeated calls per ordering — order-sensitive `assert.Equal`.
- `go build ./...` — passes.
- `go test -race ./...` — full suite passes.
- `make licensecheck` — passes.

I have not reproduced the reported flapping A/TXT records end-to-end against a live Gateway API + Cloudflare (or similar) setup — I don't have such an environment available. The validation above demonstrates and fixes the underlying nondeterminism in `MergeEndpoints` itself (traced through `plan/plan.go` and `plan/conflict.go` to the tie-break in `PerResource.ResolveCreate`), but I can't currently provide a before/after reproduction on real infrastructure. If someone who can reproduce the original issue is able to confirm this resolves it, that would be more convincing evidence than what I can offer here.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

Relates to #6632

```release-note
fix(endpoint): make MergeEndpoints result order deterministic
```
