### PR TITLE
fix(source/gateway-api): ignore parent status for a listener the route left

### DIFF
--- a/docs/sources/gateway.md
+++ b/docs/sources/gateway.md
@@ -43,6 +43,14 @@ Matching Gateways are discovered by iterating over the \*Route's `status.parents
 - Ignores parents with a `parentRef.group` other than
   `gateway.networking.k8s.io` or a `parentRef.kind` other than `Gateway`.
 
+- Ignores a `status.parents` entry whose `parentRef.sectionName` or `parentRef.port` is no
+  longer listed in `spec.parentRefs`, once every distinct `parentRef` selector the spec still
+  lists for that parent is accepted for the current Route generation and resolves a target. This stops
+  publishing the hostname of a listener the \*Route has left, while a status that has not caught
+  up with the spec is kept so its records are not dropped ([#6639](https://github.com/kubernetes-sigs/external-dns/issues/6639)).
+  A later edit that leaves `spec.parentRefs` alone still moves the Route generation, so until the
+  controller records it the retired listener's hostname is published again.
+
 - If the `--gateway-name` flag was specified, ignores parents with a `parentRef.name` other than the
   specified value.
 

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -31,12 +31,14 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/ptr"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gateway "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 	gwinformers "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions"
 	informers_v1 "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/apis/v1"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/sets"
 	"sigs.k8s.io/external-dns/pkg/events"
 	"sigs.k8s.io/external-dns/source/annotations"
 	"sigs.k8s.io/external-dns/source/informers"
@@ -400,19 +402,63 @@ func (c *gatewayRouteResolver) resolve(rt gatewayRoute) (map[string]endpoint.Tar
 		return hostTargets, nil
 	}
 
-	for _, rps := range rt.RouteStatus().Parents {
-		parent, ok := c.resolveParentRef(rt, routeParentRefs, rps)
-		if !ok {
-			continue
-		}
-		c.matchRouteToParent(rt, rtHosts, parent, hostTargets)
-	}
+	c.resolveParents(rt, rtHosts, routeParentRefs, hostTargets)
+
 	// If a Gateway has multiple matching Listeners for the same host, then we'll
 	// add its IPs to the target list multiple times and should dedupe them.
 	for host, targets := range hostTargets {
 		hostTargets[host] = uniqueTargets(targets)
 	}
 	return hostTargets, nil
+}
+
+// resolveParents adds the targets of every parent the Route attaches to. A stale status is
+// ignored only once every distinct ParentRef selector the spec still lists for that parent is
+// accepted for the current generation and resolves a target, so a lagging cache keeps the record. See #6639.
+func (c *gatewayRouteResolver) resolveParents(rt gatewayRoute, rtHosts []string, routeParentRefs []v1.ParentReference, hostTargets map[string]endpoint.Targets) {
+	meta := rt.Metadata()
+	wanted := gwRouteWantedSelectors(meta, routeParentRefs)
+
+	usable := make(map[objectRef]sets.Set[gwRouteParentSelector], len(wanted))
+	var superseded []v1.RouteParentStatus
+
+	for _, rps := range rt.RouteStatus().Parents {
+		parentRef := gwRouteParentObjectRef(rps.ParentRef, meta)
+		selector := gwRouteParentSelectorOf(rps.ParentRef)
+		if !wanted[parentRef].Has(selector) {
+			superseded = append(superseded, rps)
+			continue
+		}
+		parent, ok := c.resolveParentRef(rt, routeParentRefs, rps)
+		if !ok {
+			continue
+		}
+		if !c.matchRouteToParent(rt, rtHosts, parent, hostTargets) {
+			continue
+		}
+		if !gwRouteStatusIsCurrent(rps, meta.Generation) {
+			continue
+		}
+		if usable[parentRef] == nil {
+			usable[parentRef] = sets.New[gwRouteParentSelector]()
+		}
+		usable[parentRef].Insert(selector)
+	}
+
+	// Readiness is scoped to the parent object, not to the status writer: the
+	// confirmations count together, whoever wrote them. Keying them per controllerName
+	// would let a status left by a retired controller survive indefinitely.
+	for _, rps := range superseded {
+		parentRef := gwRouteParentObjectRef(rps.ParentRef, meta)
+		if selectors, inSpec := wanted[parentRef]; inSpec && len(usable[parentRef]) >= len(selectors) {
+			continue
+		}
+		parent, ok := c.resolveParentRef(rt, routeParentRefs, rps)
+		if !ok {
+			continue
+		}
+		c.matchRouteToParent(rt, rtHosts, parent, hostTargets)
+	}
 }
 
 func (c *gatewayRouteResolver) resolveParentRef(rt gatewayRoute, routeParentRefs []v1.ParentReference, rps v1.RouteParentStatus) (*resolvedParent, bool) {
@@ -466,7 +512,8 @@ func (c *gatewayRouteResolver) resolveParentRef(rt gatewayRoute, routeParentRefs
 	}, true
 }
 
-func (c *gatewayRouteResolver) matchRouteToParent(rt gatewayRoute, rtHosts []string, parent *resolvedParent, hostTargets map[string]endpoint.Targets) {
+// matchRouteToParent reports whether the parent contributed at least one target.
+func (c *gatewayRouteResolver) matchRouteToParent(rt gatewayRoute, rtHosts []string, parent *resolvedParent, hostTargets map[string]endpoint.Targets) bool {
 	meta := rt.Metadata()
 	match := false
 	var unattachedReason string
@@ -483,13 +530,14 @@ func (c *gatewayRouteResolver) matchRouteToParent(rt gatewayRoute, rtHosts []str
 		}
 	}
 	if match {
-		return
+		return true
 	}
 	if parent.section != "" && unattachedReason != "" {
 		log.Debugf("%s %s/%s section %q is not attached for %s %s/%s: %s", parent.kind, parent.namespace, parent.ref.Name, parent.section, c.src.rtKind, meta.Namespace, meta.Name, unattachedReason)
-		return
+		return false
 	}
 	log.Debugf("%s %s/%s section %q does not match %s %s/%s hostnames %q", parent.kind, parent.namespace, parent.ref.Name, parent.section, c.src.rtKind, meta.Namespace, meta.Name, rtHosts)
+	return false
 }
 
 func (c *gatewayRouteResolver) matchRouteToListener(rt gatewayRoute, rtHosts []string, parent *resolvedParent, lis *v1.Listener, hostTargets map[string]endpoint.Targets) bool {
@@ -517,13 +565,25 @@ func (c *gatewayRouteResolver) matchRouteToListener(rt gatewayRoute, rtHosts []s
 		if !ok {
 			continue
 		}
-		override := parent.obj.overrides
-		hostTargets[host] = append(hostTargets[host], override...)
-		if len(override) == 0 {
+		targets := make(endpoint.Targets, 0, len(parent.obj.overrides))
+		for _, target := range parent.obj.overrides {
+			if strings.TrimSpace(target) == "" {
+				continue
+			}
+			targets = append(targets, target)
+		}
+		if len(targets) == 0 && parent.obj.gateway != nil {
 			for _, addr := range parent.obj.gateway.Status.Addresses {
-				hostTargets[host] = append(hostTargets[host], addr.Value)
+				if addr.Value != "" {
+					targets = append(targets, addr.Value)
+				}
 			}
 		}
+		// Not a match without a target; matchRouteToParent reports target contribution.
+		if len(targets) == 0 {
+			continue
+		}
+		hostTargets[host] = append(hostTargets[host], targets...)
 		match = true
 	}
 	return match
@@ -770,20 +830,64 @@ func gatewayAllowsListenerSet(gw *v1.Gateway, ls *v1.ListenerSet, namespaces map
 
 func gwRouteHasParentRef(routeParentRefs []v1.ParentReference, ref v1.ParentReference, meta *metav1.ObjectMeta) bool {
 	// Ensure that the parent reference is in the routeParentRefs list
-	namespace := strVal((*string)(ref.Namespace), meta.Namespace)
-	group := strVal((*string)(ref.Group), gatewayGroup)
-	kind := strVal((*string)(ref.Kind), gatewayKind)
+	key := gwRouteParentObjectRef(ref, meta)
 	for _, rpr := range routeParentRefs {
-		rprGroup := strVal((*string)(rpr.Group), gatewayGroup)
-		rprKind := strVal((*string)(rpr.Kind), gatewayKind)
-		if rprGroup != group || rprKind != kind {
+		if gwRouteParentObjectRef(rpr, meta) == key {
+			return true
+		}
+	}
+	return false
+}
+
+// gwRouteParentObjectRef is the parent a reference points at, in the same shape the
+// resolver looks listener objects up by, without the sectionName and port.
+func gwRouteParentObjectRef(ref v1.ParentReference, meta *metav1.ObjectMeta) objectRef {
+	return newObjectRef(
+		strVal((*string)(ref.Group), gatewayGroup),
+		strVal((*string)(ref.Kind), gatewayKind),
+		strVal((*string)(ref.Namespace), meta.Namespace),
+		string(ref.Name),
+	)
+}
+
+// gwRouteParentSelector is the part of a reference that picks listeners on a parent.
+type gwRouteParentSelector struct {
+	sectionName v1.SectionName
+	port        v1.PortNumber
+	hasPort     bool
+}
+
+func gwRouteParentSelectorOf(ref v1.ParentReference) gwRouteParentSelector {
+	return gwRouteParentSelector{
+		sectionName: sectionVal(ref.SectionName, ""),
+		port:        ptr.Deref(ref.Port, 0),
+		hasPort:     ref.Port != nil,
+	}
+}
+
+// gwRouteWantedSelectors groups the listeners the spec selects by parent object.
+func gwRouteWantedSelectors(meta *metav1.ObjectMeta, routeParentRefs []v1.ParentReference) map[objectRef]sets.Set[gwRouteParentSelector] {
+	wanted := make(map[objectRef]sets.Set[gwRouteParentSelector], len(routeParentRefs))
+	for _, ref := range routeParentRefs {
+		key := gwRouteParentObjectRef(ref, meta)
+		if wanted[key] == nil {
+			wanted[key] = sets.New[gwRouteParentSelector]()
+		}
+		wanted[key].Insert(gwRouteParentSelectorOf(ref))
+	}
+	return wanted
+}
+
+// gwRouteStatusIsCurrent reports whether the controller accepted this parent at the Route's
+// current generation. It only marks a superseded status as safe to exclude, it does not gate
+// endpoints from the current status. See #5349, #5490.
+func gwRouteStatusIsCurrent(status v1.RouteParentStatus, generation int64) bool {
+	for _, condition := range status.Conditions {
+		if condition.Type != string(v1.RouteConditionAccepted) {
 			continue
 		}
-		rprNamespace := strVal((*string)(rpr.Namespace), meta.Namespace)
-		if string(rpr.Name) != string(ref.Name) || rprNamespace != namespace {
-			continue
-		}
-		return true
+		return condition.Status == metav1.ConditionTrue &&
+			condition.ObservedGeneration == generation
 	}
 	return false
 }

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -121,6 +121,22 @@ func withPortNumber(port v1.PortNumber) gwParentRefOption {
 	return func(ref *v1.ParentReference) { ref.Port = &port }
 }
 
+func gwRouteParentStatus(ref v1.ParentReference, status metav1.ConditionStatus, observedGeneration int64) v1.RouteParentStatus {
+	return v1.RouteParentStatus{
+		ParentRef: ref,
+		Conditions: []metav1.Condition{{
+			Type:               string(v1.RouteConditionAccepted),
+			Status:             status,
+			ObservedGeneration: observedGeneration,
+		}},
+	}
+}
+
+func withControllerName(rps v1.RouteParentStatus, name v1.GatewayController) v1.RouteParentStatus {
+	rps.ControllerName = name
+	return rps
+}
+
 func newTestEndpoint(dnsName string, targets ...string) *endpoint.Endpoint {
 	return newTestEndpointWithTTL(dnsName, endpoint.RecordTypeA, 0, targets...)
 }
@@ -649,6 +665,495 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			},
 		},
 		{
+			// The Route moved to another listener of the same Gateway and the Gateway
+			// controller has not pruned the status entry for the listener it left.
+			title:      "SectionNameChangedWithStaleParentStatus",
+			config:     &Config{},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{
+						{
+							Name:     "foo",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("foo.example.internal")),
+						},
+						{
+							Name:     "bar",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("bar.example.internal")),
+						},
+					},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: omWithGeneration(objectMeta("default", "test"), 2),
+				Spec: v1.HTTPRouteSpec{
+					Hostnames: hostnames("*.example.internal"),
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test", withSectionName("bar")),
+						},
+					},
+				},
+				Status: v1.HTTPRouteStatus{RouteStatus: v1.RouteStatus{Parents: []v1.RouteParentStatus{
+					gwRouteParentStatus(gwParentRef("default", "test", withSectionName("foo")), metav1.ConditionTrue, 1),
+					gwRouteParentStatus(gwParentRef("default", "test", withSectionName("bar")), metav1.ConditionTrue, 2),
+				}}},
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("bar.example.internal", "1.2.3.4"),
+			},
+		},
+		{
+			// A Gateway controller migration: the retired controller's stale "foo"
+			// entry is retired by the new controller's current "bar" entry, because
+			// readiness is scoped to the parent object, not the status writer.
+			title:      "CurrentStatusFromAnotherControllerRetiresSupersededStatus",
+			config:     &Config{},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{
+						{
+							Name:     "foo",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("foo.example.internal")),
+						},
+						{
+							Name:     "bar",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("bar.example.internal")),
+						},
+					},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: omWithGeneration(objectMeta("default", "test"), 2),
+				Spec: v1.HTTPRouteSpec{
+					Hostnames: hostnames("*.example.internal"),
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test", withSectionName("bar")),
+						},
+					},
+				},
+				Status: v1.HTTPRouteStatus{RouteStatus: v1.RouteStatus{Parents: []v1.RouteParentStatus{
+					withControllerName(gwRouteParentStatus(gwParentRef("default", "test", withSectionName("foo")), metav1.ConditionTrue, 1), "old.example.com/gateway-controller"),
+					withControllerName(gwRouteParentStatus(gwParentRef("default", "test", withSectionName("bar")), metav1.ConditionTrue, 2), "new.example.com/gateway-controller"),
+				}}},
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("bar.example.internal", "1.2.3.4"),
+			},
+		},
+		{
+			// A generation bump that leaves the parentRefs alone still leaves every status
+			// behind it, so the superseded entry is resolved again until the controller
+			// catches up. Retiring it on an older status is what #5490 reverted.
+			title:      "SupersededStatusReturnsWhileAnUnrelatedUpdateIsPending",
+			config:     &Config{},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{
+						{
+							Name:     "foo",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("foo.example.internal")),
+						},
+						{
+							Name:     "bar",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("bar.example.internal")),
+						},
+					},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: omWithGeneration(objectMeta("default", "test"), 3),
+				Spec: v1.HTTPRouteSpec{
+					Hostnames: hostnames("*.example.internal"),
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test", withSectionName("bar")),
+						},
+					},
+				},
+				Status: v1.HTTPRouteStatus{RouteStatus: v1.RouteStatus{Parents: []v1.RouteParentStatus{
+					gwRouteParentStatus(gwParentRef("default", "test", withSectionName("foo")), metav1.ConditionTrue, 1),
+					gwRouteParentStatus(gwParentRef("default", "test", withSectionName("bar")), metav1.ConditionTrue, 2),
+				}}},
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("bar.example.internal", "1.2.3.4"),
+				newTestEndpoint("foo.example.internal", "1.2.3.4"),
+			},
+		},
+		{
+			// Neither controller confirms both current selectors on its own. They count
+			// together, so the superseded entry is still retired.
+			title:      "SelectorsConfirmedByDifferentControllersRetireSupersededStatus",
+			config:     &Config{},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{
+						{
+							Name:     "stable",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("stable.example.internal")),
+						},
+						{
+							Name:     "extra",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("extra.example.internal")),
+						},
+						{
+							Name:     "old",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("old.example.internal")),
+						},
+					},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: omWithGeneration(objectMeta("default", "test"), 2),
+				Spec: v1.HTTPRouteSpec{
+					Hostnames: hostnames("*.example.internal"),
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test", withSectionName("stable")),
+							gwParentRef("default", "test", withSectionName("extra")),
+						},
+					},
+				},
+				Status: v1.HTTPRouteStatus{RouteStatus: v1.RouteStatus{Parents: []v1.RouteParentStatus{
+					withControllerName(gwRouteParentStatus(gwParentRef("default", "test", withSectionName("stable")), metav1.ConditionTrue, 2), "a.example.com/gateway-controller"),
+					withControllerName(gwRouteParentStatus(gwParentRef("default", "test", withSectionName("extra")), metav1.ConditionTrue, 2), "b.example.com/gateway-controller"),
+					gwRouteParentStatus(gwParentRef("default", "test", withSectionName("old")), metav1.ConditionTrue, 1),
+				}}},
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("stable.example.internal", "1.2.3.4"),
+				newTestEndpoint("extra.example.internal", "1.2.3.4"),
+			},
+		},
+		{
+			// The same move, but the controller does not record observedGeneration, so
+			// it never says which Route it looked at. Nothing is pruned and the source
+			// behaves as it did before this change.
+			title:      "SectionNameChangedWithoutAnObservedGeneration",
+			config:     &Config{},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{
+						{
+							Name:     "foo",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("foo.example.internal")),
+						},
+						{
+							Name:     "bar",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("bar.example.internal")),
+						},
+					},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: omWithGeneration(objectMeta("default", "test"), 2),
+				Spec: v1.HTTPRouteSpec{
+					Hostnames: hostnames("*.example.internal"),
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test", withSectionName("bar")),
+						},
+					},
+				},
+				Status: httpRouteStatus(
+					gwParentRef("default", "test", withSectionName("foo")),
+					gwParentRef("default", "test", withSectionName("bar")),
+				),
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("foo.example.internal", "1.2.3.4"),
+				newTestEndpoint("bar.example.internal", "1.2.3.4"),
+			},
+		},
+		{
+			// Only the previous listener has a status entry, so the Gateway controller
+			// has not caught up yet. Keep publishing instead of letting the records be
+			// deleted while the Route is between listeners.
+			title:      "SectionNameChangedBeforeParentStatusCaughtUp",
+			config:     &Config{},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{
+						{
+							Name:     "foo",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("foo.example.internal")),
+						},
+						{
+							Name:     "bar",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("bar.example.internal")),
+						},
+					},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.HTTPRouteSpec{
+					Hostnames: hostnames("*.example.internal"),
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test", withSectionName("bar")),
+						},
+					},
+				},
+				Status: httpRouteStatus(
+					gwParentRef("default", "test", withSectionName("foo")),
+				),
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("foo.example.internal", "1.2.3.4"),
+			},
+		},
+		{
+			// The status already names the new listener, but the cached Gateway has not
+			// caught up with it. Dropping the old entry here would take DNS down.
+			title:      "SectionNameChangedWithCurrentListenerMissing",
+			config:     &Config{},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{
+						{
+							Name:     "foo",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("foo.example.internal")),
+						},
+					},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.HTTPRouteSpec{
+					Hostnames: hostnames("*.example.internal"),
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test", withSectionName("bar")),
+						},
+					},
+				},
+				Status: httpRouteStatus(
+					gwParentRef("default", "test", withSectionName("foo")),
+					gwParentRef("default", "test", withSectionName("bar")),
+				),
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("foo.example.internal", "1.2.3.4"),
+			},
+		},
+		{
+			// The new listener exists and is accepted, but its hostname has nothing in
+			// common with the Route, so it publishes nothing. That is no proof either.
+			title:      "SectionNameChangedWithCurrentListenerMatchingNoHostname",
+			config:     &Config{},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{
+						{
+							Name:     "foo",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("foo.example.internal")),
+						},
+						{
+							Name:     "bar",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("bar.example.org")),
+						},
+					},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.HTTPRouteSpec{
+					Hostnames: hostnames("*.example.internal"),
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test", withSectionName("bar")),
+						},
+					},
+				},
+				Status: httpRouteStatus(
+					gwParentRef("default", "test", withSectionName("foo")),
+					gwParentRef("default", "test", withSectionName("bar")),
+				),
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("foo.example.internal", "1.2.3.4"),
+			},
+		},
+		{
+			// The new listener is named but the Gateway rejected it, so it is no proof
+			// that the old entry can go.
+			title:      "SectionNameChangedWithCurrentListenerRejected",
+			config:     &Config{},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{
+						{
+							Name:     "foo",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("foo.example.internal")),
+						},
+						{
+							Name:     "bar",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("bar.example.internal")),
+						},
+					},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.HTTPRouteSpec{
+					Hostnames: hostnames("*.example.internal"),
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test", withSectionName("bar")),
+						},
+					},
+				},
+				Status: v1.HTTPRouteStatus{RouteStatus: v1.RouteStatus{Parents: []v1.RouteParentStatus{
+					gwRouteParentStatus(gwParentRef("default", "test", withSectionName("foo")), metav1.ConditionTrue, 0),
+					gwRouteParentStatus(gwParentRef("default", "test", withSectionName("bar")), metav1.ConditionFalse, 0),
+				}}},
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("foo.example.internal", "1.2.3.4"),
+			},
+		},
+		{
+			// Two references to one Gateway, and only one of them has moved. The entry
+			// of the reference which is still in flight has to survive.
+			title:      "SectionNameChangedForOneOfTwoParentRefs",
+			config:     &Config{},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{
+						{
+							Name:     "stable",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("stable.example.internal")),
+						},
+						{
+							Name:     "old",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("old.example.internal")),
+						},
+						{
+							Name:     "new",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("new.example.internal")),
+						},
+					},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.HTTPRouteSpec{
+					Hostnames: hostnames("*.example.internal"),
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test", withSectionName("stable")),
+							gwParentRef("default", "test", withSectionName("new")),
+						},
+					},
+				},
+				Status: httpRouteStatus(
+					gwParentRef("default", "test", withSectionName("stable")),
+					gwParentRef("default", "test", withSectionName("old")),
+				),
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("stable.example.internal", "1.2.3.4"),
+				newTestEndpoint("old.example.internal", "1.2.3.4"),
+			},
+		},
+		{
+			// The Route went foo, then bar, then back to foo. The foo entry was accepted
+			// for the first generation, so it says nothing about the move back.
+			title:      "SectionNameReturnedToThePreviousListener",
+			config:     &Config{},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{
+						{
+							Name:     "foo",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("foo.example.internal")),
+						},
+						{
+							Name:     "bar",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("bar.example.internal")),
+						},
+					},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: omWithGeneration(objectMeta("default", "test"), 3),
+				Spec: v1.HTTPRouteSpec{
+					Hostnames: hostnames("*.example.internal"),
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test", withSectionName("foo")),
+						},
+					},
+				},
+				Status: v1.HTTPRouteStatus{RouteStatus: v1.RouteStatus{Parents: []v1.RouteParentStatus{
+					gwRouteParentStatus(gwParentRef("default", "test", withSectionName("foo")), metav1.ConditionTrue, 1),
+					gwRouteParentStatus(gwParentRef("default", "test", withSectionName("bar")), metav1.ConditionTrue, 2),
+				}}},
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("foo.example.internal", "1.2.3.4"),
+				newTestEndpoint("bar.example.internal", "1.2.3.4"),
+			},
+		},
+		{
 			// EXPERIMENTAL: https://gateway-api.sigs.k8s.io/geps/gep-957/
 			title:      "PortNumberMatch",
 			config:     &Config{},
@@ -695,6 +1200,138 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			}},
 			endpoints: []*endpoint.Endpoint{
 				newTestEndpoint("foo.example.internal", "1.2.3.4"),
+				newTestEndpoint("bar.example.internal", "1.2.3.4"),
+			},
+		},
+		{
+			// The Route moved to a listener on a different port. The current port is
+			// accepted for the current generation, so the stale port entry is dropped.
+			title:      "PortChangedWithStaleParentStatus",
+			config:     &Config{},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{
+						{
+							Name:     "foo",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("foo.example.internal")),
+							Port:     80,
+						},
+						{
+							Name:     "bar",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("bar.example.internal")),
+							Port:     8080,
+						},
+					},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: omWithGeneration(objectMeta("default", "test"), 2),
+				Spec: v1.HTTPRouteSpec{
+					Hostnames: hostnames("*.example.internal"),
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test", withPortNumber(8080)),
+						},
+					},
+				},
+				Status: v1.HTTPRouteStatus{RouteStatus: v1.RouteStatus{Parents: []v1.RouteParentStatus{
+					gwRouteParentStatus(gwParentRef("default", "test", withPortNumber(80)), metav1.ConditionTrue, 1),
+					gwRouteParentStatus(gwParentRef("default", "test", withPortNumber(8080)), metav1.ConditionTrue, 2),
+				}}},
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("bar.example.internal", "1.2.3.4"),
+			},
+		},
+		{
+			// The same move, but only the previous port has a status entry, so the
+			// controller has not caught up. Keep publishing the old listener.
+			title:      "PortChangedBeforeParentStatusCaughtUp",
+			config:     &Config{},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{
+						{
+							Name:     "foo",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("foo.example.internal")),
+							Port:     80,
+						},
+						{
+							Name:     "bar",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("bar.example.internal")),
+							Port:     8080,
+						},
+					},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: omWithGeneration(objectMeta("default", "test"), 2),
+				Spec: v1.HTTPRouteSpec{
+					Hostnames: hostnames("*.example.internal"),
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test", withPortNumber(8080)),
+						},
+					},
+				},
+				Status: v1.HTTPRouteStatus{RouteStatus: v1.RouteStatus{Parents: []v1.RouteParentStatus{
+					gwRouteParentStatus(gwParentRef("default", "test", withPortNumber(80)), metav1.ConditionTrue, 1),
+				}}},
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("foo.example.internal", "1.2.3.4"),
+			},
+		},
+		{
+			// The status lists the current listener before the stale one. The two-pass
+			// scan must give the same result regardless of that order.
+			title:      "SectionNameChangedStatusOrderDoesNotMatter",
+			config:     &Config{},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{
+						{
+							Name:     "foo",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("foo.example.internal")),
+						},
+						{
+							Name:     "bar",
+							Protocol: v1.HTTPProtocolType,
+							Hostname: new(v1.Hostname("bar.example.internal")),
+						},
+					},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: omWithGeneration(objectMeta("default", "test"), 2),
+				Spec: v1.HTTPRouteSpec{
+					Hostnames: hostnames("*.example.internal"),
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test", withSectionName("bar")),
+						},
+					},
+				},
+				Status: v1.HTTPRouteStatus{RouteStatus: v1.RouteStatus{Parents: []v1.RouteParentStatus{
+					gwRouteParentStatus(gwParentRef("default", "test", withSectionName("bar")), metav1.ConditionTrue, 2),
+					gwRouteParentStatus(gwParentRef("default", "test", withSectionName("foo")), metav1.ConditionTrue, 1),
+				}}},
+			}},
+			endpoints: []*endpoint.Endpoint{
 				newTestEndpoint("bar.example.internal", "1.2.3.4"),
 			},
 		},

