### PR TITLE
chore: bump to go version 1.26.6

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   # Temporary bump, while working on job improvements.
   machineType: 'N1_HIGHCPU_32'
 steps:
-  - name: 'docker.io/library/golang:1.26-bookworm'
+  - name: 'docker.io/library/golang:1.26.6-bookworm'
     entrypoint: make
     env:
       - VERSION=$_GIT_TAG

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/external-dns
 
-go 1.26.5
+go 1.26.6
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0

--- a/go.tool.mod
+++ b/go.tool.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/external-dns/tools
 
-go 1.26.5
+go 1.26.6
 
 tool (
 	github.com/google/yamlfmt/cmd/yamlfmt


### PR DESCRIPTION
## What does it do ?

This PR bumps to Go version 1.26.6 as there were several vulnerabilities patched in this release.

Those are:

```
GO-2026-5026	net/http	*Client.Do, *Client.PostForm, *Transport.CloseIdleConnections, *Transport.RoundTrip	v1.26.5	v1.26.6	CVE-2026-39821	Invoking failure to reject ASCII-only Punycode-encoded labels in golang.org/x/net/idna
GO-2026-5972	encoding/asn1	Unmarshal	v1.26.5	v1.26.6	CVE-2026-33818	Enforce maximum recursion depth in encoding/asn1
GO-2026-6088	encoding/xml	*Decoder.Decode, *Decoder.Skip, *Decoder.Token, Unmarshal	v1.26.5	v1.26.6	CVE-2026-56859	Add recursion depth guard during decode in encoding/xml
GO-2026-6089	net/http	*Server.Serve, ListenAndServe	v1.26.5	v1.26.6	CVE-2026-56853	Apply ReadHeaderTimeout when doing unencrypted HTTP/2 check in net/http
GO-2026-6090	crypto/tls	*Conn.Handshake, *Conn.HandshakeContext, *Conn.Read, *Conn.Write, *Dialer.DialContext	v1.26.5	v1.26.6	CVE-2026-56862	Limit handshake messages we are willing to accept post-handshake in crypto/tls
GO-2026-6091	html/template	*Template.Execute, *Template.ExecuteTemplate	v1.26.5	v1.26.6	CVE-2026-56858	Fix Javascript regexp context tracking in html/template
GO-2026-6218	net/url	*URL.Parse, *URL.ResolveReference	v1.26.5	v1.26.6	CVE-2026-56860	Avoid quadratic complexity in resolvePath in net/url
```

## Motivation

Preparing for release with a clean image without core go vulnerabilities.

<!-- What inspired you to submit this pull request? -->

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
