### PR TITLE
fix(cloudflare): pin cloudflare-go v7.7.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,9 @@ updates:
       # miss tag on v1.19.0 in 2019
       # See https://pkg.go.dev/github.com/exoscale/egoscale?tab=versions
       - dependency-name: "github.com/exoscale/egoscale"
+      # v7.8.0 dropped the dns.RecordResponseUnion discriminator, losing MX priority and SRV data
+      # See https://github.com/cloudflare/cloudflare-go/issues/4300
+      - dependency-name: "github.com/cloudflare/cloudflare-go/v7"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,9 @@ require (
 	github.com/bodgit/tsig v1.3.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/civo/civogo v0.7.2
-	github.com/cloudflare/cloudflare-go/v7 v7.9.0
+	// pinned: v7.8.0 dropped the dns.RecordResponseUnion discriminator, losing MX priority and SRV data
+	// See https://github.com/cloudflare/cloudflare-go/issues/4300
+	github.com/cloudflare/cloudflare-go/v7 v7.7.0
 	github.com/denverdino/aliyungo v0.0.0-20230411124812-ab98a9173ace
 	github.com/dnsimple/dnsimple-go v1.7.0
 	github.com/emissary-ingress/emissary/v3 v3.10.0

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/civo/civogo v0.7.2 h1:kaUDRkIM696zRDGsleLChDSV7En7JvBCKtpu9imQC1M=
 github.com/civo/civogo v0.7.2/go.mod h1:Nb15x35xtG7TjCt+Hk20UVIAtMOGMLH2eJoaW9zSj4Y=
-github.com/cloudflare/cloudflare-go/v7 v7.9.0 h1:Byn3v5kflN6xQ5trrBXP4tRs2T5FMkjDXIEyocLc0vk=
-github.com/cloudflare/cloudflare-go/v7 v7.9.0/go.mod h1:9zcoIAtu6cmcoPszCNISvqYMXs8wObtVGXE1qGFMrNU=
+github.com/cloudflare/cloudflare-go/v7 v7.7.0 h1:6e3GZXvQX+Ae7we7VuKag1eNbEbDgxuHYQUQY7E+Z9A=
+github.com/cloudflare/cloudflare-go/v7 v7.7.0/go.mod h1:9zcoIAtu6cmcoPszCNISvqYMXs8wObtVGXE1qGFMrNU=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -18,7 +18,6 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -671,6 +670,8 @@ func (p *CloudFlareProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]
 			e.SetProviderSpecificProperty(annotations.CloudflareTagsKey, strings.Join(sortedTags, ","))
 		}
 
+		normalizeMXTargets(e)
+
 		p.adjustEndpointProviderSpecificRegionKeyProperty(e)
 
 		if p.DNSRecordsConfig.Comment != "" {
@@ -682,6 +683,21 @@ func (p *CloudFlareProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]
 		adjustedEndpoints = append(adjustedEndpoints, e)
 	}
 	return adjustedEndpoints, nil
+}
+
+// normalizeMXTargets strips the trailing dot from MX hosts. Cloudflare never returns one, and the
+// CRD source does not reject it, so "10 mail.example.com." would diff on every reconcile.
+func normalizeMXTargets(ep *endpoint.Endpoint) {
+	if ep.RecordType != endpoint.RecordTypeMX {
+		return
+	}
+	for i, target := range ep.Targets {
+		mx, err := endpoint.NewMXRecord(target)
+		if err != nil {
+			continue // newCloudFlareChange reports malformed targets
+		}
+		ep.Targets[i] = fmt.Sprintf("%d %s", *mx.GetPriority(), strings.TrimSuffix(mx.GetHost(), "."))
+	}
 }
 
 // changesByZone separates a multi-zone change into a single change per zone.
