### PR TITLE
feat(gateway): support v1 TCPRoute and UDPRoute while maintaining backward compatibility with v1alph2.

### DIFF
--- a/docs/sources/gateway-api.md
+++ b/docs/sources/gateway-api.md
@@ -15,8 +15,8 @@ Experimental channels as summarized below:
 | GRPCRoute          | v1                                  | v1.1.0                               | v1.1.0                          |
 | ListenerSet        | v1                                  | v1.5.0                               | v1.5.0                          |
 | TLSRoute           | v1                                  | v1.5.0                               | v1.0.0                          |
-| TCPRoute           | v1alpha2                            | TBD                                  | v1.0.0                          |
-| UDPRoute           | v1alpha2                            | TBD                                  | v1.0.0                          |
+| TCPRoute           | v1alpha2,v1                         | TBD                                  | v1.0.0                          |
+| UDPRoute           | v1alpha2,v1                         | TBD                                  | v1.0.0                          |
 
 Gateways and HTTPRoutes were promoted to the Standard channel in Gateway API v1.0.0 and use the
 v1 API.
@@ -38,7 +38,9 @@ ExternalDNS still uses the v1alpha2 API for compatibility with older CRDs but it
 has been deprecated and will be removed from future releases, at which point ExternalDNS will
 need to migrate to v1. (See [#6247](https://github.com/kubernetes-sigs/external-dns/issues/6247))
 
-TCPRoute and UDPRoute remain experimental and are only available as v1alpha2 in the Experimental channel.
+TCPRoute and UDPRoute remain experimental in the Gateway API. ExternalDNS supports
+both the v1alpha2 and v1 API versions to maintain compatibility with clusters using
+either version.
 
 ## Hostnames
 

--- a/source/gateway_tcproute.go
+++ b/source/gateway_tcproute.go
@@ -18,39 +18,128 @@ package source
 
 import (
 	"context"
+	"errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwinformers "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions"
+	informers_v1 "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/apis/v1"
 	informers_v1a2 "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/apis/v1alpha2"
 
 	extInformers "sigs.k8s.io/external-dns/source/informers"
 )
 
-// NewGatewayTCPRouteSource creates a new Gateway TCPRoute source with the given config.
-func NewGatewayTCPRouteSource(ctx context.Context, clients ClientGenerator, config *Config) (Source, error) {
-	return newGatewayRouteSource(ctx, clients, config, "TCPRoute", func(factory gwinformers.SharedInformerFactory) gatewayRouteInformer {
-		return &gatewayTCPRouteInformer{factory.Gateway().V1alpha2().TCPRoutes()}
-	})
+func apiVersionResourceAvailable(
+	client kubernetes.Interface,
+	apiVersion string,
+	resourceName string,
+) bool {
+	resources, err := client.Discovery().ServerResourcesForGroupVersion(apiVersion)
+	if err != nil {
+		return false
+	}
+
+	for _, resource := range resources.APIResources {
+		if resource.Name == resourceName {
+			return true
+		}
+	}
+
+	return false
 }
 
-type gatewayTCPRoute struct{ route v1alpha2.TCPRoute } // NOTE: Must update TypeMeta in List when changing the APIVersion.
+func NewGatewayTCPRouteSource(ctx context.Context, clients ClientGenerator, config *Config) (Source, error) {
+	kubeClient, err := clients.KubeClient()
+	if err != nil {
+		return nil, err
+	}
 
-func (rt *gatewayTCPRoute) Object() kubeObject               { return &rt.route }
-func (rt *gatewayTCPRoute) Metadata() *metav1.ObjectMeta     { return &rt.route.ObjectMeta }
-func (rt *gatewayTCPRoute) Hostnames() []v1.Hostname         { return nil }
-func (rt *gatewayTCPRoute) ParentRefs() []v1.ParentReference { return rt.route.Spec.ParentRefs }
-func (rt *gatewayTCPRoute) Protocol() v1.ProtocolType        { return v1.TCPProtocolType }
-func (rt *gatewayTCPRoute) RouteStatus() v1.RouteStatus      { return rt.route.Status.RouteStatus }
+	switch {
+	case apiVersionResourceAvailable(
+		kubeClient,
+		v1.GroupVersion.String(),
+		"tcproutes",
+	):
+		return newGatewayRouteSource(ctx, clients, config, "TCPRoute",
+			func(factory gwinformers.SharedInformerFactory) gatewayRouteInformer {
+				return &gatewayTCPRouteV1Informer{
+					factory.Gateway().V1().TCPRoutes(),
+				}
+			})
 
-type gatewayTCPRouteInformer struct {
+	case apiVersionResourceAvailable(
+		kubeClient,
+		v1alpha2.GroupVersion.String(),
+		"tcproutes",
+	):
+		return newGatewayRouteSource(ctx, clients, config, "TCPRoute",
+			func(factory gwinformers.SharedInformerFactory) gatewayRouteInformer {
+				return &gatewayTCPRouteV1alpha2Informer{
+					factory.Gateway().V1alpha2().TCPRoutes(),
+				}
+			})
+	}
+
+	return nil, errors.New("no supported Gateway API TCPRoute version available")
+}
+
+type gatewayTCPRouteV1 struct {
+	route v1.TCPRoute
+}
+
+func (rt *gatewayTCPRouteV1) Object() kubeObject               { return &rt.route }
+func (rt *gatewayTCPRouteV1) Metadata() *metav1.ObjectMeta     { return &rt.route.ObjectMeta }
+func (rt *gatewayTCPRouteV1) Hostnames() []v1.Hostname         { return nil }
+func (rt *gatewayTCPRouteV1) ParentRefs() []v1.ParentReference { return rt.route.Spec.ParentRefs }
+func (rt *gatewayTCPRouteV1) Protocol() v1.ProtocolType        { return v1.TCPProtocolType }
+func (rt *gatewayTCPRouteV1) RouteStatus() v1.RouteStatus      { return rt.route.Status.RouteStatus }
+
+type gatewayTCPRouteV1Informer struct {
+	informers_v1.TCPRouteInformer
+}
+
+func (inf gatewayTCPRouteV1Informer) List() []gatewayRoute {
+	list := extInformers.ListIndexed[*v1.TCPRoute](inf.TCPRouteInformer.Informer().GetIndexer())
+
+	routes := make([]gatewayRoute, len(list))
+
+	for i, rt := range list {
+		// List results are supposed to be treated as read-only.
+		// We make a shallow copy since we're only interested in setting the TypeMeta.
+		clone := *rt
+		clone.TypeMeta = metav1.TypeMeta{
+			APIVersion: v1.GroupVersion.String(),
+			Kind:       "TCPRoute",
+		}
+
+		routes[i] = &gatewayTCPRouteV1{clone}
+	}
+
+	return routes
+}
+
+type gatewayTCPRouteV1alpha2 struct {
+	route v1alpha2.TCPRoute
+}
+
+func (rt *gatewayTCPRouteV1alpha2) Object() kubeObject               { return &rt.route }
+func (rt *gatewayTCPRouteV1alpha2) Metadata() *metav1.ObjectMeta     { return &rt.route.ObjectMeta }
+func (rt *gatewayTCPRouteV1alpha2) Hostnames() []v1.Hostname         { return nil }
+func (rt *gatewayTCPRouteV1alpha2) ParentRefs() []v1.ParentReference { return rt.route.Spec.ParentRefs }
+func (rt *gatewayTCPRouteV1alpha2) Protocol() v1.ProtocolType        { return v1.TCPProtocolType }
+func (rt *gatewayTCPRouteV1alpha2) RouteStatus() v1.RouteStatus      { return rt.route.Status.RouteStatus }
+
+type gatewayTCPRouteV1alpha2Informer struct {
 	informers_v1a2.TCPRouteInformer
 }
 
-func (inf gatewayTCPRouteInformer) List() []gatewayRoute {
+func (inf gatewayTCPRouteV1alpha2Informer) List() []gatewayRoute {
 	list := extInformers.ListIndexed[*v1alpha2.TCPRoute](inf.TCPRouteInformer.Informer().GetIndexer())
+
 	routes := make([]gatewayRoute, len(list))
+
 	for i, rt := range list {
 		// We make a shallow copy since we're only interested in setting the TypeMeta.
 		clone := *rt
@@ -58,7 +147,8 @@ func (inf gatewayTCPRouteInformer) List() []gatewayRoute {
 			APIVersion: v1alpha2.GroupVersion.String(),
 			Kind:       "TCPRoute",
 		}
-		routes[i] = &gatewayTCPRoute{clone}
+
+		routes[i] = &gatewayTCPRouteV1alpha2{clone}
 	}
 	return routes
 }

--- a/source/gateway_tcproute_test.go
+++ b/source/gateway_tcproute_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakediscovery "k8s.io/client-go/discovery/fake"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -38,6 +39,16 @@ import (
 	templatetest "sigs.k8s.io/external-dns/source/template/testutil"
 )
 
+func configureGatewayAPITCPDiscovery(kubeClient *kubefake.Clientset, versions ...string) {
+	discovery := kubeClient.Discovery().(*fakediscovery.FakeDiscovery)
+
+	for _, version := range versions {
+		discovery.Resources = append(discovery.Resources, &metav1.APIResourceList{
+			GroupVersion: version, APIResources: []metav1.APIResource{{Name: "tcproutes", Kind: "TCPRoute"}},
+		})
+	}
+}
+
 func TestGatewayTCPRouteSourceEndpoints(t *testing.T) {
 	t.Parallel()
 
@@ -46,6 +57,13 @@ func TestGatewayTCPRouteSourceEndpoints(t *testing.T) {
 
 	gwClient := gatewayfake.NewSimpleClientset()
 	kubeClient := kubefake.NewClientset()
+
+	configureGatewayAPITCPDiscovery(
+		kubeClient,
+		v1.GroupVersion.String(),
+		v1alpha2.GroupVersion.String(),
+	)
+
 	clients := new(testutils.MockClientGenerator)
 	clients.On("GatewayClient").Return(gwClient, nil)
 	clients.On("KubeClient").Return(kubeClient, nil)
@@ -59,6 +77,87 @@ func TestGatewayTCPRouteSourceEndpoints(t *testing.T) {
 	require.NoError(t, err, "failed to create Namespace")
 
 	ips := []string{"10.64.0.1", "10.64.0.2"}
+
+	gw := &v1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "internal",
+			Namespace: "default",
+		},
+		Spec: v1.GatewaySpec{
+			Listeners: []v1.Listener{{
+				Protocol: v1.TCPProtocolType,
+			}},
+		},
+		Status: gatewayStatus(ips...),
+	}
+	_, err = gwClient.GatewayV1().Gateways(gw.Namespace).Create(ctx, gw, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create Gateway")
+
+	rt := &v1.TCPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "api",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotations.HostnameKey: "api-annotation.foobar.internal",
+			},
+		},
+		Spec: v1.TCPRouteSpec{
+			CommonRouteSpec: v1.CommonRouteSpec{
+				ParentRefs: []v1.ParentReference{
+					gwParentRef("default", "internal"),
+				},
+			},
+		},
+		Status: v1.TCPRouteStatus{
+			RouteStatus: gwRouteStatus(gwParentRef("default", "internal")),
+		},
+	}
+
+	_, err = gwClient.GatewayV1().TCPRoutes(rt.Namespace).Create(ctx, rt, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create TCPRoute")
+
+	src, err := NewGatewayTCPRouteSource(ctx, clients, &Config{
+		TemplateEngine: templatetest.MustEngine(t, "{{.Name}}-template.foobar.internal", "", "", true),
+	})
+	require.NoError(t, err, "failed to create Gateway TCPRoute Source")
+
+	endpoints, err := src.Endpoints(ctx)
+	require.NoError(t, err, "failed to get Endpoints")
+
+	testutils.ValidateEndpoints(t, endpoints, []*endpoint.Endpoint{
+		newTestEndpoint("api-annotation.foobar.internal", ips...),
+		newTestEndpoint("api-template.foobar.internal", ips...),
+	})
+}
+
+func TestGatewayTCPRouteSourceV1alpha2Fallback(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	gwClient := gatewayfake.NewSimpleClientset()
+	kubeClient := kubefake.NewClientset()
+
+	configureGatewayAPITCPDiscovery(
+		kubeClient,
+		v1alpha2.GroupVersion.String(),
+	)
+
+	clients := new(testutils.MockClientGenerator)
+	clients.On("GatewayClient").Return(gwClient, nil)
+	clients.On("KubeClient").Return(kubeClient, nil)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+	}
+	_, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create Namespace")
+
+	ips := []string{"10.64.0.1", "10.64.0.2"}
+
 	gw := &v1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "internal",
@@ -93,20 +192,31 @@ func TestGatewayTCPRouteSourceEndpoints(t *testing.T) {
 			RouteStatus: gwRouteStatus(gwParentRef("default", "internal")),
 		},
 	}
+
 	_, err = gwClient.GatewayV1alpha2().TCPRoutes(rt.Namespace).Create(ctx, rt, metav1.CreateOptions{})
 	require.NoError(t, err, "failed to create TCPRoute")
 
-	src, err := NewGatewayTCPRouteSource(ctx, clients, &Config{
-		TemplateEngine: templatetest.MustEngine(t, "{{.Name}}-template.foobar.internal", "", "", true),
-	})
+	src, err := NewGatewayTCPRouteSource(ctx, clients, &Config{})
 	require.NoError(t, err, "failed to create Gateway TCPRoute Source")
 
 	endpoints, err := src.Endpoints(ctx)
 	require.NoError(t, err, "failed to get Endpoints")
+
 	testutils.ValidateEndpoints(t, endpoints, []*endpoint.Endpoint{
 		newTestEndpoint("api-annotation.foobar.internal", ips...),
-		newTestEndpoint("api-template.foobar.internal", ips...),
 	})
+}
+
+func TestGatewayTCPRouteSourceUnsupportedVersion(t *testing.T) {
+	t.Parallel()
+
+	kubeClient := kubefake.NewClientset()
+
+	clients := new(testutils.MockClientGenerator)
+	clients.On("KubeClient").Return(kubeClient, nil)
+
+	_, err := NewGatewayTCPRouteSource(t.Context(), clients, &Config{})
+	require.EqualError(t, err, "no supported Gateway API TCPRoute version available")
 }
 
 func TestGatewayTCPRouteSource_InformerTransform(t *testing.T) {
@@ -114,6 +224,11 @@ func TestGatewayTCPRouteSource_InformerTransform(t *testing.T) {
 
 	gwClient := gatewayfake.NewSimpleClientset()
 	kubeClient := kubefake.NewClientset()
+
+	configureGatewayAPITCPDiscovery(
+		kubeClient,
+		v1alpha2.GroupVersion.String(),
+	)
 
 	rt := &v1alpha2.TCPRoute{ObjectMeta: informerTransformObjectMeta()}
 	require.Contains(t, rt.GetAnnotations(), corev1.LastAppliedConfigAnnotation)
@@ -239,6 +354,11 @@ func TestGatewayTCPRouteIndexer(t *testing.T) {
 
 			gwClient := gatewayfake.NewSimpleClientset()
 			kubeClient := kubefake.NewClientset()
+
+			configureGatewayAPITCPDiscovery(
+				kubeClient,
+				v1alpha2.GroupVersion.String(),
+			)
 
 			gw := &v1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "gw"},

--- a/source/gateway_udproute.go
+++ b/source/gateway_udproute.go
@@ -18,11 +18,13 @@ package source
 
 import (
 	"context"
+	"errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwinformers "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions"
+	informers_v1 "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/apis/v1"
 	informers_v1a2 "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/apis/v1alpha2"
 
 	extInformers "sigs.k8s.io/external-dns/source/informers"
@@ -30,26 +32,95 @@ import (
 
 // NewGatewayUDPRouteSource creates a new Gateway UDPRoute source with the given config.
 func NewGatewayUDPRouteSource(ctx context.Context, clients ClientGenerator, config *Config) (Source, error) {
-	return newGatewayRouteSource(ctx, clients, config, "UDPRoute", func(factory gwinformers.SharedInformerFactory) gatewayRouteInformer {
-		return &gatewayUDPRouteInformer{factory.Gateway().V1alpha2().UDPRoutes()}
-	})
+	kubeClient, err := clients.KubeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	switch {
+	case apiVersionResourceAvailable(
+		kubeClient,
+		v1.GroupVersion.String(),
+		"udproutes",
+	):
+		return newGatewayRouteSource(ctx, clients, config, "UDPRoute",
+			func(factory gwinformers.SharedInformerFactory) gatewayRouteInformer {
+				return &gatewayUDPRouteV1Informer{
+					factory.Gateway().V1().UDPRoutes(),
+				}
+			})
+
+	case apiVersionResourceAvailable(
+		kubeClient,
+		v1alpha2.GroupVersion.String(),
+		"udproutes",
+	):
+		return newGatewayRouteSource(ctx, clients, config, "UDPRoute",
+			func(factory gwinformers.SharedInformerFactory) gatewayRouteInformer {
+				return &gatewayUDPRouteV1alpha2Informer{
+					factory.Gateway().V1alpha2().UDPRoutes(),
+				}
+			})
+	}
+
+	return nil, errors.New("no supported Gateway API UDPRoute version available")
 }
 
-type gatewayUDPRoute struct{ route v1alpha2.UDPRoute } // NOTE: Must update TypeMeta in List when changing the APIVersion.
+type gatewayUDPRouteV1 struct {
+	route v1.UDPRoute
+}
 
-func (rt *gatewayUDPRoute) Object() kubeObject               { return &rt.route }
-func (rt *gatewayUDPRoute) Metadata() *metav1.ObjectMeta     { return &rt.route.ObjectMeta }
-func (rt *gatewayUDPRoute) Hostnames() []v1.Hostname         { return nil }
-func (rt *gatewayUDPRoute) ParentRefs() []v1.ParentReference { return rt.route.Spec.ParentRefs }
-func (rt *gatewayUDPRoute) Protocol() v1.ProtocolType        { return v1.UDPProtocolType }
-func (rt *gatewayUDPRoute) RouteStatus() v1.RouteStatus      { return rt.route.Status.RouteStatus }
+func (rt *gatewayUDPRouteV1) Object() kubeObject               { return &rt.route }
+func (rt *gatewayUDPRouteV1) Metadata() *metav1.ObjectMeta     { return &rt.route.ObjectMeta }
+func (rt *gatewayUDPRouteV1) Hostnames() []v1.Hostname         { return nil }
+func (rt *gatewayUDPRouteV1) ParentRefs() []v1.ParentReference { return rt.route.Spec.ParentRefs }
+func (rt *gatewayUDPRouteV1) Protocol() v1.ProtocolType        { return v1.UDPProtocolType }
+func (rt *gatewayUDPRouteV1) RouteStatus() v1.RouteStatus      { return rt.route.Status.RouteStatus }
 
-type gatewayUDPRouteInformer struct {
+type gatewayUDPRouteV1Informer struct {
+	informers_v1.UDPRouteInformer
+}
+
+func (inf gatewayUDPRouteV1Informer) List() []gatewayRoute {
+	list := extInformers.ListIndexed[*v1.UDPRoute](
+		inf.UDPRouteInformer.Informer().GetIndexer(),
+	)
+
+	routes := make([]gatewayRoute, len(list))
+	for i, rt := range list {
+		// List results are supposed to be treated as read-only.
+		// We make a shallow copy since we're only interested in setting the TypeMeta.
+		clone := *rt
+		clone.TypeMeta = metav1.TypeMeta{
+			APIVersion: v1.GroupVersion.String(),
+			Kind:       "UDPRoute",
+		}
+		routes[i] = &gatewayUDPRouteV1{clone}
+	}
+
+	return routes
+}
+
+type gatewayUDPRouteV1alpha2 struct {
+	route v1alpha2.UDPRoute
+}
+
+func (rt *gatewayUDPRouteV1alpha2) Object() kubeObject               { return &rt.route }
+func (rt *gatewayUDPRouteV1alpha2) Metadata() *metav1.ObjectMeta     { return &rt.route.ObjectMeta }
+func (rt *gatewayUDPRouteV1alpha2) Hostnames() []v1.Hostname         { return nil }
+func (rt *gatewayUDPRouteV1alpha2) ParentRefs() []v1.ParentReference { return rt.route.Spec.ParentRefs }
+func (rt *gatewayUDPRouteV1alpha2) Protocol() v1.ProtocolType        { return v1.UDPProtocolType }
+func (rt *gatewayUDPRouteV1alpha2) RouteStatus() v1.RouteStatus      { return rt.route.Status.RouteStatus }
+
+type gatewayUDPRouteV1alpha2Informer struct {
 	informers_v1a2.UDPRouteInformer
 }
 
-func (inf gatewayUDPRouteInformer) List() []gatewayRoute {
-	list := extInformers.ListIndexed[*v1alpha2.UDPRoute](inf.UDPRouteInformer.Informer().GetIndexer())
+func (inf gatewayUDPRouteV1alpha2Informer) List() []gatewayRoute {
+	list := extInformers.ListIndexed[*v1alpha2.UDPRoute](
+		inf.UDPRouteInformer.Informer().GetIndexer(),
+	)
+
 	routes := make([]gatewayRoute, len(list))
 	for i, rt := range list {
 		// We make a shallow copy since we're only interested in setting the TypeMeta.
@@ -58,7 +129,8 @@ func (inf gatewayUDPRouteInformer) List() []gatewayRoute {
 			APIVersion: v1alpha2.GroupVersion.String(),
 			Kind:       "UDPRoute",
 		}
-		routes[i] = &gatewayUDPRoute{clone}
+		routes[i] = &gatewayUDPRouteV1alpha2{clone}
 	}
+
 	return routes
 }

--- a/source/gateway_udproute_test.go
+++ b/source/gateway_udproute_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakediscovery "k8s.io/client-go/discovery/fake"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -38,6 +39,16 @@ import (
 	templatetest "sigs.k8s.io/external-dns/source/template/testutil"
 )
 
+func configureGatewayAPIUDPDiscovery(kubeClient *kubefake.Clientset, versions ...string) {
+	discovery := kubeClient.Discovery().(*fakediscovery.FakeDiscovery)
+
+	for _, version := range versions {
+		discovery.Resources = append(discovery.Resources, &metav1.APIResourceList{
+			GroupVersion: version, APIResources: []metav1.APIResource{{Name: "udproutes", Kind: "UDPRoute"}},
+		})
+	}
+}
+
 func TestGatewayUDPRouteSourceEndpoints(t *testing.T) {
 	t.Parallel()
 
@@ -46,6 +57,13 @@ func TestGatewayUDPRouteSourceEndpoints(t *testing.T) {
 
 	gwClient := gatewayfake.NewSimpleClientset()
 	kubeClient := kubefake.NewClientset()
+
+	configureGatewayAPIUDPDiscovery(
+		kubeClient,
+		v1.GroupVersion.String(),
+		v1alpha2.GroupVersion.String(),
+	)
+
 	clients := new(testutils.MockClientGenerator)
 	clients.On("GatewayClient").Return(gwClient, nil)
 	clients.On("KubeClient").Return(kubeClient, nil)
@@ -59,6 +77,86 @@ func TestGatewayUDPRouteSourceEndpoints(t *testing.T) {
 	require.NoError(t, err, "failed to create Namespace")
 
 	ips := []string{"10.64.0.1", "10.64.0.2"}
+
+	gw := &v1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "internal",
+			Namespace: "default",
+		},
+		Spec: v1.GatewaySpec{
+			Listeners: []v1.Listener{{
+				Protocol: v1.UDPProtocolType,
+			}},
+		},
+		Status: gatewayStatus(ips...),
+	}
+	_, err = gwClient.GatewayV1().Gateways(gw.Namespace).Create(ctx, gw, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create Gateway")
+
+	rt := &v1.UDPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "api",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotations.HostnameKey: "api-annotation.foobar.internal",
+			},
+		},
+		Spec: v1.UDPRouteSpec{
+			CommonRouteSpec: v1.CommonRouteSpec{
+				ParentRefs: []v1.ParentReference{
+					gwParentRef("default", "internal"),
+				},
+			},
+		},
+		Status: v1.UDPRouteStatus{
+			RouteStatus: gwRouteStatus(gwParentRef("default", "internal")),
+		},
+	}
+	_, err = gwClient.GatewayV1().UDPRoutes(rt.Namespace).Create(ctx, rt, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create UDPRoute")
+
+	src, err := NewGatewayUDPRouteSource(ctx, clients, &Config{
+		TemplateEngine: templatetest.MustEngine(t, "{{.Name}}-template.foobar.internal", "", "", true),
+	})
+	require.NoError(t, err, "failed to create Gateway UDPRoute Source")
+
+	endpoints, err := src.Endpoints(ctx)
+	require.NoError(t, err, "failed to get Endpoints")
+
+	testutils.ValidateEndpoints(t, endpoints, []*endpoint.Endpoint{
+		newTestEndpoint("api-annotation.foobar.internal", ips...),
+		newTestEndpoint("api-template.foobar.internal", ips...),
+	})
+}
+
+func TestGatewayUDPRouteSourceV1alpha2Fallback(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	gwClient := gatewayfake.NewSimpleClientset()
+	kubeClient := kubefake.NewClientset()
+
+	configureGatewayAPIUDPDiscovery(
+		kubeClient,
+		v1alpha2.GroupVersion.String(),
+	)
+
+	clients := new(testutils.MockClientGenerator)
+	clients.On("GatewayClient").Return(gwClient, nil)
+	clients.On("KubeClient").Return(kubeClient, nil)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+	}
+	_, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create Namespace")
+
+	ips := []string{"10.64.0.1", "10.64.0.2"}
+
 	gw := &v1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "internal",
@@ -93,20 +191,31 @@ func TestGatewayUDPRouteSourceEndpoints(t *testing.T) {
 			RouteStatus: gwRouteStatus(gwParentRef("default", "internal")),
 		},
 	}
+
 	_, err = gwClient.GatewayV1alpha2().UDPRoutes(rt.Namespace).Create(ctx, rt, metav1.CreateOptions{})
 	require.NoError(t, err, "failed to create UDPRoute")
 
-	src, err := NewGatewayUDPRouteSource(ctx, clients, &Config{
-		TemplateEngine: templatetest.MustEngine(t, "{{.Name}}-template.foobar.internal", "", "", true),
-	})
+	src, err := NewGatewayUDPRouteSource(ctx, clients, &Config{})
 	require.NoError(t, err, "failed to create Gateway UDPRoute Source")
 
 	endpoints, err := src.Endpoints(ctx)
 	require.NoError(t, err, "failed to get Endpoints")
+
 	testutils.ValidateEndpoints(t, endpoints, []*endpoint.Endpoint{
 		newTestEndpoint("api-annotation.foobar.internal", ips...),
-		newTestEndpoint("api-template.foobar.internal", ips...),
 	})
+}
+
+func TestGatewayUDPRouteSourceUnsupportedVersion(t *testing.T) {
+	t.Parallel()
+
+	kubeClient := kubefake.NewClientset()
+
+	clients := new(testutils.MockClientGenerator)
+	clients.On("KubeClient").Return(kubeClient, nil)
+
+	_, err := NewGatewayUDPRouteSource(t.Context(), clients, &Config{})
+	require.EqualError(t, err, "no supported Gateway API UDPRoute version available")
 }
 
 func TestGatewayUDPRouteSource_InformerTransform(t *testing.T) {
@@ -114,6 +223,11 @@ func TestGatewayUDPRouteSource_InformerTransform(t *testing.T) {
 
 	gwClient := gatewayfake.NewSimpleClientset()
 	kubeClient := kubefake.NewClientset()
+
+	configureGatewayAPIUDPDiscovery(
+		kubeClient,
+		v1alpha2.GroupVersion.String(),
+	)
 
 	rt := &v1alpha2.UDPRoute{ObjectMeta: informerTransformObjectMeta()}
 	require.Contains(t, rt.GetAnnotations(), corev1.LastAppliedConfigAnnotation)
@@ -239,6 +353,11 @@ func TestGatewayUDPRouteIndexer(t *testing.T) {
 
 			gwClient := gatewayfake.NewSimpleClientset()
 			kubeClient := kubefake.NewClientset()
+
+			configureGatewayAPIUDPDiscovery(
+				kubeClient,
+				v1alpha2.GroupVersion.String(),
+			)
 
 			gw := &v1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "gw"},


### PR DESCRIPTION
## What does it do ?

Updates the Gateway API TCPRoute and UDPRoute sources in ExternalDNS to support both `v1alpha2` and `v1`.

This allows ExternalDNS to support both `v1alpha2` and `v1` during the Gateway API transition while maintaining backward compatibility.

## Motivation

The Gateway API TCPRoute and UDPRoute resources are transitioning from `v1alpha2` to `v1`.

This change allows ExternalDNS to work with clusters using either API version, avoiding a breaking change for existing `v1alpha2` users while supporting newer Gateway API implementations using `v1`.

## Testing

Tested on two EKS clusters:

- One using an older AWS Load Balancer Controller with `TCPRoute`/`UDPRoute` using `v1alpha2`.
- One using the latest AWS Load Balancer Controller with `TCPRoute`/`UDPRoute` using `v1`.

Both API versions were successfully processed by ExternalDNS.

## More

- [x] Yes, this PR title follows Conventional Commits
- [x] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly