### PR TITLE
Enable require-error checker in testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,9 +65,6 @@ linters:
       # (in addition to default
       #   suite-thelper
       # ).
-      # TODO: enable in follow-up
-      disable:
-        - require-error
     usetesting:
       # Enable/disable `context.Background()` detections.
       context-background: true

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -230,7 +230,7 @@ func TestRunOnce(t *testing.T) {
 		EventEmitter:       emitter,
 	}
 
-	assert.NoError(t, ctrl.RunOnce(t.Context()))
+	require.NoError(t, ctrl.RunOnce(t.Context()))
 
 	// Validate that the mock source was called.
 	source.AssertExpectations(t)
@@ -365,7 +365,7 @@ func testControllerFiltersDomains(t *testing.T, configuredEndpoints []*endpoint.
 		ManagedRecordTypes: cfg.ManagedDNSRecordTypes,
 	}
 
-	assert.NoError(t, ctrl.RunOnce(t.Context()))
+	require.NoError(t, ctrl.RunOnce(t.Context()))
 	assert.Equal(t, 1, provider.RecordsCallCount)
 	require.Len(t, provider.ApplyChangesCalls, len(expectedChanges))
 	for i, change := range expectedChanges {
@@ -641,8 +641,8 @@ func TestRun_HardError(t *testing.T) {
 	err = ctrl.Run(t.Context())
 
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "failed to do run once")
-	assert.ErrorContains(t, err, "simulated hard error")
+	require.ErrorContains(t, err, "failed to do run once")
+	require.ErrorContains(t, err, "simulated hard error")
 
 	source.AssertExpectations(t)
 }

--- a/controller/metrics_test.go
+++ b/controller/metrics_test.go
@@ -19,7 +19,7 @@ package controller
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/internal/testutils"
@@ -289,7 +289,7 @@ func TestAAAARecords(t *testing.T) {
 func TestGaugeMetricsWithMixedRecords(t *testing.T) {
 	ctrl := newMixedRecordsFixture()
 
-	assert.NoError(t, ctrl.RunOnce(t.Context()))
+	require.NoError(t, ctrl.RunOnce(t.Context()))
 
 	testutils.TestHelperVerifyMetricsGaugeVectorWithLabels(t, 534, sourceRecords.Gauge, map[string]string{"record_type": "a"})
 	testutils.TestHelperVerifyMetricsGaugeVectorWithLabels(t, 324, sourceRecords.Gauge, map[string]string{"record_type": "aaaa"})

--- a/endpoint/domain_filter_test.go
+++ b/endpoint/domain_filter_test.go
@@ -796,7 +796,7 @@ func TestDomainFilterNilReceiver(t *testing.T) {
 	})
 	t.Run("MarshalJSON returns empty include/exclude", func(t *testing.T) {
 		b, err := (*DomainFilter)(nil).MarshalJSON()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.JSONEq(t, `{}`, string(b))
 	})
 	t.Run("MatchParent returns true", func(t *testing.T) {
@@ -868,14 +868,14 @@ func TestDomainFilterDeserializeError(t *testing.T) {
 			var deserialized DomainFilter
 			toJson, _ := json.Marshal(tt.serialized)
 			err := json.Unmarshal(toJson, &deserialized)
-			assert.EqualError(t, err, tt.expectedError)
+			require.EqualError(t, err, tt.expectedError)
 		})
 	}
 }
 
 func assertSerializes[T any](t *testing.T, domainFilter *DomainFilter, expectedSerialization map[string]T) {
 	serialized, err := json.Marshal(domainFilter)
-	assert.NoError(t, err, "serializing")
+	require.NoError(t, err, "serializing")
 	expected, err := json.Marshal(expectedSerialization)
 	require.NoError(t, err)
 	assert.JSONEq(t, string(expected), string(serialized), "json serialization")
@@ -886,7 +886,7 @@ func deserialize[T any](t *testing.T, serialized map[string]T) *DomainFilter {
 	require.NoError(t, err)
 	var deserialized DomainFilter
 	err = json.Unmarshal(inJson, &deserialized)
-	assert.NoError(t, err, "deserializing")
+	require.NoError(t, err, "deserializing")
 
 	return &deserialized
 }

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -1128,9 +1128,9 @@ func TestNewMXTarget(t *testing.T) {
 		t.Run(tt.description, func(t *testing.T) {
 			actual, err := NewMXRecord(tt.target)
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.expected, actual)
 			}
 		})
@@ -1192,9 +1192,9 @@ func TestNewSRVRecord(t *testing.T) {
 		t.Run(tt.description, func(t *testing.T) {
 			actual, err := NewSRVRecord(tt.target)
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.expected, actual)
 			}
 		})
@@ -2186,7 +2186,7 @@ func TestNewPTREndpoint(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ep, err := NewPTREndpoint(tt.target, tt.ttl, tt.hostnames...)
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)