@@ -767,7 +783,8 @@ func (p *CloudFlareProvider) newCloudFlareChange(action changeAction, ep *endpoi
 			return &cloudFlareChange{}, fmt.Errorf("failed to parse MX record target %q: %w", target, err)
 		} else {
 			priority = float64(*mxRecord.GetPriority())
-			target = mxRecord.GetHost()
+			// undotted, else getRecordID cannot match the DNSRecordIndex built from the API
+			target = strings.TrimSuffix(mxRecord.GetHost(), ".")
 		}
 	}
 	if ep.RecordType == endpoint.RecordTypeSRV {
@@ -798,35 +815,10 @@ func newDNSRecordIndex(r dns.RecordResponse) DNSRecordIndex {
 	return DNSRecordIndex{Name: r.Name, Type: string(r.Type), Content: endpointTargetFromCloudflareRecord(r)}
 }
 
-// hydrateRecordResponse restores the fields the cloudflare-go union decoder drops.
-//
-// dns.RecordResponseUnion has no discriminator key, so the decoder resolves every payload to
-// dns.RecordResponseARecord, which carries neither Priority nor Data.
-func hydrateRecordResponse(record *dns.RecordResponse) {
-	raw := record.JSON.RawJSON()
-	if raw == "" {
-		return
-	}
-
-	switch record.Type {
-	case dns.RecordResponseTypeMX:
-		var mx dns.MXRecord
-		if err := json.Unmarshal([]byte(raw), &mx); err != nil {
-			log.Warnf("failed to decode MX record %q, its priority will be read as 0: %v", record.Name, err)
-			return
-		}
-		record.Priority = mx.Priority
-	case dns.RecordResponseTypeSRV:
-		var srv dns.SRVRecord
-		if err := json.Unmarshal([]byte(raw), &srv); err != nil {
-			log.Warnf("failed to decode SRV record %q, falling back to its content: %v", record.Name, err)
-			return
-		}
-		record.Data = srv.Data
-	}
-}
-
 // getDNSRecordsMap retrieves all DNS records for a given zone and returns them as a DNSRecordsMap.
+//
+// MX priority and SRV data need cloudflare-go to resolve dns.RecordResponseUnion by its "type"
+// discriminator. TestSDKDecodesRecordDiscriminator guards it, see the pin in go.mod.
 func (p *CloudFlareProvider) getDNSRecordsMap(ctx context.Context, zoneID string) (DNSRecordsMap, error) {
 	// for faster getRecordID lookup
 	recordsMap := make(DNSRecordsMap)
@@ -836,7 +828,6 @@ func (p *CloudFlareProvider) getDNSRecordsMap(ctx context.Context, zoneID string
 	}
 	iter := p.Client.ListDNSRecords(ctx, params)
 	for record := range autoPagerIterator(iter) {
-		hydrateRecordResponse(&record)
 		recordsMap[newDNSRecordIndex(record)] = record
 	}
 	if iter.Err() != nil {

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -801,8 +801,7 @@ func newDNSRecordIndex(r dns.RecordResponse) DNSRecordIndex {
 // hydrateRecordResponse restores the fields the cloudflare-go union decoder drops.
 //
 // dns.RecordResponseUnion has no discriminator key, so the decoder resolves every payload to
-// dns.RecordResponseARecord, which carries neither Priority nor Data. Both stay zero whatever
-// the record type. Decode them again from the raw payload the SDK keeps.
+// dns.RecordResponseARecord, which carries neither Priority nor Data.
 func hydrateRecordResponse(record *dns.RecordResponse) {
 	raw := record.JSON.RawJSON()
 	if raw == "" {
@@ -813,14 +812,14 @@ func hydrateRecordResponse(record *dns.RecordResponse) {
 	case dns.RecordResponseTypeMX:
 		var mx dns.MXRecord
 		if err := json.Unmarshal([]byte(raw), &mx); err != nil {
-			log.Debugf("failed to decode MX record %q, its priority will be read as 0: %v", record.Name, err)
+			log.Warnf("failed to decode MX record %q, its priority will be read as 0: %v", record.Name, err)
 			return
 		}
 		record.Priority = mx.Priority
 	case dns.RecordResponseTypeSRV:
 		var srv dns.SRVRecord
 		if err := json.Unmarshal([]byte(raw), &srv); err != nil {
-			log.Debugf("failed to decode SRV record %q, falling back to its content: %v", record.Name, err)
+			log.Warnf("failed to decode SRV record %q, falling back to its content: %v", record.Name, err)
 			return
 		}
 		record.Data = srv.Data

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -18,6 +18,7 @@ package cloudflare
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -797,6 +798,35 @@ func newDNSRecordIndex(r dns.RecordResponse) DNSRecordIndex {
 	return DNSRecordIndex{Name: r.Name, Type: string(r.Type), Content: endpointTargetFromCloudflareRecord(r)}
 }
 
+// hydrateRecordResponse restores the fields the cloudflare-go union decoder drops.
+//
+// dns.RecordResponseUnion has no discriminator key, so the decoder resolves every payload to
+// dns.RecordResponseARecord, which carries neither Priority nor Data. Both stay zero whatever
+// the record type. Decode them again from the raw payload the SDK keeps.
+func hydrateRecordResponse(record *dns.RecordResponse) {
+	raw := record.JSON.RawJSON()
+	if raw == "" {
+		return
+	}
+
+	switch record.Type {
+	case dns.RecordResponseTypeMX:
+		var mx dns.MXRecord
+		if err := json.Unmarshal([]byte(raw), &mx); err != nil {
+			log.Debugf("failed to decode MX record %q, its priority will be read as 0: %v", record.Name, err)
+			return
+		}
+		record.Priority = mx.Priority
+	case dns.RecordResponseTypeSRV:
+		var srv dns.SRVRecord
+		if err := json.Unmarshal([]byte(raw), &srv); err != nil {
+			log.Debugf("failed to decode SRV record %q, falling back to its content: %v", record.Name, err)
+			return
+		}
+		record.Data = srv.Data
+	}
+}
+
 // getDNSRecordsMap retrieves all DNS records for a given zone and returns them as a DNSRecordsMap.
 func (p *CloudFlareProvider) getDNSRecordsMap(ctx context.Context, zoneID string) (DNSRecordsMap, error) {
 	// for faster getRecordID lookup
@@ -807,6 +837,7 @@ func (p *CloudFlareProvider) getDNSRecordsMap(ctx context.Context, zoneID string
 	}
 	iter := p.Client.ListDNSRecords(ctx, params)
 	for record := range autoPagerIterator(iter) {
+		hydrateRecordResponse(&record)
 		recordsMap[newDNSRecordIndex(record)] = record
 	}
 	if iter.Err() != nil {

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -670,8 +670,6 @@ func (p *CloudFlareProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]
 			e.SetProviderSpecificProperty(annotations.CloudflareTagsKey, strings.Join(sortedTags, ","))
 		}
 
-		normalizeMXTargets(e)
-
 		p.adjustEndpointProviderSpecificRegionKeyProperty(e)
 
 		if p.DNSRecordsConfig.Comment != "" {
@@ -683,21 +681,6 @@ func (p *CloudFlareProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]
 		adjustedEndpoints = append(adjustedEndpoints, e)
 	}
 	return adjustedEndpoints, nil
-}
-
-// normalizeMXTargets strips the trailing dot from MX hosts. Cloudflare never returns one, and the
-// CRD source does not reject it, so "10 mail.example.com." would diff on every reconcile.
-func normalizeMXTargets(ep *endpoint.Endpoint) {
-	if ep.RecordType != endpoint.RecordTypeMX {
-		return
-	}
-	for i, target := range ep.Targets {
-		mx, err := endpoint.NewMXRecord(target)
-		if err != nil {
-			continue // newCloudFlareChange reports malformed targets
-		}
-		ep.Targets[i] = fmt.Sprintf("%d %s", *mx.GetPriority(), strings.TrimSuffix(mx.GetHost(), "."))
-	}
 }
 
 // changesByZone separates a multi-zone change into a single change per zone.
@@ -783,8 +766,7 @@ func (p *CloudFlareProvider) newCloudFlareChange(action changeAction, ep *endpoi
 			return &cloudFlareChange{}, fmt.Errorf("failed to parse MX record target %q: %w", target, err)
 		} else {
 			priority = float64(*mxRecord.GetPriority())
-			// undotted, else getRecordID cannot match the DNSRecordIndex built from the API
-			target = strings.TrimSuffix(mxRecord.GetHost(), ".")
+			target = mxRecord.GetHost()
 		}
 	}
 	if ep.RecordType == endpoint.RecordTypeSRV {
@@ -816,9 +798,6 @@ func newDNSRecordIndex(r dns.RecordResponse) DNSRecordIndex {
 }
 
 // getDNSRecordsMap retrieves all DNS records for a given zone and returns them as a DNSRecordsMap.
-//
-// MX priority and SRV data need cloudflare-go to resolve dns.RecordResponseUnion by its "type"
-// discriminator. TestSDKDecodesRecordDiscriminator guards it, see the pin in go.mod.
 func (p *CloudFlareProvider) getDNSRecordsMap(ctx context.Context, zoneID string) (DNSRecordsMap, error) {
 	// for faster getRecordID lookup
 	recordsMap := make(DNSRecordsMap)

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -3461,9 +3461,8 @@ func TestZoneServiceZoneIDByName(t *testing.T) {
 	})
 }
 
-// TestSDKDecodesRecordDiscriminator fails a bump to an SDK that decodes MX and SRV as A records.
-// v7.8.0 dropped the dns.RecordResponseUnion discriminator, making the provider read every MX
-// record with priority 0 and rewrite the zone on each reconcile (cloudflare/cloudflare-go#4300).
+// TestSDKDecodesRecordDiscriminator ensure a SDK bump won't mess up MX and SRV as A records.
+// See cloudflare/cloudflare-go#4300
 func TestSDKDecodesRecordDiscriminator(t *testing.T) {
 	const mxRaw = `{"id":"mx-1","name":"bar.com","type":"MX","content":"mx.bar.com","priority":10,"ttl":300}`
 	const srvRaw = `{"id":"srv-1","name":"_sip._tcp.bar.com","type":"SRV","content":"1 10 5060 sip.bar.com","ttl":300,` +
@@ -3532,47 +3531,4 @@ func TestGetDNSRecordsMapDecodesTypedFields(t *testing.T) {
 	assert.Equal(t, []string{"10 mx.bar.com"}, targets[endpoint.RecordTypeMX])
 	assert.Equal(t, []string{"1 10 5060 sip.bar.com."}, targets[endpoint.RecordTypeSRV])
 	assert.Equal(t, []string{"1.2.3.4"}, targets[endpoint.RecordTypeA])
-}
-
-// The CRD source lets dotted MX targets through, Cloudflare never returns one.
-func TestAdjustEndpointsNormalizesMXTargets(t *testing.T) {
-	p := &CloudFlareProvider{}
-	adjusted, err := p.AdjustEndpoints([]*endpoint.Endpoint{
-		{
-			RecordType: endpoint.RecordTypeMX,
-			DNSName:    "bar.com",
-			Targets:    endpoint.Targets{"10 mail.bar.com.", "20 backup.bar.com"},
-		},
-		{
-			// malformed, left untouched
-			RecordType: endpoint.RecordTypeMX,
-			DNSName:    "broken.bar.com",
-			Targets:    endpoint.Targets{"mail.bar.com."},
-		},
-		{
-			RecordType: endpoint.RecordTypeCNAME,
-			DNSName:    "www.bar.com",
-			Targets:    endpoint.Targets{"bar.com."},
-		},
-	})
-	require.NoError(t, err)
-	require.Len(t, adjusted, 3)
-
-	assert.Equal(t, endpoint.Targets{"10 mail.bar.com", "20 backup.bar.com"}, adjusted[0].Targets)
-	assert.Equal(t, endpoint.Targets{"mail.bar.com."}, adjusted[1].Targets)
-	assert.Equal(t, endpoint.Targets{"bar.com."}, adjusted[2].Targets)
-}
-
-// getRecordID matches on content, so a dotted MX host leaves the delete unresolvable.
-func TestNewCloudFlareChangeMXTrailingDot(t *testing.T) {
-	p := &CloudFlareProvider{}
-	ep := &endpoint.Endpoint{
-		RecordType: endpoint.RecordTypeMX,
-		DNSName:    "bar.com",
-		Targets:    endpoint.Targets{"10 mail.bar.com."},
-	}
-	change, err := p.newCloudFlareChange(cloudFlareCreate, ep, "10 mail.bar.com.", nil)
-	require.NoError(t, err)
-	assert.Equal(t, "mail.bar.com", change.ResourceRecord.Content)
-	assert.InDelta(t, float64(10), change.ResourceRecord.Priority, 0)
 }

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -3461,8 +3461,30 @@ func TestZoneServiceZoneIDByName(t *testing.T) {
 	})
 }
 
-// Records must come from an actual HTTP payload: building dns.RecordResponse values in Go
-// skips the union decoder that drops the MX priority and the SRV components.
+// TestSDKDecodesRecordDiscriminator fails a bump to an SDK that decodes MX and SRV as A records.
+// v7.8.0 dropped the dns.RecordResponseUnion discriminator, making the provider read every MX
+// record with priority 0 and rewrite the zone on each reconcile (cloudflare/cloudflare-go#4300).
+func TestSDKDecodesRecordDiscriminator(t *testing.T) {
+	const mxRaw = `{"id":"mx-1","name":"bar.com","type":"MX","content":"mx.bar.com","priority":10,"ttl":300}`
+	const srvRaw = `{"id":"srv-1","name":"_sip._tcp.bar.com","type":"SRV","content":"1 10 5060 sip.bar.com","ttl":300,` +
+		`"data":{"priority":1,"weight":10,"port":5060,"target":"sip.bar.com"}}`
+
+	// asserted on values, not union variant types: the affected releases renamed those, and a
+	// compile error would not say why the bump is unsafe
+	var mx dns.RecordResponse
+	require.NoError(t, json.Unmarshal([]byte(mxRaw), &mx))
+	assert.InDelta(t, float64(10), mx.Priority, 0,
+		"cloudflare-go dropped the MX priority, see cloudflare/cloudflare-go#4300 before bumping")
+
+	var srv dns.RecordResponse
+	require.NoError(t, json.Unmarshal([]byte(srvRaw), &srv))
+	require.IsType(t, dns.SRVRecordData{}, srv.Data,
+		"cloudflare-go dropped the SRV data, see cloudflare/cloudflare-go#4300 before bumping")
+	assert.Equal(t, "sip.bar.com", srv.Data.(dns.SRVRecordData).Target)
+}
+
+// Records must come from an HTTP payload: dns.RecordResponse values built in Go skip the union
+// decoder that carries the MX priority and the SRV components.
 func TestGetDNSRecordsMapDecodesTypedFields(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -3510,4 +3532,47 @@ func TestGetDNSRecordsMapDecodesTypedFields(t *testing.T) {
 	assert.Equal(t, []string{"10 mx.bar.com"}, targets[endpoint.RecordTypeMX])
 	assert.Equal(t, []string{"1 10 5060 sip.bar.com."}, targets[endpoint.RecordTypeSRV])
 	assert.Equal(t, []string{"1.2.3.4"}, targets[endpoint.RecordTypeA])
+}
+
+// The CRD source lets dotted MX targets through, Cloudflare never returns one.
+func TestAdjustEndpointsNormalizesMXTargets(t *testing.T) {
+	p := &CloudFlareProvider{}
+	adjusted, err := p.AdjustEndpoints([]*endpoint.Endpoint{
+		{
+			RecordType: endpoint.RecordTypeMX,
+			DNSName:    "bar.com",
+			Targets:    endpoint.Targets{"10 mail.bar.com.", "20 backup.bar.com"},
+		},
+		{
+			// malformed, left untouched
+			RecordType: endpoint.RecordTypeMX,
+			DNSName:    "broken.bar.com",
+			Targets:    endpoint.Targets{"mail.bar.com."},
+		},
+		{
+			RecordType: endpoint.RecordTypeCNAME,
+			DNSName:    "www.bar.com",
+			Targets:    endpoint.Targets{"bar.com."},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, adjusted, 3)
+
+	assert.Equal(t, endpoint.Targets{"10 mail.bar.com", "20 backup.bar.com"}, adjusted[0].Targets)
+	assert.Equal(t, endpoint.Targets{"mail.bar.com."}, adjusted[1].Targets)
+	assert.Equal(t, endpoint.Targets{"bar.com."}, adjusted[2].Targets)
+}
+
+// getRecordID matches on content, so a dotted MX host leaves the delete unresolvable.
+func TestNewCloudFlareChangeMXTrailingDot(t *testing.T) {
+	p := &CloudFlareProvider{}
+	ep := &endpoint.Endpoint{
+		RecordType: endpoint.RecordTypeMX,
+		DNSName:    "bar.com",
+		Targets:    endpoint.Targets{"10 mail.bar.com."},
+	}
+	change, err := p.newCloudFlareChange(cloudFlareCreate, ep, "10 mail.bar.com.", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "mail.bar.com", change.ResourceRecord.Content)
+	assert.InDelta(t, float64(10), change.ResourceRecord.Priority, 0)
 }

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -3460,3 +3460,54 @@ func TestZoneServiceZoneIDByName(t *testing.T) {
 		assert.Contains(t, err.Error(), "failed to list zones from CloudFlare API")
 	})
 }
+
+// Records must come from an actual HTTP payload: building dns.RecordResponse values in Go
+// skips the union decoder that drops the MX priority and the SRV components.
+func TestGetDNSRecordsMapDecodesTypedFields(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		records := []map[string]any{
+			{"id": "mx-1", "name": "bar.com", "type": "MX", "content": "mx.bar.com", "priority": 10, "ttl": 300},
+			{"id": "srv-1", "name": "_sip._tcp.bar.com", "type": "SRV", "content": "1 10 5060 sip.bar.com", "ttl": 300,
+				"data": map[string]any{"priority": 1, "weight": 10, "port": 5060, "target": "sip.bar.com"}},
+			{"id": "a-1", "name": "bar.com", "type": "A", "content": "1.2.3.4", "ttl": 300, "proxied": true},
+		}
+		// the pager keeps asking until a page comes back empty
+		if page := req.URL.Query().Get("page"); page != "" && page != "1" {
+			records = []map[string]any{}
+		}
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"result": records,
+			"result_info": map[string]any{
+				"count":       len(records),
+				"total_count": len(records),
+				"page":        1,
+				"per_page":    100,
+			},
+			"success":  true,
+			"errors":   []any{},
+			"messages": []any{},
+		}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	p := &CloudFlareProvider{Client: zoneService{service: cloudflare.NewClient(
+		option.WithBaseURL(ts.URL+"/"),
+		option.WithAPIToken("test-token"),
+		option.WithMaxRetries(0),
+	)}}
+
+	records, err := p.getDNSRecordsMap(t.Context(), "001")
+	require.NoError(t, err)
+
+	targets := map[string][]string{}
+	for _, ep := range p.groupByNameAndTypeWithCustomHostnames(records, nil) {
+		targets[ep.RecordType] = []string(ep.Targets)
+	}
+
+	assert.Equal(t, []string{"10 mx.bar.com"}, targets[endpoint.RecordTypeMX])
+	assert.Equal(t, []string{"1 10 5060 sip.bar.com."}, targets[endpoint.RecordTypeSRV])
+	assert.Equal(t, []string{"1.2.3.4"}, targets[endpoint.RecordTypeA])
+}


### PR DESCRIPTION
## What does it do ?

Pins `cloudflare-go` to v7.7.0. 

v7.8.0 regenerated `dns.RecordResponseUnion` with an empty discriminator, so every record decodes as an A record and MX `priority` / SRV `data` are lost (cloudflare/cloudflare-go#4300). 

Adds a test that fails a bump back to an affected release, plus a dependabot ignore.

## Motivation

Fixes #6655.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly
