### PR TITLE
ci(release): make the generated changelog readable

### DIFF
--- a/scripts/releaser.sh
+++ b/scripts/releaser.sh
@@ -15,31 +15,44 @@ function label_by_scope {
   sed -E -e 's/^- [a-z]+\(([^)]*)\)!?: */- [\1] /' -e 's/^- [a-z]+!?: */- /'
 }
 
-# Same, but "Others" keeps the type: "ci(e2e): use X" -> "[ci] [e2e] use X".
-# Except "chore", which carries no meaning.
-function label_by_type {
-  sed -E \
-    -e 's/^- chore\(([^)]*)\)!?: */- [\1] /' \
-    -e 's/^- chore!?: */- /' \
-    -e 's/^- ([a-z]+)\(([^)]*)\)!?: */- [\1] [\2] /' \
-    -e 's/^- ([a-z]+)!?: */- [\1] /'
-}
-
-# section <title> <formatter> <grep args...>
+# section <title> <grep args...>
 function section {
-  local title="$1" formatter="$2"
-  shift 2
+  local title="$1"
+  shift
   local body
-  body=$(grep -E "$@" "${MERGED_PRS}" | "${formatter}" | sort) || true
+  body=$(grep -E "$@" "${MERGED_PRS}" | label_by_scope | sort) || true
   [ -n "${body}" ] || return 0
   printf '\n%s\n\n%s\n' "${title}" "${body}"
 }
 