--- a/endpoint/labels_test.go
+++ b/endpoint/labels_test.go
@@ -77,14 +77,14 @@ func (suite *LabelsSuite) TestSerialize() {
 
 func (suite *LabelsSuite) TestEncryptionNonceReUsage() {
 	foo, err := NewLabelsFromString(suite.fooAsTextEncrypted, suite.aesKey)
-	suite.NoError(err, "should succeed for valid label text")
+	suite.Require().NoError(err, "should succeed for valid label text")
 	serialized := foo.Serialize(false, true, suite.aesKey)
 	suite.Equal(serialized, suite.fooAsTextEncrypted, "serialized result should be equal")
 }
 
 func (suite *LabelsSuite) TestEncryptionKeyChanged() {
 	foo, err := NewLabelsFromString(suite.fooAsTextEncrypted, suite.aesKey)
-	suite.NoError(err, "should succeed for valid label text")
+	suite.Require().NoError(err, "should succeed for valid label text")
 
 	serialised := foo.Serialize(false, true, []byte("passphrasewhichneedstobe32bytes!"))
 	suite.NotEqual(serialised, suite.fooAsTextEncrypted, "serialized result should be equal")
@@ -92,7 +92,7 @@ func (suite *LabelsSuite) TestEncryptionKeyChanged() {
 
 func (suite *LabelsSuite) TestEncryptionFailed() {
 	foo, err := NewLabelsFromString(suite.fooAsTextEncrypted, suite.aesKey)
-	suite.NoError(err, "should succeed for valid label text")
+	suite.Require().NoError(err, "should succeed for valid label text")
 
 	defer func() { log.StandardLogger().ExitFunc = nil }()
 
@@ -110,7 +110,7 @@ func (suite *LabelsSuite) TestEncryptionFailed() {
 
 func (suite *LabelsSuite) TestEncryptionFailedFaultyReader() {
 	foo, err := NewLabelsFromString(suite.fooAsTextEncrypted, suite.aesKey)
-	suite.NoError(err, "should succeed for valid label text")
+	suite.Require().NoError(err, "should succeed for valid label text")
 
 	// remove encryption nonce just for simplicity, so that we could regenerate nonce
 	delete(foo, txtEncryptionNonce)
@@ -138,31 +138,31 @@ func (suite *LabelsSuite) TestEncryptionFailedFaultyReader() {
 
 func (suite *LabelsSuite) TestDeserialize() {
 	foo, err := NewLabelsFromStringPlain(suite.fooAsText)
-	suite.NoError(err, "should succeed for valid label text")
+	suite.Require().NoError(err, "should succeed for valid label text")
 	suite.Equal(suite.foo, foo, "should reconstruct original label map")
 
 	foo, err = NewLabelsFromStringPlain(suite.fooAsTextWithQuotes)
-	suite.NoError(err, "should succeed for valid label text")
+	suite.Require().NoError(err, "should succeed for valid label text")
 	suite.Equal(suite.foo, foo, "should reconstruct original label map")
 
 	foo, err = NewLabelsFromString(suite.fooAsTextEncrypted, suite.aesKey)
-	suite.NoError(err, "should succeed for valid encrypted label text")
+	suite.Require().NoError(err, "should succeed for valid encrypted label text")
 	for key, val := range suite.foo {
 		suite.Equal(val, foo[key], "should contains all keys from original label map")
 	}
 
 	foo, err = NewLabelsFromString(suite.fooAsTextWithQuotesEncrypted, suite.aesKey)
-	suite.NoError(err, "should succeed for valid encrypted label text")
+	suite.Require().NoError(err, "should succeed for valid encrypted label text")
 	for key, val := range suite.foo {
 		suite.Equal(val, foo[key], "should contains all keys from original label map")
 	}
 
 	bar, err := NewLabelsFromStringPlain(suite.barText)
-	suite.NoError(err, "should succeed for valid label text")
+	suite.Require().NoError(err, "should succeed for valid label text")
 	suite.Equal(suite.barTextAsMap, bar, "should reconstruct original label map")
 
 	bar, err = NewLabelsFromString(suite.barText, suite.aesKey)
-	suite.NoError(err, "should succeed for valid encrypted label text")
+	suite.Require().NoError(err, "should succeed for valid encrypted label text")
 	suite.Equal(suite.barTextAsMap, bar, "should reconstruct original label map")
 
 	noHeritage, err := NewLabelsFromStringPlain(suite.noHeritageText)

--- a/endpoint/utils_external_test.go
+++ b/endpoint/utils_external_test.go
@@ -19,7 +19,7 @@ package endpoint_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/internal/testutils"
@@ -157,7 +157,7 @@ func TestEndpointsForHostsAndTargets(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result := endpoint.EndpointsForHostsAndTargets(tc.hostnames, tc.targets)
 			if tc.expected == nil {
-				assert.Nil(t, result)
+				require.Nil(t, result)
 				return
 			}
 			testutils.ValidateEndpoints(t, result, tc.expected)

--- a/internal/gen/docs/flags/main_test.go
+++ b/internal/gen/docs/flags/main_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const pathToDocs = "%s/../../../../docs"
@@ -48,7 +49,7 @@ func TestGenerateMarkdownTableRenderer(t *testing.T) {
 	}
 
 	got, err := flags.generateMarkdownTable()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Contains(t, got, "<!-- THIS FILE MUST NOT BE EDITED BY HAND -->")
 	assert.Contains(t, got, "| flag1 | description1 |")
@@ -59,7 +60,7 @@ func TestFlagsMdExists(t *testing.T) {
 	fsys := os.DirFS(fmt.Sprintf(pathToDocs, testPath))
 	fileName := "flags.md"
 	st, err := fs.Stat(fsys, fileName)
-	assert.NoError(t, err, "expected file %s to exist", fileName)
+	require.NoError(t, err, "expected file %s to exist", fileName)
 	assert.Equal(t, fileName, st.Name())
 }
 
@@ -68,11 +69,11 @@ func TestFlagsMdUpToDate(t *testing.T) {
 	fsys := os.DirFS(fmt.Sprintf(pathToDocs, testPath))
 	fileName := "flags.md"
 	expected, err := fs.ReadFile(fsys, fileName)
-	assert.NoError(t, err, "expected file %s to exist", fileName)
+	require.NoError(t, err, "expected file %s to exist", fileName)
 
 	flags := computeFlags()
 	actual, err := flags.generateMarkdownTable()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	actual += "\n"
 	assert.Equal(t, string(expected), actual, "expected file '%s' to be up to date. execute 'make generate-flags-documentation'", fileName)
 }
@@ -82,12 +83,12 @@ func TestFlagsMdExtraFlagAdded(t *testing.T) {
 	fsys := os.DirFS(fmt.Sprintf(pathToDocs, testPath))
 	filePath := "flags.md"
 	expected, err := fs.ReadFile(fsys, filePath)
-	assert.NoError(t, err, "expected file %s to exist", filePath)
+	require.NoError(t, err, "expected file %s to exist", filePath)
 
 	flags := computeFlags()
 	flags.addFlag("new-flag", "description2")
 	actual, err := flags.generateMarkdownTable()
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEqual(t, string(expected), actual)
 }

--- a/internal/gen/docs/metrics/main_test.go
+++ b/internal/gen/docs/metrics/main_test.go
@@ -48,7 +48,7 @@ func TestGenerateMarkdownTableRenderer(t *testing.T) {
 	reg := metrics.NewMetricsRegister()
 
 	got, err := generateMarkdownTable(reg, false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Contains(t, got, "# Available Metrics\n\n<!-- THIS FILE MUST NOT BE EDITED BY HAND -->\n")
 	assert.Contains(t, got, "| Name | Metric Type | Subsystem | Labels | Help |")
@@ -78,11 +78,11 @@ func TestMetricsMdUpToDate(t *testing.T) {
 	fsys := os.DirFS(fmt.Sprintf(pathToDocs, testPath))
 	fileName := "metrics.md"
 	expected, err := fs.ReadFile(fsys, fileName)
-	assert.NoError(t, err, "expected file %s to exist", fileName)
+	require.NoError(t, err, "expected file %s to exist", fileName)
 
 	reg := metrics.RegisterMetric
 	actual, err := generateMarkdownTable(reg, false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, string(expected), actual, "expected file 'docs/monitoring/metrics.md' to be up to date. execute 'make generate-metrics-documentation")
 }
 
@@ -91,7 +91,7 @@ func TestMetricsMdExtraMetricAdded(t *testing.T) {
 	fsys := os.DirFS(fmt.Sprintf(pathToDocs, testPath))
 	fileName := "metrics.md"
 	expected, err := fs.ReadFile(fsys, fileName)
-	assert.NoError(t, err, "expected file %s to exist", fileName)
+	require.NoError(t, err, "expected file %s to exist", fileName)
 
 	// Use a fresh registry to avoid mutating the global RegisterMetric.
 	reg := metrics.NewMetricsRegister()
@@ -108,7 +108,7 @@ func TestMetricsMdExtraMetricAdded(t *testing.T) {
 	))
 
 	actual, err := generateMarkdownTable(reg, false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEqual(t, string(expected), actual)
 }
 

--- a/internal/gen/docs/render/render_test.go
+++ b/internal/gen/docs/render/render_test.go
@@ -183,7 +183,7 @@ func TestFuncs(t *testing.T) {
 	for _, tt := range tests {
 		var b strings.Builder
 		err := template.Must(template.New("test").Funcs(FuncMap()).Parse(tt.tpl)).Execute(&b, tt.vars)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, tt.expect, b.String(), tt.tpl)
 	}
 }

--- a/internal/gen/docs/sources/main_test.go
+++ b/internal/gen/docs/sources/main_test.go
@@ -36,7 +36,7 @@ func TestIndexMdExists(t *testing.T) {
 	testPath, _ := os.Getwd()
 	fsys := os.DirFS(fmt.Sprintf(pathToDocs, testPath))
 	st, err := fs.Stat(fsys, fileName)
-	assert.NoError(t, err, "expected file %s to exist", fileName)
+	require.NoError(t, err, "expected file %s to exist", fileName)
 	assert.Equal(t, fileName, st.Name())
 }
 
@@ -44,13 +44,13 @@ func TestIndexMdUpToDate(t *testing.T) {
 	testPath, _ := os.Getwd()
 	fsys := os.DirFS(fmt.Sprintf(pathToDocs, testPath))
 	expected, err := fs.ReadFile(fsys, fileName)
-	assert.NoError(t, err, "expected file %s to exist", fileName)
+	require.NoError(t, err, "expected file %s to exist", fileName)
 
 	sourceDir := fmt.Sprintf("%s/../../../../source", testPath)
 	sources, err := discoverSources(sourceDir)
 	require.NoError(t, err, "expected to find sources")
 	actual, err := sources.generateMarkdown()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, string(expected), actual, "expected file 'docs/sources/index.md' to be up to date. execute 'make generate-sources-documentation'")
 }
 

--- a/internal/idna/idna_test.go
+++ b/internal/idna/idna_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProfileWithDefault(t *testing.T) {
@@ -52,7 +53,7 @@ func TestProfileWithDefault(t *testing.T) {
 	for _, tt := range tets {
 		t.Run(strings.ToLower(tt.input), func(t *testing.T) {
 			result, err := Profile.ToUnicode(tt.input)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/internal/testutils/endpoint_test.go
+++ b/internal/testutils/endpoint_test.go
@@ -26,6 +26,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
@@ -484,7 +485,7 @@ func TestWithLabel(t *testing.T) {
 	// should initialize Labels and set the key
 	returned := e.WithLabel("foo", "bar")
 	assert.Equal(t, e, returned)
-	assert.NotNil(t, e.Labels)
+	require.NotNil(t, e.Labels)
 	assert.Equal(t, "bar", e.Labels["foo"])
 
 	// overriding an existing key

--- a/pkg/apis/externaldns/validation/validation_test.go
+++ b/pkg/apis/externaldns/validation/validation_test.go
@@ -155,7 +155,7 @@ func TestValidateBadIgnoreHostnameAnnotationsConfig(t *testing.T) {
 	cfg.IgnoreHostnameAnnotation = true
 	cfg.FQDNTemplate = []string{}
 
-	assert.Error(t, ValidateConfig(cfg))
+	require.Error(t, ValidateConfig(cfg))
 }
 
 func TestValidateBadRfc2136Config(t *testing.T) {
@@ -170,7 +170,7 @@ func TestValidateBadRfc2136Config(t *testing.T) {
 
 	err := ValidateConfig(cfg)
 
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestValidateBadRfc2136Batch(t *testing.T) {
@@ -185,7 +185,7 @@ func TestValidateBadRfc2136Batch(t *testing.T) {
 
 	err := ValidateConfig(cfg)
 
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestValidateGoodRfc2136Config(t *testing.T) {
@@ -202,7 +202,7 @@ func TestValidateGoodRfc2136Config(t *testing.T) {
 
 	err := ValidateConfig(cfg)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestValidateBadRfc2136GssTsigConfig(t *testing.T) {
@@ -305,7 +305,7 @@ func TestValidateBadRfc2136GssTsigConfig(t *testing.T) {
 	for _, cfg := range invalidRfc2136GssTsigConfigs {
 		err := ValidateConfig(cfg)
 
-		assert.Error(t, err)
+		require.Error(t, err)
 	}
 }
 
@@ -332,7 +332,7 @@ func TestValidateGoodRfc2136GssTsigConfig(t *testing.T) {
 	for _, cfg := range validRfc2136GssTsigConfigs {
 		err := ValidateConfig(cfg)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 }
 
@@ -348,7 +348,7 @@ func TestValidateBadAzureConfig(t *testing.T) {
 
 	err := ValidateConfig(cfg)
 
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestValidateGoodAzureConfig(t *testing.T) {
@@ -365,7 +365,7 @@ func TestValidateGoodAzureConfig(t *testing.T) {
 
 	err := ValidateConfig(cfg)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestValidateCreatePTRRequiresManagedRecordType(t *testing.T) {
@@ -374,7 +374,7 @@ func TestValidateCreatePTRRequiresManagedRecordType(t *testing.T) {
 	// ManagedDNSRecordTypes defaults to [A, AAAA, CNAME] — no PTR
 
 	err := ValidateConfig(cfg)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--create-ptr requires PTR in --managed-record-types")
 }
 
@@ -384,5 +384,5 @@ func TestValidateCreatePTRWithPTRManagedPasses(t *testing.T) {
 	cfg.ManagedDNSRecordTypes = append(cfg.ManagedDNSRecordTypes, "PTR")
 
 	err := ValidateConfig(cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -56,7 +56,7 @@ func TestNewKubeClient(t *testing.T) {
 
 	client, err := NewKubeClient(config)
 	require.NoError(t, err)
-	assert.NotNil(t, client)
+	require.NotNil(t, client)
 }
 
 func TestInstrumentedRESTConfig_AddsMetrics(t *testing.T) {
@@ -69,8 +69,8 @@ func TestInstrumentedRESTConfig_AddsMetrics(t *testing.T) {
 	require.NotNil(t, config)
 
 	assert.Equal(t, timeout, config.Timeout)
-	assert.NotNil(t, config.WrapTransport, "WrapTransport should be set for metrics")
-	assert.NotNil(t, config.RateLimiter, "RateLimiter should always be set")
+	require.NotNil(t, config.WrapTransport, "WrapTransport should be set for metrics")
+	require.NotNil(t, config.RateLimiter, "RateLimiter should always be set")
 }
 
 func TestGetRestConfig_RecommendedHomeFile(t *testing.T) {
@@ -122,7 +122,7 @@ func TestInstrumentedRESTConfig_QPSAndBurstApplied(t *testing.T) {
 
 	assert.Equal(t, 20, int(config.QPS))
 	assert.Equal(t, 40, config.Burst)
-	assert.NotNil(t, config.RateLimiter)
+	require.NotNil(t, config.RateLimiter)
 	assert.Equal(t, 20, int(config.RateLimiter.QPS()))
 }
 
@@ -139,7 +139,7 @@ func TestInstrumentedRESTConfig_ZeroQPSKeepsConfigDefaults(t *testing.T) {
 	// qps == 0: client-go defaults applied; rate limiter still installed
 	assert.Equal(t, int(rest.DefaultQPS), int(config.QPS))
 	assert.Equal(t, rest.DefaultBurst, config.Burst)
-	assert.NotNil(t, config.RateLimiter)
+	require.NotNil(t, config.RateLimiter)
 	assert.Equal(t, int(rest.DefaultQPS), int(config.RateLimiter.QPS()))
 }
 
@@ -173,7 +173,7 @@ func TestEnrichingRateLimiter(t *testing.T) {
 	t.Run("Wait returns nil when token is available", func(t *testing.T) {
 		// burst=1: one token available immediately
 		rl := &rateLimiter{delegate: flowcontrol.NewTokenBucketRateLimiter(100, 1)}
-		assert.NoError(t, rl.Wait(t.Context()))
+		require.NoError(t, rl.Wait(t.Context()))
 	})
 }
 

--- a/pkg/events/controller_test.go
+++ b/pkg/events/controller_test.go
@@ -147,7 +147,7 @@ func TestController_Queue_EmitEvents(t *testing.T) {
 
 	item, shutdown := ctrl.queue.Get()
 	require.False(t, shutdown)
-	assert.NotNil(t, item)
+	require.NotNil(t, item)
 
 	assert.Contains(t, item.Name, "fake-object.")
 	assert.Contains(t, item.Reason, RecordReady)

--- a/pkg/http/drain_test.go
+++ b/pkg/http/drain_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type trackingReadCloser struct {
@@ -62,6 +63,6 @@ func TestDrainAndClose_OversizedBody(t *testing.T) {
 
 	// Exactly one byte should remain after the capped drain.
 	remaining, err := io.ReadAll(rc.Reader)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, remaining, 1, "expected exactly 1 byte past the drain cap to remain unread")
 }

--- a/pkg/http/http_benchmark_test.go
+++ b/pkg/http/http_benchmark_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type roundTripFunc func(req *http.Request) *http.Response
@@ -66,7 +65,9 @@ func BenchmarkRoundTripper(b *testing.B) {
 	for b.Loop() {
 		api := apiUnderTest{client, "http://example.com"}
 		body, err := api.doStuff()
-		require.NoError(b, err)
+		if err != nil {
+			b.Fatal(err)
+		}
 		assert.Equal(b, []byte("OK"), body)
 	}
 }

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -146,9 +146,9 @@ func TestRoundTrip(t *testing.T) {
 			resp, err := customRoundTripper.RoundTrip(req)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			assert.Equal(t, tt.expectedResponse, resp)

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 )
@@ -107,8 +108,8 @@ func TestUnsupportedMetricWarning(t *testing.T) {
 func TestNewMetricsRegister(t *testing.T) {
 	registry := NewMetricsRegister()
 
-	assert.NotNil(t, registry)
-	assert.NotNil(t, registry.Registerer)
+	require.NotNil(t, registry)
+	require.NotNil(t, registry.Registerer)
 	assert.Empty(t, registry.Metrics)
 	assert.Empty(t, registry.mName)
 }

--- a/pkg/metrics/models_test.go
+++ b/pkg/metrics/models_test.go
@@ -42,7 +42,7 @@ func TestNewGaugeWithOpts(t *testing.T) {
 	assert.Equal(t, "test_subsystem", gaugeMetric.Subsystem)
 	assert.Equal(t, "This is a test gauge", gaugeMetric.Help)
 	assert.Equal(t, "test_subsystem_test_gauge", gaugeMetric.FQDN)
-	assert.NotNil(t, gaugeMetric.Gauge)
+	require.NotNil(t, gaugeMetric.Gauge)
 }
 
 func TestNewCounterWithOpts(t *testing.T) {
@@ -60,7 +60,7 @@ func TestNewCounterWithOpts(t *testing.T) {
 	assert.Equal(t, "test_subsystem", counterMetric.Subsystem)
 	assert.Equal(t, "This is a test counter", counterMetric.Help)
 	assert.Equal(t, "test_subsystem_test_counter", counterMetric.FQDN)
-	assert.NotNil(t, counterMetric.Counter)
+	require.NotNil(t, counterMetric.Counter)
 }
 
 func TestNewCounterVecWithOpts(t *testing.T) {
@@ -81,7 +81,7 @@ func TestNewCounterVecWithOpts(t *testing.T) {
 	assert.Equal(t, "test_subsystem", counterVecMetric.Subsystem)
 	assert.Equal(t, "This is a test counter vector", counterVecMetric.Help)
 	assert.Equal(t, "test_subsystem_test_counter_vec", counterVecMetric.FQDN)
-	assert.NotNil(t, counterVecMetric.CounterVec)
+	require.NotNil(t, counterVecMetric.CounterVec)
 }
 
 func TestGaugeV_SetWithLabels(t *testing.T) {
@@ -96,19 +96,19 @@ func TestGaugeV_SetWithLabels(t *testing.T) {
 	gv.SetWithLabels(1.23, "Alpha", "BETA")
 
 	g, err := gv.Gauge.GetMetricWithLabelValues("alpha", "beta")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var m dto.Metric
 	err = g.Write(&m)
-	assert.NoError(t, err)
-	assert.NotNil(t, m.Gauge)
+	require.NoError(t, err)
+	require.NotNil(t, m.Gauge)
 	assert.InDelta(t, 1.23, *m.Gauge.Value, 0.01)
 
 	// Override the value
 	gv.SetWithLabels(4.56, "ALPHA", "beta")
 	// reuse g (same label combination)
 	err = g.Write(&m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.InDelta(t, 4.56, *m.Gauge.Value, 0.01)
 
 	assert.Len(t, m.Label, 2)
@@ -205,16 +205,16 @@ func TestSummaryV_SetWithLabels(t *testing.T) {
 	reg.MustRegister(sv.SummaryVec)
 
 	metricsFamilies, err := reg.Gather()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, metricsFamilies, 1)
 
 	s, err := sv.SummaryVec.GetMetricWithLabelValues("alpha", "beta")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	metricsFamilies, err = reg.Gather()
 
 	s.Observe(5.21)
 	metricsFamilies, err = reg.Gather()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.InDelta(t, 10.22, *metricsFamilies[0].Metric[0].Summary.SampleSum, 0.01)
 	assert.Len(t, metricsFamilies[0].Metric[0].Label, 2)
@@ -255,24 +255,24 @@ func TestGaugeV_AddWithLabels(t *testing.T) {
 	gv.AddWithLabels(1.0, "Alpha", "BETA")
 
 	g, err := gv.Gauge.GetMetricWithLabelValues("alpha", "beta")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var m dto.Metric
 	err = g.Write(&m)
-	assert.NoError(t, err)
-	assert.NotNil(t, m.Gauge)
+	require.NoError(t, err)
+	require.NotNil(t, m.Gauge)
 	assert.InDelta(t, 1.0, *m.Gauge.Value, 0.01)
 
 	// Add again - should increment, not override
 	gv.AddWithLabels(2.0, "ALPHA", "beta")
 	err = g.Write(&m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.InDelta(t, 3.0, *m.Gauge.Value, 0.01) // 1.0 + 2.0 = 3.0
 
 	// Add one more time
 	gv.AddWithLabels(0.5, "alpha", "Beta")
 	err = g.Write(&m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.InDelta(t, 3.5, *m.Gauge.Value, 0.01) // 3.0 + 0.5 = 3.5
 
 	assert.Len(t, m.Label, 2)

--- a/pkg/rfc2317/arpa.go
+++ b/pkg/rfc2317/arpa.go
@@ -19,9 +19,9 @@ package rfc2317
 import (
 	"fmt"
 	"net"
-	"slices"
-	"strconv"
 	"strings"
+
+	"github.com/miekg/dns"
 )
 
 // CidrToInAddr converts a CIDR block into its reverse lookup (in-addr) name.
@@ -29,100 +29,75 @@ import (
 // Given "10.20.30.0/24" returns "30.20.10.in-addr.arpa"
 // Given "10.20.30.0/25" returns "0/25.30.20.10.in-addr.arpa" (RFC2317)
 func CidrToInAddr(cidr string) (string, error) {
-	// If the user sent an IP instead of a CIDR (i.e. no "/"), turn it
-	// into a CIDR by adding /32 or /128 as appropriate.
-	ip := net.ParseIP(cidr)
-	if ip != nil {
-		if ip.To4() != nil {
-			cidr = ip.String() + "/32"
-			// Older code used `cidr + "/32"` but that didn't work with
-			// "IPv4 mapped IPv6 address". ip.String() returns the IPv4
-			// address for all IPv4 addresses no matter how they are
-			// expressed internally.
-		} else {
-			cidr += "/128"
-		}
-	}
+	cidr = normalizeCIDR(cidr)
 
 	a, c, err := net.ParseCIDR(cidr)
 	if err != nil {
 		return "", err
 	}
-	base, err := reverseaddr(a.String())
-	if err != nil {
-		return "", err
-	}
-	base = strings.TrimRight(base, ".")
 	if !a.Equal(c.IP) {
 		return "", fmt.Errorf("CIDR %v has 1 bits beyond the mask", cidr)
 	}
 
 	bits, total := c.Mask.Size()
-	var toTrim int
 	if bits == 0 {
 		return "", fmt.Errorf("cannot use /0 in reverse CIDR")
 	}
+	base, err := dns.ReverseAddr(a.String())
+	if err != nil {
+		return "", err
+	}
+	base = strings.TrimRight(base, ".")
 
 	// Handle IPv4 "Classless in-addr.arpa delegation" RFC2317:
-	if total == 32 && bits >= 25 && bits < 32 {
-		// first address / netmask . Class-b-arpa.
-		fparts := strings.Split(c.IP.String(), ".")
-		first := fparts[3]
-		bparts := strings.SplitN(base, ".", 2)
-		return fmt.Sprintf("%s/%d.%s", first, bits, bparts[1]), nil
+	if name, ok := classlessIPv4Name(base, total, bits); ok {
+		return name, nil
 	}
 
-	// Handle IPv4 Class-full and IPv6:
-	switch total {
-	case 32:
-		if bits%8 != 0 {
-			return "", fmt.Errorf("IPv4 mask must be multiple of 8 bits")
-		}
-		toTrim = (total - bits) / 8
-	case 128:
-		if bits%4 != 0 {
-			return "", fmt.Errorf("IPv6 mask must be multiple of 4 bits")
-		}
-		toTrim = (total - bits) / 4
-	default:
-		return "", fmt.Errorf("invalid address (not IPv4 or IPv6): %v", cidr)
+	toTrim, err := reverseNameTrimCount(total, bits, cidr)
+	if err != nil {
+		return "", err
 	}
 
 	parts := strings.SplitN(base, ".", toTrim+1)
 	return parts[len(parts)-1], nil
 }
 
-// copied from go source.
-// https://github.com/golang/go/blob/38b2c06e144c6ea7087c575c76c66e41265ae0b7/src/net/dnsclient.go#L26C1-L51C1
-// The go source does not export this function so we copy it here.
-
-// reverseaddr returns the in-addr.arpa. or ip6.arpa. hostname of the IP
-// address addr suitable for rDNS (PTR) record lookup or an error if it fails
-// to parse the IP address.
-func reverseaddr(addr string) (string, error) {
-	ip := net.ParseIP(addr)
+// normalizeCIDR turns a bare IP address into a host-sized CIDR. Using
+// ip.String() for IPv4 also normalizes IPv4-mapped IPv6 addresses.
+func normalizeCIDR(cidr string) string {
+	ip := net.ParseIP(cidr)
 	if ip == nil {
-		return "", &net.DNSError{Err: "unrecognized address", Name: addr}
+		return cidr
 	}
 	if ip.To4() != nil {
-		return Uitoa(uint(ip[15])) + "." + Uitoa(uint(ip[14])) + "." + Uitoa(uint(ip[13])) + "." + Uitoa(uint(ip[12])) + ".in-addr.arpa.", nil
+		return ip.String() + "/32"
 	}
-	// Must be IPv6
-	buf := make([]byte, 0, len(ip)*4+len("ip6.arpa."))
-	// Add it, in reverse, to the buffer
-	for _, v := range slices.Backward(ip) {
-		buf = append(buf, hexDigit[v&0xF],
-			'.',
-			hexDigit[v>>4],
-			'.')
-	}
-	// Append "ip6.arpa." and return (buf already has the final .)
-	buf = append(buf, "ip6.arpa."...)
-	return string(buf), nil
+	return cidr + "/128"
 }
 
-const hexDigit = "0123456789abcdef"
+func classlessIPv4Name(base string, total, bits int) (string, bool) {
+	if total != 32 || bits < 25 || bits >= 32 {
+		return "", false
+	}
 
-func Uitoa(val uint) string {
-	return strconv.FormatInt(int64(val), 10)
+	parts := strings.SplitN(base, ".", 2)
+	return fmt.Sprintf("%s/%d.%s", parts[0], bits, parts[1]), true
+}
+
+func reverseNameTrimCount(total, bits int, cidr string) (int, error) {
+	switch total {
+	case 32:
+		if bits%8 != 0 {
+			return 0, fmt.Errorf("IPv4 mask must be multiple of 8 bits")
+		}
+		return (total - bits) / 8, nil
+	case 128:
+		if bits%4 != 0 {
+			return 0, fmt.Errorf("IPv6 mask must be multiple of 4 bits")
+		}
+		return (total - bits) / 4, nil
+	default:
+		return 0, fmt.Errorf("invalid address (not IPv4 or IPv6): %v", cidr)
+	}
 }

--- a/pkg/tlsutils/tlsconfig_test.go
+++ b/pkg/tlsutils/tlsconfig_test.go
@@ -110,7 +110,7 @@ func TestCreateTLSConfig(t *testing.T) {
 			func(actual *tls.Config, err error) {
 				require.NoError(t, err)
 				assert.Equal(t, "server-name", actual.ServerName)
-				assert.NotNil(t, actual.Certificates[0])
+				require.NotNil(t, actual.Certificates[0])
 				assert.False(t, actual.InsecureSkipVerify)
 				assert.Equal(t, actual.MinVersion, uint16(defaultMinVersion))
 			},
@@ -124,7 +124,7 @@ func TestCreateTLSConfig(t *testing.T) {
 			"",
 			"",
 			func(_ *tls.Config, err error) {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), "could not parse PEM certificates from")
 			},
 		},
@@ -137,7 +137,7 @@ func TestCreateTLSConfig(t *testing.T) {
 			"",
 			"server-name",
 			func(_ *tls.Config, err error) {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), "error reading /path/does/not/exist")
 			},
 		},
@@ -152,8 +152,8 @@ func TestCreateTLSConfig(t *testing.T) {
 			func(actual *tls.Config, err error) {
 				require.NoError(t, err)
 				assert.Equal(t, "server-name", actual.ServerName)
-				assert.NotNil(t, actual.Certificates[0])
-				assert.NotNil(t, actual.RootCAs)
+				require.NotNil(t, actual.Certificates[0])
+				require.NotNil(t, actual.RootCAs)
 				assert.False(t, actual.InsecureSkipVerify)
 			},
 		},

--- a/provider/aws/aws_fixtures_test.go
+++ b/provider/aws/aws_fixtures_test.go
@@ -23,6 +23,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
 )
@@ -42,7 +43,7 @@ func TestAWSRecordsV1(t *testing.T) {
 
 	ctx := t.Context()
 	z, err := provider.Zones(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, z, 3)
 }
 
@@ -57,7 +58,7 @@ func TestAWSZonesFilterWithTags(t *testing.T) {
 
 	ctx := t.Context()
 	z, err := provider.Zones(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, z, 24)
 	assert.Equal(t, 17, stub.calls["listtagsforresource"])
 }
@@ -84,7 +85,7 @@ func TestAWSZonesFiltersWithTags(t *testing.T) {
 				WithZoneTagFilters(tt.filters),
 			)
 			z, err := provider.Zones(t.Context())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Len(t, z, tt.want)
 			assert.Equal(t, tt.calls, stub.calls["listtagsforresource"])
 		})
@@ -100,7 +101,7 @@ func TestAWSZonesSecondRequestHitsTheCache(t *testing.T) {
 
 	ctx := t.Context()
 	_, err := provider.Zones(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
 	_, _ = provider.Zones(ctx)
 

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -2315,7 +2315,7 @@ func validateEndpoints(t *testing.T, provider *AWSProvider, endpoints []*endpoin
 	assert.True(t, testutils.SameEndpoints(endpoints, expected), "actual and expected endpoints don't match. %+v:%+v", endpoints, expected)
 
 	normalized, err := provider.AdjustEndpoints(endpoints)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, testutils.SameEndpoints(normalized, expected), "normalized and expected endpoints don't match. %+v:%+v", normalized, expected)
 }
 
@@ -2853,10 +2853,10 @@ func TestGeoProximityWithAWSRegion(t *testing.T) {
 			assert.Equal(t, tt.expectedSet, result.isSet)
 
 			if tt.expectedSet {
-				assert.NotNil(t, result.location.AWSRegion)
+				require.NotNil(t, result.location.AWSRegion)
 				assert.Equal(t, tt.expectedRegion, *result.location.AWSRegion)
 			} else {
-				assert.Nil(t, result.location.AWSRegion)
+				require.Nil(t, result.location.AWSRegion)
 			}
 
 			// Verify the method returns the same instance for chaining
@@ -2913,10 +2913,10 @@ func TestGeoProximityWithLocalZoneGroup(t *testing.T) {
 			assert.Equal(t, tt.expectedSet, result.isSet)
 
 			if tt.expectedSet {
-				assert.NotNil(t, result.location.LocalZoneGroup)
+				require.NotNil(t, result.location.LocalZoneGroup)
 				assert.Equal(t, tt.expectedLocalZoneGroup, *result.location.LocalZoneGroup)
 			} else {
-				assert.Nil(t, result.location.LocalZoneGroup)
+				require.Nil(t, result.location.LocalZoneGroup)
 			}
 
 			// Verify method returns same instance for chaining
@@ -3009,11 +3009,11 @@ func TestGeoProximityWithCoordinates(t *testing.T) {
 			assert.Equal(t, tt.expectedSet, result.isSet)
 
 			if tt.shouldHaveCoords {
-				assert.NotNil(t, result.location.Coordinates)
+				require.NotNil(t, result.location.Coordinates)
 				assert.Equal(t, tt.expectedLat, *result.location.Coordinates.Latitude)
 				assert.Equal(t, tt.expectedLong, *result.location.Coordinates.Longitude)
 			} else {
-				assert.Nil(t, result.location.Coordinates)
+				require.Nil(t, result.location.Coordinates)
 			}
 		})
 	}
@@ -3109,10 +3109,10 @@ func TestGeoProximityWithBias(t *testing.T) {
 			assert.Equal(t, tt.expectedSet, result.isSet)
 
 			if tt.expectedSet {
-				assert.NotNil(t, result.location.Bias)
+				require.NotNil(t, result.location.Bias)
 				assert.Equal(t, tt.expectedBias, *result.location.Bias)
 			} else {
-				assert.Nil(t, result.location.Bias)
+				require.Nil(t, result.location.Bias)
 			}
 
 			// Verify method returns same instance for chaining

--- a/provider/aws/aws_utils_test.go
+++ b/provider/aws/aws_utils_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
 	"github.com/goccy/go-yaml"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/provider"
@@ -147,9 +147,9 @@ func unmarshalZonesFixture(obj any, t *testing.T) {
 	t.Helper()
 	path, _ := os.Getwd()
 	file, err := os.Open(path + "/fixtures/160-plus-zones.yaml")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer file.Close()
 	dec := yaml.NewDecoder(file)
 	err = dec.Decode(obj)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/provider/aws/config_test.go
+++ b/provider/aws/config_test.go
@@ -51,7 +51,7 @@ func Test_newV2Config(t *testing.T) {
 		creds, err := cfg.Credentials.Retrieve(t.Context())
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "AKID2345", creds.AccessKeyID)
 		assert.Equal(t, "SECRET2", creds.SecretAccessKey)
 	})
@@ -69,7 +69,7 @@ func Test_newV2Config(t *testing.T) {
 		creds, err := cfg.Credentials.Retrieve(t.Context())
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "AKIAIOSFODNN7EXAMPLE", creds.AccessKeyID)
 		assert.Equal(t, "topsecret", creds.SecretAccessKey)
 	})
@@ -85,7 +85,7 @@ func Test_newV2Config(t *testing.T) {
 		require.NoError(t, err)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("should configure assume role credentials", func(t *testing.T) {

--- a/provider/aws/instrumented_config_test.go
+++ b/provider/aws/instrumented_config_test.go
@@ -42,12 +42,12 @@ func Test_GetInstrumentationMiddlewares(t *testing.T) {
 		// Check Initialize stage
 		timedOperationMiddleware, found := stack.Initialize.Get("timedOperation")
 		assert.True(t, found, "timedOperation middleware should be present in Initialize stage")
-		assert.NotNil(t, timedOperationMiddleware)
+		require.NotNil(t, timedOperationMiddleware)
 
 		// Check Deserialize stage
 		extractAWSRequestParametersMiddleware, found := stack.Deserialize.Get("extractAWSRequestParameters")
 		assert.True(t, found, "extractAWSRequestParameters middleware should be present in Deserialize stage")
-		assert.NotNil(t, extractAWSRequestParametersMiddleware)
+		require.NotNil(t, extractAWSRequestParametersMiddleware)
 	})
 }
 
@@ -69,7 +69,7 @@ func Test_InitializedTimedOperationMiddleware(t *testing.T) {
 	require.NoError(t, err)
 
 	requestMetrics := middleware.GetStackValue(mockInitializeHandler.CapturedContext, requestMetricsKey{}).(requestMetrics)
-	assert.NotNil(t, requestMetrics.StartTime)
+	require.NotNil(t, requestMetrics.StartTime)
 }
 
 type MockDeserializeHandler struct {

--- a/provider/awssd/aws_sd_test.go
+++ b/provider/awssd/aws_sd_test.go
@@ -201,14 +201,14 @@ func TestAWSSDProvider_ApplyChanges(t *testing.T) {
 	err := provider.ApplyChanges(ctx, &plan.Changes{
 		Create: expectedEndpoints,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// make sure services were created
 	assert.Len(t, api.services["private"], 3)
 	existingServices, _ := provider.ListServicesByNamespaceID(t.Context(), namespaces["private"].Id)
-	assert.NotNil(t, existingServices["service1"])
-	assert.NotNil(t, existingServices["service2"])
-	assert.NotNil(t, existingServices["service3"])
+	require.NotNil(t, existingServices["service1"])
+	require.NotNil(t, existingServices["service2"])
+	require.NotNil(t, existingServices["service3"])
 
 	// make sure instances were registered
 	endpoints, _ := provider.Records(ctx)
@@ -219,7 +219,7 @@ func TestAWSSDProvider_ApplyChanges(t *testing.T) {
 	err = provider.ApplyChanges(ctx, &plan.Changes{
 		Delete: expectedEndpoints,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// make sure all instances are gone
 	endpoints, _ = provider.Records(ctx)
@@ -269,7 +269,7 @@ func TestAWSSDProvider_ApplyChanges_Update(t *testing.T) {
 	// make sure services were created
 	assert.Len(t, api.services["private"], 1)
 	existingServices, _ := provider.ListServicesByNamespaceID(ctx, namespaces["private"].Id)
-	assert.NotNil(t, existingServices["service1"])
+	require.NotNil(t, existingServices["service1"])
 
 	// make sure instances were registered
 	endpoints, _ := provider.Records(ctx)
@@ -312,7 +312,7 @@ func TestAWSSDProvider_ApplyChanges_DottedServiceName(t *testing.T) {
 	assert.Len(t, api.services["dev-local"], 1)
 	existingServices, err := provider.ListServicesByNamespaceID(ctx, namespaces["dev-local"].Id)
 	require.NoError(t, err)
-	assert.NotNil(t, existingServices["my-app.elb"], "service should be named 'my-app.elb'")
+	require.NotNil(t, existingServices["my-app.elb"], "service should be named 'my-app.elb'")
 
 	// verify the record round-trips through Records()
 	endpoints, err := provider.Records(ctx)
@@ -461,7 +461,7 @@ func TestAWSSDProvider_CreateService(t *testing.T) {
 		RecordTTL:  60,
 		Targets:    endpoint.Targets{"1.2.3.4"},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expectedServices["A-srv"] = &sdtypes.Service{
 		Name:        aws.String("A-srv"),
@@ -485,7 +485,7 @@ func TestAWSSDProvider_CreateService(t *testing.T) {
 		RecordTTL:  60,
 		Targets:    endpoint.Targets{"::1234:5678:"},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	expectedServices["AAAA-srv"] = &sdtypes.Service{
 		Name:        aws.String("AAAA-srv"),
 		Description: aws.String("AAAA-srv"),
@@ -508,7 +508,7 @@ func TestAWSSDProvider_CreateService(t *testing.T) {
 		RecordTTL:  80,
 		Targets:    endpoint.Targets{"cname.target.com"},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	expectedServices["CNAME-srv"] = &sdtypes.Service{
 		Name:        aws.String("CNAME-srv"),
 		Description: aws.String("CNAME-srv"),
@@ -531,7 +531,7 @@ func TestAWSSDProvider_CreateService(t *testing.T) {
 		RecordTTL:  100,
 		Targets:    endpoint.Targets{"load-balancer.us-east-1.elb.amazonaws.com"},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	expectedServices["ALIAS-srv"] = &sdtypes.Service{
 		Name:        aws.String("ALIAS-srv"),
 		Description: aws.String("ALIAS-srv"),
@@ -573,9 +573,9 @@ func TestAWSSDProvider_CreateServiceDryRun(t *testing.T) {
 		RecordTTL:  60,
 		Targets:    endpoint.Targets{"1.2.3.4"},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.NotNil(t, service)
+	require.NotNil(t, service)
 	assert.Equal(t, "dry-run-service", *service.Name)
 }
 
@@ -604,8 +604,8 @@ func TestAWSSDProvider_CreateService_LabelNotSet(t *testing.T) {
 		Targets:    endpoint.Targets{"1.2.3.4"},
 	})
 
-	assert.NoError(t, err)
-	assert.NotNil(t, service)
+	require.NoError(t, err)
+	require.NotNil(t, service)
 	assert.Empty(t, *service.Description)
 }
 
@@ -648,7 +648,7 @@ func TestAWSSDProvider_UpdateService(t *testing.T) {
 		RecordTTL:  100,
 	})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, api.services["private"], 1)
 	assert.Equal(t, int64(100), *api.services["private"]["srv1"].DnsConfig.DnsRecords[0].TTL)
 }
@@ -693,7 +693,7 @@ func TestAWSSDProvider_UpdateService_DryRun(t *testing.T) {
 		RecordTTL:  100,
 	})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, api.services["private"], 1)
 	// records should not be updated
 	assert.NotEqual(t, 100, api.services["private"]["srv1"].DnsConfig.DnsRecords[0].TTL)
@@ -747,17 +747,17 @@ func TestAWSSDProvider_DeleteService(t *testing.T) {
 
 	// delete first service
 	err := provider.DeleteService(t.Context(), services["private"]["srv1"])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, api.services["private"], 3)
 
 	// delete third service
 	err = provider.DeleteService(t.Context(), services["private"]["srv3"])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, api.services["private"], 2)
 
 	// delete service with no description
 	err = provider.DeleteService(t.Context(), services["private"]["srv4"])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expected := map[string]*sdtypes.Service{
 		"srv2": {
@@ -808,7 +808,7 @@ func TestAWSSDProvider_DeleteServiceEmptyDescription_Logging(t *testing.T) {
 
 	// delete service
 	err := provider.DeleteService(t.Context(), services["private"]["srv1"])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, api.services["private"], 1)
 
 	logtest.TestHelperLogContainsWithLogLevel("Skipping service removal \"service1\" because owner id (service.Description) not set, when should be", log.DebugLevel, logs, t)
@@ -844,7 +844,7 @@ func TestAWSSDProvider_DeleteServiceDryRun(t *testing.T) {
 
 	// delete first service
 	err := provider.DeleteService(t.Context(), services["private"]["srv1"])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, api.services["private"], 1)
 }
 
@@ -928,7 +928,7 @@ func TestAWSSDProvider_RegisterInstance(t *testing.T) {
 		RecordTTL:  300,
 		Targets:    endpoint.Targets{"1.2.3.4", "1.2.3.5"},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	expectedInstances["1.2.3.4"] = &sdtypes.Instance{
 		Id: aws.String("1.2.3.4"),
 		Attributes: map[string]string{
@@ -949,7 +949,7 @@ func TestAWSSDProvider_RegisterInstance(t *testing.T) {
 		RecordTTL:  300,
 		Targets:    endpoint.Targets{"load-balancer.us-east-1.elb.amazonaws.com", "load-balancer.us-west-2.elb.amazonaws.com"},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	expectedInstances["load-balancer.us-east-1.elb.amazonaws.com"] = &sdtypes.Instance{
 		Id: aws.String("load-balancer.us-east-1.elb.amazonaws.com"),
 		Attributes: map[string]string{

--- a/provider/blueprint/zone_cache_test.go
+++ b/provider/blueprint/zone_cache_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestZoneCache_SliceCache(t *testing.T) {
@@ -69,7 +70,7 @@ func TestZoneCache_CachingDisabled(t *testing.T) {
 	// Should still be expired because caching is disabled
 	assert.True(t, cache.Expired())
 	// Data should not be stored
-	assert.Nil(t, cache.Get())
+	require.Nil(t, cache.Get())
 }
 
 func TestZoneCache_Expiration_Synctest(t *testing.T) {
@@ -146,7 +147,7 @@ func TestZoneCache_ThreadSafety(t *testing.T) {
 
 	// After all writes complete, cache should have valid final state
 	finalData := cache.Get()
-	assert.NotNil(t, finalData, "cache should have data after writes")
+	require.NotNil(t, finalData, "cache should have data after writes")
 	assert.Len(t, finalData, 2, "final data should have 2 elements")
 	assert.False(t, cache.Expired(), "cache should not be expired")
 }

--- a/provider/cached_provider_test.go
+++ b/provider/cached_provider_test.go
@@ -99,7 +99,7 @@ func TestNewCachedProvider(t *testing.T) {
 	cp := NewCachedProvider(inner, delay)
 	assert.Equal(t, inner, cp.Provider)
 	assert.Equal(t, delay, cp.RefreshDelay)
-	assert.Nil(t, cp.cache)
+	require.Nil(t, cp.cache)
 	assert.True(t, cp.lastRead.IsZero())
 }
 
@@ -111,7 +111,7 @@ func TestCachedProviderRecordsError(t *testing.T) {
 	cp := NewCachedProvider(testProvider, 0)
 	_, err := cp.Records(t.Context())
 	require.ErrorIs(t, err, assert.AnError)
-	assert.Nil(t, cp.cache)
+	require.Nil(t, cp.cache)
 }
 
 func TestCachedProviderCallsProviderOnFirstCall(t *testing.T) {
@@ -123,7 +123,7 @@ func TestCachedProviderCallsProviderOnFirstCall(t *testing.T) {
 		Provider: testProvider,
 	}
 	endpoints, err := provider.Records(t.Context())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, endpoints)
 	require.Len(t, endpoints, 1)
 	require.NotNil(t, endpoints[0])
@@ -145,7 +145,7 @@ func TestCachedProviderUsesCacheWhileValid(t *testing.T) {
 	t.Run("With consecutive calls within the caching time frame", func(t *testing.T) {
 		testProvider.records = recordsNotCalled(t)
 		endpoints, err := provider.Records(t.Context())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		require.NotNil(t, endpoints)
 		require.Len(t, endpoints, 1)
 		require.NotNil(t, endpoints[0])
@@ -158,7 +158,7 @@ func TestCachedProviderUsesCacheWhileValid(t *testing.T) {
 		}
 		provider.lastRead = time.Now().Add(-20 * time.Minute)
 		endpoints, err := provider.Records(t.Context())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		require.NotNil(t, endpoints)
 		require.Len(t, endpoints, 1)
 		require.NotNil(t, endpoints[0])
@@ -184,7 +184,7 @@ func TestCachedProviderForcesCacheRefreshOnUpdate(t *testing.T) {
 			return nil
 		}
 		err := provider.ApplyChanges(t.Context(), &plan.Changes{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		t.Run("Next call to Records is cached", func(t *testing.T) {
 			testProvider.applyChanges = applyChangesNotCalled(t)
 			testProvider.records = func(_ context.Context) ([]*endpoint.Endpoint, error) {
@@ -192,7 +192,7 @@ func TestCachedProviderForcesCacheRefreshOnUpdate(t *testing.T) {
 			}
 			endpoints, err := provider.Records(t.Context())
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			require.NotNil(t, endpoints)
 			require.Len(t, endpoints, 1)
 			require.NotNil(t, endpoints[0])
@@ -210,7 +210,7 @@ func TestCachedProviderForcesCacheRefreshOnUpdate(t *testing.T) {
 				{DNSName: "hello.world"},
 			},
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		t.Run("Next call to Records is not cached", func(t *testing.T) {
 			testProvider.applyChanges = applyChangesNotCalled(t)
 			testProvider.records = func(_ context.Context) ([]*endpoint.Endpoint, error) {
@@ -218,7 +218,7 @@ func TestCachedProviderForcesCacheRefreshOnUpdate(t *testing.T) {
 			}
 			endpoints, err := provider.Records(t.Context())
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			require.NotNil(t, endpoints)
 			require.Len(t, endpoints, 1)
 			require.NotNil(t, endpoints[0])

--- a/provider/civo/civo_test.go
+++ b/provider/civo/civo_test.go
@@ -43,7 +43,7 @@ func TestNewProvider(t *testing.T) {
 
 func TestNewCivoProviderNoToken(t *testing.T) {
 	_, err := newProvider(endpoint.NewDomainFilter([]string{"test.civo.com"}), true)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	assert.Equal(t, "no token found", err.Error())
 }
@@ -61,10 +61,10 @@ func TestCivoProviderZones(t *testing.T) {
 	}
 
 	expected, err := client.ListDNSDomains()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	zones, err := provider.Zones(t.Context())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check if the return is a DNSDomain type
 	assert.ElementsMatch(t, zones, expected)
@@ -80,7 +80,7 @@ func TestCivoProviderZonesWithError(t *testing.T) {
 	}
 
 	_, err := provider.Zones(t.Context())
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestCivoProviderRecords(t *testing.T) {
@@ -115,10 +115,10 @@ func TestCivoProviderRecords(t *testing.T) {
 	}
 
 	expected, err := client.ListDNSRecords("12345")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	records, err := provider.Records(t.Context())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, strings.TrimSuffix(records[0].DNSName, ".example.com"), expected[0].Name)
 	assert.Equal(t, records[0].RecordType, string(expected[0].Type))
@@ -159,11 +159,11 @@ func TestCivoProviderRecordsWithError(t *testing.T) {
 	}
 
 	_, err := client.ListDNSRecords("12345")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	endpoint, err := provider.Records(t.Context())
-	assert.Error(t, err)
-	assert.Nil(t, endpoint)
+	require.Error(t, err)
+	require.Nil(t, endpoint)
 
 }
 
@@ -182,7 +182,7 @@ func TestCivoProviderWithoutRecords(t *testing.T) {
 	}
 
 	records, err := provider.Records(t.Context())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Empty(t, records)
 }
@@ -650,7 +650,7 @@ func TestCivoApplyChanges(t *testing.T) {
 	changes.UpdateOld = []*endpoint.Endpoint{{DNSName: "foobar.ext-dns-test.example.de", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"target-old"}}}
 	changes.UpdateNew = []*endpoint.Endpoint{{DNSName: "foobar.ext-dns-test.foo.com", Targets: endpoint.Targets{"target-new"}, RecordType: endpoint.RecordTypeCNAME, RecordTTL: 100}}
 	err := provider.ApplyChanges(t.Context(), changes)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestCivoApplyChangesError(t *testing.T) {
@@ -771,10 +771,10 @@ func TestCivoProviderFetchRecords(t *testing.T) {
 	}
 
 	expected, err := client.ListDNSRecords("12345")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	actual, err := provider.fetchRecords("12345")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.ElementsMatch(t, expected, actual)
 }
@@ -793,7 +793,7 @@ func TestCivoProviderFetchRecordsWithError(t *testing.T) {
 	}
 
 	_, err := provider.fetchRecords("235698")
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestCivo_getStrippedRecordName(t *testing.T) {
@@ -986,7 +986,7 @@ func TestCivo_submitChangesCreate(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			err := provider.submitChanges(*c.changes)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -1021,7 +1021,7 @@ func TestCivo_submitChangesDelete(t *testing.T) {
 	}
 
 	err := provider.submitChanges(changes)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestCivoChangesEmpty(t *testing.T) {

--- a/provider/cloudflare/cloudflare_batch_test.go
+++ b/provider/cloudflare/cloudflare_batch_test.go
@@ -431,10 +431,10 @@ func TestChunkBatchChanges(t *testing.T) {
 
 func TestTagsFromResponse(t *testing.T) {
 	t.Run("nil input returns nil", func(t *testing.T) {
-		assert.Nil(t, tagsFromResponse(nil))
+		require.Nil(t, tagsFromResponse(nil))
 	})
 	t.Run("non-string-slice returns nil", func(t *testing.T) {
-		assert.Nil(t, tagsFromResponse(42))
+		require.Nil(t, tagsFromResponse(42))
 	})
 	t.Run("string slice is returned unchanged", func(t *testing.T) {
 		tags := []string{"tag1", "tag2"}
@@ -598,7 +598,7 @@ func TestBuildBatchPutParam(t *testing.T) {
 		r.Content = "0 issue letsencrypt.org"
 		param, ok := buildBatchPutParam("id-caa", r)
 		assert.False(t, ok)
-		assert.Nil(t, param)
+		require.Nil(t, param)
 	})
 }
 

--- a/provider/cloudflare/cloudflare_custom_hostnames_test.go
+++ b/provider/cloudflare/cloudflare_custom_hostnames_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cloudflare/cloudflare-go/v7/dns"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	logtest "sigs.k8s.io/external-dns/internal/testutils/log"
@@ -124,7 +125,7 @@ func TestCloudflareCustomHostnameOperations(t *testing.T) {
 
 			endpoints, err := provider.AdjustEndpoints(tc.Endpoints)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			plan := &plan.Plan{
 				Current:        records,
 				Desired:        endpoints,
@@ -259,7 +260,7 @@ func TestCloudflareDisabledCustomHostnameOperations(t *testing.T) {
 
 			endpoints, err := provider.AdjustEndpoints(tc.Endpoints)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			plan := &plan.Plan{
 				Current:        records,
 				Desired:        endpoints,
@@ -360,7 +361,7 @@ func TestCloudflareCustomHostnameNotFoundOnRecordDeletion(t *testing.T) {
 
 			endpoints, err := provider.AdjustEndpoints(tc.Endpoints)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			plan := &plan.Plan{
 				Current:        records,
 				Desired:        endpoints,
@@ -445,7 +446,7 @@ func TestCloudflareListCustomHostnamesWithPagionation(t *testing.T) {
 
 	endpoints, err := provider.AdjustEndpoints(generatedEndpoints)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	plan := &plan.Plan{
 		Current:        records,
 		Desired:        endpoints,

--- a/provider/cloudflare/cloudflare_regional_test.go
+++ b/provider/cloudflare/cloudflare_regional_test.go
@@ -726,9 +726,9 @@ func Test_desiredDataLocalizationRegionalHostnames(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := desiredRegionalHostnames(tt.changes)
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			sort.Slice(got, func(i, j int) bool {
 				return got[i].hostname < got[j].hostname
@@ -834,7 +834,7 @@ func TestRecordsWithListRegionalHostnameFaillure(t *testing.T) {
 		RegionalServicesConfig: RegionalServicesConfig{Enabled: true},
 	}
 	_, err := failingProvider.Records(t.Context())
-	assert.Error(t, err, "listing regional hostnames should fail")
+	require.Error(t, err, "listing regional hostnames should fail")
 }
 
 func TestApplyChangesWithRegionalHostnamesFaillures(t *testing.T) {
@@ -1026,7 +1026,7 @@ func TestApplyChangesWithRegionalHostnamesFaillures(t *testing.T) {
 			}
 			hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
 			err := p.ApplyChanges(t.Context(), tt.args.changes)
-			assert.Error(t, err, "ApplyChanges should return an error")
+			require.Error(t, err, "ApplyChanges should return an error")
 			if tt.errMsg != "" && err != nil {
 				assert.Contains(t, err.Error(), tt.errMsg, "Expected error message to contain: %s", tt.errMsg)
 			}
@@ -1175,7 +1175,7 @@ func TestApplyChangesWithRegionalHostnamesDryRun(t *testing.T) {
 			}
 			hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
 			err := p.ApplyChanges(t.Context(), tt.args.changes)
-			assert.NoError(t, err, "ApplyChanges should not fail")
+			require.NoError(t, err, "ApplyChanges should not fail")
 			if tt.expectDebug != "" {
 				logtest.TestHelperLogContains(tt.expectDebug, hook, t)
 			}
@@ -1272,7 +1272,7 @@ func TestCloudflareAdjustEndpointsRegionalServices(t *testing.T) {
 			}
 
 			adjustedEndpoints, err := provider.AdjustEndpoints([]*endpoint.Endpoint{testEndpoint})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Len(t, adjustedEndpoints, 1)
 
 			regionKey, exists := adjustedEndpoints[0].GetProviderSpecificProperty(annotations.CloudflareRegionKey)

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -369,7 +369,7 @@ func AssertActions(t *testing.T, provider *CloudFlareProvider, endpoints []*endp
 	}
 
 	endpoints, err = provider.AdjustEndpoints(endpoints)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	domainFilter := endpoint.NewDomainFilter([]string{"bar.com"})
 	plan := &plan.Plan{
 		Current:        records,
@@ -942,7 +942,7 @@ func TestGetDNSRecordsMapWithPerPage(t *testing.T) {
 			DNSRecordsConfig: DNSRecordsConfig{PerPage: 100},
 		}
 		_, err := provider.getDNSRecordsMap(ctx, "001")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, client.dnsRecordsListParams.PerPage.Present)
 		assert.InEpsilon(t, float64(100), client.dnsRecordsListParams.PerPage.Value, 0.0001)
 	})
@@ -953,7 +953,7 @@ func TestGetDNSRecordsMapWithPerPage(t *testing.T) {
 			DNSRecordsConfig: DNSRecordsConfig{},
 		}
 		_, err := provider.getDNSRecordsMap(ctx, "001")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.False(t, client.dnsRecordsListParams.PerPage.Present)
 	})
 }
@@ -1544,7 +1544,7 @@ func TestGroupByNameAndTypeWithCustomHostnames_MX(t *testing.T) {
 	ctx := t.Context()
 	chs := customHostnamesMap{}
 	records, err := provider.getDNSRecordsMap(ctx, "001")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	endpoints := provider.groupByNameAndTypeWithCustomHostnames(records, chs)
 	assert.Len(t, endpoints, 1)
@@ -1708,7 +1708,7 @@ func TestProviderPropertiesIdempotency(t *testing.T) {
 			}
 
 			desired, err = provider.AdjustEndpoints(desired)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			plan := plan.Plan{
 				Current:        current,
@@ -1778,7 +1778,7 @@ func TestCloudflareComplexUpdate(t *testing.T) {
 			},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	plan := &plan.Plan{
 		Current:        records,
 		Desired:        endpoints,
@@ -1899,7 +1899,7 @@ func TestCloudFlareProvider_Region(t *testing.T) {
 		CustomHostnamesConfig{Enabled: false},
 		DNSRecordsConfig{PerPage: 50, Comment: ""},
 	)
-	assert.NoError(t, err, "should not fail to create provider")
+	require.NoError(t, err, "should not fail to create provider")
 	assert.True(t, provider.RegionalServicesConfig.Enabled, "expect regional services to be enabled")
 	assert.Equal(t, "us", provider.RegionalServicesConfig.RegionKey, "expected region key to be 'us'")
 }
@@ -2011,7 +2011,7 @@ func TestCloudFlareProvider_newCloudFlareChange(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			change, err := test.provider.newCloudFlareChange(cloudFlareCreate, test.endpoint, test.endpoint.Targets[0], nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if len(change.ResourceRecord.Comment) != test.expected {
 				t.Errorf("expected comment to be %d characters long, but got %d", test.expected, len(change.ResourceRecord.Comment))
 			}
@@ -2483,7 +2483,7 @@ func TestCloudflareApplyChanges_AllErrorLogPaths(t *testing.T) {
 			}
 			hook.Reset()
 			err := provider.ApplyChanges(t.Context(), tc.changes)
-			assert.NoError(t, err, "ApplyChanges should not return error for newCloudFlareChange error (it should log and continue)")
+			require.NoError(t, err, "ApplyChanges should not return error for newCloudFlareChange error (it should log and continue)")
 			errorLogCount := 0
 			for _, entry := range hook.Entries {
 				if entry.Level == log.ErrorLevel &&
@@ -2571,7 +2571,7 @@ func TestCloudflareZoneChanges(t *testing.T) {
 
 	// Test zone listing and filtering
 	zones, err := cfProvider.Zones(t.Context())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, zones, 2)
 
 	// Verify zone names
@@ -2590,7 +2590,7 @@ func TestCloudflareZoneChanges(t *testing.T) {
 	}
 
 	filteredZones, err := providerWithZoneFilter.Zones(t.Context())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, filteredZones, 1)
 	assert.Equal(t, "bar.com", filteredZones[0].Name) // zone 001 is bar.com
 	assert.Equal(t, "001", filteredZones[0].ID)
@@ -2631,9 +2631,9 @@ func TestCloudflareZoneErrors(t *testing.T) {
 	}
 
 	zones, err := cfProvider.Zones(t.Context())
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to list zones")
-	assert.Nil(t, zones)
+	require.Nil(t, zones)
 
 	// Test get zone error
 	client.listZonesError = nil
@@ -2641,8 +2641,8 @@ func TestCloudflareZoneErrors(t *testing.T) {
 
 	// This should still work for listing but fail when getting individual zones
 	zones, err = cfProvider.Zones(t.Context())
-	assert.NoError(t, err) // List works, individual gets may fail internally
-	assert.NotNil(t, zones)
+	require.NoError(t, err) // List works, individual gets may fail internally
+	require.NotNil(t, zones)
 }
 
 func TestCloudflareZoneFiltering(t *testing.T) {
@@ -2656,7 +2656,7 @@ func TestCloudflareZoneFiltering(t *testing.T) {
 	}
 
 	zones, err := cfProvider.Zones(t.Context())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, zones, 1)
 	assert.Equal(t, "foo.com", zones[0].Name)
 
@@ -2668,7 +2668,7 @@ func TestCloudflareZoneFiltering(t *testing.T) {
 	}
 
 	filteredZones, err := providerWithIDFilter.Zones(t.Context())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, filteredZones, 1)
 	assert.Equal(t, "foo.com", filteredZones[0].Name) // zone 002 is foo.com
 	assert.Equal(t, "002", filteredZones[0].ID)
@@ -2714,7 +2714,7 @@ func TestCloudflareChangesByZone(t *testing.T) {
 	}
 
 	zones, err := cfProvider.Zones(t.Context())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, zones, 2)
 
 	// Test empty changes
@@ -2864,7 +2864,7 @@ func TestConvertCloudflareError(t *testing.T) {
 			result := convertCloudflareError(tt.inputError)
 
 			if tt.expectSoftError {
-				assert.ErrorIs(t, result, provider.SoftError,
+				require.ErrorIs(t, result, provider.SoftError,
 					"Expected soft error for %s: %s", tt.name, tt.description)
 
 				// Verify error message preservation for all errors now that newCloudflareError
@@ -2872,7 +2872,7 @@ func TestConvertCloudflareError(t *testing.T) {
 				assert.Contains(t, result.Error(), tt.inputError.Error(),
 					"Original error message should be preserved")
 			} else {
-				assert.NotErrorIs(t, result, provider.SoftError,
+				require.NotErrorIs(t, result, provider.SoftError,
 					"Expected non-soft error for %s: %s", tt.name, tt.description)
 				assert.Equal(t, tt.inputError, result,
 					"Non-soft errors should be returned unchanged")
@@ -2968,7 +2968,7 @@ func TestConvertCloudflareErrorInContext(t *testing.T) {
 			}
 
 			err := tt.function(p)
-			assert.Error(t, err, "Expected an error from %s", tt.name)
+			require.Error(t, err, "Expected an error from %s", tt.name)
 
 			if tt.expectSoftError {
 				assert.ErrorIs(t, err, provider.SoftError,
@@ -3018,7 +3018,7 @@ func TestZoneIDByNameIteratorError(t *testing.T) {
 
 	// Should return empty zone ID and the wrapped iterator error
 	assert.Empty(t, zoneID)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to list zones from CloudFlare API")
 	assert.Contains(t, err.Error(), "CloudFlare API connection timeout")
 }
@@ -3037,7 +3037,7 @@ func TestZoneIDByNameZoneNotFound(t *testing.T) {
 
 	// Should return empty zone ID and the improved error message
 	assert.Empty(t, zoneID)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), `zone "nonexistent.com" not found in CloudFlare account`)
 	assert.Contains(t, err.Error(), "verify the zone exists and API credentials have access to it")
 }
@@ -3190,7 +3190,7 @@ func TestZoneService(t *testing.T) {
 	t.Run("GetZone", func(t *testing.T) {
 		t.Parallel()
 		zone, err := client.GetZone(ctx, zoneID)
-		assert.Nil(t, zone)
+		require.Nil(t, zone)
 		assert.ErrorIs(t, err, context.Canceled)
 	})
 

--- a/provider/coredns/coredns_test.go
+++ b/provider/coredns/coredns_test.go
@@ -155,8 +155,8 @@ func TestEtcdHttpsProtocol(t *testing.T) {
 	testutils.TestHelperEnvSetter(t, envs)
 
 	cfg, err := getETCDConfig()
-	assert.NoError(t, err)
-	assert.NotNil(t, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
 }
 
 func TestEtcdHttpsIncorrectConfigError(t *testing.T) {
@@ -648,7 +648,7 @@ func TestGetServices_Success(t *testing.T) {
 	}
 
 	result, err := c.GetServices(t.Context(), "/prefix")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, "example.com", result[0].Host)
 }
@@ -680,7 +680,7 @@ func TestGetServices_Duplicate(t *testing.T) {
 		}, nil)
 
 	result, err := c.GetServices(t.Context(), "/prefix")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, result, 1)
 }
 
@@ -714,7 +714,7 @@ func TestGetServices_Multiple(t *testing.T) {
 		}, nil)
 
 	result, err := c.GetServices(t.Context(), "/prefix")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, result, 2)
 	assert.Equal(t, priority, result[1].Priority)
 }
@@ -758,7 +758,7 @@ func TestGetServices_FilterOutOtherServicesOwnerSetButNothingChanged(t *testing.
 		}, nil)
 
 	result, err := c.GetServices(t.Context(), "/prefix")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, result, 3)
 }
 
@@ -801,7 +801,7 @@ func TestGetServices_FilterOutOtherServicesWithStrictlyOwned(t *testing.T) {
 		}, nil)
 
 	result, err := c.GetServices(t.Context(), "/prefix")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, "owner", result[0].Owner)
 }
@@ -829,7 +829,7 @@ func TestGetServices_UnmarshalError(t *testing.T) {
 		}, nil)
 
 	_, err := c.GetServices(t.Context(), "/prefix")
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "/prefix/1")
 }
 
@@ -845,8 +845,8 @@ func TestGetServices_GetError(t *testing.T) {
 		Return(&etcdcv3.GetResponse{}, errors.New("etcd failure"))
 
 	_, err := c.GetServices(t.Context(), "/prefix")
-	assert.Error(t, err)
-	assert.EqualError(t, err, "etcd failure")
+	require.Error(t, err)
+	require.EqualError(t, err, "etcd failure")
 }
 
 func TestDeleteService(t *testing.T) {
@@ -1279,9 +1279,9 @@ func TestSaveService(t *testing.T) {
 
 			err = c.SaveService(t.Context(), tt.service)
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			mockKV.AssertExpectations(t)
 		})
@@ -1318,7 +1318,7 @@ func TestNewProvider(t *testing.T) {
 			provider, err := newProvider(&endpoint.DomainFilter{}, "/prefix/", "", false, false)
 			if tt.wantErr {
 				require.Error(t, err)
-				assert.EqualError(t, err, tt.errMsg)
+				require.EqualError(t, err, tt.errMsg)
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, provider)
@@ -1370,7 +1370,7 @@ func TestFindEp(t *testing.T) {
 			if ok {
 				assert.Equal(t, tt.dnsName, got.DNSName)
 			} else {
-				assert.Nil(t, got)
+				require.Nil(t, got)
 			}
 		})
 	}

--- a/provider/dnsimple/dnsimple_test.go
+++ b/provider/dnsimple/dnsimple_test.go
@@ -161,17 +161,17 @@ func testDnsimpleProviderZones(t *testing.T) {
 	ctx := t.Context()
 	mockProvider.accountID = "1"
 	result, err := mockProvider.Zones(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	validateDnsimpleZones(t, result, dnsimpleListZonesResponse.Data)
 
 	mockProvider.accountID = "2"
 	_, err = mockProvider.Zones(ctx)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	mockProvider.accountID = "3"
 	t.Setenv("DNSIMPLE_ZONES", "example-from-env.com")
 	result, err = mockProvider.Zones(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	validateDnsimpleZones(t, result, dnsimpleListZonesFromEnvResponse.Data)
 
 	mockProvider.accountID = "2"
@@ -285,7 +285,7 @@ func testDnsimpleProviderRecords(t *testing.T) {
 
 			result, err := p.Records(t.Context())
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				mockDNS.AssertExpectations(t)
 				return
 			}
@@ -465,11 +465,11 @@ func testDnsimpleGetRecordID(t *testing.T) {
 
 	mockProvider.accountID = "1"
 	result, err = mockProvider.GetRecordID(t.Context(), "example.com", "example", "CNAME")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, int64(2), result)
 
 	result, err = mockProvider.GetRecordID(t.Context(), "example.com", "example-beta", "A")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, int64(1), result)
 }
 

--- a/provider/exoscale/exoscale_test.go
+++ b/provider/exoscale/exoscale_test.go
@@ -26,6 +26,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
@@ -155,14 +156,14 @@ func TestExoscaleGetRecords(t *testing.T) {
 		assert.False(t, contains(recs, "v3.bar.com"))
 		assert.False(t, contains(recs, "v1.foobar.com"))
 	} else {
-		assert.Error(t, err)
+		require.Error(t, err)
 	}
 }
 
 func TestExoscaleGetRecordsApex(t *testing.T) {
 	provider := NewExoscaleProviderWithClient(&ExoscaleClientApexStub{}, false, 0)
 	recs, err := provider.Records(t.Context())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, recs, 1)
 	// Apex record must appear as the bare zone name, not ".apex.com"
 	assert.True(t, contains(recs, "apex.com"))
@@ -225,7 +226,7 @@ func TestExoscaleApplyChangesApex(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, provider.ApplyChanges(t.Context(), changes))
+	require.NoError(t, provider.ApplyChanges(t.Context(), changes))
 
 	assert.Len(t, createExoscale, 1)
 	assert.Equal(t, v3.UUID(domainIDs[4]), createExoscale[0].domainID)
@@ -420,7 +421,7 @@ func TestExoscaleGetDomainFilter(t *testing.T) {
 		provider := NewExoscaleProviderWithClient(&errListDomainsStub{}, false, 0)
 		filter := provider.GetDomainFilter()
 		// empty filter matches nothing specific; getting a DomainFilter back is enough
-		assert.NotNil(t, filter)
+		require.NotNil(t, filter)
 	})
 }
 
@@ -439,7 +440,7 @@ func TestExoscaleApplyChangesDryRun(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, provider.ApplyChanges(t.Context(), changes))
+	require.NoError(t, provider.ApplyChanges(t.Context(), changes))
 	// dryRun: nothing should be sent to the API
 	assert.Empty(t, createExoscale)
 	assert.Empty(t, deleteExoscale)
@@ -463,7 +464,7 @@ func TestExoscaleApplyChangesWithTTL(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, provider.ApplyChanges(t.Context(), changes))
+	require.NoError(t, provider.ApplyChanges(t.Context(), changes))
 	assert.Len(t, createExoscale, 1)
 	assert.Equal(t, int64(300), createExoscale[0].req.Ttl)
 	assert.Len(t, updateExoscale, 1)
@@ -477,19 +478,19 @@ func TestExoscaleApplyChangesZonesError(t *testing.T) {
 			{DNSName: "v1.foo.com", RecordType: "A", Targets: []string{"1.2.3.4"}},
 		},
 	}
-	assert.Error(t, provider.ApplyChanges(t.Context(), changes))
+	require.Error(t, provider.ApplyChanges(t.Context(), changes))
 }
 
 func TestExoscaleRecordsZonesError(t *testing.T) {
 	provider := NewExoscaleProviderWithClient(&errListDomainsStub{}, false, 0)
 	_, err := provider.Records(t.Context())
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestExoscaleRecordsListRecordsError(t *testing.T) {
 	provider := NewExoscaleProviderWithClient(&errListRecordsStub{}, false, 0)
 	_, err := provider.Records(t.Context())
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestExoscaleZoneCacheHit(t *testing.T) {
@@ -501,10 +502,10 @@ func TestExoscaleZoneCacheHit(t *testing.T) {
 	)
 	// first call populates the cache
 	recs1, err := provider.Records(t.Context())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// second call hits the cache
 	recs2, err := provider.Records(t.Context())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, recs2, len(recs1))
 }
 

--- a/provider/factory/provider_test.go
+++ b/provider/factory/provider_test.go
@@ -122,8 +122,8 @@ func TestSelectProvider(t *testing.T) {
 			p, err := Select(t.Context(), tt.cfg, domainFilter)
 
 			if tt.expectedError != "" {
-				assert.Error(t, err)
-				assert.ErrorContains(t, err, tt.expectedError)
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.expectedError)
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, p)

--- a/provider/godaddy/client_test.go
+++ b/provider/godaddy/client_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 )
 
@@ -58,15 +59,14 @@ func TestClient_DoWhenQuotaExceeded(t *testing.T) {
 	}
 
 	resp, err := client.Do(req)
-	assert.NoError(err, "A CODE_EXCEEDED response should not return an error")
+	require.NoError(t, err, "A CODE_EXCEEDED response should not return an error")
 	assert.Equal(http.StatusTooManyRequests, resp.StatusCode, "Expected a 429 response")
 
 	respContents := GDErrorResponse{}
 	err = client.UnmarshalResponse(resp, &respContents)
-	if assert.Error(err) {
-		var apiErr *APIError
-		errors.As(err, &apiErr)
-		assert.Equal("QUOTA_EXCEEDED", apiErr.Code)
-		assert.Equal("rate limit exceeded", apiErr.Message)
-	}
+	require.Error(t, err)
+	var apiErr *APIError
+	errors.As(err, &apiErr)
+	assert.Equal("QUOTA_EXCEEDED", apiErr.Code)
+	assert.Equal("rate limit exceeded", apiErr.Message)
 }

--- a/provider/godaddy/godaddy_test.go
+++ b/provider/godaddy/godaddy_test.go
@@ -117,7 +117,7 @@ func TestGoDaddyZones(t *testing.T) {
 
 	domains, err := provider.zones()
 
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.Contains(domains, "example.com")
 	assert.NotContains(domains, "example.net")
 
@@ -126,8 +126,8 @@ func TestGoDaddyZones(t *testing.T) {
 	// Error on getting zones
 	client.On("Get", domainsURI).Return(nil, ErrAPIDown).Once()
 	domains, err = provider.zones()
-	assert.Error(err)
-	assert.Nil(domains)
+	require.Error(t, err)
+	require.Nil(t, domains)
 	client.AssertExpectations(t)
 }
 
@@ -162,7 +162,7 @@ func TestGoDaddyZoneRecords(t *testing.T) {
 
 	zones, records, err := provider.zonesRecords(t.Context(), true)
 
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	assert.ElementsMatch(zones, []string{
 		zoneNameExampleNet,
@@ -193,9 +193,9 @@ func TestGoDaddyZoneRecords(t *testing.T) {
 	// Error on getting zones list
 	client.On("Get", domainsURI).Return(nil, ErrAPIDown).Once()
 	zones, records, err = provider.zonesRecords(t.Context(), false)
-	assert.Error(err)
-	assert.Nil(zones)
-	assert.Nil(records)
+	require.Error(t, err)
+	require.Nil(t, zones)
+	require.Nil(t, records)
 	client.AssertExpectations(t)
 
 	// Error on getting zone records
@@ -209,9 +209,9 @@ func TestGoDaddyZoneRecords(t *testing.T) {
 
 	zones, records, err = provider.zonesRecords(t.Context(), false)
 
-	assert.Error(err)
-	assert.Nil(zones)
-	assert.Nil(records)
+	require.Error(t, err)
+	require.Nil(t, zones)
+	require.Nil(t, records)
 	client.AssertExpectations(t)
 
 	// Error on getting zone record detail
@@ -224,9 +224,9 @@ func TestGoDaddyZoneRecords(t *testing.T) {
 	client.On("Get", "/v1/domains/example.net/records").Return(nil, ErrAPIDown).Once()
 
 	zones, records, err = provider.zonesRecords(t.Context(), false)
-	assert.Error(err)
-	assert.Nil(zones)
-	assert.Nil(records)
+	require.Error(t, err)
+	require.Nil(t, zones)
+	require.Nil(t, records)
 	client.AssertExpectations(t)
 }
 
@@ -278,7 +278,7 @@ func TestGoDaddyRecords(t *testing.T) {
 	}, nil).Once()
 
 	endpoints, err := provider.Records(t.Context())
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	// Little fix for multi targets endpoint
 	for _, endpoint := range endpoints {
@@ -321,13 +321,12 @@ func TestGoDaddyRecords(t *testing.T) {
 	// Error getting zone
 	client.On("Get", domainsURI).Return(nil, ErrAPIDown).Once()
 	endpoints, err = provider.Records(t.Context())
-	assert.Error(err)
-	assert.Nil(endpoints)
+	require.Error(t, err)
+	require.Nil(t, endpoints)
 	client.AssertExpectations(t)
 }
 
 func TestGoDaddyChange(t *testing.T) {
-	assert := assert.New(t)
 	client := newMockGoDaddyClient(t)
 	provider := &GDProvider{
 		client: client,
@@ -385,7 +384,7 @@ func TestGoDaddyChange(t *testing.T) {
 	// Delete entry
 	client.On("Delete", "/v1/domains/example.net/records/A/godaddy").Return(nil, nil).Once()
 
-	assert.NoError(provider.ApplyChanges(t.Context(), &changes))
+	require.NoError(t, provider.ApplyChanges(t.Context(), &changes))
 
 	client.AssertExpectations(t)
 }
@@ -398,7 +397,6 @@ const (
 )
 
 func TestGoDaddyErrorResponse(t *testing.T) {
-	assert := assert.New(t)
 	client := newMockGoDaddyClient(t)
 	provider := &GDProvider{
 		client: client,
@@ -453,7 +451,7 @@ func TestGoDaddyErrorResponse(t *testing.T) {
 		}},
 	}, errors.New(operationFailedTestReason)).Once()
 
-	assert.Error(provider.ApplyChanges(t.Context(), &changes))
+	require.Error(t, provider.ApplyChanges(t.Context(), &changes))
 
 	client.AssertExpectations(t)
 }

--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -455,7 +455,7 @@ func TestGoogleApplyChangesDryRun(t *testing.T) {
 
 func TestGoogleApplyChangesEmpty(t *testing.T) {
 	provider := newGoogleProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), provider.NewZoneIDFilter([]string{""}), false, []*endpoint.Endpoint{}, nil, nil)
-	assert.NoError(t, provider.ApplyChanges(t.Context(), &plan.Changes{}))
+	require.NoError(t, provider.ApplyChanges(t.Context(), &plan.Changes{}))
 }
 
 func TestNewFilteredRecords(t *testing.T) {

--- a/provider/inmemory/inmemory_test.go
+++ b/provider/inmemory/inmemory_test.go
@@ -102,8 +102,8 @@ func testInMemoryRecords(t *testing.T) {
 			im.filter = &f
 			records, err := im.Records(t.Context())
 			if ti.expectError {
-				assert.Nil(t, records)
-				assert.EqualError(t, err, ErrZoneNotFound.Error())
+				require.Nil(t, records)
+				require.EqualError(t, err, ErrZoneNotFound.Error())
 			} else {
 				require.NoError(t, err)
 				assert.True(t, testutils.SameEndpoints(ti.expected, records), "Endpoints not the same: Expected: %+v Records: %+v", ti.expected, records)
@@ -409,9 +409,9 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 			}
 			err := c.validateChangeBatch(ti.zone, ichanges)
 			if ti.expectError {
-				assert.EqualError(t, err, ti.errorType.Error())
+				require.EqualError(t, err, ti.errorType.Error())
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -552,7 +552,7 @@ func testInMemoryApplyChanges(t *testing.T) {
 
 			err := im.ApplyChanges(t.Context(), ti.changes)
 			if ti.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, ti.expectedZonesState, c.zones)
@@ -566,7 +566,7 @@ func TestNew(t *testing.T) {
 	domainFilter := endpoint.NewDomainFilter([]string{"example.com"})
 	p, err := New(t.Context(), cfg, domainFilter)
 	require.NoError(t, err)
-	assert.NotNil(t, p)
+	require.NotNil(t, p)
 	im, ok := p.(*InMemoryProvider)
 	require.True(t, ok)
 	assert.Equal(t, domainFilter, im.domain)
@@ -623,7 +623,7 @@ func TestApplyChanges_UnknownZoneSkipped(t *testing.T) {
 		UpdateOld: []*endpoint.Endpoint{outside},
 		Delete:    []*endpoint.Endpoint{outside},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestInMemoryClient_Records_ZoneNotFound(t *testing.T) {
@@ -634,7 +634,7 @@ func TestInMemoryClient_Records_ZoneNotFound(t *testing.T) {
 
 func testNewInMemoryProvider(t *testing.T) {
 	cfg := NewInMemoryProvider()
-	assert.NotNil(t, cfg.client)
+	require.NotNil(t, cfg.client)
 }
 
 func testInMemoryCreateZone(t *testing.T) {

--- a/provider/ovh/ovh_test.go
+++ b/provider/ovh/ovh_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/ratelimit"
 
 	"sigs.k8s.io/external-dns/endpoint"
@@ -107,7 +108,7 @@ func TestOvhZones(t *testing.T) {
 	// Basic zones
 	client.On("GetWithContext", "/domain/zone").Return([]string{"example.com", "example.net"}, nil).Once()
 	domains, err := provider.zones(t.Context())
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.Contains(domains, "example.com")
 	assert.NotContains(domains, "example.net")
 	client.AssertExpectations(t)
@@ -115,8 +116,8 @@ func TestOvhZones(t *testing.T) {
 	// Error on getting zones
 	client.On("GetWithContext", "/domain/zone").Return(nil, ovh.ErrAPIDown).Once()
 	domains, err = provider.zones(t.Context())
-	assert.Error(err)
-	assert.Nil(domains)
+	require.Error(t, err)
+	require.Nil(t, domains)
 	client.AssertExpectations(t)
 }
 
@@ -133,7 +134,7 @@ func TestOvhZoneRecords(t *testing.T) {
 	client.On("GetWithContext", "/domain/zone/example.org/record/24").Return(ovhRecord{ID: 24, Zone: "example.org", FieldType: "NS", SubDomain: "ovh", TTL: 10, Target: "203.0.113.42"}, nil).Once()
 	client.On("GetWithContext", "/domain/zone/example.org/record/42").Return(ovhRecord{ID: 42, Zone: "example.org", FieldType: "A", SubDomain: "ovh", TTL: 10, Target: "203.0.113.42"}, nil).Once()
 	zones, records, err := provider.zonesRecords(t.Context())
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.ElementsMatch(zones, []string{"example.org"})
 	assert.ElementsMatch(records, []ovhRecord{{ID: 42, Zone: "example.org", FieldType: "A", SubDomain: "ovh", TTL: 10, Target: "203.0.113.42"}, {ID: 24, Zone: "example.org", FieldType: "NS", SubDomain: "ovh", TTL: 10, Target: "203.0.113.42"}})
 	client.AssertExpectations(t)
@@ -142,9 +143,9 @@ func TestOvhZoneRecords(t *testing.T) {
 	t.Log("Error on getting zones list")
 	client.On("GetWithContext", "/domain/zone").Return(nil, ovh.ErrAPIDown).Once()
 	zones, records, err = provider.zonesRecords(t.Context())
-	assert.Error(err)
-	assert.Nil(zones)
-	assert.Nil(records)
+	require.Error(t, err)
+	require.Nil(t, zones)
+	require.Nil(t, records)
 	client.AssertExpectations(t)
 
 	// Error on getting zone SOA
@@ -153,9 +154,9 @@ func TestOvhZoneRecords(t *testing.T) {
 	client.On("GetWithContext", "/domain/zone").Return([]string{"example.org"}, nil).Once()
 	client.On("GetWithContext", "/domain/zone/example.org/soa").Return(nil, ovh.ErrAPIDown).Once()
 	zones, records, err = provider.zonesRecords(t.Context())
-	assert.Error(err)
-	assert.Nil(zones)
-	assert.Nil(records)
+	require.Error(t, err)
+	require.Nil(t, zones)
+	require.Nil(t, records)
 	client.AssertExpectations(t)
 
 	// Error on getting zone records
@@ -164,9 +165,9 @@ func TestOvhZoneRecords(t *testing.T) {
 	client.On("GetWithContext", "/domain/zone/example.org/soa").Return(ovhSoa{Server: "ns.example.org.", Serial: 2022090902}, nil).Once()
 	client.On("GetWithContext", "/domain/zone/example.org/record").Return(nil, ovh.ErrAPIDown).Once()
 	zones, records, err = provider.zonesRecords(t.Context())
-	assert.Error(err)
-	assert.Nil(zones)
-	assert.Nil(records)
+	require.Error(t, err)
+	require.Nil(t, zones)
+	require.Nil(t, records)
 	client.AssertExpectations(t)
 
 	// Error on getting zone record detail
@@ -176,9 +177,9 @@ func TestOvhZoneRecords(t *testing.T) {
 	client.On("GetWithContext", "/domain/zone/example.org/record").Return([]uint64{42}, nil).Once()
 	client.On("GetWithContext", "/domain/zone/example.org/record/42").Return(nil, ovh.ErrAPIDown).Once()
 	zones, records, err = provider.zonesRecords(t.Context())
-	assert.Error(err)
-	assert.Nil(zones)
-	assert.Nil(records)
+	require.Error(t, err)
+	require.Nil(t, zones)
+	require.Nil(t, records)
 	client.AssertExpectations(t)
 }
 
@@ -197,7 +198,7 @@ func TestOvhZoneRecordsCache(t *testing.T) {
 	client.On("GetWithContext", "/domain/zone/example.org/record/42").Return(ovhRecord{ID: 42, Zone: "example.org", FieldType: "A", SubDomain: "ovh", TTL: 10, Target: "203.0.113.42"}, nil).Once()
 
 	zones, records, err := provider.zonesRecords(t.Context())
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.ElementsMatch(zones, []string{"example.org"})
 	assert.ElementsMatch(records, []ovhRecord{{ID: 42, Zone: "example.org", FieldType: "A", SubDomain: "ovh", TTL: 10, Target: "203.0.113.42"}, {ID: 24, Zone: "example.org", FieldType: "NS", SubDomain: "ovh", TTL: 10, Target: "203.0.113.42"}})
 	client.AssertExpectations(t)
@@ -214,7 +215,7 @@ func TestOvhZoneRecordsCache(t *testing.T) {
 	dnsClient.On("ExchangeContext", mock.AnythingOfType("*context.cancelCtx"), mock.AnythingOfType("*dns.Msg"), "ns.example.org:53").
 		Return(&dns.Msg{Answer: []dns.RR{&dns.SOA{Serial: 2022090901}}}, nil)
 	zones, records, err = provider.zonesRecords(t.Context())
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.ElementsMatch(zones, []string{"example.org"})
 	assert.ElementsMatch(records, []ovhRecord{{ID: 42, Zone: "example.org", FieldType: "A", SubDomain: "ovh", TTL: 10, Target: "203.0.113.42"}, {ID: 24, Zone: "example.org", FieldType: "NS", SubDomain: "ovh", TTL: 10, Target: "203.0.113.42"}})
 	client.AssertExpectations(t)
@@ -235,7 +236,7 @@ func TestOvhZoneRecordsCache(t *testing.T) {
 	client.On("GetWithContext", "/domain/zone/example.org/record/24").Return(ovhRecord{ID: 24, Zone: "example.org", FieldType: "NS", SubDomain: "ovh", TTL: 10, Target: "203.0.113.42"}, nil).Once()
 
 	zones, records, err = provider.zonesRecords(t.Context())
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.ElementsMatch(zones, []string{"example.org"})
 	assert.ElementsMatch(records, []ovhRecord{{ID: 24, Zone: "example.org", FieldType: "NS", SubDomain: "ovh", TTL: 10, Target: "203.0.113.42"}})
 	client.AssertExpectations(t)
@@ -253,7 +254,7 @@ func TestOvhZoneRecordsCache(t *testing.T) {
 		Return(&dns.Msg{Answer: []dns.RR{&dns.SOA{Serial: 2022090902}}}, nil)
 
 	zones, records, err = provider.zonesRecords(t.Context())
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.ElementsMatch(zones, []string{"example.org"})
 	assert.ElementsMatch(records, []ovhRecord{{ID: 24, Zone: "example.org", FieldType: "NS", SubDomain: "ovh", TTL: 10, Target: "203.0.113.42"}})
 	client.AssertExpectations(t)
@@ -275,7 +276,7 @@ func TestOvhZoneRecordsCache(t *testing.T) {
 	client.On("GetWithContext", "/domain/zone/example.org/record/42").Return(ovhRecord{ID: 42, Zone: "example.org", FieldType: "A", SubDomain: "ovh", TTL: 10, Target: "203.0.113.42"}, nil).Once()
 
 	zones, records, err = provider.zonesRecords(t.Context())
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.ElementsMatch(zones, []string{"example.org"})
 	assert.ElementsMatch(records, []ovhRecord{{ID: 42, Zone: "example.org", FieldType: "A", SubDomain: "ovh", TTL: 10, Target: "203.0.113.42"}, {ID: 24, Zone: "example.org", FieldType: "NS", SubDomain: "ovh", TTL: 10, Target: "203.0.113.42"}})
 	client.AssertExpectations(t)
@@ -296,7 +297,7 @@ func TestOvhRecords(t *testing.T) {
 	client.On("GetWithContext", "/domain/zone/example.net/record/24").Return(ovhRecord{ID: 24, Zone: "example.net", FieldType: "A", SubDomain: "ovh", TTL: 10, Target: "203.0.113.42"}, nil).Once()
 	client.On("GetWithContext", "/domain/zone/example.net/record/42").Return(ovhRecord{ID: 42, Zone: "example.net", FieldType: "A", SubDomain: "ovh", TTL: 10, Target: "203.0.113.43"}, nil).Once()
 	endpoints, err := provider.Records(t.Context())
-	assert.NoError(err)
+	require.NoError(t, err)
 	// Little fix for multi targets endpoint
 	for _, endpoint := range endpoints {
 		sort.Strings(endpoint.Targets)
@@ -311,8 +312,8 @@ func TestOvhRecords(t *testing.T) {
 	// Error getting zone
 	client.On("GetWithContext", "/domain/zone").Return(nil, ovh.ErrAPIDown).Once()
 	endpoints, err = provider.Records(t.Context())
-	assert.Error(err)
-	assert.Nil(endpoints)
+	require.Error(t, err)
+	require.Nil(t, endpoints)
 	client.AssertExpectations(t)
 }
 
@@ -598,30 +599,39 @@ func TestOvhApplyChangesPunyCode(t *testing.T) {
 }
 
 func TestOvhChange(t *testing.T) {
-	assert := assert.New(t)
 	client := new(mockOvhClient)
 	provider := &OVHProvider{client: client, apiRateLimiter: ratelimit.New(10), cacheInstance: cache.New(cache.NoExpiration, cache.NoExpiration)}
 
 	// Record creation
-	client.On("PostWithContext", "/domain/zone/example.net/record", ovhRecordFields{SubDomain: "ovh"}).Return(nil, nil).Once()
-	assert.NoError(provider.change(t.Context(), ovhChange{
+	client.On("PostWithContext", "/domain/zone/example.net/record", ovhRecordFields{ovhRecordFieldUpdate: ovhRecordFieldUpdate{SubDomain: "ovh"}}).Return(nil, nil).Once()
+	require.NoError(t, provider.change(t.Context(), ovhChange{
 		Action: ovhCreate,
-		Zone:   "example.net", SubDomain: "ovh",
+		ovhRecord: ovhRecord{
+			Zone: "example.net",
+			ovhRecordFields: ovhRecordFields{ovhRecordFieldUpdate: ovhRecordFieldUpdate{SubDomain: "ovh"}},
+		},
 	}))
 	client.AssertExpectations(t)
 
 	// Record deletion
 	client.On("DeleteWithContext", "/domain/zone/example.net/record/42").Return(nil, nil).Once()
-	assert.NoError(provider.change(t.Context(), ovhChange{
+	require.NoError(t, provider.change(t.Context(), ovhChange{
 		Action: ovhDelete,
-		ID:     42, Zone: "example.net", SubDomain: "ovh",
+		ovhRecord: ovhRecord{
+			ID:   42,
+			Zone: "example.net",
+			ovhRecordFields: ovhRecordFields{ovhRecordFieldUpdate: ovhRecordFieldUpdate{SubDomain: "ovh"}},
+		},
 	}))
 	client.AssertExpectations(t)
 
 	// Record deletion error
-	assert.Error(provider.change(t.Context(), ovhChange{
+	require.Error(t, provider.change(t.Context(), ovhChange{
 		Action: ovhDelete,
-		Zone:   "example.net", SubDomain: "ovh",
+		ovhRecord: ovhRecord{
+			Zone: "example.net",
+			ovhRecordFields: ovhRecordFields{ovhRecordFieldUpdate: ovhRecordFieldUpdate{SubDomain: "ovh"}},
+		},
 	}))
 	client.AssertExpectations(t)
 }

--- a/provider/ovh/ovh_test.go
+++ b/provider/ovh/ovh_test.go
@@ -601,38 +601,24 @@ func TestOvhApplyChangesPunyCode(t *testing.T) {
 func TestOvhChange(t *testing.T) {
 	client := new(mockOvhClient)
 	provider := &OVHProvider{client: client, apiRateLimiter: ratelimit.New(10), cacheInstance: cache.New(cache.NoExpiration, cache.NoExpiration)}
+	ovhUpdateFields := ovhRecordFieldUpdate{SubDomain: "ovh"}
+	ovhRecordData := ovhRecordFields{ovhRecordFieldUpdate: ovhUpdateFields}
 
 	// Record creation
-	client.On("PostWithContext", "/domain/zone/example.net/record", ovhRecordFields{ovhRecordFieldUpdate: ovhRecordFieldUpdate{SubDomain: "ovh"}}).Return(nil, nil).Once()
-	require.NoError(t, provider.change(t.Context(), ovhChange{
-		Action: ovhCreate,
-		ovhRecord: ovhRecord{
-			Zone: "example.net",
-			ovhRecordFields: ovhRecordFields{ovhRecordFieldUpdate: ovhRecordFieldUpdate{SubDomain: "ovh"}},
-		},
-	}))
+	client.On("PostWithContext", "/domain/zone/example.net/record", ovhRecordData).Return(nil, nil).Once()
+	createRecord := ovhRecord{Zone: "example.net", ovhRecordFields: ovhRecordData}
+	require.NoError(t, provider.change(t.Context(), ovhChange{Action: ovhCreate, ovhRecord: createRecord}))
 	client.AssertExpectations(t)
 
 	// Record deletion
 	client.On("DeleteWithContext", "/domain/zone/example.net/record/42").Return(nil, nil).Once()
-	require.NoError(t, provider.change(t.Context(), ovhChange{
-		Action: ovhDelete,
-		ovhRecord: ovhRecord{
-			ID:   42,
-			Zone: "example.net",
-			ovhRecordFields: ovhRecordFields{ovhRecordFieldUpdate: ovhRecordFieldUpdate{SubDomain: "ovh"}},
-		},
-	}))
+	deleteRecord := ovhRecord{ID: 42, Zone: "example.net", ovhRecordFields: ovhRecordData}
+	require.NoError(t, provider.change(t.Context(), ovhChange{Action: ovhDelete, ovhRecord: deleteRecord}))
 	client.AssertExpectations(t)
 
 	// Record deletion error
-	require.Error(t, provider.change(t.Context(), ovhChange{
-		Action: ovhDelete,
-		ovhRecord: ovhRecord{
-			Zone: "example.net",
-			ovhRecordFields: ovhRecordFields{ovhRecordFieldUpdate: ovhRecordFieldUpdate{SubDomain: "ovh"}},
-		},
-	}))
+	errRecord := ovhRecord{Zone: "example.net", ovhRecordFields: ovhRecordData}
+	require.Error(t, provider.change(t.Context(), ovhChange{Action: ovhDelete, ovhRecord: errRecord}))
 	client.AssertExpectations(t)
 }
 

--- a/provider/pdns/pdns_test.go
+++ b/provider/pdns/pdns_test.go
@@ -725,7 +725,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSProviderCreate() {
 			Server:       "http://localhost:8081",
 			DomainFilter: endpoint.NewDomainFilter([]string{""}),
 		})
-	suite.Error(err, "--pdns-api-key should be specified")
+	suite.Require().Error(err, "--pdns-api-key should be specified")
 
 	_, err = newProvider(
 		context.Background(),
@@ -734,7 +734,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSProviderCreate() {
 			APIKey:       "foo",
 			DomainFilter: endpoint.NewDomainFilter([]string{"example.com", "example.org"}),
 		})
-	suite.NoError(err, "--domain-filter should raise no error")
+	suite.Require().NoError(err, "--domain-filter should raise no error")
 
 	_, err = newProvider(
 		context.Background(),
@@ -744,7 +744,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSProviderCreate() {
 			DomainFilter: endpoint.NewDomainFilter([]string{""}),
 			DryRun:       true,
 		})
-	suite.Error(err, "--dry-run should raise an error")
+	suite.Require().Error(err, "--dry-run should raise an error")
 
 	// This is our "regular" code path, no error should be thrown
 	_, err = newProvider(
@@ -754,7 +754,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSProviderCreate() {
 			APIKey:       "foo",
 			DomainFilter: endpoint.NewDomainFilter([]string{""}),
 		})
-	suite.NoError(err, "Regular case should raise no error")
+	suite.Require().NoError(err, "Regular case should raise no error")
 }
 
 func (suite *NewPDNSProviderTestSuite) TestPDNSProviderCreateTLS() {
@@ -765,32 +765,32 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSProviderCreateTLS() {
 		return err
 	}
 
-	suite.NoError(newProvider(TLSConfig{SkipTLSVerify: true}), "Disabled TLS Config should raise no error")
+	suite.Require().NoError(newProvider(TLSConfig{SkipTLSVerify: true}), "Disabled TLS Config should raise no error")
 
-	suite.NoError(newProvider(TLSConfig{
+	suite.Require().NoError(newProvider(TLSConfig{
 		SkipTLSVerify:         true,
 		CAFilePath:            "../../internal/testresources/ca.pem",
 		ClientCertFilePath:    "../../internal/testresources/client-cert.pem",
 		ClientCertKeyFilePath: "../../internal/testresources/client-cert-key.pem",
 	}), "Disabled TLS Config with additional flags should raise no error")
 
-	suite.NoError(newProvider(TLSConfig{}), "Enabled TLS Config without --tls-ca should raise no error")
+	suite.Require().NoError(newProvider(TLSConfig{}), "Enabled TLS Config without --tls-ca should raise no error")
 
-	suite.NoError(newProvider(TLSConfig{
+	suite.Require().NoError(newProvider(TLSConfig{
 		CAFilePath: "../../internal/testresources/ca.pem",
 	}), "Enabled TLS Config with --tls-ca should raise no error")
 
-	suite.Error(newProvider(TLSConfig{
+	suite.Require().Error(newProvider(TLSConfig{
 		CAFilePath:         "../../internal/testresources/ca.pem",
 		ClientCertFilePath: "../../internal/testresources/client-cert.pem",
 	}), "Enabled TLS Config with --tls-client-cert only should raise an error")
 
-	suite.Error(newProvider(TLSConfig{
+	suite.Require().Error(newProvider(TLSConfig{
 		CAFilePath:            "../../internal/testresources/ca.pem",
 		ClientCertKeyFilePath: "../../internal/testresources/client-cert-key.pem",
 	}), "Enabled TLS Config with --tls-client-cert-key only should raise an error")
 
-	suite.NoError(newProvider(TLSConfig{
+	suite.Require().NoError(newProvider(TLSConfig{
 		CAFilePath:            "../../internal/testresources/ca.pem",
 		ClientCertFilePath:    "../../internal/testresources/client-cert.pem",
 		ClientCertKeyFilePath: "../../internal/testresources/client-cert-key.pem",
@@ -870,15 +870,15 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSRecords() {
 		client: &PDNSAPIClientStubListZoneFailure{},
 	}
 	_, err = p.Records(ctx)
-	suite.Error(err)
-	suite.ErrorIs(err, provider.SoftError)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, provider.SoftError)
 
 	p = &PDNSProvider{
 		client: &PDNSAPIClientStubListZonesFailure{},
 	}
 	_, err = p.Records(ctx)
-	suite.Error(err)
-	suite.ErrorIs(err, provider.SoftError)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, provider.SoftError)
 }
 
 func (suite *NewPDNSProviderTestSuite) TestPDNSConvertEndpointsToZones() {
@@ -891,42 +891,42 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSConvertEndpointsToZones() {
 
 	// Check inserting endpoints from a single zone
 	zlist, err := p.ConvertEndpointsToZones(endpointsSimpleRecord, PdnsReplace)
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimplePatch}, zlist)
 
 	// Check deleting endpoints from a single zone
 	zlist, err = p.ConvertEndpointsToZones(endpointsSimpleRecord, PdnsDelete)
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimpleDelete}, zlist)
 
 	// Check endpoints from multiple zones #1
 	zlist, err = p.ConvertEndpointsToZones(endpointsMultipleZones, PdnsReplace)
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimplePatch, ZoneEmptyToSimplePatch2}, zlist)
 
 	// Check endpoints from multiple zones #2
 	zlist, err = p.ConvertEndpointsToZones(endpointsMultipleZones2, PdnsReplace)
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimplePatch, ZoneEmptyToSimplePatch3}, zlist)
 
 	// Check endpoints from multiple zones where some endpoints which don't exist
 	zlist, err = p.ConvertEndpointsToZones(endpointsMultipleZonesWithNoExist, PdnsReplace)
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimplePatch}, zlist)
 
 	// Check endpoints from a zone that does not exist
 	zlist, err = p.ConvertEndpointsToZones(endpointsNonexistantZone, PdnsReplace)
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.Equal([]pgo.Zone{}, zlist)
 
 	// Check endpoints that match multiple zones (one longer than other), is assigned to the right zone
 	zlist, err = p.ConvertEndpointsToZones(endpointsLongRecord, PdnsReplace)
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToLongPatch}, zlist)
 
 	// Check endpoints of type CNAME, ALIAS, MX, SRV, and NS always have their values end with a trailing dot.
 	zlist, err = p.ConvertEndpointsToZones(endpointsMixedRecords, PdnsReplace)
-	suite.NoError(err)
+	suite.Require().NoError(err)
 
 	trailingTypes := sets.New(
 		endpoint.RecordTypeCNAME,
@@ -950,18 +950,18 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSConvertEndpointsToZones() {
 
 	// Check endpoints of type CNAME are converted to ALIAS on the domain apex
 	zlist, err = p.ConvertEndpointsToZones(endpointsApexRecords, PdnsReplace)
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToApexPatch}, zlist)
 
 	// Check endpoints of type CNAME remain CNAME when no alias annotation is set
 	zlist, err = p.ConvertEndpointsToZones(endpointsPreferAlias, PdnsReplace)
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToCNAMEPatch}, zlist)
 
 	// Check endpoints with alias annotation are converted to ALIAS
 	// Note: The --prefer-alias flag now works via PostProcessor wrapper which sets the alias annotation
 	zlist, err = p.ConvertEndpointsToZones([]*endpoint.Endpoint{endpointWithAliasAnnotation}, PdnsReplace)
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToPreferAliasPatch}, zlist)
 }
 
@@ -984,30 +984,30 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSConvertEndpointsToZonesPartitionZ
 
 	// Check endpoints from multiple zones # which one is specified in DomainFilter and one is not
 	zlist, err = p.ConvertEndpointsToZones(endpointsMultipleZones, PdnsReplace)
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimplePatch}, zlist)
 
 	// Check endpoints from multiple zones where some endpoints which don't exist and one that does
 	// and is part of DomainFilter
 	zlist, err = p.ConvertEndpointsToZones(endpointsMultipleZonesWithNoExist, PdnsReplace)
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimplePatch}, zlist)
 
 	// Check endpoints from a zone that does not exist
 	zlist, err = p.ConvertEndpointsToZones(endpointsNonexistantZone, PdnsReplace)
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.Equal([]pgo.Zone{}, zlist)
 
 	// Check endpoints that match multiple zones (one longer than other), is assigned to the right zone when the longer
 	// zone is not part of the DomainFilter
 	zlist, err = p.ConvertEndpointsToZones(endpointsMultipleZonesWithLongRecordNotInDomainFilter, PdnsReplace)
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimplePatchLongRecordIgnoredInDomainFilter}, zlist)
 
 	// Check endpoints that match multiple zones (one longer than other and one is very similar)
 	// is assigned to the right zone when the similar zone is not part of the DomainFilter
 	zlist, err = p.ConvertEndpointsToZones(endpointsMultipleZonesWithSimilarRecordNotInDomainFilter, PdnsReplace)
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimplePatch}, zlist)
 }
 
@@ -1022,7 +1022,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSmutateRecords() {
 
 	// Check inserting endpoints from a single zone
 	err := p.mutateRecords(endpointsSimpleRecord, pdnsChangeType("REPLACE"))
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimplePatch}, c.patchedZones)
 
 	// Reset the "patchedZones"
@@ -1030,7 +1030,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSmutateRecords() {
 
 	// Check deleting endpoints from a single zone
 	err = p.mutateRecords(endpointsSimpleRecord, pdnsChangeType("DELETE"))
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimpleDelete}, c.patchedZones)
 
 	// Check we fail correctly when patching fails for whatever reason
@@ -1039,8 +1039,8 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSmutateRecords() {
 	}
 	// Check inserting endpoints from a single zone
 	err = p.mutateRecords(endpointsSimpleRecord, pdnsChangeType("REPLACE"))
-	suite.Error(err)
-	suite.ErrorIs(err, provider.SoftError)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, provider.SoftError)
 }
 
 func (suite *NewPDNSProviderTestSuite) TestPDNSClientPartitionZones() {
@@ -1132,7 +1132,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSAdjustEndpoints() {
 
 	for _, tt := range tests {
 		actual, err := p.AdjustEndpoints(tt.endpoints)
-		suite.NoError(err)
+		suite.Require().NoError(err)
 		suite.Equal(tt.expected, actual)
 	}
 }

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -67,14 +67,14 @@ func TestBaseProvider_AdjustEndpoints(t *testing.T) {
 	b := BaseProvider{}
 	eps := []*endpoint.Endpoint{{DNSName: "example.com"}}
 	got, err := b.AdjustEndpoints(eps)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, eps, got)
 }
 
 func TestBaseProvider_GetDomainFilter(t *testing.T) {
 	b := BaseProvider{}
 	f := b.GetDomainFilter()
-	assert.NotNil(t, f)
+	require.NotNil(t, f)
 	assert.True(t, f.Match("example.com"))
 }
 

--- a/provider/rfc2136/rfc2136_test.go
+++ b/provider/rfc2136/rfc2136_test.go
@@ -1228,11 +1228,9 @@ func TestRfc2136AxfrEnvelopeErrorReturnsSoftError(t *testing.T) {
 		"round-robin",
 		stub,
 	)
-	assert.NoError(t, err)
-
 	records, err := providerInstance.Records(t.Context())
-	assert.Error(t, err)
-	assert.ErrorIs(t, err, provider.SoftError, "Expected SoftError when AXFR envelope carries an error")
+	require.Error(t, err)
+	require.ErrorIs(t, err, provider.SoftError, "Expected SoftError when AXFR envelope carries an error")
 	assert.Empty(t, records, "Expected no records returned when AXFR envelope carries an error")
 }
 
@@ -1316,7 +1314,7 @@ func TestRfc2136AxfrFailoverSucceedsAfterEnvelopeError(t *testing.T) {
 	require.NoError(t, err)
 
 	endpoints, err := providerInstance.Records(t.Context())
-	assert.NoError(t, err, "Expected nil error when second nameserver succeeds after first fails")
+	require.NoError(t, err, "Expected nil error when second nameserver succeeds after first fails")
 	assert.NotEmpty(t, endpoints, "Expected records from the successful second nameserver")
 }
 

--- a/provider/rfc2136/rfc2136_test.go
+++ b/provider/rfc2136/rfc2136_test.go
@@ -290,13 +290,13 @@ func TestRfc2136GetRecordsMultipleTargets(t *testing.T) {
 		"foo.com 3600 IN A 1.1.1.1",
 		"foo.com 3600 IN A 2.2.2.2",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	provider, err := createRfc2136StubProvider(stub)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	recs, err := provider.Records(t.Context())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Len(t, recs, 1, "expected single record")
 	assert.Equal(t, "foo.com", recs[0].DNSName)
@@ -312,7 +312,7 @@ func TestRfc2136GetRecordsMultipleTargets(t *testing.T) {
 func TestRfc2136PTRCreation(t *testing.T) {
 	stub := newStub()
 	p, err := createRfc2136StubProviderWithReverseZone(stub)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Simulate what the PTR source wrapper produces: both A and PTR endpoints.
 	records := []*endpoint.Endpoint{
@@ -331,7 +331,7 @@ func TestRfc2136PTRCreation(t *testing.T) {
 	err = p.ApplyChanges(t.Context(), &plan.Changes{
 		Create: records,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, stub.createMsgs, 2, "expected two records, one A and one PTR")
 	createMsgs := getSortedChanges(stub.createMsgs)
 	assert.Contains(t, strings.Join(strings.Fields(createMsgs[0]), " "), "4.3.2.1.in-addr.arpa. 300 IN PTR demo.foo.com.", "expected a PTR record")
@@ -382,7 +382,7 @@ func TestRfc2136TLSConfigWithMultiHosts(t *testing.T) {
 	stub := newStub()
 
 	caFile, err := os.CreateTemp(t.TempDir(), "rfc2136-test-XXXXXXXX.crt")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.Remove(caFile.Name())
 	_, err = caFile.Write([]byte(
 		`-----BEGIN CERTIFICATE-----
@@ -404,13 +404,13 @@ ouB5ZN+05DzKCQhBekMnygQ=
 	}
 
 	provider, err := createRfc2136TLSStubProviderWithHosts(stub, tlsConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	rawProvider := provider.(*rfc2136Provider)
 
 	for _, ns := range rawProvider.nameservers {
 		client, err := makeClient(rawProvider, ns)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// strip port from ns
 		ns = strings.Split(ns, ":")[0]
@@ -427,7 +427,7 @@ func TestRfc2136TLSConfigNoVerify(t *testing.T) {
 	stub := newStub()
 
 	caFile, err := os.CreateTemp(t.TempDir(), "rfc2136-test-XXXXXXXX.crt")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.Remove(caFile.Name())
 	_, err = caFile.Write([]byte(
 		`-----BEGIN CERTIFICATE-----
@@ -449,12 +449,12 @@ ouB5ZN+05DzKCQhBekMnygQ=
 	}
 
 	provider, err := createRfc2136TLSStubProvider(stub, tlsConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	rawProvider := provider.(*rfc2136Provider)
 
 	client, err := makeClient(rawProvider, rawProvider.nameservers[0])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "tcp-tls", client.Net)
 	assert.True(t, client.TLSConfig.InsecureSkipVerify)
@@ -467,7 +467,7 @@ func TestRfc2136TLSConfigClientAuth(t *testing.T) {
 	stub := newStub()
 
 	caFile, err := os.CreateTemp(t.TempDir(), "rfc2136-test-XXXXXXXX.crt")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.Remove(caFile.Name())
 	_, err = caFile.Write([]byte(
 		`-----BEGIN CERTIFICATE-----
@@ -481,7 +481,7 @@ ouB5ZN+05DzKCQhBekMnygQ=
 `))
 
 	certFile, err := os.CreateTemp(t.TempDir(), "rfc2136-test-XXXXXXXX-client.crt")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.Remove(certFile.Name())
 	_, err = certFile.Write([]byte(
 		`-----BEGIN CERTIFICATE-----
@@ -497,7 +497,7 @@ goRP/fRfTTTLwLg8UBpUAmALX8A8HBSBaUlTTQcaImbcwU4DRSbv5JEA8tM1mWrA
 `))
 
 	keyFile, err := os.CreateTemp(t.TempDir(), "rfc2136-test-XXXXXXXX-client.key")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.Remove(keyFile.Name())
 	_, err = keyFile.Write([]byte(
 		`-----BEGIN PRIVATE KEY-----
@@ -518,14 +518,14 @@ hl6aAPCe16pwvljB7yImxLJ+ytWk7OV/s10cmlaczrEtNeUjV1X9MTM=
 
 	provider, err := createRfc2136TLSStubProvider(stub, tlsConfig)
 	log.Infof("provider, err is: %s", err)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	rawProvider := provider.(*rfc2136Provider)
 
 	client, err := makeClient(rawProvider, rawProvider.nameservers[0])
 	log.Infof("client, err is: %v", client)
 	log.Infof("client, err is: %s", err)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "tcp-tls", client.Net)
 	assert.False(t, client.TLSConfig.InsecureSkipVerify)
@@ -545,13 +545,13 @@ func TestRfc2136GetRecords(t *testing.T) {
 		"v1.foobar.com 3600 TXT dddd",
 		"v5.foo.com 3600 DNAME target.example.com.",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	provider, err := createRfc2136StubProvider(stub, "barfoo.com", "foo.com", "bar.com", "foobar.com")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	recs, err := provider.Records(t.Context())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Len(t, recs, 7)
 	assert.True(t, contains(recs, "v1.foo.com"))
@@ -583,24 +583,24 @@ func TestRfc2136SendMessage(t *testing.T) {
 	m.Insert([]dns.RR{rr})
 
 	err = stub.SendMessage(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	rr, err = dns.NewRR(fmt.Sprintf("%s %d %s %s", "v1.bar.com.", 0, "A", "1.2.3.4"))
 	m.Insert([]dns.RR{rr})
 
 	err = stub.SendMessage(m)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	m.SetUpdate(".")
 	err = stub.SendMessage(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // These tests are use the . root zone with no filters
 func TestRfc2136ApplyChanges(t *testing.T) {
 	stub := newStub()
 	provider, err := createRfc2136StubProvider(stub)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	p := &plan.Changes{
 		Create: []*endpoint.Endpoint{
@@ -636,7 +636,7 @@ func TestRfc2136ApplyChanges(t *testing.T) {
 	}
 
 	err = provider.ApplyChanges(t.Context(), p)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Len(t, stub.createMsgs, 3)
 	assert.Contains(t, stub.createMsgs[0].String(), "v1.foo.com")
@@ -658,7 +658,7 @@ func TestRfc2136ApplyChanges(t *testing.T) {
 func TestRfc2136ApplyChangesWithZones(t *testing.T) {
 	stub := newStub()
 	provider, err := createRfc2136StubProviderWithZones(stub)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	p := &plan.Changes{
 		Create: []*endpoint.Endpoint{
@@ -694,7 +694,7 @@ func TestRfc2136ApplyChangesWithZones(t *testing.T) {
 	}
 
 	err = provider.ApplyChanges(t.Context(), p)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Len(t, stub.createMsgs, 3)
 	createMsgs := getSortedChanges(stub.createMsgs)
@@ -722,7 +722,7 @@ func TestRfc2136ApplyChangesWithZones(t *testing.T) {
 func TestRfc2136ApplyChangesWithZonesFilters(t *testing.T) {
 	stub := newStub()
 	provider, err := createRfc2136StubProviderWithZonesFilters(stub)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	p := &plan.Changes{
 		Create: []*endpoint.Endpoint{
@@ -764,7 +764,7 @@ func TestRfc2136ApplyChangesWithZonesFilters(t *testing.T) {
 	}
 
 	err = provider.ApplyChanges(t.Context(), p)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Len(t, stub.createMsgs, 3)
 	createMsgs := getSortedChanges(stub.createMsgs)
@@ -796,7 +796,7 @@ func TestRfc2136ApplyChangesWithDifferentTTLs(t *testing.T) {
 	stub := newStub()
 
 	provider, err := createRfc2136StubProvider(stub)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	p := &plan.Changes{
 		Create: []*endpoint.Endpoint{
@@ -821,7 +821,7 @@ func TestRfc2136ApplyChangesWithDifferentTTLs(t *testing.T) {
 	}
 
 	err = provider.ApplyChanges(t.Context(), p)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	createRecords := extractUpdateSectionFromMessage(stub.createMsgs[0])
 	assert.Len(t, createRecords, 3)
@@ -840,7 +840,7 @@ func TestRfc2136ApplyChangesWithUpdate(t *testing.T) {
 	stub := newStub()
 
 	provider, err := createRfc2136StubProvider(stub)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	p := &plan.Changes{
 		Create: []*endpoint.Endpoint{
@@ -859,7 +859,7 @@ func TestRfc2136ApplyChangesWithUpdate(t *testing.T) {
 	}
 
 	err = provider.ApplyChanges(t.Context(), p)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	p = &plan.Changes{
 		UpdateOld: []*endpoint.Endpoint{
@@ -891,7 +891,7 @@ func TestRfc2136ApplyChangesWithUpdate(t *testing.T) {
 	}
 
 	err = provider.ApplyChanges(t.Context(), p)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Len(t, stub.createMsgs, 4)
 	assert.Len(t, stub.updateMsgs, 2)
@@ -968,7 +968,7 @@ func TestRoundRobinLoadBalancing(t *testing.T) {
 
 	for i := range 10 {
 		err := stub.SendMessage(m)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		expectedNameserver := "rfc2136-host" + strconv.Itoa((i%3)+1)
 		assert.Equal(t, expectedNameserver, stub.lastNameserver)
 	}
@@ -989,7 +989,7 @@ func TestRandomLoadBalancing(t *testing.T) {
 
 	for range 25 {
 		err := stub.SendMessage(m)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		nameserverCounts[stub.lastNameserver]++
 	}
 
@@ -1048,7 +1048,7 @@ func TestRfc2136ApplyChangesWithMultipleChunks(t *testing.T) {
 	stub := newStub()
 
 	provider, err := createRfc2136StubProviderWithBatchChangeSize(stub, 2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var oldRecords []*endpoint.Endpoint
 	var newRecords []*endpoint.Endpoint
@@ -1074,7 +1074,7 @@ func TestRfc2136ApplyChangesWithMultipleChunks(t *testing.T) {
 	}
 
 	err = provider.ApplyChanges(t.Context(), p)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Len(t, stub.updateMsgs, 4)
 
@@ -1138,12 +1138,12 @@ func TestRfc2136NameserverFailureReturnsSoftError(t *testing.T) {
 		"round-robin",
 		failingStub,
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Test that Records() returns a SoftError when nameserver fails
 	_, err = providerInstance.Records(t.Context())
-	assert.Error(t, err)
-	assert.ErrorIs(t, err, provider.SoftError, "Expected SoftError when nameserver fails")
+	require.Error(t, err)
+	require.ErrorIs(t, err, provider.SoftError, "Expected SoftError when nameserver fails")
 
 	// Test that ApplyChanges() returns a SoftError when nameserver fails
 	p := &plan.Changes{
@@ -1156,7 +1156,7 @@ func TestRfc2136NameserverFailureReturnsSoftError(t *testing.T) {
 		},
 	}
 	err = providerInstance.ApplyChanges(t.Context(), p)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.ErrorIs(t, err, provider.SoftError, "Expected SoftError when nameserver fails in ApplyChanges")
 }
 

--- a/provider/scaleway/scaleway_test.go
+++ b/provider/scaleway/scaleway_test.go
@@ -169,7 +169,7 @@ func TestScalewayProvider_OptionnalConfigFile(t *testing.T) {
 	t.Setenv(scw.ScwSecretKeyEnv, "11111111-1111-1111-1111-111111111111")
 
 	_, err := newProvider(endpoint.NewDomainFilter([]string{"example.com"}), true)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestScalewayProvider_AdjustEndpoints(t *testing.T) {

--- a/provider/webhook/webhook_test.go
+++ b/provider/webhook/webhook_test.go
@@ -370,8 +370,12 @@ func TestAdjustEndpoints_PreservesRefObjects(t *testing.T) {
 			var eps []*endpoint.Endpoint
 			defer r.Body.Close()
 			b, err := io.ReadAll(r.Body)
-			assert.NoError(t, err)
-			assert.NoError(t, json.Unmarshal(b, &eps))
+			if !assert.NoError(t, err) {
+				return
+			}
+			if !assert.NoError(t, json.Unmarshal(b, &eps)) {
+				return
+			}
 			j, _ := json.Marshal(eps)
 			w.Write(j)
 		}))
@@ -462,9 +466,13 @@ func TestApplyChangesWithProviderSpecificProperty(t *testing.T) {
 			var changes plan.Changes
 			defer r.Body.Close()
 			b, err := io.ReadAll(r.Body)
-			assert.NoError(t, err)
+			if !assert.NoError(t, err) {
+				return
+			}
 			err = json.Unmarshal(b, &changes)
-			assert.NoError(t, err)
+			if !assert.NoError(t, err) {
+				return
+			}
 			assert.Len(t, changes.Create, 1)
 			assert.Len(t, changes.Create[0].ProviderSpecific, 1)
 			assert.Equal(t, "prop1", changes.Create[0].ProviderSpecific[0].Name)
@@ -631,7 +639,9 @@ func TestRequestWithRetry_ServerErrorRetried(t *testing.T) {
 func TestNewWebhookProvider_UsesInstrumentedTransport(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set(webhookapi.ContentTypeHeader, webhookapi.MediaTypeFormatAndVersion)
-		assert.NoError(t, json.NewEncoder(w).Encode(endpoint.NewDomainFilter(nil)))
+		if !assert.NoError(t, json.NewEncoder(w).Encode(endpoint.NewDomainFilter(nil))) {
+			return
+		}
 	}))
 	defer svr.Close()
 
@@ -646,9 +656,13 @@ func TestRecords_EmitsHTTPDurationMetric(t *testing.T) {
 		switch r.URL.Path {
 		case "/":
 			w.Header().Set(webhookapi.ContentTypeHeader, webhookapi.MediaTypeFormatAndVersion)
-			assert.NoError(t, json.NewEncoder(w).Encode(endpoint.NewDomainFilter(nil)))
+			if !assert.NoError(t, json.NewEncoder(w).Encode(endpoint.NewDomainFilter(nil))) {
+				return
+			}
 		case webhookapi.UrlRecords:
-			assert.NoError(t, json.NewEncoder(w).Encode([]*endpoint.Endpoint{}))
+			if !assert.NoError(t, json.NewEncoder(w).Encode([]*endpoint.Endpoint{})) {
+				return
+			}
 		}
 	}))
 	defer svr.Close()

--- a/registry/dynamodb/registry_test.go
+++ b/registry/dynamodb/registry_test.go
@@ -160,7 +160,7 @@ func TestDynamoDBRegistryRecordsBadTable(t *testing.T) {
 			r, _ := newRegistry(p, "test-owner", api, "test-table", "", "", "", []string{}, []string{}, nil, time.Hour)
 
 			_, err := r.Records(t.Context())
-			assert.EqualError(t, err, tc.expected)
+			require.EqualError(t, err, tc.expected)
 		})
 	}
 }
@@ -1089,9 +1089,9 @@ func TestDynamoDBRegistryApplyChanges(t *testing.T) {
 
 			err = r.ApplyChanges(ctx, &tc.changes)
 			if tc.expectedError == "" {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
-				assert.EqualError(t, err, tc.expectedError)
+				require.EqualError(t, err, tc.expectedError)
 			}
 
 			assert.Empty(t, tc.stubConfig.ExpectInsert, "all expected inserts made")
@@ -1177,7 +1177,7 @@ func newDynamoDBAPIStub(t *testing.T, stubConfig *DynamoDBStubConfig) (*DynamoDB
 }
 
 func (r *DynamoDBStub) DescribeTable(ctx context.Context, input *dynamodb.DescribeTableInput, _ ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error) {
-	assert.NotNil(r.t, ctx)
+	require.NotNil(r.t, ctx)
 	assert.Equal(r.t, "test-table", *input.TableName, "table name")
 	return &dynamodb.DescribeTableOutput{
 		Table: &r.tableDescription,
@@ -1185,12 +1185,12 @@ func (r *DynamoDBStub) DescribeTable(ctx context.Context, input *dynamodb.Descri
 }
 
 func (r *DynamoDBStub) Scan(ctx context.Context, input *dynamodb.ScanInput, _ ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error) {
-	assert.NotNil(r.t, ctx)
+	require.NotNil(r.t, ctx)
 	assert.Equal(r.t, "test-table", *input.TableName, "table name")
 	assert.Equal(r.t, "o = :ownerval", *input.FilterExpression)
 	assert.Len(r.t, input.ExpressionAttributeValues, 1)
 	var owner string
-	assert.NoError(r.t, attributevalue.Unmarshal(input.ExpressionAttributeValues[":ownerval"], &owner))
+	require.NoError(r.t, attributevalue.Unmarshal(input.ExpressionAttributeValues[":ownerval"], &owner))
 	assert.Equal(r.t, "test-owner", owner)
 	assert.Equal(r.t, "k,l", *input.ProjectionExpression)
 	assert.True(r.t, *input.ConsistentRead)
@@ -1225,7 +1225,7 @@ func (r *DynamoDBStub) Scan(ctx context.Context, input *dynamodb.ScanInput, _ ..
 }
 
 func (r *DynamoDBStub) BatchExecuteStatement(context context.Context, input *dynamodb.BatchExecuteStatementInput, _ ...func(*dynamodb.Options)) (*dynamodb.BatchExecuteStatementOutput, error) {
-	assert.NotNil(r.t, context)
+	require.NotNil(r.t, context)
 	hasDelete := strings.HasPrefix(strings.ToLower(*input.Statements[0].Statement), "delete")
 	assert.Equal(r.t, hasDelete, r.changesApplied, "delete after provider changes, everything else before")
 	assert.LessOrEqual(r.t, len(input.Statements), 25)
@@ -1243,7 +1243,7 @@ func (r *DynamoDBStub) BatchExecuteStatement(context context.Context, input *dyn
 			r.stubConfig.ExpectDelete.Delete(key)
 
 			var testOwner string
-			assert.NoError(r.t, attributevalue.Unmarshal(statement.Parameters[1], &testOwner))
+			require.NoError(r.t, attributevalue.Unmarshal(statement.Parameters[1], &testOwner))
 			assert.Equal(r.t, "test-owner", testOwner)
 
 			responses = append(responses, dynamodbtypes.BatchStatementResponse{})
@@ -1252,7 +1252,7 @@ func (r *DynamoDBStub) BatchExecuteStatement(context context.Context, input *dyn
 			assert.False(r.t, r.changesApplied, "unexpected insert after provider changes")
 
 			var key string
-			assert.NoError(r.t, attributevalue.Unmarshal(statement.Parameters[0], &key))
+			require.NoError(r.t, attributevalue.Unmarshal(statement.Parameters[0], &key))
 			if code, ok := r.stubConfig.ExpectInsertError[key]; ok {
 				delete(r.stubConfig.ExpectInsertError, key)
 				responses = append(responses, dynamodbtypes.BatchStatementResponse{
@@ -1274,7 +1274,7 @@ func (r *DynamoDBStub) BatchExecuteStatement(context context.Context, input *dyn
 
 			var labels map[string]string
 			err := attributevalue.Unmarshal(statement.Parameters[2], &labels)
-			assert.NoError(r.t, err)
+			require.NoError(r.t, err)
 
 			for label, value := range labels {
 				expectedValue, found := expectedLabels[label]
@@ -1293,7 +1293,7 @@ func (r *DynamoDBStub) BatchExecuteStatement(context context.Context, input *dyn
 			assert.False(r.t, r.changesApplied, "unexpected update after provider changes")
 
 			var key string
-			assert.NoError(r.t, attributevalue.Unmarshal(statement.Parameters[1], &key))
+			require.NoError(r.t, attributevalue.Unmarshal(statement.Parameters[1], &key))
 			if code, exists := r.stubConfig.ExpectUpdateError[key]; exists {
 				delete(r.stubConfig.ExpectInsertError, key)
 				responses = append(responses, dynamodbtypes.BatchStatementResponse{
@@ -1310,7 +1310,7 @@ func (r *DynamoDBStub) BatchExecuteStatement(context context.Context, input *dyn
 			delete(r.stubConfig.ExpectUpdate, key)
 
 			var labels map[string]string
-			assert.NoError(r.t, attributevalue.Unmarshal(statement.Parameters[0], &labels))
+			require.NoError(r.t, attributevalue.Unmarshal(statement.Parameters[0], &labels))
 
 			for label, value := range labels {
 				expectedValue, found := expectedLabels[label]

--- a/registry/factory/registry_test.go
+++ b/registry/factory/registry_test.go
@@ -118,7 +118,7 @@ func TestSelectRegistry(t *testing.T) {
 				require.Nil(t, reg)
 				require.Error(t, err)
 			} else {
-				assert.NotNil(t, reg)
+				require.NotNil(t, reg)
 				require.NoError(t, err)
 				assert.Contains(t, reflect.TypeOf(reg).String(), tt.wantType)
 			}

--- a/registry/noop/noop_test.go
+++ b/registry/noop/noop_test.go
@@ -39,7 +39,7 @@ func TestNew(t *testing.T) {
 	p := inmemory.NewInMemoryProvider()
 	r, err := New(&externaldns.Config{}, p)
 	require.NoError(t, err)
-	assert.NotNil(t, r)
+	require.NotNil(t, r)
 }
 
 func TestNoopRegistry_OwnerID(t *testing.T) {
@@ -50,7 +50,7 @@ func TestNoopRegistry_OwnerID(t *testing.T) {
 func TestNoopRegistry_GetDomainFilter(t *testing.T) {
 	p := inmemory.NewInMemoryProvider(inmemory.InMemoryWithDomain(endpoint.NewDomainFilter([]string{"example.com"})))
 	r := newRegistry(p)
-	assert.NotNil(t, r.GetDomainFilter())
+	require.NotNil(t, r.GetDomainFilter())
 }
 
 func TestNoopRegistry_AdjustEndpoints(t *testing.T) {
@@ -131,7 +131,7 @@ func testNoopApplyChanges(t *testing.T) {
 			},
 		},
 	})
-	assert.EqualError(t, err, inmemory.ErrRecordAlreadyExists.Error())
+	require.EqualError(t, err, inmemory.ErrRecordAlreadyExists.Error())
 
 	// correct changes
 	require.NoError(t, r.ApplyChanges(ctx, &plan.Changes{

--- a/registry/txt/encryption_test.go
+++ b/registry/txt/encryption_test.go
@@ -108,7 +108,7 @@ func TestGenerateTXTGenerateTextRecordEncryptionWihDecryption(t *testing.T) {
 			t.Run(fmt.Sprintf("key '%s' with decrypted result '%s'", k, test.decrypted), func(t *testing.T) {
 				key := []byte(k)
 				r, err := newRegistry(p, "", "", "owner", time.Minute, "", []string{}, []string{}, true, key, "")
-				assert.NoError(t, err, "Error creating TXT registry")
+				require.NoError(t, err, "Error creating TXT registry")
 				txtRecords := r.generateTXTRecord(test.record)
 				assert.Len(t, txtRecords, len(test.record.Targets))
 
@@ -122,10 +122,10 @@ func TestGenerateTXTGenerateTextRecordEncryptionWihDecryption(t *testing.T) {
 					// decrypt targets
 					for _, target := range txtRecords[0].Targets {
 						encryptedText, errUnquote := strconv.Unquote(target)
-						assert.NoError(t, errUnquote, "Error unquoting the encrypted text")
+						require.NoError(t, errUnquote, "Error unquoting the encrypted text")
 
 						actual, nonce, errDecrypt := endpoint.DecryptText(encryptedText, r.txtEncryptAESKey)
-						assert.NoError(t, errDecrypt, "Error decrypting the encrypted text")
+						require.NoError(t, errDecrypt, "Error decrypting the encrypted text")
 
 						assert.True(t, strings.HasPrefix(encryptedText, nonce),
 							"Nonce '%s' should be a prefix of the encrypted text: '%s'", nonce, encryptedText)

--- a/registry/txt/registry_test.go
+++ b/registry/txt/registry_test.go
@@ -144,7 +144,7 @@ func TestTXTRegistry_Records_NilLabels(t *testing.T) {
 	endpoints, err := r.Records(t.Context())
 	require.NoError(t, err)
 	require.Len(t, endpoints, 1)
-	assert.NotNil(t, endpoints[0].Labels)
+	require.NotNil(t, endpoints[0].Labels)
 }
 
 func TestNew(t *testing.T) {
@@ -158,7 +158,7 @@ func TestNew(t *testing.T) {
 	}
 	r, err := New(cfg, p)
 	require.NoError(t, err)
-	assert.NotNil(t, r)
+	require.NotNil(t, r)
 }
 
 func TestTXTRegistry_AdjustEndpoints(t *testing.T) {
@@ -860,7 +860,7 @@ func testTXTRegistryApplyChangesWithPrefix(t *testing.T) {
 			"Delete":    got.Delete,
 		}
 		assert.True(t, testutils.SamePlanChanges(mGot, mExpected))
-		assert.Nil(t, ctx.Value(provider.RecordsContextKey))
+		require.Nil(t, ctx.Value(provider.RecordsContextKey))
 	}
 	err := r.ApplyChanges(ctx, changes)
 	require.NoError(t, err)
@@ -907,7 +907,7 @@ func testTXTRegistryApplyChangesWithTemplatedPrefix(t *testing.T) {
 			"Delete":    got.Delete,
 		}
 		assert.True(t, testutils.SamePlanChanges(mGot, mExpected))
-		assert.Nil(t, ctx.Value(provider.RecordsContextKey))
+		require.Nil(t, ctx.Value(provider.RecordsContextKey))
 	}
 	err = r.ApplyChanges(ctx, changes)
 	require.NoError(t, err)
@@ -950,7 +950,7 @@ func testTXTRegistryApplyChangesWithTemplatedSuffix(t *testing.T) {
 			"Delete":    got.Delete,
 		}
 		assert.True(t, testutils.SamePlanChanges(mGot, mExpected))
-		assert.Nil(t, ctx.Value(provider.RecordsContextKey))
+		require.Nil(t, ctx.Value(provider.RecordsContextKey))
 	}
 	err := r.ApplyChanges(ctx, changes)
 	require.NoError(t, err)
@@ -1054,7 +1054,7 @@ func testTXTRegistryApplyChangesWithSuffix(t *testing.T) {
 			"Delete":    got.Delete,
 		}
 		assert.True(t, testutils.SamePlanChanges(mGot, mExpected))
-		assert.Nil(t, ctx.Value(provider.RecordsContextKey))
+		require.Nil(t, ctx.Value(provider.RecordsContextKey))
 	}
 	err = r.ApplyChanges(ctx, changes)
 	require.NoError(t, err)
@@ -1135,7 +1135,7 @@ func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 			"Delete":    got.Delete,
 		}
 		assert.True(t, testutils.SamePlanChanges(mGot, mExpected))
-		assert.Nil(t, ctx.Value(provider.RecordsContextKey))
+		require.Nil(t, ctx.Value(provider.RecordsContextKey))
 	}
 	err = r.ApplyChanges(ctx, changes)
 	require.NoError(t, err)
@@ -1502,7 +1502,7 @@ func TestNewTXTScheme(t *testing.T) {
 			"Delete":    got.Delete,
 		}
 		assert.True(t, testutils.SamePlanChanges(mGot, mExpected))
-		assert.Nil(t, ctx.Value(provider.RecordsContextKey))
+		require.Nil(t, ctx.Value(provider.RecordsContextKey))
 	}
 	err = r.ApplyChanges(ctx, changes)
 	require.NoError(t, err)
@@ -1639,7 +1639,7 @@ func TestTXTRegistryApplyChangesEncrypt(t *testing.T) {
 			"Delete": got.Delete,
 		}
 		assert.True(t, testutils.SamePlanChanges(mGot, mExpected))
-		assert.Nil(t, ctx.Value(provider.RecordsContextKey))
+		require.Nil(t, ctx.Value(provider.RecordsContextKey))
 	}
 	err = r.ApplyChanges(ctx, changes)
 	require.NoError(t, err)
@@ -2011,7 +2011,7 @@ func TestTXTRegistryRecreatesMissingRecords(t *testing.T) {
 					err := p.CreateZone(testZone)
 					require.NoError(t, err)
 					err = p.ApplyChanges(ctx, &plan.Changes{Create: existing})
-					assert.NoError(t, err)
+					require.NoError(t, err)
 
 					// The first ApplyChanges call should create the expected records.
 					// Subsequent calls are expected to be no-ops (i.e., no additional creates).
@@ -2034,7 +2034,7 @@ func TestTXTRegistryRecreatesMissingRecords(t *testing.T) {
 					// When: Apply changes to recreate missing A records
 					managedRecords := []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME, endpoint.RecordTypeAAAA, endpoint.RecordTypeTXT}
 					registry, err := newRegistry(p, "", "", ownerId, time.Hour, "", managedRecords, nil, false, nil, "")
-					assert.NoError(t, err)
+					require.NoError(t, err)
 
 					expectedRecords := append(existing, expectedCreate...) // nolint:gocritic
 
@@ -2042,7 +2042,7 @@ func TestTXTRegistryRecreatesMissingRecords(t *testing.T) {
 					reconciliationLoops := 3
 					for i := range reconciliationLoops {
 						records, err := registry.Records(ctx)
-						assert.NoError(t, err)
+						require.NoError(t, err)
 						pl := &plan.Plan{
 							Policies:       []plan.Policy{policy},
 							Current:        records,
@@ -2052,11 +2052,11 @@ func TestTXTRegistryRecreatesMissingRecords(t *testing.T) {
 						}
 						pln := pl.Calculate()
 						err = registry.ApplyChanges(ctx, pln.Changes)
-						assert.NoError(t, err)
+						require.NoError(t, err)
 
 						// Then: Verify that the missing records are recreated or the existing records are not modified
 						records, err = p.Records(ctx)
-						assert.NoError(t, err)
+						require.NoError(t, err)
 						assert.True(t, testutils.SameEndpoints(records, expectedRecords),
 							"Expected records after reconciliation loop #%d: %v, but got: %v",
 							i, expectedRecords, records,
@@ -2136,7 +2136,7 @@ func TestRecreateRecordAfterDeletion(t *testing.T) {
 	err = p.ApplyChanges(ctx, &plan.Changes{
 		Create: creates,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// 2. Simulate a "no change" reconciliation (ApplyChanges won't be called).
 	desired := []*endpoint.Endpoint{
@@ -2150,7 +2150,7 @@ func TestRecreateRecordAfterDeletion(t *testing.T) {
 	}
 
 	records, err := r.Records(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	calculated := &plan.Plan{
 		Policies:       []plan.Policy{&plan.SyncPolicy{}},
@@ -2168,11 +2168,11 @@ func TestRecreateRecordAfterDeletion(t *testing.T) {
 	err = p.ApplyChanges(ctx, &plan.Changes{
 		Delete: deletes,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// 4. Run reconciliation again — both A and TXT should be recreated.
 	records, err = r.Records(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	calculated = &plan.Plan{
 		Policies:       []plan.Policy{&plan.SyncPolicy{}},
@@ -2187,11 +2187,11 @@ func TestRecreateRecordAfterDeletion(t *testing.T) {
 	}
 
 	err = r.ApplyChanges(ctx, calculated.Changes)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// 5. Verify that both A and TXT records are recreated successfully.
 	records, err = p.Records(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, testutils.SameEndpoints(records, append(desired, txtRecord...)), "Expected records after reconciliation: %v, but got: %v", append(desired, txtRecord...), records)
 }
 
@@ -2215,9 +2215,9 @@ func TestTXTRegistryAliasARecordUsesARecordTXTPrefix(t *testing.T) {
 	require.NoError(t, r.ApplyChanges(t.Context(), &plan.Changes{Create: []*endpoint.Endpoint{aliasA}}))
 	require.NotNil(t, applied)
 
-	assert.NotNil(t, findEndpoint(applied.Create, "alias.test-zone.example.org", endpoint.RecordTypeA), "expected the A record to be applied")
-	assert.NotNil(t, findEndpoint(applied.Create, "a-alias.test-zone.example.org", endpoint.RecordTypeTXT), "expected an a- prefixed ownership TXT")
-	assert.Nil(t, findEndpoint(applied.Create, "cname-alias.test-zone.example.org", endpoint.RecordTypeTXT), "must not create a cname- TXT")
+	require.NotNil(t, findEndpoint(applied.Create, "alias.test-zone.example.org", endpoint.RecordTypeA), "expected the A record to be applied")
+	require.NotNil(t, findEndpoint(applied.Create, "a-alias.test-zone.example.org", endpoint.RecordTypeTXT), "expected an a- prefixed ownership TXT")
+	require.Nil(t, findEndpoint(applied.Create, "cname-alias.test-zone.example.org", endpoint.RecordTypeTXT), "must not create a cname- TXT")
 }
 
 // TestTXTRegistryAliasARecordForceUpdateOnMigration covers the "cname-" -> "a-" migration via Records():
@@ -2293,9 +2293,9 @@ func TestTXTRegistryAliasARecordDeleteLeavesLegacyCNAME(t *testing.T) {
 	require.NoError(t, r.ApplyChanges(t.Context(), &plan.Changes{Delete: []*endpoint.Endpoint{aliasA}}))
 	require.NotNil(t, applied)
 
-	assert.NotNil(t, findEndpoint(applied.Delete, dnsName, endpoint.RecordTypeA), "the A ALIAS record itself must be deleted")
-	assert.NotNil(t, findEndpoint(applied.Delete, "a-alias.test-zone.example.org", endpoint.RecordTypeTXT), "the new a- ownership TXT must be deleted")
-	assert.Nil(t, findEndpoint(applied.Delete, "cname-alias.test-zone.example.org", endpoint.RecordTypeTXT), "the legacy cname- TXT should be kept")
+	require.NotNil(t, findEndpoint(applied.Delete, dnsName, endpoint.RecordTypeA), "the A ALIAS record itself must be deleted")
+	require.NotNil(t, findEndpoint(applied.Delete, "a-alias.test-zone.example.org", endpoint.RecordTypeTXT), "the new a- ownership TXT must be deleted")
+	require.Nil(t, findEndpoint(applied.Delete, "cname-alias.test-zone.example.org", endpoint.RecordTypeTXT), "the legacy cname- TXT should be kept")
 }
 
 const (

--- a/source/ambassador_host_test.go
+++ b/source/ambassador_host_test.go
@@ -23,7 +23,6 @@ import (
 	"sigs.k8s.io/external-dns/internal/testutils"
 
 	ambassador "github.com/emissary-ingress/emissary/v3/pkg/api/getambassador.io/v3alpha1"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	v1 "k8s.io/api/core/v1"
@@ -631,14 +630,14 @@ func TestAmbassadorHostSource(t *testing.T) {
 
 			// Create Ambassador service
 			_, err := fakeKubernetesClient.CoreV1().Services(defaultAmbassadorNamespace).Create(t.Context(), &ti.service, metav1.CreateOptions{})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// Create host resource
 			host, err := createAmbassadorHost(&ti.host)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = fakeDynamicClient.Resource(ambHostGVR).Namespace(namespace).Create(t.Context(), host, metav1.CreateOptions{})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			source, err := NewAmbassadorHostSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
@@ -646,11 +645,11 @@ func TestAmbassadorHostSource(t *testing.T) {
 					AnnotationFilter: parseAnnotationFilterOrNil(ti.annotationFilter),
 					LabelFilter:      ti.labelSelector,
 				})
-			assert.NoError(t, err)
-			assert.NotNil(t, source)
+			require.NoError(t, err)
+			require.NotNil(t, source)
 
 			endpoints, err := source.Endpoints(t.Context())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// Validate returned endpoints against expected endpoints.
 			testutils.ValidateEndpoints(t, endpoints, ti.expected)
 		})

--- a/source/annotations/processors_test.go
+++ b/source/annotations/processors_test.go
@@ -19,6 +19,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -68,9 +69,9 @@ func TestParseAnnotationFilter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			selector, err := ParseFilter(tt.annotationFilter)
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.expectedSelector, selector)
 			}
 		})

--- a/source/connector_test.go
+++ b/source/connector_test.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/external-dns/internal/testutils"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"sigs.k8s.io/external-dns/endpoint"
@@ -134,9 +135,9 @@ func testConnectorSourceEndpoints(t *testing.T) {
 
 			endpoints, err := cs.Endpoints(t.Context())
 			if ti.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			// Validate returned endpoints against expected endpoints.

--- a/source/contour_httpproxy_test.go
+++ b/source/contour_httpproxy_test.go
@@ -102,7 +102,7 @@ func (suite *HTTPProxySuite) SetupTest() {
 			TemplateEngine: templatetest.MustEngine(suite.T(), "{{.Name}}", "", "", false),
 		},
 	)
-	suite.NoError(err, "should initialize httpproxy source")
+	suite.Require().NoError(err, "should initialize httpproxy source")
 
 	suite.httpProxy = (fakeHTTPProxy{
 		name:      "foo-httpproxy-with-targets",
@@ -112,12 +112,10 @@ func (suite *HTTPProxySuite) SetupTest() {
 
 	// Convert to unstructured
 	unstructuredHTTPProxy, err := convertHTTPProxyToUnstructured(suite.httpProxy, s)
-	if err != nil {
-		suite.Error(err)
-	}
+	suite.Require().NoError(err)
 
 	_, err = fakeDynamicClient.Resource(projectcontour.HTTPProxyGVR).Namespace(suite.httpProxy.Namespace).Create(context.Background(), unstructuredHTTPProxy, metav1.CreateOptions{})
-	suite.NoError(err, "should succeed")
+	suite.Require().NoError(err, "should succeed")
 }
 
 func (suite *HTTPProxySuite) TestResourceLabelIsSet() {
@@ -1039,9 +1037,9 @@ func testHTTPProxyEndpoints(t *testing.T) {
 
 			res, err := httpProxySource.Endpoints(t.Context())
 			if ti.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			testutils.ValidateEndpoints(t, res, ti.expected)

--- a/source/endpoint_benchmark_test.go
+++ b/source/endpoint_benchmark_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeinformers "k8s.io/client-go/informers"
@@ -39,7 +40,7 @@ import (
 
 func BenchmarkEndpointTargetsFromServicesMedium(b *testing.B) {
 	svcInformer, err := svcInformerWithServices(36, 1000)
-	assert.NoError(b, err)
+	require.NoError(b, err)
 
 	sel := map[string]string{"app": "nginx", "env": "prod"}
 
@@ -51,7 +52,7 @@ func BenchmarkEndpointTargetsFromServicesMedium(b *testing.B) {
 
 func BenchmarkEndpointTargetsFromServicesMediumIterateOverGateways(b *testing.B) {
 	svcInformer, err := svcInformerWithServices(36, 500)
-	assert.NoError(b, err)
+	require.NoError(b, err)
 
 	gateways := fixturesIstioGatewaySvcWithLabels(15, 70)
 
@@ -64,7 +65,7 @@ func BenchmarkEndpointTargetsFromServicesMediumIterateOverGateways(b *testing.B)
 
 func BenchmarkEndpointTargetsFromServicesHigh(b *testing.B) {
 	svcInformer, err := svcInformerWithServices(36, 40000)
-	assert.NoError(b, err)
+	require.NoError(b, err)
 	sel := map[string]string{"app": "nginx", "env": "prod"}
 
 	for b.Loop() {
@@ -76,7 +77,7 @@ func BenchmarkEndpointTargetsFromServicesHigh(b *testing.B) {
 // This benchmark tests the performance of EndpointTargetsFromServices with a high number of services and gateways.
 func BenchmarkEndpointTargetsFromServicesHighIterateOverGateways(b *testing.B) {
 	svcInformer, err := svcInformerWithServices(36, 40000)
-	assert.NoError(b, err)
+	require.NoError(b, err)
 
 	gateways := fixturesIstioGatewaySvcWithLabels(50, 1000)
 

--- a/source/endpoints_test.go
+++ b/source/endpoints_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeinformers "k8s.io/client-go/informers"
@@ -288,17 +289,17 @@ func TestEndpointTargetsFromServices(t *testing.T) {
 
 			for _, svc := range tt.services {
 				_, err := client.CoreV1().Services(tt.namespace).Create(t.Context(), svc, metav1.CreateOptions{})
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				err = serviceInformer.Informer().GetIndexer().Add(svc)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			result, err := EndpointTargetsFromServices(serviceInformer, tt.namespace, tt.selector)
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.expected, result)
 			}
 		})
@@ -307,11 +308,11 @@ func TestEndpointTargetsFromServices(t *testing.T) {
 
 func TestEndpointTargetsFromServicesWithFixtures(t *testing.T) {
 	svcInformer, err := svcInformerWithServices(2, 9)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	sel := map[string]string{"app": "nginx", "env": "prod"}
 
 	targets, err := EndpointTargetsFromServices(svcInformer, corev1.NamespaceDefault, sel)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 2, targets.Len())
 }

--- a/source/f5_transportserver_fqdn_test.go
+++ b/source/f5_transportserver_fqdn_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	f5 "github.com/F5Networks/k8s-bigip-ctlr/v2/config/apis/cis/v1"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -315,7 +314,7 @@ func TestF5TransportServerFQDNTemplate(t *testing.T) {
 			}
 
 			endpoints, err := src.Endpoints(t.Context())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			testutils.ValidateEndpoints(t, endpoints, tt.expected)
 		})
 	}

--- a/source/f5_transportserver_test.go
+++ b/source/f5_transportserver_test.go
@@ -427,11 +427,11 @@ func TestF5TransportServerEndpoints(t *testing.T) {
 
 			transportServerJSON, err := json.Marshal(tc.transportServer)
 			require.NoError(t, err)
-			assert.NoError(t, transportServer.UnmarshalJSON(transportServerJSON))
+			require.NoError(t, transportServer.UnmarshalJSON(transportServerJSON))
 
 			// Create TransportServer resources
 			_, err = fakeDynamicClient.Resource(f5TransportServerGVR).Namespace(defaultF5TransportServerNamespace).Create(t.Context(), &transportServer, metav1.CreateOptions{})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			labelFilter := tc.labelFilter
 			if labelFilter == nil {
@@ -444,7 +444,7 @@ func TestF5TransportServerEndpoints(t *testing.T) {
 					LabelFilter:      labelFilter,
 				})
 			require.NoError(t, err)
-			assert.NotNil(t, source)
+			require.NotNil(t, source)
 
 			count := &unstructured.UnstructuredList{}
 			for len(count.Items) < 1 {

--- a/source/f5_virtualserver_fqdn_test.go
+++ b/source/f5_virtualserver_fqdn_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	f5 "github.com/F5Networks/k8s-bigip-ctlr/v2/config/apis/cis/v1"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -365,7 +364,7 @@ func TestF5VirtualServerFQDNTemplate(t *testing.T) {
 			}
 
 			endpoints, err := src.Endpoints(t.Context())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			testutils.ValidateEndpoints(t, endpoints, tt.expected)
 		})
 	}

--- a/source/f5_virtualserver_test.go
+++ b/source/f5_virtualserver_test.go
@@ -670,11 +670,11 @@ func TestF5VirtualServerEndpoints(t *testing.T) {
 
 			virtualServerJSON, err := json.Marshal(tc.virtualServer)
 			require.NoError(t, err)
-			assert.NoError(t, virtualServer.UnmarshalJSON(virtualServerJSON))
+			require.NoError(t, virtualServer.UnmarshalJSON(virtualServerJSON))
 
 			// Create VirtualServer resources
 			_, err = fakeDynamicClient.Resource(f5VirtualServerGVR).Namespace(defaultF5VirtualServerNamespace).Create(t.Context(), &virtualServer, metav1.CreateOptions{})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			labelFilter := tc.labelFilter
 			if labelFilter == nil {
@@ -687,7 +687,7 @@ func TestF5VirtualServerEndpoints(t *testing.T) {
 					LabelFilter:      labelFilter,
 				})
 			require.NoError(t, err)
-			assert.NotNil(t, source)
+			require.NotNil(t, source)
 
 			count := &unstructured.UnstructuredList{}
 			for len(count.Items) < 1 {

--- a/source/fake_test.go
+++ b/source/fake_test.go
@@ -91,8 +91,8 @@ func TestFakeSource_RecordTypes(t *testing.T) {
 				t.Helper()
 				require.Len(t, ep.Targets, 1)
 				ip := net.ParseIP(ep.Targets[0])
-				assert.NotNil(t, ip, "A record target %q is not a valid IP", ep.Targets[0])
-				assert.NotNil(t, ip.To4(), "A record target %q must be IPv4", ep.Targets[0])
+				require.NotNil(t, ip, "A record target %q is not a valid IP", ep.Targets[0])
+				require.NotNil(t, ip.To4(), "A record target %q must be IPv4", ep.Targets[0])
 				refs := ep.RefObjects()
 				require.NotEmpty(t, refs)
 				assert.Equal(t, "Pod", refs[0].Kind())
@@ -157,7 +157,7 @@ func TestFakeSource_RecordTypes(t *testing.T) {
 				assert.Equal(t, defaultFQDNTemplate, ep.DNSName)
 				require.Len(t, ep.Targets, 1)
 				_, err := endpoint.NewMXRecord(ep.Targets[0])
-				assert.NoError(t, err, "MX target %q is invalid", ep.Targets[0])
+				require.NoError(t, err, "MX target %q is invalid", ep.Targets[0])
 			},
 		},
 		{

--- a/source/gloo_proxy_fqdn_test.go
+++ b/source/gloo_proxy_fqdn_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -296,7 +295,7 @@ func TestGlooProxyFQDNTemplate(t *testing.T) {
 			}
 
 			endpoints, err := src.Endpoints(t.Context())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			testutils.ValidateEndpoints(t, endpoints, tt.expected)
 		})
 	}

--- a/source/gloo_proxy_test.go
+++ b/source/gloo_proxy_test.go
@@ -451,99 +451,99 @@ func TestGlooSource(t *testing.T) {
 	targetAnnotatedProxySourceUnstructured := unstructured.Unstructured{}
 
 	internalProxyAsJSON, err := json.Marshal(internalProxy)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	externalProxyAsJSON, err := json.Marshal(externalProxy)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	gatewayIngressAnnotatedProxyAsJSON, err := json.Marshal(gatewayIngressAnnotatedProxy)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	gatewayIngressAnnotatedProxyGatewayAsJSON, err := json.Marshal(gatewayIngressAnnotatedProxyGateway)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	proxyMetadataStaticAsJSON, err := json.Marshal(proxyWithMetadataStatic)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	targetAnnotatedProxyAsJSON, err := json.Marshal(targetAnnotatedProxy)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	aggregateListenerProxyAsJSON, err := json.Marshal(aggregateListenerProxy)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	internalProxySvcAsJSON, err := json.Marshal(internalProxySource)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	externalProxySvcAsJSON, err := json.Marshal(externalProxySource)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	proxyMetadataStaticSvcAsJSON, err := json.Marshal(proxyWithMetadataStaticSource)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	targetAnnotatedProxySvcAsJSON, err := json.Marshal(targetAnnotatedProxySource)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.NoError(t, internalProxyUnstructured.UnmarshalJSON(internalProxyAsJSON))
-	assert.NoError(t, externalProxyUnstructured.UnmarshalJSON(externalProxyAsJSON))
-	assert.NoError(t, gatewayIngressAnnotatedProxyUnstructured.UnmarshalJSON(gatewayIngressAnnotatedProxyAsJSON))
-	assert.NoError(t, gatewayIngressAnnotatedProxyGatewayUnstructured.UnmarshalJSON(gatewayIngressAnnotatedProxyGatewayAsJSON))
-	assert.NoError(t, proxyMetadataStaticUnstructured.UnmarshalJSON(proxyMetadataStaticAsJSON))
-	assert.NoError(t, targetAnnotatedProxyUnstructured.UnmarshalJSON(targetAnnotatedProxyAsJSON))
-	assert.NoError(t, aggregateListenerProxyUnstructured.UnmarshalJSON(aggregateListenerProxyAsJSON))
+	require.NoError(t, internalProxyUnstructured.UnmarshalJSON(internalProxyAsJSON))
+	require.NoError(t, externalProxyUnstructured.UnmarshalJSON(externalProxyAsJSON))
+	require.NoError(t, gatewayIngressAnnotatedProxyUnstructured.UnmarshalJSON(gatewayIngressAnnotatedProxyAsJSON))
+	require.NoError(t, gatewayIngressAnnotatedProxyGatewayUnstructured.UnmarshalJSON(gatewayIngressAnnotatedProxyGatewayAsJSON))
+	require.NoError(t, proxyMetadataStaticUnstructured.UnmarshalJSON(proxyMetadataStaticAsJSON))
+	require.NoError(t, targetAnnotatedProxyUnstructured.UnmarshalJSON(targetAnnotatedProxyAsJSON))
+	require.NoError(t, aggregateListenerProxyUnstructured.UnmarshalJSON(aggregateListenerProxyAsJSON))
 
-	assert.NoError(t, internalProxySourceUnstructured.UnmarshalJSON(internalProxySvcAsJSON))
-	assert.NoError(t, externalProxySourceUnstructured.UnmarshalJSON(externalProxySvcAsJSON))
-	assert.NoError(t, proxyMetadataStaticSourceUnstructured.UnmarshalJSON(proxyMetadataStaticSvcAsJSON))
-	assert.NoError(t, targetAnnotatedProxySourceUnstructured.UnmarshalJSON(targetAnnotatedProxySvcAsJSON))
+	require.NoError(t, internalProxySourceUnstructured.UnmarshalJSON(internalProxySvcAsJSON))
+	require.NoError(t, externalProxySourceUnstructured.UnmarshalJSON(externalProxySvcAsJSON))
+	require.NoError(t, proxyMetadataStaticSourceUnstructured.UnmarshalJSON(proxyMetadataStaticSvcAsJSON))
+	require.NoError(t, targetAnnotatedProxySourceUnstructured.UnmarshalJSON(targetAnnotatedProxySvcAsJSON))
 
 	_, err = fakeKubernetesClient.CoreV1().Services(internalProxySvc.GetNamespace()).Create(t.Context(), &internalProxySvc, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = fakeKubernetesClient.CoreV1().Services(externalProxySvc.GetNamespace()).Create(t.Context(), &externalProxySvc, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = fakeKubernetesClient.CoreV1().Services(proxyWithMetadataStaticSvc.GetNamespace()).Create(t.Context(), &proxyWithMetadataStaticSvc, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = fakeKubernetesClient.CoreV1().Services(targetAnnotatedProxySvc.GetNamespace()).Create(t.Context(), &targetAnnotatedProxySvc, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = fakeKubernetesClient.NetworkingV1().Ingresses(gatewayIngressAnnotatedProxyIngress.GetNamespace()).Create(t.Context(), &gatewayIngressAnnotatedProxyIngress, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Create proxy resources
 	_, err = fakeDynamicClient.Resource(proxyGVR).Namespace(defaultGlooNamespace).Create(t.Context(), &internalProxyUnstructured, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = fakeDynamicClient.Resource(proxyGVR).Namespace(defaultGlooNamespace).Create(t.Context(), &externalProxyUnstructured, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = fakeDynamicClient.Resource(proxyGVR).Namespace(defaultGlooNamespace).Create(t.Context(), &proxyMetadataStaticUnstructured, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = fakeDynamicClient.Resource(proxyGVR).Namespace(defaultGlooNamespace).Create(t.Context(), &targetAnnotatedProxyUnstructured, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = fakeDynamicClient.Resource(proxyGVR).Namespace(defaultGlooNamespace).Create(t.Context(), &gatewayIngressAnnotatedProxyUnstructured, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = fakeDynamicClient.Resource(proxyGVR).Namespace(defaultGlooNamespace).Create(t.Context(), &aggregateListenerProxyUnstructured, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Create proxy source
 	_, err = fakeDynamicClient.Resource(virtualServiceGVR).Namespace(internalProxySource.Namespace).Create(t.Context(), &internalProxySourceUnstructured, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = fakeDynamicClient.Resource(virtualServiceGVR).Namespace(externalProxySource.Namespace).Create(t.Context(), &externalProxySourceUnstructured, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = fakeDynamicClient.Resource(virtualServiceGVR).Namespace(proxyWithMetadataStaticSource.Namespace).Create(t.Context(), &proxyMetadataStaticSourceUnstructured, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = fakeDynamicClient.Resource(virtualServiceGVR).Namespace(targetAnnotatedProxySource.Namespace).Create(t.Context(), &targetAnnotatedProxySourceUnstructured, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Create gateway resource
 	_, err = fakeDynamicClient.Resource(gatewayGVR).Namespace(gatewayIngressAnnotatedProxyGateway.Namespace).Create(t.Context(), &gatewayIngressAnnotatedProxyGatewayUnstructured, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	source, err := NewGlooSource(t.Context(), fakeDynamicClient, fakeKubernetesClient, &Config{
 		GlooNamespaces: []string{defaultGlooNamespace},
 	})
-	assert.NoError(t, err)
-	assert.NotNil(t, source)
+	require.NoError(t, err)
+	require.NotNil(t, source)
 
 	endpoints, err := source.Endpoints(t.Context())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, endpoints, 12)
 
 	testutils.ValidateEndpoints(t, endpoints, []*endpoint.Endpoint{

--- a/source/informers/indexers_test.go
+++ b/source/informers/indexers_test.go
@@ -41,7 +41,7 @@ func TestIndexerWithOptions_FilterByAnnotation(t *testing.T) {
 	obj.SetName("test-object")
 
 	keys, err := indexers[IndexWithSelectors](obj)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"default/test-object"}, keys)
 }
 
@@ -57,7 +57,7 @@ func TestIndexerWithOptions_FilterByLabel(t *testing.T) {
 	obj.SetName("test-object")
 
 	keys, err := indexers[IndexWithSelectors](obj)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"default/test-object"}, keys)
 }
 
@@ -73,8 +73,8 @@ func TestIndexerWithOptions_NoMatch(t *testing.T) {
 	obj.SetName("test-object")
 
 	keys, err := indexers[IndexWithSelectors](obj)
-	assert.NoError(t, err)
-	assert.Nil(t, keys)
+	require.NoError(t, err)
+	require.Nil(t, keys)
 }
 
 func TestIndexerWithOptions_InvalidType(t *testing.T) {
@@ -83,8 +83,8 @@ func TestIndexerWithOptions_InvalidType(t *testing.T) {
 	obj := "invalid-object"
 
 	keys, err := indexers[IndexWithSelectors](obj)
-	assert.Error(t, err)
-	assert.Nil(t, keys)
+	require.Error(t, err)
+	require.Nil(t, keys)
 	assert.Contains(t, err.Error(), "object is not of type")
 }
 
@@ -96,7 +96,7 @@ func TestIndexerWithOptions_EmptyOptions(t *testing.T) {
 		obj.SetName("test-object")
 
 		keys, err := indexers[IndexWithSelectors](obj)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, []string{"default/test-object"}, keys)
 	})
 
@@ -106,7 +106,7 @@ func TestIndexerWithOptions_EmptyOptions(t *testing.T) {
 		node.SetName("my-node")
 
 		keys, err := indexers[IndexWithSelectors](node)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, []string{"my-node"}, keys)
 	})
 }
@@ -124,8 +124,8 @@ func TestIndexerWithOptions_AnnotationFilterNoMatch(t *testing.T) {
 	obj.SetName("test-object")
 
 	keys, err := indexers[IndexWithSelectors](obj)
-	assert.NoError(t, err)
-	assert.Nil(t, keys)
+	require.NoError(t, err)
+	require.Nil(t, keys)
 }
 
 func TestIndexSelectorWithAnnotationFilter(t *testing.T) {
@@ -141,7 +141,7 @@ func TestIndexSelectorWithAnnotationFilter(t *testing.T) {
 	t.Run("nil selector stored as nil", func(t *testing.T) {
 		options := &IndexSelectorOptions{}
 		IndexSelectorWithAnnotationFilter(nil)(options)
-		assert.Nil(t, options.annotationFilter)
+		require.Nil(t, options.annotationFilter)
 	})
 }
 
@@ -158,7 +158,7 @@ func TestIndexerWithOptions_LabelKey(t *testing.T) {
 		es.SetLabels(map[string]string{discoveryv1.LabelServiceName: "my-service"})
 
 		keys, err := indexFn(es)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, []string{"default/my-service"}, keys)
 	})
 
@@ -169,14 +169,14 @@ func TestIndexerWithOptions_LabelKey(t *testing.T) {
 		es.SetLabels(map[string]string{})
 
 		keys, err := indexFn(es)
-		assert.NoError(t, err)
-		assert.Nil(t, keys)
+		require.NoError(t, err)
+		require.Nil(t, keys)
 	})
 
 	t.Run("wrong type returns error", func(t *testing.T) {
 		keys, err := indexFn(&corev1.Service{})
-		assert.Error(t, err)
-		assert.Nil(t, keys)
+		require.Error(t, err)
+		require.Nil(t, keys)
 	})
 }
 
@@ -187,11 +187,11 @@ func TestGetByKey_ObjectExists(t *testing.T) {
 	pod.SetName("test-pod")
 
 	err := indexer.Add(pod)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	result, err := GetByKey[*corev1.Pod](indexer, "default/test-pod")
-	assert.NoError(t, err)
-	assert.NotNil(t, result)
+	require.NoError(t, err)
+	require.NotNil(t, result)
 	assert.Equal(t, "test-pod", result.GetName())
 }
 
@@ -199,8 +199,8 @@ func TestGetByKey_ObjectDoesNotExist(t *testing.T) {
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 
 	result, err := GetByKey[*corev1.Pod](indexer, "default/non-existent-pod")
-	assert.NoError(t, err)
-	assert.Nil(t, result)
+	require.NoError(t, err)
+	require.Nil(t, result)
 }
 
 func TestGetByKey_TypeAssertionFailure(t *testing.T) {
@@ -210,12 +210,12 @@ func TestGetByKey_TypeAssertionFailure(t *testing.T) {
 	service.SetName("test-service")
 
 	err := indexer.Add(service)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	result, err := GetByKey[*corev1.Pod](indexer, "default/test-service")
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "object is not of type")
-	assert.Nil(t, result)
+	require.Nil(t, result)
 }
 
 type errIndexer struct {
@@ -400,11 +400,11 @@ func TestIndexSelectorWithFunctions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			keys, err := tt.indexers[IndexWithSelectors](tt.obj)
 			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Nil(t, keys)
+				require.Error(t, err)
+				require.Nil(t, keys)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.wantKeys, keys)
 		})
 	}

--- a/source/informers/informers_test.go
+++ b/source/informers/informers_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -73,10 +74,10 @@ func TestWaitForCacheSync(t *testing.T) {
 			err := WaitForCacheSync(ctx, factory)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Errorf(t, err, tt.errorMsg)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -115,10 +116,10 @@ func TestWaitForDynamicCacheSync(t *testing.T) {
 			err := WaitForDynamicCacheSync(ctx, factory)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Errorf(t, err, tt.errorMsg)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/source/informers/transformers_test.go
+++ b/source/informers/transformers_test.go
@@ -155,14 +155,14 @@ func TestTransformRemoveStatusConditions(t *testing.T) {
 		conditions, found, err := unstructured.NestedSlice(unstructuredSvcObj.Object, "status", "conditions")
 		require.NoError(t, err)
 		assert.False(t, found)
-		assert.Nil(t, conditions)
+		require.Nil(t, conditions)
 
 		// Status.LoadBalancer must be preserved
 		assert.Contains(t, result.Object["status"], "loadBalancer")
 		loadBalancerStatus, found, err := unstructured.NestedMap(unstructuredSvcObj.Object, "status", "loadBalancer")
 		require.NoError(t, err)
 		assert.True(t, found)
-		assert.NotNil(t, loadBalancerStatus)
+		require.NotNil(t, loadBalancerStatus)
 	})
 
 	t.Run("no-op when conditions are already empty", func(t *testing.T) {
@@ -212,7 +212,7 @@ func TestTransformKeepAnnotationPrefix(t *testing.T) {
 		transform := TransformerWithOptions[*corev1.Pod](TransformKeepAnnotationPrefix("external-dns.kubernetes.io/"))
 		got, err := transform(pod)
 		require.NoError(t, err)
-		assert.Nil(t, got.(*corev1.Pod).Annotations)
+		require.Nil(t, got.(*corev1.Pod).Annotations)
 	})
 }
 
@@ -237,7 +237,7 @@ func TestTransformRequireAnnotation(t *testing.T) {
 		transform := TransformerWithOptions[*corev1.Service](TransformRequireAnnotation(sel))
 		got, err := transform(svc)
 		require.NoError(t, err)
-		assert.Nil(t, got)
+		require.Nil(t, got)
 	})
 
 	t.Run("nil selector is a no-op", func(t *testing.T) {
@@ -245,7 +245,7 @@ func TestTransformRequireAnnotation(t *testing.T) {
 		transform := TransformerWithOptions[*corev1.Service](TransformRequireAnnotation(nil))
 		got, err := transform(svc)
 		require.NoError(t, err)
-		assert.NotNil(t, got)
+		require.NotNil(t, got)
 	})
 
 	t.Run("empty selector is a no-op", func(t *testing.T) {
@@ -253,7 +253,7 @@ func TestTransformRequireAnnotation(t *testing.T) {
 		transform := TransformerWithOptions[*corev1.Service](TransformRequireAnnotation(labels.Everything()))
 		got, err := transform(svc)
 		require.NoError(t, err)
-		assert.NotNil(t, got)
+		require.NotNil(t, got)
 	})
 
 	t.Run("drops object after annotation mutation (simulates MODIFIED event)", func(t *testing.T) {
@@ -271,7 +271,7 @@ func TestTransformRequireAnnotation(t *testing.T) {
 		svc.Annotations["external-dns.kubernetes.io/hostname"] = "other.com"
 		got, err = transform(svc)
 		require.NoError(t, err)
-		assert.Nil(t, got, "mutated object must be dropped as a local guard")
+		require.Nil(t, got, "mutated object must be dropped as a local guard")
 	})
 }
 
@@ -304,14 +304,14 @@ func TestTransformerWithOptions_TypeMismatch(t *testing.T) {
 		transform := TransformerWithOptions[*corev1.Service](TransformRemoveManagedFields())
 		got, err := transform(fakePod())
 		require.NoError(t, err)
-		assert.Nil(t, got)
+		require.Nil(t, got)
 	})
 
 	t.Run("non-matching primitive returns nil", func(t *testing.T) {
 		transform := TransformerWithOptions[*corev1.Service]()
 		got, err := transform("not-a-service")
 		require.NoError(t, err)
-		assert.Nil(t, got)
+		require.Nil(t, got)
 	})
 }
 

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -60,7 +60,7 @@ func (suite *IngressSuite) SetupTest() {
 		hostnames: []string{"v1"},
 	}).Ingress()
 	_, err := fakeClient.NetworkingV1().Ingresses(suite.fooWithTargets.Namespace).Create(context.Background(), suite.fooWithTargets, metav1.CreateOptions{})
-	suite.NoError(err, "should succeed")
+	suite.Require().NoError(err, "should succeed")
 
 	suite.sc, err = NewIngressSource(
 		context.TODO(),
@@ -70,7 +70,7 @@ func (suite *IngressSuite) SetupTest() {
 			LabelFilter:    labels.Everything(),
 		},
 	)
-	suite.NoError(err, "should initialize ingress source")
+	suite.Require().NoError(err, "should initialize ingress source")
 }
 
 func (suite *IngressSuite) TestResourceLabelIsSet() {
@@ -131,9 +131,9 @@ func TestNewIngressSource(t *testing.T) {
 				},
 			)
 			if ti.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/source/istio_gateway_test.go
+++ b/source/istio_gateway_test.go
@@ -76,7 +76,7 @@ func (suite *GatewaySuite) SetupTest() {
 
 	for _, service := range suite.lbServices {
 		_, err = fakeKubernetesClient.CoreV1().Services(service.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
-		suite.NoError(err, "should succeed")
+		suite.Require().NoError(err, "should succeed")
 	}
 
 	suite.ingresses = []*networkv1.Ingress{
@@ -96,7 +96,7 @@ func (suite *GatewaySuite) SetupTest() {
 
 	for _, ingress := range suite.ingresses {
 		_, err = fakeKubernetesClient.NetworkingV1().Ingresses(ingress.Namespace).Create(context.Background(), ingress, metav1.CreateOptions{})
-		suite.NoError(err, "should succeed")
+		suite.Require().NoError(err, "should succeed")
 	}
 
 	suite.source, err = NewIstioGatewaySource(
@@ -1507,9 +1507,9 @@ func testGatewayEndpoints(t *testing.T) {
 
 			res, err := gatewaySource.Endpoints(t.Context())
 			if ti.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			testutils.ValidateEndpoints(t, res, ti.expected)
@@ -1859,7 +1859,7 @@ func TestSingleGatewayMultipleServicesPointingToSameLoadBalancer(t *testing.T) {
 		},
 	}
 
-	assert.NotNil(t, services)
+	require.NotNil(t, services)
 
 	for _, svc := range services {
 		_, err := fakeKubeClient.CoreV1().Services(svc.Namespace).Create(t.Context(), svc, metav1.CreateOptions{})

--- a/source/istio_virtualservice_test.go
+++ b/source/istio_virtualservice_test.go
@@ -78,7 +78,7 @@ func (suite *VirtualServiceSuite) SetupTest() {
 
 	for _, service := range suite.lbServices {
 		_, err = fakeKubernetesClient.CoreV1().Services(service.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
-		suite.NoError(err, "should succeed")
+		suite.Require().NoError(err, "should succeed")
 	}
 
 	suite.ingresses = []*networkv1.Ingress{
@@ -98,7 +98,7 @@ func (suite *VirtualServiceSuite) SetupTest() {
 
 	for _, ingress := range suite.ingresses {
 		_, err = fakeKubernetesClient.NetworkingV1().Ingresses(ingress.Namespace).Create(context.Background(), ingress, metav1.CreateOptions{})
-		suite.NoError(err, "should succeed")
+		suite.Require().NoError(err, "should succeed")
 	}
 
 	suite.gwconfig = (fakeGatewayConfig{
@@ -107,7 +107,7 @@ func (suite *VirtualServiceSuite) SetupTest() {
 		dnsnames:  [][]string{{"*"}},
 	}).Config()
 	_, err = fakeIstioClient.NetworkingV1().Gateways(suite.gwconfig.Namespace).Create(context.Background(), suite.gwconfig, metav1.CreateOptions{})
-	suite.NoError(err, "should succeed")
+	suite.Require().NoError(err, "should succeed")
 
 	suite.vsconfig = (fakeVirtualServiceConfig{
 		name:      "foo-virtualservice",
@@ -116,7 +116,7 @@ func (suite *VirtualServiceSuite) SetupTest() {
 		dnsnames:  []string{"foo"},
 	}).Config()
 	_, err = fakeIstioClient.NetworkingV1().VirtualServices(suite.vsconfig.Namespace).Create(context.Background(), suite.vsconfig, metav1.CreateOptions{})
-	suite.NoError(err, "should succeed")
+	suite.Require().NoError(err, "should succeed")
 
 	suite.source, err = NewIstioVirtualServiceSource(
 		context.TODO(),
@@ -126,12 +126,12 @@ func (suite *VirtualServiceSuite) SetupTest() {
 			TemplateEngine: templatetest.MustEngine(suite.T(), "{{.Name}}", "", "", false),
 		},
 	)
-	suite.NoError(err, "should initialize virtualservice source")
+	suite.Require().NoError(err, "should initialize virtualservice source")
 }
 
 func (suite *VirtualServiceSuite) TestResourceLabelIsSet() {
 	endpoints, err := suite.source.Endpoints(context.Background())
-	suite.NoError(err, "should succeed")
+	suite.Require().NoError(err, "should succeed")
 	suite.Len(endpoints, 2, "should return the correct number of endpoints")
 	for _, ep := range endpoints {
 		suite.Equal("virtualservice/istio-other/foo-virtualservice", ep.Labels[endpoint.ResourceLabelKey], "should set correct resource label")
@@ -2091,9 +2091,9 @@ func testVirtualServiceEndpoints(t *testing.T) {
 
 			res, err := virtualServiceSource.Endpoints(t.Context())
 			if ti.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			testutils.ValidateEndpoints(t, res, ti.expected)
@@ -2256,7 +2256,7 @@ func TestVirtualServiceSourceGetGateway(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.fields.virtualServiceSource.getGateway(tt.args.ctx, tt.args.gatewayStr, tt.args.virtualService)
 			if tt.expectedErrStr != "" {
-				assert.EqualError(t, err, tt.expectedErrStr, "getGateway(%v, %v, %v)", tt.args.ctx, tt.args.gatewayStr, tt.args.virtualService)
+				require.EqualError(t, err, tt.expectedErrStr, "getGateway(%v, %v, %v)", tt.args.ctx, tt.args.gatewayStr, tt.args.virtualService)
 				return
 			} else {
 				require.NoError(t, err)

--- a/source/kong_tcpingress_test.go
+++ b/source/kong_tcpingress_test.go
@@ -466,13 +466,13 @@ func TestKongTCPIngressEndpoints(t *testing.T) {
 			tcpi := unstructured.Unstructured{}
 
 			tcpIngressAsJSON, err := json.Marshal(ti.tcpProxy)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
-			assert.NoError(t, tcpi.UnmarshalJSON(tcpIngressAsJSON))
+			require.NoError(t, tcpi.UnmarshalJSON(tcpIngressAsJSON))
 
 			// Create proxy resources
 			_, err = fakeDynamicClient.Resource(kongGroupdVersionResource).Namespace(defaultKongNamespace).Create(t.Context(), &tcpi, metav1.CreateOptions{})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			labelFilter := ti.labelFilter
 			if labelFilter == nil {
@@ -485,8 +485,8 @@ func TestKongTCPIngressEndpoints(t *testing.T) {
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 					LabelFilter:              labelFilter,
 				})
-			assert.NoError(t, err)
-			assert.NotNil(t, source)
+			require.NoError(t, err)
+			require.NotNil(t, source)
 
 			count := &unstructured.UnstructuredList{}
 			for len(count.Items) < 1 {
@@ -494,7 +494,7 @@ func TestKongTCPIngressEndpoints(t *testing.T) {
 			}
 
 			endpoints, err := source.Endpoints(t.Context())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			testutils.ValidateEndpoints(t, endpoints, ti.expected)
 		})
 	}

--- a/source/openshift_route_test.go
+++ b/source/openshift_route_test.go
@@ -73,10 +73,10 @@ func (suite *OCPRouteSuite) SetupTest() {
 		},
 	}
 
-	suite.NoError(err, "should initialize route source")
+	suite.Require().NoError(err, "should initialize route source")
 
 	_, err = fakeClient.RouteV1().Routes(suite.routeWithTargets.Namespace).Create(context.Background(), suite.routeWithTargets, metav1.CreateOptions{})
-	suite.NoError(err, "should successfully create route")
+	suite.Require().NoError(err, "should successfully create route")
 }
 
 func (suite *OCPRouteSuite) TestResourceLabelIsSet() {

--- a/source/pod_indexer_test.go
+++ b/source/pod_indexer_test.go
@@ -140,11 +140,11 @@ func TestPodsWithAnnotationsAndLabels(t *testing.T) {
 				Name: pod.Spec.NodeName,
 			}
 			if _, err := client.CoreV1().Nodes().Create(t.Context(), node, metav1.CreateOptions{}); err != nil {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		}
 		if _, err := client.CoreV1().Pods(pod.Namespace).Create(t.Context(), pod, metav1.CreateOptions{}); err != nil {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
 	}
 

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -77,7 +77,7 @@ func (suite *ServiceSuite) SetupTest() {
 		},
 	}
 	_, err := fakeClient.CoreV1().Services(suite.fooWithTargets.Namespace).Create(context.Background(), suite.fooWithTargets, metav1.CreateOptions{})
-	suite.NoError(err, "should successfully create service")
+	suite.Require().NoError(err, "should successfully create service")
 
 	suite.sc, err = NewServiceSource(
 		context.TODO(),
@@ -114,9 +114,9 @@ func testServiceSourceImplementsSource(t *testing.T) {
 // testServiceSourceEndpoints tests that various services generate the correct endpoints.
 func testServiceSourceEndpoints(t *testing.T) {
 	exampleDotComIP4, err := net.DefaultResolver.LookupNetIP(t.Context(), "ip4", "example.com")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	exampleDotComIP6, err := net.DefaultResolver.LookupNetIP(t.Context(), "ip6", "example.com")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	t.Parallel()
 
@@ -3388,7 +3388,7 @@ func TestMultipleServicesPointingToSameLoadBalancer(t *testing.T) {
 		},
 	}
 
-	assert.NotNil(t, services)
+	require.NotNil(t, services)
 
 	for _, svc := range services {
 		_, err := kubernetes.CoreV1().Services(svc.Namespace).Create(t.Context(), svc, metav1.CreateOptions{})
@@ -3403,7 +3403,7 @@ func TestMultipleServicesPointingToSameLoadBalancer(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	assert.NotNil(t, src)
+	require.NotNil(t, src)
 
 	got, err := src.Endpoints(t.Context())
 	require.NoError(t, err)
@@ -3485,7 +3485,7 @@ func TestMultipleHeadlessServicesPointingToPodsOnTheSameNode(t *testing.T) {
 		},
 	}
 
-	assert.NotNil(t, headless)
+	require.NotNil(t, headless)
 
 	pods := []*v1.Pod{
 		{
@@ -3744,7 +3744,7 @@ func TestMultipleHeadlessServicesPointingToPodsOnTheSameNode(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	assert.NotNil(t, src)
+	require.NotNil(t, src)
 
 	got, err := src.Endpoints(t.Context())
 	require.NoError(t, err)
@@ -4456,64 +4456,64 @@ func TestNewServiceSourceInformersEnabled(t *testing.T) {
 		{
 			name: "serviceTypeFilter is set to empty",
 			asserts: func(svc *serviceSource) {
-				assert.NotNil(t, svc)
-				assert.NotNil(t, svc.serviceTypeFilter)
+				require.NotNil(t, svc)
+				require.NotNil(t, svc.serviceTypeFilter)
 				assert.False(t, svc.serviceTypeFilter.enabled)
-				assert.NotNil(t, svc.nodeInformer)
-				assert.NotNil(t, svc.serviceInformer)
-				assert.NotNil(t, svc.endpointSlicesInformer)
+				require.NotNil(t, svc.nodeInformer)
+				require.NotNil(t, svc.serviceInformer)
+				require.NotNil(t, svc.endpointSlicesInformer)
 			},
 		},
 		{
 			name:      "serviceTypeFilter contains NodePort",
 			svcFilter: []string{string(v1.ServiceTypeClusterIP)},
 			asserts: func(svc *serviceSource) {
-				assert.NotNil(t, svc)
-				assert.NotNil(t, svc.serviceTypeFilter)
+				require.NotNil(t, svc)
+				require.NotNil(t, svc.serviceTypeFilter)
 				assert.True(t, svc.serviceTypeFilter.enabled)
-				assert.NotNil(t, svc.serviceInformer)
-				assert.Nil(t, svc.nodeInformer)
-				assert.NotNil(t, svc.endpointSlicesInformer)
-				assert.NotNil(t, svc.podInformer)
+				require.NotNil(t, svc.serviceInformer)
+				require.Nil(t, svc.nodeInformer)
+				require.NotNil(t, svc.endpointSlicesInformer)
+				require.NotNil(t, svc.podInformer)
 			},
 		},
 		{
 			name:      "serviceTypeFilter contains NodePort and ExternalName",
 			svcFilter: []string{string(v1.ServiceTypeNodePort), string(v1.ServiceTypeExternalName)},
 			asserts: func(svc *serviceSource) {
-				assert.NotNil(t, svc)
-				assert.NotNil(t, svc.serviceTypeFilter)
+				require.NotNil(t, svc)
+				require.NotNil(t, svc.serviceTypeFilter)
 				assert.True(t, svc.serviceTypeFilter.enabled)
-				assert.NotNil(t, svc.serviceInformer)
-				assert.NotNil(t, svc.nodeInformer)
-				assert.NotNil(t, svc.endpointSlicesInformer)
-				assert.NotNil(t, svc.podInformer)
+				require.NotNil(t, svc.serviceInformer)
+				require.NotNil(t, svc.nodeInformer)
+				require.NotNil(t, svc.endpointSlicesInformer)
+				require.NotNil(t, svc.podInformer)
 			},
 		},
 		{
 			name:      "serviceTypeFilter contains ExternalName",
 			svcFilter: []string{string(v1.ServiceTypeExternalName)},
 			asserts: func(svc *serviceSource) {
-				assert.NotNil(t, svc)
-				assert.NotNil(t, svc.serviceTypeFilter)
+				require.NotNil(t, svc)
+				require.NotNil(t, svc.serviceTypeFilter)
 				assert.True(t, svc.serviceTypeFilter.enabled)
-				assert.NotNil(t, svc.serviceInformer)
-				assert.Nil(t, svc.nodeInformer)
-				assert.Nil(t, svc.endpointSlicesInformer)
-				assert.Nil(t, svc.podInformer)
+				require.NotNil(t, svc.serviceInformer)
+				require.Nil(t, svc.nodeInformer)
+				require.Nil(t, svc.endpointSlicesInformer)
+				require.Nil(t, svc.podInformer)
 			},
 		},
 		{
 			name:      "serviceTypeFilter contains LoadBalancer",
 			svcFilter: []string{string(v1.ServiceTypeLoadBalancer)},
 			asserts: func(svc *serviceSource) {
-				assert.NotNil(t, svc)
-				assert.NotNil(t, svc.serviceTypeFilter)
+				require.NotNil(t, svc)
+				require.NotNil(t, svc.serviceTypeFilter)
 				assert.True(t, svc.serviceTypeFilter.enabled)
-				assert.NotNil(t, svc.serviceInformer)
-				assert.Nil(t, svc.nodeInformer)
-				assert.Nil(t, svc.endpointSlicesInformer)
-				assert.Nil(t, svc.podInformer)
+				require.NotNil(t, svc.serviceInformer)
+				require.Nil(t, svc.nodeInformer)
+				require.Nil(t, svc.endpointSlicesInformer)
+				require.Nil(t, svc.podInformer)
 			},
 		},
 	}
@@ -4631,10 +4631,10 @@ func TestNewServiceTypes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			st, err := newServiceTypesFilter(tt.filter)
 			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Nil(t, st)
+				require.Error(t, err)
+				require.Nil(t, st)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.wantEnabled, st.enabled)
 				if tt.wantTypes != nil {
 					assert.Equal(t, tt.wantTypes, st.types)
@@ -5328,7 +5328,7 @@ func TestFindPodForEndpoint(t *testing.T) {
 		}
 
 		result := findPodForEndpoint(endpoint, pods)
-		assert.NotNil(t, result)
+		require.NotNil(t, result)
 		assert.Equal(t, "pod1", result.Name)
 	})
 
@@ -5338,7 +5338,7 @@ func TestFindPodForEndpoint(t *testing.T) {
 		}
 
 		result := findPodForEndpoint(endpoint, pods)
-		assert.Nil(t, result)
+		require.Nil(t, result)
 	})
 
 	t.Run("returns nil for non-Pod kind", func(t *testing.T) {
@@ -5350,7 +5350,7 @@ func TestFindPodForEndpoint(t *testing.T) {
 		}
 
 		result := findPodForEndpoint(endpoint, pods)
-		assert.Nil(t, result)
+		require.Nil(t, result)
 	})
 
 	t.Run("returns nil for non-empty APIVersion", func(t *testing.T) {
@@ -5363,7 +5363,7 @@ func TestFindPodForEndpoint(t *testing.T) {
 		}
 
 		result := findPodForEndpoint(endpoint, pods)
-		assert.Nil(t, result)
+		require.Nil(t, result)
 	})
 
 	t.Run("returns nil for non-existent pod", func(t *testing.T) {
@@ -5375,7 +5375,7 @@ func TestFindPodForEndpoint(t *testing.T) {
 		}
 
 		result := findPodForEndpoint(endpoint, pods)
-		assert.Nil(t, result)
+		require.Nil(t, result)
 	})
 }
 
@@ -5397,7 +5397,7 @@ func TestBuildHeadlessEndpoints(t *testing.T) {
 
 		// Check A record
 		aRecord := findEndpointByType(result, endpoint.RecordTypeA)
-		assert.NotNil(t, aRecord)
+		require.NotNil(t, aRecord)
 		assert.Equal(t, "test.example.com", aRecord.DNSName)
 		assert.Contains(t, aRecord.Targets, "1.2.3.4")
 		assert.Contains(t, aRecord.Targets, "5.6.7.8")
@@ -5405,7 +5405,7 @@ func TestBuildHeadlessEndpoints(t *testing.T) {
 
 		// Check AAAA record
 		aaaaRecord := findEndpointByType(result, endpoint.RecordTypeAAAA)
-		assert.NotNil(t, aaaaRecord)
+		require.NotNil(t, aaaaRecord)
 		assert.Equal(t, "test.example.com", aaaaRecord.DNSName)
 		assert.Contains(t, aaaaRecord.Targets, "2001:db8::1")
 	})
@@ -5693,7 +5693,7 @@ func TestNodesExternalTrafficPolicyTypeLocal(t *testing.T) {
 			[]*v1.Pod{},
 		)
 		got := sc.nodesExternalTrafficPolicyTypeLocal(svc)
-		assert.Nil(t, got)
+		require.Nil(t, got)
 	})
 
 	t.Run("returns only non-terminating ready nodes when mixed with terminating ready nodes", func(t *testing.T) {

--- a/source/skipper_routegroup_test.go
+++ b/source/skipper_routegroup_test.go
@@ -86,7 +86,9 @@ func TestRouteGroupClientGetRouteGroupList(t *testing.T) {
 			assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
 			w.Header().Set("Content-Type", "application/json")
 			_, err := w.Write([]byte(`{"kind":"RouteGroupList","apiVersion":"zalando.org/v1","items":[{"metadata":{"name":"rg1"}}]}`))
-			assert.NoError(t, err)
+			if !assert.NoError(t, err) {
+				return
+			}
 		}))
 		defer server.Close()
 
@@ -111,8 +113,8 @@ func TestRouteGroupClientGetRouteGroupList(t *testing.T) {
 		client := &routeGroupClient{client: server.Client()}
 		got, err := client.getRouteGroupList(server.URL)
 
-		assert.Nil(t, got)
-		assert.ErrorContains(t, err, "503 Service Unavailable")
+		require.Nil(t, got)
+		require.ErrorContains(t, err, "503 Service Unavailable")
 	})
 
 	t.Run("invalid JSON response", func(t *testing.T) {
@@ -120,15 +122,17 @@ func TestRouteGroupClientGetRouteGroupList(t *testing.T) {
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			_, err := w.Write([]byte(`{"items":`))
-			assert.NoError(t, err)
+			if !assert.NoError(t, err) {
+				return
+			}
 		}))
 		defer server.Close()
 
 		client := &routeGroupClient{client: server.Client()}
 		got, err := client.getRouteGroupList(server.URL)
 
-		assert.Nil(t, got)
-		assert.Error(t, err)
+		require.Nil(t, got)
+		require.Error(t, err)
 	})
 
 	t.Run("request failure", func(t *testing.T) {
@@ -140,8 +144,8 @@ func TestRouteGroupClientGetRouteGroupList(t *testing.T) {
 
 		got, err := client.getRouteGroupList(server.URL)
 
-		assert.Nil(t, got)
-		assert.Error(t, err)
+		require.Nil(t, got)
+		require.Error(t, err)
 	})
 }
 
@@ -154,8 +158,8 @@ func TestRouteGroupClientGetAndDo(t *testing.T) {
 		client := &routeGroupClient{}
 		resp, err := client.get("://invalid")
 
-		assert.Nil(t, resp)
-		assert.Error(t, err)
+		require.Nil(t, resp)
+		require.Error(t, err)
 	})
 
 	t.Run("existing authorization header is preserved", func(t *testing.T) {
@@ -235,7 +239,7 @@ func TestNewRouteGroupSource(t *testing.T) {
 			got, err := NewRouteGroupSource(&config, "test-token", "", tt.apiServer)
 			if tt.wantErr {
 				require.Error(t, err)
-				assert.Nil(t, got)
+				require.Nil(t, got)
 				return
 			}
 			require.NoError(t, err)

--- a/source/store_test.go
+++ b/source/store_test.go
@@ -113,7 +113,7 @@ func (suite *ByNamesTestSuite) TestAllInitialized() {
 	sources, err := ByNames(context.TODO(), &Config{
 		sources: ss,
 	}, mockClientGenerator)
-	suite.NoError(err, "should not generate errors")
+	suite.Require().NoError(err, "should not generate errors")
 	suite.Len(sources, 9, "should generate all nine sources")
 }
 
@@ -124,7 +124,7 @@ func (suite *ByNamesTestSuite) TestOnlyFake() {
 	sources, err := ByNames(context.TODO(), &Config{
 		sources: []string{types.Fake},
 	}, mockClientGenerator)
-	suite.NoError(err, "should not generate errors")
+	suite.Require().NoError(err, "should not generate errors")
 	suite.Len(sources, 1, "should generate fake source")
 	suite.Nil(mockClientGenerator.KubeClientValue, "client should not be created")
 }
@@ -342,7 +342,7 @@ func TestSingletonClientGenerator_RESTConfig_SharedAcrossClients(t *testing.T) {
 		"Internal restConfig field should match returned value")
 
 	// All calls should return the same error
-	assert.Error(t, err1, "First call should return error when kubeconfig is invalid")
+	require.Error(t, err1, "First call should return error when kubeconfig is invalid")
 	assert.Equal(t, err1, err2, "Second call should return same error as first call")
 	assert.Equal(t, err1, err3, "Third call should return same error as first call")
 }
@@ -372,16 +372,16 @@ func TestSingletonClientGenerator_ErrorPersistence(t *testing.T) {
 		t.Run(m.name, func(t *testing.T) {
 			client1, err1 := m.call()
 			require.Error(t, err1, "first call must return an error for invalid kubeconfig")
-			assert.Nil(t, client1, "first call must return nil client on error")
+			require.Nil(t, client1, "first call must return nil client on error")
 
 			client2, err2 := m.call()
 			require.Error(t, err2, "second call must still return the init error, not nil")
-			assert.Nil(t, client2, "second call must return nil client on error")
+			require.Nil(t, client2, "second call must return nil client on error")
 			assert.Equal(t, err1, err2, "second call must return the same error as first call")
 
 			client3, err3 := m.call()
 			require.Error(t, err3, "third call must still return the init error, not nil")
-			assert.Nil(t, client3, "third call must return nil client on error")
+			require.Nil(t, client3, "third call must return nil client on error")
 			assert.Equal(t, err1, err3, "third call must return the same error as first call")
 		})
 	}
@@ -483,7 +483,7 @@ func TestNewSourceConfig(t *testing.T) {
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.errContains != "" {
-					assert.ErrorContains(t, err, tt.errContains)
+					require.ErrorContains(t, err, tt.errContains)
 				}
 				return
 			}

--- a/source/template/engine_test.go
+++ b/source/template/engine_test.go
@@ -98,9 +98,9 @@ func TestNewEngine(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := NewEngine(tt.fqdn, tt.target, tt.fqdnTarget, false)
 			if tt.errContains != "" {
-				assert.ErrorContains(t, err, tt.errContains)
+				require.ErrorContains(t, err, tt.errContains)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -469,7 +469,7 @@ func TestExecFQDNNilObject(t *testing.T) {
 	engine, err := NewEngine([]string{"{{ toLower .Labels.department }}.example.org"}, nil, nil, false)
 	require.NoError(t, err)
 	_, err = engine.ExecFQDN(nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 // A shared --fqdn-template using JSON-style Spec keys must succeed on typed objects too.
@@ -772,9 +772,9 @@ func TestValidateTemplates(t *testing.T) {
 			err := validateTemplates(tt.templates, tt.flagName)
 			if tt.errContains != "" {
 				require.Error(t, err)
-				assert.ErrorContains(t, err, tt.errContains)
+				require.ErrorContains(t, err, tt.errContains)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/source/traefik_proxy_fqdn_test.go
+++ b/source/traefik_proxy_fqdn_test.go
@@ -19,7 +19,6 @@ package source
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -235,7 +234,7 @@ func TestTraefikFQDNTemplateIngressRoute(t *testing.T) {
 			}
 
 			endpoints, err := src.Endpoints(t.Context())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			testutils.ValidateEndpoints(t, endpoints, tt.expected)
 		})
 	}
@@ -410,7 +409,7 @@ func TestTraefikFQDNTemplateIngressRouteTCP(t *testing.T) {
 			}
 
 			endpoints, err := src.Endpoints(t.Context())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			testutils.ValidateEndpoints(t, endpoints, tt.expected)
 		})
 	}
@@ -581,7 +580,7 @@ func TestTraefikFQDNTemplateIngressRouteUDP(t *testing.T) {
 			}
 
 			endpoints, err := src.Endpoints(t.Context())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			testutils.ValidateEndpoints(t, endpoints, tt.expected)
 		})
 	}

--- a/source/traefik_proxy_test.go
+++ b/source/traefik_proxy_test.go
@@ -437,13 +437,13 @@ func TestTraefikProxyIngressRouteEndpoints(t *testing.T) {
 			ir := unstructured.Unstructured{}
 
 			ingressRouteAsJSON, err := json.Marshal(ti.ingressRoute)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
-			assert.NoError(t, ir.UnmarshalJSON(ingressRouteAsJSON))
+			require.NoError(t, ir.UnmarshalJSON(ingressRouteAsJSON))
 
 			// Create proxy resources
 			_, err = fakeDynamicClient.Resource(ingressRouteGVR).Namespace(defaultTraefikNamespace).Create(t.Context(), &ir, metav1.CreateOptions{})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			labelFilter := ti.labelFilter
 			if labelFilter == nil {
@@ -456,8 +456,8 @@ func TestTraefikProxyIngressRouteEndpoints(t *testing.T) {
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 					LabelFilter:              labelFilter,
 				})
-			assert.NoError(t, err)
-			assert.NotNil(t, source)
+			require.NoError(t, err)
+			require.NotNil(t, source)
 
 			count := &unstructured.UnstructuredList{}
 			for len(count.Items) < 1 {
@@ -465,7 +465,7 @@ func TestTraefikProxyIngressRouteEndpoints(t *testing.T) {
 			}
 
 			endpoints, err := source.Endpoints(t.Context())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			testutils.ValidateEndpoints(t, endpoints, ti.expected)
 		})
 	}
@@ -755,7 +755,7 @@ func TestTraefikProxyIngressRouteTCPEndpoints(t *testing.T) {
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 				})
 			require.NoError(t, err)
-			assert.NotNil(t, source)
+			require.NotNil(t, source)
 
 			count := &unstructured.UnstructuredList{}
 			for len(count.Items) < 1 {
@@ -885,13 +885,13 @@ func TestTraefikProxyIngressRouteUDPEndpoints(t *testing.T) {
 			ir := unstructured.Unstructured{}
 
 			ingressRouteAsJSON, err := json.Marshal(ti.ingressRouteUDP)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
-			assert.NoError(t, ir.UnmarshalJSON(ingressRouteAsJSON))
+			require.NoError(t, ir.UnmarshalJSON(ingressRouteAsJSON))
 
 			// Create proxy resources
 			_, err = fakeDynamicClient.Resource(ingressRouteUDPGVR).Namespace(defaultTraefikNamespace).Create(t.Context(), &ir, metav1.CreateOptions{})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			source, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
@@ -900,8 +900,8 @@ func TestTraefikProxyIngressRouteUDPEndpoints(t *testing.T) {
 					LabelFilter:              labels.Everything(),
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 				})
-			assert.NoError(t, err)
-			assert.NotNil(t, source)
+			require.NoError(t, err)
+			require.NotNil(t, source)
 
 			count := &unstructured.UnstructuredList{}
 			for len(count.Items) < 1 {
@@ -909,7 +909,7 @@ func TestTraefikProxyIngressRouteUDPEndpoints(t *testing.T) {
 			}
 
 			endpoints, err := source.Endpoints(t.Context())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			testutils.ValidateEndpoints(t, endpoints, ti.expected)
 		})
 	}
@@ -1219,13 +1219,13 @@ func TestTraefikProxyOldIngressRouteEndpoints(t *testing.T) {
 			ir := unstructured.Unstructured{}
 
 			ingressRouteAsJSON, err := json.Marshal(ti.ingressRoute)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
-			assert.NoError(t, ir.UnmarshalJSON(ingressRouteAsJSON))
+			require.NoError(t, ir.UnmarshalJSON(ingressRouteAsJSON))
 
 			// Create proxy resources
 			_, err = fakeDynamicClient.Resource(oldIngressRouteGVR).Namespace(defaultTraefikNamespace).Create(t.Context(), &ir, metav1.CreateOptions{})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			source, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
@@ -1235,8 +1235,8 @@ func TestTraefikProxyOldIngressRouteEndpoints(t *testing.T) {
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 					TraefikEnableLegacy:      true,
 				})
-			assert.NoError(t, err)
-			assert.NotNil(t, source)
+			require.NoError(t, err)
+			require.NotNil(t, source)
 
 			count := &unstructured.UnstructuredList{}
 			for len(count.Items) < 1 {
@@ -1244,7 +1244,7 @@ func TestTraefikProxyOldIngressRouteEndpoints(t *testing.T) {
 			}
 
 			endpoints, err := source.Endpoints(t.Context())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			testutils.ValidateEndpoints(t, endpoints, ti.expected)
 		})
 	}
@@ -1518,13 +1518,13 @@ func TestTraefikProxyOldIngressRouteTCPEndpoints(t *testing.T) {
 			ir := unstructured.Unstructured{}
 
 			ingressRouteAsJSON, err := json.Marshal(ti.ingressRouteTCP)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
-			assert.NoError(t, ir.UnmarshalJSON(ingressRouteAsJSON))
+			require.NoError(t, ir.UnmarshalJSON(ingressRouteAsJSON))
 
 			// Create proxy resources
 			_, err = fakeDynamicClient.Resource(oldIngressRouteTCPGVR).Namespace(defaultTraefikNamespace).Create(t.Context(), &ir, metav1.CreateOptions{})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			source, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
@@ -1534,8 +1534,8 @@ func TestTraefikProxyOldIngressRouteTCPEndpoints(t *testing.T) {
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 					TraefikEnableLegacy:      true,
 				})
-			assert.NoError(t, err)
-			assert.NotNil(t, source)
+			require.NoError(t, err)
+			require.NotNil(t, source)
 
 			count := &unstructured.UnstructuredList{}
 			for len(count.Items) < 1 {
@@ -1543,7 +1543,7 @@ func TestTraefikProxyOldIngressRouteTCPEndpoints(t *testing.T) {
 			}
 
 			endpoints, err := source.Endpoints(t.Context())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			testutils.ValidateEndpoints(t, endpoints, ti.expected)
 		})
 	}
@@ -1665,13 +1665,13 @@ func TestTraefikProxyOldIngressRouteUDPEndpoints(t *testing.T) {
 			ir := unstructured.Unstructured{}
 
 			ingressRouteAsJSON, err := json.Marshal(ti.ingressRouteUDP)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
-			assert.NoError(t, ir.UnmarshalJSON(ingressRouteAsJSON))
+			require.NoError(t, ir.UnmarshalJSON(ingressRouteAsJSON))
 
 			// Create proxy resources
 			_, err = fakeDynamicClient.Resource(oldIngressRouteUDPGVR).Namespace(defaultTraefikNamespace).Create(t.Context(), &ir, metav1.CreateOptions{})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			source, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
@@ -1681,8 +1681,8 @@ func TestTraefikProxyOldIngressRouteUDPEndpoints(t *testing.T) {
 					IgnoreHostnameAnnotation: ti.ignoreHostnameAnnotation,
 					TraefikEnableLegacy:      true,
 				})
-			assert.NoError(t, err)
-			assert.NotNil(t, source)
+			require.NoError(t, err)
+			require.NotNil(t, source)
 
 			count := &unstructured.UnstructuredList{}
 			for len(count.Items) < 1 {
@@ -1690,7 +1690,7 @@ func TestTraefikProxyOldIngressRouteUDPEndpoints(t *testing.T) {
 			}
 
 			endpoints, err := source.Endpoints(t.Context())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			testutils.ValidateEndpoints(t, endpoints, ti.expected)
 		})
 	}
@@ -1833,13 +1833,13 @@ func TestTraefikAPIGroupFlags(t *testing.T) {
 			ir := unstructured.Unstructured{}
 
 			ingressRouteAsJSON, err := json.Marshal(ti.ingressRoute)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
-			assert.NoError(t, ir.UnmarshalJSON(ingressRouteAsJSON))
+			require.NoError(t, ir.UnmarshalJSON(ingressRouteAsJSON))
 
 			// Create proxy resources
 			_, err = fakeDynamicClient.Resource(ti.gvr).Namespace(defaultTraefikNamespace).Create(t.Context(), &ir, metav1.CreateOptions{})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			source, err := NewTraefikSource(t.Context(), fakeDynamicClient, fakeKubernetesClient,
 				&Config{
@@ -1850,8 +1850,8 @@ func TestTraefikAPIGroupFlags(t *testing.T) {
 					TraefikEnableLegacy:      ti.enableLegacy,
 					TraefikDisableNew:        ti.disableNew,
 				})
-			assert.NoError(t, err)
-			assert.NotNil(t, source)
+			require.NoError(t, err)
+			require.NotNil(t, source)
 
 			count := &unstructured.UnstructuredList{}
 			for len(count.Items) < 1 {
@@ -1859,7 +1859,7 @@ func TestTraefikAPIGroupFlags(t *testing.T) {
 			}
 
 			endpoints, err := source.Endpoints(t.Context())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			testutils.ValidateEndpoints(t, endpoints, ti.expected)
 		})
 	}

--- a/source/utils_test.go
+++ b/source/utils_test.go
@@ -72,9 +72,9 @@ func TestParseIngress(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gotNS, gotName, err := ParseIngress(tt.ingress)
 			if tt.wantError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, tt.wantNS, gotNS)
 			assert.Equal(t, tt.wantName, gotName)

--- a/source/wrappers/build_test.go
+++ b/source/wrappers/build_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/external-dns/internal/testutils"
@@ -100,7 +99,7 @@ func TestBuildWrappedSource(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			assert.NotNil(t, src)
+			require.NotNil(t, src)
 		})
 	}
 }

--- a/source/wrappers/multisource_test.go
+++ b/source/wrappers/multisource_test.go
@@ -121,7 +121,7 @@ func testMultiSourceEndpointsWithError(t *testing.T) {
 
 	// Get endpoints from our source.
 	_, err := source.Endpoints(t.Context())
-	assert.EqualError(t, err, "some error")
+	require.EqualError(t, err, "some error")
 
 	// Validate that the nested source was called.
 	src.AssertExpectations(t)

--- a/source/wrappers/nat64source_test.go
+++ b/source/wrappers/nat64source_test.go
@@ -180,9 +180,9 @@ func TestNewNAT64Source(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			src, err := NewNAT64Source(tt.args.source, tt.args.nat64Prefixes)
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, tt.want, src)
 		})
@@ -201,7 +201,7 @@ func TestNat64SourceEndpoints_VariousCases(t *testing.T) {
 			name:      "expect source error propagation",
 			mockError: assert.AnError,
 			asserts: func(eps []*endpoint.Endpoint, err error) {
-				assert.Nil(t, eps)
+				require.Nil(t, eps)
 				require.Error(t, err)
 				require.ErrorIs(t, err, assert.AnError)
 			},
@@ -212,7 +212,7 @@ func TestNat64SourceEndpoints_VariousCases(t *testing.T) {
 				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{"10.10.10.11"}},
 			},
 			asserts: func(eps []*endpoint.Endpoint, err error) {
-				assert.NotNil(t, eps)
+				require.NotNil(t, eps)
 				assert.Len(t, eps, 1)
 				require.NoError(t, err)
 			},
@@ -223,9 +223,9 @@ func TestNat64SourceEndpoints_VariousCases(t *testing.T) {
 				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{"not-an-ip"}},
 			},
 			asserts: func(eps []*endpoint.Endpoint, err error) {
-				assert.Nil(t, eps)
+				require.Nil(t, eps)
 				require.Error(t, err)
-				assert.EqualError(t, err, "ParseAddr(\"not-an-ip\"): unable to parse IP")
+				require.EqualError(t, err, "ParseAddr(\"not-an-ip\"): unable to parse IP")
 			},
 		},
 		{
@@ -243,9 +243,9 @@ func TestNat64SourceEndpoints_VariousCases(t *testing.T) {
 				})
 			},
 			asserts: func(eps []*endpoint.Endpoint, err error) {
-				assert.Nil(t, eps)
+				require.Nil(t, eps)
 				require.Error(t, err)
-				assert.EqualError(t, err, "could not parse [192 0 2 42] to IPv4 address")
+				require.EqualError(t, err, "could not parse [192 0 2 42] to IPv4 address")
 			},
 		},
 	}

--- a/source/wrappers/types_test.go
+++ b/source/wrappers/types_test.go
@@ -89,8 +89,8 @@ func TestWrapSources(t *testing.T) {
 func TestWrapSources_NAT64Error(t *testing.T) {
 	cfg := NewConfig(WithNAT64Networks([]string{"badnet"}))
 	src, err := wrapSources(nil, cfg)
-	assert.Nil(t, src)
-	assert.Error(t, err)
+	require.Nil(t, src)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create NAT64 source wrapper")
 }
 

--- a/tests/integration/toolkit/toolkit_test.go
+++ b/tests/integration/toolkit/toolkit_test.go
@@ -46,7 +46,7 @@ scenarios:
 
 func TestLoadScenarios_InvalidYAML(t *testing.T) {
 	_, err := LoadScenarios([]byte(":\tinvalid"))
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestLoadScenarios_MissingName(t *testing.T) {
@@ -57,7 +57,7 @@ scenarios:
       sources: ["service"]
 `)
 	_, err := LoadScenarios(yaml)
-	assert.ErrorContains(t, err, "missing required field: name")
+	require.ErrorContains(t, err, "missing required field: name")
 }
 
 func TestLoadScenarios_MissingDescription(t *testing.T) {
@@ -68,7 +68,7 @@ scenarios:
       sources: ["service"]
 `)
 	_, err := LoadScenarios(yaml)
-	assert.ErrorContains(t, err, "missing required field: description")
+	require.ErrorContains(t, err, "missing required field: description")
 }
 
 func TestLoadScenarios_MissingSources(t *testing.T) {
@@ -79,7 +79,7 @@ scenarios:
     config: {}
 `)
 	_, err := LoadScenarios(yaml)
-	assert.ErrorContains(t, err, "missing required field: config.sources")
+	require.ErrorContains(t, err, "missing required field: config.sources")
 }
 
 func rawService() []byte {
@@ -209,14 +209,14 @@ metadata:
 	_, err := ParseResources([]ResourceWithDependencies{
 		{Resource: runtime.RawExtension{Raw: raw}},
 	})
-	assert.ErrorContains(t, err, "unsupported resource type")
+	require.ErrorContains(t, err, "unsupported resource type")
 }
 
 func TestParseResources_InvalidRaw(t *testing.T) {
 	_, err := ParseResources([]ResourceWithDependencies{
 		{Resource: runtime.RawExtension{Raw: []byte("not yaml")}},
 	})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestLoadResources_Service(t *testing.T) {
@@ -320,7 +320,7 @@ func TestLoadResources_ParseError(t *testing.T) {
 			{Resource: runtime.RawExtension{Raw: []byte("not yaml")}},
 		},
 	})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestCreateWrappedSource(t *testing.T) {
@@ -335,7 +335,7 @@ func TestCreateWrappedSource(t *testing.T) {
 		Sources: []string{"service"},
 	})
 	require.NoError(t, err)
-	assert.NotNil(t, src)
+	require.NotNil(t, src)
 }
 
 func TestCreateWrappedSource_CRD(t *testing.T) {
@@ -350,7 +350,7 @@ func TestCreateWrappedSource_CRD(t *testing.T) {
 		Sources: []string{"crd"},
 	})
 	require.NoError(t, err)
-	assert.NotNil(t, src)
+	require.NotNil(t, src)
 }
 
 func TestScenarioToConfig(t *testing.T) {
@@ -362,7 +362,7 @@ func TestScenarioToConfig(t *testing.T) {
 		Provider:          "inmemory",
 	})
 	require.NoError(t, err)
-	assert.NotNil(t, cfg)
+	require.NotNil(t, cfg)
 }
 
 // encodeObject serializes a runtime.Object to JSON for use as RawExtension.Raw.


### PR DESCRIPTION
This PR enables the `require-error` checker in testifylint to enforce fail-fast assertions for error checks across the entire test suite.

## Changes

- Enable `require-error` rule in `.golangci.yml` by removing the disable entry
- Convert error assertions across 89 test files from `assert`/`suite` patterns to `require` semantics
- Update suite-based tests to use `suite.Require().NoError()` and `suite.Require().Error()`
- Fix invalid `require` call signatures that were missing the `testing.T` parameter
- Replace handler-local `require` calls with guard-checked `assert` patterns in HTTP handlers to avoid `go-require` violations

## Validation

- ✅ All tests pass: `go test ./...`
- ✅ All linters pass: `golangci-lint run --timeout 10m ./...`
- ✅ 0 testifylint issues reported

Fixes issue #6636