### PR TITLE
fix(source/gateway-api): treat an explicit empty parentRef group as the core group

### DIFF
--- a/docs/sources/gateway.md
+++ b/docs/sources/gateway.md
@@ -102,6 +102,36 @@ Iterates over all listeners for the parent's `parentRef.sectionName`:
 
 - Ignores listeners which specify an `allowedRoutes` which does not allow the route.
 
+### API group defaulting
+
+`parentRef.group`, and the `group` of each entry in a listener's `allowedRoutes.kinds`, are optional
+and default to `gateway.networking.k8s.io` when they are omitted. An explicit empty string is not
+the same thing: it names the core API group, which holds no Gateway and no \*Route kind.
+
+| written as                         | resolves to                 |
+| ---------------------------------- | --------------------------- |
+| `group` omitted                    | `gateway.networking.k8s.io` |
+| `group: gateway.networking.k8s.io` | `gateway.networking.k8s.io` |
+| `group: ""`                        | the core API group          |
+
+Earlier versions read an explicit `group: ""` as `gateway.networking.k8s.io`. A `parentRef` written
+that way resolved to the same-named Gateway, and a listener whose `allowedRoutes.kinds` was written
+that way accepted Gateway API \*Routes. Both now follow the API, so records that existed only
+because of the old reading are no longer generated.
+
+With `--policy=sync` and a TXT registry, those records and the ownership TXT records that go with
+them are deleted on the next reconcile. Before upgrading, look for `parentRefs` and
+`allowedRoutes.kinds` entries with an explicit empty group, and either set the group to
+`gateway.networking.k8s.io` or drop the field wherever a Gateway API object was meant.
+
+Do not change `group: ""` everywhere. It is the correct way to name an object in the core API
+group, such as the Service in the `backendRef` of the example below. Only references that were
+meant to name a Gateway or a \*Route kind are affected.
+
+`--policy=upsert-only` suppresses the deletion during a rollout, but it does not clean the stale
+records up afterwards and it still allows existing record sets to be updated, so it is a way to
+stage the change rather than a guarantee that nothing moves.
+
 ## Targets
 
 The targets of the DNS entries created from a \*Route are sourced from the following places:

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -418,14 +418,12 @@ func (c *gatewayRouteResolver) resolve(rt gatewayRoute) (map[string]endpoint.Tar
 func (c *gatewayRouteResolver) resolveParentRef(rt gatewayRoute, routeParentRefs []v1.ParentReference, rps v1.RouteParentStatus) (*resolvedParent, bool) {
 	meta := rt.Metadata()
 	ref := rps.ParentRef
-	namespace := strVal((*string)(ref.Namespace), meta.Namespace)
+	group, kind, namespace := normParentRef(ref, meta.Namespace)
 	if !gwRouteHasParentRef(routeParentRefs, ref, meta) {
 		log.Debugf("Parent reference %s/%s not found in routeParentRefs for %s %s/%s", namespace, string(ref.Name), c.src.rtKind, meta.Namespace, meta.Name)
 		return nil, false
 	}
 
-	group := strVal((*string)(ref.Group), gatewayGroup)
-	kind := strVal((*string)(ref.Kind), gatewayKind)
 	if group != gatewayGroup || (kind != gatewayKind && kind != listenerSetKind) {
 		log.Debugf("Unsupported parent %s/%s for %s %s/%s", group, kind, c.src.rtKind, meta.Namespace, meta.Name)
 		return nil, false
@@ -633,7 +631,7 @@ func (c *gatewayRouteResolver) routeIsAllowed(ownerNamespace string, lis *v1.Lis
 	}
 	gvk := rt.Object().GetObjectKind().GroupVersionKind()
 	for _, gk := range allow.Kinds {
-		group := strVal((*string)(gk.Group), gatewayGroup)
+		group := gwGroupOrDefault(gk.Group)
 		if gvk.Group == group && gvk.Kind == string(gk.Kind) {
 			return true
 		}
@@ -768,19 +766,34 @@ func gatewayAllowsListenerSet(gw *v1.Gateway, ls *v1.ListenerSet, namespaces map
 	}
 }
 
+// gwGroupOrDefault defaults an omitted group to the Gateway API group. An explicit empty group is
+// the core group, so it is kept as is.
+func gwGroupOrDefault(group *v1.Group) string {
+	if group == nil {
+		return gatewayGroup
+	}
+	return string(*group)
+}
+
+// normParentRef returns the group, kind and namespace that identify a parent, with the API
+// defaults applied, so that membership and lookup cannot drift apart.
+func normParentRef(ref v1.ParentReference, defaultNamespace string) (string, string, string) {
+	kind := gatewayKind
+	if ref.Kind != nil {
+		kind = string(*ref.Kind)
+	}
+	return gwGroupOrDefault(ref.Group), kind, strVal((*string)(ref.Namespace), defaultNamespace)
+}
+
 func gwRouteHasParentRef(routeParentRefs []v1.ParentReference, ref v1.ParentReference, meta *metav1.ObjectMeta) bool {
 	// Ensure that the parent reference is in the routeParentRefs list
-	namespace := strVal((*string)(ref.Namespace), meta.Namespace)
-	group := strVal((*string)(ref.Group), gatewayGroup)
-	kind := strVal((*string)(ref.Kind), gatewayKind)
+	group, kind, namespace := normParentRef(ref, meta.Namespace)
 	for _, rpr := range routeParentRefs {
-		rprGroup := strVal((*string)(rpr.Group), gatewayGroup)
-		rprKind := strVal((*string)(rpr.Kind), gatewayKind)
-		if rprGroup != group || rprKind != kind {
+		rprGroup, rprKind, rprNamespace := normParentRef(rpr, meta.Namespace)
+		if rprGroup != group || rprKind != kind || rprNamespace != namespace {
 			continue
 		}
-		rprNamespace := strVal((*string)(rpr.Namespace), meta.Namespace)
-		if string(rpr.Name) != string(ref.Name) || rprNamespace != namespace {
+		if string(rpr.Name) != string(ref.Name) {
 			continue
 		}
 		return true

--- a/source/gateway_httproute_test.go
+++ b/source/gateway_httproute_test.go
@@ -121,6 +121,10 @@ func withPortNumber(port v1.PortNumber) gwParentRefOption {
 	return func(ref *v1.ParentReference) { ref.Port = &port }
 }
 
+func withGroup(group v1.Group) gwParentRefOption {
+	return func(ref *v1.ParentReference) { ref.Group = &group }
+}
+
 func newTestEndpoint(dnsName string, targets ...string) *endpoint.Endpoint {
 	return newTestEndpointWithTTL(dnsName, endpoint.RecordTypeA, 0, targets...)
 }
@@ -142,6 +146,16 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 		Namespaces: &v1.RouteNamespaces{
 			From: &fromAll,
 		},
+	}
+	coreGroup := v1.Group("")
+	allowCoreGroupHTTPRoute := &v1.AllowedRoutes{
+		Namespaces: &v1.RouteNamespaces{From: &fromAll},
+		// The core API group holds no HTTPRoute, so this listener accepts none.
+		Kinds: []v1.RouteGroupKind{{Group: &coreGroup, Kind: "HTTPRoute"}},
+	}
+	allowOmittedGroupHTTPRoute := &v1.AllowedRoutes{
+		Namespaces: &v1.RouteNamespaces{From: &fromAll},
+		Kinds:      []v1.RouteGroupKind{{Kind: "HTTPRoute"}},
 	}
 	objectMeta := func(namespace, name string) metav1.ObjectMeta {
 		return metav1.ObjectMeta{
@@ -1639,6 +1653,105 @@ func TestGatewayHTTPRouteSourceEndpoints(t *testing.T) {
 			endpoints: []*endpoint.Endpoint{},
 			logExpectations: []string{
 				"Parent reference gateway-namespace/other-gateway not found in routeParentRefs for HTTPRoute route-namespace/test",
+			},
+		},
+		{
+			title: "ExplicitCoreGroupParentIsNotAGateway",
+			config: &Config{
+				GatewayNamespace: "gateway-namespace",
+			},
+			namespaces: namespaces("gateway-namespace", "route-namespace"),
+			gateways: []*v1.Gateway{
+				{
+					ObjectMeta: objectMeta("gateway-namespace", "test"),
+					Spec: v1.GatewaySpec{
+						Listeners: []v1.Listener{{
+							Protocol:      v1.HTTPProtocolType,
+							AllowedRoutes: allowAllNamespaces,
+						}},
+					},
+					Status: gatewayStatus("1.2.3.4"),
+				},
+			},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: objectMeta("route-namespace", "test"),
+				Spec: v1.HTTPRouteSpec{
+					Hostnames: hostnames("test.example.internal"),
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{
+							gwParentRef("gateway-namespace", "test", withGroup(v1.Group(""))),
+						},
+					},
+				},
+				Status: httpRouteStatus(
+					// The spec selects the core API group, which holds no Gateway.
+					gwParentRef("gateway-namespace", "test", withGroup(v1.Group(""))),
+					// A stale entry on the Gateway API group, from before the group was set.
+					gwParentRef("gateway-namespace", "test"),
+				),
+			}},
+			endpoints: []*endpoint.Endpoint{},
+		},
+		{
+			title: "ExplicitCoreGroupAllowedRouteKindTakesNoRoute",
+			config: &Config{
+				GatewayNamespace: "gateway-namespace",
+			},
+			namespaces: namespaces("gateway-namespace", "route-namespace"),
+			gateways: []*v1.Gateway{
+				{
+					ObjectMeta: objectMeta("gateway-namespace", "test"),
+					Spec: v1.GatewaySpec{
+						Listeners: []v1.Listener{{
+							Protocol:      v1.HTTPProtocolType,
+							AllowedRoutes: allowCoreGroupHTTPRoute,
+						}},
+					},
+					Status: gatewayStatus("1.2.3.4"),
+				},
+			},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: objectMeta("route-namespace", "test"),
+				Spec: v1.HTTPRouteSpec{
+					Hostnames: hostnames("test.example.internal"),
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{gwParentRef("gateway-namespace", "test")},
+					},
+				},
+				Status: httpRouteStatus(gwParentRef("gateway-namespace", "test")),
+			}},
+			endpoints: []*endpoint.Endpoint{},
+		},
+		{
+			title: "OmittedGroupAllowedRouteKindTakesTheGatewayAPIRoute",
+			config: &Config{
+				GatewayNamespace: "gateway-namespace",
+			},
+			namespaces: namespaces("gateway-namespace", "route-namespace"),
+			gateways: []*v1.Gateway{
+				{
+					ObjectMeta: objectMeta("gateway-namespace", "test"),
+					Spec: v1.GatewaySpec{
+						Listeners: []v1.Listener{{
+							Protocol:      v1.HTTPProtocolType,
+							AllowedRoutes: allowOmittedGroupHTTPRoute,
+						}},
+					},
+					Status: gatewayStatus("1.2.3.4"),
+				},
+			},
+			routes: []*v1.HTTPRoute{{
+				ObjectMeta: objectMeta("route-namespace", "test"),
+				Spec: v1.HTTPRouteSpec{
+					Hostnames: hostnames("test.example.internal"),
+					CommonRouteSpec: v1.CommonRouteSpec{
+						ParentRefs: []v1.ParentReference{gwParentRef("gateway-namespace", "test")},
+					},
+				},
+				Status: httpRouteStatus(gwParentRef("gateway-namespace", "test")),
+			}},
+			endpoints: []*endpoint.Endpoint{
+				newTestEndpoint("test.example.internal", "1.2.3.4"),
 			},
 		},
 		{

--- a/source/gateway_test.go
+++ b/source/gateway_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -241,6 +242,42 @@ func TestIsDNS1123Domain(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			if ok := isDNS1123Domain(tt.in); ok != tt.ok {
 				t.Errorf("isDNS1123Domain(%q); got: %v; want: %v", tt.in, ok, tt.ok)
+			}
+		})
+	}
+}
+
+func TestGatewayRouteHasParentRefDefaulting(t *testing.T) {
+	meta := &metav1.ObjectMeta{Namespace: "default"}
+	coreGroup := v1.Group("")
+	gatewayAPIGroup := v1.Group(gatewayGroup)
+	gatewayKindVal := v1.Kind(gatewayKind)
+	serviceKind := v1.Kind("Service")
+
+	omitted := v1.ParentReference{Name: "gw"}
+	explicitGateway := v1.ParentReference{Name: "gw", Group: &gatewayAPIGroup}
+	explicitCore := v1.ParentReference{Name: "gw", Group: &coreGroup}
+	explicitGatewayKind := v1.ParentReference{Name: "gw", Kind: &gatewayKindVal}
+	explicitServiceKind := v1.ParentReference{Name: "gw", Kind: &serviceKind}
+
+	tests := []struct {
+		desc string
+		spec v1.ParentReference
+		ref  v1.ParentReference
+		want bool
+	}{
+		{"an omitted group matches an omitted group", omitted, omitted, true},
+		{"an omitted group matches the spelled out Gateway API group", omitted, explicitGateway, true},
+		{"an omitted group does not match an explicit core group", omitted, explicitCore, false},
+		{"an explicit core group matches itself", explicitCore, explicitCore, true},
+		{"an omitted kind matches the spelled out Gateway kind", omitted, explicitGatewayKind, true},
+		{"an omitted kind does not match a Service kind", omitted, explicitServiceKind, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if got := gwRouteHasParentRef([]v1.ParentReference{tt.spec}, tt.ref, meta); got != tt.want {
+				t.Errorf("gwRouteHasParentRef = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## What does it do?

Gateway API defaults `parentRef.group` to `gateway.networking.k8s.io` only when the field is omitted. An explicitly empty group denotes the Kubernetes core API group.

The Gateway source previously used `strVal`, which treated an omitted group and an explicit empty group the same. As a result, a reference with `group: ""` and `kind: Gateway` or `kind: ListenerSet` could resolve to a same-named Gateway API object.

This change applies nil-only defaulting when matching spec and status ParentRefs and when resolving the referenced parent object.

`RouteGroupKind.Group`, in a listener's `allowedRoutes.kinds`, is the same optional field with the same default, and it went through `strVal` too. It now uses the same helper. Its `Kind` is required and has no default, so the `Gateway` default that `ParentReference.Kind` carries is not applied to it.

## Compatibility

Valid Gateway and ListenerSet ParentRefs are unchanged.

A Route that explicitly uses `group: ""` with `kind: Gateway` or `kind: ListenerSet` will no longer produce endpoints from a same-named Gateway API object. Such a reference targets the core API group, not `gateway.networking.k8s.io`.

A listener whose `allowedRoutes.kinds` entry uses `group: ""` no longer accepts the Route, so a ParentRef that is correct on its own can also stop producing endpoints.

With `--policy=sync` and a TXT registry, records that existed only because of the old reading are deleted on the next reconcile, and the ownership TXT records go with them. `docs/sources/gateway.md` lists the affected fields and what to check before upgrading.

## Testing

The tests cover:

- omitted group versus the explicit Gateway API group;
- explicit core group versus the Gateway API group;
- omitted kind versus explicit `Gateway` and `Service`;
- the complete HTTPRoute source path with a same-named Gateway, a core-group spec/status reference, and a stale Gateway API-group status;
- a listener whose `allowedRoutes.kinds` names the core group, and one that omits the group, through the same source path.

The complete source fixture produces an endpoint on master and none with this change.

This was split from #6638 so the stale-listener behavior can be reviewed independently.

Follow-up to #5241.