--- a/source/gateway_test.go
+++ b/source/gateway_test.go
@@ -20,7 +20,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"sigs.k8s.io/external-dns/endpoint"
 )
 
 func TestGatewayMatchingHost(t *testing.T) {
@@ -242,6 +246,131 @@ func TestIsDNS1123Domain(t *testing.T) {
 			if ok := isDNS1123Domain(tt.in); ok != tt.ok {
 				t.Errorf("isDNS1123Domain(%q); got: %v; want: %v", tt.in, ok, tt.ok)
 			}
+		})
+	}
+}
+
+func TestGatewayRouteStatusIsCurrent(t *testing.T) {
+	ref := gwParentRef("default", "gw", withSectionName("bar"))
+
+	condition := func(status metav1.ConditionStatus, observed int64) v1.RouteParentStatus {
+		return v1.RouteParentStatus{
+			ParentRef: ref,
+			Conditions: []metav1.Condition{{
+				Type:               string(v1.RouteConditionAccepted),
+				Status:             status,
+				ObservedGeneration: observed,
+			}},
+		}
+	}
+
+	tests := []struct {
+		desc       string
+		status     v1.RouteParentStatus
+		generation int64
+		want       bool
+	}{
+		{"accepted for the generation in hand", condition(metav1.ConditionTrue, 3), 3, true},
+		{"accepted, but for an older generation", condition(metav1.ConditionTrue, 1), 3, false},
+		{"accepted, but for a generation newer than the object", condition(metav1.ConditionTrue, 4), 3, false},
+		{"accepted, but with no generation recorded", condition(metav1.ConditionTrue, 0), 3, false},
+		{"not accepted", condition(metav1.ConditionFalse, 3), 3, false},
+		{"acceptance still Unknown", condition(metav1.ConditionUnknown, 3), 3, false},
+		{"no accepted condition at all", v1.RouteParentStatus{ParentRef: ref}, 3, false},
+		{
+			"looks past the conditions a controller writes alongside Accepted",
+			v1.RouteParentStatus{
+				ParentRef: ref,
+				Conditions: []metav1.Condition{
+					{Type: string(v1.RouteConditionResolvedRefs), Status: metav1.ConditionTrue, ObservedGeneration: 1},
+					{Type: string(v1.RouteConditionAccepted), Status: metav1.ConditionTrue, ObservedGeneration: 3},
+				},
+			},
+			3, true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			require.Equal(t, tt.want, gwRouteStatusIsCurrent(tt.status, tt.generation))
+		})
+	}
+}
+
+func TestGatewayRouteHasParentRef(t *testing.T) {
+	meta := &metav1.ObjectMeta{Namespace: "default"}
+	gatewayAPIGroup := v1.Group(gatewayGroup)
+
+	omitted := v1.ParentReference{Name: "gw"}
+	explicitGateway := v1.ParentReference{Name: "gw", Group: &gatewayAPIGroup}
+
+	tests := []struct {
+		desc string
+		spec v1.ParentReference
+		got  v1.ParentReference
+		want bool
+	}{
+		{"an omitted group matches an omitted group", omitted, omitted, true},
+		{"an omitted group matches the spelled out Gateway API group", omitted, explicitGateway, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			require.Equal(t, tt.want, gwRouteHasParentRef([]v1.ParentReference{tt.spec}, tt.got, meta))
+		})
+	}
+}
+
+func TestGatewayMatchRouteToParent(t *testing.T) {
+	c := &gatewayRouteResolver{src: &gatewayRouteSource{rtKind: "HTTPRoute"}}
+	rt := &gatewayHTTPRoute{route: v1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route"},
+	}}
+	rtHosts := []string{"example.net"}
+
+	// A listener with no hostname matches any of the route's hostnames.
+	parent := func(gw *v1.Gateway, overrides endpoint.Targets) *resolvedParent {
+		return &resolvedParent{
+			kind:      "Gateway",
+			namespace: "default",
+			ref:       gwParentRef("default", "gw"),
+			obj: &listenerObject{
+				gateway:        gw,
+				ownerNamespace: "default",
+				overrides:      overrides,
+			},
+			listeners: []listenerSection{{
+				listener: v1.Listener{Name: "web", Protocol: v1.HTTPProtocolType},
+				attached: true,
+			}},
+		}
+	}
+
+	withAddress := &v1.Gateway{Status: v1.GatewayStatus{
+		Addresses: []v1.GatewayStatusAddress{{Value: "203.0.113.1"}},
+	}}
+
+	tests := []struct {
+		desc    string
+		parent  *resolvedParent
+		want    bool
+		targets endpoint.Targets
+	}{
+		{"a matched listener with no target does not attach", parent(&v1.Gateway{}, nil), false, nil},
+		{"a Gateway status address is a target", parent(withAddress, nil), true, endpoint.Targets{"203.0.113.1"}},
+		{"a target annotation override is a target", parent(&v1.Gateway{}, endpoint.Targets{"lb.example.net"}), true, endpoint.Targets{"lb.example.net"}},
+		{"a blank target annotation override is not a target", parent(&v1.Gateway{}, endpoint.Targets{"", " "}), false, nil},
+		{"a blank override falls back to the Gateway address", parent(withAddress, endpoint.Targets{"", " "}), true, endpoint.Targets{"203.0.113.1"}},
+		{"a usable override keeps the Gateway address out", parent(withAddress, endpoint.Targets{"lb.example.net", " "}), true, endpoint.Targets{"lb.example.net"}},
+	}
+
+	// Targets are asserted too: filtering blank overrides decides whether the Gateway
+	// address is used instead.
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			hostTargets := map[string]endpoint.Targets{}
+			require.Equal(t, tt.want, c.matchRouteToParent(rt, rtHosts, tt.parent, hostTargets))
+			require.Equal(t, tt.targets, hostTargets["example.net"])
 		})
 	}
 }


