### PR TITLE
fix(civo): normalize @ apex record names

### DIFF
--- a/provider/civo/civo.go
+++ b/provider/civo/civo.go
@@ -133,11 +133,10 @@ func (p *CivoProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 		for _, r := range records {
 			toUpper := strings.ToUpper(string(r.Type))
 			if provider.SupportedRecordType(toUpper) {
-				name := fmt.Sprintf("%s.%s", r.Name, zone.Name)
+				recordName := normalizeCivoRecordName(toUpper, r.Name)
+				name := fmt.Sprintf("%s.%s", recordName, zone.Name)
 
-				// root name is identified by the empty string and should be
-				// translated to zone name for the endpoint entry.
-				if r.Name == "" {
+				if recordName == "" {
 					name = zone.Name
 				}
 
@@ -544,10 +543,20 @@ func getRecordID(records []civogo.DNSRecord, zone civogo.DNSDomain, ep endpoint.
 	for _, record := range records {
 		stripedName := getStrippedRecordName(zone, ep)
 		toUpper := strings.ToUpper(string(record.Type))
-		if record.Name == stripedName && toUpper == ep.RecordType {
+		recordName := normalizeCivoRecordName(toUpper, record.Name)
+		if recordName == stripedName && toUpper == ep.RecordType {
 			matchedRecords = append(matchedRecords, record)
 		}
 	}
 
 	return matchedRecords
+}
+
+// normalizeCivoRecordName converts Civo's @ apex marker for address records to the internal empty-name convention.
+func normalizeCivoRecordName(recordType, name string) string {
+	if name == "@" && (recordType == endpoint.RecordTypeA || recordType == endpoint.RecordTypeAAAA) {
+		return ""
+	}
+
+	return name
 }

--- a/provider/civo/civo_test.go
+++ b/provider/civo/civo_test.go
@@ -129,6 +129,49 @@ func TestCivoProviderRecords(t *testing.T) {
 	assert.Equal(t, int(records[1].RecordTTL), expected[1].TTL)
 }
 
+func TestCivoProviderRecordsApexAt(t *testing.T) {
+	client, server, _ := civogo.NewAdvancedClientForTesting([]civogo.ConfigAdvanceClientForTesting{
+		{
+			Method: "GET",
+			Value: []civogo.ValueAdvanceClientForTesting{
+				{
+					RequestBody: ``,
+					URL:         "/v2/dns/12345/records",
+					ResponseBody: `[
+						{"id": "1", "domain_id":"12345", "account_id": "1", "name": "@", "type": "A", "value": "10.0.0.0", "ttl": 600},
+						{"id": "2", "account_id": "1", "domain_id":"12345", "name": "www", "type": "A", "value": "10.0.0.1", "ttl": 600}
+						]`,
+				},
+				{
+					RequestBody: ``,
+					URL:         "/v2/dns",
+					ResponseBody: `[
+						{"id": "12345", "account_id": "1", "name": "example.com"}
+						]`,
+				},
+			},
+		},
+	})
+	defer server.Close()
+
+	provider := &CivoProvider{
+		Client:       *client,
+		domainFilter: endpoint.NewDomainFilter([]string{"example.com"}),
+	}
+
+	records, err := provider.Records(t.Context())
+	assert.NoError(t, err)
+	assert.Len(t, records, 2)
+
+	// The "@" apex record should be translated to the zone name.
+	assert.Equal(t, "example.com", records[0].DNSName)
+	assert.Equal(t, "A", records[0].RecordType)
+	assert.Equal(t, "10.0.0.0", records[0].Targets[0])
+
+	// Regular subdomain records should work as before.
+	assert.Equal(t, "www.example.com", records[1].DNSName)
+}
+
 func TestCivoProviderRecordsWithError(t *testing.T) {
 	client, server, _ := civogo.NewAdvancedClientForTesting([]civogo.ConfigAdvanceClientForTesting{
 		{
@@ -863,6 +906,70 @@ func TestCivoProviderGetRecordID(t *testing.T) {
 	id := getRecordID(record, zone, endPoint)
 
 	assert.Equal(t, id[0].ID, record[0].ID)
+}
+
+func TestCivoProviderGetRecordIDApexAt(t *testing.T) {
+	zone := civogo.DNSDomain{
+		ID:   "12345",
+		Name: "test.com",
+	}
+
+	// Civo API may return "@" for apex record names.
+	records := []civogo.DNSRecord{{
+		ID:          "1",
+		Type:        "A",
+		Name:        "@",
+		Value:       "10.0.0.0",
+		DNSDomainID: "12345",
+		TTL:         600,
+	}}
+
+	// Apex endpoint: DNSName == zone name, so getStrippedRecordName returns "".
+	ep := endpoint.Endpoint{DNSName: "test.com", Targets: endpoint.Targets{"10.0.0.0"}, RecordType: "A"}
+	matched := getRecordID(records, zone, ep)
+
+	assert.Len(t, matched, 1)
+	assert.Equal(t, "1", matched[0].ID)
+}
+
+func TestNormalizeCivoRecordName(t *testing.T) {
+	testCases := []struct {
+		name       string
+		recordType string
+		recordName string
+		expected   string
+	}{
+		{
+			name:       "A apex",
+			recordType: endpoint.RecordTypeA,
+			recordName: "@",
+			expected:   "",
+		},
+		{
+			name:       "AAAA apex",
+			recordType: endpoint.RecordTypeAAAA,
+			recordName: "@",
+			expected:   "",
+		},
+		{
+			name:       "CNAME apex marker is unchanged",
+			recordType: endpoint.RecordTypeCNAME,
+			recordName: "@",
+			expected:   "@",
+		},
+		{
+			name:       "subdomain",
+			recordType: endpoint.RecordTypeA,
+			recordName: "www",
+			expected:   "www",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, normalizeCivoRecordName(testCase.recordType, testCase.recordName))
+		})
+	}
 }
 
 func TestCivo_submitChangesCreate(t *testing.T) {


### PR DESCRIPTION
## What does it do ?

Normalizes Civo's `"@"` apex marker to ExternalDNS's empty-name convention for A and AAAA records. This lets apex records resolve and match as `example.com` instead of `@.example.com`.

## Motivation

Civo returns `"@"` for apex address records. Without normalization, reconciliation cannot match existing apex records and repeatedly attempts to recreate them.

This reopens the stale [#6184](https://github.com/kubernetes-sigs/external-dns/pull/6184) from @cjohnhanson. It incorporates @ivankatliarchuk's feedback: normalization is extracted into a helper and restricted to A/AAAA records. Create/update responses are not used; matching occurs against listed records before changes are submitted.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

Verified: go test -race ./provider/civo passes.