### PR TITLE
docs: add the Akamai Edge DNS webhook provider to the registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ from the usage of any externally developed webhook.
 | --------------------- | -------------------------------------------------------------------- |
 | Abion                 | https://github.com/abiondevelopment/external-dns-webhook-abion       |
 | Adguard Home Provider | https://github.com/muhlba91/external-dns-provider-adguard            |
+| Akamai Edge DNS       | https://github.com/PixiBixi/external-dns-akamai-webhook              |
 | Anexia                | https://github.com/anexia/k8s-external-dns-webhook                   |
 | Bizfly Cloud          | https://github.com/bizflycloud/external-dns-bizflycloud-webhook      |
 | ClouDNS               | https://github.com/rwunderer/external-dns-cloudns-webhook            |


### PR DESCRIPTION
Follow-up to #6681, which was closed with "please create a webhook out of tree".
Here it is: https://github.com/PixiBixi/external-dns-akamai-webhook

Apache 2.0, and the Edge DNS logic keeps the copyright header from the in-tree
provider it derives from.

Tested against a live Akamai account, not just unit tests: creation, deletion
and ownership on a real zone, driven by ExternalDNS v0.22 in a kind cluster,
from both the service and CRD sources. Records outside the TXT registry were
left untouched under `--policy=sync`.

One line, and no endorsement implied on your side as the section says.