### PR DESCRIPTION
## What does it do ?

external-dns resolves the endpoints of a Gateway API Route from every entry in `status.parents`. This change makes it resolve only the entries whose `sectionName` and `port` still exist in `spec.parentRefs`. An older entry is dropped only when the listener the Route now selects is accepted for the current generation and produces a target in the same snapshot. Otherwise every entry is kept, the same as today.

## Motivation

`gwRouteHasParentRef` only matched group, kind, namespace and name. #5241 made it that way on purpose, so a Route whose status is behind its spec still resolves and does not lose its records. @abursavich noted the trade-off in that review:

> In theory I would want to match the sectionName and port too, but in practice that could lead to undesirable outcomes like deleting DNS records when moving from one section to another on the same Gateway.

The problem appears when a Route moves between two listeners of the same Gateway. Before the controller prunes the old listener from `status.parents`, that entry still matches, `resolveParentRef` reads its `sectionName`, and the old listener hostname keeps going out alongside the new one.

I reproduced it with a real controller, Envoy Gateway v1.9.0, and the `inmemory` provider. After the Route moves from listener `foo` to `bar` on the same Gateway, the controller keeps both parents:

    generation: 2, spec.parentRefs: [bar]
    foo: Accepted=True, observedGeneration=1
    bar: Accepted=True, observedGeneration=2

