### PR TITLE
fix(rfc2136): match zones on a dot boundary in findMsgZone

### DIFF
--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -674,7 +674,7 @@ func chunkBy(slice []*endpoint.Endpoint, chunkSize int) [][]*endpoint.Endpoint {
 
 func findMsgZone(ep *endpoint.Endpoint, zoneNames []string) string {
 	for _, zone := range zoneNames {
-		if strings.HasSuffix(ep.DNSName, zone) {
+		if ep.DNSName == zone || strings.HasSuffix(ep.DNSName, "."+zone) {
 			return dns.Fqdn(zone)
 		}
 	}

--- a/provider/rfc2136/rfc2136_test.go
+++ b/provider/rfc2136/rfc2136_test.go
@@ -913,6 +913,53 @@ func TestRfc2136ApplyChangesWithUpdate(t *testing.T) {
 	assert.Contains(t, stub.updateMsgs[1].String(), "boom")
 }
 
+func TestFindMsgZone(t *testing.T) {
+	tests := []struct {
+		name      string
+		dnsName   string
+		zoneNames []string
+		expected  string
+	}{
+		{
+			name:      "exact zone match",
+			dnsName:   "example.com",
+			zoneNames: []string{"example.com"},
+			expected:  "example.com.",
+		},
+		{
+			name:      "subdomain of zone matches",
+			dnsName:   "foo.example.com",
+			zoneNames: []string{"example.com"},
+			expected:  "example.com.",
+		},
+		{
+			name:      "domain sharing a suffix but not a dot boundary does not match",
+			dnsName:   "fooexample.com",
+			zoneNames: []string{"example.com"},
+			expected:  ".",
+		},
+		{
+			name:      "no configured zone matches falls back to root",
+			dnsName:   "foo.other.com",
+			zoneNames: []string{"example.com"},
+			expected:  ".",
+		},
+		{
+			name:      "most specific zone wins when zones are nested",
+			dnsName:   "foo.sub.example.com",
+			zoneNames: []string{"sub.example.com", "example.com"},
+			expected:  "sub.example.com.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := &endpoint.Endpoint{DNSName: tt.dnsName}
+			assert.Equal(t, tt.expected, findMsgZone(ep, tt.zoneNames))
+		})
+	}
+}
+
 func TestChunkBy(t *testing.T) {
 	var records []*endpoint.Endpoint
 


### PR DESCRIPTION
## What does it do ?

Fixes `provider/rfc2136`'s `findMsgZone()` so it matches a configured zone on an actual domain boundary instead of a raw string suffix.

`findMsgZone()` picked the target zone with `strings.HasSuffix(ep.DNSName, zone)`. That has no separator check, so a record named `fooexample.com` gets routed to zone `example.com` even though it isn't a subdomain of it — `"fooexample.com"` simply ends with the characters `"example.com"`. With `--rfc2136-zone=example.com` and no `--domain-filter` set (the default), a record for an unrelated domain that happens to share that suffix silently ends up in the wrong zone's update message.

The fix matches on exact equality or a `"."`-prefixed suffix instead, the same boundary-aware pattern `endpoint.DomainFilter`'s `matchFilter()` already uses right next to this code (`endpoint/domain_filter.go`).

## Motivation

Found while auditing the rfc2136 provider. Confirmed with a standalone unit test that reproduces the exact misrouting (`fooexample.com` resolving to zone `example.com.`) against the unpatched function, and that same test fails on `master` and passes after the fix.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly
