### PR TITLE
fix(registry/txt): force TXT owner update when migrating from old owner

### DIFF
--- a/registry/txt/registry.go
+++ b/registry/txt/registry.go
@@ -279,10 +279,7 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 
 		if im.oldOwnerID != "" && ep.Labels[endpoint.OwnerLabelKey] == im.oldOwnerID {
 			ep.Labels[endpoint.OwnerLabelKey] = im.ownerID
-			// Force the planner to see this as a change even when no other field differs:
-			// the owner label is rewritten in-memory right here, so by the time the plan
-			// diffs current against desired they already carry the same owner and the
-			// migration would otherwise be silently skipped.
+			// Owner already rewritten above, so current == desired unless we force it.
 			ep.WithProviderSpecific(providerSpecificForceUpdate, "true")
 		}
 

--- a/registry/txt/registry.go
+++ b/registry/txt/registry.go
@@ -279,6 +279,11 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 
 		if im.oldOwnerID != "" && ep.Labels[endpoint.OwnerLabelKey] == im.oldOwnerID {
 			ep.Labels[endpoint.OwnerLabelKey] = im.ownerID
+			// Force the planner to see this as a change even when no other field differs:
+			// the owner label is rewritten in-memory right here, so by the time the plan
+			// diffs current against desired they already carry the same owner and the
+			// migration would otherwise be silently skipped.
+			ep.WithProviderSpecific(providerSpecificForceUpdate, "true")
 		}
 
 		// TODO: remove this migration logic in some future release

--- a/registry/txt/registry_test.go
+++ b/registry/txt/registry_test.go
@@ -2264,10 +2264,8 @@ func TestTXTRegistryAliasARecordForceUpdateOnMigration(t *testing.T) {
 	}
 }
 
-// TestTXTRegistryOwnerIDMigrationForceUpdate covers the --migrate-from-txt-owner path: a record still
-// owned by the old owner ID must be armed with force-update so the planner treats the owner change as
-// a real diff even when every other field (target, TTL, provider-specific) is identical. Without this,
-// plan.Changes.HasChanges() sees an unchanged record and the migration is silently skipped.
+// TestTXTRegistryOwnerIDMigrationForceUpdate verifies that a record still owned by the old owner ID
+// gets force-updated during --migrate-from-txt-owner, even when nothing else about it changed.
 func TestTXTRegistryOwnerIDMigrationForceUpdate(t *testing.T) {
 	const dnsName = "same.test-zone.example.org"
 	const oldOwner = "\"heritage=external-dns,external-dns/owner=cluster-1\""

--- a/registry/txt/registry_test.go
+++ b/registry/txt/registry_test.go
@@ -2264,6 +2264,49 @@ func TestTXTRegistryAliasARecordForceUpdateOnMigration(t *testing.T) {
 	}
 }
 
+// TestTXTRegistryOwnerIDMigrationForceUpdate covers the --migrate-from-txt-owner path: a record still
+// owned by the old owner ID must be armed with force-update so the planner treats the owner change as
+// a real diff even when every other field (target, TTL, provider-specific) is identical. Without this,
+// plan.Changes.HasChanges() sees an unchanged record and the migration is silently skipped.
+func TestTXTRegistryOwnerIDMigrationForceUpdate(t *testing.T) {
+	const dnsName = "same.test-zone.example.org"
+	const oldOwner = "\"heritage=external-dns,external-dns/owner=cluster-1\""
+
+	for _, tt := range []struct {
+		name        string
+		recordOwner string
+		wantOwner   string
+		wantForce   bool
+	}{
+		{"record owned by old owner: migrated and force-updated", oldOwner, "cluster-2", true},
+		{"record already owned by current owner: left alone", "\"heritage=external-dns,external-dns/owner=cluster-2\"", "cluster-2", false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			p := inmemory.NewInMemoryProvider()
+			require.NoError(t, p.CreateZone(testZone))
+
+			seed := []*endpoint.Endpoint{
+				newEndpointWithOwner(dnsName, "target.com", endpoint.RecordTypeCNAME, ""),
+				newTXTEndpointWithOwnedRecord("cname-"+dnsName, tt.recordOwner, dnsName),
+			}
+			require.NoError(t, p.ApplyChanges(t.Context(), &plan.Changes{Create: seed}))
+
+			r, err := newRegistry(p, "", "", "cluster-2", time.Hour, "", []string{endpoint.RecordTypeCNAME}, []string{}, false, nil, "cluster-1")
+			require.NoError(t, err)
+
+			records, err := r.Records(t.Context())
+			require.NoError(t, err)
+
+			ep := findEndpoint(records, dnsName, endpoint.RecordTypeCNAME)
+			require.NotNil(t, ep, "expected the CNAME record to be returned")
+			assert.Equal(t, tt.wantOwner, ep.Labels[endpoint.OwnerLabelKey])
+
+			forceUpdate, _ := ep.GetProviderSpecificProperty(providerSpecificForceUpdate)
+			assert.Equal(t, tt.wantForce, forceUpdate == "true")
+		})
+	}
+}
+
 // TestTXTRegistryAliasARecordDeleteLeavesLegacyCNAME verifies that deleting an A ALIAS removes only
 // the "a-" TXT; the obsolete "cname-" is left behind for the cleanup script.
 func TestTXTRegistryAliasARecordDeleteLeavesLegacyCNAME(t *testing.T) {


### PR DESCRIPTION
## What does it do?

`--migrate-from-txt-owner` can silently fail to update a record's TXT ownership marker when nothing else about the record changed. `TXTRegistry.Records()` rewrites the owner label from old to new in memory before the planner sees it, so "current" and "desired" end up identical and `plan.Changes.HasChanges()` returns false — the controller skips `ApplyChanges()` and the TXT record's owner is never rewritten in the zone. This PR marks the record with the existing `txt/force-update` provider-specific property (already used for the legacy-format migration) so the planner treats the owner change as a real diff.

## Known limitation

@mloiseleur pointed out, with a full-sync reproduction against the in-memory provider, that this only masks the symptom: `Records()` overwrites the owner label in place, so the TXT value later generated for `UpdateOld` shows the *new* owner instead of what's actually stored in the zone. Route53 tolerates this because it upserts by name, but providers that key off the old value (or validate it) don't. I reproduced this and also tried the root-cause fix they suggested (stop rewriting the owner in `Records()`, flip `isOldOwnerIDSetAndDifferent` to `==`), but that trades the bug for a different one: `inheritOwner` still copies the old owner onto the desired endpoint, so both get dropped entirely by the `FilterEndpointsByOwnerID` check in `plan.Calculate()`. A correct fix needs changes to shared logic in `plan/plan.go` used by every registry, not just the TXT registry — still being worked out.

## Validation

- `TestTXTRegistryOwnerIDMigrationForceUpdate` in `registry/txt/registry_test.go` covers the force-update marker itself.
- `go test -race ./...` passes.
- `golangci-lint run ./registry/txt/... --new-from-rev=upstream/master`: 0 new issues.

Fixes #6671

```release-note
fix(registry/txt): force TXT owner update when migrating from old owner
```

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly
