### PR TITLE
fix(rfc2136): do not swallow AXFR envelope errors

### DIFF
--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -340,12 +340,10 @@ func (r *rfc2136Provider) List() ([]dns.RR, error) {
 						log.Errorf("AXFR error: %v", e.Error)
 					}
 					attemptErr = e.Error
-					// The producer sends a single error envelope and then closes the
-					// channel, so breaking here does not leak it.
+					// Producer closes the channel after a single error envelope.
 					break
 				}
-				// Only reached when e.Error is nil: error envelopes can still
-				// carry RRs, which must not be accumulated.
+				// Error envelopes can carry RRs; those must not be accumulated.
 				attempt = append(attempt, e.RR...)
 			}
 			if attemptErr != nil {
@@ -353,10 +351,9 @@ func (r *rfc2136Provider) List() ([]dns.RR, error) {
 				r.listLastErr = lastErr
 				continue
 			}
-			// A later attempt succeeded: clear any error from an earlier attempt so
-			// the post-loop guard does not report a failure that was already retried
-			// away. r.listLastErr is intentionally left alone — getNextNameserverFor(nameserverOpList)
-			// reads and resets it under r.mu to drive the "disabled" strategy's counter.
+			// Clear an earlier attempt's error so the post-loop guard does not report
+			// a failure that was already retried away. r.listLastErr is left alone:
+			// getNextNameserverFor reads and resets it to drive the "disabled" strategy.
 			lastErr = nil
 			records = append(records, attempt...)
 			// If records were fetched successfully, break out of the loop

--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -312,16 +312,17 @@ func (r *rfc2136Provider) List() ([]dns.RR, error) {
 	for _, zone := range r.zoneNames {
 		log.Debugf("Fetching records for '%q'", zone)
 
-		m := new(dns.Msg)
-		m.SetAxfr(dns.Fqdn(zone))
-		if !r.insecure && !r.gssTsig {
-			m.SetTsig(r.tsigKeyName, r.tsigSecretAlg, clockSkew, time.Now().Unix())
-		}
-
 		var lastErr error
 		for i := 0; i < len(r.nameservers); i++ {
 			nameserver := r.getNextNameserverFor(nameserverOpList)
 			log.Debugf("Fetching records from nameserver: %s", nameserver)
+
+			// Signing strips the TSIG RR, so a reused message goes out unsigned.
+			m := new(dns.Msg)
+			m.SetAxfr(dns.Fqdn(zone))
+			if !r.insecure && !r.gssTsig {
+				m.SetTsig(r.tsigKeyName, r.tsigSecretAlg, clockSkew, time.Now().Unix())
+			}
 
 			env, err := r.actions.IncomeTransfer(m, nameserver)
 			if err != nil {

--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -325,11 +325,13 @@ func (r *rfc2136Provider) List() ([]dns.RR, error) {
 
 			env, err := r.actions.IncomeTransfer(m, nameserver)
 			if err != nil {
-				lastErr = fmt.Errorf("failed to fetch records via AXFR: %w", err)
+				lastErr = fmt.Errorf("failed to fetch records via AXFR for zone %q from %s: %w", zone, nameserver, err)
 				r.listLastErr = lastErr
 				continue
 			}
 
+			var attempt []dns.RR
+			var attemptErr error
 			for e := range env {
 				if e.Error != nil {
 					if errors.Is(e.Error, dns.ErrSoa) {
@@ -337,10 +339,26 @@ func (r *rfc2136Provider) List() ([]dns.RR, error) {
 					} else {
 						log.Errorf("AXFR error: %v", e.Error)
 					}
-					continue
+					attemptErr = e.Error
+					// The producer sends a single error envelope and then closes the
+					// channel, so breaking here does not leak it.
+					break
 				}
-				records = append(records, e.RR...)
+				// Only reached when e.Error is nil: error envelopes can still
+				// carry RRs, which must not be accumulated.
+				attempt = append(attempt, e.RR...)
 			}
+			if attemptErr != nil {
+				lastErr = fmt.Errorf("failed to read AXFR response for zone %q from %s: %w", zone, nameserver, attemptErr)
+				r.listLastErr = lastErr
+				continue
+			}
+			// A later attempt succeeded: clear any error from an earlier attempt so
+			// the post-loop guard does not report a failure that was already retried
+			// away. r.listLastErr is intentionally left alone — getNextNameserverFor(nameserverOpList)
+			// reads and resets it under r.mu to drive the "disabled" strategy's counter.
+			lastErr = nil
+			records = append(records, attempt...)
 			// If records were fetched successfully, break out of the loop
 			if len(records) > 0 {
 				break

--- a/provider/rfc2136/rfc2136_test.go
+++ b/provider/rfc2136/rfc2136_test.go
@@ -1162,8 +1162,7 @@ func TestRfc2136NameserverFailureReturnsSoftError(t *testing.T) {
 	assert.ErrorIs(t, err, provider.SoftError, "Expected SoftError when nameserver fails in ApplyChanges")
 }
 
-// axfrEnvelopeErrorStub simulates a nameserver that returns valid envelopes
-// followed by an error envelope mid-transfer (e.g. a read timeout).
+// axfrEnvelopeErrorStub returns a valid envelope followed by an error envelope.
 type axfrEnvelopeErrorStub struct {
 	rfc2136Stub
 }
@@ -1171,8 +1170,7 @@ type axfrEnvelopeErrorStub struct {
 func (r *axfrEnvelopeErrorStub) IncomeTransfer(_ *dns.Msg, _ string) (chan *dns.Envelope, error) {
 	outChan := make(chan *dns.Envelope)
 	go func() {
-		// Send one valid envelope before the error to confirm partial records
-		// are not returned on a failed transfer.
+		// Partial records must not be returned on a failed transfer.
 		outChan <- &dns.Envelope{
 			RR: []dns.RR{
 				&dns.A{
@@ -1186,16 +1184,13 @@ func (r *axfrEnvelopeErrorStub) IncomeTransfer(_ *dns.Msg, _ string) (chan *dns.
 				},
 			},
 		}
-		// Then send an error envelope (e.g. i/o timeout mid-stream).
 		outChan <- &dns.Envelope{Error: fmt.Errorf("i/o timeout")}
 		close(outChan)
 	}()
 	return outChan, nil
 }
 
-// TestRfc2136AxfrEnvelopeErrorReturnsSoftError verifies that an error envelope
-// received during an AXFR transfer surfaces as a SoftError rather than being
-// swallowed and returning a (partial, nil) result.
+// An AXFR error envelope must surface as a SoftError, not a (partial, nil) result.
 func TestRfc2136AxfrEnvelopeErrorReturnsSoftError(t *testing.T) {
 	stub := &axfrEnvelopeErrorStub{
 		rfc2136Stub: rfc2136Stub{
@@ -1245,10 +1240,8 @@ func TestRfc2136AxfrEnvelopeErrorReturnsSoftError(t *testing.T) {
 	assert.Empty(t, records, "Expected no records returned when AXFR envelope carries an error")
 }
 
-// axfrFailoverStub simulates two nameservers: the first returns an error
-// envelope (e.g. a read timeout), the second returns a clean transfer with a
-// valid A record. Used to verify that a successful retry is not poisoned by
-// the earlier failure.
+// axfrFailoverStub fails the first nameserver with an error envelope, then
+// serves a clean transfer from the second.
 type axfrFailoverStub struct {
 	rfc2136Stub
 	calls int
@@ -1258,14 +1251,12 @@ func (r *axfrFailoverStub) IncomeTransfer(_ *dns.Msg, _ string) (chan *dns.Envel
 	r.calls++
 	outChan := make(chan *dns.Envelope)
 	if r.calls == 1 {
-		// First nameserver: return an error envelope mid-stream.
 		go func() {
 			outChan <- &dns.Envelope{Error: fmt.Errorf("i/o timeout on ns1")}
 			close(outChan)
 		}()
 		return outChan, nil
 	}
-	// Second nameserver: return a clean transfer with one A record.
 	go func() {
 		outChan <- &dns.Envelope{
 			RR: []dns.RR{
@@ -1285,11 +1276,8 @@ func (r *axfrFailoverStub) IncomeTransfer(_ *dns.Msg, _ string) (chan *dns.Envel
 	return outChan, nil
 }
 
-// TestRfc2136AxfrFailoverSucceedsAfterEnvelopeError verifies that when the
-// first nameserver returns an error envelope and a second nameserver succeeds,
-// List() returns the records from the successful attempt with a nil error.
-// Regression test for REL-01: lastErr was not cleared on a successful retry,
-// causing the post-loop guard to fire even after a good transfer.
+// Regression: lastErr was not cleared on a successful retry, so the post-loop
+// guard fired even after a later nameserver returned a clean transfer.
 func TestRfc2136AxfrFailoverSucceedsAfterEnvelopeError(t *testing.T) {
 	stub := &axfrFailoverStub{
 		rfc2136Stub: rfc2136Stub{

--- a/provider/rfc2136/rfc2136_test.go
+++ b/provider/rfc2136/rfc2136_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"net"
 	"os"
 	"regexp"
 	"sort"
@@ -1159,6 +1160,182 @@ func TestRfc2136NameserverFailureReturnsSoftError(t *testing.T) {
 	err = providerInstance.ApplyChanges(t.Context(), p)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, provider.SoftError, "Expected SoftError when nameserver fails in ApplyChanges")
+}
+
+// axfrEnvelopeErrorStub simulates a nameserver that returns valid envelopes
+// followed by an error envelope mid-transfer (e.g. a read timeout).
+type axfrEnvelopeErrorStub struct {
+	rfc2136Stub
+}
+
+func (r *axfrEnvelopeErrorStub) IncomeTransfer(_ *dns.Msg, _ string) (chan *dns.Envelope, error) {
+	outChan := make(chan *dns.Envelope)
+	go func() {
+		// Send one valid envelope before the error to confirm partial records
+		// are not returned on a failed transfer.
+		outChan <- &dns.Envelope{
+			RR: []dns.RR{
+				&dns.A{
+					Hdr: dns.RR_Header{
+						Name:   "test.example.com.",
+						Rrtype: dns.TypeA,
+						Class:  dns.ClassINET,
+						Ttl:    300,
+					},
+					A: net.ParseIP("1.2.3.4"),
+				},
+			},
+		}
+		// Then send an error envelope (e.g. i/o timeout mid-stream).
+		outChan <- &dns.Envelope{Error: fmt.Errorf("i/o timeout")}
+		close(outChan)
+	}()
+	return outChan, nil
+}
+
+// TestRfc2136AxfrEnvelopeErrorReturnsSoftError verifies that an error envelope
+// received during an AXFR transfer surfaces as a SoftError rather than being
+// swallowed and returning a (partial, nil) result.
+func TestRfc2136AxfrEnvelopeErrorReturnsSoftError(t *testing.T) {
+	stub := &axfrEnvelopeErrorStub{
+		rfc2136Stub: rfc2136Stub{
+			output:                make([]*dns.Envelope, 0),
+			updateMsgs:            make([]*dns.Msg, 0),
+			createMsgs:            make([]*dns.Msg, 0),
+			nameservers:           []string{"nameserver:53"},
+			randGen:               rand.New(rand.NewSource(time.Now().UnixNano())),
+			loadBalancingStrategy: "round-robin",
+		},
+	}
+
+	tlsConfig := TLSConfig{
+		UseTLS:                false,
+		SkipTLSVerify:         false,
+		CAFilePath:            "",
+		ClientCertFilePath:    "",
+		ClientCertKeyFilePath: "",
+	}
+
+	providerInstance, err := newProvider(
+		[]string{"nameserver"},
+		53,
+		[]string{"example.com"},
+		false,
+		"key",
+		"secret",
+		"hmac-sha512",
+		true,
+		&endpoint.DomainFilter{},
+		false,
+		300*time.Second,
+		false,
+		"",
+		"",
+		"",
+		50,
+		tlsConfig,
+		"round-robin",
+		stub,
+	)
+	assert.NoError(t, err)
+
+	records, err := providerInstance.Records(t.Context())
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, provider.SoftError, "Expected SoftError when AXFR envelope carries an error")
+	assert.Empty(t, records, "Expected no records returned when AXFR envelope carries an error")
+}
+
+// axfrFailoverStub simulates two nameservers: the first returns an error
+// envelope (e.g. a read timeout), the second returns a clean transfer with a
+// valid A record. Used to verify that a successful retry is not poisoned by
+// the earlier failure.
+type axfrFailoverStub struct {
+	rfc2136Stub
+	calls int
+}
+
+func (r *axfrFailoverStub) IncomeTransfer(_ *dns.Msg, _ string) (chan *dns.Envelope, error) {
+	r.calls++
+	outChan := make(chan *dns.Envelope)
+	if r.calls == 1 {
+		// First nameserver: return an error envelope mid-stream.
+		go func() {
+			outChan <- &dns.Envelope{Error: fmt.Errorf("i/o timeout on ns1")}
+			close(outChan)
+		}()
+		return outChan, nil
+	}
+	// Second nameserver: return a clean transfer with one A record.
+	go func() {
+		outChan <- &dns.Envelope{
+			RR: []dns.RR{
+				&dns.A{
+					Hdr: dns.RR_Header{
+						Name:   "failover.example.com.",
+						Rrtype: dns.TypeA,
+						Class:  dns.ClassINET,
+						Ttl:    300,
+					},
+					A: net.ParseIP("2.3.4.5"),
+				},
+			},
+		}
+		close(outChan)
+	}()
+	return outChan, nil
+}
+
+// TestRfc2136AxfrFailoverSucceedsAfterEnvelopeError verifies that when the
+// first nameserver returns an error envelope and a second nameserver succeeds,
+// List() returns the records from the successful attempt with a nil error.
+// Regression test for REL-01: lastErr was not cleared on a successful retry,
+// causing the post-loop guard to fire even after a good transfer.
+func TestRfc2136AxfrFailoverSucceedsAfterEnvelopeError(t *testing.T) {
+	stub := &axfrFailoverStub{
+		rfc2136Stub: rfc2136Stub{
+			output:                make([]*dns.Envelope, 0),
+			updateMsgs:            make([]*dns.Msg, 0),
+			createMsgs:            make([]*dns.Msg, 0),
+			nameservers:           []string{"ns1:53", "ns2:53"},
+			randGen:               rand.New(rand.NewSource(time.Now().UnixNano())),
+			loadBalancingStrategy: "round-robin",
+		},
+	}
+
+	tlsConfig := TLSConfig{
+		UseTLS:                false,
+		SkipTLSVerify:         false,
+		CAFilePath:            "",
+		ClientCertFilePath:    "",
+		ClientCertKeyFilePath: "",
+	}
+
+	providerInstance, err := newProvider(
+		[]string{"ns1", "ns2"},
+		53,
+		[]string{"example.com"},
+		false,
+		"key",
+		"secret",
+		"hmac-sha512",
+		true,
+		&endpoint.DomainFilter{},
+		false,
+		300*time.Second,
+		false,
+		"",
+		"",
+		"",
+		50,
+		tlsConfig,
+		"round-robin",
+		stub,
+	)
+	require.NoError(t, err)
+
+	endpoints, err := providerInstance.Records(t.Context())
+	assert.NoError(t, err, "Expected nil error when second nameserver succeeds after first fails")
+	assert.NotEmpty(t, endpoints, "Expected records from the successful second nameserver")
 }
 
 func TestRfc2136MissingAXFRWarns(t *testing.T) {

--- a/provider/rfc2136/rfc2136_test.go
+++ b/provider/rfc2136/rfc2136_test.go
@@ -1326,6 +1326,100 @@ func TestRfc2136AxfrFailoverSucceedsAfterEnvelopeError(t *testing.T) {
 	assert.NotEmpty(t, endpoints, "Expected records from the successful second nameserver")
 }
 
+// axfrTsigStripStub drops the TSIG RR like dns.TsigGenerateWithProvider does,
+// and fails the first nameserver to force a second attempt.
+type axfrTsigStripStub struct {
+	rfc2136Stub
+	calls  int
+	signed []bool
+}
+
+func (r *axfrTsigStripStub) IncomeTransfer(m *dns.Msg, _ string) (chan *dns.Envelope, error) {
+	r.calls++
+	if m.IsTsig() != nil {
+		r.signed = append(r.signed, true)
+		m.Extra = m.Extra[:len(m.Extra)-1]
+	} else {
+		r.signed = append(r.signed, false)
+	}
+
+	outChan := make(chan *dns.Envelope)
+	if r.calls == 1 {
+		go func() {
+			outChan <- &dns.Envelope{Error: fmt.Errorf("i/o timeout on ns1")}
+			close(outChan)
+		}()
+		return outChan, nil
+	}
+	go func() {
+		outChan <- &dns.Envelope{
+			RR: []dns.RR{
+				&dns.A{
+					Hdr: dns.RR_Header{
+						Name:   "signed.example.com.",
+						Rrtype: dns.TypeA,
+						Class:  dns.ClassINET,
+						Ttl:    300,
+					},
+					A: net.ParseIP("3.4.5.6"),
+				},
+			},
+		}
+		close(outChan)
+	}()
+	return outChan, nil
+}
+
+// Regression: one message shared by all nameservers left every retry unsigned.
+func TestRfc2136AxfrSignsEveryNameserverAttempt(t *testing.T) {
+	stub := &axfrTsigStripStub{
+		rfc2136Stub: rfc2136Stub{
+			output:                make([]*dns.Envelope, 0),
+			updateMsgs:            make([]*dns.Msg, 0),
+			createMsgs:            make([]*dns.Msg, 0),
+			nameservers:           []string{"ns1:53", "ns2:53"},
+			randGen:               rand.New(rand.NewSource(time.Now().UnixNano())),
+			loadBalancingStrategy: "round-robin",
+		},
+	}
+
+	tlsConfig := TLSConfig{
+		UseTLS:                false,
+		SkipTLSVerify:         false,
+		CAFilePath:            "",
+		ClientCertFilePath:    "",
+		ClientCertKeyFilePath: "",
+	}
+
+	providerInstance, err := newProvider(
+		[]string{"ns1", "ns2"},
+		53,
+		[]string{"example.com"},
+		false,
+		"key",
+		"secret",
+		"hmac-sha512",
+		true,
+		&endpoint.DomainFilter{},
+		false,
+		300*time.Second,
+		false,
+		"",
+		"",
+		"",
+		50,
+		tlsConfig,
+		"round-robin",
+		stub,
+	)
+	require.NoError(t, err)
+
+	endpoints, err := providerInstance.Records(t.Context())
+	require.NoError(t, err)
+	assert.NotEmpty(t, endpoints, "Expected records from the successful second nameserver")
+	assert.Equal(t, []bool{true, true}, stub.signed, "Expected every nameserver attempt to carry a TSIG record")
+}
+
 func TestRfc2136MissingAXFRWarns(t *testing.T) {
 	const warning = "--rfc2136-axfr is not set"
 


### PR DESCRIPTION
## What does it do ?

`provider/rfc2136` `List()` discarded errors arriving on the AXFR envelope channel with a bare `continue`. Only `IncomeTransfer`'s return value was routed into `lastErr`, so the `if lastErr != nil` guard could never fire for in-stream failures — a failed transfer was returned to the caller as `(partial-or-empty, nil)`.

Three changes:

1. Envelope errors are wrapped into `lastErr`, so the existing `provider.SoftError` path reports them.
2. Records are buffered per nameserver attempt and merged only after a clean transfer, so a partial read is never mixed into the result of a retry against another nameserver.
3. `lastErr` is cleared when an attempt succeeds, so a healthy nameserver's result is not poisoned by an earlier failure. Without this, (1) alone would make a successful failover report `SoftError`. This also covers the same latent issue on the pre-existing connection-error path.

Known limitation, deliberately left in scope: with multiple `--rfc2136-zone` values, a failure on any zone returns `(nil, SoftError)` and discards earlier zones for that cycle. This is safe — nothing is applied on a `SoftError` — but the shared `records` accumulator deserves its own fix.

## Motivation

`IncomeTransfer` returning `nil` only means a connection was opened and the AXFR query was written. Every response-side failure — read timeout, TSIG verification failure on a response envelope, non-NOERROR rcode, `dns.ErrSoa`, `dns.ErrId`, mid-stream I/O error — is reported in-band as `Envelope.Error`. Dropping those makes "this zone is empty" indistinguishable from "I could not read this zone".

With `--registry=txt` this fails open: an empty read makes every desired endpoint take the "dns name not taken" branch in `plan.go`, which leaves the owner-mismatch guard unreachable because it iterates `row.current`. A second ExternalDNS instance then creates ownership TXT records for names owned by another instance.

Observed in production: a 5.26 s AXFR exceeded `miekg/dns`'s non-configurable 2 s per-envelope read deadline, the zone was treated as empty, and ownership was claimed for names managed elsewhere.

Related to #6561 and #6567, which address stale errors after a *successful* fallback — this is the inverse case. Authored on top of #6591, which split the shared rotation state into per-operation `listLastErr` / `sendLastErr`; the two are complementary.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

This PR was written with assistance from Anthropic models