### PR TITLE
fix(mx): keep null MX and strip trailing dot

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -288,17 +288,14 @@ func NewEndpoint(dnsName, recordType string, targets ...string) *Endpoint {
 	return NewEndpointWithTTL(dnsName, recordType, TTL(0), targets...)
 }
 
-// trimMXTarget drops the trailing dot from the host of an MX target. The null MX target
-// "0 ." (RFC 7505) is left alone: there the dot is the host, not a trailing separator.
-func trimMXTarget(target string) string {
+// TrimMXTarget drops the trailing dot from an MX target. Unparseable ones and the null MX
+// "0 ." (RFC 7505, the dot is the host) are returned as-is, as is spacing and priority.
+func TrimMXTarget(target string) string {
 	mx, err := NewMXRecord(target)
-	if err != nil {
-		return strings.TrimSuffix(target, ".")
-	}
-	if mx.GetHost() == "." {
+	if err != nil || mx.GetHost() == "." {
 		return target
 	}
-	return fmt.Sprintf("%d %s", *mx.GetPriority(), strings.TrimSuffix(mx.GetHost(), "."))
+	return strings.TrimSuffix(target, ".")
 }
 
 // NewEndpointWithTTL initialization method to be used to create an endpoint with a TTL struct
@@ -312,7 +309,7 @@ func NewEndpointWithTTL(dnsName, recordType string, ttl TTL, targets ...string) 
 		case RecordTypeTXT, RecordTypeNAPTR, RecordTypeSRV:
 			cleanTargets[idx] = target
 		case RecordTypeMX:
-			cleanTargets[idx] = trimMXTarget(target)
+			cleanTargets[idx] = TrimMXTarget(target)
 		default:
 			cleanTargets[idx] = strings.TrimSuffix(target, ".")
 		}

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -288,6 +288,19 @@ func NewEndpoint(dnsName, recordType string, targets ...string) *Endpoint {
 	return NewEndpointWithTTL(dnsName, recordType, TTL(0), targets...)
 }
 
+// trimMXTarget drops the trailing dot from the host of an MX target. The null MX target
+// "0 ." (RFC 7505) is left alone: there the dot is the host, not a trailing separator.
+func trimMXTarget(target string) string {
+	mx, err := NewMXRecord(target)
+	if err != nil {
+		return strings.TrimSuffix(target, ".")
+	}
+	if mx.GetHost() == "." {
+		return target
+	}
+	return fmt.Sprintf("%d %s", *mx.GetPriority(), strings.TrimSuffix(mx.GetHost(), "."))
+}
+
 // NewEndpointWithTTL initialization method to be used to create an endpoint with a TTL struct
 func NewEndpointWithTTL(dnsName, recordType string, ttl TTL, targets ...string) *Endpoint {
 	cleanTargets := make([]string, len(targets))
@@ -298,6 +311,8 @@ func NewEndpointWithTTL(dnsName, recordType string, ttl TTL, targets ...string) 
 		switch recordType {
 		case RecordTypeTXT, RecordTypeNAPTR, RecordTypeSRV:
 			cleanTargets[idx] = target
+		case RecordTypeMX:
+			cleanTargets[idx] = trimMXTarget(target)
 		default:
 			cleanTargets[idx] = strings.TrimSuffix(target, ".")
 		}

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -288,14 +288,18 @@ func NewEndpoint(dnsName, recordType string, targets ...string) *Endpoint {
 	return NewEndpointWithTTL(dnsName, recordType, TTL(0), targets...)
 }
 
-// TrimMXTarget drops the trailing dot from an MX target. Unparseable ones and the null MX
-// "0 ." (RFC 7505, the dot is the host) are returned as-is, as is spacing and priority.
-func TrimMXTarget(target string) string {
+// NormalizeMXTarget renders an MX target as "<preference> <host>", the form providers read back.
+// Unparseable targets pass through; the null MX "0 ." (RFC 7505) keeps its dot, which is the host.
+func NormalizeMXTarget(target string) string {
 	mx, err := NewMXRecord(target)
-	if err != nil || mx.GetHost() == "." {
+	if err != nil {
 		return target
 	}
-	return strings.TrimSuffix(target, ".")
+	host := mx.GetHost()
+	if host != "." {
+		host = strings.TrimSuffix(host, ".")
+	}
+	return fmt.Sprintf("%d %s", *mx.GetPriority(), host)
 }
 
 // NewEndpointWithTTL initialization method to be used to create an endpoint with a TTL struct
@@ -309,7 +313,7 @@ func NewEndpointWithTTL(dnsName, recordType string, ttl TTL, targets ...string) 
 		case RecordTypeTXT, RecordTypeNAPTR, RecordTypeSRV:
 			cleanTargets[idx] = target
 		case RecordTypeMX:
-			cleanTargets[idx] = TrimMXTarget(target)
+			cleanTargets[idx] = NormalizeMXTarget(target)
 		default:
 			cleanTargets[idx] = strings.TrimSuffix(target, ".")
 		}

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -1815,10 +1815,12 @@ func TestNewEndpointWithTTLMXTargets(t *testing.T) {
 	}{
 		{"trailing dot trimmed", "10 mail.example.com.", "10 mail.example.com"},
 		{"already undotted", "10 mail.example.com", "10 mail.example.com"},
-		// RFC 7505: the dot is the host, trimming it leaves a target that no longer parses
+		// RFC 7505: the dot is the host
 		{"null MX preserved", "0 .", "0 ."},
-		{"extra whitespace collapsed", "10   mail.example.com.", "10 mail.example.com"},
-		{"malformed left alone", "mail.example.com", "mail.example.com"},
+		{"malformed left alone", "mail.example.com.", "mail.example.com."},
+		// only the dot is touched, else these diff against sources that pass them through
+		{"whitespace kept", "10   mail.example.com.", "10   mail.example.com"},
+		{"leading zero kept", "010 mail.example.com", "010 mail.example.com"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -1807,6 +1807,30 @@ func TestNewEndpointWithTTLPreservesDotsInTXTRecords(t *testing.T) {
 	assert.Equal(t, "target.example.com", cnameEndpoint.Targets[0], "CNAME record should have trailing dot trimmed")
 }
 
+func TestNewEndpointWithTTLMXTargets(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   string
+		expected string
+	}{
+		{"trailing dot trimmed", "10 mail.example.com.", "10 mail.example.com"},
+		{"already undotted", "10 mail.example.com", "10 mail.example.com"},
+		// RFC 7505: the dot is the host, trimming it leaves a target that no longer parses
+		{"null MX preserved", "0 .", "0 ."},
+		{"extra whitespace collapsed", "10   mail.example.com.", "10 mail.example.com"},
+		{"malformed left alone", "mail.example.com", "mail.example.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := NewEndpointWithTTL("example.com", RecordTypeMX, TTL(300), tt.target)
+			require.NotNil(t, ep)
+			assert.Equal(t, tt.expected, ep.Targets[0])
+		})
+	}
+
+	assert.True(t, Targets{"0 ."}.ValidateMXRecord(), "null MX must stay a valid MX target")
+}
+
 func TestGetAliasProperty(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -1814,13 +1814,13 @@ func TestNewEndpointWithTTLMXTargets(t *testing.T) {
 		expected string
 	}{
 		{"trailing dot trimmed", "10 mail.example.com.", "10 mail.example.com"},
-		{"already undotted", "10 mail.example.com", "10 mail.example.com"},
+		{"already canonical", "10 mail.example.com", "10 mail.example.com"},
 		// RFC 7505: the dot is the host
 		{"null MX preserved", "0 .", "0 ."},
 		{"malformed left alone", "mail.example.com.", "mail.example.com."},
-		// only the dot is touched, else these diff against sources that pass them through
-		{"whitespace kept", "10   mail.example.com.", "10   mail.example.com"},
-		{"leading zero kept", "010 mail.example.com", "010 mail.example.com"},
+		{"whitespace collapsed", "10   mail.example.com.", "10 mail.example.com"},
+		{"leading zero dropped", "010 mail.example.com", "10 mail.example.com"},
+		{"surrounding space trimmed", "  10 mail.example.com  ", "10 mail.example.com"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -670,8 +670,6 @@ func (p *CloudFlareProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]
 			e.SetProviderSpecificProperty(annotations.CloudflareTagsKey, strings.Join(sortedTags, ","))
 		}
 
-		normalizeMXTargets(e)
-
 		p.adjustEndpointProviderSpecificRegionKeyProperty(e)
 
 		if p.DNSRecordsConfig.Comment != "" {
@@ -683,20 +681,6 @@ func (p *CloudFlareProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]
 		adjustedEndpoints = append(adjustedEndpoints, e)
 	}
 	return adjustedEndpoints, nil
-}
-
-// normalizeMXTargets renders MX targets the way the read path does, so both sides of the plan match.
-func normalizeMXTargets(ep *endpoint.Endpoint) {
-	if ep.RecordType != endpoint.RecordTypeMX {
-		return
-	}
-	for i, target := range ep.Targets {
-		mx, err := endpoint.NewMXRecord(target)
-		if err != nil {
-			continue // newCloudFlareChange reports malformed targets
-		}
-		ep.Targets[i] = fmt.Sprintf("%d %s", *mx.GetPriority(), cloudflareHost(mx.GetHost()))
-	}
 }
 
 // changesByZone separates a multi-zone change into a single change per zone.
@@ -782,7 +766,7 @@ func (p *CloudFlareProvider) newCloudFlareChange(action changeAction, ep *endpoi
 			return &cloudFlareChange{}, fmt.Errorf("failed to parse MX record target %q: %w", target, err)
 		} else {
 			priority = float64(*mxRecord.GetPriority())
-			// undotted, else getRecordID cannot match the DNSRecordIndex built from the API
+			// undotted, else getRecordID cannot match the DNSRecordIndex
 			target = cloudflareHost(mxRecord.GetHost())
 		}
 	}

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -685,9 +685,8 @@ func (p *CloudFlareProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]
 	return adjustedEndpoints, nil
 }
 
-// normalizeMXTargets strips the trailing dot from MX hosts. The CRD source exempts MX from its
-// target format check, so "10 mail.example.com." reaches the provider and would diff forever
-// against the undotted host Cloudflare reports back.
+// normalizeMXTargets renders MX targets the way the read path does, so both sides of the plan
+// match. Spacing and priority included, since the read path builds every target with Sprintf.
 func normalizeMXTargets(ep *endpoint.Endpoint) {
 	if ep.RecordType != endpoint.RecordTypeMX {
 		return

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -670,6 +670,8 @@ func (p *CloudFlareProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]
 			e.SetProviderSpecificProperty(annotations.CloudflareTagsKey, strings.Join(sortedTags, ","))
 		}
 
+		normalizeMXTargets(e)
+
 		p.adjustEndpointProviderSpecificRegionKeyProperty(e)
 
 		if p.DNSRecordsConfig.Comment != "" {
@@ -681,6 +683,22 @@ func (p *CloudFlareProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]
 		adjustedEndpoints = append(adjustedEndpoints, e)
 	}
 	return adjustedEndpoints, nil
+}
+
+// normalizeMXTargets strips the trailing dot from MX hosts. The CRD source exempts MX from its
+// target format check, so "10 mail.example.com." reaches the provider and would diff forever
+// against the undotted host Cloudflare reports back.
+func normalizeMXTargets(ep *endpoint.Endpoint) {
+	if ep.RecordType != endpoint.RecordTypeMX {
+		return
+	}
+	for i, target := range ep.Targets {
+		mx, err := endpoint.NewMXRecord(target)
+		if err != nil {
+			continue // newCloudFlareChange reports malformed targets
+		}
+		ep.Targets[i] = fmt.Sprintf("%d %s", *mx.GetPriority(), cloudflareHost(mx.GetHost()))
+	}
 }
 
 // changesByZone separates a multi-zone change into a single change per zone.
@@ -766,7 +784,8 @@ func (p *CloudFlareProvider) newCloudFlareChange(action changeAction, ep *endpoi
 			return &cloudFlareChange{}, fmt.Errorf("failed to parse MX record target %q: %w", target, err)
 		} else {
 			priority = float64(*mxRecord.GetPriority())
-			target = mxRecord.GetHost()
+			// undotted, else getRecordID cannot match the DNSRecordIndex built from the API
+			target = cloudflareHost(mxRecord.GetHost())
 		}
 	}
 	if ep.RecordType == endpoint.RecordTypeSRV {

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -766,8 +766,7 @@ func (p *CloudFlareProvider) newCloudFlareChange(action changeAction, ep *endpoi
 			return &cloudFlareChange{}, fmt.Errorf("failed to parse MX record target %q: %w", target, err)
 		} else {
 			priority = float64(*mxRecord.GetPriority())
-			// undotted, else getRecordID cannot match the DNSRecordIndex
-			target = cloudflareHost(mxRecord.GetHost())
+			target = mxRecord.GetHost()
 		}
 	}
 	if ep.RecordType == endpoint.RecordTypeSRV {

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -685,8 +685,7 @@ func (p *CloudFlareProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]
 	return adjustedEndpoints, nil
 }
 
-// normalizeMXTargets renders MX targets the way the read path does, so both sides of the plan
-// match. Spacing and priority included, since the read path builds every target with Sprintf.
+// normalizeMXTargets renders MX targets the way the read path does, so both sides of the plan match.
 func normalizeMXTargets(ep *endpoint.Endpoint) {
 	if ep.RecordType != endpoint.RecordTypeMX {
 		return

--- a/provider/cloudflare/cloudflare_batch.go
+++ b/provider/cloudflare/cloudflare_batch.go
@@ -182,9 +182,8 @@ func tagsFromResponse(tags any) []dns.RecordTagsParam {
 	return nil
 }
 
-// cloudflareHost drops the trailing dot Cloudflare never stores. The root "." is left alone:
-// it is a host in its own right, both as an SRV "no service" target (RFC 2782) and as a null
-// MX (RFC 7505).
+// cloudflareHost drops the trailing dot Cloudflare never stores. The root "." is itself a host:
+// SRV "no service" (RFC 2782), null MX (RFC 7505).
 func cloudflareHost(host string) string {
 	if host == "." {
 		return host

--- a/provider/cloudflare/cloudflare_batch.go
+++ b/provider/cloudflare/cloudflare_batch.go
@@ -182,11 +182,14 @@ func tagsFromResponse(tags any) []dns.RecordTagsParam {
 	return nil
 }
 
-func cloudflareSRVTarget(target string) string {
-	if target == "." {
-		return target
+// cloudflareHost drops the trailing dot Cloudflare never stores. The root "." is left alone:
+// it is a host in its own right, both as an SRV "no service" target (RFC 2782) and as a null
+// MX (RFC 7505).
+func cloudflareHost(host string) string {
+	if host == "." {
+		return host
 	}
-	return strings.TrimSuffix(target, ".")
+	return strings.TrimSuffix(host, ".")
 }
 
 func externalDNSSRVTarget(target string) string {
@@ -201,7 +204,7 @@ func srvRecordDataParam(target *endpoint.SRVTarget) dns.SRVRecordDataParam {
 		Priority: cloudflare.F(float64(target.GetPriority())),
 		Weight:   cloudflare.F(float64(target.GetWeight())),
 		Port:     cloudflare.F(float64(target.GetPort())),
-		Target:   cloudflare.F(cloudflareSRVTarget(target.GetHost())),
+		Target:   cloudflare.F(cloudflareHost(target.GetHost())),
 	}
 }
 

--- a/provider/cloudflare/cloudflare_batch.go
+++ b/provider/cloudflare/cloudflare_batch.go
@@ -182,13 +182,13 @@ func tagsFromResponse(tags any) []dns.RecordTagsParam {
 	return nil
 }
 
-// cloudflareHost drops the trailing dot Cloudflare never stores. Root "." is itself a host:
-// SRV "no service" (RFC 2782), null MX (RFC 7505).
-func cloudflareHost(host string) string {
-	if host == "." {
-		return host
+// cloudflareSRVTarget drops the trailing dot Cloudflare never stores.
+// Root "." is itself a host: SRV "no service" (RFC 2782).
+func cloudflareSRVTarget(target string) string {
+	if target == "." {
+		return target
 	}
-	return strings.TrimSuffix(host, ".")
+	return strings.TrimSuffix(target, ".")
 }
 
 func externalDNSSRVTarget(target string) string {
@@ -203,7 +203,7 @@ func srvRecordDataParam(target *endpoint.SRVTarget) dns.SRVRecordDataParam {
 		Priority: cloudflare.F(float64(target.GetPriority())),
 		Weight:   cloudflare.F(float64(target.GetWeight())),
 		Port:     cloudflare.F(float64(target.GetPort())),
-		Target:   cloudflare.F(cloudflareHost(target.GetHost())),
+		Target:   cloudflare.F(cloudflareSRVTarget(target.GetHost())),
 	}
 }
 

--- a/provider/cloudflare/cloudflare_batch.go
+++ b/provider/cloudflare/cloudflare_batch.go
@@ -182,7 +182,7 @@ func tagsFromResponse(tags any) []dns.RecordTagsParam {
 	return nil
 }
 
-// cloudflareHost drops the trailing dot Cloudflare never stores. The root "." is itself a host:
+// cloudflareHost drops the trailing dot Cloudflare never stores. Root "." is itself a host:
 // SRV "no service" (RFC 2782), null MX (RFC 7505).
 func cloudflareHost(host string) string {
 	if host == "." {

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -3533,47 +3533,28 @@ func TestGetDNSRecordsMapDecodesTypedFields(t *testing.T) {
 	assert.Equal(t, []string{"1.2.3.4"}, targets[endpoint.RecordTypeA])
 }
 
-// The CRD source lets dotted MX targets through, Cloudflare never returns one.
-func TestAdjustEndpointsNormalizesMXTargets(t *testing.T) {
-	p := &CloudFlareProvider{}
-	adjusted, err := p.AdjustEndpoints([]*endpoint.Endpoint{
-		{
-			RecordType: endpoint.RecordTypeMX,
-			DNSName:    "bar.com",
-			Targets:    endpoint.Targets{"10 mail.bar.com.", "20 backup.bar.com"},
-		},
-		{
-			// null MX (RFC 7505), the dot is the host
-			RecordType: endpoint.RecordTypeMX,
-			DNSName:    "nomail.bar.com",
-			Targets:    endpoint.Targets{"0 ."},
-		},
-		{
-			// malformed, left untouched
-			RecordType: endpoint.RecordTypeMX,
-			DNSName:    "broken.bar.com",
-			Targets:    endpoint.Targets{"mail.bar.com."},
-		},
-		{
-			// canonicalized like the read path renders it
-			RecordType: endpoint.RecordTypeMX,
-			DNSName:    "odd.bar.com",
-			Targets:    endpoint.Targets{"010  mail.bar.com."},
-		},
-		{
-			RecordType: endpoint.RecordTypeCNAME,
-			DNSName:    "www.bar.com",
-			Targets:    endpoint.Targets{"bar.com."},
+// Read path must render what NormalizeMXTarget produces, else the plan diffs forever.
+func TestGroupByNameAndTypeNullMX(t *testing.T) {
+	t.Parallel()
+	client := NewMockCloudFlareClientWithRecords(map[string][]dns.RecordResponse{
+		"001": {
+			{
+				ID:       "mx-null",
+				Name:     "nomail.bar.com",
+				Type:     endpoint.RecordTypeMX,
+				TTL:      3600,
+				Content:  ".",
+				Priority: 0,
+			},
 		},
 	})
+	p := &CloudFlareProvider{Client: client}
+	records, err := p.getDNSRecordsMap(t.Context(), "001")
 	require.NoError(t, err)
-	require.Len(t, adjusted, 5)
 
-	assert.Equal(t, endpoint.Targets{"10 mail.bar.com", "20 backup.bar.com"}, adjusted[0].Targets)
-	assert.Equal(t, endpoint.Targets{"0 ."}, adjusted[1].Targets)
-	assert.Equal(t, endpoint.Targets{"mail.bar.com."}, adjusted[2].Targets)
-	assert.Equal(t, endpoint.Targets{"10 mail.bar.com"}, adjusted[3].Targets)
-	assert.Equal(t, endpoint.Targets{"bar.com."}, adjusted[4].Targets)
+	endpoints := p.groupByNameAndTypeWithCustomHostnames(records, customHostnamesMap{})
+	require.Len(t, endpoints, 1)
+	assert.Equal(t, endpoint.Targets{"0 ."}, endpoints[0].Targets)
 }
 
 // getRecordID matches on content, a dotted MX host leaves the delete unresolvable.
@@ -3585,6 +3566,7 @@ func TestNewCloudFlareChangeMXTrailingDot(t *testing.T) {
 	}{
 		{"trailing dot trimmed", "10 mail.bar.com.", "mail.bar.com"},
 		{"null MX preserved", "0 .", "."},
+		{"non-canonical target still parsed", "010  mail.bar.com.", "mail.bar.com"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -3532,3 +3532,64 @@ func TestGetDNSRecordsMapDecodesTypedFields(t *testing.T) {
 	assert.Equal(t, []string{"1 10 5060 sip.bar.com."}, targets[endpoint.RecordTypeSRV])
 	assert.Equal(t, []string{"1.2.3.4"}, targets[endpoint.RecordTypeA])
 }
+
+// The CRD source lets dotted MX targets through, Cloudflare never returns one.
+func TestAdjustEndpointsNormalizesMXTargets(t *testing.T) {
+	p := &CloudFlareProvider{}
+	adjusted, err := p.AdjustEndpoints([]*endpoint.Endpoint{
+		{
+			RecordType: endpoint.RecordTypeMX,
+			DNSName:    "bar.com",
+			Targets:    endpoint.Targets{"10 mail.bar.com.", "20 backup.bar.com"},
+		},
+		{
+			// null MX (RFC 7505), the dot is the host
+			RecordType: endpoint.RecordTypeMX,
+			DNSName:    "nomail.bar.com",
+			Targets:    endpoint.Targets{"0 ."},
+		},
+		{
+			// malformed, left untouched
+			RecordType: endpoint.RecordTypeMX,
+			DNSName:    "broken.bar.com",
+			Targets:    endpoint.Targets{"mail.bar.com."},
+		},
+		{
+			RecordType: endpoint.RecordTypeCNAME,
+			DNSName:    "www.bar.com",
+			Targets:    endpoint.Targets{"bar.com."},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, adjusted, 4)
+
+	assert.Equal(t, endpoint.Targets{"10 mail.bar.com", "20 backup.bar.com"}, adjusted[0].Targets)
+	assert.Equal(t, endpoint.Targets{"0 ."}, adjusted[1].Targets)
+	assert.Equal(t, endpoint.Targets{"mail.bar.com."}, adjusted[2].Targets)
+	assert.Equal(t, endpoint.Targets{"bar.com."}, adjusted[3].Targets)
+}
+
+// getRecordID matches on content, so a dotted MX host leaves the delete unresolvable.
+func TestNewCloudFlareChangeMXTrailingDot(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   string
+		expected string
+	}{
+		{"trailing dot trimmed", "10 mail.bar.com.", "mail.bar.com"},
+		{"null MX preserved", "0 .", "."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &CloudFlareProvider{}
+			ep := &endpoint.Endpoint{
+				RecordType: endpoint.RecordTypeMX,
+				DNSName:    "bar.com",
+				Targets:    endpoint.Targets{tt.target},
+			}
+			change, err := p.newCloudFlareChange(cloudFlareCreate, ep, tt.target, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, change.ResourceRecord.Content)
+		})
+	}
+}

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -3555,21 +3555,28 @@ func TestAdjustEndpointsNormalizesMXTargets(t *testing.T) {
 			Targets:    endpoint.Targets{"mail.bar.com."},
 		},
 		{
+			// canonicalized like the read path renders it
+			RecordType: endpoint.RecordTypeMX,
+			DNSName:    "odd.bar.com",
+			Targets:    endpoint.Targets{"010  mail.bar.com."},
+		},
+		{
 			RecordType: endpoint.RecordTypeCNAME,
 			DNSName:    "www.bar.com",
 			Targets:    endpoint.Targets{"bar.com."},
 		},
 	})
 	require.NoError(t, err)
-	require.Len(t, adjusted, 4)
+	require.Len(t, adjusted, 5)
 
 	assert.Equal(t, endpoint.Targets{"10 mail.bar.com", "20 backup.bar.com"}, adjusted[0].Targets)
 	assert.Equal(t, endpoint.Targets{"0 ."}, adjusted[1].Targets)
 	assert.Equal(t, endpoint.Targets{"mail.bar.com."}, adjusted[2].Targets)
-	assert.Equal(t, endpoint.Targets{"bar.com."}, adjusted[3].Targets)
+	assert.Equal(t, endpoint.Targets{"10 mail.bar.com"}, adjusted[3].Targets)
+	assert.Equal(t, endpoint.Targets{"bar.com."}, adjusted[4].Targets)
 }
 
-// getRecordID matches on content, so a dotted MX host leaves the delete unresolvable.
+// getRecordID matches on content, a dotted MX host leaves the delete unresolvable.
 func TestNewCloudFlareChangeMXTrailingDot(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -3557,28 +3557,30 @@ func TestGroupByNameAndTypeNullMX(t *testing.T) {
 	assert.Equal(t, endpoint.Targets{"0 ."}, endpoints[0].Targets)
 }
 
-// getRecordID matches on content, a dotted MX host leaves the delete unresolvable.
+// getRecordID matches on content, so the host must reach the change undotted. Endpoints are built
+// through NewEndpointWithTTL, the way every source and the read path do, since newCloudFlareChange
+// relies on NormalizeMXTarget having run.
 func TestNewCloudFlareChangeMXTrailingDot(t *testing.T) {
 	tests := []struct {
 		name     string
 		target   string
-		expected string
+		content  string
+		priority float64
 	}{
-		{"trailing dot trimmed", "10 mail.bar.com.", "mail.bar.com"},
-		{"null MX preserved", "0 .", "."},
-		{"non-canonical target still parsed", "010  mail.bar.com.", "mail.bar.com"},
+		{"trailing dot trimmed", "10 mail.bar.com.", "mail.bar.com", 10},
+		{"null MX preserved", "0 .", ".", 0},
+		{"non-canonical target normalized", "010  mail.bar.com.", "mail.bar.com", 10},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &CloudFlareProvider{}
-			ep := &endpoint.Endpoint{
-				RecordType: endpoint.RecordTypeMX,
-				DNSName:    "bar.com",
-				Targets:    endpoint.Targets{tt.target},
-			}
-			change, err := p.newCloudFlareChange(cloudFlareCreate, ep, tt.target, nil)
+			ep := endpoint.NewEndpointWithTTL("bar.com", endpoint.RecordTypeMX, endpoint.TTL(300), tt.target)
+			require.NotNil(t, ep)
+
+			change, err := p.newCloudFlareChange(cloudFlareCreate, ep, ep.Targets[0], nil)
 			require.NoError(t, err)
-			assert.Equal(t, tt.expected, change.ResourceRecord.Content)
+			assert.Equal(t, tt.content, change.ResourceRecord.Content)
+			assert.InDelta(t, tt.priority, change.ResourceRecord.Priority, 0)
 		})
 	}
 }

--- a/source/crd.go
+++ b/source/crd.go
@@ -122,8 +122,7 @@ func (cs *crdSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 				case endpoint.RecordTypeTXT:
 					continue // no format constraint on targets
 				case endpoint.RecordTypeMX:
-					// normalized, not rejected: every other source gets this from
-					// NewEndpointWithTTL, so a dotted host would diff on every reconcile
+					// normalized, to avoid reconcile diff on dotted host
 					ep.Targets[i] = endpoint.TrimMXTarget(target)
 					continue
 				case endpoint.RecordTypeSRV:

--- a/source/crd.go
+++ b/source/crd.go
@@ -111,7 +111,7 @@ func (cs *crdSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 				log.Debugf("Endpoint %s with DNSName %s has an empty list of targets, allowing it to pass through for default-targets processing", dnsEndpoint.Name, ep.DNSName)
 			}
 			illegalTarget := false
-			for _, target := range ep.Targets {
+			for i, target := range ep.Targets {
 				// CNAME/DNAME targets are domain names where a trailing dot is
 				// valid (RFC 1035 §5.1 absolute FQDN), so accept both dotted and
 				// bare forms.
@@ -119,8 +119,13 @@ func (cs *crdSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 					continue
 				}
 				switch ep.RecordType {
-				case endpoint.RecordTypeTXT, endpoint.RecordTypeMX:
+				case endpoint.RecordTypeTXT:
 					continue // no format constraint on targets
+				case endpoint.RecordTypeMX:
+					// normalized, not rejected: every other source gets this from
+					// NewEndpointWithTTL, so a dotted host would diff on every reconcile
+					ep.Targets[i] = endpoint.TrimMXTarget(target)
+					continue
 				case endpoint.RecordTypeSRV:
 					// SRV targets are "<prio> <weight> <port> <host>"; RFC 2782
 					// requires the host to be an absolute FQDN and

--- a/source/crd.go
+++ b/source/crd.go
@@ -111,7 +111,7 @@ func (cs *crdSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 				log.Debugf("Endpoint %s with DNSName %s has an empty list of targets, allowing it to pass through for default-targets processing", dnsEndpoint.Name, ep.DNSName)
 			}
 			illegalTarget := false
-			for i, target := range ep.Targets {
+			for key, target := range ep.Targets {
 				// CNAME/DNAME targets are domain names where a trailing dot is
 				// valid (RFC 1035 §5.1 absolute FQDN), so accept both dotted and
 				// bare forms.
@@ -122,8 +122,8 @@ func (cs *crdSource) Endpoints(ctx context.Context) ([]*endpoint.Endpoint, error
 				case endpoint.RecordTypeTXT:
 					continue // no format constraint on targets
 				case endpoint.RecordTypeMX:
-					// normalized, to avoid reconcile diff on dotted host
-					ep.Targets[i] = endpoint.TrimMXTarget(target)
+					// normalized, else it diffs against the provider's rendering
+					ep.Targets[key] = endpoint.NormalizeMXTarget(target)
 					continue
 				case endpoint.RecordTypeSRV:
 					// SRV targets are "<prio> <weight> <port> <host>"; RFC 2782

--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -661,6 +661,42 @@ func TestCRDSourceIllegalTargetWarnings(t *testing.T) {
 	}
 }
 
+// MX targets are normalized rather than rejected, so a dotted host stops diffing against the
+// undotted one providers read back.
+func TestCRDSourceNormalizesMXTargets(t *testing.T) {
+	for _, ti := range []struct {
+		title  string
+		target string
+		want   string
+	}{
+		{"trailing dot trimmed", "10 mail.example.com.", "10 mail.example.com"},
+		{"already undotted", "10 mail.example.com", "10 mail.example.com"},
+		{"null MX preserved", "0 .", "0 ."},
+		{"unparseable left alone", "example.com.", "example.com."},
+	} {
+		t.Run(ti.title, func(t *testing.T) {
+			obj := &apiv1alpha1.DNSEndpoint{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", Generation: 1},
+				Spec: apiv1alpha1.DNSEndpointSpec{Endpoints: []*endpoint.Endpoint{{
+					DNSName:    "example.org",
+					Targets:    endpoint.Targets{ti.target},
+					RecordType: endpoint.RecordTypeMX,
+					RecordTTL:  180,
+				}}},
+			}
+
+			fakeCache := newFakeCRDCache(t, nil, fakeCRDCacheFilter{}, obj)
+			cs, err := newCrdSource(t.Context(), fakeCache, fakeCache.Client, "", nil)
+			require.NoError(t, err)
+
+			got, err := cs.Endpoints(t.Context())
+			require.NoError(t, err)
+			require.Len(t, got, 1)
+			require.Equal(t, endpoint.Targets{ti.want}, got[0].Targets)
+		})
+	}
+}
+
 func TestCRDSource_Endpoints_ObservedGenerationUpdateFailure(t *testing.T) {
 	hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
 

--- a/source/crd_test.go
+++ b/source/crd_test.go
@@ -661,8 +661,7 @@ func TestCRDSourceIllegalTargetWarnings(t *testing.T) {
 	}
 }
 
-// MX targets are normalized rather than rejected, so a dotted host stops diffing against the
-// undotted one providers read back.
+// MX targets are normalized rather than rejected, else they diff against the provider's rendering.
 func TestCRDSourceNormalizesMXTargets(t *testing.T) {
 	for _, ti := range []struct {
 		title  string
@@ -670,7 +669,9 @@ func TestCRDSourceNormalizesMXTargets(t *testing.T) {
 		want   string
 	}{
 		{"trailing dot trimmed", "10 mail.example.com.", "10 mail.example.com"},
-		{"already undotted", "10 mail.example.com", "10 mail.example.com"},
+		{"already canonical", "10 mail.example.com", "10 mail.example.com"},
+		{"whitespace collapsed", "10   mail.example.com.", "10 mail.example.com"},
+		{"leading zero dropped", "010 mail.example.com", "10 mail.example.com"},
 		{"null MX preserved", "0 .", "0 ."},
 		{"unparseable left alone", "example.com.", "example.com."},
 	} {


### PR DESCRIPTION
## What does it do ?

`NewEndpointWithTTL` trimmed the trailing dot off the whole MX target, turning the null MX
`0 .` (RFC 7505) into `0 `, which no longer parses as an MX record.

`source/crd.go` passed MX targets through unchecked while every other source normalizes them
via `NewEndpointWithTTL`, so a DNSEndpoint with `10 mail.example.com.` diffed on every
reconcile — on any provider. 

It now normalizes instead, leaving unparseable targets and the null MX alone.

## Motivation

Follow-up to #6660, split out per review.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly
