### PR TITLE
feat(docker): FIPS 140-3 image build target and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ build.image-arm/v7:
 	$(MAKE) ARCH=arm/v7 build.image
 
 .PHONY: build.image-fips
-#? build.image-fips: Build a FIPS 140-3 flagged image variant (tagged <version>-fips), not pushed
+#? build.image-fips: Build a FIPS 140-3 image variant (tagged <version>-fips); see scripts/build-fips-image.sh --help
 build.image-fips: ko
 	scripts/build-fips-image.sh
 

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,11 @@ build.image-arm64:
 build.image-arm/v7:
 	$(MAKE) ARCH=arm/v7 build.image
 
+.PHONY: build.image-fips
+#? build.image-fips: Build a FIPS 140-3 flagged image variant (tagged <version>-fips), not pushed
+build.image-fips: ko
+	scripts/build-fips-image.sh
+
 build.push:
 	$(MAKE) IMG_PLATFORM=linux/$(ARCH) build.push/multiarch
 

--- a/docs/tutorials/fips.md
+++ b/docs/tutorials/fips.md
@@ -7,7 +7,8 @@ tags: ["tutorial", "fips", "security", "compliance"]
 ## Overview
 
 ExternalDNS does not ship pre-built FIPS-compliant images, and there's no current plan to add them. The supported
-path today is building your own FIPS-capable binary/image from source, using [Go's native FIPS 140-3
+path today is building your own FIPS-capable binary/image from source (or using an [alternative vendor-hardened
+image](#alternative-vendor-hardened-images)), using [Go's native FIPS 140-3
 support](https://go.dev/doc/security/fips140) (Go 1.24+): setting `GOFIPS140` at build time compiles in Go's
 CMVP-validated cryptographic module and makes `crypto/tls` restrict itself to FIPS-approved algorithms for every TLS
 connection ExternalDNS makes - to the Kubernetes API server, to DNS provider APIs, and to webhook providers. It's

--- a/docs/tutorials/fips.md
+++ b/docs/tutorials/fips.md
@@ -26,21 +26,8 @@ alone.
 make build.image-fips
 ```
 
-This builds with `--push=false` and no `--local`, matching the existing `build.image` targets in the Makefile - it
-proves the build succeeds without publishing or loading anything locally. Since there's no local artifact yet to
-inspect, verify the FIPS module lands in the binary by building it the same way directly:
-
-```sh
-GOFIPS140=v1.0.0 CGO_ENABLED=0 go build -o build/external-dns .
-go version -m build/external-dns | grep -i -E "fips|GODEBUG"
-
-build	-tags=fips140v1.0
-build	DefaultGODEBUG=fips140=on
-build	GOFIPS140=v1.0.0-c2097c7c
-```
-
-`DefaultGODEBUG=fips140=on` means FIPS mode is the runtime default the moment the binary is built this way - there's
-no need to also set `GODEBUG=fips140=on` on the container. A default (non-FIPS) build shows none of these lines.
+This builds the image, verifies the FIPS module landed in the binary, and loads the result into your local Docker
+daemon for testing.
 
 ## Alternative: Vendor-Hardened Images
 
@@ -67,6 +54,9 @@ env vars (or extra args) on the deployment:
 AWS_USE_FIPS_ENDPOINT=true
 AWS_REGION=us-east-1  # must be a region with a FIPS endpoint for the services you use (Route53, Cloud Map, DynamoDB, etc.)
 ```
+
+Check [AWS Compliance - FIPS](https://aws.amazon.com/compliance/fips) for which services have FIPS endpoints and in
+which regions.
 
 The AWS SDK resolves to the FIPS endpoint (e.g. `route53-fips.amazonaws.com`) for that region on its own. Don't
 conflate this with the `GOFIPS140` build flag above - one picks which AWS hostname to call, the other governs which

--- a/docs/tutorials/fips.md
+++ b/docs/tutorials/fips.md
@@ -32,9 +32,6 @@ daemon for testing.
 
 ## Alternative: Vendor-Hardened Images
 
-Rolling your own with `build.image-fips` proves the mechanism works, but the ongoing burden - tracking
-module/certificate staleness, rebuild cadence, and producing audit-ready evidence - stays with your team.
-
 Vendors like [Chainguard](https://images.chainguard.dev/directory/image/external-dns-fips/overview) ship a pre-built
 `external-dns-fips` image and carry that burden as part of a support relationship: daily rebuilds, SLSA Level 3
 provenance, and Sigstore-signed attestations. Their kernel-independence is achieved differently from what's described
@@ -42,9 +39,6 @@ above, though - Chainguard relocates the SP 800-90B entropy source into userspac
 [Jitter Entropy Library](https://www.chainguard.dev/unchained/kernel-independent-fips-images), rather than Go's native
 FIPS 140-3 module. Both approaches avoid depending on a FIPS-enabled kernel, just via different mechanisms - see also
 Chainguard's [overview of when/where/why FIPS-validated images are needed](https://www.chainguard.dev/unchained/fips-validated-container-images-when-where-why).
-
-If an auditor wants outside evidence of a continuously maintained compliance boundary, a vendor image is usually the
-better fit than self-building.
 
 ## Using It with AWS
 

--- a/docs/tutorials/fips.md
+++ b/docs/tutorials/fips.md
@@ -1,0 +1,88 @@
+---
+tags: ["tutorial", "fips", "security", "compliance"]
+---
+
+# FIPS 140-3 Builds
+
+## Overview
+
+ExternalDNS can be built as a FIPS 140-3 capable image using [Go's native FIPS 140-3 support](https://go.dev/doc/security/fips140)
+(Go 1.24+). Setting `GOFIPS140` at build time compiles in Go's CMVP-validated cryptographic module and makes `crypto/tls`
+restrict itself to FIPS-approved algorithms for every TLS connection ExternalDNS makes - to the Kubernetes API server, to
+DNS provider APIs, and to webhook providers.
+
+This gets you a FIPS-*capable* build. It does not, by itself, make a deployment FIPS *accredited* - that's an
+organizational process (ATO, operational environment review, etc.) on top of the build. Treat this page as the
+building block, not the whole compliance story.
+
+FIPS-capable is not FIPS-compliant. Auditors under FedRAMP, DoD, HIPAA, or similar frameworks require proof that FIPS
+enforcement is active at runtime, not just that a FIPS-capable build exists - verify enforcement (see below) rather
+than relying on a `-fips` tag or vendor claims alone.
+
+No BoringCrypto, cgo, or an OpenSSL FIPS provider is involved - the module is pure Go, so there's no separate crypto
+toolchain to maintain alongside the regular build.
+
+## Build and Verify the Image
+
+```sh
+make build.image-fips
+```
+
+This builds with `--push=false` and no `--local`, matching the existing `build.image` targets in the Makefile - it
+proves the build succeeds without publishing or loading anything locally. Since there's no local artifact yet to
+inspect, verify the FIPS module lands in the binary by building it the same way directly:
+
+```sh
+GOFIPS140=v1.0.0 CGO_ENABLED=0 go build -o build/external-dns .
+go version -m build/external-dns | grep -i -E "fips|GODEBUG"
+
+build	-tags=fips140v1.0
+build	DefaultGODEBUG=fips140=on
+build	GOFIPS140=v1.0.0-c2097c7c
+```
+
+`DefaultGODEBUG=fips140=on` means FIPS mode is the runtime default the moment the binary is built this way - there's
+no need to also set `GODEBUG=fips140=on` on the container. A default (non-FIPS) build shows none of these lines.
+
+## Alternative: Vendor-Hardened Images
+
+Rolling your own with `build.image-fips` proves the mechanism works, but the ongoing burden - tracking
+module/certificate staleness, rebuild cadence, and producing audit-ready evidence - stays with your team.
+
+Vendors like [Chainguard](https://images.chainguard.dev/directory/image/external-dns-fips/overview) ship a pre-built
+`external-dns-fips` image and carry that burden as part of a support relationship: daily rebuilds, SLSA Level 3
+provenance, and Sigstore-signed attestations. Their kernel-independence is achieved differently from what's described
+above, though - Chainguard relocates the SP 800-90B entropy source into userspace via OpenSSL and the
+[Jitter Entropy Library](https://www.chainguard.dev/unchained/kernel-independent-fips-images), rather than Go's native
+FIPS 140-3 module. Both approaches avoid depending on a FIPS-enabled kernel, just via different mechanisms - see also
+Chainguard's [overview of when/where/why FIPS-validated images are needed](https://www.chainguard.dev/unchained/fips-validated-container-images-when-where-why).
+
+If an auditor wants outside evidence of a continuously maintained compliance boundary, a vendor image is usually the
+better fit than self-building.
+
+## Using It with AWS
+
+FIPS image or not, AWS endpoint routing is a separate, already-solved concern - no code change needed. Set these as
+env vars (or extra args) on the deployment:
+
+```sh
+AWS_USE_FIPS_ENDPOINT=true
+AWS_REGION=us-east-1  # must be a region with a FIPS endpoint for the services you use (Route53, Cloud Map, DynamoDB, etc.)
+```
+
+The AWS SDK resolves to the FIPS endpoint (e.g. `route53-fips.amazonaws.com`) for that region on its own. Don't
+conflate this with the `GOFIPS140` build flag above - one picks which AWS hostname to call, the other governs which
+crypto module TLS uses to make that call.
+
+## A Note Before You Deploy
+
+If you're running a FIPS-hardened `external-dns` controller in production - self-built or vendor image - please open
+a PR to update this guide with what you learned. This page reflects a first pass; real deployment experience
+(verification steps, gotchas, auditor feedback) is the part most worth sharing.
+
+## Additional Resources
+
+- [Go FIPS 140-3 support](https://go.dev/doc/security/fips140)
+- [Chainguard: FIPS-validated container images - when, where, why](https://www.chainguard.dev/unchained/fips-validated-container-images-when-where-why)
+- [Chainguard: kernel-independent FIPS images](https://www.chainguard.dev/unchained/kernel-independent-fips-images)
+- [Chainguard external-dns-fips image](https://images.chainguard.dev/directory/image/external-dns-fips/overview)

--- a/docs/tutorials/fips.md
+++ b/docs/tutorials/fips.md
@@ -62,7 +62,7 @@ The AWS SDK resolves to the FIPS endpoint (e.g. `route53-fips.amazonaws.com`) fo
 conflate this with the `GOFIPS140` build flag above - one picks which AWS hostname to call, the other governs which
 crypto module TLS uses to make that call.
 
-## A Note Before You Deploy
+## Help Improve This Guide
 
 If you're running a FIPS-hardened `external-dns` controller in production - self-built or vendor image - please open
 a PR to update this guide with what you learned. This page reflects a first pass; real deployment experience

--- a/docs/tutorials/fips.md
+++ b/docs/tutorials/fips.md
@@ -2,25 +2,23 @@
 tags: ["tutorial", "fips", "security", "compliance"]
 ---
 
-# FIPS 140-3 Builds
+# Compiling ExternalDNS for FIPS
 
 ## Overview
 
-ExternalDNS can be built as a FIPS 140-3 capable image using [Go's native FIPS 140-3 support](https://go.dev/doc/security/fips140)
-(Go 1.24+). Setting `GOFIPS140` at build time compiles in Go's CMVP-validated cryptographic module and makes `crypto/tls`
-restrict itself to FIPS-approved algorithms for every TLS connection ExternalDNS makes - to the Kubernetes API server, to
-DNS provider APIs, and to webhook providers.
+ExternalDNS does not ship pre-built FIPS-compliant images, and there's no current plan to add them. The supported
+path today is building your own FIPS-capable binary/image from source, using [Go's native FIPS 140-3
+support](https://go.dev/doc/security/fips140) (Go 1.24+): setting `GOFIPS140` at build time compiles in Go's
+CMVP-validated cryptographic module and makes `crypto/tls` restrict itself to FIPS-approved algorithms for every TLS
+connection ExternalDNS makes - to the Kubernetes API server, to DNS provider APIs, and to webhook providers. It's
+pure Go - no BoringCrypto, cgo, or OpenSSL FIPS provider, so there's no separate crypto toolchain to maintain
+alongside the regular build.
 
-This gets you a FIPS-*capable* build. It does not, by itself, make a deployment FIPS *accredited* - that's an
-organizational process (ATO, operational environment review, etc.) on top of the build. Treat this page as the
-building block, not the whole compliance story.
-
-FIPS-capable is not FIPS-compliant. Auditors under FedRAMP, DoD, HIPAA, or similar frameworks require proof that FIPS
-enforcement is active at runtime, not just that a FIPS-capable build exists - verify enforcement (see below) rather
-than relying on a `-fips` tag or vendor claims alone.
-
-No BoringCrypto, cgo, or an OpenSSL FIPS provider is involved - the module is pure Go, so there's no separate crypto
-toolchain to maintain alongside the regular build.
+This gets you a FIPS-*capable* build, not a FIPS-*accredited* deployment - accreditation is an organizational
+process (ATO, operational environment review, etc.) layered on top. And capable is not the same as compliant:
+auditors under FedRAMP, DoD, HIPAA, or similar frameworks require proof that FIPS enforcement is active at runtime,
+not just that a FIPS-capable build exists - verify enforcement rather than relying on a `-fips` tag or vendor claims
+alone.
 
 ## Build and Verify the Image
 

--- a/scripts/build-fips-image.sh
+++ b/scripts/build-fips-image.sh
@@ -16,7 +16,7 @@
 # build-fips-image.sh
 #
 # Builds a FIPS 140-3 flagged variant of the external-dns image, using Go's
-# native FIPS 140-3 module (see https://go.dev/doc/security/fips140). 
+# native FIPS 140-3 module (see https://go.dev/doc/security/fips140).
 #
 # Usage:
 #   ./scripts/build-fips-image.sh [-h|--help]

--- a/scripts/build-fips-image.sh
+++ b/scripts/build-fips-image.sh
@@ -21,17 +21,37 @@
 # build setting.
 #
 # Usage:
-#   ./scripts/build-fips-image.sh
+#   ./scripts/build-fips-image.sh [-h|--help]
 #   make build.image-fips  # calls this script
-#
-# Env vars (all optional, matching the Makefile's build.push/multiarch vars):
-#   VERSION       Image tag prefix; final tag is "${VERSION}-fips" (default: git describe)
-#   IMAGE         KO_DOCKER_REPO to build into (default: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns)
-#   GIT_REVISION  Recorded in the image's revision label (default: git rev-parse HEAD)
-#   IMG_PLATFORM  Target platform(s) (default: linux/amd64,linux/arm64,linux/arm/v7)
-#   IMG_PUSH      Whether to push the built image (default: false)
-#   GOFIPS140     Go FIPS 140-3 module version to build with (default: v1.0.0, the
-#                 CMVP-validated module; "latest"/"v1.26.0" is still Pending Review)
+
+show_help() {
+cat << EOF
+Build a FIPS 140-3 flagged variant of the external-dns image.
+
+Usage: $(basename "$0") [-h|--help]
+
+Env vars (all optional, matching the Makefile's build.push/multiarch vars):
+    VERSION       Image tag prefix; final tag is "\${VERSION}-fips" (default: git describe)
+    IMAGE         KO_DOCKER_REPO to build into (default: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns,
+                  or "external-dns" when IMG_LOCAL=true)
+    GIT_REVISION  Recorded in the image's revision label (default: git rev-parse HEAD)
+    IMG_PLATFORM  Target platform(s) (default: linux/amd64,linux/arm64,linux/arm/v7,
+                  or the host platform when IMG_LOCAL=true)
+    IMG_PUSH      Whether to push the built image (default: false; forced false when IMG_LOCAL=true)
+    IMG_LOCAL     Load the built image into the local Docker daemon and verify the FIPS
+                  module landed in the binary. Set to "false" to just prove the build
+                  succeeds, without loading or verifying (default: true)
+    GOFIPS140     Go FIPS 140-3 module version to build with (default: v1.0.0, the
+                  CMVP-validated module; "latest"/"v1.26.0" is still Pending Review)
+EOF
+}
+
+case "${1:-}" in
+	-h|--help)
+		show_help
+		exit 0
+		;;
+esac
 
 set -euo pipefail
 
@@ -39,15 +59,30 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 cd "${PROJECT_ROOT}"
 
+IMG_LOCAL="${IMG_LOCAL:-true}"
+
 VERSION="${VERSION:-$(git describe --tags --always --dirty --match "v*")}"
-IMAGE="${IMAGE:-us.gcr.io/k8s-artifacts-prod/external-dns/external-dns}"
 GIT_REVISION="${GIT_REVISION:-$(git rev-parse HEAD)}"
-IMG_PLATFORM="${IMG_PLATFORM:-linux/amd64,linux/arm64,linux/arm/v7}"
-IMG_PUSH="${IMG_PUSH:-false}"
 GOFIPS140="${GOFIPS140:-v1.0.0}"
 
+if [[ "${IMG_LOCAL}" == "true" ]]; then
+	IMAGE="${IMAGE:-external-dns}"
+	IMG_PLATFORM="${IMG_PLATFORM:-linux/$(go env GOARCH)}"
+	IMG_PUSH=false
+else
+	IMAGE="${IMAGE:-us.gcr.io/k8s-artifacts-prod/external-dns/external-dns}"
+	IMG_PLATFORM="${IMG_PLATFORM:-linux/amd64,linux/arm64,linux/arm/v7}"
+	IMG_PUSH="${IMG_PUSH:-false}"
+fi
+
 tmp_ko_dir="$(mktemp -d)"
-trap 'rm -rf "${tmp_ko_dir}"' EXIT
+verify_container=""
+cleanup() {
+	rm -rf "${tmp_ko_dir}"
+	[[ -n "${verify_container}" ]] && docker rm -f "${verify_container}" >/dev/null 2>&1
+	return 0
+}
+trap cleanup EXIT
 tmp_ko_config="${tmp_ko_dir}/ko.yaml"
 
 echo ">> generating temporary ko config with GOFIPS140=${GOFIPS140}"
@@ -72,4 +107,20 @@ VERSION="${VERSION}" \
 ko build --tags "${VERSION}-fips" --bare --sbom spdx \
 	--image-label org.opencontainers.image.source="https://github.com/kubernetes-sigs/external-dns" \
 	--image-label org.opencontainers.image.revision="${GIT_REVISION}" \
-	--platform="${IMG_PLATFORM}" --push="${IMG_PUSH}" .
+	--platform="${IMG_PLATFORM}" --push="${IMG_PUSH}" --local="${IMG_LOCAL}" .
+
+if [[ "${IMG_LOCAL}" == "true" ]]; then
+	echo ">> verifying FIPS module in ${IMAGE}:${VERSION}-fips"
+	verify_container="$(docker create "${IMAGE}:${VERSION}-fips")"
+	tmp_binary="${tmp_ko_dir}/external-dns"
+	docker cp "${verify_container}:/ko-app/external-dns" "${tmp_binary}" >/dev/null
+	docker rm "${verify_container}" >/dev/null
+	verify_container=""
+
+	fips_info="$(go version -m "${tmp_binary}" | grep -E '^\s+build\s' | grep -Ei 'fips|godebug' || true)"
+	if [[ -z "${fips_info}" ]]; then
+		echo "FIPS module not found in built binary" >&2
+		exit 1
+	fi
+	echo "${fips_info}"
+fi

--- a/scripts/build-fips-image.sh
+++ b/scripts/build-fips-image.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# build-fips-image.sh
+#
+# Builds a FIPS 140-3 flagged variant of the external-dns image, using Go's
+# native FIPS 140-3 module (see https://go.dev/doc/security/fips140). No
+# BoringCrypto/cgo/OpenSSL provider is involved - GOFIPS140 is a pure Go
+# build setting.
+#
+# Usage:
+#   ./scripts/build-fips-image.sh
+#   make build.image-fips  # calls this script
+#
+# Env vars (all optional, matching the Makefile's build.push/multiarch vars):
+#   VERSION       Image tag prefix; final tag is "${VERSION}-fips" (default: git describe)
+#   IMAGE         KO_DOCKER_REPO to build into (default: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns)
+#   GIT_REVISION  Recorded in the image's revision label (default: git rev-parse HEAD)
+#   IMG_PLATFORM  Target platform(s) (default: linux/amd64,linux/arm64,linux/arm/v7)
+#   IMG_PUSH      Whether to push the built image (default: false)
+#   GOFIPS140     Go FIPS 140-3 module version to build with (default: v1.0.0, the
+#                 CMVP-validated module; "latest"/"v1.26.0" is still Pending Review)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${PROJECT_ROOT}"
+
+VERSION="${VERSION:-$(git describe --tags --always --dirty --match "v*")}"
+IMAGE="${IMAGE:-us.gcr.io/k8s-artifacts-prod/external-dns/external-dns}"
+GIT_REVISION="${GIT_REVISION:-$(git rev-parse HEAD)}"
+IMG_PLATFORM="${IMG_PLATFORM:-linux/amd64,linux/arm64,linux/arm/v7}"
+IMG_PUSH="${IMG_PUSH:-false}"
+GOFIPS140="${GOFIPS140:-v1.0.0}"
+
+tmp_ko_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_ko_dir}"' EXIT
+tmp_ko_config="${tmp_ko_dir}/ko.yaml"
+
+echo ">> generating temporary ko config with GOFIPS140=${GOFIPS140}"
+cat > "${tmp_ko_config}" <<EOF
+defaultBaseImage: gcr.io/distroless/static-debian12:latest
+builds:
+- env:
+  - CGO_ENABLED=0
+  - GOFIPS140=${GOFIPS140}
+  flags:
+  - -v
+  ldflags:
+  - -s
+  - -w
+  - -X sigs.k8s.io/external-dns/pkg/apis/externaldns.Version={{.Env.VERSION}}
+EOF
+
+echo ">> building FIPS-flagged image: ${IMAGE}:${VERSION}-fips"
+KO_CONFIG_PATH="${tmp_ko_config}" \
+KO_DOCKER_REPO="${IMAGE}" \
+VERSION="${VERSION}" \
+ko build --tags "${VERSION}-fips" --bare --sbom spdx \
+	--image-label org.opencontainers.image.source="https://github.com/kubernetes-sigs/external-dns" \
+	--image-label org.opencontainers.image.revision="${GIT_REVISION}" \
+	--platform="${IMG_PLATFORM}" --push="${IMG_PUSH}" .

--- a/scripts/build-fips-image.sh
+++ b/scripts/build-fips-image.sh
@@ -16,9 +16,7 @@
 # build-fips-image.sh
 #
 # Builds a FIPS 140-3 flagged variant of the external-dns image, using Go's
-# native FIPS 140-3 module (see https://go.dev/doc/security/fips140). No
-# BoringCrypto/cgo/OpenSSL provider is involved - GOFIPS140 is a pure Go
-# build setting.
+# native FIPS 140-3 module (see https://go.dev/doc/security/fips140). 
 #
 # Usage:
 #   ./scripts/build-fips-image.sh [-h|--help]


### PR DESCRIPTION
## What does it do ?

- Adds make build.image-fips target (Makefile) that invokes a new scripts/build-fips-image.sh to build a <version>-fips-tagged image via ko, matching existing build.image* targets (not pushed by default).
- scripts/build-fips-image.sh generates a local FIPS image
- New docs/tutorials/fips.md tutorial covering: how to create a FIPS-capable image

## Motivation

Closes #5124
Closes #1772
Relates https://github.com/kubernetes-sigs/external-dns/pull/6641

- Users deploying in FedRAMP/DoD/HIPAA-style environments need a FIPS 140-3 capable build of external-dns, but no build path exists today. This describes options to them and possible target to build image themselves.
-  - Go 1.24+ ships a native, pure-Go FIPS 140-3 module (GOFIPS140), avoiding the need for cgo/BoringCrypto/OpenSSL FIPS providers.
  - No existing documentation covers how to build, verify, or reason about FIPS compliance (build vs. accreditation, self-built vs. vendor image) for this project.
  
## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

```
❯ scripts/build-fips-image.sh --help
Build a FIPS 140-3 flagged variant of the external-dns image.

Usage: build-fips-image.sh [-h|--help]

Env vars (all optional, matching the Makefile's build.push/multiarch vars):
    VERSION       Image tag prefix; final tag is "${VERSION}-fips" (default: git describe)
    IMAGE         KO_DOCKER_REPO to build into (default: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns,
                  or "external-dns" when IMG_LOCAL=true)
    GIT_REVISION  Recorded in the image's revision label (default: git rev-parse HEAD)
    IMG_PLATFORM  Target platform(s) (default: linux/amd64,linux/arm64,linux/arm/v7,
                  or the host platform when IMG_LOCAL=true)
    IMG_PUSH      Whether to push the built image (default: false; forced false when IMG_LOCAL=true)
    IMG_LOCAL     Load the built image into the local Docker daemon and verify the FIPS
                  module landed in the binary. Set to "false" to just prove the build
                  succeeds, without loading or verifying (default: true)
    GOFIPS140     Go FIPS 140-3 module version to build with (default: v1.0.0, the
                  CMVP-validated module; "latest"/"v1.26.0" is still Pending Review)
```