+# Everything left, folded per type: the type is the summary, so entries keep only their scope.
+function others {
+  # "chore(deps)" is a dependency bump, not a chore: fold it with the "deps" type.
+  local rest
+  rest=$(grep -vE -e "${BREAKING_RE}" -e "${FEAT_RE}" -e "${FIX_RE}" -e "${DOCS_RE}" "${MERGED_PRS}" \
+    | sed -E 's/^- chore\(deps\)/- deps/') || true
+  [ -n "${rest}" ] || return 0
+
+  printf '\n## :package: Others\n'
+  local type
+  for type in $(printf '%s\n' "${rest}" | sed -nE 's/^- ([a-z]+)[(:].*/\1/p' | sort -u); do
+    printf '\n<details><summary>%s</summary>\n\n%s\n\n</details>\n' \
+      "${type}" "$(printf '%s\n' "${rest}" | grep -E "^- ${type}[(:]" | label_by_scope | sort)"
+  done
+
+  # Titles that are not conventional commits at all, left as they are.
+  local misc
+  misc=$(printf '%s\n' "${rest}" | grep -vE '^- [a-z]+[(:]' | sort) || true
+  if [ -n "${misc}" ]; then
+    printf '\n%s\n' "${misc}"
+  fi
+}
+
 function generate_changelog {
-  section "## :warning: Breaking Changes" label_by_scope "${BREAKING_RE}"
-  section "## :rocket: Features" label_by_scope "${FEAT_RE}"
-  section "## :bug: Bug fixes" label_by_scope "${FIX_RE}"
-  section "## :memo: Documentation" label_by_scope "${DOCS_RE}"
+  section "## :warning: Breaking Changes" "${BREAKING_RE}"
+  section "## :rocket: Features" "${FEAT_RE}"
+  section "## :bug: Bug fixes" "${FIX_RE}"
+  section "## :memo: Documentation" "${DOCS_RE}"
 
   printf '\n## :package: Docker Image\n\n'
   echo '```sh'
@@ -47,7 +60,7 @@ function generate_changelog {
   echo "docker pull registry.k8s.io/external-dns/external-dns:${VERSION}"
   echo '```'
 
-  section "## :package: Others" label_by_type -v -e "${BREAKING_RE}" -e "${FEAT_RE}" -e "${FIX_RE}" -e "${DOCS_RE}"
+  others
 }
 
 LATEST=$(gh release list -L 10 --json name,isLatest,publishedAt --jq '.[] | select(.isLatest) | "\(.name)\t\(.publishedAt)\t\(.publishedAt | fromdateiso8601)"')

--- a/scripts/releaser.sh
+++ b/scripts/releaser.sh
@@ -1,88 +1,92 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
+# Conventional-commit matchers, anchored on the "- " list marker.
+BREAKING_RE='^- [a-z]+(\([^)]*\))?!: '
+FEAT_RE='^- feat(\([^)]*\))?: '
+FIX_RE='^- fix(\([^)]*\))?: '
+DOCS_RE='^- docs(\([^)]*\))?: '
 
+# The Helm chart has its own release cycle.
+CHART_RE='charts?|helm'
+
+# "feat(aws): add X" -> "[aws] add X" ; "feat: add X" -> "add X"
+function label_by_scope {
+  sed -E -e 's/^- [a-z]+\(([^)]*)\)!?: */- [\1] /' -e 's/^- [a-z]+!?: */- /'
+}
+
+# Same, but "Others" keeps the type: "ci(e2e): use X" -> "[ci] [e2e] use X".
+# Except "chore", which carries no meaning.
+function label_by_type {
+  sed -E \
+    -e 's/^- chore\(([^)]*)\)!?: */- [\1] /' \
+    -e 's/^- chore!?: */- /' \
+    -e 's/^- ([a-z]+)\(([^)]*)\)!?: */- [\1] [\2] /' \
+    -e 's/^- ([a-z]+)!?: */- [\1] /'
+}
+
+# section <title> <formatter> <grep args...>
+function section {
+  local title="$1" formatter="$2"
+  shift 2
+  local body
+  body=$(grep -E "$@" "${MERGED_PRS}" | "${formatter}" | sort) || true
+  [ -n "${body}" ] || return 0
+  printf '\n%s\n\n%s\n' "${title}" "${body}"
+}
 
 function generate_changelog {
-  MERGED_PRS="$1"
+  section "## :warning: Breaking Changes" label_by_scope "${BREAKING_RE}"
+  section "## :rocket: Features" label_by_scope "${FEAT_RE}"
+  section "## :bug: Bug fixes" label_by_scope "${FIX_RE}"
+  section "## :memo: Documentation" label_by_scope "${DOCS_RE}"
 
-  echo
-  echo "## :warning: Breaking Changes"
-  echo
-  cat "${MERGED_PRS}" | grep "\!" || true # no breaking change, section should be removed.
-
-  echo
-  echo "## :rocket: Features"
-  echo
-  cat "${MERGED_PRS}" | grep feat[:\(]
-
-  echo
-  echo "## :bug: Bug fixes"
-  echo
-  cat "${MERGED_PRS}" | grep fix[:\(]
-
-  echo
-  echo "## :memo: Documentation"
-  echo
-  cat "${MERGED_PRS}" | grep docs[:\(]
-
-  echo
-  echo "## :package: Others"
-  echo
-  cat "${MERGED_PRS}" | grep -v "\!" | grep -v feat[:\(] | grep -v fix[:\(] | grep -v docs[:\(]
-
-  echo
-  echo "## :package: Docker Image"
-  echo
-  echo "\`\`\`sh"
+  printf '\n## :package: Docker Image\n\n'
+  echo '```sh'
   echo "# This pull command only works when it's released"
   echo "docker pull registry.k8s.io/external-dns/external-dns:${VERSION}"
-  echo "\`\`\`"
+  echo '```'
 
+  section "## :package: Others" label_by_type -v -e "${BREAKING_RE}" -e "${FEAT_RE}" -e "${FIX_RE}" -e "${DOCS_RE}"
 }
 
-function create_release {
-  generate_changelog | sort # | gh release create "$1" -t "$1" -F -
-}
-
-function latest_release {
-  gh release list -L 10 --json name,isLatest --jq '.[] | select(.isLatest)|.name'
-}
-
-function latest_release_date {
-  gh release list -L 10 --json name,isLatest,publishedAt --jq '.[] | select(.isLatest)|.publishedAt'
-}
-
-function latest_release_ts {
-  gh release list -L 10 --json name,isLatest,publishedAt --jq '.[] | select(.isLatest)|.publishedAt | fromdateiso8601'
-}
+LATEST=$(gh release list -L 10 --json name,isLatest,publishedAt --jq '.[] | select(.isLatest) | "\(.name)\t\(.publishedAt)\t\(.publishedAt | fromdateiso8601)"')
+IFS=$'\t' read -r RELEASE_NAME RELEASE_DATE TIMESTAMP <<< "${LATEST}"
 
 if [ $# -ne 1 ]; then
     echo "** DRY RUN **"
 fi
 
-printf "Latest release: %s (%s)\n" $(latest_release) $(latest_release_date)
+printf "Latest release: %s (%s)\n" "${RELEASE_NAME}" "${RELEASE_DATE}"
 
-TIMESTAMP=$(latest_release_ts)
+ALL_PRS=$(mktemp)
 MERGED_PRS=$(mktemp)
+trap 'rm -f "${ALL_PRS}" "${MERGED_PRS}"' EXIT
+
 gh pr list \
   --state merged \
   --json author,number,mergeCommit,mergedAt,url,title \
   --limit 999 \
   --jq ".[] |
     select (.mergedAt | fromdateiso8601 > ${TIMESTAMP}) | \
-    \"- \(.title) by @\(.author.login) in #\(.number)\"
-  " | sort > "${MERGED_PRS}"
+    \"- \(.title | sub(\"^\\\\s+\";\"\") | sub(\"\\\\s+$\";\"\")) by @\(.author.login) in #\(.number)\"
+  " | sort > "${ALL_PRS}"
+
+grep -viwE "${CHART_RE}" "${ALL_PRS}" > "${MERGED_PRS}" || true
+
+# On stderr, so it never lands in the release body.
+if grep -iwE "${CHART_RE}" "${ALL_PRS}" >&2; then
+  printf "^^ excluded from the changelog: chart-only changes, released separately\n\n" >&2
+fi
 
 if [ $# -ne 1 ]; then
   export VERSION="v0.x.0"
-  generate_changelog "${MERGED_PRS}"
+  generate_changelog
+  echo
   echo "** DRY RUN **"
   echo
   echo "To create a release: ./releaser.sh v0.x.0"
 else
   export VERSION="$1"
-  generate_changelog "${MERGED_PRS}" | gh release create "${VERSION}" -t "${VERSION}" -p -F -
+  generate_changelog | gh release create "${VERSION}" -t "${VERSION}" -p -F -
 fi
-
-rm -f "${MERGED_PRS}"


### PR DESCRIPTION
## What does it do ?

Update changelog script to make release notes more readable.

See release notes [v0.22.0](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.22.0) (done with this version) vs [v0.21.0](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.21.0) (done with previous version)

## Motivation

`scripts/releaser.sh` printed the conventional-commit prefix on every line, which makes the release notes tedious to read.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
