### PR TITLE
fix(mapper): split TXT names at zone boundary for dotted hostnames

### DIFF
--- a/registry/dynamodb/registry.go
+++ b/registry/dynamodb/registry.go
@@ -118,7 +118,7 @@ func newRegistry(
 		ownerID:             ownerID,
 		dynamodbAPI:         dynamodbAPI,
 		table:               table,
-		mapper:              mapper.NewAffixNameMapper(txtPrefix, txtSuffix, txtWildcardReplacement),
+		mapper:              mapper.NewAffixNameMapperWithZones(txtPrefix, txtSuffix, txtWildcardReplacement, mapper.ZonesFromDomainFilter(provider.GetDomainFilter())),
 		wildcardReplacement: txtWildcardReplacement,
 		managedRecordTypes:  managedRecordTypes,
 		excludeRecordTypes:  excludeRecordTypes,

--- a/registry/mapper/mapper.go
+++ b/registry/mapper/mapper.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mapper
 
 import (
+	"sort"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -55,15 +56,68 @@ type AffixNameMapper struct {
 	prefix              string
 	suffix              string
 	wildcardReplacement string
+	// zones, longest first, split hostname from domain for names that
+	// contain dots in the host label group (e.g. name-192.168.0.1.example.com).
+	zones []string
 }
 
 // NewAffixNameMapper returns a new AffixNameMapper.
 func NewAffixNameMapper(prefix, suffix, wildcardReplacement string) AffixNameMapper {
+	return NewAffixNameMapperWithZones(prefix, suffix, wildcardReplacement, nil)
+}
+
+// NewAffixNameMapperWithZones returns a mapper that splits TXT names at a
+// known zone boundary instead of the first dot. An empty zone list keeps the
+// legacy first-dot split so existing records stay unchanged.
+func NewAffixNameMapperWithZones(prefix, suffix, wildcardReplacement string, zones []string) AffixNameMapper {
+	normalized := make([]string, 0, len(zones))
+	for _, zone := range zones {
+		z := strings.ToLower(strings.Trim(zone, "."))
+		if z != "" {
+			normalized = append(normalized, z)
+		}
+	}
+	sort.Slice(normalized, func(i, j int) bool {
+		return len(normalized[i]) > len(normalized[j])
+	})
 	return AffixNameMapper{
 		prefix:              strings.ToLower(prefix),
 		suffix:              strings.ToLower(suffix),
 		wildcardReplacement: strings.ToLower(wildcardReplacement),
+		zones:               normalized,
 	}
+}
+
+// ZonesFromDomainFilter returns include filters for zone-aware TXT mapping.
+func ZonesFromDomainFilter(df endpoint.DomainFilterInterface) []string {
+	d, ok := df.(*endpoint.DomainFilter)
+	if !ok || d == nil {
+		return nil
+	}
+	return d.Filters
+}
+
+func (a AffixNameMapper) findZone(dns string) string {
+	dns = strings.ToLower(strings.TrimSuffix(dns, "."))
+	for _, zone := range a.zones {
+		if strings.HasSuffix(dns, "."+zone) {
+			return zone
+		}
+	}
+	return ""
+}
+
+func (a AffixNameMapper) splitName(dns string) (hostname, domain string) {
+	dns = strings.TrimSuffix(dns, ".")
+	if zone := a.findZone(dns); zone != "" {
+		return strings.TrimSuffix(dns, "."+zone), zone
+	}
+	parts := strings.SplitN(dns, ".", 2)
+	hostname = parts[0]
+	if len(parts) > 1 {
+		domain = parts[1]
+	}
+	return hostname, domain
 }
 
 func (a AffixNameMapper) ToEndpointName(dns string) (string, string) {
@@ -76,6 +130,14 @@ func (a AffixNameMapper) ToEndpointName(dns string) (string, string) {
 
 	// drop suffix
 	if a.isSuffix() {
+		if zone := a.findZone(lowerDNSName); zone != "" {
+			hostPart := strings.TrimSuffix(lowerDNSName, "."+zone)
+			r, rType := a.dropAffixExtractType(hostPart)
+			if r == "" && rType == "" {
+				return "", ""
+			}
+			return r + "." + zone, rType
+		}
 		dc := strings.Count(a.suffix, ".")
 		parts := strings.SplitN(lowerDNSName, ".", 2+dc)
 		if len(parts) <= dc {
@@ -92,7 +154,7 @@ func (a AffixNameMapper) ToEndpointName(dns string) (string, string) {
 }
 
 func (a AffixNameMapper) ToTXTName(dns, recordType string) string {
-	parts := strings.SplitN(dns, ".", 2)
+	hostname, domain := a.splitName(dns)
 	recordType = strings.ToLower(recordType)
 	recordT := recordType + "-"
 
@@ -100,19 +162,19 @@ func (a AffixNameMapper) ToTXTName(dns, recordType string) string {
 	suffix := a.normalizeAffixTemplate(a.suffix, recordType)
 
 	// If specified, replace a leading asterisk in the generated txt record name with some other string
-	if a.wildcardReplacement != "" && parts[0] == "*" {
-		parts[0] = a.wildcardReplacement
+	if a.wildcardReplacement != "" && hostname == "*" {
+		hostname = a.wildcardReplacement
 	}
 
 	if !a.recordTypeInAffix() {
-		parts[0] = recordT + parts[0]
+		hostname = recordT + hostname
 	}
 
-	if len(parts) < 2 {
-		return prefix + parts[0] + suffix
+	if domain == "" {
+		return prefix + hostname + suffix
 	}
 
-	return prefix + parts[0] + suffix + "." + parts[1]
+	return prefix + hostname + suffix + "." + domain
 }
 
 func (a AffixNameMapper) recordTypeInAffix() bool {

--- a/registry/mapper/mapper_test.go
+++ b/registry/mapper/mapper_test.go
@@ -206,6 +206,13 @@ func TestAffixNameMapper_ToEndpointName(t *testing.T) {
 			wantEndpointName: "",
 			wantRecordType:   "",
 		},
+		{
+			name:             "suffix dotted hostname with zone round-trips",
+			mapper:           NewAffixNameMapperWithZones("", "-txtsuffix", "", []string{"example.com"}),
+			input:            "a-name-192.168.0.1-txtsuffix.example.com",
+			wantEndpointName: "name-192.168.0.1.example.com",
+			wantRecordType:   endpoint.RecordTypeA,
+		},
 	}
 
 	for _, tt := range tests {
@@ -412,6 +419,34 @@ func TestAffixNameMapper_ToTXTName(t *testing.T) {
 			recordType:  endpoint.RecordTypeTXT,
 			wantTXTName: "txt-foo.example.com",
 		},
+		{
+			name:        "suffix dotted hostname without zones keeps first-dot split",
+			mapper:      NewAffixNameMapper("", "-txtsuffix", ""),
+			dns:         "name-192.168.0.1.example.com",
+			recordType:  endpoint.RecordTypeA,
+			wantTXTName: "a-name-192-txtsuffix.168.0.1.example.com",
+		},
+		{
+			name:        "suffix dotted hostname with zone preserves host labels",
+			mapper:      NewAffixNameMapperWithZones("", "-txtsuffix", "", []string{"example.com"}),
+			dns:         "name-192.168.0.1.example.com",
+			recordType:  endpoint.RecordTypeA,
+			wantTXTName: "a-name-192.168.0.1-txtsuffix.example.com",
+		},
+		{
+			name:        "prefix dotted hostname with zone preserves host labels",
+			mapper:      NewAffixNameMapperWithZones("txt-", "", "", []string{"example.com"}),
+			dns:         "name-192.168.0.1.example.com",
+			recordType:  endpoint.RecordTypeA,
+			wantTXTName: "txt-a-name-192.168.0.1.example.com",
+		},
+		{
+			name:        "longest zone wins",
+			mapper:      NewAffixNameMapperWithZones("", "-txtsuffix", "", []string{"example.com", "168.0.1.example.com"}),
+			dns:         "name-192.168.0.1.example.com",
+			recordType:  endpoint.RecordTypeA,
+			wantTXTName: "a-name-192-txtsuffix.168.0.1.example.com",
+		},
 	}
 
 	for _, tt := range tests {
@@ -430,6 +465,16 @@ func TestAffixNameMapper_ToTXTName(t *testing.T) {
 	for _, recordType := range supportedRecords {
 		assert.True(t, testedRecords.Has(recordType), "Record type %s is in supportedRecords but not tested in TestAffixNameMapper_ToTXTName", recordType)
 	}
+}
+
+func TestAffixNameMapper_DottedHostnameRoundTrip(t *testing.T) {
+	m := NewAffixNameMapperWithZones("", "-txtsuffix", "", []string{"example.com"})
+	dns := "name-192.168.0.1.example.com"
+	txt := m.ToTXTName(dns, endpoint.RecordTypeA)
+	got, rType := m.ToEndpointName(txt)
+	assert.Equal(t, "a-name-192.168.0.1-txtsuffix.example.com", txt)
+	assert.Equal(t, dns, got)
+	assert.Equal(t, endpoint.RecordTypeA, rType)
 }
 
 func TestAffixNameMapper_RecordTypeInAffix(t *testing.T) {

--- a/registry/txt/registry.go
+++ b/registry/txt/registry.go
@@ -156,7 +156,7 @@ func newRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID strin
 	return &TXTRegistry{
 		provider:            provider,
 		ownerID:             ownerID,
-		mapper:              mapper.NewAffixNameMapper(txtPrefix, txtSuffix, txtWildcardReplacement),
+		mapper:              mapper.NewAffixNameMapperWithZones(txtPrefix, txtSuffix, txtWildcardReplacement, mapper.ZonesFromDomainFilter(provider.GetDomainFilter())),
 		cacheInterval:       cacheInterval,
 		wildcardReplacement: txtWildcardReplacement,
 		managedRecordTypes:  managedRecordTypes,


### PR DESCRIPTION
Fixes #5151

## What does it do?

Teaches `AffixNameMapper` the managed zones so that endpoint names whose
hostname part contains dots (e.g. `name-192.168.0.1.example.com` with
`--txt-suffix`) keep their dotted host labels in the generated TXT name:

| | TXT name |
|---|---|
| before | `a-name-192-txtsuffix.168.0.1.example.com` |
| after (zones known) | `a-name-192.168.0.1-txtsuffix.example.com` |

`ToEndpointName` mirrors the same split, so the `ToTXTName` →
`ToEndpointName` round trip restores the original endpoint name and
record type.

Zone awareness is opt-in: the mapper is built from the provider's
domain filter (`NewAffixNameMapperWithZones`, longest zone wins). When
no zones are known the legacy first-dot split is used unchanged, so
existing deployments keep their current TXT record names. This is a
narrower alternative to #6494, which adds a new constructor and injects
zones into the mapper struct from the registry.

## Motivation

With `--txt-suffix`, `ToTXTName` split at the first dot, so a dotted
hostname like `name-192.168.0.1.example.com` produced an ownership TXT
record of `a-name-192-txtsuffix.168.0.1.example.com` instead of
keeping the full host label group.

## Checklist

- [x] Unit tests (`registry/mapper`, including round-trip and
      longest-zone-wins cases; the pre-existing flaky
      `TestTXTRegistryApplyChangesEncrypt` failure in
      `registry/txt` reproduces on unmodified master and is unrelated)
- [x] Commits are signed via [DCO](https://istio-plugin.artifacts.buildkite.com/sigs.k8s.io/external-dns/main/clmdk5bgc0j7n28chmv3ilp5s/018f83f8-ca72-4c86-a516-fb3ee8e00c6b.pdf)
- [ ] Tests updated
- [x] Documentation updated
- [x] Title matches the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
