### PR TITLE
fix(registry): delete TXT records with their stored value

### DIFF
--- a/registry/txt/registry.go
+++ b/registry/txt/registry.go
@@ -73,11 +73,11 @@ type TXTRegistry struct {
 	obsoleteTXTWarned sets.Set[string]
 }
 
-// existingTXTs stores pre‑existing TXT records to avoid duplicate creation.
+// existingTXTs maps pre‑existing TXT records to the value they hold at the provider.
 // It relies on the fact that Records() is always called **before** ApplyChanges()
 // within a single reconciliation cycle.
 type existingTXTs struct {
-	entries sets.Set[recordKey]
+	entries map[recordKey]string
 }
 
 type recordKey struct {
@@ -87,32 +87,41 @@ type recordKey struct {
 
 func newExistingTXTs() *existingTXTs {
 	return &existingTXTs{
-		entries: sets.New[recordKey](),
+		entries: map[recordKey]string{},
 	}
 }
 
 func (im *existingTXTs) add(r *endpoint.Endpoint) {
-	key := recordKey{
-		dnsName:       r.DNSName,
-		setIdentifier: r.SetIdentifier,
+	var value string
+	if len(r.Targets) > 0 {
+		value = r.Targets[0]
 	}
-	im.entries.Insert(key)
+	im.entries[keyFor(r)] = value
 }
 
 // isAbsent returns true when there is no entry for the given name in the store.
 // This is intended for the "if absent -> create" pattern.
 func (im *existingTXTs) isAbsent(ep *endpoint.Endpoint) bool {
-	key := recordKey{
-		dnsName:       ep.DNSName,
-		setIdentifier: ep.SetIdentifier,
-	}
-	return !im.entries.Has(key)
+	_, ok := im.entries[keyFor(ep)]
+	return !ok
+}
+
+func (im *existingTXTs) storedValue(ep *endpoint.Endpoint) (string, bool) {
+	value, ok := im.entries[keyFor(ep)]
+	return value, ok && value != ""
 }
 
 func (im *existingTXTs) reset() {
 	// Reset the existing TXT records for the next reconciliation loop.
 	// This is necessary because the existing TXT records are only relevant for the current reconciliation cycle.
-	im.entries = sets.New[recordKey]()
+	im.entries = map[recordKey]string{}
+}
+
+func keyFor(ep *endpoint.Endpoint) recordKey {
+	return recordKey{
+		dnsName:       ep.DNSName,
+		setIdentifier: ep.SetIdentifier,
+	}
 }
 
 // New creates a TXTRegistry from the given configuration.
@@ -183,18 +192,19 @@ func (im *TXTRegistry) OwnerID() string {
 // If TXT records was created previously to indicate ownership its corresponding value
 // will be added to the endpoints Labels map
 func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	// If we have the zones cached AND we have refreshed the cache since the
+	// last given interval, then just use the cached results. existingTXTs is left
+	// untouched so that it keeps describing the records behind that cache.
+	if im.recordsCache != nil && time.Since(im.recordsCacheRefreshTime) < im.cacheInterval {
+		log.Debug("Using cached records.")
+		return im.recordsCache, nil
+	}
+
 	// existingTXTs must always hold the latest TXT records, so it needs to be reset every time.
 	// Previously, it was reset with a defer after ApplyChanges, but ApplyChanges is not called
 	// when plan.HasChanges() is false (i.e., when there are no changes to apply).
 	// In that case, stale TXT record information could remain, so we reset it here instead.
 	im.existingTXTs.reset()
-
-	// If we have the zones cached AND we have refreshed the cache since the
-	// last given interval, then just use the cached results.
-	if im.recordsCache != nil && time.Since(im.recordsCacheRefreshTime) < im.cacheInterval {
-		log.Debug("Using cached records.")
-		return im.recordsCache, nil
-	}
 
 	records, err := im.provider.Records(ctx)
 	if err != nil {
@@ -353,8 +363,24 @@ func (im *TXTRegistry) generateTXTRecordWithFilter(r *endpoint.Endpoint, filter 
 	return endpoints
 }
 
-// ApplyChanges updates dns provider with the changes
-// for each created/deleted record it will also take into account TXT records for creation/deletion
+// generateTXTRecordForRemoval builds the TXT records to delete alongside an endpoint, preferring
+// the value read from the provider over a regenerated one, as deletes match by value.
+// With gzip output, a regenerated one can differ between two Go standard library implementations.
+func (im *TXTRegistry) generateTXTRecordForRemoval(r *endpoint.Endpoint) []*endpoint.Endpoint {
+	txts := im.generateTXTRecord(r)
+	for _, txt := range txts {
+		stored, ok := im.existingTXTs.storedValue(txt)
+		if !ok {
+			// Records() saw no TXT under this name; keep the generated value.
+			continue
+		}
+		// Match the quoting Serialize() applies, so only the payload differs.
+		txt.Targets = endpoint.Targets{"\"" + strings.Trim(stored, "\"") + "\""}
+	}
+	return txts
+}
+
+// ApplyChanges updates dns provider with the changes, and updates ownership TXT records accordingly
 func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
 	filteredChanges := &plan.Changes{
 		Create:    changes.Create,
@@ -377,10 +403,8 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 	}
 
 	for _, r := range filteredChanges.Delete {
-		// when we delete TXT records for which value has changed (due to new label) this would still work because
-		// !!! TXT record value is uniquely generated from the Labels of the endpoint. Hence old TXT record can be uniquely reconstructed
 		// !!! After migration to the new TXT registry format we can drop records in old format here!!!
-		filteredChanges.Delete = append(filteredChanges.Delete, im.generateTXTRecord(r)...)
+		filteredChanges.Delete = append(filteredChanges.Delete, im.generateTXTRecordForRemoval(r)...)
 
 		if im.cacheInterval > 0 {
 			im.removeFromCache(r)
@@ -389,9 +413,7 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 
 	// make sure TXT records are consistently updated as well
 	for _, r := range filteredChanges.UpdateOld {
-		// when we updateOld TXT records for which value has changed (due to new label) this would still work because
-		// !!! TXT record value is uniquely generated from the Labels of the endpoint. Hence old TXT record can be uniquely reconstructed
-		filteredChanges.UpdateOld = append(filteredChanges.UpdateOld, im.generateTXTRecord(r)...)
+		filteredChanges.UpdateOld = append(filteredChanges.UpdateOld, im.generateTXTRecordForRemoval(r)...)
 		// remove old version of record from cache
 		if im.cacheInterval > 0 {
 			im.removeFromCache(r)

--- a/registry/txt/registry.go
+++ b/registry/txt/registry.go
@@ -200,10 +200,9 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 		return im.recordsCache, nil
 	}
 
-	// existingTXTs must always hold the latest TXT records, so it needs to be reset every time.
-	// Previously, it was reset with a defer after ApplyChanges, but ApplyChanges is not called
-	// when plan.HasChanges() is false (i.e., when there are no changes to apply).
-	// In that case, stale TXT record information could remain, so we reset it here instead.
+	// existingTXTs is only ever added to, so it has to be dropped before the read below repopulates it.
+	// A key surviving from an earlier cycle would claim its TXT still
+	// exists, and isAbsent would then skip re-creating it.
 	im.existingTXTs.reset()
 
 	records, err := im.provider.Records(ctx)

--- a/registry/txt/registry.go
+++ b/registry/txt/registry.go
@@ -373,8 +373,7 @@ func (im *TXTRegistry) generateTXTRecordForRemoval(r *endpoint.Endpoint) []*endp
 			// Records() saw no TXT under this name; keep the generated value.
 			continue
 		}
-		// Match the quoting Serialize() applies, so only the payload differs.
-		txt.Targets = endpoint.Targets{"\"" + strings.Trim(stored, "\"") + "\""}
+		txt.Targets = endpoint.Targets{stored}
 	}
 	return txts
 }

--- a/registry/txt/registry_test.go
+++ b/registry/txt/registry_test.go
@@ -2297,3 +2297,137 @@ func TestTXTRegistryAliasARecordDeleteLeavesLegacyCNAME(t *testing.T) {
 	assert.NotNil(t, findEndpoint(applied.Delete, "a-alias.test-zone.example.org", endpoint.RecordTypeTXT), "the new a- ownership TXT must be deleted")
 	assert.Nil(t, findEndpoint(applied.Delete, "cname-alias.test-zone.example.org", endpoint.RecordTypeTXT), "the legacy cname- TXT should be kept")
 }
+
+const (
+	storedDNSName = "foo." + testZone
+	storedTXTName = "cname-foo." + testZone
+)
+
+// seedZoneWithTXT creates a CNAME and its ownership TXT holding txtValue verbatim, and returns a
+// registry over that zone plus an accessor for the changes the provider received.
+func seedZoneWithTXT(t *testing.T, txtValue string, encrypt bool, aesKey []byte, cacheInterval time.Duration) (*TXTRegistry, func() *plan.Changes) {
+	t.Helper()
+
+	p := inmemory.NewInMemoryProvider()
+	require.NoError(t, p.CreateZone(testZone))
+	require.NoError(t, p.ApplyChanges(t.Context(), &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			newEndpointWithOwner(storedDNSName, "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
+			newTXTEndpointWithOwnedRecord(storedTXTName, txtValue, storedDNSName),
+		},
+	}))
+
+	r, err := newRegistry(p, "", "", "owner", cacheInterval, "", []string{}, []string{}, encrypt, aesKey, "")
+	require.NoError(t, err)
+
+	var applied *plan.Changes
+	p.OnApplyChanges = func(_ context.Context, got *plan.Changes) { applied = got }
+
+	return r, func() *plan.Changes { return applied }
+}
+
+// ownedRecordFrom returns the endpoint Records() produced for the seeded CNAME, as the plan would.
+func ownedRecordFrom(t *testing.T, r *TXTRegistry) *endpoint.Endpoint {
+	t.Helper()
+	records, err := r.Records(t.Context())
+	require.NoError(t, err)
+	ep := findEndpoint(records, storedDNSName, endpoint.RecordTypeCNAME)
+	require.NotNil(t, ep)
+	require.Equal(t, "owner", ep.Labels[endpoint.OwnerLabelKey], "the TXT record must be recognized as owned")
+	return ep
+}
+
+// Deleting a TXT with a value that is not the one in the zone makes value-matching providers such
+// as Route53 reject the whole change batch.
+func TestTXTRegistryDeleteUsesStoredValue(t *testing.T) {
+	// A token without the heritage prefix is dropped on parse, so re-serializing drifts,
+	// same shape as the Go 1.27 gzip change.
+	stored := "\"heritage=external-dns,external-dns/owner=owner,drift=1\""
+
+	r, applied := seedZoneWithTXT(t, stored, false, nil, 0)
+	ep := ownedRecordFrom(t, r)
+
+	require.NoError(t, r.ApplyChanges(t.Context(), &plan.Changes{Delete: []*endpoint.Endpoint{ep}}))
+
+	txt := findEndpoint(applied().Delete, storedTXTName, endpoint.RecordTypeTXT)
+	require.NotNil(t, txt, "the ownership TXT must be deleted alongside the record")
+	assert.Equal(t, stored, txt.Targets[0])
+}
+
+func TestTXTRegistryUpdateOldUsesStoredValue(t *testing.T) {
+	stored := "\"heritage=external-dns,external-dns/owner=owner,drift=1\""
+
+	r, applied := seedZoneWithTXT(t, stored, false, nil, 0)
+	ep := ownedRecordFrom(t, r)
+
+	updated := cloneEndpointWithOpts(ep, func(e *endpoint.Endpoint) {
+		e.Targets = endpoint.Targets{"new.loadbalancer.com"}
+	})
+	require.NoError(t, r.ApplyChanges(t.Context(), &plan.Changes{
+		UpdateOld: []*endpoint.Endpoint{ep},
+		UpdateNew: []*endpoint.Endpoint{updated},
+	}))
+
+	oldTXT := findEndpoint(applied().UpdateOld, storedTXTName, endpoint.RecordTypeTXT)
+	require.NotNil(t, oldTXT)
+	assert.Equal(t, stored, oldTXT.Targets[0], "the old side of the update must carry the stored value")
+
+	newTXT := findEndpoint(applied().UpdateNew, storedTXTName, endpoint.RecordTypeTXT)
+	require.NotNil(t, newTXT)
+	assert.NotEqual(t, stored, newTXT.Targets[0], "the new side must carry a freshly serialized value")
+}
+
+// Same drift through the encrypted path: the nonce is recovered from the record, so re-encrypting
+// is deterministic and differs only because the plaintext does.
+func TestTXTRegistryDeleteUsesStoredValueEncrypted(t *testing.T) {
+	aesKey := []byte(";k&l)nUC/33:{?d{3)54+,AD?]SX%yh^")
+
+	nonce, err := endpoint.GenerateNonce()
+	require.NoError(t, err)
+	ciphertext, err := endpoint.EncryptText("heritage=external-dns,external-dns/owner=owner,drift=1", aesKey, nonce)
+	require.NoError(t, err)
+	stored := "\"" + ciphertext + "\""
+
+	regenerated, err := endpoint.EncryptText("heritage=external-dns,external-dns/owner=owner", aesKey, nonce)
+	require.NoError(t, err)
+	require.NotEqual(t, ciphertext, regenerated, "the test is meaningless unless re-serializing drifts")
+
+	r, applied := seedZoneWithTXT(t, stored, true, aesKey, 0)
+	ep := ownedRecordFrom(t, r)
+
+	require.NoError(t, r.ApplyChanges(t.Context(), &plan.Changes{Delete: []*endpoint.Endpoint{ep}}))
+
+	txt := findEndpoint(applied().Delete, storedTXTName, endpoint.RecordTypeTXT)
+	require.NotNil(t, txt)
+	assert.Equal(t, stored, txt.Targets[0])
+	assert.NotEqual(t, "\""+regenerated+"\"", txt.Targets[0])
+}
+
+// A cached Records() does not re-read the provider; existingTXTs has to survive that.
+func TestTXTRegistryDeleteUsesStoredValueFromCachedRecords(t *testing.T) {
+	stored := "\"heritage=external-dns,external-dns/owner=owner,drift=1\""
+
+	r, applied := seedZoneWithTXT(t, stored, false, nil, time.Hour)
+	_ = ownedRecordFrom(t, r)
+	ep := ownedRecordFrom(t, r) // served from the cache
+
+	require.NoError(t, r.ApplyChanges(t.Context(), &plan.Changes{Delete: []*endpoint.Endpoint{ep}}))
+
+	txt := findEndpoint(applied().Delete, storedTXTName, endpoint.RecordTypeTXT)
+	require.NotNil(t, txt)
+	assert.Equal(t, stored, txt.Targets[0])
+}
+
+// Without a preceding Records() there is no stored value to use.
+func TestTXTRegistryDeleteFallsBackToGeneratedValue(t *testing.T) {
+	stored := "\"heritage=external-dns,external-dns/owner=owner\""
+
+	r, applied := seedZoneWithTXT(t, stored, false, nil, 0)
+	ep := newEndpointWithOwner(storedDNSName, "foo.loadbalancer.com", endpoint.RecordTypeCNAME, "owner")
+
+	require.NoError(t, r.ApplyChanges(t.Context(), &plan.Changes{Delete: []*endpoint.Endpoint{ep}}))
+
+	txt := findEndpoint(applied().Delete, storedTXTName, endpoint.RecordTypeTXT)
+	require.NotNil(t, txt)
+	assert.Equal(t, stored, txt.Targets[0])
+}


### PR DESCRIPTION
## What does it do ?

Deletes rebuilt the ownership TXT value by re-serializing the endpoint labels, which only matches
what is in the zone while serialization stays byte-for-byte stable. Use the value read in `Records()` instead.

Also moves `existingTXTs.reset()` below the cache hit in `Records()`: a cached call reset the store
and returned without repopulating it, so create-dedup was dead whenever `--txt-cache-interval` was set.

## Motivation

Go 1.27 changed gzip output, so under `--txt-encrypt-enabled` the regenerated value no longer matches
and value-matching providers reject the whole change batch — including the non-TXT records in it.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly
