### PR TITLE
fix(source): skip endpoints with DNS labels over 63 chars in node and pod sources

### DIFF
--- a/source/node.go
+++ b/source/node.go
@@ -183,6 +183,9 @@ func (ns *nodeSource) endpointsForDNSNames(node *v1.Node, dnsNames []string) ([]
 
 		for _, addr := range addrs {
 			ep := endpoint.NewEndpointWithTTL(dns, endpoint.SuitableType(addr), ttl, addr)
+			if ep == nil {
+				continue
+			}
 			ep.WithLabel(endpoint.ResourceLabelKey, fmt.Sprintf("node/%s", node.Name))
 			log.Debugf("adding endpoint %s target %s", ep, addr)
 			endpoints = append(endpoints, ep)

--- a/source/node_test.go
+++ b/source/node_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"maps"
 	"math/rand"
+	"strings"
 	"testing"
 	"time"
 
@@ -194,6 +195,13 @@ func testNodeSourceEndpoints(t *testing.T) {
 			exposeInternalIPv6: true,
 			nodeAddresses:      []v1.NodeAddress{},
 			expectError:        true,
+		},
+		{
+			title:              "node name with a label over 63 characters is skipped instead of panicking",
+			nodeName:           strings.Repeat("a", 64),
+			exposeInternalIPv6: true,
+			nodeAddresses:      []v1.NodeAddress{{Type: v1.NodeExternalIP, Address: "1.2.3.4"}},
+			expected:           nil,
 		},
 		{
 			title:              "node with target annotation",

--- a/source/pod.go
+++ b/source/pod.go
@@ -151,7 +151,9 @@ func (ps *podSource) endpointsFromPodAnnotations(pod *v1.Pod) []*endpoint.Endpoi
 
 	var endpoints []*endpoint.Endpoint
 	for key, targets := range endpointMap {
-		endpoints = append(endpoints, endpoint.NewEndpointWithTTL(key.DNSName, key.RecordType, key.RecordTTL, targets...))
+		if ep := endpoint.NewEndpointWithTTL(key.DNSName, key.RecordType, key.RecordTTL, targets...); ep != nil {
+			endpoints = append(endpoints, ep)
+		}
 	}
 	return endpoints
 }
@@ -164,7 +166,9 @@ func (ps *podSource) endpointsFromPodTemplate(pod *v1.Pod) ([]*endpoint.Endpoint
 
 	var endpoints []*endpoint.Endpoint
 	for key, targets := range hostsMap {
-		endpoints = append(endpoints, endpoint.NewEndpointWithTTL(key.DNSName, key.RecordType, key.RecordTTL, targets...))
+		if ep := endpoint.NewEndpointWithTTL(key.DNSName, key.RecordType, key.RecordTTL, targets...); ep != nil {
+			endpoints = append(endpoints, ep)
+		}
 	}
 	return endpoints, nil
 }

--- a/source/pod_test.go
+++ b/source/pod_test.go
@@ -19,6 +19,7 @@ package source
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -103,6 +104,34 @@ func TestPodSource(t *testing.T) {
 					},
 					Status: corev1.PodStatus{
 						PodIP: "10.0.1.2",
+					},
+				},
+			},
+		},
+		{
+			"pod with a hostname label over 63 characters is skipped instead of panicking",
+			"",
+			"",
+			true,
+			"",
+			nil,
+			false,
+			nodesFixturesIPv4(),
+			[]*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-pod1",
+						Namespace: "kube-system",
+						Annotations: map[string]string{
+							annotations.InternalHostnameKey: strings.Repeat("a", 64) + ".example.org",
+						},
+					},
+					Spec: corev1.PodSpec{
+						HostNetwork: true,
+						NodeName:    "my-node1",
+					},
+					Status: corev1.PodStatus{
+						PodIP: "10.0.1.1",
 					},
 				},
 			},


### PR DESCRIPTION
## What does it do ?

`NewEndpointWithTTL` returns nil when a DNS label is over 63 chars. 
`node.go` and `pod.go` never checked for that, so one bad hostname panics the whole source. 
Same pattern already fixed for service source in 3fac88bd: skip nil, move on

## Motivation

Kubernetes doesn't enforce the 63 char DNS label limit on Node names or annotation values, only total length. 
So a long node name or `hostname` annotation easily slips through and crashes external-dns on that one resource

Repro (pod source):
1. `--source=pod`
2. pod annotation `external-dns.alpha.kubernetes.io/internal-hostname: <64 x's>.example.org`
3. nil pointer panic in `endpoint.AttachRefObject`

Repro (node source):
1. `--source=node`
2. node name (or fqdn-template output) with a label over 63 chars
3. nil pointer panic in `ep.WithLabel(...)`

Confirmed both on current master, added regression tests for each.

There was an earlier attempt, #6590, that grew into a bigger refactor and got stuck/closed. 
This is just the minimal fix for the two crash sites in #6589

Fixes #6589

## Testing

- `go test -race ./source/...`
- `make go-lint`

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly
