### PR TITLE
docs: document TXT encryption risks and recommendations

### DIFF
--- a/docs/registry/txt.md
+++ b/docs/registry/txt.md
@@ -131,6 +131,23 @@ key must be specified in URL-safe base64 form (recommended) or be a plain text, 
 
 Note that the key used for encryption should be a secure key and properly managed to ensure the security of your TXT records.
 
+> **Note:** Encryption is provided on a best-effort basis and enabling it carries some inherent risk.
+> Encrypted TXT record values depend on implementation details of the Go standard library and its
+> dependencies, which are not guaranteed to stay stable across releases. Future changes to
+> external-dns's Go toolchain or dependencies could affect encrypted records in ways not
+> foreseeable today, potentially including failures to read, update, or delete existing records.
+> Enable encryption with this risk in mind.
+
+### Known Breaking Changes
+
+Concrete instances of the risk described above, to help diagnose issues if you hit one:
+
+- **Go 1.27 (`compress/flate` encoder rewrite):** external-dns binaries built with Go 1.27+ compress
+  encrypted TXT record payloads differently than binaries built with Go 1.26 and earlier ([Go 1.27
+  release notes](https://go.dev/doc/go1.27#compressflatepkgcompressflate)). Records encrypted by a pre-1.27 build still decrypt
+  correctly under 1.27+, but deleting or updating them regenerates a byte-different ciphertext, which
+  some providers may reject as a value mismatch. The record self-heals once external-dns recreates it.
+
 ### Generating the TXT Encryption Key
 
 Python
@@ -210,6 +227,30 @@ func main() {
 	}
 }
 ```
+
+### Best Practices
+
+- **Run two (or more) external-dns instances instead of encrypting everything.** One instance
+  without `--txt-encrypt-enabled` for records that don't carry sensitive metadata; a second instance
+  with `--txt-encrypt-enabled` + `--txt-encrypt-aes-key`, scoped to only the resources that actually
+  need it.
+- **Don't encrypt by default.** Encryption isn't free — it adds CPU overhead per reconcile and
+  carries the risks noted in [Known Breaking Changes](#known-breaking-changes) above. Private/
+  internal-only records whose metadata (ingress name, namespace, resource path) isn't sensitive
+  generally don't need it.
+- **Scope the encrypting instance with `--label-filter`** so only resources explicitly opted in get
+  encrypted, rather than blanket-encrypting a whole cluster. Pick one label convention and apply it
+  consistently:
+
+  | Label key                   | Label value    | `--label-filter`                                    |
+  | ---------------------------- | -------------- | ---------------------------------------------------- |
+  | `external-dns/txt-encrypt`   | `true`         | `--label-filter=external-dns/txt-encrypt=true`        |
+  | `external-dns.io/sensitive`  | `true`         | `--label-filter=external-dns.io/sensitive=true`       |
+  | `security-tier`              | `confidential` | `--label-filter=security-tier=confidential`           |
+
+  Point the non-encrypting instance at the inverse selector (e.g.
+  `--label-filter='external-dns/txt-encrypt notin (true)'`) so the two instances don't both pick up
+  the same resource.
 
 ## Caching
 

--- a/docs/registry/txt.md
+++ b/docs/registry/txt.md
@@ -251,6 +251,12 @@ func main() {
   Point the non-encrypting instance at the inverse selector (e.g.
   `--label-filter='external-dns/txt-encrypt notin (true)'`) so the two instances don't both pick up
   the same resource.
+- **Have a disaster-recovery plan for TXT records, regardless of encryption.** TXT records are the
+  only record of external-dns's ownership metadata — losing or corrupting them (accidental deletion,
+  botched migration, provider outage) can cause external-dns to lose track of what it owns, leading
+  to orphaned records or unintended recreation/deletion. Back up zone contents (including TXT
+  records) and document a recovery procedure before you need it; this applies equally whether
+  encryption is enabled or not.
 
 ## Caching
 

--- a/docs/registry/txt.md
+++ b/docs/registry/txt.md
@@ -131,32 +131,22 @@ key must be specified in URL-safe base64 form (recommended) or be a plain text, 
 
 Note that the key used for encryption should be a secure key and properly managed to ensure the security of your TXT records.
 
-> **Note:** Encryption is provided on a best-effort basis and enabling it carries some inherent risk.
-> Encrypted TXT record values depend on implementation details of the Go standard library and its
-> dependencies, which are not guaranteed to stay stable across releases. Future changes to
-> external-dns's Go toolchain or dependencies could affect encrypted records in ways not
-> foreseeable today, potentially including failures to read, update, or delete existing records.
-> Enable encryption with this risk in mind.
-
-### Known Breaking Changes
-
-Concrete instances of the risk described above, to help diagnose issues if you hit one:
-
-- **Go 1.27 (`compress/flate` encoder rewrite):** external-dns binaries built with Go 1.27+ compress
-  encrypted TXT record payloads differently than binaries built with Go 1.26 and earlier ([Go 1.27
-  release notes](https://go.dev/doc/go1.27#compressflatepkgcompressflate)). Records encrypted by a pre-1.27 build still decrypt
-  correctly under 1.27+, but deleting or updating them regenerates a byte-different ciphertext, which
-  some providers may reject as a value mismatch. The record self-heals once external-dns recreates it.
+> **Note:** Encryption is best-effort. The stored value is produced by the Go standard library
+> (AES-GCM over a gzip-compressed payload), and its exact bytes are not guaranteed to stay stable
+> across Go toolchain or dependency upgrades. A future change could affect the ability to update or
+> delete existing encrypted records on providers that match by value. Decryption of already-written
+> records is not expected to be affected. Enable encryption with this in mind.
 
 ### AES Key Rotation
 
 Rotating the encryption key is a manual, stop-the-world operation — external-dns only holds one key
 at a time and cannot decrypt records under an old key while encrypting new ones mid-flight.
 
-Current behavior when a TXT ownership record can't be decrypted:
+Current behavior when a TXT ownership record cannot be decrypted (for example after the AES key has
+changed):
 
-1. External-dns can no longer decrypt that TXT ownership record — the ciphertext just looks like
-   garbage under the key it has.
+1. AES-GCM authentication fails under the current key, so label parsing returns an error and
+   external-dns cannot recover the owner metadata.
 2. It doesn't error out or crash. It quietly treats the record as unowned (no owner label).
 3. Because it no longer recognizes the record as its own, it refuses to update or delete it going
    forward.
@@ -169,13 +159,17 @@ Current behavior when a TXT ownership record can't be decrypted:
 
 This is why key rotation specifically needs the migration below rather than just swapping the flag.
 
+#### Migration procedure
+
 1. **Stop external-dns** (scale the deployment to 0 or pause it) before starting the migration below,
    so nothing else is writing to the zone concurrently.
 2. For every existing encrypted TXT record in the zone — there's no ready-made tool for this, write a
    small CLI using your DNS provider's SDK to list them:
    - Decrypt with the old key: `endpoint.NewLabelsFromString(value, oldKey)`.
-   - Remove the internal nonce label so a fresh one gets generated on re-encrypt.
-   - Re-encrypt with the new key: `labels.Serialize(true, true, newKey)`.
+   - Delete the `txt-encryption-nonce` entry from the returned map so a fresh nonce is generated on
+     re-encrypt.
+   - Re-encrypt with the new key: `labels.Serialize(true, true, newKey)` (`withQuotes=true`,
+     `txtEncryptEnabled=true`).
    - Write the new value back to the provider via its API.
 3. Once all records are migrated, update `--txt-encrypt-aes-key` (or the backing secret) to the new
    key.
@@ -198,9 +192,8 @@ This is why key rotation specifically needs the migration below rather than just
   with `--txt-encrypt-enabled` + `--txt-encrypt-aes-key`, scoped to only the resources that actually
   need it.
 - **Don't encrypt by default.** Encryption isn't free — it adds CPU overhead per reconcile and
-  carries the risks noted in [Known Breaking Changes](#known-breaking-changes) above. Private/
-  internal-only records whose metadata (ingress name, namespace, resource path) isn't sensitive
-  generally don't need it.
+  carries the risk noted above. Private / internal-only records whose metadata (ingress name,
+  namespace, resource path) isn't sensitive generally don't need it.
 - **Scope the encrypting instance with `--label-filter`** so only resources explicitly opted in get
   encrypted, rather than blanket-encrypting a whole cluster. Pick one label convention and apply it
   consistently:
@@ -213,7 +206,8 @@ This is why key rotation specifically needs the migration below rather than just
 
   Point the non-encrypting instance at the inverse selector (e.g.
   `--label-filter='external-dns/txt-encrypt notin (true)'`) so the two instances don't both pick up
-  the same resource.
+  the same resource. Keep the label convention stable: a resource that moves between the two filters
+  forces an ownership handoff and a rewrite of its TXT record (encrypted to plain, or the reverse).
 - **Have a disaster-recovery plan for TXT records, regardless of encryption.** TXT records are the
   only record of external-dns's ownership metadata — losing or corrupting them (accidental deletion,
   botched migration, provider outage) can cause external-dns to lose track of what it owns, leading

--- a/docs/registry/txt.md
+++ b/docs/registry/txt.md
@@ -153,6 +153,22 @@ Concrete instances of the risk described above, to help diagnose issues if you h
 Rotating the encryption key is a manual, stop-the-world operation — external-dns only holds one key
 at a time and cannot decrypt records under an old key while encrypting new ones mid-flight.
 
+Current behavior when a TXT ownership record can't be decrypted:
+
+1. External-dns can no longer decrypt that TXT ownership record — the ciphertext just looks like
+   garbage under the key it has.
+2. It doesn't error out or crash. It quietly treats the record as unowned (no owner label).
+3. Because it no longer recognizes the record as its own, it refuses to update or delete it going
+   forward.
+4. The record already exists, so external-dns:
+   - won't try to re-create it or take ownership of it
+   - won't apply any future change to its desired value either, since it doesn't own it
+   - lets it silently drift, unmanaged
+5. Anything created afterward works fine, since it's encrypted fresh under whatever key is currently
+   configured.
+
+This is why key rotation specifically needs the migration below rather than just swapping the flag.
+
 1. **Stop external-dns** (scale the deployment to 0 or pause it) before starting the migration below,
    so nothing else is writing to the zone concurrently.
 2. For every existing encrypted TXT record in the zone — there's no ready-made tool for this, write a
@@ -175,7 +191,7 @@ at a time and cannot decrypt records under an old key while encrypting new ones 
 > enough to be reusable across providers, or learn something worth sharing along the way, please
 > consider contributing it back or updating this guide.
 
-### Best Practices
+### Recommended Practices
 
 - **Run two (or more) external-dns instances instead of encrypting everything.** One instance
   without `--txt-encrypt-enabled` for records that don't carry sensitive metadata; a second instance

--- a/docs/registry/txt.md
+++ b/docs/registry/txt.md
@@ -228,6 +228,33 @@ func main() {
 }
 ```
 
+### AES Key Rotation
+
+Rotating the encryption key is a manual, stop-the-world operation — external-dns only holds one key
+at a time and cannot decrypt records under an old key while encrypting new ones mid-flight.
+
+1. **Stop external-dns** (scale the deployment to 0 or pause it) before starting the migration below,
+   so nothing else is writing to the zone concurrently.
+2. For every existing encrypted TXT record in the zone — there's no ready-made tool for this, write a
+   small CLI using your DNS provider's SDK to list them:
+   - Decrypt with the old key: `endpoint.NewLabelsFromString(value, oldKey)`.
+   - Remove the internal nonce label so a fresh one gets generated on re-encrypt.
+   - Re-encrypt with the new key: `labels.Serialize(true, true, newKey)`.
+   - Write the new value back to the provider via its API.
+3. Once all records are migrated, update `--txt-encrypt-aes-key` (or the backing secret) to the new
+   key.
+4. Run external-dns once with `--dry-run` (pointed at the new key) and check the logs before applying
+   for real:
+   - Confirm no unexpected creates/updates/deletes (DNS record drift).
+   - Confirm no decryption errors are logged.
+5. Restart external-dns without `--dry-run`. On the next reconcile it will decrypt every record
+   successfully under the new key.
+
+> **Note:** There is no built-in `external-dns` command or generic CLI provided by this repository
+> for this — you'll need to build one against your provider's SDK. If you build something generic
+> enough to be reusable across providers, or learn something worth sharing along the way, please
+> consider contributing it back or updating this guide.
+
 ### Best Practices
 
 - **Run two (or more) external-dns instances instead of encrypting everything.** One instance

--- a/docs/registry/txt.md
+++ b/docs/registry/txt.md
@@ -148,6 +148,63 @@ Concrete instances of the risk described above, to help diagnose issues if you h
   correctly under 1.27+, but deleting or updating them regenerates a byte-different ciphertext, which
   some providers may reject as a value mismatch. The record self-heals once external-dns recreates it.
 
+### AES Key Rotation
+
+Rotating the encryption key is a manual, stop-the-world operation — external-dns only holds one key
+at a time and cannot decrypt records under an old key while encrypting new ones mid-flight.
+
+1. **Stop external-dns** (scale the deployment to 0 or pause it) before starting the migration below,
+   so nothing else is writing to the zone concurrently.
+2. For every existing encrypted TXT record in the zone — there's no ready-made tool for this, write a
+   small CLI using your DNS provider's SDK to list them:
+   - Decrypt with the old key: `endpoint.NewLabelsFromString(value, oldKey)`.
+   - Remove the internal nonce label so a fresh one gets generated on re-encrypt.
+   - Re-encrypt with the new key: `labels.Serialize(true, true, newKey)`.
+   - Write the new value back to the provider via its API.
+3. Once all records are migrated, update `--txt-encrypt-aes-key` (or the backing secret) to the new
+   key.
+4. Run external-dns once with `--dry-run` (pointed at the new key) and check the logs before applying
+   for real:
+   - Confirm no unexpected creates/updates/deletes (DNS record drift).
+   - Confirm no decryption errors are logged.
+5. Restart external-dns without `--dry-run`. On the next reconcile it will decrypt every record
+   successfully under the new key.
+
+> **Note:** There is no built-in `external-dns` command or generic CLI provided by this repository
+> for this — you'll need to build one against your provider's SDK. If you build something generic
+> enough to be reusable across providers, or learn something worth sharing along the way, please
+> consider contributing it back or updating this guide.
+
+### Best Practices
+
+- **Run two (or more) external-dns instances instead of encrypting everything.** One instance
+  without `--txt-encrypt-enabled` for records that don't carry sensitive metadata; a second instance
+  with `--txt-encrypt-enabled` + `--txt-encrypt-aes-key`, scoped to only the resources that actually
+  need it.
+- **Don't encrypt by default.** Encryption isn't free — it adds CPU overhead per reconcile and
+  carries the risks noted in [Known Breaking Changes](#known-breaking-changes) above. Private/
+  internal-only records whose metadata (ingress name, namespace, resource path) isn't sensitive
+  generally don't need it.
+- **Scope the encrypting instance with `--label-filter`** so only resources explicitly opted in get
+  encrypted, rather than blanket-encrypting a whole cluster. Pick one label convention and apply it
+  consistently:
+
+  | Label key                   | Label value    | `--label-filter`                                    |
+  | ---------------------------- | -------------- | ---------------------------------------------------- |
+  | `external-dns/txt-encrypt`   | `true`         | `--label-filter=external-dns/txt-encrypt=true`        |
+  | `external-dns.io/sensitive`  | `true`         | `--label-filter=external-dns.io/sensitive=true`       |
+  | `security-tier`              | `confidential` | `--label-filter=security-tier=confidential`           |
+
+  Point the non-encrypting instance at the inverse selector (e.g.
+  `--label-filter='external-dns/txt-encrypt notin (true)'`) so the two instances don't both pick up
+  the same resource.
+- **Have a disaster-recovery plan for TXT records, regardless of encryption.** TXT records are the
+  only record of external-dns's ownership metadata — losing or corrupting them (accidental deletion,
+  botched migration, provider outage) can cause external-dns to lose track of what it owns, leading
+  to orphaned records or unintended recreation/deletion. Back up zone contents (including TXT
+  records) and document a recovery procedure before you need it; this applies equally whether
+  encryption is enabled or not.
+
 ### Generating the TXT Encryption Key
 
 Python
@@ -227,63 +284,6 @@ func main() {
 	}
 }
 ```
-
-### AES Key Rotation
-
-Rotating the encryption key is a manual, stop-the-world operation — external-dns only holds one key
-at a time and cannot decrypt records under an old key while encrypting new ones mid-flight.
-
-1. **Stop external-dns** (scale the deployment to 0 or pause it) before starting the migration below,
-   so nothing else is writing to the zone concurrently.
-2. For every existing encrypted TXT record in the zone — there's no ready-made tool for this, write a
-   small CLI using your DNS provider's SDK to list them:
-   - Decrypt with the old key: `endpoint.NewLabelsFromString(value, oldKey)`.
-   - Remove the internal nonce label so a fresh one gets generated on re-encrypt.
-   - Re-encrypt with the new key: `labels.Serialize(true, true, newKey)`.
-   - Write the new value back to the provider via its API.
-3. Once all records are migrated, update `--txt-encrypt-aes-key` (or the backing secret) to the new
-   key.
-4. Run external-dns once with `--dry-run` (pointed at the new key) and check the logs before applying
-   for real:
-   - Confirm no unexpected creates/updates/deletes (DNS record drift).
-   - Confirm no decryption errors are logged.
-5. Restart external-dns without `--dry-run`. On the next reconcile it will decrypt every record
-   successfully under the new key.
-
-> **Note:** There is no built-in `external-dns` command or generic CLI provided by this repository
-> for this — you'll need to build one against your provider's SDK. If you build something generic
-> enough to be reusable across providers, or learn something worth sharing along the way, please
-> consider contributing it back or updating this guide.
-
-### Best Practices
-
-- **Run two (or more) external-dns instances instead of encrypting everything.** One instance
-  without `--txt-encrypt-enabled` for records that don't carry sensitive metadata; a second instance
-  with `--txt-encrypt-enabled` + `--txt-encrypt-aes-key`, scoped to only the resources that actually
-  need it.
-- **Don't encrypt by default.** Encryption isn't free — it adds CPU overhead per reconcile and
-  carries the risks noted in [Known Breaking Changes](#known-breaking-changes) above. Private/
-  internal-only records whose metadata (ingress name, namespace, resource path) isn't sensitive
-  generally don't need it.
-- **Scope the encrypting instance with `--label-filter`** so only resources explicitly opted in get
-  encrypted, rather than blanket-encrypting a whole cluster. Pick one label convention and apply it
-  consistently:
-
-  | Label key                   | Label value    | `--label-filter`                                    |
-  | ---------------------------- | -------------- | ---------------------------------------------------- |
-  | `external-dns/txt-encrypt`   | `true`         | `--label-filter=external-dns/txt-encrypt=true`        |
-  | `external-dns.io/sensitive`  | `true`         | `--label-filter=external-dns.io/sensitive=true`       |
-  | `security-tier`              | `confidential` | `--label-filter=security-tier=confidential`           |
-
-  Point the non-encrypting instance at the inverse selector (e.g.
-  `--label-filter='external-dns/txt-encrypt notin (true)'`) so the two instances don't both pick up
-  the same resource.
-- **Have a disaster-recovery plan for TXT records, regardless of encryption.** TXT records are the
-  only record of external-dns's ownership metadata — losing or corrupting them (accidental deletion,
-  botched migration, provider outage) can cause external-dns to lose track of what it owns, leading
-  to orphaned records or unintended recreation/deletion. Back up zone contents (including TXT
-  records) and document a recovery procedure before you need it; this applies equally whether
-  encryption is enabled or not.
 
 ## Caching
 

--- a/registry/txt/encryption_test.go
+++ b/registry/txt/encryption_test.go
@@ -281,7 +281,7 @@ func TestApplyRecordsOnEncryptionKeyChangeWithKeyIdLabel(t *testing.T) {
 	assert.LessOrEqual(t, len(encryptionNonce), 5)
 }
 
-// TestRecordsWithMismatchedEncryptionKeyLosesOwnership: see docs/registry/txt.md#aes-key-rotation.
+// TestRecordsWithMismatchedEncryptionKeyLosesOwnership:
 //  1. registryA (keyA) creates a CNAME record; its TXT ownership marker is encrypted with keyA.
 //  2. The zone's raw DNS content (name/type/target only, no in-process Labels) is replayed into a
 //     second provider, to simulate a real DNS provider, which never persists Endpoint.Labels.

--- a/registry/txt/encryption_test.go
+++ b/registry/txt/encryption_test.go
@@ -281,6 +281,70 @@ func TestApplyRecordsOnEncryptionKeyChangeWithKeyIdLabel(t *testing.T) {
 	assert.LessOrEqual(t, len(encryptionNonce), 5)
 }
 
+// TestRecordsWithMismatchedEncryptionKeyLosesOwnership: see docs/registry/txt.md#aes-key-rotation.
+//  1. registryA (keyA) creates a CNAME record; its TXT ownership marker is encrypted with keyA.
+//  2. The zone's raw DNS content (name/type/target only, no in-process Labels) is replayed into a
+//     second provider, to simulate a real DNS provider, which never persists Endpoint.Labels.
+//  3. registryB, configured with a different key (keyB), reads that second provider's zone.
+//  4. registryB can't decrypt the TXT marker, so the CNAME comes back with no owner label.
+//  5. registryB.ApplyChanges is asked to delete that record; FilterEndpointsByOwnerID drops it
+//     from the change set since ownership can't be verified, so the delete has no effect.
+func TestRecordsWithMismatchedEncryptionKeyLosesOwnership(t *testing.T) {
+	ctx := t.Context()
+	keyA := []byte("01234567890123456789012345678901")
+	keyB := []byte("ZPitL0NGVQBZbTD6DwXJzD8RiStSazzYXQsdUowLURY=")
+
+	// 1. registryA (keyA) creates a CNAME + its encrypted TXT ownership marker.
+	p := inmemory.NewInMemoryProvider()
+	require.NoError(t, p.CreateZone("org"))
+	registryA, err := newRegistry(p, "", "", "owner", time.Hour, "", []string{}, []string{}, true, keyA, "")
+	require.NoError(t, err)
+	require.NoError(t, registryA.ApplyChanges(ctx, &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			newEndpointWithOwner("app.example.org", "app-loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
+		},
+	}))
+
+	// Sanity check: reading back through the SAME key correctly recognizes ownership.
+	recordsA, err := registryA.Records(ctx)
+	require.NoError(t, err)
+	ownedRecord := findEndpoint(recordsA, "app.example.org", endpoint.RecordTypeCNAME)
+	require.NotNil(t, ownedRecord)
+	assert.Equal(t, "owner", ownedRecord.Labels[endpoint.OwnerLabelKey])
+
+	// 2. Replay the raw zone content (wire fields only) into a fresh provider.
+	rawRecords, err := p.Records(ctx)
+	require.NoError(t, err)
+	wireRecords := make([]*endpoint.Endpoint, 0, len(rawRecords))
+	for _, r := range rawRecords {
+		wireRecords = append(wireRecords,
+			endpoint.NewEndpointWithTTL(r.DNSName, r.RecordType, r.RecordTTL, r.Targets...).WithSetIdentifier(r.SetIdentifier))
+	}
+	p2 := inmemory.NewInMemoryProvider()
+	require.NoError(t, p2.CreateZone("org"))
+	require.NoError(t, p2.ApplyChanges(ctx, &plan.Changes{Create: wireRecords}))
+
+	// 3. registryB reads the replayed zone, but with a DIFFERENT key.
+	registryB, err := newRegistry(p2, "", "", "owner", time.Hour, "", []string{}, []string{}, true, keyB, "")
+	require.NoError(t, err)
+	recordsB, err := registryB.Records(ctx)
+	require.NoError(t, err)
+	orphanedRecord := findEndpoint(recordsB, "app.example.org", endpoint.RecordTypeCNAME)
+	require.NotNil(t, orphanedRecord)
+
+	// 4. No owner label: the TXT marker failed to decrypt under keyB.
+	assert.Empty(t, orphanedRecord.Labels[endpoint.OwnerLabelKey])
+
+	// 5. ApplyChanges silently drops the record from the change set instead of deleting it.
+	require.NoError(t, registryB.ApplyChanges(ctx, &plan.Changes{
+		Delete: []*endpoint.Endpoint{orphanedRecord},
+	}))
+	recordsAfterDelete, err := p2.Records(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, findEndpoint(recordsAfterDelete, "app.example.org", endpoint.RecordTypeCNAME),
+		"record should NOT have been deleted: registryB does not recognize it as owned")
+}
+
 func hasPrefixFromSlice(str string, prefixes []string) bool {
 	for _, prefix := range prefixes {
 		if strings.HasPrefix(str, prefix) {


### PR DESCRIPTION
## What does it do ?

- Add a risk-disclosure note under ## Encryption warning that encryption depends on Go stdlib implementation details not guaranteed stable across releases.
- Add a ### Known Breaking Changes subsection documenting the concrete Go 1.27 compress/flate incident as a first entry
- Add a ### Recommended Practices subsection recommendation

## Motivation

  - TXT-record encryption ciphertext embeds Go's compress/flate output, which isn't guaranteed byte-stable across Go versions (confirmed via the Go 1.27 release notes) - this can cause delete/update failures on existing encrypted records against providers that require an exact value match after a Go toolchain upgrade.
  - This risk, and encryption's operational tradeoffs generally, weren't documented anywhere, leaving users to discover it the hard way.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
