### PR TITLE
docs: update staging image link in release notes

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -7,7 +7,7 @@ You might want to ask in our Slack channel [external-dns](https://kubernetes.sla
 
 ## Staging Release cycle
 
-A new staging image is released weekly and can be found on [the official staging registry]([https://console.cloud.google.com/gcr/images/k8s-staging-external-dns/GLOBAL/external-dns?pli=1&inv=1&invt=AboL6Q](https://console.cloud.google.com/artifacts/docker/k8s-staging-external-dns/us/gcr.io/external-dns?project=k8s-staging-external-dns)).
+A new staging image is released weekly and can be found on [the official staging registry](https://console.cloud.google.com/artifacts/docker/k8s-staging-external-dns/us/gcr.io/external-dns?project=k8s-staging-external-dns).
 
 > There is a time lag between merging changes into the master branch and the subsequent creation of the staging image.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -7,7 +7,7 @@ You might want to ask in our Slack channel [external-dns](https://kubernetes.sla
 
 ## Staging Release cycle
 
-A new staging image is released weekly and can be found at [gcr.io/k8s-staging-external-dns/external-dns](https://console.cloud.google.com/gcr/images/k8s-staging-external-dns/GLOBAL/external-dns?pli=1&inv=1&invt=AboL6Q).
+A new staging image is released weekly and can be found on [the official staging registry]([https://console.cloud.google.com/gcr/images/k8s-staging-external-dns/GLOBAL/external-dns?pli=1&inv=1&invt=AboL6Q](https://console.cloud.google.com/artifacts/docker/k8s-staging-external-dns/us/gcr.io/external-dns?project=k8s-staging-external-dns)).
 
 > There is a time lag between merging changes into the master branch and the subsequent creation of the staging image.
 


### PR DESCRIPTION
## What does it do ?

The old link was wrong, this PR fixes it. 

## Motivation

This is due to internal changes to GCR.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
