### PR TITLE
fix(endpoint): compare every target in Targets.Same

### DIFF
--- a/controller/reconcile_ipv6_test.go
+++ b/controller/reconcile_ipv6_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
+	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
+	"sigs.k8s.io/external-dns/provider/inmemory"
+	"sigs.k8s.io/external-dns/registry/txt"
+	"sigs.k8s.io/external-dns/source"
+	"sigs.k8s.io/external-dns/source/annotations"
+	templatetest "sigs.k8s.io/external-dns/source/template/testutil"
+)
+
+// canonicalizingProvider stores IPv6 targets in their canonical short form, which is
+// what Route53, Cloudflare and Azure DNS do with an AAAA target. Everything else is
+// delegated to the in-memory provider.
+type canonicalizingProvider struct {
+	*inmemory.InMemoryProvider
+}
+
+func (p *canonicalizingProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
+	for _, eps := range [][]*endpoint.Endpoint{changes.Create, changes.UpdateNew, changes.UpdateOld, changes.Delete} {
+		for _, ep := range eps {
+			for i, t := range ep.Targets {
+				if ip, err := netip.ParseAddr(t); err == nil {
+					ep.Targets[i] = ip.String()
+				}
+			}
+		}
+	}
+	return p.InMemoryProvider.ApplyChanges(ctx, changes)
+}
+
+func providerAAAATargets(t *testing.T, p provider.Provider, dnsName string) endpoint.Targets {
+	t.Helper()
+	records, err := p.Records(t.Context())
+	require.NoError(t, err)
+	for _, r := range records {
+		if r.DNSName == dnsName && r.RecordType == endpoint.RecordTypeAAAA {
+			return r.Targets
+		}
+	}
+	return nil
+}
+
+func ipv6TargetService(target string) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "app",
+			Annotations: map[string]string{
+				annotations.HostnameKey: "app.example.com",
+				annotations.TargetKey:   target,
+			},
+		},
+		Spec: v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{Ingress: []v1.LoadBalancerIngress{{IP: "2001:db8::1"}}},
+		},
+	}
+}
+
+func ipv6ServiceSource(t *testing.T, ctx context.Context, kube *fake.Clientset) source.Source {
+	t.Helper()
+	src, err := source.NewServiceSource(ctx, kube, &source.Config{
+		Namespace:      "default",
+		LabelFilter:    labels.Everything(),
+		TemplateEngine: templatetest.MustEngine(t, "", "", "", false),
+	})
+	require.NoError(t, err)
+	return src
+}
+
+// A Service whose target annotation carries an expanded IPv6 alongside a second
+// target. The provider stores the first one canonicalized, so on the next sync the
+// two forms differ as strings while denoting the same address. Changing only the
+// second target must still reach the provider.
+func TestReconcileIPv6SecondTargetChangeReachesProvider(t *testing.T) {
+	ctx := t.Context()
+	kube := fake.NewClientset()
+
+	const expanded = "2001:0db8:0000:0000:0000:0000:0000:0001"
+	_, err := kube.CoreV1().Services("default").Create(ctx, ipv6TargetService(expanded+",2001:db8::2"), metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	prov := &canonicalizingProvider{inmemory.NewInMemoryProvider(inmemory.InMemoryInitZones([]string{"example.com"}))}
+	registry, err := txt.New(&externaldns.Config{
+		TXTOwnerID:            "test-cluster",
+		ManagedDNSRecordTypes: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}, prov)
+	require.NoError(t, err)
+
+	ctrl := &Controller{
+		Source:             ipv6ServiceSource(t, ctx, kube),
+		Registry:           registry,
+		Policy:             &plan.SyncPolicy{},
+		ManagedRecordTypes: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	require.NoError(t, ctrl.RunOnce(ctx))
+	require.ElementsMatch(t, []string{"2001:db8::1", "2001:db8::2"}, providerAAAATargets(t, prov, "app.example.com"),
+		"first sync should create the record")
+
+	// The user edits the annotation and changes only the second target.
+	_, err = kube.CoreV1().Services("default").Update(ctx, ipv6TargetService(expanded+",2001:db8::3"), metav1.UpdateOptions{})
+	require.NoError(t, err)
+	ctrl.Source = ipv6ServiceSource(t, ctx, kube)
+
+	require.NoError(t, ctrl.RunOnce(ctx))
+	assert.ElementsMatch(t, []string{"2001:db8::1", "2001:db8::3"}, providerAAAATargets(t, prov, "app.example.com"),
+		"the change to the second target never reached the provider")
+}

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -149,28 +149,31 @@ func (t Targets) Same(o Targets) bool {
 	sort.Stable(o)
 
 	for i, e := range t {
-		if !strings.EqualFold(e, o[i]) {
-			// IPv6 can be shortened, so it should be parsed for equality checking
-			ipA, err := netip.ParseAddr(e)
-			if err != nil {
-				log.WithFields(log.Fields{
-					"targets":           t,
-					"comparisonTargets": o,
-				}).Debugf("Couldn't parse %s as an IP address: %v", e, err)
-			}
+		if strings.EqualFold(e, o[i]) {
+			continue
+		}
 
-			ipB, err := netip.ParseAddr(o[i])
-			if err != nil {
-				log.WithFields(log.Fields{
-					"targets":           t,
-					"comparisonTargets": o,
-				}).Debugf("Couldn't parse %s as an IP address: %v", e, err)
-			}
+		// IPv6 can be shortened, so it should be parsed for equality checking
+		ipA, errA := netip.ParseAddr(e)
+		if errA != nil {
+			log.WithFields(log.Fields{
+				"targets":           t,
+				"comparisonTargets": o,
+			}).Debugf("Couldn't parse %s as an IP address: %v", e, errA)
+		}
 
-			// IPv6 Address Shortener == IPv6 Address Expander
-			if ipA.IsValid() && ipB.IsValid() {
-				return ipA.String() == ipB.String()
-			}
+		ipB, errB := netip.ParseAddr(o[i])
+		if errB != nil {
+			log.WithFields(log.Fields{
+				"targets":           t,
+				"comparisonTargets": o,
+			}).Debugf("Couldn't parse %s as an IP address: %v", o[i], errB)
+		}
+
+		// IPv6 Address Shortener == IPv6 Address Expander. Keep checking the
+		// remaining targets: returning here let the first pair decide for the
+		// whole list, so later differences were never seen.
+		if errA != nil || errB != nil || ipA != ipB {
 			return false
 		}
 	}

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -124,6 +124,40 @@ func TestSameSuccess(t *testing.T) {
 	}
 }
 
+// Same must keep comparing after an equivalent pair. A shortened and an expanded
+// form of the same IPv6 are not string-equal, so they reach the IP fallback, and
+// that fallback used to return outright, hiding every later target.
+func TestSameComparesAllTargetsAfterAnEquivalentPair(t *testing.T) {
+	tests := []struct {
+		name string
+		a    Targets
+		b    Targets
+	}{
+		{
+			name: "equivalent IPv6 first, differing IPv6 after",
+			a:    Targets{"::1", "::2"},
+			b:    Targets{"0:0:0:0:0:0:0:1", "::3"},
+		},
+		{
+			name: "equivalent IPv6 first, differing hostname after",
+			a:    Targets{"::1", "foo.example.com"},
+			b:    Targets{"::0001", "bar.example.com"},
+		},
+		{
+			name: "equivalent IPv6 first, difference on the third target",
+			a:    Targets{"::1", "::2", "::3"},
+			b:    Targets{"::0001", "::2", "::4"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.False(t, tt.a.Same(tt.b), "%v should not be Same as %v", tt.a, tt.b)
+			assert.False(t, tt.b.Same(tt.a), "%v should not be Same as %v", tt.b, tt.a)
+		})
+	}
+}
+
 func TestSameFailures(t *testing.T) {
 	tests := []struct {
 		a Targets


### PR DESCRIPTION
## What does it do ?

`Targets.Same` returned on the first differing pair when both sides parsed as IP
addresses, so that one pair decided the whole comparison. It now keeps going
through the rest of the targets.

While in there, `Same` and `IsLess` no longer sort their receiver and their
argument in place.

## Motivation

Found this reading through the plan and registry path. If the first target is an
IPv6 that the provider returns in a different form than the source has it
(shortened vs expanded), the two strings differ, both parse as IPs, and the
function returns "same" right there. Anything after it is never looked at.

```go
a := Targets{"::1", "foo.example.com"}
b := Targets{"::0001", "bar.example.com"}
a.Same(b) // true
```

`plan.targetChanged` uses this, so no update gets planned and the record stays
stale. No error, nothing in the logs.

The in-place sort is a separate thing I noticed while writing the test. `plan`
calls `Same` on endpoints the TXT registry keeps in its cache, so the reordering
survives into the next reconciliation. It sorts a copy now, and skips it when the
targets are already in order.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly
