### PR TITLE
feat(chart): release 1.22 for extdns v0.22.0

### DIFF
--- a/charts/external-dns/CHANGELOG.md
+++ b/charts/external-dns/CHANGELOG.md
@@ -18,20 +18,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
-- Add value `.service.enabled` to enable the creation of the Kubernetes service. [#6400](https://github.com/kubernetes-sigs/external-dns/pull/6400) _@jullianow_
-- Add value `replicaCount` to set the number of `external-dns` replicas (bounded to `0` or `1`, since external-dns does not support leader election). [#6503](https://github.com/kubernetes-sigs/external-dns/pull/6503) _@yugstar_
-- Add `crd` as a valid `registry` value and grant the matching RBAC on `dnsrecords` for the CRD registry. [#6513](https://github.com/kubernetes-sigs/external-dns/pull/6513) _@mloiseleur_
-- Add value `hostAliases` to inject entries into the `Pod`'s `/etc/hosts`, for reaching a provider or webhook by a hostname that cluster DNS cannot resolve. [#6588](https://github.com/kubernetes-sigs/external-dns/pull/6588) _@jetersen_
+## [v1.22.0] - 2026-09-11
+
+### Added
+
+- Add value `.service.enabled` to enable the creation of the Kubernetes service. [#6400](https://github.com/kubernetes-sigs/external-dns/pull/6400) @jullianow
+- Add value `replicaCount` to set the number of `external-dns` replicas (bounded to `0` or `1`, since external-dns does not support leader election). [#6503](https://github.com/kubernetes-sigs/external-dns/pull/6503) @yugstar
+- Add `crd` as a valid `registry` value and grant the matching RBAC on `dnsrecords` for the CRD registry. [#6513](https://github.com/kubernetes-sigs/external-dns/pull/6513) @mloiseleur
+- Add value `hostAliases` to inject entries into the `Pod`'s `/etc/hosts`, for reaching a provider or webhook by a hostname that cluster DNS cannot resolve. [#6588](https://github.com/kubernetes-sigs/external-dns/pull/6588) @jetersen
 
 ### Changed
 
-- **Breaking:** `policy` no longer defaults to `upsert-only` and is now required. You must set `policy` explicitly to one of `create-only`, `sync`, or `upsert-only`. [#6508](https://github.com/kubernetes-sigs/external-dns/pull/6508) _@mloiseleur_
+- **Breaking:** `policy` no longer defaults to `upsert-only` and is now required. You must set `policy` explicitly to one of `create-only`, `sync`, or `upsert-only`. [#6508](https://github.com/kubernetes-sigs/external-dns/pull/6508) @mloiseleur
+- Update _ExternalDNS_ OCI image version to [`v0.22.0`](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.22.0). [#6650](https://github.com/kubernetes-sigs/external-dns/pull/5479) @stevehipwell
 
 ### Fixed
 
-- RBAC compliance checkbox for dnsendpoints/status [#6442](https://github.com/kubernetes-sigs/external-dns/pull/6442) _@vflaux_
+- RBAC compliance checkbox for dnsendpoints/status [#6442](https://github.com/kubernetes-sigs/external-dns/pull/6442) @vflaux
 
-## [v1.21.1]
+## [v1.21.1] - 2026-04-30
 
 ### Added
 
@@ -50,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure container arguments are passed in as strings ([#6264](https://github.com/kubernetes-sigs/external-dns/pull/6264)) _@KhooHaoYit_
 - Ensure container arguments are passed in as strings when extraArgs is a map ([#6284](https://github.com/kubernetes-sigs/external-dns/pull/6284)) _@vflaux_
 
-## [v1.20.0]
+## [v1.20.0] - 2026-01-02
 
 ### Added
 
@@ -174,7 +179,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for `extraContainers` argument. ([#4432](https://github.com/kubernetes-sigs/external-dns/pull/4432)) _@omerap12_
-- Added support for setting `excludeDomains` argument.  ([#4380](https://github.com/kubernetes-sigs/external-dns/pull/4380)) _@bford-evs_
+- Added support for setting `excludeDomains` argument. ([#4380](https://github.com/kubernetes-sigs/external-dns/pull/4380)) _@bford-evs_
 
 ### Changed
 
@@ -224,7 +229,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the option to explicitly enable or disable service account token automounting. ([#3983](https://github.com/kubernetes-sigs/external-dns/pull/3983)) [@gilles-gosuin](https://github.com/gilles-gosuin)
 - Added the option to configure revisionHistoryLimit on the K8s Deployment resource. ([#4008](https://github.com/kubernetes-sigs/external-dns/pull/4008)) [@arnisoph](https://github.com/arnisoph)
 - Added support for webhook providers, as a sidecar. ([#4032](https://github.com/kubernetes-sigs/external-dns/pull/4032) [@mloiseleur](https://github.com/mloiseleur)
-- Added the option to configure ipFamilyPolicy and ipFamilies of external-dns Service.  ([#4153](https://github.com/kubernetes-sigs/external-dns/pull/4153)) [@dongjiang1989](https://github.com/dongjiang1989)
+- Added the option to configure ipFamilyPolicy and ipFamilies of external-dns Service. ([#4153](https://github.com/kubernetes-sigs/external-dns/pull/4153)) [@dongjiang1989](https://github.com/dongjiang1989)
 
 ### Changed
 
@@ -338,6 +343,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 RELEASE LINKS
 -->
 [UNRELEASED]: https://github.com/kubernetes-sigs/external-dns/tree/master/charts/external-dns
+[v1.22.0]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.22.0
 [v1.21.1]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.21.1
 [v1.20.0]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.20.0
 [v1.19.0]: https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.19.0

--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: external-dns
 description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 type: application
-version: 1.21.1
-appVersion: 0.21.0
+version: 1.22.0
+appVersion: 0.22.0
 keywords:
   - kubernetes
   - k8s

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -2,7 +2,7 @@
 
 <!-- markdownlint-disable MD060 -->
 
-![Version: 1.21.1](https://img.shields.io/badge/Version-1.21.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.21.0](https://img.shields.io/badge/AppVersion-0.21.0-informational?style=flat-square)
+![Version: 1.22.0](https://img.shields.io/badge/Version-1.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.22.0](https://img.shields.io/badge/AppVersion-0.22.0-informational?style=flat-square)
 
 ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
 
@@ -29,7 +29,7 @@ helm repo add external-dns https://kubernetes-sigs.github.io/external-dns/
 After you've installed the repo you can install the chart.
 
 ```shell
-helm upgrade --install external-dns external-dns/external-dns --version 1.21.1
+helm upgrade --install external-dns external-dns/external-dns --version 1.22.0
 ```
 
 ## Providers


### PR DESCRIPTION
## What does it do ?

This PR updates and releases the Helm chart for the `v0.22.0` version.

Closes #6646

## Motivation

<!-- What inspired you to submit this pull request? -->

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
