### PR TITLE
fix(source): collect annotation hostnames before FQDN template

### DIFF
--- a/source/gateway.go
+++ b/source/gateway.go
@@ -546,9 +546,8 @@ func (c *gatewayRouteResolver) matchRouteToListener(rt gatewayRoute, rtHosts []s
 	return match
 }
 
-// appendFQDNTemplate appends the FQDN-template-generated hostnames to hostnames when the
-// template engine is configured and either nothing else has supplied a hostname yet or the
-// engine is set to combine with existing hostnames.
+// appendFQDNTemplate appends the template-generated hostnames, unless another source already
+// supplied one and the template is not combining.
 // TODO: The combine-fqdn-annotation flag is similarly vague.
 func (c *gatewayRouteResolver) appendFQDNTemplate(hostnames []string, rt gatewayRoute) ([]string, error) {
 	if c.src.templateEngine.IsConfigured() && (len(hostnames) == 0 || c.src.templateEngine.Combining()) {
@@ -561,10 +560,8 @@ func (c *gatewayRouteResolver) appendFQDNTemplate(hostnames []string, rt gateway
 	return hostnames, nil
 }
 
-// resolveHostnames determines the DNS hostnames for a route: spec hostnames, then annotation
-// hostnames, then the FQDN template result, honoring the gateway-hostname-source annotation
-// override. Annotation hostnames are collected before the template runs, so a configured
-// template does not fire when the annotation already named the record.
+// resolveHostnames returns a route's hostnames in the order documented for the gateway sources:
+// spec, annotation, FQDN template, listener fallback, subject to gateway-hostname-source.
 func (c *gatewayRouteResolver) resolveHostnames(rt gatewayRoute) ([]string, error) {
 	var hostnames []string
 	for _, name := range rt.Hostnames() {
@@ -590,9 +587,7 @@ func (c *gatewayRouteResolver) resolveHostnames(rt gatewayRoute) ([]string, erro
 	}
 
 	if !c.src.ignoreHostnameAnnotation {
-		// An empty-string annotation value (key present, no hostname given) must not count as
-		// "a hostname was already supplied": it should still let the FQDN template fall back,
-		// same as when the annotation is absent entirely.
+		// Skip empty values so an empty annotation does not gate the template below.
 		for _, hostname := range annotations.HostnamesFromAnnotations(rt.Metadata().Annotations) {
 			if hostname != "" {
 				hostnames = append(hostnames, hostname)
@@ -603,9 +598,8 @@ func (c *gatewayRouteResolver) resolveHostnames(rt gatewayRoute) ([]string, erro
 	if err != nil {
 		return nil, err
 	}
-	// This means that the route doesn't specify a hostname (or gave an invalid override) and
-	// should use any provided by attached Gateway Listeners. This is only useful for
-	// {HTTP,TLS}Routes, but it doesn't break {TCP,UDP}Routes.
+	// The route named no hostname of its own, so fall back to the attached listeners' hostnames.
+	// Only useful for {HTTP,TLS}Routes, but it doesn't break {TCP,UDP}Routes.
 	if len(rt.Hostnames()) == 0 {
 		hostnames = append(hostnames, "")
 	}

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -404,7 +404,7 @@ func newGatewayRouteResolver(src *gatewayRouteSource, gateways []*v1.Gateway, li
 }
 
 func (c *gatewayRouteResolver) resolve(rt gatewayRoute) (map[string]endpoint.Targets, error) {
-	rtHosts, err := c.hosts(rt)
+	rtHosts, err := c.resolveHostnames(rt)
 	if err != nil {
 		return nil, err
 	}
@@ -546,12 +546,11 @@ func (c *gatewayRouteResolver) matchRouteToListener(rt gatewayRoute, rtHosts []s
 	return match
 }
 
-func (c *gatewayRouteResolver) hosts(rt gatewayRoute) ([]string, error) {
-	var hostnames []string
-	for _, name := range rt.Hostnames() {
-		hostnames = append(hostnames, string(name))
-	}
-	// TODO: The combine-fqdn-annotation flag is similarly vague.
+// appendFQDNTemplate appends the FQDN-template-generated hostnames to hostnames when the
+// template engine is configured and either nothing else has supplied a hostname yet or the
+// engine is set to combine with existing hostnames.
+// TODO: The combine-fqdn-annotation flag is similarly vague.
+func (c *gatewayRouteResolver) appendFQDNTemplate(hostnames []string, rt gatewayRoute) ([]string, error) {
 	if c.src.templateEngine.IsConfigured() && (len(hostnames) == 0 || c.src.templateEngine.Combining()) {
 		hosts, err := c.src.templateEngine.ExecFQDN(rt.Object())
 		if err != nil {
@@ -559,42 +558,51 @@ func (c *gatewayRouteResolver) hosts(rt gatewayRoute) ([]string, error) {
 		}
 		hostnames = append(hostnames, hosts...)
 	}
+	return hostnames, nil
+}
+
+// resolveHostnames determines the DNS hostnames for a route: spec hostnames, then annotation
+// hostnames, then the FQDN template result, honoring the gateway-hostname-source annotation
+// override. Annotation hostnames are collected before the template runs, so a configured
+// template does not fire when the annotation already named the record.
+func (c *gatewayRouteResolver) resolveHostnames(rt gatewayRoute) ([]string, error) {
+	var hostnames []string
+	for _, name := range rt.Hostnames() {
+		hostnames = append(hostnames, string(name))
+	}
 
 	hostNameAnnotation, hostNameAnnotationExists := rt.Metadata().Annotations[annotations.GatewayHostnameSourceKey]
-	if !hostNameAnnotationExists {
-		// This means that the route doesn't specify a hostname and should use any provided by
-		// attached Gateway Listeners. This is only useful for {HTTP,TLS}Routes, but it doesn't
-		// break {TCP,UDP}Routes.
-		if len(rt.Hostnames()) == 0 {
-			hostnames = append(hostnames, "")
+	if hostNameAnnotationExists {
+		switch strings.ToLower(hostNameAnnotation) {
+		case gatewayHostnameSourceAnnotationOnlyValue:
+			if c.src.ignoreHostnameAnnotation {
+				return []string{}, nil
+			}
+			return annotations.HostnamesFromAnnotations(rt.Metadata().Annotations), nil
+		case gatewayHostnameSourceDefinedHostsOnlyValue:
+			// Explicitly use only defined hostnames (route spec and optional template result)
+			return c.appendFQDNTemplate(hostnames, rt)
+		default:
+			// Invalid value provided: warn and fall back to default behavior (as if the annotation is absent)
+			log.Warnf("Invalid value for %q on %s/%s: %q. Falling back to default behavior.",
+				annotations.GatewayHostnameSourceKey, rt.Metadata().Namespace, rt.Metadata().Name, hostNameAnnotation)
 		}
-		if !c.src.ignoreHostnameAnnotation {
-			hostnames = append(hostnames, annotations.HostnamesFromAnnotations(rt.Metadata().Annotations)...)
-		}
-		return hostnames, nil
 	}
 
-	switch strings.ToLower(hostNameAnnotation) {
-	case gatewayHostnameSourceAnnotationOnlyValue:
-		if c.src.ignoreHostnameAnnotation {
-			return []string{}, nil
-		}
-		return annotations.HostnamesFromAnnotations(rt.Metadata().Annotations), nil
-	case gatewayHostnameSourceDefinedHostsOnlyValue:
-		// Explicitly use only defined hostnames (route spec and optional template result)
-		return hostnames, nil
-	default:
-		// Invalid value provided: warn and fall back to default behavior (as if the annotation is absent)
-		log.Warnf("Invalid value for %q on %s/%s: %q. Falling back to default behavior.",
-			annotations.GatewayHostnameSourceKey, rt.Metadata().Namespace, rt.Metadata().Name, hostNameAnnotation)
-		if len(rt.Hostnames()) == 0 {
-			hostnames = append(hostnames, "")
-		}
-		if !c.src.ignoreHostnameAnnotation {
-			hostnames = append(hostnames, annotations.HostnamesFromAnnotations(rt.Metadata().Annotations)...)
-		}
-		return hostnames, nil
+	if !c.src.ignoreHostnameAnnotation {
+		hostnames = append(hostnames, annotations.HostnamesFromAnnotations(rt.Metadata().Annotations)...)
 	}
+	hostnames, err := c.appendFQDNTemplate(hostnames, rt)
+	if err != nil {
+		return nil, err
+	}
+	// This means that the route doesn't specify a hostname (or gave an invalid override) and
+	// should use any provided by attached Gateway Listeners. This is only useful for
+	// {HTTP,TLS}Routes, but it doesn't break {TCP,UDP}Routes.
+	if len(rt.Hostnames()) == 0 {
+		hostnames = append(hostnames, "")
+	}
+	return hostnames, nil
 }
 
 func (c *gatewayRouteResolver) routeIsAllowed(ownerNamespace string, lis *v1.Listener, rt gatewayRoute) bool {

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -590,7 +590,14 @@ func (c *gatewayRouteResolver) resolveHostnames(rt gatewayRoute) ([]string, erro
 	}
 
 	if !c.src.ignoreHostnameAnnotation {
-		hostnames = append(hostnames, annotations.HostnamesFromAnnotations(rt.Metadata().Annotations)...)
+		// An empty-string annotation value (key present, no hostname given) must not count as
+		// "a hostname was already supplied": it should still let the FQDN template fall back,
+		// same as when the annotation is absent entirely.
+		for _, hostname := range annotations.HostnamesFromAnnotations(rt.Metadata().Annotations) {
+			if hostname != "" {
+				hostnames = append(hostnames, hostname)
+			}
+		}
 	}
 	hostnames, err := c.appendFQDNTemplate(hostnames, rt)
 	if err != nil {

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -920,8 +920,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			},
 		},
 		{
-			// Annotation hostnames must be collected before the FQDN template so a
-			// configured template does not run when the annotation already named the record.
+			// The annotation already named the record, so the template must not fire.
 			title: "AnnotationBeforeFQDNTemplate",
 			config: &Config{
 				TemplateEngine: templatetest.MustEngine(t, "{{.Name}}.template.internal", "", "", false),
@@ -957,8 +956,7 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			},
 		},
 		{
-			// A hostname annotation present with an empty value contributes no hostname, so it
-			// must not suppress the FQDN template fallback either.
+			// An empty annotation names no record, so it must not suppress the template either.
 			title: "EmptyHostnameAnnotationFallsBackToFQDNTemplate",
 			config: &Config{
 				TemplateEngine: templatetest.MustEngine(t, "{{.Name}}.template.internal", "", "", false),

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -920,6 +920,43 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			},
 		},
 		{
+			// Annotation hostnames must be collected before the FQDN template so a
+			// configured template does not run when the annotation already named the record.
+			title: "AnnotationBeforeFQDNTemplate",
+			config: &Config{
+				TemplateEngine: templatetest.MustEngine(t, "{{.Name}}.template.internal", "", "", false),
+			},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{{Protocol: v1.HTTPProtocolType}},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "annotated-route",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.HostnameKey: "service.example.com",
+					},
+				},
+				Spec: v1.HTTPRouteSpec{
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test"),
+						},
+					},
+					Hostnames: nil,
+				},
+				Status: httpRouteStatus(gwParentRef("default", "test")),
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("service.example.com", "1.2.3.4"),
+			},
+		},
+		{
 			title: "IgnoreHostnameAnnotation",
 			config: &Config{
 				IgnoreHostnameAnnotation: true,

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -957,6 +957,43 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			},
 		},
 		{
+			// A hostname annotation present with an empty value contributes no hostname, so it
+			// must not suppress the FQDN template fallback either.
+			title: "EmptyHostnameAnnotationFallsBackToFQDNTemplate",
+			config: &Config{
+				TemplateEngine: templatetest.MustEngine(t, "{{.Name}}.template.internal", "", "", false),
+			},
+			namespaces: namespaces("default"),
+			gateways: []*v1.Gateway{{
+				ObjectMeta: objectMeta("default", "test"),
+				Spec: v1.GatewaySpec{
+					Listeners: []v1.Listener{{Protocol: v1.HTTPProtocolType}},
+				},
+				Status: gatewayStatus("1.2.3.4"),
+			}},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "empty-annotated-route",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.HostnameKey: "",
+					},
+				},
+				Spec: v1.HTTPRouteSpec{
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("default", "test"),
+						},
+					},
+					Hostnames: nil,
+				},
+				Status: httpRouteStatus(gwParentRef("default", "test")),
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("empty-annotated-route.template.internal", "1.2.3.4"),
+			},
+		},
+		{
 			title: "IgnoreHostnameAnnotation",
 			config: &Config{
 				IgnoreHostnameAnnotation: true,


### PR DESCRIPTION
Split out of #6600 per review feedback from @ivankatliarchuk and @mloiseleur, who asked for the template/annotation ordering fix to land as its own PR for a clean changelog/review/revert story.

## Problem

`gatewayRouteResolver`'s hostname resolution ran the FQDN template before collecting annotation hostnames. The documented/intended order for the `gateway-*` sources is spec hostnames → annotation → template → listener fallback, but the template evaluation happened first, so:

- A non-combining template could still fire and get appended even when an annotation would otherwise have already named the record.
- The `Combining()` (`--combine-fqdn-annotation`) branch's decision of "did anything already supply a hostname" was made before annotation hostnames existed.

## Fix

Move template evaluation to after annotation hostname collection. Also renamed the two collaborating functions for clarity (raised independently in review): `hosts` → `resolveHostnames` (it resolves the final hostname list, not just "the hosts"), and `applyGatewayTemplate` → `appendFQDNTemplate` (it conditionally appends template output, it doesn't unconditionally "apply" anything).

## Test plan

- [x] Added `AnnotationBeforeFQDNTemplate`: annotation-named route with a non-combining template configured must not have the template fire.
- [x] `go test -race ./source/...` passes.
- [x] Verified against #6600's existing gateway test suite (`CombineFQDN`, `FQDNTemplate`, etc.) — no behavior change outside the annotation/template ordering.

This report was prepared with AI coding-agent assistance, independently verified against current source and tests before opening.