base publishes both hostnames; this change publishes only `bar`:

    base: CREATE foo.6638.example.test    CREATE bar.6638.example.test
    PR:   CREATE bar.6638.example.test

When the controller is behind, so the current listener still has no accepted status for the current generation, the resolver falls back and keeps the old entry, so the record is not deleted:

    generation: 3, spec.parentRefs: [foo], status still on foo(gen1)+bar(gen2)
    PR: CREATE foo.6638.example.test    CREATE bar.6638.example.test

The full manifests, the live status, and the base vs PR output are in #6639.

### Risks for existing deployments

- Once the current listener is accepted and resolvable, the old listener hostname is no longer published. A setup that keeps both hostnames on purpose during a migration will see the old one removed earlier than before.
- During a Gateway controller migration, a current status written by the new controller can cause a superseded listener status from the old controller to be ignored. Readiness is scoped to the parent object, not the status writer.
- `Accepted=True` with a target is not proof that the data plane is ready, so a controller that writes status before the listener is programmed can still have a cutover race.
- A controller that never sets `observedGeneration` never meets the check, so nothing is pruned for it and the source behaves as today. The fix does not reach those controllers.
- The resolver is shared by every Gateway Route source. HTTPRoute is the reproduced case; the behavior applies to the others too.

This PR does not introduce an additional parent identity change. After rebasing, all parent object keys reuse the group and kind defaulting helpers added by #6679.

Depends on #6679.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

Fixes #6639.
Follow-up to #5241.
