### PR TITLE
feat(endpoint): Add error return to NewEndpoint()

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -594,7 +594,7 @@ func TestRunOnce_EmitChangeEvent(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			source := new(testutils.MockSource)
 			source.On("Endpoints").Return([]*endpoint.Endpoint{
-				endpoint.NewEndpoint("dot.com", endpoint.RecordTypeA, "1.2.3.4").
+				endpoint.MustNewEndpoint("dot.com", endpoint.RecordTypeA, "1.2.3.4").
 					WithRefObject(&events.ObjectReference{}),
 			}, nil)
 

--- a/controller/events_test.go
+++ b/controller/events_test.go
@@ -40,15 +40,15 @@ func TestEmit_RecordReady(t *testing.T) {
 			name: "create, update and delete endpoints",
 			changes: plan.Changes{
 				Create: []*endpoint.Endpoint{
-					endpoint.NewEndpoint("one.example.com", endpoint.RecordTypeA, "10.10.10.0").WithRefObject(refObj),
-					endpoint.NewEndpoint("two.example.com", endpoint.RecordTypeA, "10.10.10.1").WithRefObject(refObj),
+					endpoint.MustNewEndpoint("one.example.com", endpoint.RecordTypeA, "10.10.10.0").WithRefObject(refObj),
+					endpoint.MustNewEndpoint("two.example.com", endpoint.RecordTypeA, "10.10.10.1").WithRefObject(refObj),
 				},
 				UpdateNew: []*endpoint.Endpoint{
-					endpoint.NewEndpoint("three.example.com", endpoint.RecordTypeA, "10.10.10.2").WithRefObject(refObj),
-					endpoint.NewEndpoint("four.example.com", endpoint.RecordTypeA, "10.10.10.3").WithRefObject(refObj),
+					endpoint.MustNewEndpoint("three.example.com", endpoint.RecordTypeA, "10.10.10.2").WithRefObject(refObj),
+					endpoint.MustNewEndpoint("four.example.com", endpoint.RecordTypeA, "10.10.10.3").WithRefObject(refObj),
 				},
 				Delete: []*endpoint.Endpoint{
-					endpoint.NewEndpoint("five.example.com", endpoint.RecordTypeA, "192.10.10.0").WithRefObject(refObj),
+					endpoint.MustNewEndpoint("five.example.com", endpoint.RecordTypeA, "192.10.10.0").WithRefObject(refObj),
 				},
 			},
 			asserts: func(em *fake.EventEmitter, ch plan.Changes) {
@@ -70,7 +70,7 @@ func TestEmit_RecordReady(t *testing.T) {
 				Create:    []*endpoint.Endpoint{},
 				UpdateNew: []*endpoint.Endpoint{},
 				Delete: []*endpoint.Endpoint{
-					endpoint.NewEndpoint("five.example.com", endpoint.RecordTypeA, "192.10.10.0").WithRefObject(refObj),
+					endpoint.MustNewEndpoint("five.example.com", endpoint.RecordTypeA, "192.10.10.0").WithRefObject(refObj),
 				},
 			},
 			asserts: func(em *fake.EventEmitter, ch plan.Changes) {
@@ -118,13 +118,13 @@ func TestEmit_RecordError(t *testing.T) {
 			name: "create, update and delete endpoints",
 			changes: plan.Changes{
 				Create: []*endpoint.Endpoint{
-					endpoint.NewEndpoint("one.example.com", endpoint.RecordTypeA, "10.10.10.0").WithRefObject(refObj),
+					endpoint.MustNewEndpoint("one.example.com", endpoint.RecordTypeA, "10.10.10.0").WithRefObject(refObj),
 				},
 				UpdateNew: []*endpoint.Endpoint{
-					endpoint.NewEndpoint("two.example.com", endpoint.RecordTypeA, "10.10.10.1").WithRefObject(refObj),
+					endpoint.MustNewEndpoint("two.example.com", endpoint.RecordTypeA, "10.10.10.1").WithRefObject(refObj),
 				},
 				Delete: []*endpoint.Endpoint{
-					endpoint.NewEndpoint("three.example.com", endpoint.RecordTypeA, "10.10.10.2").WithRefObject(refObj),
+					endpoint.MustNewEndpoint("three.example.com", endpoint.RecordTypeA, "10.10.10.2").WithRefObject(refObj),
 				},
 			},
 			asserts: func(em *fake.EventEmitter, ch plan.Changes) {
@@ -140,7 +140,7 @@ func TestEmit_RecordError(t *testing.T) {
 				Create:    []*endpoint.Endpoint{},
 				UpdateNew: []*endpoint.Endpoint{},
 				Delete: []*endpoint.Endpoint{
-					endpoint.NewEndpoint("five.example.com", endpoint.RecordTypeA, "192.10.10.0").WithRefObject(refObj),
+					endpoint.MustNewEndpoint("five.example.com", endpoint.RecordTypeA, "192.10.10.0").WithRefObject(refObj),
 				},
 			},
 			asserts: func(em *fake.EventEmitter, ch plan.Changes) {

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -284,12 +284,12 @@ type Endpoint struct {
 }
 
 // NewEndpoint initialization method to be used to create an endpoint
-func NewEndpoint(dnsName, recordType string, targets ...string) *Endpoint {
+func NewEndpoint(dnsName, recordType string, targets ...string) (*Endpoint, error) {
 	return NewEndpointWithTTL(dnsName, recordType, TTL(0), targets...)
 }
 
 // NewEndpointWithTTL initialization method to be used to create an endpoint with a TTL struct
-func NewEndpointWithTTL(dnsName, recordType string, ttl TTL, targets ...string) *Endpoint {
+func NewEndpointWithTTL(dnsName, recordType string, ttl TTL, targets ...string) (*Endpoint, error) {
 	cleanTargets := make([]string, len(targets))
 	for idx, target := range targets {
 		// Only trim trailing dots for domain name record types, not for TXT or NAPTR records
@@ -305,8 +305,7 @@ func NewEndpointWithTTL(dnsName, recordType string, ttl TTL, targets ...string) 
 
 	for label := range strings.SplitSeq(dnsName, ".") {
 		if len(label) > 63 {
-			log.Errorf("label %s in %s is longer than 63 characters. Cannot create endpoint", label, dnsName)
-			return nil
+			return nil, fmt.Errorf("label %s in %s is longer than 63 characters", label, dnsName)
 		}
 	}
 
@@ -316,7 +315,21 @@ func NewEndpointWithTTL(dnsName, recordType string, ttl TTL, targets ...string) 
 		RecordType: recordType,
 		Labels:     NewLabels(),
 		RecordTTL:  ttl,
+	}, nil
+}
+
+// MustNewEndpoint builds an endpoint and panic if creation fails.
+func MustNewEndpoint(dnsName, recordType string, targets ...string) *Endpoint {
+	return MustNewEndpointWithTTL(dnsName, recordType, TTL(0), targets...)
+}
+
+// MustNewEndpointWithTTL builds an endpoint with a TTL and panic if creation fails.
+func MustNewEndpointWithTTL(dnsName string, recordType string, ttl TTL, targets ...string) *Endpoint {
+	e, err := NewEndpointWithTTL(dnsName, recordType, ttl, targets...)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create endpoint for %s with type %s: %v", dnsName, recordType, err))
 	}
+	return e
 }
 
 // WithSetIdentifier applies the given set identifier to the endpoint.
@@ -528,7 +541,7 @@ func NewPTREndpoint(target string, ttl TTL, hostnames ...string) (*Endpoint, err
 		return nil, fmt.Errorf("failed to compute reverse address for %s: %w", target, err)
 	}
 	ptrName := strings.TrimSuffix(revAddr, ".")
-	return NewEndpointWithTTL(ptrName, RecordTypePTR, ttl, hostnames...), nil
+	return NewEndpointWithTTL(ptrName, RecordTypePTR, ttl, hostnames...)
 }
 
 // String returns a human-readable representation of the endpoint in zone-file style.

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -31,7 +31,8 @@ import (
 )
 
 func TestNewEndpoint(t *testing.T) {
-	e := NewEndpoint("example.org", "CNAME", "foo.com")
+	e, err := NewEndpoint("example.org", "CNAME", "foo.com")
+	require.NoError(t, err)
 	if e.DNSName != "example.org" || e.Targets[0] != "foo.com" || e.RecordType != "CNAME" {
 		t.Error("endpoint is not initialized correctly")
 	}
@@ -39,7 +40,8 @@ func TestNewEndpoint(t *testing.T) {
 		t.Error("Labels is not initialized")
 	}
 
-	w := NewEndpoint("example.org.", "", "load-balancer.com.")
+	w, err := NewEndpoint("example.org.", "", "load-balancer.com.")
+	require.NoError(t, err)
 	if w.DNSName != "example.org" || w.Targets[0] != "load-balancer.com" || w.RecordType != "" {
 		t.Error("endpoint is not initialized correctly")
 	}
@@ -195,7 +197,8 @@ func TestEndpoint_WithLabel(t *testing.T) {
 	})
 
 	t.Run("existing Labels map is updated", func(t *testing.T) {
-		ep := NewEndpoint("example.com", RecordTypeA, "1.2.3.4") // Labels already initialised
+		ep, err := NewEndpoint("example.com", RecordTypeA, "1.2.3.4") // Labels already initialised
+		require.NoError(t, err)
 		ep.WithLabel("key", "value")
 		assert.Equal(t, "value", ep.Labels["key"])
 	})
@@ -1784,10 +1787,11 @@ func TestEndpoint_WithMinTTL(t *testing.T) {
 // TestNewEndpointWithTTLPreservesDotsInTXTRecords tests that trailing dots are preserved in TXT records
 func TestNewEndpointWithTTLPreservesDotsInTXTRecords(t *testing.T) {
 	// TXT records should preserve trailing dots (and any arbitrary text)
-	txtEndpoint := NewEndpointWithTTL("example.com", RecordTypeTXT, TTL(300),
+	txtEndpoint, err := NewEndpointWithTTL("example.com", RecordTypeTXT, TTL(300),
 		"v=1;some_signature=aBx3d5..",
 		"text.with.dots...",
 		"simple-text")
+	require.NoError(t, err)
 
 	require.NotNil(t, txtEndpoint, "TXT endpoint should be created")
 	require.Len(t, txtEndpoint.Targets, 3, "should have 3 targets")
@@ -1798,11 +1802,13 @@ func TestNewEndpointWithTTLPreservesDotsInTXTRecords(t *testing.T) {
 	assert.Equal(t, "simple-text", txtEndpoint.Targets[2])
 
 	// Domain name record types should still have trailing dots trimmed
-	aEndpoint := NewEndpointWithTTL("example.com", RecordTypeA, TTL(300), "1.2.3.4.")
+	aEndpoint, err := NewEndpointWithTTL("example.com", RecordTypeA, TTL(300), "1.2.3.4.")
+	require.NoError(t, err)
 	require.NotNil(t, aEndpoint, "A endpoint should be created")
 	assert.Equal(t, "1.2.3.4", aEndpoint.Targets[0], "A record should have trailing dot trimmed")
 
-	cnameEndpoint := NewEndpointWithTTL("example.com", RecordTypeCNAME, TTL(300), "target.example.com.")
+	cnameEndpoint, err := NewEndpointWithTTL("example.com", RecordTypeCNAME, TTL(300), "target.example.com.")
+	require.NoError(t, err)
 	require.NotNil(t, cnameEndpoint, "CNAME endpoint should be created")
 	assert.Equal(t, "target.example.com", cnameEndpoint.Targets[0], "CNAME record should have trailing dot trimmed")
 }
@@ -1908,7 +1914,9 @@ func TestWithAliasProperty(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := NewEndpoint("example.com", "A", "1.2.3.4").WithAliasProperty(tt.input)
+			e, err := NewEndpoint("example.com", "A", "1.2.3.4")
+			require.NoError(t, err)
+			e = e.WithAliasProperty(tt.input)
 			assert.Equal(t, tt.expected, e.GetAliasProperty())
 		})
 	}
@@ -2135,13 +2143,15 @@ func TestGetNakedDomain(t *testing.T) {
 }
 
 func TestRequestedRecordType(t *testing.T) {
-	ep := NewEndpoint("example.com", RecordTypeA, "1.2.3.4").
-		WithProviderSpecific(ProviderSpecificRecordType, "ptr")
+	ep, err := NewEndpoint("example.com", RecordTypeA, "1.2.3.4")
+	require.NoError(t, err)
+	ep.WithProviderSpecific(ProviderSpecificRecordType, "ptr")
 	val, ok := ep.RequestedRecordType()
 	assert.True(t, ok)
 	assert.Equal(t, "ptr", val)
 
-	ep2 := NewEndpoint("example.com", RecordTypeA, "1.2.3.4")
+	ep2, err := NewEndpoint("example.com", RecordTypeA, "1.2.3.4")
+	require.NoError(t, err)
 	_, ok = ep2.RequestedRecordType()
 	assert.False(t, ok)
 }

--- a/endpoint/utils.go
+++ b/endpoint/utils.go
@@ -85,8 +85,9 @@ func EndpointsForHostname(hostname string, targets Targets, ttl TTL, providerSpe
 		if len(byType[rt]) == 0 {
 			continue
 		}
-		ep := NewEndpointWithTTL(hostname, rt, ttl, byType[rt]...)
-		if ep == nil {
+		ep, err := NewEndpointWithTTL(hostname, rt, ttl, byType[rt]...)
+		if err != nil {
+			log.Errorf("Failed to create endpoint for %s with targets %v: %v", hostname, byType[rt], err)
 			continue
 		}
 		ep.ProviderSpecific = providerSpecific
@@ -137,7 +138,12 @@ func EndpointsForHostsAndTargets(hostnames, targets []string) []*Endpoint {
 	endpoints := make([]*Endpoint, 0, len(sortedHosts)*len(sortedTypes))
 	for _, hostname := range sortedHosts {
 		for _, recordType := range sortedTypes {
-			endpoints = append(endpoints, NewEndpoint(hostname, recordType, sortedTargets[recordType]...))
+			ep, err := NewEndpoint(hostname, recordType, sortedTargets[recordType]...)
+			if err != nil {
+				log.Errorf("Failed to create endpoint for %s with targets %v: %v", hostname, sortedTargets[recordType], err)
+				continue
+			}
+			endpoints = append(endpoints, ep)
 		}
 	}
 	return endpoints

--- a/endpoint/utils_external_test.go
+++ b/endpoint/utils_external_test.go
@@ -61,7 +61,7 @@ func TestEndpointsForHostsAndTargets(t *testing.T) {
 			hostnames: []string{"example.com"},
 			targets:   []string{"192.168.1.1"},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "192.168.1.1"),
+				endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeA, "192.168.1.1"),
 			},
 		},
 		{
@@ -69,7 +69,7 @@ func TestEndpointsForHostsAndTargets(t *testing.T) {
 			hostnames: []string{"example.com"},
 			targets:   []string{"2001:db8::1"},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001:db8::1"),
+				endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001:db8::1"),
 			},
 		},
 		{
@@ -77,7 +77,7 @@ func TestEndpointsForHostsAndTargets(t *testing.T) {
 			hostnames: []string{"example.com"},
 			targets:   []string{"lb.example.com"},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+				endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
 			},
 		},
 		{
@@ -85,7 +85,7 @@ func TestEndpointsForHostsAndTargets(t *testing.T) {
 			hostnames: []string{"example.com", "example.com"},
 			targets:   []string{"192.168.1.1"},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "192.168.1.1"),
+				endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeA, "192.168.1.1"),
 			},
 		},
 		{
@@ -93,7 +93,7 @@ func TestEndpointsForHostsAndTargets(t *testing.T) {
 			hostnames: []string{"example.com"},
 			targets:   []string{"192.168.1.1", "192.168.1.1", "192.168.1.2"},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "192.168.1.1", "192.168.1.2"),
+				endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeA, "192.168.1.1", "192.168.1.2"),
 			},
 		},
 		{
@@ -101,7 +101,7 @@ func TestEndpointsForHostsAndTargets(t *testing.T) {
 			hostnames: []string{"example.com."},
 			targets:   []string{"192.168.1.1"},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "192.168.1.1"),
+				endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeA, "192.168.1.1"),
 			},
 		},
 		{
@@ -109,8 +109,8 @@ func TestEndpointsForHostsAndTargets(t *testing.T) {
 			hostnames: []string{"example.com", "example.com"},
 			targets:   []string{"192.168.1.1", "192.168.1.1", "2001:db8::1"},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "192.168.1.1"),
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001:db8::1"),
+				endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeA, "192.168.1.1"),
+				endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001:db8::1"),
 			},
 		},
 		{
@@ -118,8 +118,8 @@ func TestEndpointsForHostsAndTargets(t *testing.T) {
 			hostnames: []string{"example.com", "www.example.com"},
 			targets:   []string{"192.168.1.1"},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "192.168.1.1"),
-				endpoint.NewEndpoint("www.example.com", endpoint.RecordTypeA, "192.168.1.1"),
+				endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeA, "192.168.1.1"),
+				endpoint.MustNewEndpoint("www.example.com", endpoint.RecordTypeA, "192.168.1.1"),
 			},
 		},
 		{
@@ -127,9 +127,9 @@ func TestEndpointsForHostsAndTargets(t *testing.T) {
 			hostnames: []string{"example.com"},
 			targets:   []string{"192.168.1.1", "2001:db8::1", "lb.example.com"},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "192.168.1.1"),
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001:db8::1"),
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+				endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeA, "192.168.1.1"),
+				endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001:db8::1"),
+				endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
 			},
 		},
 		{
@@ -137,9 +137,9 @@ func TestEndpointsForHostsAndTargets(t *testing.T) {
 			hostnames: []string{"example.com"},
 			targets:   []string{"192.168.1.1", "192.168.1.2", "2001:db8::1", "2001:db8::2", "a.example.com", "b.example.com"},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "192.168.1.1", "192.168.1.2"),
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001:db8::1", "2001:db8::2"),
-				endpoint.NewEndpoint("example.com", endpoint.RecordTypeCNAME, "a.example.com", "b.example.com"),
+				endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeA, "192.168.1.1", "192.168.1.2"),
+				endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001:db8::1", "2001:db8::2"),
+				endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeCNAME, "a.example.com", "b.example.com"),
 			},
 		},
 		{
@@ -147,8 +147,8 @@ func TestEndpointsForHostsAndTargets(t *testing.T) {
 			hostnames: []string{"z.example.com", "a.example.com"},
 			targets:   []string{"192.168.1.1"},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("a.example.com", endpoint.RecordTypeA, "192.168.1.1"),
-				endpoint.NewEndpoint("z.example.com", endpoint.RecordTypeA, "192.168.1.1"),
+				endpoint.MustNewEndpoint("a.example.com", endpoint.RecordTypeA, "192.168.1.1"),
+				endpoint.MustNewEndpoint("z.example.com", endpoint.RecordTypeA, "192.168.1.1"),
 			},
 		},
 	}

--- a/endpoint/utils_test.go
+++ b/endpoint/utils_test.go
@@ -97,7 +97,7 @@ func TestHasEmptyEndpoints(t *testing.T) {
 		{
 			name: "single endpoint returns false",
 			endpoints: []*Endpoint{
-				NewEndpoint("example.org", "A", "1.2.3.4"),
+				MustNewEndpoint("example.org", "A", "1.2.3.4"),
 			},
 			rType:    "Service",
 			entity:   &mockObjectMetaAccessor{namespace: "default", name: "my-service"},
@@ -106,8 +106,8 @@ func TestHasEmptyEndpoints(t *testing.T) {
 		{
 			name: "multiple endpoints returns false",
 			endpoints: []*Endpoint{
-				NewEndpoint("example.org", "A", "1.2.3.4"),
-				NewEndpoint("test.example.org", "CNAME", "example.org"),
+				MustNewEndpoint("example.org", "A", "1.2.3.4"),
+				MustNewEndpoint("test.example.org", "CNAME", "example.org"),
 			},
 			rType:    "Ingress",
 			entity:   &mockObjectMetaAccessor{namespace: "production", name: "frontend"},
@@ -231,8 +231,8 @@ func TestEndpointsForHostname(t *testing.T) {
 func TestAttachRefObject(t *testing.T) {
 	ref := events.NewObjectReferenceFromParts("Service", "", "default", "svc", "", "")
 	eps := []*Endpoint{
-		NewEndpoint("a.example.com", RecordTypeA, "1.2.3.4"),
-		NewEndpoint("b.example.com", RecordTypeA, "5.6.7.8"),
+		MustNewEndpoint("a.example.com", RecordTypeA, "1.2.3.4"),
+		MustNewEndpoint("b.example.com", RecordTypeA, "5.6.7.8"),
 	}
 
 	AttachRefObject(eps, ref)
@@ -327,114 +327,114 @@ func TestMergeEndpoints(t *testing.T) {
 		{
 			name: "duplicate targets deduplicated",
 			input: []*Endpoint{
-				NewEndpoint("example.com", RecordTypeA, "1.2.3.4", "1.2.3.4", "5.6.7.8"),
+				MustNewEndpoint("example.com", RecordTypeA, "1.2.3.4", "1.2.3.4", "5.6.7.8"),
 			},
 			expected: []*Endpoint{
-				NewEndpoint("example.com", RecordTypeA, "1.2.3.4", "5.6.7.8"),
+				MustNewEndpoint("example.com", RecordTypeA, "1.2.3.4", "5.6.7.8"),
 			},
 		},
 		{
 			name: "duplicate targets across merged endpoints deduplicated",
 			input: []*Endpoint{
-				NewEndpoint("example.com", RecordTypeA, "1.2.3.4"),
-				NewEndpoint("example.com", RecordTypeA, "1.2.3.4", "5.6.7.8"),
+				MustNewEndpoint("example.com", RecordTypeA, "1.2.3.4"),
+				MustNewEndpoint("example.com", RecordTypeA, "1.2.3.4", "5.6.7.8"),
 			},
 			expected: []*Endpoint{
-				NewEndpoint("example.com", RecordTypeA, "1.2.3.4", "5.6.7.8"),
+				MustNewEndpoint("example.com", RecordTypeA, "1.2.3.4", "5.6.7.8"),
 			},
 		},
 		{
 			name: "CNAME endpoints not merged",
 			input: []*Endpoint{
-				NewEndpoint("example.com", RecordTypeCNAME, "a.elb.com"),
-				NewEndpoint("example.com", RecordTypeCNAME, "b.elb.com"),
+				MustNewEndpoint("example.com", RecordTypeCNAME, "a.elb.com"),
+				MustNewEndpoint("example.com", RecordTypeCNAME, "b.elb.com"),
 			},
 			expected: []*Endpoint{
-				NewEndpoint("example.com", RecordTypeCNAME, "a.elb.com"),
-				NewEndpoint("example.com", RecordTypeCNAME, "b.elb.com"),
+				MustNewEndpoint("example.com", RecordTypeCNAME, "a.elb.com"),
+				MustNewEndpoint("example.com", RecordTypeCNAME, "b.elb.com"),
 			},
 		},
 		{
 			name: "CNAME with no targets is skipped",
 			input: []*Endpoint{
-				NewEndpoint("example.com", RecordTypeCNAME),
-				NewEndpoint("example.com", RecordTypeA, "1.2.3.4"),
+				MustNewEndpoint("example.com", RecordTypeCNAME),
+				MustNewEndpoint("example.com", RecordTypeA, "1.2.3.4"),
 			},
 			expected: []*Endpoint{
-				NewEndpoint("example.com", RecordTypeA, "1.2.3.4"),
+				MustNewEndpoint("example.com", RecordTypeA, "1.2.3.4"),
 			},
 		},
 		{
 			name: "identical CNAME endpoints deduplicated",
 			input: []*Endpoint{
-				NewEndpoint("example.com", RecordTypeCNAME, "a.elb.com"),
-				NewEndpoint("example.com", RecordTypeCNAME, "a.elb.com"),
+				MustNewEndpoint("example.com", RecordTypeCNAME, "a.elb.com"),
+				MustNewEndpoint("example.com", RecordTypeCNAME, "a.elb.com"),
 			},
 			expected: []*Endpoint{
-				NewEndpoint("example.com", RecordTypeCNAME, "a.elb.com"),
+				MustNewEndpoint("example.com", RecordTypeCNAME, "a.elb.com"),
 			},
 		},
 		{
 			name: "same key with different TTL not merged",
 			input: []*Endpoint{
-				NewEndpointWithTTL("example.com", RecordTypeA, 300, "1.2.3.4"),
-				NewEndpointWithTTL("example.com", RecordTypeA, 600, "5.6.7.8"),
+				MustNewEndpointWithTTL("example.com", RecordTypeA, 300, "1.2.3.4"),
+				MustNewEndpointWithTTL("example.com", RecordTypeA, 600, "5.6.7.8"),
 			},
 			expected: []*Endpoint{
-				NewEndpointWithTTL("example.com", RecordTypeA, 300, "1.2.3.4"),
-				NewEndpointWithTTL("example.com", RecordTypeA, 600, "5.6.7.8"),
+				MustNewEndpointWithTTL("example.com", RecordTypeA, 300, "1.2.3.4"),
+				MustNewEndpointWithTTL("example.com", RecordTypeA, 600, "5.6.7.8"),
 			},
 		},
 		{
 			name: "same DNSName and RecordType with different SetIdentifier not merged",
 			input: []*Endpoint{
-				NewEndpoint("example.com", RecordTypeA, "1.2.3.4").WithSetIdentifier("us-east-1"),
-				NewEndpoint("example.com", RecordTypeA, "5.6.7.8").WithSetIdentifier("eu-west-1"),
+				MustNewEndpoint("example.com", RecordTypeA, "1.2.3.4").WithSetIdentifier("us-east-1"),
+				MustNewEndpoint("example.com", RecordTypeA, "5.6.7.8").WithSetIdentifier("eu-west-1"),
 			},
 			expected: []*Endpoint{
-				NewEndpoint("example.com", RecordTypeA, "1.2.3.4").WithSetIdentifier("us-east-1"),
-				NewEndpoint("example.com", RecordTypeA, "5.6.7.8").WithSetIdentifier("eu-west-1"),
+				MustNewEndpoint("example.com", RecordTypeA, "1.2.3.4").WithSetIdentifier("us-east-1"),
+				MustNewEndpoint("example.com", RecordTypeA, "5.6.7.8").WithSetIdentifier("eu-west-1"),
 			},
 		},
 		{
 			name: "same DNSName, RecordType and SetIdentifier targets are merged",
 			input: []*Endpoint{
-				NewEndpoint("example.com", RecordTypeA, "1.2.3.4").WithSetIdentifier("us-east-1"),
-				NewEndpoint("example.com", RecordTypeA, "5.6.7.8").WithSetIdentifier("us-east-1"),
+				MustNewEndpoint("example.com", RecordTypeA, "1.2.3.4").WithSetIdentifier("us-east-1"),
+				MustNewEndpoint("example.com", RecordTypeA, "5.6.7.8").WithSetIdentifier("us-east-1"),
 			},
 			expected: []*Endpoint{
-				NewEndpoint("example.com", RecordTypeA, "1.2.3.4", "5.6.7.8").WithSetIdentifier("us-east-1"),
+				MustNewEndpoint("example.com", RecordTypeA, "1.2.3.4", "5.6.7.8").WithSetIdentifier("us-east-1"),
 			},
 		},
 		{
 			name: "DNAME endpoints not merged",
 			input: []*Endpoint{
-				NewEndpoint("example.com", RecordTypeDNAME, "a.example.net"),
-				NewEndpoint("example.com", RecordTypeDNAME, "b.example.net"),
+				MustNewEndpoint("example.com", RecordTypeDNAME, "a.example.net"),
+				MustNewEndpoint("example.com", RecordTypeDNAME, "b.example.net"),
 			},
 			expected: []*Endpoint{
-				NewEndpoint("example.com", RecordTypeDNAME, "a.example.net"),
-				NewEndpoint("example.com", RecordTypeDNAME, "b.example.net"),
+				MustNewEndpoint("example.com", RecordTypeDNAME, "a.example.net"),
+				MustNewEndpoint("example.com", RecordTypeDNAME, "b.example.net"),
 			},
 		},
 		{
 			name: "DNAME with no targets is skipped",
 			input: []*Endpoint{
-				NewEndpoint("example.com", RecordTypeDNAME),
-				NewEndpoint("example.com", RecordTypeA, "1.2.3.4"),
+				MustNewEndpoint("example.com", RecordTypeDNAME),
+				MustNewEndpoint("example.com", RecordTypeA, "1.2.3.4"),
 			},
 			expected: []*Endpoint{
-				NewEndpoint("example.com", RecordTypeA, "1.2.3.4"),
+				MustNewEndpoint("example.com", RecordTypeA, "1.2.3.4"),
 			},
 		},
 		{
 			name: "identical DNAME endpoints deduplicated",
 			input: []*Endpoint{
-				NewEndpoint("example.com", RecordTypeDNAME, "a.example.net"),
-				NewEndpoint("example.com", RecordTypeDNAME, "a.example.net"),
+				MustNewEndpoint("example.com", RecordTypeDNAME, "a.example.net"),
+				MustNewEndpoint("example.com", RecordTypeDNAME, "a.example.net"),
 			},
 			expected: []*Endpoint{
-				NewEndpoint("example.com", RecordTypeDNAME, "a.example.net"),
+				MustNewEndpoint("example.com", RecordTypeDNAME, "a.example.net"),
 			},
 		},
 	}
@@ -464,7 +464,7 @@ func TestMergeEndpoints_RefObjects(t *testing.T) {
 			name: "single endpoint",
 			input: func() []*Endpoint {
 				return []*Endpoint{
-					NewEndpoint("example.com", RecordTypeA, "1.2.3.4").WithRefObject(
+					MustNewEndpoint("example.com", RecordTypeA, "1.2.3.4").WithRefObject(
 						events.NewObjectReference(&v1.Service{
 							ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default", UID: "123"},
 						}, "service")),
@@ -483,11 +483,11 @@ func TestMergeEndpoints_RefObjects(t *testing.T) {
 			name: "two endpoints merged — both distinct refObjects collected",
 			input: func() []*Endpoint {
 				return []*Endpoint{
-					NewEndpoint("a.example.com", RecordTypeA, "1.1.1.1").WithRefObject(
+					MustNewEndpoint("a.example.com", RecordTypeA, "1.1.1.1").WithRefObject(
 						events.NewObjectReference(&v1.Service{
 							ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default", UID: "123"},
 						}, "service")),
-					NewEndpoint("a.example.com", RecordTypeA, "2.2.2.2").WithRefObject(
+					MustNewEndpoint("a.example.com", RecordTypeA, "2.2.2.2").WithRefObject(
 						events.NewObjectReference(&v1.Service{
 							ObjectMeta: metav1.ObjectMeta{Name: "bar", Namespace: "ns", UID: "345"},
 						}, "service")),
@@ -508,8 +508,8 @@ func TestMergeEndpoints_RefObjects(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default", UID: "123"},
 				}, "service")
 				return []*Endpoint{
-					NewEndpoint("a.example.com", RecordTypeA, "1.1.1.1").WithRefObject(ref),
-					NewEndpoint("a.example.com", RecordTypeA, "2.2.2.2").WithRefObject(ref),
+					MustNewEndpoint("a.example.com", RecordTypeA, "1.1.1.1").WithRefObject(ref),
+					MustNewEndpoint("a.example.com", RecordTypeA, "2.2.2.2").WithRefObject(ref),
 				}
 			},
 			expected: func(t *testing.T, ep []*Endpoint) {
@@ -523,11 +523,11 @@ func TestMergeEndpoints_RefObjects(t *testing.T) {
 			name: "two endpoints not merged and two refObject preserved",
 			input: func() []*Endpoint {
 				return []*Endpoint{
-					NewEndpoint("a.example.com", RecordTypeA, "1.1.1.1").WithRefObject(
+					MustNewEndpoint("a.example.com", RecordTypeA, "1.1.1.1").WithRefObject(
 						events.NewObjectReference(&v1.Service{
 							ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default", UID: "123"},
 						}, "service")),
-					NewEndpoint("b.example.com", RecordTypeA, "1.1.1.2").WithRefObject(
+					MustNewEndpoint("b.example.com", RecordTypeA, "1.1.1.2").WithRefObject(
 						events.NewObjectReference(&v1.Service{
 							ObjectMeta: metav1.ObjectMeta{Name: "bar", Namespace: "ns", UID: "345"},
 						}, "service")),
@@ -560,8 +560,8 @@ func TestMergeEndpointsLogging(t *testing.T) {
 		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
 
 		MergeEndpoints([]*Endpoint{
-			NewEndpoint("example.com", RecordTypeCNAME, "a.elb.com"),
-			NewEndpoint("example.com", RecordTypeCNAME, "b.elb.com"),
+			MustNewEndpoint("example.com", RecordTypeCNAME, "a.elb.com"),
+			MustNewEndpoint("example.com", RecordTypeCNAME, "b.elb.com"),
 		})
 
 		logtest.TestHelperLogContainsWithLogLevel("Only one CNAME per name", log.WarnLevel, hook, t)
@@ -573,8 +573,8 @@ func TestMergeEndpointsLogging(t *testing.T) {
 		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
 
 		MergeEndpoints([]*Endpoint{
-			NewEndpoint("example.com", RecordTypeCNAME, "a.elb.com"),
-			NewEndpoint("example.com", RecordTypeCNAME, "a.elb.com"),
+			MustNewEndpoint("example.com", RecordTypeCNAME, "a.elb.com"),
+			MustNewEndpoint("example.com", RecordTypeCNAME, "a.elb.com"),
 		})
 
 		logtest.TestHelperLogNotContains("Only one CNAME per name", hook, t)
@@ -584,8 +584,8 @@ func TestMergeEndpointsLogging(t *testing.T) {
 		hook := logtest.LogsUnderTestWithLogLevel(log.WarnLevel, t)
 
 		MergeEndpoints([]*Endpoint{
-			NewEndpoint("example.com", RecordTypeCNAME, "a.elb.com").WithSetIdentifier("weight-1"),
-			NewEndpoint("example.com", RecordTypeCNAME, "b.elb.com").WithSetIdentifier("weight-2"),
+			MustNewEndpoint("example.com", RecordTypeCNAME, "a.elb.com").WithSetIdentifier("weight-1"),
+			MustNewEndpoint("example.com", RecordTypeCNAME, "b.elb.com").WithSetIdentifier("weight-2"),
 		})
 
 		logtest.TestHelperLogNotContains("Only one CNAME per name", hook, t)
@@ -595,7 +595,7 @@ func TestMergeEndpointsLogging(t *testing.T) {
 		hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
 
 		MergeEndpoints([]*Endpoint{
-			NewEndpoint("example.com", RecordTypeCNAME),
+			MustNewEndpoint("example.com", RecordTypeCNAME),
 		})
 
 		logtest.TestHelperLogContainsWithLogLevel("Skipping CNAME endpoint", log.DebugLevel, hook, t)

--- a/internal/testutils/endpoint.go
+++ b/internal/testutils/endpoint.go
@@ -204,7 +204,7 @@ func GenerateTestEndpointsWithDistribution(
 // The record type is inferred from target: A for IPv4, AAAA for IPv6, CNAME otherwise.
 // Kind and APIVersion are resolved from the client-go scheme, so TypeMeta need not be set on obj.
 func NewEndpointWithRef(dns, target string, obj ctrlclient.Object, source string) *endpoint.Endpoint {
-	return endpoint.NewEndpoint(dns, endpoint.SuitableType(target), target).
+	return endpoint.MustNewEndpoint(dns, endpoint.SuitableType(target), target).
 		WithRefObject(events.NewObjectReference(obj, source))
 }
 

--- a/provider/alibabacloud/alibaba_cloud.go
+++ b/provider/alibabacloud/alibaba_cloud.go
@@ -340,7 +340,11 @@ func (p *AlibabaCloudProvider) recordsForDNS() ([]*endpoint.Endpoint, error) {
 		for _, record := range recordList {
 			targets = append(targets, record.Value)
 		}
-		ep := endpoint.NewEndpointWithTTL(name, recordType, endpoint.TTL(ttl), targets...)
+		ep, err := endpoint.NewEndpointWithTTL(name, recordType, endpoint.TTL(ttl), targets...)
+		if err != nil {
+			log.Errorf("Failed to create endpoint for %s: %v", name, err)
+			continue
+		}
 		endpoints = append(endpoints, ep)
 	}
 	return endpoints, nil
@@ -836,7 +840,11 @@ func (p *AlibabaCloudProvider) privateZoneRecords() ([]*endpoint.Endpoint, error
 			for _, record := range recordList {
 				targets = append(targets, record.Value)
 			}
-			ep := endpoint.NewEndpointWithTTL(name, recordType, endpoint.TTL(ttl), targets...)
+			ep, err := endpoint.NewEndpointWithTTL(name, recordType, endpoint.TTL(ttl), targets...)
+			if err != nil {
+				log.Errorf("Failed to create endpoint for %s: %v", name, err)
+				continue
+			}
 			endpoints = append(endpoints, ep)
 		}
 	}

--- a/provider/alibabacloud/alibaba_cloud_test.go
+++ b/provider/alibabacloud/alibaba_cloud_test.go
@@ -417,9 +417,9 @@ func getSubname(domain string, ep *endpoint.Endpoint) string {
 
 func createDefaultEndpoints(domain string) []*endpoint.Endpoint {
 	endpoints := []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("abc."+domain, "A", 300, "1.2.3.4"),
-		endpoint.NewEndpointWithTTL("abc."+domain, "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
-		endpoint.NewEndpointWithTTL("a-abc."+domain, "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
+		endpoint.MustNewEndpointWithTTL("abc."+domain, "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
+		endpoint.MustNewEndpointWithTTL("a-abc."+domain, "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
+		endpoint.MustNewEndpointWithTTL("abc."+domain, "A", 300, "1.2.3.4"),
 	}
 
 	return endpoints
@@ -444,15 +444,15 @@ func TestAlibabaCloudProvider_ApplyChanges(t *testing.T) {
 	provider := newTestAlibabaCloudProvider(false)
 	changes := plan.Changes{
 		Create: []*endpoint.Endpoint{
-			endpoint.NewEndpointWithTTL("xyz.container-service.top", "A", 300, "4.3.2.1"),
-			endpoint.NewEndpointWithTTL("ttl.container-service.top", "A", defaultTTL, "4.3.2.1"),
+			endpoint.MustNewEndpointWithTTL("xyz.container-service.top", "A", 300, "4.3.2.1"),
+			endpoint.MustNewEndpointWithTTL("ttl.container-service.top", "A", defaultTTL, "4.3.2.1"),
 		},
 		UpdateNew: []*endpoint.Endpoint{
-			endpoint.NewEndpointWithTTL("abc.container-service.top", "A", 500, "1.2.3.4", "5.6.7.8"),
-			endpoint.NewEndpointWithTTL("a-abc.container-service.top", "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
+			endpoint.MustNewEndpointWithTTL("abc.container-service.top", "A", 500, "1.2.3.4", "5.6.7.8"),
+			endpoint.MustNewEndpointWithTTL("a-abc.container-service.top", "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
 		},
 		Delete: []*endpoint.Endpoint{
-			endpoint.NewEndpointWithTTL("abc.container-service.top", "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
+			endpoint.MustNewEndpointWithTTL("abc.container-service.top", "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
 		},
 	}
 
@@ -464,8 +464,8 @@ func TestAlibabaCloudProvider_ApplyChanges(t *testing.T) {
 	require.NoError(t, err, "Failed to get records: %v", err)
 
 	changedEndpoints := append([]*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("abc.container-service.top", "A", 500, "1.2.3.4", "5.6.7.8"),
-		endpoint.NewEndpointWithTTL("a-abc.container-service.top", "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
+		endpoint.MustNewEndpointWithTTL("abc.container-service.top", "A", 500, "1.2.3.4", "5.6.7.8"),
+		endpoint.MustNewEndpointWithTTL("a-abc.container-service.top", "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
 	}, changes.Create...)
 
 	require.Len(t, endpoints, len(changedEndpoints), "Incorrect number of records: %d", len(endpoints))
@@ -477,15 +477,15 @@ func TestAlibabaCloudProvider_ApplyChanges_UndefinedZoneDomain(t *testing.T) {
 	changes := plan.Changes{
 		Create: []*endpoint.Endpoint{
 			// no found this zone by API: DescribeDomains
-			endpoint.NewEndpointWithTTL("www.example.com", "A", 300, "9.9.9.9"),
+			endpoint.MustNewEndpointWithTTL("www.example.com", "A", 300, "9.9.9.9"),
 			// can create this domain record
-			endpoint.NewEndpointWithTTL("ttl.container-service.top", "A", defaultTTL, "4.3.2.1"),
+			endpoint.MustNewEndpointWithTTL("ttl.container-service.top", "A", defaultTTL, "4.3.2.1"),
 		},
 		UpdateNew: []*endpoint.Endpoint{
-			endpoint.NewEndpointWithTTL("abc.container-service.top", "A", 500, "1.2.3.4", "5.6.7.8"),
+			endpoint.MustNewEndpointWithTTL("abc.container-service.top", "A", 500, "1.2.3.4", "5.6.7.8"),
 		},
 		Delete: []*endpoint.Endpoint{
-			endpoint.NewEndpointWithTTL("abc.container-service.top", "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
+			endpoint.MustNewEndpointWithTTL("abc.container-service.top", "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
 		},
 	}
 
@@ -497,8 +497,8 @@ func TestAlibabaCloudProvider_ApplyChanges_UndefinedZoneDomain(t *testing.T) {
 	require.NoError(t, err, "Failed to get records: %v", err)
 
 	changedEndpoints := append([]*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("abc.container-service.top", "A", 500, "1.2.3.4", "5.6.7.8"),
-		endpoint.NewEndpointWithTTL("a-abc.container-service.top", "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
+		endpoint.MustNewEndpointWithTTL("abc.container-service.top", "A", 500, "1.2.3.4", "5.6.7.8"),
+		endpoint.MustNewEndpointWithTTL("a-abc.container-service.top", "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
 	}, changes.Create[1]) // Only one new one was created
 
 	require.Len(t, endpoints, len(changedEndpoints), "Incorrect number of records: %d", len(endpoints))
@@ -524,14 +524,14 @@ func TestAlibabaCloudProvider_PrivateZone_ApplyChanges(t *testing.T) {
 	provider := newTestAlibabaCloudProvider(true)
 	changes := plan.Changes{
 		Create: []*endpoint.Endpoint{
-			endpoint.NewEndpointWithTTL("xyz.container-service.top", "A", 300, "4.3.2.1"),
+			endpoint.MustNewEndpointWithTTL("xyz.container-service.top", "A", 300, "4.3.2.1"),
 		},
 		UpdateNew: []*endpoint.Endpoint{
-			endpoint.NewEndpointWithTTL("abc.container-service.top", "A", 500, "1.2.3.4", "5.6.7.8"),
-			endpoint.NewEndpointWithTTL("a-abc.container-service.top", "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
+			endpoint.MustNewEndpointWithTTL("abc.container-service.top", "A", 500, "1.2.3.4", "5.6.7.8"),
+			endpoint.MustNewEndpointWithTTL("a-abc.container-service.top", "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
 		},
 		Delete: []*endpoint.Endpoint{
-			endpoint.NewEndpointWithTTL("abc.container-service.top", "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
+			endpoint.MustNewEndpointWithTTL("abc.container-service.top", "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
 		},
 	}
 
@@ -543,8 +543,8 @@ func TestAlibabaCloudProvider_PrivateZone_ApplyChanges(t *testing.T) {
 	require.NoError(t, err, "Failed to get records: %v", err)
 
 	changedEndpoints := append([]*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("abc.container-service.top", "A", 500, "1.2.3.4", "5.6.7.8"),
-		endpoint.NewEndpointWithTTL("a-abc.container-service.top", "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
+		endpoint.MustNewEndpointWithTTL("abc.container-service.top", "A", 500, "1.2.3.4", "5.6.7.8"),
+		endpoint.MustNewEndpointWithTTL("a-abc.container-service.top", "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\""),
 	}, changes.Create...)
 
 	require.Len(t, endpoints, len(changedEndpoints), "Incorrect number of records: %d", len(endpoints))

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -543,11 +543,15 @@ func (p *AWSProvider) records(ctx context.Context, zones map[string]*profiledZon
 						targets[idx] = *rr.Value
 					}
 
-					ep := endpoint.NewEndpointWithTTL(name, string(r.Type), ttl, targets...)
-					if r.Type == endpoint.RecordTypeCNAME {
-						ep = ep.WithAliasProperty(endpoint.AliasFalse)
+					ep, err := endpoint.NewEndpointWithTTL(name, string(r.Type), ttl, targets...)
+					if err != nil {
+						log.Errorf("Failed to create endpoint for record %s in zone %s using aws profile %q: %s", *r.Name, *z.zone.Id, z.profile, err)
+					} else {
+						if r.Type == endpoint.RecordTypeCNAME {
+							ep = ep.WithAliasProperty(endpoint.AliasFalse)
+						}
+						newEndpoints = append(newEndpoints, ep)
 					}
-					newEndpoints = append(newEndpoints, ep)
 				}
 
 				if r.AliasTarget != nil {
@@ -556,11 +560,14 @@ func (p *AWSProvider) records(ctx context.Context, zones map[string]*profiledZon
 						ttl = defaultTTL
 					}
 					aliasTarget := convertOctalToAscii(wildcardUnescape(*r.AliasTarget.DNSName))
-					ep := endpoint.
-						NewEndpointWithTTL(name, string(r.Type), ttl, aliasTarget).
-						WithProviderSpecific(providerSpecificEvaluateTargetHealth, fmt.Sprintf("%t", r.AliasTarget.EvaluateTargetHealth)).
-						WithAliasProperty(endpoint.AliasTrue)
-					newEndpoints = append(newEndpoints, ep)
+					ep, err := endpoint.NewEndpointWithTTL(name, string(r.Type), ttl, aliasTarget)
+					if err != nil {
+						log.Errorf("Failed to create endpoint for alias record %s in zone %s using aws profile %q: %s", *r.Name, *z.zone.Id, z.profile, err)
+					} else {
+						ep.WithProviderSpecific(providerSpecificEvaluateTargetHealth, fmt.Sprintf("%t", r.AliasTarget.EvaluateTargetHealth)).
+							WithAliasProperty(endpoint.AliasTrue)
+						newEndpoints = append(newEndpoints, ep)
+					}
 				}
 
 				for _, ep := range newEndpoints {

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -665,37 +665,37 @@ func TestAWSRecords(t *testing.T) {
 	require.NoError(t, err)
 
 	validateEndpoints(t, provider, records, []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("list-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.2.3.4"),
-		endpoint.NewEndpointWithTTL("list-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("*.wildcard-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("escape-%!s(<nil>)-codes.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, endpoint.TTL(defaultTTL), "example").WithAliasProperty(endpoint.AliasFalse),
-		endpoint.NewEndpointWithTTL("escape-%!s(<nil>)-codes-a.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.2.3.4"),
-		endpoint.NewEndpointWithTTL("escape-%!s(<nil>)-codes-alias.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "escape-codes.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false").WithAliasProperty(endpoint.AliasTrue),
-		endpoint.NewEndpointWithTTL("escape-%!s(<nil>)-codes-alias.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(defaultTTL), "escape-codes.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false").WithAliasProperty(endpoint.AliasTrue),
-		endpoint.NewEndpointWithTTL("list-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false").WithAliasProperty(endpoint.AliasTrue),
-		endpoint.NewEndpointWithTTL("list-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(defaultTTL), "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false").WithAliasProperty(endpoint.AliasTrue),
-		endpoint.NewEndpointWithTTL("*.wildcard-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false").WithAliasProperty(endpoint.AliasTrue),
-		endpoint.NewEndpointWithTTL("*.wildcard-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(defaultTTL), "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false").WithAliasProperty(endpoint.AliasTrue),
-		endpoint.NewEndpointWithTTL("wildcard-alias-target.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "*.wildcard-target.zone-1.ext-dns-test-2.teapot.zalan.do").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false").WithAliasProperty(endpoint.AliasTrue),
-		endpoint.NewEndpointWithTTL("list-test-alias-evaluate.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true").WithAliasProperty(endpoint.AliasTrue),
-		endpoint.NewEndpointWithTTL("list-test-alias-evaluate.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(defaultTTL), "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true").WithAliasProperty(endpoint.AliasTrue),
-		endpoint.NewEndpointWithTTL("list-test-multiple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "8.8.8.8", "8.8.4.4"),
-		endpoint.NewEndpointWithTTL("prefix-*.wildcard.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeTXT, endpoint.TTL(defaultTTL), "random"),
-		endpoint.NewEndpointWithTTL("weight-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.2.3.4").WithSetIdentifier("test-set-1").WithProviderSpecific(providerSpecificWeight, "10"),
-		endpoint.NewEndpointWithTTL("weight-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "4.3.2.1").WithSetIdentifier("test-set-2").WithProviderSpecific(providerSpecificWeight, "20"),
-		endpoint.NewEndpointWithTTL("latency-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.2.3.4").WithSetIdentifier("test-set").WithProviderSpecific(providerSpecificRegion, "us-east-1"),
-		endpoint.NewEndpointWithTTL("failover-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.2.3.4").WithSetIdentifier("test-set").WithProviderSpecific(providerSpecificFailover, "PRIMARY"),
-		endpoint.NewEndpointWithTTL("multi-value-answer-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.2.3.4").WithSetIdentifier("test-set").WithProviderSpecific(providerSpecificMultiValueAnswer, ""),
-		endpoint.NewEndpointWithTTL("geolocation-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.2.3.4").WithSetIdentifier("test-set-1").WithProviderSpecific(providerSpecificGeolocationContinentCode, "EU"),
-		endpoint.NewEndpointWithTTL("geolocation-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "4.3.2.1").WithSetIdentifier("test-set-2").WithProviderSpecific(providerSpecificGeolocationCountryCode, "DE"),
-		endpoint.NewEndpointWithTTL("geolocation-subdivision-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.2.3.4").WithSetIdentifier("test-set-1").WithProviderSpecific(providerSpecificGeolocationSubdivisionCode, "NY"),
-		endpoint.NewEndpointWithTTL("geoproximitylocation-region.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.2.3.4").WithSetIdentifier("test-set-1").WithProviderSpecific(providerSpecificGeoProximityLocationAWSRegion, "us-west-2").WithProviderSpecific(providerSpecificGeoProximityLocationBias, "10"),
-		endpoint.NewEndpointWithTTL("geoproximitylocation-localzone.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.2.3.4").WithSetIdentifier("test-set-1").WithProviderSpecific(providerSpecificGeoProximityLocationLocalZoneGroup, "usw2-pdx1-az1").WithProviderSpecific(providerSpecificGeoProximityLocationBias, "10"),
-		endpoint.NewEndpointWithTTL("geoproximitylocation-coordinates.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.2.3.4").WithSetIdentifier("test-set-1").WithProviderSpecific(providerSpecificGeoProximityLocationCoordinates, "90,90").WithProviderSpecific(providerSpecificGeoProximityLocationBias, "0"),
-		endpoint.NewEndpointWithTTL("healthcheck-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, endpoint.TTL(defaultTTL), "foo.example.com").WithSetIdentifier("test-set-1").WithProviderSpecific(providerSpecificWeight, "10").WithProviderSpecific(providerSpecificHealthCheckID, "foo-bar-healthcheck-id").WithAliasProperty(endpoint.AliasFalse),
-		endpoint.NewEndpointWithTTL("healthcheck-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "4.3.2.1").WithSetIdentifier("test-set-2").WithProviderSpecific(providerSpecificWeight, "20").WithProviderSpecific(providerSpecificHealthCheckID, "abc-def-healthcheck-id"),
-		endpoint.NewEndpointWithTTL("mail.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeMX, endpoint.TTL(defaultTTL), "10 mailhost1.example.com", "20 mailhost2.example.com"),
-		endpoint.NewEndpointWithTTL("naptr.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeNAPTR, endpoint.TTL(defaultTTL), `10 "U" "SIP+DTU" "" _sip._udp.sip1.example.com`, `10 "U" "SIPS+D2T" "" _sips._tcp.sip1.example.com`),
+		endpoint.MustNewEndpointWithTTL("list-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.2.3.4"),
+		endpoint.MustNewEndpointWithTTL("list-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "8.8.8.8"),
+		endpoint.MustNewEndpointWithTTL("*.wildcard-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "8.8.8.8"),
+		endpoint.MustNewEndpointWithTTL("escape-%!s(<nil>)-codes.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, endpoint.TTL(defaultTTL), "example").WithAliasProperty(endpoint.AliasFalse),
+		endpoint.MustNewEndpointWithTTL("escape-%!s(<nil>)-codes-a.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.2.3.4"),
+		endpoint.MustNewEndpointWithTTL("escape-%!s(<nil>)-codes-alias.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "escape-codes.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false").WithAliasProperty(endpoint.AliasTrue),
+		endpoint.MustNewEndpointWithTTL("escape-%!s(<nil>)-codes-alias.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(defaultTTL), "escape-codes.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false").WithAliasProperty(endpoint.AliasTrue),
+		endpoint.MustNewEndpointWithTTL("list-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false").WithAliasProperty(endpoint.AliasTrue),
+		endpoint.MustNewEndpointWithTTL("list-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(defaultTTL), "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false").WithAliasProperty(endpoint.AliasTrue),
+		endpoint.MustNewEndpointWithTTL("*.wildcard-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false").WithAliasProperty(endpoint.AliasTrue),
+		endpoint.MustNewEndpointWithTTL("*.wildcard-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(defaultTTL), "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false").WithAliasProperty(endpoint.AliasTrue),
+		endpoint.MustNewEndpointWithTTL("wildcard-alias-target.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "*.wildcard-target.zone-1.ext-dns-test-2.teapot.zalan.do").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false").WithAliasProperty(endpoint.AliasTrue),
+		endpoint.MustNewEndpointWithTTL("list-test-alias-evaluate.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true").WithAliasProperty(endpoint.AliasTrue),
+		endpoint.MustNewEndpointWithTTL("list-test-alias-evaluate.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(defaultTTL), "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true").WithAliasProperty(endpoint.AliasTrue),
+		endpoint.MustNewEndpointWithTTL("list-test-multiple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "8.8.8.8", "8.8.4.4"),
+		endpoint.MustNewEndpointWithTTL("prefix-*.wildcard.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeTXT, endpoint.TTL(defaultTTL), "random"),
+		endpoint.MustNewEndpointWithTTL("weight-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.2.3.4").WithSetIdentifier("test-set-1").WithProviderSpecific(providerSpecificWeight, "10"),
+		endpoint.MustNewEndpointWithTTL("weight-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "4.3.2.1").WithSetIdentifier("test-set-2").WithProviderSpecific(providerSpecificWeight, "20"),
+		endpoint.MustNewEndpointWithTTL("latency-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.2.3.4").WithSetIdentifier("test-set").WithProviderSpecific(providerSpecificRegion, "us-east-1"),
+		endpoint.MustNewEndpointWithTTL("failover-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.2.3.4").WithSetIdentifier("test-set").WithProviderSpecific(providerSpecificFailover, "PRIMARY"),
+		endpoint.MustNewEndpointWithTTL("multi-value-answer-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.2.3.4").WithSetIdentifier("test-set").WithProviderSpecific(providerSpecificMultiValueAnswer, ""),
+		endpoint.MustNewEndpointWithTTL("geolocation-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.2.3.4").WithSetIdentifier("test-set-1").WithProviderSpecific(providerSpecificGeolocationContinentCode, "EU"),
+		endpoint.MustNewEndpointWithTTL("geolocation-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "4.3.2.1").WithSetIdentifier("test-set-2").WithProviderSpecific(providerSpecificGeolocationCountryCode, "DE"),
+		endpoint.MustNewEndpointWithTTL("geolocation-subdivision-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.2.3.4").WithSetIdentifier("test-set-1").WithProviderSpecific(providerSpecificGeolocationSubdivisionCode, "NY"),
+		endpoint.MustNewEndpointWithTTL("geoproximitylocation-region.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.2.3.4").WithSetIdentifier("test-set-1").WithProviderSpecific(providerSpecificGeoProximityLocationAWSRegion, "us-west-2").WithProviderSpecific(providerSpecificGeoProximityLocationBias, "10"),
+		endpoint.MustNewEndpointWithTTL("geoproximitylocation-localzone.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.2.3.4").WithSetIdentifier("test-set-1").WithProviderSpecific(providerSpecificGeoProximityLocationLocalZoneGroup, "usw2-pdx1-az1").WithProviderSpecific(providerSpecificGeoProximityLocationBias, "10"),
+		endpoint.MustNewEndpointWithTTL("geoproximitylocation-coordinates.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.2.3.4").WithSetIdentifier("test-set-1").WithProviderSpecific(providerSpecificGeoProximityLocationCoordinates, "90,90").WithProviderSpecific(providerSpecificGeoProximityLocationBias, "0"),
+		endpoint.MustNewEndpointWithTTL("healthcheck-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, endpoint.TTL(defaultTTL), "foo.example.com").WithSetIdentifier("test-set-1").WithProviderSpecific(providerSpecificWeight, "10").WithProviderSpecific(providerSpecificHealthCheckID, "foo-bar-healthcheck-id").WithAliasProperty(endpoint.AliasFalse),
+		endpoint.MustNewEndpointWithTTL("healthcheck-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "4.3.2.1").WithSetIdentifier("test-set-2").WithProviderSpecific(providerSpecificWeight, "20").WithProviderSpecific(providerSpecificHealthCheckID, "abc-def-healthcheck-id"),
+		endpoint.MustNewEndpointWithTTL("mail.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeMX, endpoint.TTL(defaultTTL), "10 mailhost1.example.com", "20 mailhost2.example.com"),
+		endpoint.MustNewEndpointWithTTL("naptr.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeNAPTR, endpoint.TTL(defaultTTL), `10 "U" "SIP+DTU" "" _sip._udp.sip1.example.com`, `10 "U" "SIPS+D2T" "" _sips._tcp.sip1.example.com`),
 	})
 }
 
@@ -719,33 +719,33 @@ func TestAWSAdjustEndpoints(t *testing.T) {
 	provider, _ := newAWSProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), defaultEvaluateTargetHealth, false, false, nil)
 
 	records := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("a-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
-		endpoint.NewEndpoint("cname-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.example.com"),
-		endpoint.NewEndpointWithTTL("cname-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, 60, "alias-target.zone-2.ext-dns-test-2.teapot.zalan.do").WithAliasProperty(endpoint.AliasTrue),
-		endpoint.NewEndpointWithTTL("cname-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, 60, "alias-target.zone-2.ext-dns-test-2.teapot.zalan.do").WithAliasProperty(endpoint.AliasTrue),
-		endpoint.NewEndpoint("cname-test-elb.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com"),
-		endpoint.NewEndpoint("cname-test-elb-no-alias.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasFalse),
-		endpoint.NewEndpoint("cname-test-elb-no-eth.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false"), // eth = evaluate target health
-		endpoint.NewEndpoint("cname-test-elb-alias.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue).WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true"),
-		endpoint.NewEndpoint("a-test-geoproximity-no-bias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8").WithSetIdentifier("test-set-1").WithProviderSpecific(providerSpecificGeoProximityLocationAWSRegion, "us-west-2"),
+		endpoint.MustNewEndpoint("a-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
+		endpoint.MustNewEndpoint("cname-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.example.com"),
+		endpoint.MustNewEndpointWithTTL("cname-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, 60, "alias-target.zone-2.ext-dns-test-2.teapot.zalan.do").WithAliasProperty(endpoint.AliasTrue),
+		endpoint.MustNewEndpointWithTTL("cname-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, 60, "alias-target.zone-2.ext-dns-test-2.teapot.zalan.do").WithAliasProperty(endpoint.AliasTrue),
+		endpoint.MustNewEndpoint("cname-test-elb.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("cname-test-elb-no-alias.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasFalse),
+		endpoint.MustNewEndpoint("cname-test-elb-no-eth.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com").WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false"), // eth = evaluate target health
+		endpoint.MustNewEndpoint("cname-test-elb-alias.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue).WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true"),
+		endpoint.MustNewEndpoint("a-test-geoproximity-no-bias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8").WithSetIdentifier("test-set-1").WithProviderSpecific(providerSpecificGeoProximityLocationAWSRegion, "us-west-2"),
 	}
 
 	records, err := provider.AdjustEndpoints(records)
 	require.NoError(t, err)
 
 	validateEndpoints(t, provider, records, []*endpoint.Endpoint{
-		endpoint.NewEndpoint("a-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
-		endpoint.NewEndpoint("cname-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.example.com").WithAliasProperty(endpoint.AliasFalse),
-		endpoint.NewEndpointWithTTL("cname-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, 300, "alias-target.zone-2.ext-dns-test-2.teapot.zalan.do").WithAliasProperty(endpoint.AliasTrue).WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true"),
-		endpoint.NewEndpointWithTTL("cname-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, 300, "alias-target.zone-2.ext-dns-test-2.teapot.zalan.do").WithAliasProperty(endpoint.AliasTrue).WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true"),
-		endpoint.NewEndpoint("cname-test-elb.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "foo.eu-central-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue).WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true"),
-		endpoint.NewEndpoint("cname-test-elb.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "foo.eu-central-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue).WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true"),
-		endpoint.NewEndpoint("cname-test-elb-no-alias.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasFalse),
-		endpoint.NewEndpoint("cname-test-elb-no-eth.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "foo.eu-central-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue).WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false"),    // eth = evaluate target health
-		endpoint.NewEndpoint("cname-test-elb-no-eth.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "foo.eu-central-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue).WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false"), // eth = evaluate target health
-		endpoint.NewEndpoint("cname-test-elb-alias.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "foo.eu-central-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue).WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true"),
-		endpoint.NewEndpoint("cname-test-elb-alias.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "foo.eu-central-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue).WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true"),
-		endpoint.NewEndpoint("a-test-geoproximity-no-bias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8").WithSetIdentifier("test-set-1").WithProviderSpecific(providerSpecificGeoProximityLocationAWSRegion, "us-west-2").WithProviderSpecific(providerSpecificGeoProximityLocationBias, "0"),
+		endpoint.MustNewEndpoint("a-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
+		endpoint.MustNewEndpoint("cname-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.example.com").WithAliasProperty(endpoint.AliasFalse),
+		endpoint.MustNewEndpointWithTTL("cname-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, 300, "alias-target.zone-2.ext-dns-test-2.teapot.zalan.do").WithAliasProperty(endpoint.AliasTrue).WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true"),
+		endpoint.MustNewEndpointWithTTL("cname-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, 300, "alias-target.zone-2.ext-dns-test-2.teapot.zalan.do").WithAliasProperty(endpoint.AliasTrue).WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true"),
+		endpoint.MustNewEndpoint("cname-test-elb.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "foo.eu-central-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue).WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true"),
+		endpoint.MustNewEndpoint("cname-test-elb.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "foo.eu-central-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue).WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true"),
+		endpoint.MustNewEndpoint("cname-test-elb-no-alias.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasFalse),
+		endpoint.MustNewEndpoint("cname-test-elb-no-eth.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "foo.eu-central-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue).WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false"),    // eth = evaluate target health
+		endpoint.MustNewEndpoint("cname-test-elb-no-eth.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "foo.eu-central-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue).WithProviderSpecific(providerSpecificEvaluateTargetHealth, "false"), // eth = evaluate target health
+		endpoint.MustNewEndpoint("cname-test-elb-alias.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "foo.eu-central-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue).WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true"),
+		endpoint.MustNewEndpoint("cname-test-elb-alias.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "foo.eu-central-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue).WithProviderSpecific(providerSpecificEvaluateTargetHealth, "true"),
+		endpoint.MustNewEndpoint("a-test-geoproximity-no-bias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8").WithSetIdentifier("test-set-1").WithProviderSpecific(providerSpecificGeoProximityLocationAWSRegion, "us-west-2").WithProviderSpecific(providerSpecificGeoProximityLocationBias, "0"),
 	})
 }
 
@@ -1000,88 +1000,88 @@ func TestAWSApplyChanges(t *testing.T) {
 		})
 
 		createRecords := []*endpoint.Endpoint{
-			endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
-			endpoint.NewEndpoint("create-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
-			endpoint.NewEndpoint("create-test-aaaa.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1111"),
-			endpoint.NewEndpoint("create-test-aaaa.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1001"),
-			endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.elb.amazonaws.com"),
-			endpoint.NewEndpoint("create-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.elb.amazonaws.com"),
-			endpoint.NewEndpoint("create-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8", "8.8.4.4"),
-			endpoint.NewEndpoint("create-test-multiple-aaaa.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1111", "2606:4700:4700::1001"),
-			endpoint.NewEndpoint("create-test-mx.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeMX, "10 mailhost1.foo.elb.amazonaws.com"),
-			endpoint.NewEndpoint("create-test-naptr.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeNAPTR, `10 "U" "SIP+DTU" "" _sip._udp.sip1.example.com.`),
-			endpoint.NewEndpoint("create-test-geoproximity-region.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8").
+			endpoint.MustNewEndpoint("create-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
+			endpoint.MustNewEndpoint("create-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
+			endpoint.MustNewEndpoint("create-test-aaaa.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1111"),
+			endpoint.MustNewEndpoint("create-test-aaaa.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1001"),
+			endpoint.MustNewEndpoint("create-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.elb.amazonaws.com"),
+			endpoint.MustNewEndpoint("create-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.elb.amazonaws.com"),
+			endpoint.MustNewEndpoint("create-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8", "8.8.4.4"),
+			endpoint.MustNewEndpoint("create-test-multiple-aaaa.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1111", "2606:4700:4700::1001"),
+			endpoint.MustNewEndpoint("create-test-mx.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeMX, "10 mailhost1.foo.elb.amazonaws.com"),
+			endpoint.MustNewEndpoint("create-test-naptr.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeNAPTR, `10 "U" "SIP+DTU" "" _sip._udp.sip1.example.com.`),
+			endpoint.MustNewEndpoint("create-test-geoproximity-region.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8").
 				WithSetIdentifier("geoproximity-region").
 				WithProviderSpecific(providerSpecificGeoProximityLocationAWSRegion, "us-west-2").
 				WithProviderSpecific(providerSpecificGeoProximityLocationBias, "10"),
-			endpoint.NewEndpoint("create-test-geoproximity-coordinates.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8").
+			endpoint.MustNewEndpoint("create-test-geoproximity-coordinates.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8").
 				WithSetIdentifier("geoproximity-coordinates").
 				WithProviderSpecific(providerSpecificGeoProximityLocationCoordinates, "60,60"),
 		}
 
 		currentRecords := []*endpoint.Endpoint{
-			endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
-			endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
-			endpoint.NewEndpoint("update-test-aaaa.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1111"),
-			endpoint.NewEndpoint("update-test-aaaa.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1001"),
-			endpoint.NewEndpoint("update-test-a-to-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.1.1.1"),
-			endpoint.NewEndpoint("update-test-alias-to-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "foo.eu-central-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue),
-			endpoint.NewEndpoint("update-test-alias-to-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "foo.eu-central-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue),
-			endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "bar.elb.amazonaws.com"),
-			endpoint.NewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "bar.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue),
-			endpoint.NewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "bar.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue),
-			endpoint.NewEndpoint("update-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8", "8.8.4.4"),
-			endpoint.NewEndpoint("update-test-multiple-aaaa.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1111", "2606:4700:4700::1001"),
-			endpoint.NewEndpoint("update-test-geoproximity.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").
+			endpoint.MustNewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
+			endpoint.MustNewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
+			endpoint.MustNewEndpoint("update-test-aaaa.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1111"),
+			endpoint.MustNewEndpoint("update-test-aaaa.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1001"),
+			endpoint.MustNewEndpoint("update-test-a-to-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.1.1.1"),
+			endpoint.MustNewEndpoint("update-test-alias-to-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "foo.eu-central-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue),
+			endpoint.MustNewEndpoint("update-test-alias-to-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "foo.eu-central-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue),
+			endpoint.MustNewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "bar.elb.amazonaws.com"),
+			endpoint.MustNewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "bar.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue),
+			endpoint.MustNewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "bar.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue),
+			endpoint.MustNewEndpoint("update-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8", "8.8.4.4"),
+			endpoint.MustNewEndpoint("update-test-multiple-aaaa.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1111", "2606:4700:4700::1001"),
+			endpoint.MustNewEndpoint("update-test-geoproximity.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").
 				WithSetIdentifier("geoproximity-update").
 				WithProviderSpecific(providerSpecificGeoProximityLocationLocalZoneGroup, "usw2-lax1-az2"),
-			endpoint.NewEndpoint("weighted-to-simple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("weighted-to-simple").WithProviderSpecific(providerSpecificWeight, "10"),
-			endpoint.NewEndpoint("simple-to-weighted.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
-			endpoint.NewEndpoint("policy-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("policy-change").WithProviderSpecific(providerSpecificWeight, "10"),
-			endpoint.NewEndpoint("set-identifier-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("before").WithProviderSpecific(providerSpecificWeight, "10"),
-			endpoint.NewEndpoint("set-identifier-no-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("no-change").WithProviderSpecific(providerSpecificWeight, "10"),
-			endpoint.NewEndpoint("update-test-mx.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeMX, "10 mailhost2.bar.elb.amazonaws.com"),
-			endpoint.NewEndpoint("update-test-naptr.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeNAPTR, `10 "U" "SIP+DTU" "" _sip._udp.sip1.example.com.`),
-			endpoint.NewEndpoint("escape-%!s(<nil>)-codes.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("policy-change").WithSetIdentifier("no-change").WithProviderSpecific(providerSpecificWeight, "10"),
+			endpoint.MustNewEndpoint("weighted-to-simple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("weighted-to-simple").WithProviderSpecific(providerSpecificWeight, "10"),
+			endpoint.MustNewEndpoint("simple-to-weighted.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
+			endpoint.MustNewEndpoint("policy-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("policy-change").WithProviderSpecific(providerSpecificWeight, "10"),
+			endpoint.MustNewEndpoint("set-identifier-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("before").WithProviderSpecific(providerSpecificWeight, "10"),
+			endpoint.MustNewEndpoint("set-identifier-no-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("no-change").WithProviderSpecific(providerSpecificWeight, "10"),
+			endpoint.MustNewEndpoint("update-test-mx.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeMX, "10 mailhost2.bar.elb.amazonaws.com"),
+			endpoint.MustNewEndpoint("update-test-naptr.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeNAPTR, `10 "U" "SIP+DTU" "" _sip._udp.sip1.example.com.`),
+			endpoint.MustNewEndpoint("escape-%!s(<nil>)-codes.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("policy-change").WithSetIdentifier("no-change").WithProviderSpecific(providerSpecificWeight, "10"),
 		}
 		updatedRecords := []*endpoint.Endpoint{
-			endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
-			endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "4.3.2.1"),
-			endpoint.NewEndpoint("update-test-aaaa.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1001"),
-			endpoint.NewEndpoint("update-test-aaaa.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1111"),
-			endpoint.NewEndpoint("update-test-a-to-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "foo.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue),
-			endpoint.NewEndpoint("update-test-a-to-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "foo.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue),
-			endpoint.NewEndpoint("update-test-alias-to-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "my-internal-host.example.com"),
-			endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "baz.elb.amazonaws.com"),
-			endpoint.NewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "baz.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue),
-			endpoint.NewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "baz.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue),
-			endpoint.NewEndpoint("update-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4", "4.3.2.1"),
-			endpoint.NewEndpoint("update-test-multiple-aaaa.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1001", "2606:4700:4700::1111"),
-			endpoint.NewEndpoint("update-test-geoproximity.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").
+			endpoint.MustNewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
+			endpoint.MustNewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "4.3.2.1"),
+			endpoint.MustNewEndpoint("update-test-aaaa.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1001"),
+			endpoint.MustNewEndpoint("update-test-aaaa.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1111"),
+			endpoint.MustNewEndpoint("update-test-a-to-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "foo.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue),
+			endpoint.MustNewEndpoint("update-test-a-to-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "foo.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue),
+			endpoint.MustNewEndpoint("update-test-alias-to-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "my-internal-host.example.com"),
+			endpoint.MustNewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "baz.elb.amazonaws.com"),
+			endpoint.MustNewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "baz.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue),
+			endpoint.MustNewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "baz.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue),
+			endpoint.MustNewEndpoint("update-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4", "4.3.2.1"),
+			endpoint.MustNewEndpoint("update-test-multiple-aaaa.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1001", "2606:4700:4700::1111"),
+			endpoint.MustNewEndpoint("update-test-geoproximity.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").
 				WithSetIdentifier("geoproximity-update").
 				WithProviderSpecific(providerSpecificGeoProximityLocationLocalZoneGroup, "usw2-phx2-az1"),
-			endpoint.NewEndpoint("weighted-to-simple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
-			endpoint.NewEndpoint("simple-to-weighted.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("simple-to-weighted").WithProviderSpecific(providerSpecificWeight, "10"),
-			endpoint.NewEndpoint("policy-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("policy-change").WithProviderSpecific(providerSpecificRegion, "us-east-1"),
-			endpoint.NewEndpoint("set-identifier-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("after").WithProviderSpecific(providerSpecificWeight, "10"),
-			endpoint.NewEndpoint("set-identifier-no-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("no-change").WithProviderSpecific(providerSpecificWeight, "20"),
-			endpoint.NewEndpoint("update-test-mx.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeMX, "20 mailhost3.foo.elb.amazonaws.com"),
-			endpoint.NewEndpoint("update-test-naptr.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeNAPTR, `20 "U" "SIP+DTU" "" _sip._udp.sip2.example.com.`),
+			endpoint.MustNewEndpoint("weighted-to-simple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
+			endpoint.MustNewEndpoint("simple-to-weighted.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("simple-to-weighted").WithProviderSpecific(providerSpecificWeight, "10"),
+			endpoint.MustNewEndpoint("policy-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("policy-change").WithProviderSpecific(providerSpecificRegion, "us-east-1"),
+			endpoint.MustNewEndpoint("set-identifier-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("after").WithProviderSpecific(providerSpecificWeight, "10"),
+			endpoint.MustNewEndpoint("set-identifier-no-change.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("no-change").WithProviderSpecific(providerSpecificWeight, "20"),
+			endpoint.MustNewEndpoint("update-test-mx.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeMX, "20 mailhost3.foo.elb.amazonaws.com"),
+			endpoint.MustNewEndpoint("update-test-naptr.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeNAPTR, `20 "U" "SIP+DTU" "" _sip._udp.sip2.example.com.`),
 		}
 
 		deleteRecords := []*endpoint.Endpoint{
-			endpoint.NewEndpoint("delete-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
-			endpoint.NewEndpoint("delete-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
-			endpoint.NewEndpoint("delete-test-aaaa.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1111"),
-			endpoint.NewEndpoint("delete-test-aaaa.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1001"),
-			endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "qux.elb.amazonaws.com"),
-			endpoint.NewEndpoint("delete-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "qux.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue),
-			endpoint.NewEndpoint("delete-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "qux.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue),
-			endpoint.NewEndpoint("delete-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4", "4.3.2.1"),
-			endpoint.NewEndpoint("delete-test-multiple-aaaa.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1111", "2606:4700:4700::1001"),
-			endpoint.NewEndpoint("delete-test-geoproximity.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("geoproximity-delete").WithProviderSpecific(providerSpecificGeoProximityLocationAWSRegion, "us-west-2").WithProviderSpecific(providerSpecificGeoProximityLocationBias, "10"),
-			endpoint.NewEndpoint("delete-test-mx.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeMX, "30 mailhost1.foo.elb.amazonaws.com"),
-			endpoint.NewEndpoint("delete-test-naptr.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeNAPTR, `10 "U" "SIP+DTU" "" _sip._udp.sip1.example.com.`),
+			endpoint.MustNewEndpoint("delete-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
+			endpoint.MustNewEndpoint("delete-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
+			endpoint.MustNewEndpoint("delete-test-aaaa.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1111"),
+			endpoint.MustNewEndpoint("delete-test-aaaa.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1001"),
+			endpoint.MustNewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "qux.elb.amazonaws.com"),
+			endpoint.MustNewEndpoint("delete-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "qux.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue),
+			endpoint.MustNewEndpoint("delete-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "qux.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue),
+			endpoint.MustNewEndpoint("delete-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4", "4.3.2.1"),
+			endpoint.MustNewEndpoint("delete-test-multiple-aaaa.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "2606:4700:4700::1111", "2606:4700:4700::1001"),
+			endpoint.MustNewEndpoint("delete-test-geoproximity.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4").WithSetIdentifier("geoproximity-delete").WithProviderSpecific(providerSpecificGeoProximityLocationAWSRegion, "us-west-2").WithProviderSpecific(providerSpecificGeoProximityLocationBias, "10"),
+			endpoint.MustNewEndpoint("delete-test-mx.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeMX, "30 mailhost1.foo.elb.amazonaws.com"),
+			endpoint.MustNewEndpoint("delete-test-naptr.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeNAPTR, `10 "U" "SIP+DTU" "" _sip._udp.sip1.example.com.`),
 		}
 
 		changes := &plan.Changes{
@@ -1429,40 +1429,40 @@ func TestAWSApplyChangesDryRun(t *testing.T) {
 	provider, _ := newAWSProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), defaultEvaluateTargetHealth, false, true, originalRecords)
 
 	createRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
-		endpoint.NewEndpoint("create-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
-		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.elb.amazonaws.com"),
-		endpoint.NewEndpoint("create-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.elb.amazonaws.com"),
-		endpoint.NewEndpoint("create-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8", "8.8.4.4"),
-		endpoint.NewEndpoint("create-test-mx.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeMX, "30 mail.foo.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("create-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
+		endpoint.MustNewEndpoint("create-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
+		endpoint.MustNewEndpoint("create-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("create-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("create-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8", "8.8.4.4"),
+		endpoint.MustNewEndpoint("create-test-mx.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeMX, "30 mail.foo.elb.amazonaws.com"),
 	}
 
 	currentRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
-		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
-		endpoint.NewEndpoint("update-test-a-to-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.1.1.1"),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "bar.elb.amazonaws.com"),
-		endpoint.NewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "bar.elb.amazonaws.com"),
-		endpoint.NewEndpoint("update-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8", "8.8.4.4"),
-		endpoint.NewEndpoint("update-test-mx.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeMX, "20 mail.foo.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
+		endpoint.MustNewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
+		endpoint.MustNewEndpoint("update-test-a-to-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.1.1.1"),
+		endpoint.MustNewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "bar.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "bar.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("update-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8", "8.8.4.4"),
+		endpoint.MustNewEndpoint("update-test-mx.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeMX, "20 mail.foo.elb.amazonaws.com"),
 	}
 	updatedRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
-		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "4.3.2.1"),
-		endpoint.NewEndpoint("update-test-a-to-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.elb.amazonaws.com"),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "baz.elb.amazonaws.com"),
-		endpoint.NewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "baz.elb.amazonaws.com"),
-		endpoint.NewEndpoint("update-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4", "4.3.2.1"),
-		endpoint.NewEndpoint("update-test-mx.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeMX, "10 mail.bar.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
+		endpoint.MustNewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "4.3.2.1"),
+		endpoint.MustNewEndpoint("update-test-a-to-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "baz.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "baz.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("update-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4", "4.3.2.1"),
+		endpoint.MustNewEndpoint("update-test-mx.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeMX, "10 mail.bar.elb.amazonaws.com"),
 	}
 
 	deleteRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("delete-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
-		endpoint.NewEndpoint("delete-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
-		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "qux.elb.amazonaws.com"),
-		endpoint.NewEndpoint("delete-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "qux.elb.amazonaws.com"),
-		endpoint.NewEndpoint("delete-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4", "4.3.2.1"),
-		endpoint.NewEndpoint("delete-test-mx.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeMX, "10 mail.bar.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("delete-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
+		endpoint.MustNewEndpoint("delete-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
+		endpoint.MustNewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "qux.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("delete-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "qux.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("delete-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4", "4.3.2.1"),
+		endpoint.MustNewEndpoint("delete-test-mx.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeMX, "10 mail.bar.elb.amazonaws.com"),
 	}
 
 	changes := &plan.Changes{
@@ -1709,7 +1709,7 @@ func TestAWSsubmitChanges(t *testing.T) {
 		for j := 1; j < (hosts + 1); j++ {
 			hostname := fmt.Sprintf("subnet%dhost%d.zone-1.ext-dns-test-2.teapot.zalan.do", i, j)
 			ip := fmt.Sprintf("1.1.%d.%d", i, j)
-			ep := endpoint.NewEndpointWithTTL(hostname, endpoint.RecordTypeA, endpoint.TTL(defaultTTL), ip)
+			ep := endpoint.MustNewEndpointWithTTL(hostname, endpoint.RecordTypeA, endpoint.TTL(defaultTTL), ip)
 			endpoints = append(endpoints, ep)
 		}
 	}
@@ -1736,7 +1736,7 @@ func TestAWSsubmitChangesError(t *testing.T) {
 	zones, err := provider.zones(ctx)
 	require.NoError(t, err)
 
-	ep := endpoint.NewEndpointWithTTL("fail.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.0.0.1")
+	ep := endpoint.MustNewEndpointWithTTL("fail.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.0.0.1")
 	cs := provider.newChanges(route53types.ChangeActionCreate, []*endpoint.Endpoint{ep})
 
 	require.Error(t, provider.submitChanges(ctx, cs, zones))
@@ -1749,11 +1749,11 @@ func TestAWSsubmitChangesRetryOnError(t *testing.T) {
 	zones, err := provider.zones(ctx)
 	require.NoError(t, err)
 
-	ep1 := endpoint.NewEndpointWithTTL("success.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.0.0.1")
-	ep2 := endpoint.NewEndpointWithTTL("fail.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.0.0.2")
-	ep3 := endpoint.NewEndpointWithTTL("success2.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.0.0.3")
+	ep1 := endpoint.MustNewEndpointWithTTL("success.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.0.0.1")
+	ep2 := endpoint.MustNewEndpointWithTTL("fail.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.0.0.2")
+	ep3 := endpoint.MustNewEndpointWithTTL("success2.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.0.0.3")
 
-	ep2txt := endpoint.NewEndpointWithTTL("fail__edns_housekeeping.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeTXT, endpoint.TTL(defaultTTL), "something") // "__edns_housekeeping" is the TXT suffix
+	ep2txt := endpoint.MustNewEndpointWithTTL("fail__edns_housekeeping.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeTXT, endpoint.TTL(defaultTTL), "something") // "__edns_housekeeping" is the TXT suffix
 	ep2txt.Labels = map[string]string{
 		endpoint.OwnedRecordLabelKey: "fail.zone-1.ext-dns-test-2.teapot.zalan.do",
 	}
@@ -2561,26 +2561,26 @@ func containsRecordWithDNSName(records []*endpoint.Endpoint, dnsName string) boo
 func TestRequiresDeleteCreate(t *testing.T) {
 	provider, _ := newAWSProvider(t, endpoint.NewDomainFilter([]string{"foo.bar."}), provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), defaultEvaluateTargetHealth, false, false, nil)
 
-	oldRecordType := endpoint.NewEndpointWithTTL("recordType", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "8.8.8.8")
-	newRecordType := endpoint.NewEndpointWithTTL("recordType", endpoint.RecordTypeCNAME, endpoint.TTL(defaultTTL), "bar").WithAliasProperty(endpoint.AliasFalse)
+	oldRecordType := endpoint.MustNewEndpointWithTTL("recordType", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "8.8.8.8")
+	newRecordType := endpoint.MustNewEndpointWithTTL("recordType", endpoint.RecordTypeCNAME, endpoint.TTL(defaultTTL), "bar").WithAliasProperty(endpoint.AliasFalse)
 
 	assert.False(t, provider.requiresDeleteCreate(oldRecordType, oldRecordType), "actual and expected endpoints don't match. %+v:%+v", oldRecordType, oldRecordType)
 	assert.True(t, provider.requiresDeleteCreate(oldRecordType, newRecordType), "actual and expected endpoints don't match. %+v:%+v", oldRecordType, newRecordType)
 
-	oldAtoAlias := endpoint.NewEndpointWithTTL("AtoAlias", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.1.1.1")
-	newAtoAlias := endpoint.NewEndpointWithTTL("AtoAlias", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "bar.us-east-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue)
+	oldAtoAlias := endpoint.MustNewEndpointWithTTL("AtoAlias", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "1.1.1.1")
+	newAtoAlias := endpoint.MustNewEndpointWithTTL("AtoAlias", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "bar.us-east-1.elb.amazonaws.com").WithAliasProperty(endpoint.AliasTrue)
 
 	assert.False(t, provider.requiresDeleteCreate(oldAtoAlias, oldAtoAlias), "actual and expected endpoints don't match. %+v:%+v", oldAtoAlias, oldAtoAlias.DNSName)
 	assert.True(t, provider.requiresDeleteCreate(oldAtoAlias, newAtoAlias), "actual and expected endpoints don't match. %+v:%+v", oldAtoAlias, newAtoAlias)
 
-	oldPolicy := endpoint.NewEndpointWithTTL("policy", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "8.8.8.8").WithSetIdentifier("nochange").WithProviderSpecific(providerSpecificRegion, "us-east-1")
-	newPolicy := endpoint.NewEndpointWithTTL("policy", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "8.8.8.8").WithSetIdentifier("nochange").WithProviderSpecific(providerSpecificWeight, "10")
+	oldPolicy := endpoint.MustNewEndpointWithTTL("policy", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "8.8.8.8").WithSetIdentifier("nochange").WithProviderSpecific(providerSpecificRegion, "us-east-1")
+	newPolicy := endpoint.MustNewEndpointWithTTL("policy", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "8.8.8.8").WithSetIdentifier("nochange").WithProviderSpecific(providerSpecificWeight, "10")
 
 	assert.False(t, provider.requiresDeleteCreate(oldPolicy, oldPolicy), "actual and expected endpoints don't match. %+v:%+v", oldPolicy, oldPolicy)
 	assert.True(t, provider.requiresDeleteCreate(oldPolicy, newPolicy), "actual and expected endpoints don't match. %+v:%+v", oldPolicy, newPolicy)
 
-	oldSetIdentifier := endpoint.NewEndpointWithTTL("setIdentifier", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "8.8.8.8").WithSetIdentifier("old")
-	newSetIdentifier := endpoint.NewEndpointWithTTL("setIdentifier", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "8.8.8.8").WithSetIdentifier("new")
+	oldSetIdentifier := endpoint.MustNewEndpointWithTTL("setIdentifier", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "8.8.8.8").WithSetIdentifier("old")
+	newSetIdentifier := endpoint.MustNewEndpointWithTTL("setIdentifier", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "8.8.8.8").WithSetIdentifier("new")
 
 	assert.False(t, provider.requiresDeleteCreate(oldSetIdentifier, oldSetIdentifier), "actual and expected endpoints don't match. %+v:%+v", oldSetIdentifier, oldSetIdentifier)
 	assert.True(t, provider.requiresDeleteCreate(oldSetIdentifier, newSetIdentifier), "actual and expected endpoints don't match. %+v:%+v", oldSetIdentifier, newSetIdentifier)
@@ -2958,13 +2958,13 @@ func TestAWSProvider_createUpdateChanges_NewMoreThanOld(t *testing.T) {
 	provider, _ := newAWSProvider(t, endpoint.NewDomainFilter([]string{"foo.bar."}), provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), true, false, false, nil)
 
 	oldEndpoints := []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("record1.foo.bar.", endpoint.RecordTypeA, endpoint.TTL(300), "1.1.1.1"),
+		endpoint.MustNewEndpointWithTTL("record1.foo.bar.", endpoint.RecordTypeA, endpoint.TTL(300), "1.1.1.1"),
 		nil,
 	}
 	newEndpoints := []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("record1.foo.bar.", endpoint.RecordTypeA, endpoint.TTL(300), "1.1.1.1"),
-		endpoint.NewEndpointWithTTL("record2.foo.bar.", endpoint.RecordTypeA, endpoint.TTL(300), "2.2.2.2"),
-		endpoint.NewEndpointWithTTL("record3.foo.bar.", endpoint.RecordTypeA, endpoint.TTL(300), "3.3.3.3"),
+		endpoint.MustNewEndpointWithTTL("record1.foo.bar.", endpoint.RecordTypeA, endpoint.TTL(300), "1.1.1.1"),
+		endpoint.MustNewEndpointWithTTL("record2.foo.bar.", endpoint.RecordTypeA, endpoint.TTL(300), "2.2.2.2"),
+		endpoint.MustNewEndpointWithTTL("record3.foo.bar.", endpoint.RecordTypeA, endpoint.TTL(300), "3.3.3.3"),
 	}
 
 	changes := provider.createUpdateChanges(newEndpoints, oldEndpoints)

--- a/provider/awssd/aws_sd_test.go
+++ b/provider/awssd/aws_sd_test.go
@@ -1052,7 +1052,7 @@ func TestAWSSDProvider_DeregisterInstance(t *testing.T) {
 
 	provider := newTestAWSSDProvider(api, endpoint.NewDomainFilter([]string{}), "", "")
 
-	_ = provider.DeregisterInstance(t.Context(), services["private"]["srv1"], endpoint.NewEndpoint("srv1.private.com.", endpoint.RecordTypeA, "1.2.3.4"))
+	_ = provider.DeregisterInstance(t.Context(), services["private"]["srv1"], endpoint.MustNewEndpoint("srv1.private.com.", endpoint.RecordTypeA, "1.2.3.4"))
 
 	assert.Empty(t, instances["srv1"])
 }

--- a/provider/azure/azure.go
+++ b/provider/azure/azure.go
@@ -169,7 +169,11 @@ func (p *AzureProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, erro
 				if recordSet.Properties.TTL != nil {
 					ttl = endpoint.TTL(*recordSet.Properties.TTL)
 				}
-				ep := endpoint.NewEndpointWithTTL(name, recordType, ttl, targets...)
+				ep, err := endpoint.NewEndpointWithTTL(name, recordType, ttl, targets...)
+				if err != nil {
+					log.Errorf("Failed to create endpoint for '%s' with type '%s': %v", name, recordType, err)
+					continue
+				}
 				extractMetadataFromRecordSet(ep, recordSet)
 				log.Debugf(
 					"Found %s record for '%s' with target '%s'.",

--- a/provider/azure/azure_private_dns.go
+++ b/provider/azure/azure_private_dns.go
@@ -168,7 +168,11 @@ func (p *AzurePrivateDNSProvider) Records(ctx context.Context) ([]*endpoint.Endp
 					ttl = endpoint.TTL(*recordSet.Properties.TTL)
 				}
 
-				ep := endpoint.NewEndpointWithTTL(name, recordType, ttl, targets...)
+				ep, err := endpoint.NewEndpointWithTTL(name, recordType, ttl, targets...)
+				if err != nil {
+					log.Warnf("Failed to create endpoint for '%s' with type '%s': %v", name, recordType, err)
+					continue
+				}
 				log.Debugf(
 					"Found %s record for '%s' with target '%s'.",
 					ep.RecordType,

--- a/provider/azure/azure_privatedns_test.go
+++ b/provider/azure/azure_privatedns_test.go
@@ -93,14 +93,15 @@ func (client *mockPrivateRecordSetsClient) NewListPager(_ string, _ string, _ *p
 }
 
 func (client *mockPrivateRecordSetsClient) Delete(_ context.Context, _ string, privateZoneName string, recordType privatedns.RecordType, relativeRecordSetName string, _ *privatedns.RecordSetsClientDeleteOptions) (privatedns.RecordSetsClientDeleteResponse, error) {
-	client.deletedEndpoints = append(
-		client.deletedEndpoints,
-		endpoint.NewEndpoint(
-			formatAzureDNSName(relativeRecordSetName, privateZoneName),
-			string(recordType),
-			"",
-		),
+	ep, err := endpoint.NewEndpoint(
+		formatAzureDNSName(relativeRecordSetName, privateZoneName),
+		string(recordType),
+		"",
 	)
+	if err != nil {
+		return privatedns.RecordSetsClientDeleteResponse{}, err
+	}
+	client.deletedEndpoints = append(client.deletedEndpoints, ep)
 	return privatedns.RecordSetsClientDeleteResponse{}, nil
 }
 
@@ -109,15 +110,16 @@ func (client *mockPrivateRecordSetsClient) CreateOrUpdate(_ context.Context, _ s
 	if parameters.Properties.TTL != nil {
 		ttl = endpoint.TTL(*parameters.Properties.TTL)
 	}
-	client.updatedEndpoints = append(
-		client.updatedEndpoints,
-		endpoint.NewEndpointWithTTL(
-			formatAzureDNSName(relativeRecordSetName, privateZoneName),
-			string(recordType),
-			ttl,
-			extractAzurePrivateDNSTargets(&parameters)...,
-		),
+	ep, err := endpoint.NewEndpointWithTTL(
+		formatAzureDNSName(relativeRecordSetName, privateZoneName),
+		string(recordType),
+		ttl,
+		extractAzurePrivateDNSTargets(&parameters)...,
 	)
+	if err != nil {
+		return privatedns.RecordSetsClientCreateOrUpdateResponse{}, err
+	}
+	client.updatedEndpoints = append(client.updatedEndpoints, ep)
 	return privatedns.RecordSetsClientCreateOrUpdateResponse{}, nil
 }
 
@@ -268,14 +270,14 @@ func TestAzurePrivateDNSRecord(t *testing.T) {
 		t.Fatal(err)
 	}
 	expected := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "123.123.123.122"),
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001::123:123:123:122"),
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeTXT, "heritage=external-dns,external-dns/owner=default"),
-		endpoint.NewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeA, 3600, "123.123.123.123"),
-		endpoint.NewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeAAAA, 3600, "2001::123:123:123:123"),
-		endpoint.NewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeTXT, recordTTL, "heritage=external-dns,external-dns/owner=default"),
-		endpoint.NewEndpointWithTTL("hack.example.com", endpoint.RecordTypeCNAME, 10, "hack.azurewebsites.net"),
-		endpoint.NewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, 4000, "10 example.com"),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeA, "123.123.123.122"),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001::123:123:123:122"),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeTXT, "heritage=external-dns,external-dns/owner=default"),
+		endpoint.MustNewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeA, 3600, "123.123.123.123"),
+		endpoint.MustNewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeAAAA, 3600, "2001::123:123:123:123"),
+		endpoint.MustNewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeTXT, recordTTL, "heritage=external-dns,external-dns/owner=default"),
+		endpoint.MustNewEndpointWithTTL("hack.example.com", endpoint.RecordTypeCNAME, 10, "hack.azurewebsites.net"),
+		endpoint.MustNewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, 4000, "10 example.com"),
 	}
 
 	validateAzureEndpoints(t, actual, expected)
@@ -304,14 +306,14 @@ func TestAzurePrivateDNSMultiRecord(t *testing.T) {
 		t.Fatal(err)
 	}
 	expected := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "123.123.123.122", "234.234.234.233"),
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001::123:123:123:122", "2001::234:234:234:233"),
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeTXT, "heritage=external-dns,external-dns/owner=default"),
-		endpoint.NewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeA, 3600, "123.123.123.123", "234.234.234.234"),
-		endpoint.NewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeAAAA, 3600, "2001::123:123:123:123", "2001::234:234:234:234"),
-		endpoint.NewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeTXT, recordTTL, "heritage=external-dns,external-dns/owner=default"),
-		endpoint.NewEndpointWithTTL("hack.example.com", endpoint.RecordTypeCNAME, 10, "hack.azurewebsites.net"),
-		endpoint.NewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, 4000, "10 example.com", "20 backup.example.com"),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeA, "123.123.123.122", "234.234.234.233"),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001::123:123:123:122", "2001::234:234:234:233"),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeTXT, "heritage=external-dns,external-dns/owner=default"),
+		endpoint.MustNewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeA, 3600, "123.123.123.123", "234.234.234.234"),
+		endpoint.MustNewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeAAAA, 3600, "2001::123:123:123:123", "2001::234:234:234:234"),
+		endpoint.MustNewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeTXT, recordTTL, "heritage=external-dns,external-dns/owner=default"),
+		endpoint.MustNewEndpointWithTTL("hack.example.com", endpoint.RecordTypeCNAME, 10, "hack.azurewebsites.net"),
+		endpoint.MustNewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, 4000, "10 example.com", "20 backup.example.com"),
 	}
 
 	validateAzureEndpoints(t, actual, expected)
@@ -323,29 +325,29 @@ func TestAzurePrivateDNSApplyChanges(t *testing.T) {
 	testAzurePrivateDNSApplyChangesInternal(t, false, &recordsClient)
 
 	validateAzureEndpoints(t, recordsClient.deletedEndpoints, []*endpoint.Endpoint{
-		endpoint.NewEndpoint("deleted.example.com", endpoint.RecordTypeA, ""),
-		endpoint.NewEndpoint("deletedaaaa.example.com", endpoint.RecordTypeAAAA, ""),
-		endpoint.NewEndpoint("deletedcname.example.com", endpoint.RecordTypeCNAME, ""),
+		endpoint.MustNewEndpoint("deleted.example.com", endpoint.RecordTypeA, ""),
+		endpoint.MustNewEndpoint("deletedaaaa.example.com", endpoint.RecordTypeAAAA, ""),
+		endpoint.MustNewEndpoint("deletedcname.example.com", endpoint.RecordTypeCNAME, ""),
 	})
 
 	validateAzureEndpoints(t, recordsClient.updatedEndpoints, []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4"),
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "2001::1:2:3:4"),
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
-		endpoint.NewEndpointWithTTL("foo.example.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4", "1.2.3.5"),
-		endpoint.NewEndpointWithTTL("foo.example.com", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "2001::1:2:3:4", "2001::1:2:3:5"),
-		endpoint.NewEndpointWithTTL("foo.example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
-		endpoint.NewEndpointWithTTL("bar.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL), "other.com"),
-		endpoint.NewEndpointWithTTL("bar.example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
-		endpoint.NewEndpointWithTTL("other.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "5.6.7.8"),
-		endpoint.NewEndpointWithTTL("other.com", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "2001::5:6:7:8"),
-		endpoint.NewEndpointWithTTL("other.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
-		endpoint.NewEndpointWithTTL("new.example.com", endpoint.RecordTypeA, 3600, "111.222.111.222"),
-		endpoint.NewEndpointWithTTL("new.example.com", endpoint.RecordTypeAAAA, 3600, "2001::111:222:111:222"),
-		endpoint.NewEndpointWithTTL("newcname.example.com", endpoint.RecordTypeCNAME, 10, "other.com"),
-		endpoint.NewEndpointWithTTL("newmail.example.com", endpoint.RecordTypeMX, 7200, "40 bar.other.com"),
-		endpoint.NewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, endpoint.TTL(recordTTL), "10 other.com"),
-		endpoint.NewEndpointWithTTL("mail.example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4"),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "2001::1:2:3:4"),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
+		endpoint.MustNewEndpointWithTTL("foo.example.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4", "1.2.3.5"),
+		endpoint.MustNewEndpointWithTTL("foo.example.com", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "2001::1:2:3:4", "2001::1:2:3:5"),
+		endpoint.MustNewEndpointWithTTL("foo.example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
+		endpoint.MustNewEndpointWithTTL("bar.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL), "other.com"),
+		endpoint.MustNewEndpointWithTTL("bar.example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
+		endpoint.MustNewEndpointWithTTL("other.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "5.6.7.8"),
+		endpoint.MustNewEndpointWithTTL("other.com", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "2001::5:6:7:8"),
+		endpoint.MustNewEndpointWithTTL("other.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
+		endpoint.MustNewEndpointWithTTL("new.example.com", endpoint.RecordTypeA, 3600, "111.222.111.222"),
+		endpoint.MustNewEndpointWithTTL("new.example.com", endpoint.RecordTypeAAAA, 3600, "2001::111:222:111:222"),
+		endpoint.MustNewEndpointWithTTL("newcname.example.com", endpoint.RecordTypeCNAME, 10, "other.com"),
+		endpoint.MustNewEndpointWithTTL("newmail.example.com", endpoint.RecordTypeMX, 7200, "40 bar.other.com"),
+		endpoint.MustNewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, endpoint.TTL(recordTTL), "10 other.com"),
+		endpoint.MustNewEndpointWithTTL("mail.example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
 	})
 }
 
@@ -378,45 +380,45 @@ func testAzurePrivateDNSApplyChangesInternal(t *testing.T, dryRun bool, client P
 	)
 
 	createRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4"),
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001::1:2:3:4"),
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeTXT, "tag"),
-		endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.5", "1.2.3.4"),
-		endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeAAAA, "2001::1:2:3:5", "2001::1:2:3:4"),
-		endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeTXT, "tag"),
-		endpoint.NewEndpoint("bar.example.com", endpoint.RecordTypeCNAME, "other.com"),
-		endpoint.NewEndpoint("bar.example.com", endpoint.RecordTypeTXT, "tag"),
-		endpoint.NewEndpoint("other.com", endpoint.RecordTypeA, "5.6.7.8"),
-		endpoint.NewEndpoint("other.com", endpoint.RecordTypeAAAA, "2001::5:6:7:8"),
-		endpoint.NewEndpoint("other.com", endpoint.RecordTypeTXT, "tag"),
-		endpoint.NewEndpoint("nope.com", endpoint.RecordTypeA, "4.4.4.4"),
-		endpoint.NewEndpoint("nope.com", endpoint.RecordTypeAAAA, "2001::4:4:4:4"),
-		endpoint.NewEndpoint("nope.com", endpoint.RecordTypeTXT, "tag"),
-		endpoint.NewEndpoint("mail.example.com", endpoint.RecordTypeMX, "10 other.com"),
-		endpoint.NewEndpoint("mail.example.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4"),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001::1:2:3:4"),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.5", "1.2.3.4"),
+		endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeAAAA, "2001::1:2:3:5", "2001::1:2:3:4"),
+		endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.MustNewEndpoint("bar.example.com", endpoint.RecordTypeCNAME, "other.com"),
+		endpoint.MustNewEndpoint("bar.example.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.MustNewEndpoint("other.com", endpoint.RecordTypeA, "5.6.7.8"),
+		endpoint.MustNewEndpoint("other.com", endpoint.RecordTypeAAAA, "2001::5:6:7:8"),
+		endpoint.MustNewEndpoint("other.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.MustNewEndpoint("nope.com", endpoint.RecordTypeA, "4.4.4.4"),
+		endpoint.MustNewEndpoint("nope.com", endpoint.RecordTypeAAAA, "2001::4:4:4:4"),
+		endpoint.MustNewEndpoint("nope.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.MustNewEndpoint("mail.example.com", endpoint.RecordTypeMX, "10 other.com"),
+		endpoint.MustNewEndpoint("mail.example.com", endpoint.RecordTypeTXT, "tag"),
 	}
 
 	currentRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("old.example.com", endpoint.RecordTypeA, "121.212.121.212"),
-		endpoint.NewEndpoint("oldcname.example.com", endpoint.RecordTypeCNAME, "other.com"),
-		endpoint.NewEndpoint("old.nope.com", endpoint.RecordTypeA, "121.212.121.212"),
-		endpoint.NewEndpoint("oldmail.example.com", endpoint.RecordTypeMX, "20 foo.other.com"),
+		endpoint.MustNewEndpoint("old.example.com", endpoint.RecordTypeA, "121.212.121.212"),
+		endpoint.MustNewEndpoint("oldcname.example.com", endpoint.RecordTypeCNAME, "other.com"),
+		endpoint.MustNewEndpoint("old.nope.com", endpoint.RecordTypeA, "121.212.121.212"),
+		endpoint.MustNewEndpoint("oldmail.example.com", endpoint.RecordTypeMX, "20 foo.other.com"),
 	}
 	updatedRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("new.example.com", endpoint.RecordTypeA, 3600, "111.222.111.222"),
-		endpoint.NewEndpointWithTTL("new.example.com", endpoint.RecordTypeAAAA, 3600, "2001::111:222:111:222"),
-		endpoint.NewEndpointWithTTL("newcname.example.com", endpoint.RecordTypeCNAME, 10, "other.com"),
-		endpoint.NewEndpoint("new.nope.com", endpoint.RecordTypeA, "222.111.222.111"),
-		endpoint.NewEndpoint("new.nope.com", endpoint.RecordTypeAAAA, "2001::222:111:222:111"),
-		endpoint.NewEndpointWithTTL("newmail.example.com", endpoint.RecordTypeMX, 7200, "40 bar.other.com"),
+		endpoint.MustNewEndpointWithTTL("new.example.com", endpoint.RecordTypeA, 3600, "111.222.111.222"),
+		endpoint.MustNewEndpointWithTTL("new.example.com", endpoint.RecordTypeAAAA, 3600, "2001::111:222:111:222"),
+		endpoint.MustNewEndpointWithTTL("newcname.example.com", endpoint.RecordTypeCNAME, 10, "other.com"),
+		endpoint.MustNewEndpoint("new.nope.com", endpoint.RecordTypeA, "222.111.222.111"),
+		endpoint.MustNewEndpoint("new.nope.com", endpoint.RecordTypeAAAA, "2001::222:111:222:111"),
+		endpoint.MustNewEndpointWithTTL("newmail.example.com", endpoint.RecordTypeMX, 7200, "40 bar.other.com"),
 	}
 
 	deleteRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("deleted.example.com", endpoint.RecordTypeA, "111.222.111.222"),
-		endpoint.NewEndpoint("deletedaaaa.example.com", endpoint.RecordTypeAAAA, "2001::111:222:111:222"),
-		endpoint.NewEndpoint("deletedcname.example.com", endpoint.RecordTypeCNAME, "other.com"),
-		endpoint.NewEndpoint("deleted.nope.com", endpoint.RecordTypeA, "222.111.222.111"),
-		endpoint.NewEndpoint("deleted.nope.com", endpoint.RecordTypeAAAA, "2001::222:111:222:111"),
+		endpoint.MustNewEndpoint("deleted.example.com", endpoint.RecordTypeA, "111.222.111.222"),
+		endpoint.MustNewEndpoint("deletedaaaa.example.com", endpoint.RecordTypeAAAA, "2001::111:222:111:222"),
+		endpoint.MustNewEndpoint("deletedcname.example.com", endpoint.RecordTypeCNAME, "other.com"),
+		endpoint.MustNewEndpoint("deleted.nope.com", endpoint.RecordTypeA, "222.111.222.111"),
+		endpoint.MustNewEndpoint("deleted.nope.com", endpoint.RecordTypeAAAA, "2001::222:111:222:111"),
 	}
 
 	changes := &plan.Changes{
@@ -455,10 +457,10 @@ func TestAzurePrivateDNSNameFilter(t *testing.T) {
 		t.Fatal(err)
 	}
 	expected := []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("test.nginx.example.com", endpoint.RecordTypeA, 3600, "123.123.123.123"),
-		endpoint.NewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeA, 3600, "123.123.123.123"),
-		endpoint.NewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeTXT, recordTTL, "heritage=external-dns,external-dns/owner=default"),
-		endpoint.NewEndpointWithTTL("mail.nginx.example.com", endpoint.RecordTypeMX, recordTTL, "20 example.com"),
+		endpoint.MustNewEndpointWithTTL("test.nginx.example.com", endpoint.RecordTypeA, 3600, "123.123.123.123"),
+		endpoint.MustNewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeA, 3600, "123.123.123.123"),
+		endpoint.MustNewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeTXT, recordTTL, "heritage=external-dns,external-dns/owner=default"),
+		endpoint.MustNewEndpointWithTTL("mail.nginx.example.com", endpoint.RecordTypeMX, recordTTL, "20 example.com"),
 	}
 
 	validateAzureEndpoints(t, actual, expected)
@@ -470,18 +472,18 @@ func TestAzurePrivateDNSApplyChangesZoneName(t *testing.T) {
 	testAzurePrivateDNSApplyChangesInternalZoneName(t, false, &recordsClient)
 
 	validateAzureEndpoints(t, recordsClient.deletedEndpoints, []*endpoint.Endpoint{
-		endpoint.NewEndpoint("deleted.foo.example.com", endpoint.RecordTypeA, ""),
-		endpoint.NewEndpoint("deletedaaaa.foo.example.com", endpoint.RecordTypeAAAA, ""),
-		endpoint.NewEndpoint("deletedcname.foo.example.com", endpoint.RecordTypeCNAME, ""),
+		endpoint.MustNewEndpoint("deleted.foo.example.com", endpoint.RecordTypeA, ""),
+		endpoint.MustNewEndpoint("deletedaaaa.foo.example.com", endpoint.RecordTypeAAAA, ""),
+		endpoint.MustNewEndpoint("deletedcname.foo.example.com", endpoint.RecordTypeCNAME, ""),
 	})
 
 	validateAzureEndpoints(t, recordsClient.updatedEndpoints, []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("foo.example.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4", "1.2.3.5"),
-		endpoint.NewEndpointWithTTL("foo.example.com", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "2001::1:2:3:4", "2001::1:2:3:5"),
-		endpoint.NewEndpointWithTTL("foo.example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
-		endpoint.NewEndpointWithTTL("new.foo.example.com", endpoint.RecordTypeA, 3600, "111.222.111.222"),
-		endpoint.NewEndpointWithTTL("new.foo.example.com", endpoint.RecordTypeAAAA, 3600, "2001::111:222:111:222"),
-		endpoint.NewEndpointWithTTL("newcname.foo.example.com", endpoint.RecordTypeCNAME, 10, "other.com"),
+		endpoint.MustNewEndpointWithTTL("foo.example.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4", "1.2.3.5"),
+		endpoint.MustNewEndpointWithTTL("foo.example.com", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "2001::1:2:3:4", "2001::1:2:3:5"),
+		endpoint.MustNewEndpointWithTTL("foo.example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
+		endpoint.MustNewEndpointWithTTL("new.foo.example.com", endpoint.RecordTypeA, 3600, "111.222.111.222"),
+		endpoint.MustNewEndpointWithTTL("new.foo.example.com", endpoint.RecordTypeAAAA, 3600, "2001::111:222:111:222"),
+		endpoint.MustNewEndpointWithTTL("newcname.foo.example.com", endpoint.RecordTypeCNAME, 10, "other.com"),
 	})
 }
 
@@ -503,38 +505,38 @@ func testAzurePrivateDNSApplyChangesInternalZoneName(t *testing.T, dryRun bool, 
 	)
 
 	createRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4"),
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001::1:2:3:4"),
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeTXT, "tag"),
-		endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.5", "1.2.3.4"),
-		endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeAAAA, "2001::1:2:3:5", "2001::1:2:3:4"),
-		endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeTXT, "tag"),
-		endpoint.NewEndpoint("bar.example.com", endpoint.RecordTypeCNAME, "other.com"),
-		endpoint.NewEndpoint("bar.example.com", endpoint.RecordTypeTXT, "tag"),
-		endpoint.NewEndpoint("other.com", endpoint.RecordTypeA, "5.6.7.8"),
-		endpoint.NewEndpoint("other.com", endpoint.RecordTypeTXT, "tag"),
-		endpoint.NewEndpoint("nope.com", endpoint.RecordTypeA, "4.4.4.4"),
-		endpoint.NewEndpoint("nope.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4"),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001::1:2:3:4"),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.5", "1.2.3.4"),
+		endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeAAAA, "2001::1:2:3:5", "2001::1:2:3:4"),
+		endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.MustNewEndpoint("bar.example.com", endpoint.RecordTypeCNAME, "other.com"),
+		endpoint.MustNewEndpoint("bar.example.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.MustNewEndpoint("other.com", endpoint.RecordTypeA, "5.6.7.8"),
+		endpoint.MustNewEndpoint("other.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.MustNewEndpoint("nope.com", endpoint.RecordTypeA, "4.4.4.4"),
+		endpoint.MustNewEndpoint("nope.com", endpoint.RecordTypeTXT, "tag"),
 	}
 
 	currentRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("old.foo.example.com", endpoint.RecordTypeA, "121.212.121.212"),
-		endpoint.NewEndpoint("oldcname.foo.example.com", endpoint.RecordTypeCNAME, "other.com"),
-		endpoint.NewEndpoint("old.nope.example.com", endpoint.RecordTypeA, "121.212.121.212"),
+		endpoint.MustNewEndpoint("old.foo.example.com", endpoint.RecordTypeA, "121.212.121.212"),
+		endpoint.MustNewEndpoint("oldcname.foo.example.com", endpoint.RecordTypeCNAME, "other.com"),
+		endpoint.MustNewEndpoint("old.nope.example.com", endpoint.RecordTypeA, "121.212.121.212"),
 	}
 	updatedRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("new.foo.example.com", endpoint.RecordTypeA, 3600, "111.222.111.222"),
-		endpoint.NewEndpointWithTTL("new.foo.example.com", endpoint.RecordTypeAAAA, 3600, "2001::111:222:111:222"),
-		endpoint.NewEndpointWithTTL("newcname.foo.example.com", endpoint.RecordTypeCNAME, 10, "other.com"),
-		endpoint.NewEndpoint("new.nope.example.com", endpoint.RecordTypeA, "222.111.222.111"),
-		endpoint.NewEndpoint("new.nope.example.com", endpoint.RecordTypeAAAA, "2001::222:111:222:111"),
+		endpoint.MustNewEndpointWithTTL("new.foo.example.com", endpoint.RecordTypeA, 3600, "111.222.111.222"),
+		endpoint.MustNewEndpointWithTTL("new.foo.example.com", endpoint.RecordTypeAAAA, 3600, "2001::111:222:111:222"),
+		endpoint.MustNewEndpointWithTTL("newcname.foo.example.com", endpoint.RecordTypeCNAME, 10, "other.com"),
+		endpoint.MustNewEndpoint("new.nope.example.com", endpoint.RecordTypeA, "222.111.222.111"),
+		endpoint.MustNewEndpoint("new.nope.example.com", endpoint.RecordTypeAAAA, "2001::222:111:222:111"),
 	}
 
 	deleteRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("deleted.foo.example.com", endpoint.RecordTypeA, "111.222.111.222"),
-		endpoint.NewEndpoint("deletedaaaa.foo.example.com", endpoint.RecordTypeAAAA, "2001::111:222:111:222"),
-		endpoint.NewEndpoint("deletedcname.foo.example.com", endpoint.RecordTypeCNAME, "other.com"),
-		endpoint.NewEndpoint("deleted.nope.example.com", endpoint.RecordTypeA, "222.111.222.111"),
+		endpoint.MustNewEndpoint("deleted.foo.example.com", endpoint.RecordTypeA, "111.222.111.222"),
+		endpoint.MustNewEndpoint("deletedaaaa.foo.example.com", endpoint.RecordTypeAAAA, "2001::111:222:111:222"),
+		endpoint.MustNewEndpoint("deletedcname.foo.example.com", endpoint.RecordTypeCNAME, "other.com"),
+		endpoint.MustNewEndpoint("deleted.nope.example.com", endpoint.RecordTypeA, "222.111.222.111"),
 	}
 
 	changes := &plan.Changes{

--- a/provider/azure/azure_test.go
+++ b/provider/azure/azure_test.go
@@ -91,14 +91,15 @@ func (client *mockRecordSetsClient) NewListAllByDNSZonePager(_ string, _ string,
 }
 
 func (client *mockRecordSetsClient) Delete(_ context.Context, _ string, zoneName string, relativeRecordSetName string, recordType dns.RecordType, _ *dns.RecordSetsClientDeleteOptions) (dns.RecordSetsClientDeleteResponse, error) {
-	client.deletedEndpoints = append(
-		client.deletedEndpoints,
-		endpoint.NewEndpoint(
-			formatAzureDNSName(relativeRecordSetName, zoneName),
-			string(recordType),
-			"",
-		),
+	ep, err := endpoint.NewEndpoint(
+		formatAzureDNSName(relativeRecordSetName, zoneName),
+		string(recordType),
+		"",
 	)
+	if err != nil {
+		return dns.RecordSetsClientDeleteResponse{}, err
+	}
+	client.deletedEndpoints = append(client.deletedEndpoints, ep)
 	return dns.RecordSetsClientDeleteResponse{}, nil
 }
 
@@ -107,15 +108,16 @@ func (client *mockRecordSetsClient) CreateOrUpdate(_ context.Context, _ string, 
 	if parameters.Properties.TTL != nil {
 		ttl = endpoint.TTL(*parameters.Properties.TTL)
 	}
-	client.updatedEndpoints = append(
-		client.updatedEndpoints,
-		endpoint.NewEndpointWithTTL(
-			formatAzureDNSName(relativeRecordSetName, zoneName),
-			string(recordType),
-			ttl,
-			extractAzureTargets(&parameters)...,
-		),
+	ep, err := endpoint.NewEndpointWithTTL(
+		formatAzureDNSName(relativeRecordSetName, zoneName),
+		string(recordType),
+		ttl,
+		extractAzureTargets(&parameters)...,
 	)
+	if err != nil {
+		return dns.RecordSetsClientCreateOrUpdateResponse{}, err
+	}
+	client.updatedEndpoints = append(client.updatedEndpoints, ep)
 	return dns.RecordSetsClientCreateOrUpdateResponse{}, nil
 }
 
@@ -290,17 +292,17 @@ func TestAzureRecord(t *testing.T) {
 		t.Fatal(err)
 	}
 	expected := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeNS, "ns1-03.azure-dns.com."),
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "123.123.123.122"),
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001::123:123:123:122"),
-		endpoint.NewEndpoint("cloud.example.com", endpoint.RecordTypeNS, "ns1.example.com."),
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeTXT, "heritage=external-dns,external-dns/owner=default"),
-		endpoint.NewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeA, 3600, "123.123.123.123"),
-		endpoint.NewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeAAAA, 3600, "2001::123:123:123:123"),
-		endpoint.NewEndpointWithTTL("cloud-ttl.example.com", endpoint.RecordTypeNS, 10, "ns1-ttl.example.com."),
-		endpoint.NewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeTXT, recordTTL, "heritage=external-dns,external-dns/owner=default"),
-		endpoint.NewEndpointWithTTL("hack.example.com", endpoint.RecordTypeCNAME, 10, "hack.azurewebsites.net"),
-		endpoint.NewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, 4000, "10 example.com"),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeNS, "ns1-03.azure-dns.com."),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeA, "123.123.123.122"),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001::123:123:123:122"),
+		endpoint.MustNewEndpoint("cloud.example.com", endpoint.RecordTypeNS, "ns1.example.com."),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeTXT, "heritage=external-dns,external-dns/owner=default"),
+		endpoint.MustNewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeA, 3600, "123.123.123.123"),
+		endpoint.MustNewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeAAAA, 3600, "2001::123:123:123:123"),
+		endpoint.MustNewEndpointWithTTL("cloud-ttl.example.com", endpoint.RecordTypeNS, 10, "ns1-ttl.example.com."),
+		endpoint.MustNewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeTXT, recordTTL, "heritage=external-dns,external-dns/owner=default"),
+		endpoint.MustNewEndpointWithTTL("hack.example.com", endpoint.RecordTypeCNAME, 10, "hack.azurewebsites.net"),
+		endpoint.MustNewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, 4000, "10 example.com"),
 	}
 
 	validateAzureEndpoints(t, actual, expected)
@@ -332,17 +334,17 @@ func TestAzureMultiRecord(t *testing.T) {
 		t.Fatal(err)
 	}
 	expected := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeNS, "ns1-03.azure-dns.com."),
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "123.123.123.122", "234.234.234.233"),
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001::123:123:123:122", "2001::234:234:234:233"),
-		endpoint.NewEndpoint("cloud.example.com", endpoint.RecordTypeNS, "ns1.example.com.", "ns2.example.com."),
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeTXT, "heritage=external-dns,external-dns/owner=default"),
-		endpoint.NewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeA, 3600, "123.123.123.123", "234.234.234.234"),
-		endpoint.NewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeAAAA, 3600, "2001::123:123:123:123", "2001::234:234:234:234"),
-		endpoint.NewEndpointWithTTL("cloud-ttl.example.com", endpoint.RecordTypeNS, 10, "ns1-ttl.example.com.", "ns2-ttl.example.com."),
-		endpoint.NewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeTXT, recordTTL, "heritage=external-dns,external-dns/owner=default"),
-		endpoint.NewEndpointWithTTL("hack.example.com", endpoint.RecordTypeCNAME, 10, "hack.azurewebsites.net"),
-		endpoint.NewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, 4000, "10 example.com", "20 backup.example.com"),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeNS, "ns1-03.azure-dns.com."),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeA, "123.123.123.122", "234.234.234.233"),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001::123:123:123:122", "2001::234:234:234:233"),
+		endpoint.MustNewEndpoint("cloud.example.com", endpoint.RecordTypeNS, "ns1.example.com.", "ns2.example.com."),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeTXT, "heritage=external-dns,external-dns/owner=default"),
+		endpoint.MustNewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeA, 3600, "123.123.123.123", "234.234.234.234"),
+		endpoint.MustNewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeAAAA, 3600, "2001::123:123:123:123", "2001::234:234:234:234"),
+		endpoint.MustNewEndpointWithTTL("cloud-ttl.example.com", endpoint.RecordTypeNS, 10, "ns1-ttl.example.com.", "ns2-ttl.example.com."),
+		endpoint.MustNewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeTXT, recordTTL, "heritage=external-dns,external-dns/owner=default"),
+		endpoint.MustNewEndpointWithTTL("hack.example.com", endpoint.RecordTypeCNAME, 10, "hack.azurewebsites.net"),
+		endpoint.MustNewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, 4000, "10 example.com", "20 backup.example.com"),
 	}
 
 	validateAzureEndpoints(t, actual, expected)
@@ -354,34 +356,34 @@ func TestAzureApplyChanges(t *testing.T) {
 	testAzureApplyChangesInternal(t, false, &recordsClient)
 
 	validateAzureEndpoints(t, recordsClient.deletedEndpoints, []*endpoint.Endpoint{
-		endpoint.NewEndpoint("deleted.example.com", endpoint.RecordTypeA, ""),
-		endpoint.NewEndpoint("deletedaaaa.example.com", endpoint.RecordTypeAAAA, ""),
-		endpoint.NewEndpoint("deletedcname.example.com", endpoint.RecordTypeCNAME, ""),
-		endpoint.NewEndpoint("deletedns.example.com", endpoint.RecordTypeNS, ""),
+		endpoint.MustNewEndpoint("deleted.example.com", endpoint.RecordTypeA, ""),
+		endpoint.MustNewEndpoint("deletedaaaa.example.com", endpoint.RecordTypeAAAA, ""),
+		endpoint.MustNewEndpoint("deletedcname.example.com", endpoint.RecordTypeCNAME, ""),
+		endpoint.MustNewEndpoint("deletedns.example.com", endpoint.RecordTypeNS, ""),
 	})
 
 	validateAzureEndpoints(t, recordsClient.updatedEndpoints, []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4"),
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "2001::1:2:3:4"),
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
-		endpoint.NewEndpointWithTTL("foo.example.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4", "1.2.3.5"),
-		endpoint.NewEndpointWithTTL("foo.example.com", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "2001::1:2:3:4", "2001::1:2:3:5"),
-		endpoint.NewEndpointWithTTL("cloud.example.com", endpoint.RecordTypeNS, endpoint.TTL(recordTTL), "ns1.example.com."),
-		endpoint.NewEndpointWithTTL("foo.example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
-		endpoint.NewEndpointWithTTL("bar.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL), "other.com"),
-		endpoint.NewEndpointWithTTL("bar.example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
-		endpoint.NewEndpointWithTTL("other.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "5.6.7.8"),
-		endpoint.NewEndpointWithTTL("other.com", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "2001::5:6:7:8"),
-		endpoint.NewEndpointWithTTL("cloud.other.com", endpoint.RecordTypeNS, endpoint.TTL(recordTTL), "ns2.other.com."),
-		endpoint.NewEndpointWithTTL("other.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
-		endpoint.NewEndpointWithTTL("new.example.com", endpoint.RecordTypeA, 3600, "111.222.111.222"),
-		endpoint.NewEndpointWithTTL("new.example.com", endpoint.RecordTypeAAAA, 3600, "2001::111:222:111:222"),
-		endpoint.NewEndpointWithTTL("newcname.example.com", endpoint.RecordTypeCNAME, 10, "other.com"),
-		endpoint.NewEndpointWithTTL("newns.example.com", endpoint.RecordTypeNS, 10, "ns1.example.com."),
-		endpoint.NewEndpointWithTTL("newmail.example.com", endpoint.RecordTypeMX, 7200, "40 bar.other.com"),
-		endpoint.NewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, endpoint.TTL(recordTTL), "10 other.com"),
-		endpoint.NewEndpointWithTTL("mail.example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
-		endpoint.NewEndpointWithTTL("metadata.example.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4"),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4"),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "2001::1:2:3:4"),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
+		endpoint.MustNewEndpointWithTTL("foo.example.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4", "1.2.3.5"),
+		endpoint.MustNewEndpointWithTTL("foo.example.com", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "2001::1:2:3:4", "2001::1:2:3:5"),
+		endpoint.MustNewEndpointWithTTL("cloud.example.com", endpoint.RecordTypeNS, endpoint.TTL(recordTTL), "ns1.example.com."),
+		endpoint.MustNewEndpointWithTTL("foo.example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
+		endpoint.MustNewEndpointWithTTL("bar.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL), "other.com"),
+		endpoint.MustNewEndpointWithTTL("bar.example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
+		endpoint.MustNewEndpointWithTTL("other.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "5.6.7.8"),
+		endpoint.MustNewEndpointWithTTL("other.com", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "2001::5:6:7:8"),
+		endpoint.MustNewEndpointWithTTL("cloud.other.com", endpoint.RecordTypeNS, endpoint.TTL(recordTTL), "ns2.other.com."),
+		endpoint.MustNewEndpointWithTTL("other.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
+		endpoint.MustNewEndpointWithTTL("new.example.com", endpoint.RecordTypeA, 3600, "111.222.111.222"),
+		endpoint.MustNewEndpointWithTTL("new.example.com", endpoint.RecordTypeAAAA, 3600, "2001::111:222:111:222"),
+		endpoint.MustNewEndpointWithTTL("newcname.example.com", endpoint.RecordTypeCNAME, 10, "other.com"),
+		endpoint.MustNewEndpointWithTTL("newns.example.com", endpoint.RecordTypeNS, 10, "ns1.example.com."),
+		endpoint.MustNewEndpointWithTTL("newmail.example.com", endpoint.RecordTypeMX, 7200, "40 bar.other.com"),
+		endpoint.MustNewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, endpoint.TTL(recordTTL), "10 other.com"),
+		endpoint.MustNewEndpointWithTTL("mail.example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
+		endpoint.MustNewEndpointWithTTL("metadata.example.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4"),
 	})
 }
 
@@ -416,56 +418,56 @@ func testAzureApplyChangesInternal(t *testing.T, dryRun bool, client RecordSetsC
 	)
 
 	createRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4"),
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001::1:2:3:4"),
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeTXT, "tag"),
-		endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.5", "1.2.3.4"),
-		endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeAAAA, "2001::1:2:3:5", "2001::1:2:3:4"),
-		endpoint.NewEndpoint("cloud.example.com", endpoint.RecordTypeNS, "ns1.example.com."),
-		endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeTXT, "tag"),
-		endpoint.NewEndpoint("bar.example.com", endpoint.RecordTypeCNAME, "other.com"),
-		endpoint.NewEndpoint("bar.example.com", endpoint.RecordTypeTXT, "tag"),
-		endpoint.NewEndpoint("other.com", endpoint.RecordTypeA, "5.6.7.8"),
-		endpoint.NewEndpoint("other.com", endpoint.RecordTypeAAAA, "2001::5:6:7:8"),
-		endpoint.NewEndpoint("other.com", endpoint.RecordTypeTXT, "tag"),
-		endpoint.NewEndpoint("cloud.other.com", endpoint.RecordTypeNS, "ns2.other.com."),
-		endpoint.NewEndpoint("nope.com", endpoint.RecordTypeA, "4.4.4.4"),
-		endpoint.NewEndpoint("nope.com", endpoint.RecordTypeAAAA, "2001::4:4:4:4"),
-		endpoint.NewEndpoint("cloud.nope.com", endpoint.RecordTypeNS, "ns1.nope.com."),
-		endpoint.NewEndpoint("nope.com", endpoint.RecordTypeTXT, "tag"),
-		endpoint.NewEndpoint("mail.example.com", endpoint.RecordTypeMX, "10 other.com"),
-		endpoint.NewEndpoint("mail.example.com", endpoint.RecordTypeTXT, "tag"),
-		endpoint.NewEndpointWithTTL("metadata.example.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4").
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4"),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001::1:2:3:4"),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.5", "1.2.3.4"),
+		endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeAAAA, "2001::1:2:3:5", "2001::1:2:3:4"),
+		endpoint.MustNewEndpoint("cloud.example.com", endpoint.RecordTypeNS, "ns1.example.com."),
+		endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.MustNewEndpoint("bar.example.com", endpoint.RecordTypeCNAME, "other.com"),
+		endpoint.MustNewEndpoint("bar.example.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.MustNewEndpoint("other.com", endpoint.RecordTypeA, "5.6.7.8"),
+		endpoint.MustNewEndpoint("other.com", endpoint.RecordTypeAAAA, "2001::5:6:7:8"),
+		endpoint.MustNewEndpoint("other.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.MustNewEndpoint("cloud.other.com", endpoint.RecordTypeNS, "ns2.other.com."),
+		endpoint.MustNewEndpoint("nope.com", endpoint.RecordTypeA, "4.4.4.4"),
+		endpoint.MustNewEndpoint("nope.com", endpoint.RecordTypeAAAA, "2001::4:4:4:4"),
+		endpoint.MustNewEndpoint("cloud.nope.com", endpoint.RecordTypeNS, "ns1.nope.com."),
+		endpoint.MustNewEndpoint("nope.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.MustNewEndpoint("mail.example.com", endpoint.RecordTypeMX, "10 other.com"),
+		endpoint.MustNewEndpoint("mail.example.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.MustNewEndpointWithTTL("metadata.example.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4").
 			WithProviderSpecific("azure/metadata-foo", "bar").
 			WithProviderSpecific("azure/metadata-baz", "qux"),
 	}
 
 	currentRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("old.example.com", endpoint.RecordTypeA, "121.212.121.212"),
-		endpoint.NewEndpoint("oldcname.example.com", endpoint.RecordTypeCNAME, "other.com"),
-		endpoint.NewEndpoint("oldcloud.example.com", endpoint.RecordTypeNS, "ns1.example.com."),
-		endpoint.NewEndpoint("old.nope.com", endpoint.RecordTypeA, "121.212.121.212"),
-		endpoint.NewEndpoint("oldmail.example.com", endpoint.RecordTypeMX, "20 foo.other.com"),
+		endpoint.MustNewEndpoint("old.example.com", endpoint.RecordTypeA, "121.212.121.212"),
+		endpoint.MustNewEndpoint("oldcname.example.com", endpoint.RecordTypeCNAME, "other.com"),
+		endpoint.MustNewEndpoint("oldcloud.example.com", endpoint.RecordTypeNS, "ns1.example.com."),
+		endpoint.MustNewEndpoint("old.nope.com", endpoint.RecordTypeA, "121.212.121.212"),
+		endpoint.MustNewEndpoint("oldmail.example.com", endpoint.RecordTypeMX, "20 foo.other.com"),
 	}
 	updatedRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("new.example.com", endpoint.RecordTypeA, 3600, "111.222.111.222"),
-		endpoint.NewEndpointWithTTL("new.example.com", endpoint.RecordTypeAAAA, 3600, "2001::111:222:111:222"),
-		endpoint.NewEndpointWithTTL("newcname.example.com", endpoint.RecordTypeCNAME, 10, "other.com"),
-		endpoint.NewEndpointWithTTL("newns.example.com", endpoint.RecordTypeNS, 10, "ns1.example.com."),
-		endpoint.NewEndpoint("new.nope.com", endpoint.RecordTypeA, "222.111.222.111"),
-		endpoint.NewEndpoint("new.nope.com", endpoint.RecordTypeAAAA, "2001::222:111:222:111"),
-		endpoint.NewEndpoint("newns.nope.com", endpoint.RecordTypeNS, "ns1.example.com"),
-		endpoint.NewEndpointWithTTL("newmail.example.com", endpoint.RecordTypeMX, 7200, "40 bar.other.com"),
+		endpoint.MustNewEndpointWithTTL("new.example.com", endpoint.RecordTypeA, 3600, "111.222.111.222"),
+		endpoint.MustNewEndpointWithTTL("new.example.com", endpoint.RecordTypeAAAA, 3600, "2001::111:222:111:222"),
+		endpoint.MustNewEndpointWithTTL("newcname.example.com", endpoint.RecordTypeCNAME, 10, "other.com"),
+		endpoint.MustNewEndpointWithTTL("newns.example.com", endpoint.RecordTypeNS, 10, "ns1.example.com."),
+		endpoint.MustNewEndpoint("new.nope.com", endpoint.RecordTypeA, "222.111.222.111"),
+		endpoint.MustNewEndpoint("new.nope.com", endpoint.RecordTypeAAAA, "2001::222:111:222:111"),
+		endpoint.MustNewEndpoint("newns.nope.com", endpoint.RecordTypeNS, "ns1.example.com"),
+		endpoint.MustNewEndpointWithTTL("newmail.example.com", endpoint.RecordTypeMX, 7200, "40 bar.other.com"),
 	}
 
 	deleteRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("deleted.example.com", endpoint.RecordTypeA, "111.222.111.222"),
-		endpoint.NewEndpoint("deletedaaaa.example.com", endpoint.RecordTypeAAAA, "2001::111:222:111:222"),
-		endpoint.NewEndpoint("deletedcname.example.com", endpoint.RecordTypeCNAME, "other.com"),
-		endpoint.NewEndpoint("deletedns.example.com", endpoint.RecordTypeNS, "ns1.example.com."),
-		endpoint.NewEndpoint("deleted.nope.com", endpoint.RecordTypeA, "222.111.222.111"),
-		endpoint.NewEndpoint("deleted.nope.com", endpoint.RecordTypeAAAA, "2001::222:111:222:111"),
-		endpoint.NewEndpoint("deletedns.nope.com", endpoint.RecordTypeNS, "ns1.example.com."),
+		endpoint.MustNewEndpoint("deleted.example.com", endpoint.RecordTypeA, "111.222.111.222"),
+		endpoint.MustNewEndpoint("deletedaaaa.example.com", endpoint.RecordTypeAAAA, "2001::111:222:111:222"),
+		endpoint.MustNewEndpoint("deletedcname.example.com", endpoint.RecordTypeCNAME, "other.com"),
+		endpoint.MustNewEndpoint("deletedns.example.com", endpoint.RecordTypeNS, "ns1.example.com."),
+		endpoint.MustNewEndpoint("deleted.nope.com", endpoint.RecordTypeA, "222.111.222.111"),
+		endpoint.MustNewEndpoint("deleted.nope.com", endpoint.RecordTypeAAAA, "2001::222:111:222:111"),
+		endpoint.MustNewEndpoint("deletedns.nope.com", endpoint.RecordTypeNS, "ns1.example.com."),
 	}
 
 	changes := &plan.Changes{
@@ -506,11 +508,11 @@ func TestAzureNameFilter(t *testing.T) {
 		t.Fatal(err)
 	}
 	expected := []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("test.nginx.example.com", endpoint.RecordTypeA, 3600, "123.123.123.123"),
-		endpoint.NewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeA, 3600, "123.123.123.123"),
-		endpoint.NewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeNS, 3600, "ns1.example.com."),
-		endpoint.NewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeTXT, recordTTL, "heritage=external-dns,external-dns/owner=default"),
-		endpoint.NewEndpointWithTTL("mail.nginx.example.com", endpoint.RecordTypeMX, recordTTL, "20 example.com"),
+		endpoint.MustNewEndpointWithTTL("test.nginx.example.com", endpoint.RecordTypeA, 3600, "123.123.123.123"),
+		endpoint.MustNewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeA, 3600, "123.123.123.123"),
+		endpoint.MustNewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeNS, 3600, "ns1.example.com."),
+		endpoint.MustNewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeTXT, recordTTL, "heritage=external-dns,external-dns/owner=default"),
+		endpoint.MustNewEndpointWithTTL("mail.nginx.example.com", endpoint.RecordTypeMX, recordTTL, "20 example.com"),
 	}
 
 	validateAzureEndpoints(t, actual, expected)
@@ -522,21 +524,21 @@ func TestAzureApplyChangesZoneName(t *testing.T) {
 	testAzureApplyChangesInternalZoneName(t, false, &recordsClient)
 
 	validateAzureEndpoints(t, recordsClient.deletedEndpoints, []*endpoint.Endpoint{
-		endpoint.NewEndpoint("deleted.foo.example.com", endpoint.RecordTypeA, ""),
-		endpoint.NewEndpoint("deletedaaaa.foo.example.com", endpoint.RecordTypeAAAA, ""),
-		endpoint.NewEndpoint("deletedcname.foo.example.com", endpoint.RecordTypeCNAME, ""),
-		endpoint.NewEndpoint("deletedns.foo.example.com", endpoint.RecordTypeNS, ""),
+		endpoint.MustNewEndpoint("deleted.foo.example.com", endpoint.RecordTypeA, ""),
+		endpoint.MustNewEndpoint("deletedaaaa.foo.example.com", endpoint.RecordTypeAAAA, ""),
+		endpoint.MustNewEndpoint("deletedcname.foo.example.com", endpoint.RecordTypeCNAME, ""),
+		endpoint.MustNewEndpoint("deletedns.foo.example.com", endpoint.RecordTypeNS, ""),
 	})
 
 	validateAzureEndpoints(t, recordsClient.updatedEndpoints, []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("foo.example.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4", "1.2.3.5"),
-		endpoint.NewEndpointWithTTL("foo.example.com", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "2001::1:2:3:4", "2001::1:2:3:5"),
-		endpoint.NewEndpointWithTTL("foo.example.com", endpoint.RecordTypeNS, endpoint.TTL(recordTTL), "ns1.example.com."),
-		endpoint.NewEndpointWithTTL("foo.example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
-		endpoint.NewEndpointWithTTL("new.foo.example.com", endpoint.RecordTypeA, 3600, "111.222.111.222"),
-		endpoint.NewEndpointWithTTL("new.foo.example.com", endpoint.RecordTypeAAAA, 3600, "2001::111:222:111:222"),
-		endpoint.NewEndpointWithTTL("newns.foo.example.com", endpoint.RecordTypeNS, 10, "ns1.foo.example.com."),
-		endpoint.NewEndpointWithTTL("newcname.foo.example.com", endpoint.RecordTypeCNAME, 10, "other.com"),
+		endpoint.MustNewEndpointWithTTL("foo.example.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4", "1.2.3.5"),
+		endpoint.MustNewEndpointWithTTL("foo.example.com", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "2001::1:2:3:4", "2001::1:2:3:5"),
+		endpoint.MustNewEndpointWithTTL("foo.example.com", endpoint.RecordTypeNS, endpoint.TTL(recordTTL), "ns1.example.com."),
+		endpoint.MustNewEndpointWithTTL("foo.example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
+		endpoint.MustNewEndpointWithTTL("new.foo.example.com", endpoint.RecordTypeA, 3600, "111.222.111.222"),
+		endpoint.MustNewEndpointWithTTL("new.foo.example.com", endpoint.RecordTypeAAAA, 3600, "2001::111:222:111:222"),
+		endpoint.MustNewEndpointWithTTL("newns.foo.example.com", endpoint.RecordTypeNS, 10, "ns1.foo.example.com."),
+		endpoint.MustNewEndpointWithTTL("newcname.foo.example.com", endpoint.RecordTypeCNAME, 10, "other.com"),
 	})
 }
 
@@ -557,44 +559,44 @@ func testAzureApplyChangesInternalZoneName(t *testing.T, dryRun bool, client Rec
 	)
 
 	createRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4"),
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001::1:2:3:4"),
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeTXT, "tag"),
-		endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.5", "1.2.3.4"),
-		endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeAAAA, "2001::1:2:3:5", "2001::1:2:3:4"),
-		endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeNS, "ns1.example.com."),
-		endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeTXT, "tag"),
-		endpoint.NewEndpoint("bar.example.com", endpoint.RecordTypeCNAME, "other.com"),
-		endpoint.NewEndpoint("barns.example.com", endpoint.RecordTypeNS, "ns1.example.com."),
-		endpoint.NewEndpoint("bar.example.com", endpoint.RecordTypeTXT, "tag"),
-		endpoint.NewEndpoint("other.com", endpoint.RecordTypeA, "5.6.7.8"),
-		endpoint.NewEndpoint("foons.other.com", endpoint.RecordTypeNS, "ns1.other.com"),
-		endpoint.NewEndpoint("other.com", endpoint.RecordTypeTXT, "tag"),
-		endpoint.NewEndpoint("nope.com", endpoint.RecordTypeA, "4.4.4.4"),
-		endpoint.NewEndpoint("nope.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4"),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeAAAA, "2001::1:2:3:4"),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.5", "1.2.3.4"),
+		endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeAAAA, "2001::1:2:3:5", "2001::1:2:3:4"),
+		endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeNS, "ns1.example.com."),
+		endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.MustNewEndpoint("bar.example.com", endpoint.RecordTypeCNAME, "other.com"),
+		endpoint.MustNewEndpoint("barns.example.com", endpoint.RecordTypeNS, "ns1.example.com."),
+		endpoint.MustNewEndpoint("bar.example.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.MustNewEndpoint("other.com", endpoint.RecordTypeA, "5.6.7.8"),
+		endpoint.MustNewEndpoint("foons.other.com", endpoint.RecordTypeNS, "ns1.other.com"),
+		endpoint.MustNewEndpoint("other.com", endpoint.RecordTypeTXT, "tag"),
+		endpoint.MustNewEndpoint("nope.com", endpoint.RecordTypeA, "4.4.4.4"),
+		endpoint.MustNewEndpoint("nope.com", endpoint.RecordTypeTXT, "tag"),
 	}
 
 	currentRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("old.foo.example.com", endpoint.RecordTypeA, "121.212.121.212"),
-		endpoint.NewEndpoint("oldcname.foo.example.com", endpoint.RecordTypeCNAME, "other.com"),
-		endpoint.NewEndpoint("old.nope.example.com", endpoint.RecordTypeA, "121.212.121.212"),
+		endpoint.MustNewEndpoint("old.foo.example.com", endpoint.RecordTypeA, "121.212.121.212"),
+		endpoint.MustNewEndpoint("oldcname.foo.example.com", endpoint.RecordTypeCNAME, "other.com"),
+		endpoint.MustNewEndpoint("old.nope.example.com", endpoint.RecordTypeA, "121.212.121.212"),
 	}
 	updatedRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("new.foo.example.com", endpoint.RecordTypeA, 3600, "111.222.111.222"),
-		endpoint.NewEndpointWithTTL("new.foo.example.com", endpoint.RecordTypeAAAA, 3600, "2001::111:222:111:222"),
-		endpoint.NewEndpointWithTTL("newcname.foo.example.com", endpoint.RecordTypeCNAME, 10, "other.com"),
-		endpoint.NewEndpointWithTTL("newns.foo.example.com", endpoint.RecordTypeNS, 10, "ns1.foo.example.com."),
-		endpoint.NewEndpoint("new.nope.example.com", endpoint.RecordTypeA, "222.111.222.111"),
-		endpoint.NewEndpoint("new.nope.example.com", endpoint.RecordTypeAAAA, "2001::222:111:222:111"),
-		endpoint.NewEndpointWithTTL("newns.nope.example.com", endpoint.RecordTypeNS, 10, "ns1.nope.example.com."),
+		endpoint.MustNewEndpointWithTTL("new.foo.example.com", endpoint.RecordTypeA, 3600, "111.222.111.222"),
+		endpoint.MustNewEndpointWithTTL("new.foo.example.com", endpoint.RecordTypeAAAA, 3600, "2001::111:222:111:222"),
+		endpoint.MustNewEndpointWithTTL("newcname.foo.example.com", endpoint.RecordTypeCNAME, 10, "other.com"),
+		endpoint.MustNewEndpointWithTTL("newns.foo.example.com", endpoint.RecordTypeNS, 10, "ns1.foo.example.com."),
+		endpoint.MustNewEndpoint("new.nope.example.com", endpoint.RecordTypeA, "222.111.222.111"),
+		endpoint.MustNewEndpoint("new.nope.example.com", endpoint.RecordTypeAAAA, "2001::222:111:222:111"),
+		endpoint.MustNewEndpointWithTTL("newns.nope.example.com", endpoint.RecordTypeNS, 10, "ns1.nope.example.com."),
 	}
 
 	deleteRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("deleted.foo.example.com", endpoint.RecordTypeA, "111.222.111.222"),
-		endpoint.NewEndpoint("deletedaaaa.foo.example.com", endpoint.RecordTypeAAAA, "2001::111:222:111:222"),
-		endpoint.NewEndpoint("deletedcname.foo.example.com", endpoint.RecordTypeCNAME, "other.com"),
-		endpoint.NewEndpoint("deletedns.foo.example.com", endpoint.RecordTypeNS, "ns1.foo.example.com."),
-		endpoint.NewEndpoint("deleted.nope.example.com", endpoint.RecordTypeA, "222.111.222.111"),
+		endpoint.MustNewEndpoint("deleted.foo.example.com", endpoint.RecordTypeA, "111.222.111.222"),
+		endpoint.MustNewEndpoint("deletedaaaa.foo.example.com", endpoint.RecordTypeAAAA, "2001::111:222:111:222"),
+		endpoint.MustNewEndpoint("deletedcname.foo.example.com", endpoint.RecordTypeCNAME, "other.com"),
+		endpoint.MustNewEndpoint("deletedns.foo.example.com", endpoint.RecordTypeNS, "ns1.foo.example.com."),
+		endpoint.MustNewEndpoint("deleted.nope.example.com", endpoint.RecordTypeA, "222.111.222.111"),
 	}
 
 	changes := &plan.Changes{
@@ -634,7 +636,7 @@ func TestAzureAdjustEndpoints(t *testing.T) {
 	}{
 		{
 			name: "Azure tags annotation is parsed",
-			endpoint: endpoint.NewEndpoint("test.example.com", endpoint.RecordTypeA, "1.2.3.4").
+			endpoint: endpoint.MustNewEndpoint("test.example.com", endpoint.RecordTypeA, "1.2.3.4").
 				WithProviderSpecific("azure/tags", "cost-center=12345,owner=backend-team"),
 			expected: endpoint.ProviderSpecific{
 				{Name: "azure/metadata-cost-center", Value: "12345"},
@@ -643,7 +645,7 @@ func TestAzureAdjustEndpoints(t *testing.T) {
 		},
 		{
 			name: "Azure tags annotation with spaces is parsed correctly",
-			endpoint: endpoint.NewEndpoint("test.example.com", endpoint.RecordTypeA, "1.2.3.4").
+			endpoint: endpoint.MustNewEndpoint("test.example.com", endpoint.RecordTypeA, "1.2.3.4").
 				WithProviderSpecific("azure/tags", "environment=production, app=myapp "),
 			expected: endpoint.ProviderSpecific{
 				{Name: "azure/metadata-environment", Value: "production"},
@@ -652,7 +654,7 @@ func TestAzureAdjustEndpoints(t *testing.T) {
 		},
 		{
 			name: "Azure tags annotation with empty tags is handled",
-			endpoint: endpoint.NewEndpoint("test.example.com", endpoint.RecordTypeA, "1.2.3.4").
+			endpoint: endpoint.MustNewEndpoint("test.example.com", endpoint.RecordTypeA, "1.2.3.4").
 				WithProviderSpecific("azure/tags", "key=value,,other=test"),
 			expected: endpoint.ProviderSpecific{
 				{Name: "azure/metadata-key", Value: "value"},
@@ -661,7 +663,7 @@ func TestAzureAdjustEndpoints(t *testing.T) {
 		},
 		{
 			name:     "Endpoint without Azure tags is unchanged",
-			endpoint: endpoint.NewEndpoint("test.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+			endpoint: endpoint.MustNewEndpoint("test.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			expected: endpoint.ProviderSpecific{},
 		},
 	}

--- a/provider/civo/civo.go
+++ b/provider/civo/civo.go
@@ -141,7 +141,12 @@ func (p *CivoProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 					name = zone.Name
 				}
 
-				endpoints = append(endpoints, endpoint.NewEndpointWithTTL(name, toUpper, endpoint.TTL(r.TTL), r.Value))
+				ep, err := endpoint.NewEndpointWithTTL(name, toUpper, endpoint.TTL(r.TTL), r.Value)
+				if err != nil {
+					log.Errorf("Failed to create endpoint for record %s.%s: %v", r.Name, zone.Name, err)
+					continue
+				}
+				endpoints = append(endpoints, ep)
 			}
 		}
 	}

--- a/provider/civo/civo_test.go
+++ b/provider/civo/civo_test.go
@@ -213,7 +213,7 @@ func TestCivoProcessCreateActionsLogs(t *testing.T) {
 
 		updateByZone := map[string][]*endpoint.Endpoint{
 			"example.com": {
-				endpoint.NewEndpoint("abc.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("abc.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		}
 		var civoChanges CivoChanges
@@ -275,8 +275,8 @@ func TestCivoProcessCreateActions(t *testing.T) {
 
 	createsByZone := map[string][]*endpoint.Endpoint{
 		"example.com": {
-			endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.4"),
-			endpoint.NewEndpoint("txt.example.com", endpoint.RecordTypeCNAME, "foo.example.com"),
+			endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+			endpoint.MustNewEndpoint("txt.example.com", endpoint.RecordTypeCNAME, "foo.example.com"),
 		},
 	}
 
@@ -345,8 +345,8 @@ func TestCivoProcessCreateActionsWithError(t *testing.T) {
 
 	createsByZone := map[string][]*endpoint.Endpoint{
 		"example.com": {
-			endpoint.NewEndpoint("foo.example.com", "AAAA", "1.2.3.4"),
-			endpoint.NewEndpoint("txt.example.com", endpoint.RecordTypeCNAME, "foo.example.com"),
+			endpoint.MustNewEndpoint("foo.example.com", "AAAA", "1.2.3.4"),
+			endpoint.MustNewEndpoint("txt.example.com", endpoint.RecordTypeCNAME, "foo.example.com"),
 		},
 	}
 
@@ -382,8 +382,8 @@ func TestCivoProcessUpdateActionsWithError(t *testing.T) {
 
 	updatesByZone := map[string][]*endpoint.Endpoint{
 		"example.com": {
-			endpoint.NewEndpoint("foo.example.com", "AAAA", "1.2.3.4"),
-			endpoint.NewEndpoint("txt.example.com", endpoint.RecordTypeCNAME, "foo.example.com"),
+			endpoint.MustNewEndpoint("foo.example.com", "AAAA", "1.2.3.4"),
+			endpoint.MustNewEndpoint("txt.example.com", endpoint.RecordTypeCNAME, "foo.example.com"),
 		},
 	}
 
@@ -435,8 +435,8 @@ func TestCivoProcessUpdateActions(t *testing.T) {
 
 	updatesByZone := map[string][]*endpoint.Endpoint{
 		"example.com": {
-			endpoint.NewEndpoint("txt.example.com", endpoint.RecordTypeA, "10.20.30.40"),
-			endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeCNAME, "bar.example.com"),
+			endpoint.MustNewEndpoint("txt.example.com", endpoint.RecordTypeA, "10.20.30.40"),
+			endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeCNAME, "bar.example.com"),
 		},
 	}
 
@@ -564,8 +564,8 @@ func TestCivoProcessDeleteAction(t *testing.T) {
 
 	deleteByDomain := map[string][]*endpoint.Endpoint{
 		"example.com": {
-			endpoint.NewEndpoint("txt.example.com", endpoint.RecordTypeA, "1.2.3.4"),
-			endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "5.6.7.8"),
+			endpoint.MustNewEndpoint("txt.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+			endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeA, "5.6.7.8"),
 		},
 	}
 
@@ -687,7 +687,7 @@ func TestCivoApplyChangesError(t *testing.T) {
 			Name: "invalid record type from processCreateActions",
 			changes: &plan.Changes{
 				Create: []*endpoint.Endpoint{
-					endpoint.NewEndpoint("bad.example.com", "AAAA", "1.2.3.4"),
+					endpoint.MustNewEndpoint("bad.example.com", "AAAA", "1.2.3.4"),
 				},
 			},
 		},
@@ -695,10 +695,10 @@ func TestCivoApplyChangesError(t *testing.T) {
 			Name: "invalid record type from processUpdateActions",
 			changes: &plan.Changes{
 				UpdateOld: []*endpoint.Endpoint{
-					endpoint.NewEndpoint("bad.example.com", "AAAA", "1.2.3.4"),
+					endpoint.MustNewEndpoint("bad.example.com", "AAAA", "1.2.3.4"),
 				},
 				UpdateNew: []*endpoint.Endpoint{
-					endpoint.NewEndpoint("bad.example.com", "AAAA", "5.6.7.8"),
+					endpoint.MustNewEndpoint("bad.example.com", "AAAA", "5.6.7.8"),
 				},
 			},
 		},

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -885,15 +885,16 @@ func (p *CloudFlareProvider) groupByNameAndTypeWithCustomHostnames(records DNSRe
 				targets[i] = endpointTargetFromCloudflareRecord(record)
 			}
 		}
-		e := endpoint.NewEndpointWithTTL(
+		e, err := endpoint.NewEndpointWithTTL(
 			records[0].Name,
 			string(records[0].Type),
 			endpoint.TTL(records[0].TTL),
 			targets...)
-		proxied := records[0].Proxied
-		if e == nil {
+		if err != nil {
+			log.Errorf("Failed to create endpoint for record %q: %s", records[0].Name, err)
 			continue
 		}
+		proxied := records[0].Proxied
 		e = e.WithProviderSpecific(annotations.CloudflareProxiedKey, strconv.FormatBool(proxied))
 		// noop (customHostnames is empty) if custom hostnames feature is not in use
 		if customHostnames, ok := customHostnames[records[0].Name]; ok {

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -2198,7 +2198,7 @@ func TestCloudflareLongRecordsErrorLog(t *testing.T) {
 	if err != nil {
 		t.Errorf("should not fail - too long record, %s", err)
 	}
-	logtest.TestHelperLogContains("s longer than 63 characters. Cannot create endpoint", hook, t)
+	logtest.TestHelperLogContains("is longer than 63 characters", hook, t)
 }
 
 // check if the error is expected

--- a/provider/coredns/coredns.go
+++ b/provider/coredns/coredns.go
@@ -339,12 +339,16 @@ func (p coreDNSProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, err
 				if isPTRDomain(dnsName) {
 					recordType = endpoint.RecordTypePTR
 				}
-				ep = endpoint.NewEndpointWithTTL(
+				ep, err = endpoint.NewEndpointWithTTL(
 					dnsName,
 					recordType,
 					endpoint.TTL(service.TTL),
 					service.Host,
 				)
+				if err != nil {
+					log.Errorf("Failed to create endpoint for %s: %s", dnsName, err)
+					continue
+				}
 				if service.Group != "" {
 					ep.WithProviderSpecific(providerSpecificGroup, service.Group)
 				}
@@ -359,11 +363,15 @@ func (p coreDNSProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, err
 			result = append(result, ep)
 		}
 		if service.Text != "" {
-			ep := endpoint.NewEndpoint(
+			ep, err := endpoint.NewEndpoint(
 				dnsName,
 				endpoint.RecordTypeTXT,
 				service.Text,
 			)
+			if err != nil {
+				log.Errorf("Failed to create TXT endpoint for %s: %s", dnsName, err)
+				continue
+			}
 			if p.strictlyOwned {
 				ep.Labels[endpoint.OwnerLabelKey] = service.Owner
 			}

--- a/provider/coredns/coredns_test.go
+++ b/provider/coredns/coredns_test.go
@@ -238,8 +238,8 @@ func TestCoreDNSRoundTrip(t *testing.T) {
 	}
 
 	desired := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("a.example.org", endpoint.RecordTypeA, "172.18.0.2"),
-		endpoint.NewEndpoint("aa.example.org", endpoint.RecordTypeAAAA, "2001:db8::1"),
+		endpoint.MustNewEndpoint("a.example.org", endpoint.RecordTypeA, "172.18.0.2"),
+		endpoint.MustNewEndpoint("aa.example.org", endpoint.RecordTypeAAAA, "2001:db8::1"),
 	}
 
 	// Write the records (controller's ApplyChanges with the source's desired state).
@@ -423,9 +423,9 @@ func TestDeleteTXTDoesNotOverDeleteARecord(t *testing.T) {
 	// Create A + TXT for domain1, and A for domain2
 	err := coredns.ApplyChanges(t.Context(), &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			endpoint.NewEndpoint("domain1.local", endpoint.RecordTypeA, "5.5.5.5"),
-			endpoint.NewEndpoint("domain1.local", endpoint.RecordTypeTXT, "owner-marker"),
-			endpoint.NewEndpoint("domain2.local", endpoint.RecordTypeA, "6.6.6.6"),
+			endpoint.MustNewEndpoint("domain1.local", endpoint.RecordTypeA, "5.5.5.5"),
+			endpoint.MustNewEndpoint("domain1.local", endpoint.RecordTypeTXT, "owner-marker"),
+			endpoint.MustNewEndpoint("domain2.local", endpoint.RecordTypeA, "6.6.6.6"),
 		},
 	})
 	require.NoError(t, err)
@@ -442,7 +442,7 @@ func TestDeleteTXTDoesNotOverDeleteARecord(t *testing.T) {
 	// Delete ONLY the TXT for domain1 (not the A record)
 	err = coredns.ApplyChanges(t.Context(), &plan.Changes{
 		Delete: []*endpoint.Endpoint{
-			endpoint.NewEndpoint("domain1.local", endpoint.RecordTypeTXT, "owner-marker"),
+			endpoint.MustNewEndpoint("domain1.local", endpoint.RecordTypeTXT, "owner-marker"),
 		},
 	})
 	require.NoError(t, err)
@@ -475,9 +475,9 @@ func TestCoreDNSApplyChanges(t *testing.T) {
 
 	changes1 := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			endpoint.NewEndpoint("domain1.local", endpoint.RecordTypeA, "5.5.5.5"),
-			endpoint.NewEndpoint("domain1.local", endpoint.RecordTypeTXT, "string1"),
-			endpoint.NewEndpoint("domain2.local", endpoint.RecordTypeCNAME, "site.local"),
+			endpoint.MustNewEndpoint("domain1.local", endpoint.RecordTypeA, "5.5.5.5"),
+			endpoint.MustNewEndpoint("domain1.local", endpoint.RecordTypeTXT, "string1"),
+			endpoint.MustNewEndpoint("domain2.local", endpoint.RecordTypeCNAME, "site.local"),
 		},
 	}
 	err := coredns.ApplyChanges(t.Context(), changes1)
@@ -491,10 +491,10 @@ func TestCoreDNSApplyChanges(t *testing.T) {
 
 	changes2 := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			endpoint.NewEndpoint("domain3.local", endpoint.RecordTypeA, "7.7.7.7"),
+			endpoint.MustNewEndpoint("domain3.local", endpoint.RecordTypeA, "7.7.7.7"),
 		},
 		UpdateNew: []*endpoint.Endpoint{
-			endpoint.NewEndpoint("domain1.local", "A", "6.6.6.6"),
+			endpoint.MustNewEndpoint("domain1.local", "A", "6.6.6.6"),
 		},
 	}
 	records, _ := coredns.Records(t.Context())
@@ -515,9 +515,9 @@ func TestCoreDNSApplyChanges(t *testing.T) {
 
 	changes3 := &plan.Changes{
 		Delete: []*endpoint.Endpoint{
-			endpoint.NewEndpoint("domain1.local", endpoint.RecordTypeA, "6.6.6.6"),
-			endpoint.NewEndpoint("domain1.local", endpoint.RecordTypeTXT, "string"),
-			endpoint.NewEndpoint("domain3.local", endpoint.RecordTypeA, "7.7.7.7"),
+			endpoint.MustNewEndpoint("domain1.local", endpoint.RecordTypeA, "6.6.6.6"),
+			endpoint.MustNewEndpoint("domain1.local", endpoint.RecordTypeTXT, "string"),
+			endpoint.MustNewEndpoint("domain3.local", endpoint.RecordTypeA, "7.7.7.7"),
 		},
 	}
 
@@ -532,9 +532,9 @@ func TestCoreDNSApplyChanges(t *testing.T) {
 	// Test for multiple A records for the same FQDN
 	changes4 := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			endpoint.NewEndpoint("domain1.local", endpoint.RecordTypeA, "5.5.5.5"),
-			endpoint.NewEndpoint("domain1.local", endpoint.RecordTypeA, "6.6.6.6"),
-			endpoint.NewEndpoint("domain1.local", endpoint.RecordTypeA, "7.7.7.7"),
+			endpoint.MustNewEndpoint("domain1.local", endpoint.RecordTypeA, "5.5.5.5"),
+			endpoint.MustNewEndpoint("domain1.local", endpoint.RecordTypeA, "6.6.6.6"),
+			endpoint.MustNewEndpoint("domain1.local", endpoint.RecordTypeA, "7.7.7.7"),
 		},
 	}
 	err = coredns.ApplyChanges(t.Context(), changes4)
@@ -557,9 +557,9 @@ func TestCoreDNSApplyChanges_DomainDoNotMatch(t *testing.T) {
 
 	changes1 := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			endpoint.NewEndpoint("domain1.local", endpoint.RecordTypeA, "5.5.5.5"),
-			endpoint.NewEndpoint("example.local", endpoint.RecordTypeTXT, "string1"),
-			endpoint.NewEndpoint("domain2.local", endpoint.RecordTypeCNAME, "site.local"),
+			endpoint.MustNewEndpoint("domain1.local", endpoint.RecordTypeA, "5.5.5.5"),
+			endpoint.MustNewEndpoint("example.local", endpoint.RecordTypeTXT, "string1"),
+			endpoint.MustNewEndpoint("domain2.local", endpoint.RecordTypeCNAME, "site.local"),
 		},
 	}
 	hook := logtest.LogsUnderTestWithLogLevel(log.DebugLevel, t)
@@ -1435,9 +1435,9 @@ func TestApplyChangesAWithGroupServiceTranslation(t *testing.T) {
 
 	changes1 := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			endpoint.NewEndpoint("domain1.local", endpoint.RecordTypeA, "5.5.5.5").WithProviderSpecific(providerSpecificGroup, "test1"),
-			endpoint.NewEndpoint("domain2.local", endpoint.RecordTypeA, "5.5.5.6").WithProviderSpecific(providerSpecificGroup, "test1"),
-			endpoint.NewEndpoint("domain3.local", endpoint.RecordTypeA, "5.5.5.7").WithProviderSpecific(providerSpecificGroup, "test2"),
+			endpoint.MustNewEndpoint("domain1.local", endpoint.RecordTypeA, "5.5.5.5").WithProviderSpecific(providerSpecificGroup, "test1"),
+			endpoint.MustNewEndpoint("domain2.local", endpoint.RecordTypeA, "5.5.5.6").WithProviderSpecific(providerSpecificGroup, "test1"),
+			endpoint.MustNewEndpoint("domain3.local", endpoint.RecordTypeA, "5.5.5.7").WithProviderSpecific(providerSpecificGroup, "test2"),
 		},
 	}
 	coredns.ApplyChanges(t.Context(), changes1)
@@ -1615,8 +1615,8 @@ func TestPTRRecords(t *testing.T) {
 		// Create PTR records
 		changes := &plan.Changes{
 			Create: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "coredns-etcd-worker"),
-				endpoint.NewEndpoint("3.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "coredns-etcd-control-plane"),
+				endpoint.MustNewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "coredns-etcd-worker"),
+				endpoint.MustNewEndpoint("3.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "coredns-etcd-control-plane"),
 			},
 		}
 		err := coredns.ApplyChanges(t.Context(), changes)
@@ -1632,7 +1632,7 @@ func TestPTRRecords(t *testing.T) {
 		// Delete PTR records
 		deleteChanges := &plan.Changes{
 			Delete: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "coredns-etcd-worker"),
+				endpoint.MustNewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "coredns-etcd-worker"),
 			},
 		}
 		err = applyServiceChanges(coredns, deleteChanges)
@@ -1658,7 +1658,7 @@ func TestPTRRecords(t *testing.T) {
 		// Step 1: Create a PTR record pointing to "old-host"
 		createChanges := &plan.Changes{
 			Create: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "old-host"),
+				endpoint.MustNewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "old-host"),
 			},
 		}
 		require.NoError(t, coredns.ApplyChanges(t.Context(), createChanges))
@@ -1671,7 +1671,7 @@ func TestPTRRecords(t *testing.T) {
 		require.NoError(t, err)
 		oldEP := records[0]
 
-		newEP := endpoint.NewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "new-host")
+		newEP := endpoint.MustNewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "new-host")
 		require.NoError(t, coredns.ApplyChanges(t.Context(), &plan.Changes{
 			UpdateNew: []*endpoint.Endpoint{newEP},
 			UpdateOld: []*endpoint.Endpoint{oldEP},
@@ -1690,8 +1690,8 @@ func TestPTRRecords(t *testing.T) {
 		// a byte-prefix of .20)
 		require.NoError(t, coredns.ApplyChanges(t.Context(), &plan.Changes{
 			Create: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "host-2"),
-				endpoint.NewEndpoint("20.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "host-20"),
+				endpoint.MustNewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "host-2"),
+				endpoint.MustNewEndpoint("20.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "host-20"),
 			},
 		}))
 
@@ -1703,7 +1703,7 @@ func TestPTRRecords(t *testing.T) {
 		// Delete ONLY .2
 		require.NoError(t, coredns.ApplyChanges(t.Context(), &plan.Changes{
 			Delete: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "host-2"),
+				endpoint.MustNewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "host-2"),
 			},
 		}))
 
@@ -1733,7 +1733,7 @@ func TestPTRRecords(t *testing.T) {
 		require.Equal(t, "host-1", oldEP.Targets[0])
 
 		// Update: change target from host-1 to host-2
-		newEP := endpoint.NewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "host-2")
+		newEP := endpoint.MustNewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "host-2")
 		updateChanges := &plan.Changes{
 			UpdateNew: []*endpoint.Endpoint{newEP},
 			UpdateOld: []*endpoint.Endpoint{oldEP},
@@ -1761,7 +1761,7 @@ func TestPTRRecords(t *testing.T) {
 		require.NoError(t, err)
 		oldEP := records[0]
 
-		newEP := endpoint.NewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "host-2")
+		newEP := endpoint.MustNewEndpoint("2.0.26.172.in-addr.arpa", endpoint.RecordTypePTR, "host-2")
 		updateChanges := &plan.Changes{
 			UpdateNew: []*endpoint.Endpoint{newEP},
 			UpdateOld: []*endpoint.Endpoint{oldEP},

--- a/provider/dnsimple/dnsimple.go
+++ b/provider/dnsimple/dnsimple.go
@@ -221,7 +221,12 @@ func (p *dnsimpleProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, e
 				if record.Name == "" {
 					dnsName = record.ZoneID
 				}
-				endpoints = append(endpoints, endpoint.NewEndpointWithTTL(dnsName, record.Type, endpoint.TTL(record.TTL), record.Content))
+				ep, err := endpoint.NewEndpointWithTTL(dnsName, record.Type, endpoint.TTL(record.TTL), record.Content)
+				if err != nil {
+					log.Errorf("Failed to create endpoint for record %q: %v", record.Name, err)
+					continue
+				}
+				endpoints = append(endpoints, ep)
 			}
 			page++
 			if page > records.Pagination.TotalPages {

--- a/provider/dnsimple/dnsimple_test.go
+++ b/provider/dnsimple/dnsimple_test.go
@@ -213,12 +213,12 @@ func testDnsimpleProviderRecords(t *testing.T) {
 				), nil)
 			},
 			want: []*endpoint.Endpoint{
-				endpoint.NewEndpointWithTTL("a.example.com", endpoint.RecordTypeA, 3600, "127.0.0.1"),
-				endpoint.NewEndpointWithTTL("aaaa.example.com", endpoint.RecordTypeAAAA, 3600, "fd00::1"),
-				endpoint.NewEndpointWithTTL("cname.example.com", endpoint.RecordTypeCNAME, 7200, "target"),
-				endpoint.NewEndpointWithTTL("txt.example.com", endpoint.RecordTypeTXT, 3600, "hello"),
-				endpoint.NewEndpointWithTTL("srv.example.com", endpoint.RecordTypeSRV, 3600, "1 10 5060 sip.example.com"),
-				endpoint.NewEndpointWithTTL("ns.example.com", endpoint.RecordTypeNS, 3600, "ns1.example.com"),
+				endpoint.MustNewEndpointWithTTL("a.example.com", endpoint.RecordTypeA, 3600, "127.0.0.1"),
+				endpoint.MustNewEndpointWithTTL("aaaa.example.com", endpoint.RecordTypeAAAA, 3600, "fd00::1"),
+				endpoint.MustNewEndpointWithTTL("cname.example.com", endpoint.RecordTypeCNAME, 7200, "target"),
+				endpoint.MustNewEndpointWithTTL("txt.example.com", endpoint.RecordTypeTXT, 3600, "hello"),
+				endpoint.MustNewEndpointWithTTL("srv.example.com", endpoint.RecordTypeSRV, 3600, "1 10 5060 sip.example.com"),
+				endpoint.MustNewEndpointWithTTL("ns.example.com", endpoint.RecordTypeNS, 3600, "ns1.example.com"),
 			},
 		},
 		{
@@ -231,8 +231,8 @@ func testDnsimpleProviderRecords(t *testing.T) {
 				), nil)
 			},
 			want: []*endpoint.Endpoint{
-				endpoint.NewEndpointWithTTL("www.example.com", endpoint.RecordTypeA, 3600, "127.0.0.1"),
-				endpoint.NewEndpointWithTTL("www.example.com", endpoint.RecordTypeAAAA, 3600, "fd00::1"),
+				endpoint.MustNewEndpointWithTTL("www.example.com", endpoint.RecordTypeA, 3600, "127.0.0.1"),
+				endpoint.MustNewEndpointWithTTL("www.example.com", endpoint.RecordTypeAAAA, 3600, "fd00::1"),
 			},
 		},
 		{
@@ -244,7 +244,7 @@ func testDnsimpleProviderRecords(t *testing.T) {
 				), nil)
 			},
 			want: []*endpoint.Endpoint{
-				endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, 3600, "127.0.0.1"),
+				endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeA, 3600, "127.0.0.1"),
 			},
 		},
 		{
@@ -257,7 +257,7 @@ func testDnsimpleProviderRecords(t *testing.T) {
 				), nil)
 			},
 			want: []*endpoint.Endpoint{
-				endpoint.NewEndpointWithTTL("a.example.com", endpoint.RecordTypeA, 3600, "127.0.0.1"),
+				endpoint.MustNewEndpointWithTTL("a.example.com", endpoint.RecordTypeA, 3600, "127.0.0.1"),
 			},
 		},
 		{

--- a/provider/exoscale/exoscale.go
+++ b/provider/exoscale/exoscale.go
@@ -327,7 +327,11 @@ func (ep *ExoscaleProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, 
 				fqdn = record.Name + "." + zoneName
 			}
 
-			e := endpoint.NewEndpointWithTTL(fqdn, string(record.Type), endpoint.TTL(record.Ttl), record.Content)
+			e, err := endpoint.NewEndpointWithTTL(fqdn, string(record.Type), endpoint.TTL(record.Ttl), record.Content)
+			if err != nil {
+				log.Errorf("Failed to create endpoint for record %q: %v", record.Name, err)
+				continue
+			}
 			endpoints = append(endpoints, e)
 		}
 	}

--- a/provider/factory/alias_normalizer_test.go
+++ b/provider/factory/alias_normalizer_test.go
@@ -91,7 +91,7 @@ func TestAliasNormalizingMiddleware(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ep := endpoint.NewEndpoint("example.com", tt.recordType, "target.example.com")
+			ep := endpoint.MustNewEndpoint("example.com", tt.recordType, "target.example.com")
 			if tt.aliasIn != endpoint.AliasNone {
 				ep = ep.WithProviderSpecific(endpoint.ProviderSpecificAlias, string(tt.aliasIn))
 			}

--- a/provider/godaddy/godaddy.go
+++ b/provider/godaddy/godaddy.go
@@ -301,12 +301,16 @@ func (p *GDProvider) groupByNameAndType(zoneRecords []gdRecords) []*endpoint.End
 				recordName = strings.TrimPrefix(fmt.Sprintf("%s.%s", records[0].Name, zoneName), ".")
 			}
 
-			ep := endpoint.NewEndpointWithTTL(
+			ep, err := endpoint.NewEndpointWithTTL(
 				recordName,
 				records[0].Type,
 				endpoint.TTL(records[0].TTL),
 				targets...,
 			)
+			if err != nil {
+				log.Errorf("Failed to create endpoint for record %q: %v", recordName, err)
+				continue
+			}
 
 			endpoints = append(endpoints, ep)
 		}

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -221,7 +221,12 @@ func (p *GoogleProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, err
 			if !p.SupportedRecordType(r.Type) {
 				continue
 			}
-			endpoints = append(endpoints, endpoint.NewEndpointWithTTL(r.Name, r.Type, endpoint.TTL(r.Ttl), r.Rrdatas...))
+			ep, err := endpoint.NewEndpointWithTTL(r.Name, r.Type, endpoint.TTL(r.Ttl), r.Rrdatas...)
+			if err != nil {
+				log.Errorf("Failed to create endpoint for record %q: %v", r.Name, err)
+				continue
+			}
+			endpoints = append(endpoints, ep)
 		}
 
 		return nil

--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -264,9 +264,9 @@ func TestGoogleZonesVisibilityFilterPrivatePeering(t *testing.T) {
 
 func TestGoogleRecords(t *testing.T) {
 	originalEndpoints := []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("list-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, endpoint.TTL(1), "1.2.3.4"),
-		endpoint.NewEndpointWithTTL("list-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, endpoint.TTL(2), "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("list-test-alias.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, endpoint.TTL(3), "foo.elb.amazonaws.com"),
+		endpoint.MustNewEndpointWithTTL("list-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, endpoint.TTL(1), "1.2.3.4"),
+		endpoint.MustNewEndpointWithTTL("list-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, endpoint.TTL(2), "8.8.8.8"),
+		endpoint.MustNewEndpointWithTTL("list-test-alias.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, endpoint.TTL(3), "foo.elb.amazonaws.com"),
 	}
 
 	provider := newGoogleProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), provider.NewZoneIDFilter([]string{""}), false, originalEndpoints, nil, nil)
@@ -279,12 +279,12 @@ func TestGoogleRecords(t *testing.T) {
 
 func TestGoogleRecordsFilter(t *testing.T) {
 	originalEndpoints := []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.4.4"),
-		endpoint.NewEndpointWithTTL("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.4.4"),
-		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, defaultTTL, "bar.elb.amazonaws.com"),
-		endpoint.NewEndpointWithTTL("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, defaultTTL, "qux.elb.amazonaws.com"),
+		endpoint.MustNewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.8.8"),
+		endpoint.MustNewEndpointWithTTL("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.8.8"),
+		endpoint.MustNewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.4.4"),
+		endpoint.MustNewEndpointWithTTL("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.4.4"),
+		endpoint.MustNewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, defaultTTL, "bar.elb.amazonaws.com"),
+		endpoint.MustNewEndpointWithTTL("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, defaultTTL, "qux.elb.amazonaws.com"),
 	}
 
 	provider := newGoogleProvider(
@@ -306,12 +306,12 @@ func TestGoogleRecordsFilter(t *testing.T) {
 
 	// these records should be filtered out since they don't match a hosted zone or domain filter.
 	ignoredEndpoints := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("filter-create-test.zone-0.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.2"),
-		endpoint.NewEndpoint("filter-update-test.zone-0.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.2"),
-		endpoint.NewEndpoint("filter-delete-test.zone-0.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.2"),
-		endpoint.NewEndpoint("filter-create-test.zone-3.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.2"),
-		endpoint.NewEndpoint("filter-update-test.zone-3.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.2"),
-		endpoint.NewEndpoint("filter-delete-test.zone-3.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.2"),
+		endpoint.MustNewEndpoint("filter-create-test.zone-0.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.2"),
+		endpoint.MustNewEndpoint("filter-update-test.zone-0.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.2"),
+		endpoint.MustNewEndpoint("filter-delete-test.zone-0.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.2"),
+		endpoint.MustNewEndpoint("filter-create-test.zone-3.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.2"),
+		endpoint.MustNewEndpoint("filter-update-test.zone-3.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.2"),
+		endpoint.MustNewEndpoint("filter-delete-test.zone-3.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.2"),
 	}
 
 	require.NoError(t, provider.ApplyChanges(t.Context(), &plan.Changes{
@@ -339,45 +339,45 @@ func TestGoogleApplyChanges(t *testing.T) {
 		provider.NewZoneIDFilter([]string{""}),
 		false,
 		[]*endpoint.Endpoint{
-			endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.8.8"),
-			endpoint.NewEndpointWithTTL("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.8.8"),
-			endpoint.NewEndpointWithTTL("update-test-ttl.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, endpoint.TTL(10), "8.8.4.4"),
-			endpoint.NewEndpointWithTTL("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.4.4"),
-			endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, defaultTTL, "bar.elb.amazonaws.com"),
-			endpoint.NewEndpointWithTTL("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, defaultTTL, "qux.elb.amazonaws.com"),
+			endpoint.MustNewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.8.8"),
+			endpoint.MustNewEndpointWithTTL("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.8.8"),
+			endpoint.MustNewEndpointWithTTL("update-test-ttl.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, endpoint.TTL(10), "8.8.4.4"),
+			endpoint.MustNewEndpointWithTTL("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.4.4"),
+			endpoint.MustNewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, defaultTTL, "bar.elb.amazonaws.com"),
+			endpoint.MustNewEndpointWithTTL("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, defaultTTL, "qux.elb.amazonaws.com"),
 		},
 		nil,
 		nil,
 	)
 
 	createRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("create-test-ttl.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, endpoint.TTL(15), "8.8.4.4"),
-		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, "foo.elb.amazonaws.com"),
-		endpoint.NewEndpoint("filter-create-test.zone-3.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.2"),
-		endpoint.NewEndpoint("nomatch-create-test.zone-0.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.1"),
+		endpoint.MustNewEndpoint("create-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
+		endpoint.MustNewEndpointWithTTL("create-test-ttl.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, endpoint.TTL(15), "8.8.4.4"),
+		endpoint.MustNewEndpoint("create-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, "foo.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("filter-create-test.zone-3.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.2"),
+		endpoint.MustNewEndpoint("nomatch-create-test.zone-0.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.1"),
 	}
 
 	currentRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
-		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, "bar.elb.amazonaws.com"),
-		endpoint.NewEndpoint("filter-update-test.zone-3.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.2"),
+		endpoint.MustNewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
+		endpoint.MustNewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
+		endpoint.MustNewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, "bar.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("filter-update-test.zone-3.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.2"),
 	}
 	updatedRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
-		endpoint.NewEndpointWithTTL("update-test-ttl.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, endpoint.TTL(25), "4.3.2.1"),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, "baz.elb.amazonaws.com"),
-		endpoint.NewEndpoint("filter-update-test.zone-3.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "5.6.7.8"),
-		endpoint.NewEndpoint("nomatch-update-test.zone-0.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.7.6.5"),
+		endpoint.MustNewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
+		endpoint.MustNewEndpointWithTTL("update-test-ttl.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, endpoint.TTL(25), "4.3.2.1"),
+		endpoint.MustNewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, "baz.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("filter-update-test.zone-3.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "5.6.7.8"),
+		endpoint.MustNewEndpoint("nomatch-update-test.zone-0.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.7.6.5"),
 	}
 
 	deleteRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
-		endpoint.NewEndpoint("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
-		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, "qux.elb.amazonaws.com"),
-		endpoint.NewEndpoint("filter-delete-test.zone-3.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.2"),
-		endpoint.NewEndpoint("nomatch-delete-test.zone-0.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.1"),
+		endpoint.MustNewEndpoint("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
+		endpoint.MustNewEndpoint("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
+		endpoint.MustNewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, "qux.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("filter-delete-test.zone-3.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.2"),
+		endpoint.MustNewEndpoint("nomatch-delete-test.zone-0.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.2.2.1"),
 	}
 
 	changes := &plan.Changes{
@@ -393,48 +393,48 @@ func TestGoogleApplyChanges(t *testing.T) {
 	require.NoError(t, err)
 
 	validateEndpoints(t, records, []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("create-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "1.2.3.4"),
-		endpoint.NewEndpointWithTTL("create-test-ttl.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, endpoint.TTL(15), "8.8.4.4"),
-		endpoint.NewEndpointWithTTL("update-test-ttl.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, endpoint.TTL(25), "4.3.2.1"),
-		endpoint.NewEndpointWithTTL("create-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, defaultTTL, "foo.elb.amazonaws.com"),
-		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, defaultTTL, "baz.elb.amazonaws.com"),
+		endpoint.MustNewEndpointWithTTL("create-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.8.8"),
+		endpoint.MustNewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "1.2.3.4"),
+		endpoint.MustNewEndpointWithTTL("create-test-ttl.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, endpoint.TTL(15), "8.8.4.4"),
+		endpoint.MustNewEndpointWithTTL("update-test-ttl.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, endpoint.TTL(25), "4.3.2.1"),
+		endpoint.MustNewEndpointWithTTL("create-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, defaultTTL, "foo.elb.amazonaws.com"),
+		endpoint.MustNewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, defaultTTL, "baz.elb.amazonaws.com"),
 	})
 }
 
 func TestGoogleApplyChangesDryRun(t *testing.T) {
 	originalEndpoints := []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.4.4"),
-		endpoint.NewEndpointWithTTL("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.4.4"),
-		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, defaultTTL, "bar.elb.amazonaws.com"),
-		endpoint.NewEndpointWithTTL("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, defaultTTL, "qux.elb.amazonaws.com"),
+		endpoint.MustNewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.8.8"),
+		endpoint.MustNewEndpointWithTTL("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.8.8"),
+		endpoint.MustNewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.4.4"),
+		endpoint.MustNewEndpointWithTTL("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, defaultTTL, "8.8.4.4"),
+		endpoint.MustNewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, defaultTTL, "bar.elb.amazonaws.com"),
+		endpoint.MustNewEndpointWithTTL("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, defaultTTL, "qux.elb.amazonaws.com"),
 	}
 
 	provider := newGoogleProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), provider.NewZoneIDFilter([]string{""}), true, originalEndpoints, nil, nil)
 
 	createRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
-		endpoint.NewEndpoint("create-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
-		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, "foo.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("create-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
+		endpoint.MustNewEndpoint("create-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
+		endpoint.MustNewEndpoint("create-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, "foo.elb.amazonaws.com"),
 	}
 
 	currentRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
-		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, "bar.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
+		endpoint.MustNewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
+		endpoint.MustNewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, "bar.elb.amazonaws.com"),
 	}
 	updatedRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
-		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.3.2.1"),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, "baz.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
+		endpoint.MustNewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "4.3.2.1"),
+		endpoint.MustNewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, "baz.elb.amazonaws.com"),
 	}
 
 	deleteRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
-		endpoint.NewEndpoint("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
-		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, "qux.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
+		endpoint.MustNewEndpoint("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
+		endpoint.MustNewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, "qux.elb.amazonaws.com"),
 	}
 
 	changes := &plan.Changes{
@@ -462,16 +462,16 @@ func TestNewFilteredRecords(t *testing.T) {
 	provider := newGoogleProvider(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), provider.NewZoneIDFilter([]string{""}), false, []*endpoint.Endpoint{}, nil, nil)
 
 	records := provider.newFilteredRecords([]*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, 1, "8.8.4.4"),
-		endpoint.NewEndpointWithTTL("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, 120, "8.8.4.4"),
-		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, 4000, "bar.elb.amazonaws.com"),
-		endpoint.NewEndpointWithTTL("update-test-ns.zone-1.ext-dns-test-2.gcp.zalan.do.", endpoint.RecordTypeNS, 120, "foo.elb.amazonaws.com"),
+		endpoint.MustNewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, 1, "8.8.4.4"),
+		endpoint.MustNewEndpointWithTTL("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, 120, "8.8.4.4"),
+		endpoint.MustNewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, 4000, "bar.elb.amazonaws.com"),
+		endpoint.MustNewEndpointWithTTL("update-test-ns.zone-1.ext-dns-test-2.gcp.zalan.do.", endpoint.RecordTypeNS, 120, "foo.elb.amazonaws.com"),
 		// test fallback to Ttl:300 when Ttl==0 :
-		endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, 0, "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("update-test-mx.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeMX, 6000, "10 mail.elb.amazonaws.com"),
-		endpoint.NewEndpoint("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
-		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, "qux.elb.amazonaws.com"),
-		endpoint.NewEndpoint("delete-test-ns.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeNS, "foo.elb.amazonaws.com"),
+		endpoint.MustNewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, 0, "8.8.8.8"),
+		endpoint.MustNewEndpointWithTTL("update-test-mx.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeMX, 6000, "10 mail.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
+		endpoint.MustNewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, "qux.elb.amazonaws.com"),
+		endpoint.MustNewEndpoint("delete-test-ns.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeNS, "foo.elb.amazonaws.com"),
 	})
 
 	validateChangeRecords(t, records, []*dns.ResourceRecordSet{

--- a/provider/inmemory/inmemory.go
+++ b/provider/inmemory/inmemory.go
@@ -211,7 +211,12 @@ func (im *InMemoryProvider) ApplyChanges(ctx context.Context, changes *plan.Chan
 func copyEndpoints(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint {
 	records := make([]*endpoint.Endpoint, 0, len(endpoints))
 	for _, ep := range endpoints {
-		newEp := endpoint.NewEndpointWithTTL(ep.DNSName, ep.RecordType, ep.RecordTTL, ep.Targets...).WithSetIdentifier(ep.SetIdentifier)
+		newEp, err := endpoint.NewEndpointWithTTL(ep.DNSName, ep.RecordType, ep.RecordTTL, ep.Targets...)
+		if err != nil {
+			log.Errorf("Failed to copy endpoint for %s: %s", ep.DNSName, err)
+			continue
+		}
+		newEp.WithSetIdentifier(ep.SetIdentifier)
 		newEp.Labels = endpoint.NewLabels()
 		maps.Copy(newEp.Labels, ep.Labels)
 		newEp.ProviderSpecific = append(endpoint.ProviderSpecific(nil), ep.ProviderSpecific...)

--- a/provider/inmemory/inmemory_test.go
+++ b/provider/inmemory/inmemory_test.go
@@ -579,8 +579,8 @@ func TestInMemoryWithLogging(t *testing.T) {
 	p := NewInMemoryProvider(InMemoryWithLogging())
 	require.NoError(t, p.CreateZone("example.com"))
 
-	ep := endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.4")
-	epNew := endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "5.6.7.8")
+	ep := endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.4")
+	epNew := endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeA, "5.6.7.8")
 
 	require.NoError(t, p.ApplyChanges(t.Context(), &plan.Changes{
 		Create: []*endpoint.Endpoint{ep},
@@ -616,7 +616,7 @@ func TestInMemoryInitZones(t *testing.T) {
 
 func TestApplyChanges_UnknownZoneSkipped(t *testing.T) {
 	p := NewInMemoryProvider(InMemoryInitZones([]string{"example.com"}))
-	outside := endpoint.NewEndpoint("foo.other.org", endpoint.RecordTypeA, "1.2.3.4")
+	outside := endpoint.MustNewEndpoint("foo.other.org", endpoint.RecordTypeA, "1.2.3.4")
 
 	err := p.ApplyChanges(t.Context(), &plan.Changes{
 		UpdateNew: []*endpoint.Endpoint{outside},
@@ -652,7 +652,7 @@ func makeZone(s ...string) map[endpoint.EndpointKey]*endpoint.Endpoint {
 
 	output := map[endpoint.EndpointKey]*endpoint.Endpoint{}
 	for i := 0; i < len(s); i += 3 {
-		ep := endpoint.NewEndpoint(s[i], s[i+2], s[i+1])
+		ep := endpoint.MustNewEndpoint(s[i], s[i+2], s[i+1])
 		output[ep.Key()] = ep
 	}
 

--- a/provider/linode/linode.go
+++ b/provider/linode/linode.go
@@ -143,7 +143,12 @@ func (p *LinodeProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, err
 					name = zone.Domain
 				}
 
-				endpoints = append(endpoints, endpoint.NewEndpointWithTTL(name, string(r.Type), endpoint.TTL(r.TTLSec), r.Target))
+				ep, err := endpoint.NewEndpointWithTTL(name, string(r.Type), endpoint.TTL(r.TTLSec), r.Target)
+				if err != nil {
+					log.Errorf("Failed to create endpoint for record %q: %v", r.Name, err)
+					continue
+				}
+				endpoints = append(endpoints, ep)
 			}
 		}
 	}

--- a/provider/ns1/ns1.go
+++ b/provider/ns1/ns1.go
@@ -178,13 +178,17 @@ func (p *NS1Provider) Records(_ context.Context) ([]*endpoint.Endpoint, error) {
 
 		for _, record := range zoneData.Records {
 			if provider.SupportedRecordType(record.Type) {
-				endpoints = append(endpoints, endpoint.NewEndpointWithTTL(
+				ep, err := endpoint.NewEndpointWithTTL(
 					record.Domain,
 					record.Type,
 					endpoint.TTL(record.TTL),
 					record.ShortAns...,
-				),
 				)
+				if err != nil {
+					log.Errorf("Failed to create endpoint for record %q: %v", record.Domain, err)
+					continue
+				}
+				endpoints = append(endpoints, ep)
 			}
 		}
 	}

--- a/provider/oci/oci.go
+++ b/provider/oci/oci.go
@@ -217,7 +217,11 @@ func mergeEndpointsMultiTargets(endpoints []*endpoint.Endpoint) []*endpoint.Endp
 			targets[i] = e.Targets[0]
 		}
 
-		e := endpoint.NewEndpointWithTTL(dnsName, recordType, recordTTL, targets...)
+		e, err := endpoint.NewEndpointWithTTL(dnsName, recordType, recordTTL, targets...)
+		if err != nil {
+			log.Errorf("Failed to create merged endpoint for %q (%q): %v", dnsName, recordType, err)
+			continue
+		}
 		mergedEndpoints = append(mergedEndpoints, e)
 	}
 
@@ -299,14 +303,17 @@ func (p *OCIProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error)
 				if !provider.SupportedRecordType(*record.Rtype) {
 					continue
 				}
-				endpoints = append(endpoints,
-					endpoint.NewEndpointWithTTL(
-						*record.Domain,
-						*record.Rtype,
-						endpoint.TTL(*record.Ttl),
-						*record.Rdata,
-					),
+				ep, err := endpoint.NewEndpointWithTTL(
+					*record.Domain,
+					*record.Rtype,
+					endpoint.TTL(*record.Ttl),
+					*record.Rdata,
 				)
+				if err != nil {
+					log.Errorf("Failed to create endpoint for record %q: %v", *record.Domain, err)
+					continue
+				}
+				endpoints = append(endpoints, ep)
 			}
 
 			if page = resp.OpcNextPage; resp.OpcNextPage == nil {

--- a/provider/oci/oci_test.go
+++ b/provider/oci/oci_test.go
@@ -336,26 +336,26 @@ func TestOCIRecords(t *testing.T) {
 			domainFilter: endpoint.NewDomainFilter([]string{""}),
 			zoneIDFilter: provider.NewZoneIDFilter([]string{""}),
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpointWithTTL("foo.foo.com", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "127.0.0.1"),
-				endpoint.NewEndpointWithTTL("foo.foo.com", endpoint.RecordTypeTXT, endpoint.TTL(defaultTTL), "heritage=external-dns,external-dns/owner=default,external-dns/resource=service/default/my-svc"),
-				endpoint.NewEndpointWithTTL("bar.foo.com", endpoint.RecordTypeCNAME, endpoint.TTL(defaultTTL), "bar.com."),
-				endpoint.NewEndpointWithTTL("foo.bar.com", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "127.0.0.1"),
+				endpoint.MustNewEndpointWithTTL("foo.foo.com", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "127.0.0.1"),
+				endpoint.MustNewEndpointWithTTL("foo.foo.com", endpoint.RecordTypeTXT, endpoint.TTL(defaultTTL), "heritage=external-dns,external-dns/owner=default,external-dns/resource=service/default/my-svc"),
+				endpoint.MustNewEndpointWithTTL("bar.foo.com", endpoint.RecordTypeCNAME, endpoint.TTL(defaultTTL), "bar.com."),
+				endpoint.MustNewEndpointWithTTL("foo.bar.com", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "127.0.0.1"),
 			},
 		}, {
 			name:         "DomainFilter_foo.com",
 			domainFilter: endpoint.NewDomainFilter([]string{"foo.com"}),
 			zoneIDFilter: provider.NewZoneIDFilter([]string{""}),
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpointWithTTL("foo.foo.com", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "127.0.0.1"),
-				endpoint.NewEndpointWithTTL("foo.foo.com", endpoint.RecordTypeTXT, endpoint.TTL(defaultTTL), "heritage=external-dns,external-dns/owner=default,external-dns/resource=service/default/my-svc"),
-				endpoint.NewEndpointWithTTL("bar.foo.com", endpoint.RecordTypeCNAME, endpoint.TTL(defaultTTL), "bar.com."),
+				endpoint.MustNewEndpointWithTTL("foo.foo.com", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "127.0.0.1"),
+				endpoint.MustNewEndpointWithTTL("foo.foo.com", endpoint.RecordTypeTXT, endpoint.TTL(defaultTTL), "heritage=external-dns,external-dns/owner=default,external-dns/resource=service/default/my-svc"),
+				endpoint.MustNewEndpointWithTTL("bar.foo.com", endpoint.RecordTypeCNAME, endpoint.TTL(defaultTTL), "bar.com."),
 			},
 		}, {
 			name:         "ZoneIDFilter_ocid1.dns-zone.oc1..502aeddba262b92fd13ed7874f6f1404",
 			domainFilter: endpoint.NewDomainFilter([]string{""}),
 			zoneIDFilter: provider.NewZoneIDFilter([]string{"ocid1.dns-zone.oc1..502aeddba262b92fd13ed7874f6f1404"}),
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpointWithTTL("foo.bar.com", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "127.0.0.1"),
+				endpoint.MustNewEndpointWithTTL("foo.bar.com", endpoint.RecordTypeA, endpoint.TTL(defaultTTL), "127.0.0.1"),
 			},
 		},
 	}
@@ -379,7 +379,7 @@ func TestNewRecordOperation(t *testing.T) {
 		{
 			name:   "A_record",
 			opType: dns.RecordOperationOperationAdd,
-			ep: endpoint.NewEndpointWithTTL(
+			ep: endpoint.MustNewEndpointWithTTL(
 				"foo.foo.com",
 				endpoint.RecordTypeA,
 				endpoint.TTL(defaultTTL),
@@ -394,7 +394,7 @@ func TestNewRecordOperation(t *testing.T) {
 		}, {
 			name:   "TXT_record",
 			opType: dns.RecordOperationOperationAdd,
-			ep: endpoint.NewEndpointWithTTL(
+			ep: endpoint.MustNewEndpointWithTTL(
 				"foo.foo.com",
 				endpoint.RecordTypeTXT,
 				endpoint.TTL(defaultTTL),
@@ -409,7 +409,7 @@ func TestNewRecordOperation(t *testing.T) {
 		}, {
 			name:   "CNAME_record",
 			opType: dns.RecordOperationOperationAdd,
-			ep: endpoint.NewEndpointWithTTL(
+			ep: endpoint.MustNewEndpointWithTTL(
 				"foo.foo.com",
 				endpoint.RecordTypeCNAME,
 				endpoint.TTL(defaultTTL),
@@ -733,14 +733,14 @@ func TestOCIApplyChanges(t *testing.T) {
 				Name: new("foo.com"),
 			}},
 			changes: &plan.Changes{
-				Create: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL(
+				Create: []*endpoint.Endpoint{endpoint.MustNewEndpointWithTTL(
 					"foo.foo.com",
 					endpoint.RecordTypeA,
 					endpoint.TTL(defaultTTL),
 					"127.0.0.1",
 				)},
 			},
-			expectedEndpoints: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL(
+			expectedEndpoints: []*endpoint.Endpoint{endpoint.MustNewEndpointWithTTL(
 				"foo.foo.com",
 				endpoint.RecordTypeA,
 				endpoint.TTL(defaultTTL),
@@ -766,14 +766,14 @@ func TestOCIApplyChanges(t *testing.T) {
 				}},
 			},
 			changes: &plan.Changes{
-				Delete: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL(
+				Delete: []*endpoint.Endpoint{endpoint.MustNewEndpointWithTTL(
 					"foo.foo.com",
 					endpoint.RecordTypeTXT,
 					endpoint.TTL(defaultTTL),
 					"127.0.0.1",
 				)},
 			},
-			expectedEndpoints: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL(
+			expectedEndpoints: []*endpoint.Endpoint{endpoint.MustNewEndpointWithTTL(
 				"foo.foo.com",
 				endpoint.RecordTypeA,
 				endpoint.TTL(defaultTTL),
@@ -794,20 +794,20 @@ func TestOCIApplyChanges(t *testing.T) {
 				}},
 			},
 			changes: &plan.Changes{
-				UpdateOld: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL(
+				UpdateOld: []*endpoint.Endpoint{endpoint.MustNewEndpointWithTTL(
 					"foo.foo.com",
 					endpoint.RecordTypeA,
 					endpoint.TTL(defaultTTL),
 					"127.0.0.1",
 				)},
-				UpdateNew: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL(
+				UpdateNew: []*endpoint.Endpoint{endpoint.MustNewEndpointWithTTL(
 					"foo.foo.com",
 					endpoint.RecordTypeA,
 					endpoint.TTL(defaultTTL),
 					"10.0.0.1",
 				)},
 			},
-			expectedEndpoints: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL(
+			expectedEndpoints: []*endpoint.Endpoint{endpoint.MustNewEndpointWithTTL(
 				"foo.foo.com",
 				endpoint.RecordTypeA,
 				endpoint.TTL(defaultTTL),
@@ -828,7 +828,7 @@ func TestOCIApplyChanges(t *testing.T) {
 				}},
 			},
 			changes: &plan.Changes{
-				Delete: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL(
+				Delete: []*endpoint.Endpoint{endpoint.MustNewEndpointWithTTL(
 					"foo.foo.com",
 					endpoint.RecordTypeA,
 					endpoint.TTL(defaultTTL),
@@ -836,7 +836,7 @@ func TestOCIApplyChanges(t *testing.T) {
 				)},
 			},
 			dryRun: true,
-			expectedEndpoints: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL(
+			expectedEndpoints: []*endpoint.Endpoint{endpoint.MustNewEndpointWithTTL(
 				"foo.foo.com",
 				endpoint.RecordTypeA,
 				endpoint.TTL(defaultTTL),
@@ -867,25 +867,25 @@ func TestOCIApplyChanges(t *testing.T) {
 				}},
 			},
 			changes: &plan.Changes{
-				Delete: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL(
+				Delete: []*endpoint.Endpoint{endpoint.MustNewEndpointWithTTL(
 					"foo.foo.com",
 					endpoint.RecordTypeA,
 					endpoint.TTL(defaultTTL),
 					"127.0.0.1",
 				)},
-				UpdateOld: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL(
+				UpdateOld: []*endpoint.Endpoint{endpoint.MustNewEndpointWithTTL(
 					"car.foo.com",
 					endpoint.RecordTypeCNAME,
 					endpoint.TTL(defaultTTL),
 					"baz.com.",
 				)},
-				UpdateNew: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL(
+				UpdateNew: []*endpoint.Endpoint{endpoint.MustNewEndpointWithTTL(
 					"bar.foo.com",
 					endpoint.RecordTypeCNAME,
 					endpoint.TTL(defaultTTL),
 					"foo.bar.com.",
 				)},
-				Create: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL(
+				Create: []*endpoint.Endpoint{endpoint.MustNewEndpointWithTTL(
 					"baz.foo.com",
 					endpoint.RecordTypeA,
 					endpoint.TTL(defaultTTL),
@@ -893,13 +893,13 @@ func TestOCIApplyChanges(t *testing.T) {
 				)},
 			},
 			expectedEndpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpointWithTTL(
+				endpoint.MustNewEndpointWithTTL(
 					"bar.foo.com",
 					endpoint.RecordTypeCNAME,
 					endpoint.TTL(defaultTTL),
 					"foo.bar.com.",
 				),
-				endpoint.NewEndpointWithTTL(
+				endpoint.MustNewEndpointWithTTL(
 					"baz.foo.com",
 					endpoint.RecordTypeA,
 					endpoint.TTL(defaultTTL),
@@ -914,19 +914,19 @@ func TestOCIApplyChanges(t *testing.T) {
 			}},
 
 			changes: &plan.Changes{
-				Create: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL(
+				Create: []*endpoint.Endpoint{endpoint.MustNewEndpointWithTTL(
 					"foo.foo.com",
 					endpoint.RecordTypeA,
 					endpoint.TTL(defaultTTL),
 					"192.168.1.2",
-				), endpoint.NewEndpointWithTTL(
+				), endpoint.MustNewEndpointWithTTL(
 					"foo.foo.com",
 					endpoint.RecordTypeA,
 					endpoint.TTL(defaultTTL),
 					"192.168.2.5",
 				)},
 			},
-			expectedEndpoints: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL(
+			expectedEndpoints: []*endpoint.Endpoint{endpoint.MustNewEndpointWithTTL(
 				"foo.foo.com",
 				endpoint.RecordTypeA,
 				endpoint.TTL(defaultTTL), "192.168.1.2", "192.168.2.5",
@@ -952,14 +952,14 @@ func TestOCIApplyChanges(t *testing.T) {
 				}},
 			},
 			changes: &plan.Changes{
-				Delete: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL(
+				Delete: []*endpoint.Endpoint{endpoint.MustNewEndpointWithTTL(
 					"foo.foo.com",
 					endpoint.RecordTypeA,
 					endpoint.TTL(defaultTTL),
 					"192.168.1.2",
 				)},
 			},
-			expectedEndpoints: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL(
+			expectedEndpoints: []*endpoint.Endpoint{endpoint.MustNewEndpointWithTTL(
 				"foo.foo.com",
 				endpoint.RecordTypeA,
 				endpoint.TTL(defaultTTL), "192.168.2.5",
@@ -980,20 +980,20 @@ func TestOCIApplyChanges(t *testing.T) {
 				}},
 			},
 			changes: &plan.Changes{
-				UpdateOld: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL(
+				UpdateOld: []*endpoint.Endpoint{endpoint.MustNewEndpointWithTTL(
 					"first.foo.com",
 					endpoint.RecordTypeA,
 					endpoint.TTL(defaultTTL),
 					"10.77.4.5",
 				)},
-				UpdateNew: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL(
+				UpdateNew: []*endpoint.Endpoint{endpoint.MustNewEndpointWithTTL(
 					"first.foo.com",
 					endpoint.RecordTypeA,
 					endpoint.TTL(defaultTTL),
 					"10.77.6.10",
 				)},
 			},
-			expectedEndpoints: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL(
+			expectedEndpoints: []*endpoint.Endpoint{endpoint.MustNewEndpointWithTTL(
 				"first.foo.com",
 				endpoint.RecordTypeA,
 				endpoint.TTL(defaultTTL),
@@ -1015,14 +1015,14 @@ func TestOCIApplyChanges(t *testing.T) {
 				}},
 			},
 			changes: &plan.Changes{
-				Create: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL(
+				Create: []*endpoint.Endpoint{endpoint.MustNewEndpointWithTTL(
 					"first.foo.com",
 					endpoint.RecordTypeA,
 					endpoint.TTL(defaultTTL),
 					"10.77.6.10",
 				)},
 			},
-			expectedEndpoints: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL(
+			expectedEndpoints: []*endpoint.Endpoint{endpoint.MustNewEndpointWithTTL(
 				"first.foo.com",
 				endpoint.RecordTypeA,
 				endpoint.TTL(defaultTTL),

--- a/provider/ovh/ovh.go
+++ b/provider/ovh/ovh.go
@@ -510,12 +510,16 @@ func ovhGroupByNameAndType(records []ovhRecord) []*endpoint.Endpoint {
 		for _, record := range records {
 			targets = append(targets, record.Target)
 		}
-		ep := endpoint.NewEndpointWithTTL(
+		ep, err := endpoint.NewEndpointWithTTL(
 			strings.TrimPrefix(records[0].SubDomain+"."+records[0].Zone, "."),
 			records[0].FieldType,
 			endpoint.TTL(records[0].TTL),
 			targets...,
 		)
+		if err != nil {
+			log.Errorf("Failed to create endpoint for record %q: %v", records[0].SubDomain+"."+records[0].Zone, err)
+			continue
+		}
 		endpoints = append(endpoints, ep)
 	}
 

--- a/provider/pdns/pdns.go
+++ b/provider/pdns/pdns.go
@@ -346,7 +346,12 @@ func (p *PDNSProvider) convertRRSetToEndpoints(rr pgo.RRset) []*endpoint.Endpoin
 	if rrType == string(pgo.RRTypeALIAS) {
 		rrType = endpoint.RecordTypeCNAME
 	}
-	endpoints = append(endpoints, endpoint.NewEndpointWithTTL(pgo.StringValue(rr.Name), rrType, endpoint.TTL(pgo.Uint32Value(rr.TTL)), targets...))
+	ep, err := endpoint.NewEndpointWithTTL(pgo.StringValue(rr.Name), rrType, endpoint.TTL(pgo.Uint32Value(rr.TTL)), targets...)
+	if err != nil {
+		log.Errorf("Failed to create endpoint for record %q: %v", pgo.StringValue(rr.Name), err)
+		return endpoints
+	}
+	endpoints = append(endpoints, ep)
 	return endpoints
 }
 

--- a/provider/pdns/pdns_test.go
+++ b/provider/pdns/pdns_test.go
@@ -160,101 +160,101 @@ var (
 	}
 
 	endpointsDisabledRecord = []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8"),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8"),
 	}
 
 	endpointsSimpleRecord = []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8"),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
 	}
 
 	endpointsLongRecord = []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("a.very.long.domainname.example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("a.very.long.domainname.example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
+		endpoint.MustNewEndpointWithTTL("a.very.long.domainname.example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8"),
+		endpoint.MustNewEndpointWithTTL("a.very.long.domainname.example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
 	}
 
 	endpointsNonexistantZone = []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("does.not.exist.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("does.not.exist.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
+		endpoint.MustNewEndpointWithTTL("does.not.exist.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8"),
+		endpoint.MustNewEndpointWithTTL("does.not.exist.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
 	}
 	endpointsMultipleRecords = []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8", "8.8.4.4", "4.4.4.4"),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8", "8.8.4.4", "4.4.4.4"),
 	}
 
 	endpointsMXRecord = []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, endpoint.TTL(300), "10 example.com"),
+		endpoint.MustNewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, endpoint.TTL(300), "10 example.com"),
 	}
 
 	endpointsMXRecordInvalidFormatTooManyArgs = []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, endpoint.TTL(300), "10 example.com abc"),
+		endpoint.MustNewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, endpoint.TTL(300), "10 example.com abc"),
 	}
 
 	endpointsMultipleMXRecordsWithSingleInvalid = []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, endpoint.TTL(300), "abc example.com"),
-		endpoint.NewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, endpoint.TTL(300), "20 backup.example.com"),
+		endpoint.MustNewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, endpoint.TTL(300), "abc example.com"),
+		endpoint.MustNewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, endpoint.TTL(300), "20 backup.example.com"),
 	}
 
 	endpointsMultipleInvalidMXRecords = []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, endpoint.TTL(300), "example.com"),
-		endpoint.NewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, endpoint.TTL(300), "backup.example.com"),
+		endpoint.MustNewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, endpoint.TTL(300), "example.com"),
+		endpoint.MustNewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, endpoint.TTL(300), "backup.example.com"),
 	}
 
 	endpointsMixedRecords = []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("cname.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(300), "example.com"),
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "'would smell as sweet'"),
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8", "8.8.4.4", "4.4.4.4"),
-		endpoint.NewEndpointWithTTL("alias.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(300), "example.by.any.other.name.com"),
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeMX, endpoint.TTL(300), "10 mailhost1.example.com", "10 mailhost2.example.com"),
-		endpoint.NewEndpointWithTTL("_service._tls.example.com", endpoint.RecordTypeSRV, endpoint.TTL(300), "100 1 443 service.example.com"),
-		endpoint.NewEndpointWithTTL("sub.example.com", endpoint.RecordTypeNS, endpoint.TTL(300), "ns1.example.com", "ns2.example.com"),
-		endpoint.NewEndpointWithTTL("4.3.2.1.in-addr.arpa", endpoint.RecordTypePTR, endpoint.TTL(300), "host.example.com"),
+		endpoint.MustNewEndpointWithTTL("cname.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(300), "example.com"),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "'would smell as sweet'"),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8", "8.8.4.4", "4.4.4.4"),
+		endpoint.MustNewEndpointWithTTL("alias.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(300), "example.by.any.other.name.com"),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeMX, endpoint.TTL(300), "10 mailhost1.example.com", "10 mailhost2.example.com"),
+		endpoint.MustNewEndpointWithTTL("_service._tls.example.com", endpoint.RecordTypeSRV, endpoint.TTL(300), "100 1 443 service.example.com"),
+		endpoint.MustNewEndpointWithTTL("sub.example.com", endpoint.RecordTypeNS, endpoint.TTL(300), "ns1.example.com", "ns2.example.com"),
+		endpoint.MustNewEndpointWithTTL("4.3.2.1.in-addr.arpa", endpoint.RecordTypePTR, endpoint.TTL(300), "host.example.com"),
 	}
 
 	endpointsMultipleZones = []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
-		endpoint.NewEndpointWithTTL("mock.test", endpoint.RecordTypeA, endpoint.TTL(300), "9.9.9.9"),
-		endpoint.NewEndpointWithTTL("mock.test", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8"),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
+		endpoint.MustNewEndpointWithTTL("mock.test", endpoint.RecordTypeA, endpoint.TTL(300), "9.9.9.9"),
+		endpoint.MustNewEndpointWithTTL("mock.test", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
 	}
 
 	endpointsMultipleZones2 = []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
-		endpoint.NewEndpointWithTTL("abcd.mock.test", endpoint.RecordTypeA, endpoint.TTL(300), "9.9.9.9"),
-		endpoint.NewEndpointWithTTL("abcd.mock.test", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8"),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
+		endpoint.MustNewEndpointWithTTL("abcd.mock.test", endpoint.RecordTypeA, endpoint.TTL(300), "9.9.9.9"),
+		endpoint.MustNewEndpointWithTTL("abcd.mock.test", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
 	}
 
 	endpointsMultipleZonesWithNoExist = []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
-		endpoint.NewEndpointWithTTL("abcd.mock.noexist", endpoint.RecordTypeA, endpoint.TTL(300), "9.9.9.9"),
-		endpoint.NewEndpointWithTTL("abcd.mock.noexist", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8"),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
+		endpoint.MustNewEndpointWithTTL("abcd.mock.noexist", endpoint.RecordTypeA, endpoint.TTL(300), "9.9.9.9"),
+		endpoint.MustNewEndpointWithTTL("abcd.mock.noexist", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
 	}
 	endpointsMultipleZonesWithLongRecordNotInDomainFilter = []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
-		endpoint.NewEndpointWithTTL("a.very.long.domainname.example.com", endpoint.RecordTypeA, endpoint.TTL(300), "9.9.9.9"),
-		endpoint.NewEndpointWithTTL("a.very.long.domainname.example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8"),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
+		endpoint.MustNewEndpointWithTTL("a.very.long.domainname.example.com", endpoint.RecordTypeA, endpoint.TTL(300), "9.9.9.9"),
+		endpoint.MustNewEndpointWithTTL("a.very.long.domainname.example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
 	}
 	endpointsMultipleZonesWithSimilarRecordNotInDomainFilter = []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8"),
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
-		endpoint.NewEndpointWithTTL("test.simexample.com", endpoint.RecordTypeA, endpoint.TTL(300), "9.9.9.9"),
-		endpoint.NewEndpointWithTTL("test.simexample.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8"),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
+		endpoint.MustNewEndpointWithTTL("test.simexample.com", endpoint.RecordTypeA, endpoint.TTL(300), "9.9.9.9"),
+		endpoint.MustNewEndpointWithTTL("test.simexample.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
 	}
 	endpointsApexRecords = []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("cname.example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
-		endpoint.NewEndpointWithTTL("cname.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(300), "example.by.any.other.name.com"),
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
-		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeCNAME, endpoint.TTL(300), "example.by.any.other.name.com"),
+		endpoint.MustNewEndpointWithTTL("cname.example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
+		endpoint.MustNewEndpointWithTTL("cname.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(300), "example.by.any.other.name.com"),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "\"heritage=external-dns,external-dns/owner=tower-pdns\""),
+		endpoint.MustNewEndpointWithTTL("example.com", endpoint.RecordTypeCNAME, endpoint.TTL(300), "example.by.any.other.name.com"),
 	}
 
 	// Endpoint with alias annotation
-	endpointWithAliasAnnotation = endpoint.NewEndpointWithTTL("sub.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(300), "target.example.com").WithAliasProperty(endpoint.AliasTrue)
+	endpointWithAliasAnnotation = endpoint.MustNewEndpointWithTTL("sub.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(300), "target.example.com").WithAliasProperty(endpoint.AliasTrue)
 
 	// Endpoints for preferAlias test
 	endpointsPreferAlias = []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("sub.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(300), "target.example.com"),
+		endpoint.MustNewEndpointWithTTL("sub.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(300), "target.example.com"),
 	}
 
 	ZoneEmptyToPreferAliasPatch = pgo.Zone{
@@ -801,25 +801,25 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSHasAliasAnnotation() {
 	p := &PDNSProvider{}
 
 	// Test endpoint without alias annotation
-	epWithoutAlias := endpoint.NewEndpoint("test.example.com", endpoint.RecordTypeCNAME, "target.example.com")
+	epWithoutAlias := endpoint.MustNewEndpoint("test.example.com", endpoint.RecordTypeCNAME, "target.example.com")
 	suite.False(p.hasAliasAnnotation(epWithoutAlias))
 
 	// Test endpoint with alias=false
-	epWithAliasFalse := endpoint.NewEndpoint("test.example.com", endpoint.RecordTypeCNAME, "target.example.com")
+	epWithAliasFalse := endpoint.MustNewEndpoint("test.example.com", endpoint.RecordTypeCNAME, "target.example.com")
 	epWithAliasFalse.ProviderSpecific = endpoint.ProviderSpecific{
 		{Name: endpoint.ProviderSpecificAlias, Value: "false"},
 	}
 	suite.False(p.hasAliasAnnotation(epWithAliasFalse))
 
 	// Test endpoint with alias=true
-	epWithAliasTrue := endpoint.NewEndpoint("test.example.com", endpoint.RecordTypeCNAME, "target.example.com")
+	epWithAliasTrue := endpoint.MustNewEndpoint("test.example.com", endpoint.RecordTypeCNAME, "target.example.com")
 	epWithAliasTrue.ProviderSpecific = endpoint.ProviderSpecific{
 		{Name: endpoint.ProviderSpecificAlias, Value: "true"},
 	}
 	suite.True(p.hasAliasAnnotation(epWithAliasTrue))
 
 	// Test endpoint with other provider specific but no alias
-	epWithOtherPS := endpoint.NewEndpoint("test.example.com", endpoint.RecordTypeCNAME, "target.example.com")
+	epWithOtherPS := endpoint.MustNewEndpoint("test.example.com", endpoint.RecordTypeCNAME, "target.example.com")
 	epWithOtherPS.ProviderSpecific = endpoint.ProviderSpecific{
 		{Name: "other", Value: "value"},
 	}
@@ -1108,7 +1108,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSAdjustEndpoints() {
 			description: "Valid MX endpoint is not removed",
 			endpoints:   endpointsMXRecord,
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, endpoint.TTL(300), "10 example.com"),
+				endpoint.MustNewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, endpoint.TTL(300), "10 example.com"),
 			},
 		},
 		{
@@ -1120,7 +1120,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSAdjustEndpoints() {
 			description: "Invalid MX endpoint is removed among valid endpoints",
 			endpoints:   endpointsMultipleMXRecordsWithSingleInvalid,
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, endpoint.TTL(300), "20 backup.example.com"),
+				endpoint.MustNewEndpointWithTTL("mail.example.com", endpoint.RecordTypeMX, endpoint.TTL(300), "20 backup.example.com"),
 			},
 		},
 		{

--- a/provider/pihole/client.go
+++ b/provider/pihole/client.go
@@ -161,7 +161,11 @@ func (p *piholeClient) listRecords(ctx context.Context, rtype string) ([]*endpoi
 			}
 		}
 
-		ep := endpoint.NewEndpointWithTTL(dnsName, rtype, ttl, target)
+		ep, err := endpoint.NewEndpointWithTTL(dnsName, rtype, ttl, target)
+		if err != nil {
+			log.Errorf("Failed to create endpoint for record %q: %v", dnsName, err)
+			continue
+		}
 
 		if oldEp, ok := endpoints[dnsName]; ok {
 			ep.Targets = append(oldEp.Targets, target) // nolint: gocritic // appendAssign

--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -271,12 +271,16 @@ OuterLoop:
 			}
 		}
 
-		ep := endpoint.NewEndpointWithTTL(
+		ep, err := endpoint.NewEndpointWithTTL(
 			rrFqdn,
 			rrType,
 			rrTTL,
 			rrValues...,
 		)
+		if err != nil {
+			log.Errorf("Failed to create endpoint for record %q: %v", rrFqdn, err)
+			continue
+		}
 
 		eps = append(eps, ep)
 	}

--- a/provider/scaleway/scaleway.go
+++ b/provider/scaleway/scaleway.go
@@ -178,7 +178,11 @@ func (p *ScalewayProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, e
 				existingEndpoint.Targets = append(existingEndpoint.Targets, record.Data)
 				log.Infof("Appending target %s to record %s, using TTL and priority of target %s", record.Data, fullRecordName, existingEndpoint.Targets[0])
 			} else {
-				ep := endpoint.NewEndpointWithTTL(fullRecordName, record.Type.String(), endpoint.TTL(record.TTL), record.Data)
+				ep, err := endpoint.NewEndpointWithTTL(fullRecordName, record.Type.String(), endpoint.TTL(record.TTL), record.Data)
+				if err != nil {
+					log.Errorf("Failed to create endpoint for record %q: %v", fullRecordName, err)
+					continue
+				}
 				ep = ep.WithProviderSpecific(scalewayPriorityKey, fmt.Sprintf("%d", record.Priority))
 				endpoints[record.Type.String()+"/"+fullRecordName] = ep
 			}

--- a/provider/webhook/webhook_test.go
+++ b/provider/webhook/webhook_test.go
@@ -386,7 +386,7 @@ func TestAdjustEndpoints_PreservesRefObjects(t *testing.T) {
 
 		ref := events.NewObjectReferenceFromParts("Service", "v1", "default", "my-svc", "uid-1", "service")
 		adjusted, err := p.AdjustEndpoints([]*endpoint.Endpoint{
-			endpoint.NewEndpoint("test.example.com", "A", "1.2.3.4").WithRefObject(ref),
+			endpoint.MustNewEndpoint("test.example.com", "A", "1.2.3.4").WithRefObject(ref),
 		})
 		require.NoError(t, err)
 		require.Len(t, adjusted, 1)
@@ -405,7 +405,7 @@ func TestAdjustEndpoints_PreservesRefObjects(t *testing.T) {
 		ref1 := events.NewObjectReferenceFromParts("Service", "v1", "default", "svc-a", "uid-1", "service")
 		ref2 := events.NewObjectReferenceFromParts("Service", "v1", "default", "svc-b", "uid-2", "service")
 		adjusted, err := p.AdjustEndpoints([]*endpoint.Endpoint{
-			endpoint.NewEndpoint("test.example.com", "A", "1.2.3.4").
+			endpoint.MustNewEndpoint("test.example.com", "A", "1.2.3.4").
 				WithRefObject(ref1).
 				WithRefObject(ref2),
 		})

--- a/registry/awssd/registry_test.go
+++ b/registry/awssd/registry_test.go
@@ -111,18 +111,18 @@ func TestAWSSDRegistryTest_Records(t *testing.T) {
 func TestAWSSDRegistry_Records_ApplyChanges(t *testing.T) {
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			endpoint.NewEndpoint("new-record-1.test-zone.example.org", endpoint.RecordTypeCNAME, "new-loadbalancer-1.lb.com"),
+			endpoint.MustNewEndpoint("new-record-1.test-zone.example.org", endpoint.RecordTypeCNAME, "new-loadbalancer-1.lb.com"),
 		},
 		Delete: []*endpoint.Endpoint{
-			endpoint.NewEndpoint("foobar.test-zone.example.org", endpoint.RecordTypeA, "1.2.3.4").
+			endpoint.MustNewEndpoint("foobar.test-zone.example.org", endpoint.RecordTypeA, "1.2.3.4").
 				WithLabel(endpoint.OwnerLabelKey, "owner"),
 		},
 		UpdateNew: []*endpoint.Endpoint{
-			endpoint.NewEndpoint("tar.test-zone.example.org", endpoint.RecordTypeCNAME, "new-tar.loadbalancer.com").
+			endpoint.MustNewEndpoint("tar.test-zone.example.org", endpoint.RecordTypeCNAME, "new-tar.loadbalancer.com").
 				WithLabel(endpoint.OwnerLabelKey, "owner"),
 		},
 		UpdateOld: []*endpoint.Endpoint{
-			endpoint.NewEndpoint("tar.test-zone.example.org", endpoint.RecordTypeCNAME, "tar.loadbalancer.com").
+			endpoint.MustNewEndpoint("tar.test-zone.example.org", endpoint.RecordTypeCNAME, "tar.loadbalancer.com").
 				WithLabel(endpoint.OwnerLabelKey, "owner"),
 		},
 	}
@@ -163,7 +163,7 @@ func TestAWSSDRegistry_Records_ApplyChanges(t *testing.T) {
 }
 
 func newEndpointWithOwnerAndDescription(dnsName, target, recordType, ownerID string, description string) *endpoint.Endpoint {
-	e := endpoint.NewEndpoint(dnsName, recordType, target)
+	e := endpoint.MustNewEndpoint(dnsName, recordType, target)
 	e.Labels[endpoint.OwnerLabelKey] = ownerID
 	e.Labels[endpoint.AWSSDDescriptionLabel] = description
 	return e

--- a/registry/crd/crd_test.go
+++ b/registry/crd/crd_test.go
@@ -501,7 +501,11 @@ func (m *mockProvider) ApplyChanges(_ context.Context, changes *plan.Changes) er
 	endpoints := changes.Create
 	m.records = make([]*endpoint.Endpoint, 0, len(endpoints))
 	for _, ep := range endpoints {
-		newEp := endpoint.NewEndpointWithTTL(ep.DNSName, ep.RecordType, ep.RecordTTL, ep.Targets...).WithSetIdentifier(ep.SetIdentifier)
+		newEp, err := endpoint.NewEndpointWithTTL(ep.DNSName, ep.RecordType, ep.RecordTTL, ep.Targets...)
+		if err != nil {
+			return fmt.Errorf("failed to create new endpoint: %w", err)
+		}
+		newEp.WithSetIdentifier(ep.SetIdentifier)
 		newEp.Labels = endpoint.NewLabels()
 		maps.Copy(newEp.Labels, ep.Labels)
 		newEp.ProviderSpecific = append(endpoint.ProviderSpecific(nil), ep.ProviderSpecific...)

--- a/registry/dynamodb/registry_test.go
+++ b/registry/dynamodb/registry_test.go
@@ -246,10 +246,10 @@ func TestDynamoDBRegistryRecords(t *testing.T) {
 	r, _ := newRegistry(p, "test-owner", api, "test-table", "txt.", "", "", []string{}, []string{}, nil, time.Hour)
 	_ = p.(*wrappedProvider).Provider.ApplyChanges(t.Context(), &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			endpoint.NewEndpoint("migrate.test-zone.example.org", endpoint.RecordTypeA, "3.3.3.3").WithSetIdentifier("set-3"),
-			endpoint.NewEndpoint("txt.migrate.test-zone.example.org", endpoint.RecordTypeTXT, "\"heritage=external-dns,external-dns/owner=test-owner,external-dns/resource=ingress/default/other-ingress\"").WithSetIdentifier("set-3"),
-			endpoint.NewEndpoint("txt.orphaned.test-zone.example.org", endpoint.RecordTypeTXT, "\"heritage=external-dns,external-dns/owner=test-owner,external-dns/resource=ingress/default/other-ingress\"").WithSetIdentifier("set-3"),
-			endpoint.NewEndpoint("txt.baz.test-zone.example.org", endpoint.RecordTypeTXT, "\"heritage=external-dns,external-dns/owner=test-owner,external-dns/resource=ingress/default/other-ingress\"").WithSetIdentifier("set-2"),
+			endpoint.MustNewEndpoint("migrate.test-zone.example.org", endpoint.RecordTypeA, "3.3.3.3").WithSetIdentifier("set-3"),
+			endpoint.MustNewEndpoint("txt.migrate.test-zone.example.org", endpoint.RecordTypeTXT, "\"heritage=external-dns,external-dns/owner=test-owner,external-dns/resource=ingress/default/other-ingress\"").WithSetIdentifier("set-3"),
+			endpoint.MustNewEndpoint("txt.orphaned.test-zone.example.org", endpoint.RecordTypeTXT, "\"heritage=external-dns,external-dns/owner=test-owner,external-dns/resource=ingress/default/other-ingress\"").WithSetIdentifier("set-3"),
+			endpoint.MustNewEndpoint("txt.baz.test-zone.example.org", endpoint.RecordTypeTXT, "\"heritage=external-dns,external-dns/owner=test-owner,external-dns/resource=ingress/default/other-ingress\"").WithSetIdentifier("set-2"),
 		},
 	})
 
@@ -1164,10 +1164,10 @@ func newDynamoDBAPIStub(t *testing.T, stubConfig *DynamoDBStubConfig) (*DynamoDB
 	_ = p.CreateZone(testZone)
 	_ = p.ApplyChanges(t.Context(), &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			endpoint.NewEndpoint("foo.test-zone.example.org", endpoint.RecordTypeCNAME, "foo.loadbalancer.com"),
-			endpoint.NewEndpoint("bar.test-zone.example.org", endpoint.RecordTypeCNAME, "my-domain.com"),
-			endpoint.NewEndpoint("baz.test-zone.example.org", endpoint.RecordTypeA, "1.1.1.1").WithSetIdentifier("set-1"),
-			endpoint.NewEndpoint("baz.test-zone.example.org", endpoint.RecordTypeA, "2.2.2.2").WithSetIdentifier("set-2"),
+			endpoint.MustNewEndpoint("foo.test-zone.example.org", endpoint.RecordTypeCNAME, "foo.loadbalancer.com"),
+			endpoint.MustNewEndpoint("bar.test-zone.example.org", endpoint.RecordTypeCNAME, "my-domain.com"),
+			endpoint.MustNewEndpoint("baz.test-zone.example.org", endpoint.RecordTypeA, "1.1.1.1").WithSetIdentifier("set-1"),
+			endpoint.MustNewEndpoint("baz.test-zone.example.org", endpoint.RecordTypeA, "2.2.2.2").WithSetIdentifier("set-2"),
 		},
 	})
 	return stub, &wrappedProvider{

--- a/registry/noop/noop_test.go
+++ b/registry/noop/noop_test.go
@@ -55,7 +55,7 @@ func TestNoopRegistry_GetDomainFilter(t *testing.T) {
 
 func TestNoopRegistry_AdjustEndpoints(t *testing.T) {
 	r := newRegistry(inmemory.NewInMemoryProvider())
-	eps := []*endpoint.Endpoint{endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4")}
+	eps := []*endpoint.Endpoint{endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4")}
 	got, err := r.AdjustEndpoints(eps)
 	require.NoError(t, err)
 	assert.Equal(t, eps, got)

--- a/registry/txt/encryption_test.go
+++ b/registry/txt/encryption_test.go
@@ -291,7 +291,7 @@ func hasPrefixFromSlice(str string, prefixes []string) bool {
 }
 
 func newEndpointWithOwnerAndOwnedRecordWithKeyIDLabel(dnsName, target, recordType, ownerID string, resource string, keyId string) *endpoint.Endpoint {
-	e := endpoint.NewEndpoint(dnsName, recordType, target)
+	e := endpoint.MustNewEndpoint(dnsName, recordType, target)
 	e.Labels[endpoint.OwnerLabelKey] = ownerID
 	e.Labels[endpoint.ResourceLabelKey] = resource
 	e.Labels["key-id"] = keyId

--- a/registry/txt/registry.go
+++ b/registry/txt/registry.go
@@ -350,14 +350,16 @@ func (im *TXTRegistry) generateTXTRecordWithFilter(r *endpoint.Endpoint, filter 
 		r.Labels[endpoint.OwnerLabelKey] = im.ownerID
 	}
 
-	txtNew := endpoint.NewEndpoint(im.mapper.ToTXTName(r.DNSName, recordType), endpoint.RecordTypeTXT, r.Labels.Serialize(true, im.txtEncryptEnabled, im.txtEncryptAESKey))
-	if txtNew != nil {
-		txtNew.WithSetIdentifier(r.SetIdentifier)
-		txtNew.Labels[endpoint.OwnedRecordLabelKey] = r.DNSName
-		txtNew.ProviderSpecific = r.ProviderSpecific
-		if filter(txtNew) {
-			endpoints = append(endpoints, txtNew)
-		}
+	txtNew, err := endpoint.NewEndpoint(im.mapper.ToTXTName(r.DNSName, recordType), endpoint.RecordTypeTXT, r.Labels.Serialize(true, im.txtEncryptEnabled, im.txtEncryptAESKey))
+	if err != nil {
+		log.Errorf("Failed to generate TXT record for %s: %v", r.DNSName, err)
+		return endpoints
+	}
+	txtNew.WithSetIdentifier(r.SetIdentifier)
+	txtNew.Labels[endpoint.OwnedRecordLabelKey] = r.DNSName
+	txtNew.ProviderSpecific = r.ProviderSpecific
+	if filter(txtNew) {
+		endpoints = append(endpoints, txtNew)
 	}
 	return endpoints
 }

--- a/registry/txt/registry_test.go
+++ b/registry/txt/registry_test.go
@@ -131,7 +131,10 @@ type nilLabelsProvider struct {
 }
 
 func (p *nilLabelsProvider) Records(_ context.Context) ([]*endpoint.Endpoint, error) {
-	ep := endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.4")
+	ep, err := endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.4")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new endpoint: %w", err)
+	}
 	ep.Labels = nil
 	return []*endpoint.Endpoint{ep}, nil
 }
@@ -166,7 +169,7 @@ func TestTXTRegistry_AdjustEndpoints(t *testing.T) {
 	r, err := newRegistry(p, "", "", "owner", time.Hour, "", []string{}, []string{}, false, nil, "")
 	require.NoError(t, err)
 	eps := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4"),
+		endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4"),
 	}
 	got, err := r.AdjustEndpoints(eps)
 	require.NoError(t, err)
@@ -1163,8 +1166,8 @@ func testTXTRegistryMissingRecordsNoPrefix(t *testing.T) {
 			newEndpointWithOwner("noheritage.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("oldformat-otherowner.test-zone.example.org", "bar.loadbalancer.com", endpoint.RecordTypeA, ""),
 			newEndpointWithOwner("oldformat-otherowner.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=otherowner\"", endpoint.RecordTypeTXT, ""),
-			endpoint.NewEndpoint("unmanaged1.test-zone.example.org", endpoint.RecordTypeA, "unmanaged1.loadbalancer.com"),
-			endpoint.NewEndpoint("unmanaged2.test-zone.example.org", endpoint.RecordTypeCNAME, "unmanaged2.loadbalancer.com"),
+			endpoint.MustNewEndpoint("unmanaged1.test-zone.example.org", endpoint.RecordTypeA, "unmanaged1.loadbalancer.com"),
+			endpoint.MustNewEndpoint("unmanaged2.test-zone.example.org", endpoint.RecordTypeCNAME, "unmanaged2.loadbalancer.com"),
 			newEndpointWithOwner("this-is-a-63-characters-long-label-that-we-do-expect-will-work.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
 			newEndpointWithOwner("this-is-a-63-characters-long-label-that-we-do-expect-will-work.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 		},
@@ -1272,8 +1275,8 @@ func testTXTRegistryMissingRecordsWithPrefix(t *testing.T) {
 			newEndpointWithOwner("noheritage.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("oldformat-otherowner.test-zone.example.org", "bar.loadbalancer.com", endpoint.RecordTypeA, ""),
 			newEndpointWithOwner("txt.oldformat-otherowner.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=otherowner\"", endpoint.RecordTypeTXT, ""),
-			endpoint.NewEndpoint("unmanaged1.test-zone.example.org", endpoint.RecordTypeA, "unmanaged1.loadbalancer.com"),
-			endpoint.NewEndpoint("unmanaged2.test-zone.example.org", endpoint.RecordTypeCNAME, "unmanaged2.loadbalancer.com"),
+			endpoint.MustNewEndpoint("unmanaged1.test-zone.example.org", endpoint.RecordTypeA, "unmanaged1.loadbalancer.com"),
+			endpoint.MustNewEndpoint("unmanaged2.test-zone.example.org", endpoint.RecordTypeCNAME, "unmanaged2.loadbalancer.com"),
 		},
 	})
 	require.NoError(t, err)

--- a/registry/txt/utils_test.go
+++ b/registry/txt/utils_test.go
@@ -35,14 +35,14 @@ func newTXTEndpointWithOwnedRecord(dnsName, target, ownedRecord string) *endpoin
 }
 
 func newMultiTargetEndpointWithOwnerAndLabels(dnsName string, targets endpoint.Targets, recordType, ownerID string, labels endpoint.Labels) *endpoint.Endpoint {
-	e := endpoint.NewEndpoint(dnsName, recordType, targets...)
+	e := endpoint.MustNewEndpoint(dnsName, recordType, targets...)
 	e.Labels[endpoint.OwnerLabelKey] = ownerID
 	maps.Copy(e.Labels, labels)
 	return e
 }
 
 func newEndpointWithOwnerAndLabels(dnsName, target, recordType, ownerID string, labels endpoint.Labels) *endpoint.Endpoint {
-	e := endpoint.NewEndpoint(dnsName, recordType, target)
+	e := endpoint.MustNewEndpoint(dnsName, recordType, target)
 	e.Labels[endpoint.OwnerLabelKey] = ownerID
 	maps.Copy(e.Labels, labels)
 	return e
@@ -59,7 +59,7 @@ func findEndpoint(eps []*endpoint.Endpoint, dnsName, recordType string) *endpoin
 }
 
 func newCNAMEEndpointWithOwnerResource(dnsName, target, ownerID, resource string) *endpoint.Endpoint {
-	e := endpoint.NewEndpoint(dnsName, endpoint.RecordTypeCNAME, target)
+	e := endpoint.MustNewEndpoint(dnsName, endpoint.RecordTypeCNAME, target)
 	e.Labels[endpoint.OwnerLabelKey] = ownerID
 	e.Labels[endpoint.ResourceLabelKey] = resource
 	return e

--- a/source/compatibility.go
+++ b/source/compatibility.go
@@ -19,6 +19,7 @@ package source
 import (
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -63,10 +64,10 @@ func legacyEndpointsFromMateService(svc *v1.Service) []*endpoint.Endpoint {
 	// Create a corresponding endpoint for each configured external entrypoint.
 	for _, lb := range svc.Status.LoadBalancer.Ingress {
 		if lb.IP != "" {
-			endpoints = append(endpoints, endpoint.NewEndpoint(hostname, endpoint.RecordTypeA, lb.IP))
+			endpoints = appendNewEndpoint(endpoints, hostname, endpoint.RecordTypeA, lb.IP)
 		}
 		if lb.Hostname != "" {
-			endpoints = append(endpoints, endpoint.NewEndpoint(hostname, endpoint.RecordTypeCNAME, lb.Hostname))
+			endpoints = appendNewEndpoint(endpoints, hostname, endpoint.RecordTypeCNAME, lb.Hostname)
 		}
 	}
 
@@ -95,10 +96,10 @@ func legacyEndpointsFromMoleculeService(svc *v1.Service) []*endpoint.Endpoint {
 		// Create a corresponding endpoint for each configured external entrypoint.
 		for _, lb := range svc.Status.LoadBalancer.Ingress {
 			if lb.IP != "" {
-				endpoints = append(endpoints, endpoint.NewEndpoint(hostname, endpoint.RecordTypeA, lb.IP))
+				endpoints = appendNewEndpoint(endpoints, hostname, endpoint.RecordTypeA, lb.IP)
 			}
 			if lb.Hostname != "" {
-				endpoints = append(endpoints, endpoint.NewEndpoint(hostname, endpoint.RecordTypeCNAME, lb.Hostname))
+				endpoints = appendNewEndpoint(endpoints, hostname, endpoint.RecordTypeCNAME, lb.Hostname)
 			}
 		}
 	}
@@ -160,10 +161,10 @@ func legacyEndpointsFromDNSControllerNodePortService(svc *v1.Service, sc *servic
 				recordType := endpoint.SuitableType(address.Address)
 				// IPv6 addresses are labeled as NodeInternalIP despite being usable externally as well.
 				if isExternal && (address.Type == v1.NodeExternalIP || (sc.exposeInternalIPv6 && address.Type == v1.NodeInternalIP && recordType == endpoint.RecordTypeAAAA)) {
-					endpoints = append(endpoints, endpoint.NewEndpoint(hostname, recordType, address.Address))
+					endpoints = appendNewEndpoint(endpoints, hostname, recordType, address.Address)
 				}
 				if isInternal && address.Type == v1.NodeInternalIP {
-					endpoints = append(endpoints, endpoint.NewEndpoint(hostname, recordType, address.Address))
+					endpoints = appendNewEndpoint(endpoints, hostname, recordType, address.Address)
 				}
 			}
 		}
@@ -196,13 +197,24 @@ func legacyEndpointsFromDNSControllerLoadBalancerService(svc *v1.Service) []*end
 		// Create a corresponding endpoint for each configured external entrypoint.
 		for _, lb := range svc.Status.LoadBalancer.Ingress {
 			if lb.IP != "" {
-				endpoints = append(endpoints, endpoint.NewEndpoint(hostname, endpoint.RecordTypeA, lb.IP))
+				endpoints = appendNewEndpoint(endpoints, hostname, endpoint.RecordTypeA, lb.IP)
 			}
 			if lb.Hostname != "" {
-				endpoints = append(endpoints, endpoint.NewEndpoint(hostname, endpoint.RecordTypeCNAME, lb.Hostname))
+				endpoints = appendNewEndpoint(endpoints, hostname, endpoint.RecordTypeCNAME, lb.Hostname)
 			}
 		}
 	}
 
 	return endpoints
+}
+
+// appendNewEndpoint creates a new endpoint and appends it to the given slice of endpoints.
+// If the endpoint creation fails, it logs the error and returns the original slice.
+func appendNewEndpoint(endpoints []*endpoint.Endpoint, dnsName string, recordType string, targets ...string) []*endpoint.Endpoint {
+	ep, err := endpoint.NewEndpoint(dnsName, recordType, targets...)
+	if err != nil {
+		log.Warnf("Failed to create endpoint for %s: %v", dnsName, err)
+		return endpoints
+	}
+	return append(endpoints, ep)
 }

--- a/source/f5_transportserver_fqdn_test.go
+++ b/source/f5_transportserver_fqdn_test.go
@@ -68,7 +68,7 @@ func TestF5TransportServerFQDNTemplate(t *testing.T) {
 			fqdnTemplate:   "{{.Name}}.example.com",
 			targetTemplate: "lb.example.com",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-ts.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+				endpoint.MustNewEndpoint("my-ts.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
 			},
 		},
 		{
@@ -91,7 +91,7 @@ func TestF5TransportServerFQDNTemplate(t *testing.T) {
 			},
 			fqdnTargetTemplate: "{{.Name}}.example.com:1.2.3.4",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-ts.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("my-ts.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 		{
@@ -259,7 +259,7 @@ func TestF5TransportServerFQDNTemplate(t *testing.T) {
 			fqdnTemplate:   "{{.Kind | toLower}}.{{.Name}}.example.com",
 			targetTemplate: "lb.example.com",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("transportserver.my-ts.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+				endpoint.MustNewEndpoint("transportserver.my-ts.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
 			},
 		},
 		{
@@ -278,7 +278,7 @@ func TestF5TransportServerFQDNTemplate(t *testing.T) {
 			},
 			fqdnTargetTemplate: `{{.Name}}.{{replace "/" "." .APIVersion}}.example.com:1.2.3.4`,
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-ts.cis.f5.com.v1.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("my-ts.cis.f5.com.v1.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 	}

--- a/source/f5_virtualserver_fqdn_test.go
+++ b/source/f5_virtualserver_fqdn_test.go
@@ -68,7 +68,7 @@ func TestF5VirtualServerFQDNTemplate(t *testing.T) {
 			fqdnTemplate:   "{{.Name}}.example.com",
 			targetTemplate: "lb.example.com",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-vs.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+				endpoint.MustNewEndpoint("my-vs.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
 			},
 		},
 		{
@@ -91,7 +91,7 @@ func TestF5VirtualServerFQDNTemplate(t *testing.T) {
 			},
 			fqdnTargetTemplate: "{{.Name}}.example.com:1.2.3.4",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-vs.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("my-vs.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 		{
@@ -309,7 +309,7 @@ func TestF5VirtualServerFQDNTemplate(t *testing.T) {
 			fqdnTemplate:   "{{.Kind | toLower}}.{{.Name}}.example.com",
 			targetTemplate: "lb.example.com",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("virtualserver.my-vs.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+				endpoint.MustNewEndpoint("virtualserver.my-vs.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
 			},
 		},
 		{
@@ -328,7 +328,7 @@ func TestF5VirtualServerFQDNTemplate(t *testing.T) {
 			},
 			fqdnTargetTemplate: `{{.Name}}.{{replace "/" "." .APIVersion}}.example.com:1.2.3.4`,
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-vs.cis.f5.com.v1.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("my-vs.cis.f5.com.v1.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 	}

--- a/source/fake.go
+++ b/source/fake.go
@@ -107,24 +107,25 @@ func (sc *fakeSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, error)
 
 func (sc *fakeSource) generateEndpointForType(recordType, dnsName string) (*endpoint.Endpoint, error) {
 	var ep *endpoint.Endpoint
+	var err error
 
 	switch recordType {
 	case endpoint.RecordTypeA:
-		ep = endpoint.NewEndpoint(sc.generateDNSName(4, dnsName), endpoint.RecordTypeA, generateTargets(len(sc.dnsNames), sc.generateIPv4Address)...)
+		ep, err = endpoint.NewEndpoint(sc.generateDNSName(4, dnsName), endpoint.RecordTypeA, generateTargets(len(sc.dnsNames), sc.generateIPv4Address)...)
 	case endpoint.RecordTypeAAAA:
-		ep = endpoint.NewEndpoint(sc.generateDNSName(4, dnsName), endpoint.RecordTypeAAAA, generateTargets(len(sc.dnsNames), sc.generateIPv6Address)...)
+		ep, err = endpoint.NewEndpoint(sc.generateDNSName(4, dnsName), endpoint.RecordTypeAAAA, generateTargets(len(sc.dnsNames), sc.generateIPv6Address)...)
 	case endpoint.RecordTypeCNAME:
-		ep = endpoint.NewEndpoint(sc.generateDNSName(4, dnsName), endpoint.RecordTypeCNAME, sc.generateDNSName(4, dnsName))
+		ep, err = endpoint.NewEndpoint(sc.generateDNSName(4, dnsName), endpoint.RecordTypeCNAME, sc.generateDNSName(4, dnsName))
 	case endpoint.RecordTypeDNAME:
-		ep = endpoint.NewEndpoint(sc.generateDNSName(4, dnsName), endpoint.RecordTypeDNAME, sc.generateDNSName(4, dnsName))
+		ep, err = endpoint.NewEndpoint(sc.generateDNSName(4, dnsName), endpoint.RecordTypeDNAME, sc.generateDNSName(4, dnsName))
 	case endpoint.RecordTypeTXT:
-		ep = endpoint.NewEndpoint(sc.generateDNSName(4, dnsName), endpoint.RecordTypeTXT, `"heritage=external-dns,external-dns/owner=fake"`)
+		ep, err = endpoint.NewEndpoint(sc.generateDNSName(4, dnsName), endpoint.RecordTypeTXT, `"heritage=external-dns,external-dns/owner=fake"`)
 	case endpoint.RecordTypeSRV:
 		// SRV target format: "priority weight port target." (target must end with a dot per RFC 2782)
 		name := sc.generateDNSName(4, dnsName)
-		ep = endpoint.NewEndpoint(fmt.Sprintf("_sip._udp.%s", dnsName), endpoint.RecordTypeSRV, fmt.Sprintf("10 20 5060 %s.", name))
+		ep, err = endpoint.NewEndpoint(fmt.Sprintf("_sip._udp.%s", dnsName), endpoint.RecordTypeSRV, fmt.Sprintf("10 20 5060 %s.", name))
 	case endpoint.RecordTypeNS:
-		ep = endpoint.NewEndpoint(dnsName, endpoint.RecordTypeNS, sc.generateDNSName(3, dnsName))
+		ep, err = endpoint.NewEndpoint(dnsName, endpoint.RecordTypeNS, sc.generateDNSName(3, dnsName))
 	case endpoint.RecordTypePTR:
 		name := sc.generateDNSName(4, dnsName)
 		var err error
@@ -133,22 +134,23 @@ func (sc *fakeSource) generateEndpointForType(recordType, dnsName string) (*endp
 			return nil, err
 		}
 	case endpoint.RecordTypeMX:
-		ep = endpoint.NewEndpoint(dnsName, endpoint.RecordTypeMX, fmt.Sprintf("10 %s", sc.generateDNSName(4, dnsName)))
+		ep, err = endpoint.NewEndpoint(dnsName, endpoint.RecordTypeMX, fmt.Sprintf("10 %s", sc.generateDNSName(4, dnsName)))
 	case endpoint.RecordTypeNAPTR:
 		// NAPTR target format: "order preference flags service regexp replacement"
-		ep = endpoint.NewEndpoint(fmt.Sprintf("_sip._udp.%s", dnsName), endpoint.RecordTypeNAPTR, fmt.Sprintf(`100 10 "u" "E2U+sip" "!^.*$!sip:info@%s!" .`, dnsName))
+		ep, err = endpoint.NewEndpoint(fmt.Sprintf("_sip._udp.%s", dnsName), endpoint.RecordTypeNAPTR, fmt.Sprintf(`100 10 "u" "E2U+sip" "!^.*$!sip:info@%s!" .`, dnsName))
 	default:
 		return nil, fmt.Errorf("unsupported record type: %s", recordType)
 	}
-
-	if ep != nil {
-		pod := fakePod
-		pod.Name = fakePodName(ep.DNSName)
-		ep.SetIdentifier = types.Fake
-		ep.WithLabel(endpoint.ResourceLabelKey, fmt.Sprintf("%s/%s/%s", types.Fake, pod.Namespace, ep.DNSName))
-		ep.WithRefObject(events.NewObjectReference(&pod, types.Fake))
-		log.Debugf("fake source generated %s endpoint: %s -> %v", ep.RecordType, ep.DNSName, ep.Targets)
+	if err != nil {
+		return nil, fmt.Errorf("creating endpoint: %w", err)
 	}
+
+	pod := fakePod
+	pod.Name = fakePodName(ep.DNSName)
+	ep.SetIdentifier = types.Fake
+	ep.WithLabel(endpoint.ResourceLabelKey, fmt.Sprintf("%s/%s/%s", types.Fake, pod.Namespace, ep.DNSName))
+	ep.WithRefObject(events.NewObjectReference(&pod, types.Fake))
+	log.Debugf("fake source generated %s endpoint: %s -> %v", ep.RecordType, ep.DNSName, ep.Targets)
 	return ep, nil
 }
 

--- a/source/gloo_proxy_fqdn_test.go
+++ b/source/gloo_proxy_fqdn_test.go
@@ -102,7 +102,7 @@ func TestGlooProxyFQDNTemplate(t *testing.T) {
 			fqdnTemplate:   "{{.Name}}.example.com",
 			targetTemplate: "lb.example.com",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-proxy.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+				endpoint.MustNewEndpoint("my-proxy.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
 			},
 		},
 		{
@@ -111,7 +111,7 @@ func TestGlooProxyFQDNTemplate(t *testing.T) {
 			svc:                makeEmptySvc("my-proxy"),
 			fqdnTargetTemplate: "{{.Name}}.example.com:1.2.3.4",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-proxy.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("my-proxy.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 		{
@@ -201,7 +201,7 @@ func TestGlooProxyFQDNTemplate(t *testing.T) {
 			fqdnTemplate:   "{{.Kind | toLower}}.{{.Name}}.example.com",
 			targetTemplate: "lb.example.com",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("proxy.my-proxy.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+				endpoint.MustNewEndpoint("proxy.my-proxy.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
 			},
 		},
 		{
@@ -210,7 +210,7 @@ func TestGlooProxyFQDNTemplate(t *testing.T) {
 			svc:                makeEmptySvc("my-proxy"),
 			fqdnTargetTemplate: `{{.Name}}.{{replace "/" "." .APIVersion}}.example.com:1.2.3.4`,
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-proxy.gloo.solo.io.v1.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("my-proxy.gloo.solo.io.v1.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 		{

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -1663,11 +1663,11 @@ func TestIngressWithConfiguration(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("keycloak.blah.com", endpoint.RecordTypeCNAME, "blah-1922533626.us-west-2.elb.amazonaws.com").
+				endpoint.MustNewEndpoint("keycloak.blah.com", endpoint.RecordTypeCNAME, "blah-1922533626.us-west-2.elb.amazonaws.com").
 					WithLabel(endpoint.ResourceLabelKey, "ingress/default/keycloak"),
-				endpoint.NewEndpoint("keycloak.blah.com", endpoint.RecordTypeCNAME, "blah-3488114.us-west-2.elb.amazonaws.com").
+				endpoint.MustNewEndpoint("keycloak.blah.com", endpoint.RecordTypeCNAME, "blah-3488114.us-west-2.elb.amazonaws.com").
 					WithLabel(endpoint.ResourceLabelKey, "ingress/default/keycloak-another"),
-				endpoint.NewEndpoint("anotherkeycloak.blah.com", endpoint.RecordTypeCNAME, "blah-3488114.us-west-2.elb.amazonaws.com").
+				endpoint.MustNewEndpoint("anotherkeycloak.blah.com", endpoint.RecordTypeCNAME, "blah-3488114.us-west-2.elb.amazonaws.com").
 					WithLabel(endpoint.ResourceLabelKey, "ingress/default/keycloak-another"),
 			},
 		},

--- a/source/istio_gateway_test.go
+++ b/source/istio_gateway_test.go
@@ -1529,7 +1529,7 @@ func TestGatewaySource_GWSelectorMatchServiceSelector(t *testing.T) {
 				"version": "v1",
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.org", endpoint.RecordTypeA, "10.10.10.255").WithLabel("resource", "gateway/default/fake-gateway"),
+				endpoint.MustNewEndpoint("example.org", endpoint.RecordTypeA, "10.10.10.255").WithLabel("resource", "gateway/default/fake-gateway"),
 			},
 		},
 		{
@@ -1544,7 +1544,7 @@ func TestGatewaySource_GWSelectorMatchServiceSelector(t *testing.T) {
 				"tier":    "backend",
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.org", endpoint.RecordTypeA, "10.10.10.255").WithLabel("resource", "gateway/default/fake-gateway"),
+				endpoint.MustNewEndpoint("example.org", endpoint.RecordTypeA, "10.10.10.255").WithLabel("resource", "gateway/default/fake-gateway"),
 			},
 		},
 		{
@@ -1556,7 +1556,7 @@ func TestGatewaySource_GWSelectorMatchServiceSelector(t *testing.T) {
 				"app":     "demo",
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.org", endpoint.RecordTypeA, "10.10.10.255").WithLabel("resource", "gateway/default/fake-gateway"),
+				endpoint.MustNewEndpoint("example.org", endpoint.RecordTypeA, "10.10.10.255").WithLabel("resource", "gateway/default/fake-gateway"),
 			},
 		},
 	}
@@ -1898,7 +1898,7 @@ func TestSingleGatewayMultipleServicesPointingToSameLoadBalancer(t *testing.T) {
 	require.NoError(t, err)
 
 	testutils.ValidateEndpoints(t, got, []*endpoint.Endpoint{
-		endpoint.NewEndpoint("example.org", endpoint.RecordTypeA, "34.66.66.77").WithLabel(endpoint.ResourceLabelKey, "gateway/argocd/argocd"),
+		endpoint.MustNewEndpoint("example.org", endpoint.RecordTypeA, "34.66.66.77").WithLabel(endpoint.ResourceLabelKey, "gateway/argocd/argocd"),
 	})
 }
 

--- a/source/istio_virtualservice_test.go
+++ b/source/istio_virtualservice_test.go
@@ -2286,7 +2286,7 @@ func TestIstioVirtualServiceSource_GWServiceSelectorMatchServiceSelector(t *test
 				"version": "v1",
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.org", endpoint.RecordTypeA, "10.10.10.255").WithLabel("resource", "virtualservice/default/fake-vservice"),
+				endpoint.MustNewEndpoint("example.org", endpoint.RecordTypeA, "10.10.10.255").WithLabel("resource", "virtualservice/default/fake-vservice"),
 			},
 		},
 		{
@@ -2301,7 +2301,7 @@ func TestIstioVirtualServiceSource_GWServiceSelectorMatchServiceSelector(t *test
 				"tier":    "backend",
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.org", endpoint.RecordTypeA, "10.10.10.255").WithLabel("resource", "virtualservice/default/fake-vservice"),
+				endpoint.MustNewEndpoint("example.org", endpoint.RecordTypeA, "10.10.10.255").WithLabel("resource", "virtualservice/default/fake-vservice"),
 			},
 		},
 		{
@@ -2313,7 +2313,7 @@ func TestIstioVirtualServiceSource_GWServiceSelectorMatchServiceSelector(t *test
 				"app":     "demo",
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("example.org", endpoint.RecordTypeA, "10.10.10.255").WithLabel("resource", "virtualservice/default/fake-vservice"),
+				endpoint.MustNewEndpoint("example.org", endpoint.RecordTypeA, "10.10.10.255").WithLabel("resource", "virtualservice/default/fake-vservice"),
 			},
 		},
 	}

--- a/source/node.go
+++ b/source/node.go
@@ -182,8 +182,9 @@ func (ns *nodeSource) endpointsForDNSNames(node *v1.Node, dnsNames []string) ([]
 		log.Debugf("adding endpoint with %d targets", len(addrs))
 
 		for _, addr := range addrs {
-			ep := endpoint.NewEndpointWithTTL(dns, endpoint.SuitableType(addr), ttl, addr)
-			if ep == nil {
+			ep, err := endpoint.NewEndpointWithTTL(dns, endpoint.SuitableType(addr), ttl, addr)
+			if err != nil {
+				log.Warnf("Skipping invalid node address %q for node %s: %v", addr, node.Name, err)
 				continue
 			}
 			ep.WithLabel(endpoint.ResourceLabelKey, fmt.Sprintf("node/%s", node.Name))

--- a/source/node_fqdn_test.go
+++ b/source/node_fqdn_test.go
@@ -61,14 +61,14 @@ func TestNodeFQDNTemplate(t *testing.T) {
 			title:              "fqdn-target-template generates A record when no other endpoints",
 			fqdnTargetTemplate: "{{.Name}}.example.com:1.2.3.4",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint(nodeName+".example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint(nodeName+".example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 		{
 			title:              "fqdn-target-template generates CNAME for hostname target",
 			fqdnTargetTemplate: "{{.Name}}.example.com:lb.example.com",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint(nodeName+".example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+				endpoint.MustNewEndpoint(nodeName+".example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
 			},
 		},
 		{
@@ -92,14 +92,14 @@ func TestNodeFQDNTemplate(t *testing.T) {
 			title:              "fqdn-target-template can reference .Kind",
 			fqdnTargetTemplate: "{{.Kind | toLower}}.{{.Name}}.example.com:1.2.3.4",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("node."+nodeName+".example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("node."+nodeName+".example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 		{
 			title:              "fqdn-target-template can reference .APIVersion",
 			fqdnTargetTemplate: "{{.Name}}.{{.APIVersion}}.example.com:1.2.3.4",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint(nodeName+".v1.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint(nodeName+".v1.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 		{

--- a/source/pod.go
+++ b/source/pod.go
@@ -151,9 +151,12 @@ func (ps *podSource) endpointsFromPodAnnotations(pod *v1.Pod) []*endpoint.Endpoi
 
 	var endpoints []*endpoint.Endpoint
 	for key, targets := range endpointMap {
-		if ep := endpoint.NewEndpointWithTTL(key.DNSName, key.RecordType, key.RecordTTL, targets...); ep != nil {
-			endpoints = append(endpoints, ep)
+		ep, err := endpoint.NewEndpointWithTTL(key.DNSName, key.RecordType, key.RecordTTL, targets...)
+		if err != nil {
+			log.Warnf("Skipping invalid endpoint for pod %q: %v", pod.Name, err)
+			continue
 		}
+		endpoints = append(endpoints, ep)
 	}
 	return endpoints
 }
@@ -166,9 +169,12 @@ func (ps *podSource) endpointsFromPodTemplate(pod *v1.Pod) ([]*endpoint.Endpoint
 
 	var endpoints []*endpoint.Endpoint
 	for key, targets := range hostsMap {
-		if ep := endpoint.NewEndpointWithTTL(key.DNSName, key.RecordType, key.RecordTTL, targets...); ep != nil {
-			endpoints = append(endpoints, ep)
+		ep, err := endpoint.NewEndpointWithTTL(key.DNSName, key.RecordType, key.RecordTTL, targets...)
+		if err != nil {
+			log.Warnf("Skipping invalid endpoint for pod %q: %v", pod.Name, err)
+			continue
 		}
+		endpoints = append(endpoints, ep)
 	}
 	return endpoints, nil
 }

--- a/source/pod_fqdn_test.go
+++ b/source/pod_fqdn_test.go
@@ -71,14 +71,14 @@ func TestPodFQDNTemplate(t *testing.T) {
 			title:              "fqdn-target-template generates A record when no annotation-derived endpoints",
 			fqdnTargetTemplate: "{{.Name}}.example.com:1.2.3.4",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint(podName+".example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint(podName+".example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 		{
 			title:              "fqdn-target-template generates CNAME for hostname target",
 			fqdnTargetTemplate: "{{.Name}}.example.com:lb.example.com",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint(podName+".example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+				endpoint.MustNewEndpoint(podName+".example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
 			},
 		},
 		{
@@ -108,7 +108,7 @@ func TestPodFQDNTemplate(t *testing.T) {
 			title:              "fqdn-target-template can reference .Kind",
 			fqdnTargetTemplate: "{{.Kind | toLower}}.{{.Name}}.example.com:1.2.3.4",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("pod."+podName+".example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("pod."+podName+".example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 		{
@@ -126,7 +126,7 @@ func TestPodFQDNTemplate(t *testing.T) {
 			title:              "fqdn-target-template can reference .APIVersion",
 			fqdnTargetTemplate: "{{.Name}}.{{.APIVersion}}.example.com:1.2.3.4",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint(podName+".v1.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint(podName+".v1.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 		// ── fqdn-template cases ───────────────────────────────────────────────

--- a/source/service.go
+++ b/source/service.go
@@ -459,11 +459,13 @@ func buildHeadlessEndpoints(svc *v1.Service, targetsByHeadlessDomainAndType map[
 			deduppedTargets.Insert(target)
 			targets = append(targets, target)
 		}
-		ep := endpoint.NewEndpointWithTTL(headlessKey.DNSName, headlessKey.RecordType, ttl, targets...)
-		if ep != nil {
-			ep.WithLabel(endpoint.ResourceLabelKey, fmt.Sprintf("service/%s/%s", svc.Namespace, svc.Name))
-			endpoints = append(endpoints, ep)
+		ep, err := endpoint.NewEndpointWithTTL(headlessKey.DNSName, headlessKey.RecordType, ttl, targets...)
+		if err != nil {
+			log.Warnf("Unable to create endpoint for service %s/%s: %v", svc.Namespace, svc.Name, err)
+			continue
 		}
+		ep.WithLabel(endpoint.ResourceLabelKey, fmt.Sprintf("service/%s/%s", svc.Namespace, svc.Name))
+		endpoints = append(endpoints, ep)
 	}
 	return endpoints
 }
@@ -764,11 +766,13 @@ func (sc *serviceSource) extractNodePortEndpoints(svc *v1.Service, hostname stri
 
 			recordName := fmt.Sprintf("_%s._%s.%s", svc.Name, protocol, hostname)
 
-			ep := endpoint.NewEndpointWithTTL(recordName, endpoint.RecordTypeSRV, ttl, target)
-			if ep != nil {
-				ep.WithLabel(endpoint.ResourceLabelKey, fmt.Sprintf("service/%s/%s", svc.Namespace, svc.Name))
-				endpoints = append(endpoints, ep)
+			ep, err := endpoint.NewEndpointWithTTL(recordName, endpoint.RecordTypeSRV, ttl, target)
+			if err != nil {
+				log.Errorf("Failed to create endpoint for service %s/%s: %v", svc.Namespace, svc.Name, err)
+				continue
 			}
+			ep.WithLabel(endpoint.ResourceLabelKey, fmt.Sprintf("service/%s/%s", svc.Namespace, svc.Name))
+			endpoints = append(endpoints, ep)
 		}
 	}
 

--- a/source/service_fqdn_test.go
+++ b/source/service_fqdn_test.go
@@ -68,14 +68,14 @@ func TestServiceFQDNTemplate(t *testing.T) {
 			title:              "fqdn-target-template generates A record when no annotation-derived endpoints",
 			fqdnTargetTemplate: "{{.Name}}.example.com:1.2.3.4",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint(svcName+".example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint(svcName+".example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 		{
 			title:              "fqdn-target-template generates CNAME for hostname target",
 			fqdnTargetTemplate: "{{.Name}}.example.com:lb.example.com",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint(svcName+".example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+				endpoint.MustNewEndpoint(svcName+".example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
 			},
 		},
 		{
@@ -105,7 +105,7 @@ func TestServiceFQDNTemplate(t *testing.T) {
 			title:              "fqdn-target-template can reference .Kind",
 			fqdnTargetTemplate: "{{.Kind | toLower}}.{{.Name}}.example.com:1.2.3.4",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("service."+svcName+".example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("service."+svcName+".example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 		{
@@ -123,7 +123,7 @@ func TestServiceFQDNTemplate(t *testing.T) {
 			title:              "fqdn-target-template can reference .APIVersion",
 			fqdnTargetTemplate: "{{.Name}}.{{.APIVersion}}.example.com:1.2.3.4",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint(svcName+".v1.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint(svcName+".v1.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 		// ── fqdn-template cases ───────────────────────────────────────────────

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -3497,7 +3497,7 @@ func TestMultipleServicesPointingToSameLoadBalancer(t *testing.T) {
 	require.NoError(t, err)
 
 	testutils.ValidateEndpoints(t, got, []*endpoint.Endpoint{
-		endpoint.NewEndpoint("example.org", endpoint.RecordTypeA, "34.66.66.77").WithLabel(endpoint.ResourceLabelKey, "service/default/istio-ingressgateway"),
+		endpoint.MustNewEndpoint("example.org", endpoint.RecordTypeA, "34.66.66.77").WithLabel(endpoint.ResourceLabelKey, "service/default/istio-ingressgateway"),
 	})
 }
 

--- a/source/template/engine.go
+++ b/source/template/engine.go
@@ -201,7 +201,13 @@ func (e Engine) endpointsFromFQDNTargetTemplate(obj kubeObject) ([]*endpoint.End
 				pair, kind, obj.GetNamespace(), obj.GetName())
 			continue
 		}
-		eps = append(eps, endpoint.NewEndpoint(host, endpoint.SuitableType(target), target))
+		ep, err := endpoint.NewEndpoint(host, endpoint.SuitableType(target), target)
+		if err != nil {
+			log.Debugf("Skipping invalid host:target pair %q from %s %s/%s: %v",
+				pair, kind, obj.GetNamespace(), obj.GetName(), err)
+			continue
+		}
+		eps = append(eps, ep)
 	}
 	return endpoint.MergeEndpoints(eps), nil
 }

--- a/source/template/engine_test.go
+++ b/source/template/engine_test.go
@@ -648,10 +648,10 @@ func TestCombineWithEndpoints(t *testing.T) {
 	require.NoError(t, err)
 
 	annotationEndpoints := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("annotation.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+		endpoint.MustNewEndpoint("annotation.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 	}
 	templatedEndpoints := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("template.example.com", endpoint.RecordTypeA, "5.6.7.8"),
+		endpoint.MustNewEndpoint("template.example.com", endpoint.RecordTypeA, "5.6.7.8"),
 	}
 
 	successTemplateFunc := func() ([]*endpoint.Endpoint, error) {

--- a/source/traefik_proxy_fqdn_test.go
+++ b/source/traefik_proxy_fqdn_test.go
@@ -62,7 +62,7 @@ func TestTraefikFQDNTemplateIngressRoute(t *testing.T) {
 			fqdnTemplate:   "{{.Name}}.example.com",
 			targetTemplate: "lb.example.com",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-app.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+				endpoint.MustNewEndpoint("my-app.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
 			},
 		},
 		{
@@ -82,7 +82,7 @@ func TestTraefikFQDNTemplateIngressRoute(t *testing.T) {
 			},
 			fqdnTargetTemplate: "{{.Name}}.example.com:1.2.3.4",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-app.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("my-app.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 		{
@@ -178,7 +178,7 @@ func TestTraefikFQDNTemplateIngressRoute(t *testing.T) {
 			fqdnTemplate:   "{{.Kind | toLower}}.{{.Name}}.example.com",
 			targetTemplate: "lb.example.com",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("ingressroute.my-app.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+				endpoint.MustNewEndpoint("ingressroute.my-app.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
 			},
 		},
 		{
@@ -198,7 +198,7 @@ func TestTraefikFQDNTemplateIngressRoute(t *testing.T) {
 			},
 			fqdnTargetTemplate: `{{.Name}}.{{replace "/" "." .APIVersion}}.example.com:1.2.3.4`,
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-app.traefik.io.v1alpha1.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("my-app.traefik.io.v1alpha1.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 	}
@@ -271,7 +271,7 @@ func TestTraefikFQDNTemplateIngressRouteTCP(t *testing.T) {
 			fqdnTemplate:   "{{.Name}}.example.com",
 			targetTemplate: "lb.example.com",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-tcp-app.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+				endpoint.MustNewEndpoint("my-tcp-app.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
 			},
 		},
 		{
@@ -291,7 +291,7 @@ func TestTraefikFQDNTemplateIngressRouteTCP(t *testing.T) {
 			},
 			fqdnTargetTemplate: "{{.Name}}.example.com:1.2.3.4",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-tcp-app.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("my-tcp-app.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 		{
@@ -353,7 +353,7 @@ func TestTraefikFQDNTemplateIngressRouteTCP(t *testing.T) {
 			fqdnTemplate:   "{{.Kind | toLower}}.{{.Name}}.example.com",
 			targetTemplate: "lb.example.com",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("ingressroutetcp.my-tcp-app.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+				endpoint.MustNewEndpoint("ingressroutetcp.my-tcp-app.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
 			},
 		},
 		{
@@ -373,7 +373,7 @@ func TestTraefikFQDNTemplateIngressRouteTCP(t *testing.T) {
 			},
 			fqdnTargetTemplate: `{{.Name}}.{{replace "/" "." .APIVersion}}.example.com:1.2.3.4`,
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-tcp-app.traefik.io.v1alpha1.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("my-tcp-app.traefik.io.v1alpha1.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 	}
@@ -446,7 +446,7 @@ func TestTraefikFQDNTemplateIngressRouteUDP(t *testing.T) {
 			fqdnTemplate:   "{{.Name}}.example.com",
 			targetTemplate: "lb.example.com",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-udp-app.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+				endpoint.MustNewEndpoint("my-udp-app.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
 			},
 		},
 		{
@@ -466,7 +466,7 @@ func TestTraefikFQDNTemplateIngressRouteUDP(t *testing.T) {
 			},
 			fqdnTargetTemplate: "{{.Name}}.example.com:1.2.3.4",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-udp-app.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("my-udp-app.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 		{
@@ -524,7 +524,7 @@ func TestTraefikFQDNTemplateIngressRouteUDP(t *testing.T) {
 			fqdnTemplate:   "{{.Kind | toLower}}.{{.Name}}.example.com",
 			targetTemplate: "lb.example.com",
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("ingressrouteudp.my-udp-app.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
+				endpoint.MustNewEndpoint("ingressrouteudp.my-udp-app.example.com", endpoint.RecordTypeCNAME, "lb.example.com"),
 			},
 		},
 		{
@@ -544,7 +544,7 @@ func TestTraefikFQDNTemplateIngressRouteUDP(t *testing.T) {
 			},
 			fqdnTargetTemplate: `{{.Name}}.{{replace "/" "." .APIVersion}}.example.com:1.2.3.4`,
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-udp-app.traefik.io.v1alpha1.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("my-udp-app.traefik.io.v1alpha1.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 	}

--- a/source/unstructured_fqdn_test.go
+++ b/source/unstructured_fqdn_test.go
@@ -73,9 +73,9 @@ func TestUnstructuredFqdnTemplatingExamples(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("entry1.internal.tld", endpoint.RecordTypeA, "10.10.10.10").
+				endpoint.MustNewEndpoint("entry1.internal.tld", endpoint.RecordTypeA, "10.10.10.10").
 					WithLabel(endpoint.ResourceLabelKey, "configmap/default/multi-dns"),
-				endpoint.NewEndpoint("entry2.example.tld", endpoint.RecordTypeA, "10.10.10.10").
+				endpoint.MustNewEndpoint("entry2.example.tld", endpoint.RecordTypeA, "10.10.10.10").
 					WithLabel(endpoint.ResourceLabelKey, "configmap/default/multi-dns"),
 			},
 		},
@@ -107,7 +107,7 @@ func TestUnstructuredFqdnTemplatingExamples(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-vm.main.vmi.com", endpoint.RecordTypeA, "10.244.1.50").
+				endpoint.MustNewEndpoint("my-vm.main.vmi.com", endpoint.RecordTypeA, "10.244.1.50").
 					WithLabel(endpoint.ResourceLabelKey, "virtualmachineinstance/default/my-vm"),
 			},
 		},
@@ -138,7 +138,7 @@ func TestUnstructuredFqdnTemplatingExamples(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("prod-postgres.db.example.com", endpoint.RecordTypeCNAME, "prod-postgres.abc123.us-east-1.rds.").
+				endpoint.MustNewEndpoint("prod-postgres.db.example.com", endpoint.RecordTypeCNAME, "prod-postgres.abc123.us-east-1.rds.").
 					WithLabel(endpoint.ResourceLabelKey, "rdsinstance/default/prod-postgres"),
 			},
 		},
@@ -182,9 +182,9 @@ func TestUnstructuredFqdnTemplatingExamples(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("vm-one.vmi.example.com", endpoint.RecordTypeA, "10.244.1.10").
+				endpoint.MustNewEndpoint("vm-one.vmi.example.com", endpoint.RecordTypeA, "10.244.1.10").
 					WithLabel(endpoint.ResourceLabelKey, "virtualmachineinstance/default/vm-one"),
-				endpoint.NewEndpoint("vm-two.vmi.example.com", endpoint.RecordTypeA, "10.244.1.20").
+				endpoint.MustNewEndpoint("vm-two.vmi.example.com", endpoint.RecordTypeA, "10.244.1.20").
 					WithLabel(endpoint.ResourceLabelKey, "virtualmachineinstance/default/vm-two"),
 			},
 		},
@@ -213,9 +213,9 @@ func TestUnstructuredFqdnTemplatingExamples(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("reviews.internal.com", endpoint.RecordTypeCNAME, "promo.svc.local").
+				endpoint.MustNewEndpoint("reviews.internal.com", endpoint.RecordTypeCNAME, "promo.svc.local").
 					WithLabel(endpoint.ResourceLabelKey, "proxyservice/default/reviews"),
-				endpoint.NewEndpoint("reviews.mesh.com", endpoint.RecordTypeCNAME, "promo.svc.local").
+				endpoint.MustNewEndpoint("reviews.mesh.com", endpoint.RecordTypeCNAME, "promo.svc.local").
 					WithLabel(endpoint.ResourceLabelKey, "proxyservice/default/reviews"),
 			},
 		},
@@ -245,7 +245,7 @@ func TestUnstructuredFqdnTemplatingExamples(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("guestbook-prod.apps.com", endpoint.RecordTypeCNAME, "lb.example.com").
+				endpoint.MustNewEndpoint("guestbook-prod.apps.com", endpoint.RecordTypeCNAME, "lb.example.com").
 					WithLabel(endpoint.ResourceLabelKey, "application/default/guestbook"),
 			},
 		},
@@ -278,7 +278,7 @@ func TestUnstructuredFqdnTemplatingExamples(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpointWithTTL("guestbook-prod.apps.com", endpoint.RecordTypeCNAME, 300, "lb.example.com").
+				endpoint.MustNewEndpointWithTTL("guestbook-prod.apps.com", endpoint.RecordTypeCNAME, 300, "lb.example.com").
 					WithLabel(endpoint.ResourceLabelKey, "application/ns/guestbook"),
 			},
 		},
@@ -330,9 +330,9 @@ func TestUnstructuredFqdnTemplatingExamples(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-db.databases.com", endpoint.RecordTypeCNAME, "my-db.abc123.us-west-2.rds").
+				endpoint.MustNewEndpoint("my-db.databases.com", endpoint.RecordTypeCNAME, "my-db.abc123.us-west-2.rds").
 					WithLabel(endpoint.ResourceLabelKey, "rdsinstance/databases/my-db"),
-				endpoint.NewEndpoint("my-vm.vms.com", endpoint.RecordTypeA, "10.244.1.100").
+				endpoint.MustNewEndpoint("my-vm.vms.com", endpoint.RecordTypeA, "10.244.1.100").
 					WithLabel(endpoint.ResourceLabelKey, "virtualmachineinstance/vms/my-vm"),
 			},
 		},
@@ -375,9 +375,9 @@ func TestUnstructuredFqdnTemplatingExamples(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("api-tgb.TargetGroupBinding.example.com", endpoint.RecordTypeCNAME, "lb.api.example.com").
+				endpoint.MustNewEndpoint("api-tgb.TargetGroupBinding.example.com", endpoint.RecordTypeCNAME, "lb.api.example.com").
 					WithLabel(endpoint.ResourceLabelKey, "targetgroupbinding/default/api-tgb"),
-				endpoint.NewEndpoint("web-server.VirtualMachineInstance.example.com", endpoint.RecordTypeA, "192.168.1.10").
+				endpoint.MustNewEndpoint("web-server.VirtualMachineInstance.example.com", endpoint.RecordTypeA, "192.168.1.10").
 					WithLabel(endpoint.ResourceLabelKey, "virtualmachineinstance/default/web-server"),
 			},
 		},
@@ -413,9 +413,9 @@ func TestUnstructuredFqdnTemplatingExamples(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-vm.annotation.example.com", endpoint.RecordTypeA, "192.168.1.100").
+				endpoint.MustNewEndpoint("my-vm.annotation.example.com", endpoint.RecordTypeA, "192.168.1.100").
 					WithLabel(endpoint.ResourceLabelKey, "virtualmachineinstance/default/my-vm"),
-				endpoint.NewEndpoint("my-vm.template.example.com", endpoint.RecordTypeA, "10.244.1.50").
+				endpoint.MustNewEndpoint("my-vm.template.example.com", endpoint.RecordTypeA, "10.244.1.50").
 					WithLabel(endpoint.ResourceLabelKey, "virtualmachineinstance/default/my-vm"),
 			},
 		},
@@ -502,11 +502,11 @@ func TestUnstructuredFqdnTemplatingExamples(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("httpbin.route.com", endpoint.RecordTypeCNAME, "apisix-gateway.ingress-apisix.svc.cluster.local").
+				endpoint.MustNewEndpoint("httpbin.route.com", endpoint.RecordTypeCNAME, "apisix-gateway.ingress-apisix.svc.cluster.local").
 					WithLabel(endpoint.ResourceLabelKey, "apisixroute/ingress-apisix/httpbin"),
-				endpoint.NewEndpoint("my-tgb.tgb.com", endpoint.RecordTypeCNAME, "my-alb.us-east-1.elb.amazonaws.com").
+				endpoint.MustNewEndpoint("my-tgb.tgb.com", endpoint.RecordTypeCNAME, "my-alb.us-east-1.elb.amazonaws.com").
 					WithLabel(endpoint.ResourceLabelKey, "targetgroupbinding/apps/my-tgb"),
-				endpoint.NewEndpoint("my-vm.vm.com", endpoint.RecordTypeA, "10.0.0.1").
+				endpoint.MustNewEndpoint("my-vm.vm.com", endpoint.RecordTypeA, "10.0.0.1").
 					WithLabel(endpoint.ResourceLabelKey, "virtualmachineinstance/vms/my-vm"),
 			},
 		},
@@ -598,7 +598,7 @@ func TestUnstructuredFqdnTemplatingExamples(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("application-user-data-cm.s3.example.com", endpoint.RecordTypeCNAME, "doc-example-bucket.s3.amazonaws.com").
+				endpoint.MustNewEndpoint("application-user-data-cm.s3.example.com", endpoint.RecordTypeCNAME, "doc-example-bucket.s3.amazonaws.com").
 					WithLabel(endpoint.ResourceLabelKey, "configmap/default/application-user-data-cm"),
 			},
 		},
@@ -662,11 +662,11 @@ func TestUnstructuredFqdnTemplatingExamples(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("app-abc12.pod.com", endpoint.RecordTypeA, "10.244.1.2").
+				endpoint.MustNewEndpoint("app-abc12.pod.com", endpoint.RecordTypeA, "10.244.1.2").
 					WithLabel(endpoint.ResourceLabelKey, "endpointslice/default/test-headless-abc12"),
-				endpoint.NewEndpoint("app-abc12.pod.com", endpoint.RecordTypeAAAA, "2001:db8::1").
+				endpoint.MustNewEndpoint("app-abc12.pod.com", endpoint.RecordTypeAAAA, "2001:db8::1").
 					WithLabel(endpoint.ResourceLabelKey, "endpointslice/default/test-headless-abc12"),
-				endpoint.NewEndpoint("app-def34.pod.com", endpoint.RecordTypeA, "10.244.2.3", "10.244.2.4").
+				endpoint.MustNewEndpoint("app-def34.pod.com", endpoint.RecordTypeA, "10.244.2.3", "10.244.2.4").
 					WithLabel(endpoint.ResourceLabelKey, "endpointslice/default/test-headless-abc12"),
 			},
 		},
@@ -731,7 +731,7 @@ func TestUnstructuredFqdnTemplatingExamples(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-headless.example.com", endpoint.RecordTypeA, "10.244.1.2", "10.244.2.3", "10.244.2.4").
+				endpoint.MustNewEndpoint("my-headless.example.com", endpoint.RecordTypeA, "10.244.1.2", "10.244.2.3", "10.244.2.4").
 					WithLabel(endpoint.ResourceLabelKey, "endpointslice/default/test-headless-abc12"),
 			},
 		},
@@ -811,12 +811,12 @@ func TestUnstructuredFqdnTemplatingExamples(t *testing.T) {
 			},
 			expected: []*endpoint.Endpoint{
 				// from fqdnTargetTemplate: per-interface 1:1 host:IP pairs
-				endpoint.NewEndpoint("my-vm-eth0.ifaces.example.com", endpoint.RecordTypeA, "10.244.1.50").
+				endpoint.MustNewEndpoint("my-vm-eth0.ifaces.example.com", endpoint.RecordTypeA, "10.244.1.50").
 					WithLabel(endpoint.ResourceLabelKey, "virtualmachineinstance/default/my-vm"),
-				endpoint.NewEndpoint("my-vm-eth1.ifaces.example.com", endpoint.RecordTypeA, "192.168.1.50").
+				endpoint.MustNewEndpoint("my-vm-eth1.ifaces.example.com", endpoint.RecordTypeA, "192.168.1.50").
 					WithLabel(endpoint.ResourceLabelKey, "virtualmachineinstance/default/my-vm"),
 				// from fqdnTemplate + targetTemplate: service-level record for the primary interface
-				endpoint.NewEndpoint("my-vm.vmi.example.com", endpoint.RecordTypeA, "10.244.1.50").
+				endpoint.MustNewEndpoint("my-vm.vmi.example.com", endpoint.RecordTypeA, "10.244.1.50").
 					WithLabel(endpoint.ResourceLabelKey, "virtualmachineinstance/default/my-vm"),
 			},
 		},
@@ -904,7 +904,7 @@ func TestUnstructuredFqdnTemplatingExamples(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("reviews.bookinfo.example.com", endpoint.RecordTypeCNAME, "promo.svc.local").
+				endpoint.MustNewEndpoint("reviews.bookinfo.example.com", endpoint.RecordTypeCNAME, "promo.svc.local").
 					WithLabel(endpoint.ResourceLabelKey, "proxyservice/default/reviews"),
 			},
 		},
@@ -933,7 +933,7 @@ func TestUnstructuredFqdnTemplatingExamples(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("real.example.com", endpoint.RecordTypeCNAME, "promo.svc.local").
+				endpoint.MustNewEndpoint("real.example.com", endpoint.RecordTypeCNAME, "promo.svc.local").
 					WithLabel(endpoint.ResourceLabelKey, "proxyservice/default/reviews"),
 			},
 		},
@@ -963,7 +963,7 @@ func TestUnstructuredFqdnTemplatingExamples(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("reviews.nested.example.com", endpoint.RecordTypeCNAME, "promo.svc.local").
+				endpoint.MustNewEndpoint("reviews.nested.example.com", endpoint.RecordTypeCNAME, "promo.svc.local").
 					WithLabel(endpoint.ResourceLabelKey, "proxyservice/default/reviews"),
 			},
 		},

--- a/source/unstructured_test.go
+++ b/source/unstructured_test.go
@@ -109,7 +109,7 @@ func TestUnstructured_DifferentScenarios(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-vm.example.com", endpoint.RecordTypeAAAA, "::1234:5678").
+				endpoint.MustNewEndpoint("my-vm.example.com", endpoint.RecordTypeAAAA, "::1234:5678").
 					WithLabel(endpoint.ResourceLabelKey, "virtualmachineinstance/default/my-vm"),
 			},
 		},
@@ -144,7 +144,7 @@ func TestUnstructured_DifferentScenarios(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpointWithTTL("my-node-1.nodes.example.com", endpoint.RecordTypeA, 300, "203.0.113.10").
+				endpoint.MustNewEndpointWithTTL("my-node-1.nodes.example.com", endpoint.RecordTypeA, 300, "203.0.113.10").
 					WithLabel(endpoint.ResourceLabelKey, "node/cattle-system/my-node-1"),
 			},
 		},
@@ -171,7 +171,7 @@ func TestUnstructured_DifferentScenarios(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("my-vm.redis.tld", endpoint.RecordTypeA, "1.1.1.0").
+				endpoint.MustNewEndpoint("my-vm.redis.tld", endpoint.RecordTypeA, "1.1.1.0").
 					WithLabel(endpoint.ResourceLabelKey, "replicationgroup/default/cache"),
 			},
 		},
@@ -242,7 +242,7 @@ func TestUnstructured_DifferentScenarios(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("prod-vm.example.com", endpoint.RecordTypeA, "10.0.0.1").
+				endpoint.MustNewEndpoint("prod-vm.example.com", endpoint.RecordTypeA, "10.0.0.1").
 					WithLabel(endpoint.ResourceLabelKey, "virtualmachineinstance/default/prod-vm"),
 			},
 		},
@@ -312,7 +312,7 @@ func TestUnstructured_DifferentScenarios(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("platform-vm.example.com", endpoint.RecordTypeA, "10.0.0.1").
+				endpoint.MustNewEndpoint("platform-vm.example.com", endpoint.RecordTypeA, "10.0.0.1").
 					WithLabel(endpoint.ResourceLabelKey, "virtualmachineinstance/default/platform-vm"),
 			},
 		},
@@ -405,7 +405,7 @@ func TestUnstructured_DifferentScenarios(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("prod-platform-vm.example.com", endpoint.RecordTypeA, "10.0.0.1").
+				endpoint.MustNewEndpoint("prod-platform-vm.example.com", endpoint.RecordTypeA, "10.0.0.1").
 					WithLabel(endpoint.ResourceLabelKey, "virtualmachineinstance/default/prod-platform-vm"),
 			},
 		},
@@ -443,7 +443,7 @@ func TestUnstructured_DifferentScenarios(t *testing.T) {
 				},
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("control-plane.example.com", endpoint.RecordTypeA, "10.0.0.1").
+				endpoint.MustNewEndpoint("control-plane.example.com", endpoint.RecordTypeA, "10.0.0.1").
 					WithLabel(endpoint.ResourceLabelKey, "machine/default/control-plane"),
 			},
 		},

--- a/source/wrappers/dedupsource_test.go
+++ b/source/wrappers/dedupsource_test.go
@@ -628,7 +628,7 @@ func TestDedupSource_RefObjects(t *testing.T) {
 					testutils.NewEndpointWithRef("example.com", "1.2.3.4", &v1.Service{
 						ObjectMeta: metav1.ObjectMeta{Name: "my-service", Namespace: "default", UID: "123"},
 					}, types.Service),
-					endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4"),
+					endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4"),
 				}
 			},
 			expected: func(t *testing.T, ep []*endpoint.Endpoint) {
@@ -644,7 +644,7 @@ func TestDedupSource_RefObjects(t *testing.T) {
 			name: "duplicate endpoints with first having nil RefObject - second RefObject merged in",
 			input: func() []*endpoint.Endpoint {
 				return []*endpoint.Endpoint{
-					endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4"),
+					endpoint.MustNewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4"),
 					testutils.NewEndpointWithRef("example.com", "1.2.3.4", &v1.Service{
 						ObjectMeta: metav1.ObjectMeta{Name: "my-service", Namespace: "default", UID: "345"},
 					}, types.Service),
@@ -680,11 +680,11 @@ func TestDedupSource_DeduplicatedEndpointsMetric(t *testing.T) {
 	deduplicatedEndpoints.Reset()
 
 	eps := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("web.example.com", endpoint.RecordTypeA, "192.168.1.1"),
-		endpoint.NewEndpoint("web.example.com", endpoint.RecordTypeA, "192.168.1.1"), // duplicate
-		endpoint.NewEndpoint("api.example.com", endpoint.RecordTypeAAAA, "2001:db8::1"),
-		endpoint.NewEndpoint("api.example.com", endpoint.RecordTypeAAAA, "2001:db8::1"), // duplicate
-		endpoint.NewEndpoint("api.example.com", endpoint.RecordTypeAAAA, "2001:db8::1"), // another duplicate
+		endpoint.MustNewEndpoint("web.example.com", endpoint.RecordTypeA, "192.168.1.1"),
+		endpoint.MustNewEndpoint("web.example.com", endpoint.RecordTypeA, "192.168.1.1"), // duplicate
+		endpoint.MustNewEndpoint("api.example.com", endpoint.RecordTypeAAAA, "2001:db8::1"),
+		endpoint.MustNewEndpoint("api.example.com", endpoint.RecordTypeAAAA, "2001:db8::1"), // duplicate
+		endpoint.MustNewEndpoint("api.example.com", endpoint.RecordTypeAAAA, "2001:db8::1"), // another duplicate
 	}
 
 	mockSource := testutils.NewMockSource(eps...)
@@ -708,7 +708,7 @@ func TestDedupSource_InvalidEndpointsMetric(t *testing.T) {
 
 	eps := []*endpoint.Endpoint{
 		// valid A record
-		endpoint.NewEndpoint("web.example.com", endpoint.RecordTypeA, "192.168.1.1"),
+		endpoint.MustNewEndpoint("web.example.com", endpoint.RecordTypeA, "192.168.1.1"),
 		// invalid SRV record (missing port and target host)
 		{DNSName: "_svc._tcp.example.org", RecordType: endpoint.RecordTypeSRV, Targets: endpoint.Targets{"10 mail.example.org"}},
 	}

--- a/source/wrappers/post_processor_test.go
+++ b/source/wrappers/post_processor_test.go
@@ -140,28 +140,28 @@ func TestPostProcessorEndpointsWithTTL(t *testing.T) {
 			title: "process endpoints with TTL set",
 			ttl:   "6s",
 			endpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo-1", "A", "1.2.3.4"),
-				endpoint.NewEndpointWithTTL("foo-2", "A", 60, "1.2.3.5"),
-				endpoint.NewEndpointWithTTL("foo-3", "A", 0, "1.2.3.6"),
+				endpoint.MustNewEndpoint("foo-1", "A", "1.2.3.4"),
+				endpoint.MustNewEndpointWithTTL("foo-2", "A", 60, "1.2.3.5"),
+				endpoint.MustNewEndpointWithTTL("foo-3", "A", 0, "1.2.3.6"),
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpointWithTTL("foo-1", "A", 6, "1.2.3.4"),
-				endpoint.NewEndpointWithTTL("foo-2", "A", 60, "1.2.3.5"),
-				endpoint.NewEndpointWithTTL("foo-3", "A", 6, "1.2.3.6"),
+				endpoint.MustNewEndpointWithTTL("foo-1", "A", 6, "1.2.3.4"),
+				endpoint.MustNewEndpointWithTTL("foo-2", "A", 60, "1.2.3.5"),
+				endpoint.MustNewEndpointWithTTL("foo-3", "A", 6, "1.2.3.6"),
 			},
 		},
 		{
 			title: "skip endpoints processing with TTL set to 0",
 			ttl:   "0s",
 			endpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo-1", "A", "1.2.3.4"),
-				endpoint.NewEndpointWithTTL("foo-2", "A", 60, "1.2.3.5"),
-				endpoint.NewEndpointWithTTL("foo-3", "A", 0, "1.2.3.6"),
+				endpoint.MustNewEndpoint("foo-1", "A", "1.2.3.4"),
+				endpoint.MustNewEndpointWithTTL("foo-2", "A", 60, "1.2.3.5"),
+				endpoint.MustNewEndpointWithTTL("foo-3", "A", 0, "1.2.3.6"),
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo-1", "A", "1.2.3.4"),
-				endpoint.NewEndpointWithTTL("foo-2", "A", 60, "1.2.3.5"),
-				endpoint.NewEndpointWithTTL("foo-3", "A", 0, "1.2.3.6"),
+				endpoint.MustNewEndpoint("foo-1", "A", "1.2.3.4"),
+				endpoint.MustNewEndpointWithTTL("foo-2", "A", 60, "1.2.3.5"),
+				endpoint.MustNewEndpointWithTTL("foo-3", "A", 0, "1.2.3.6"),
 			},
 		},
 		{
@@ -169,11 +169,11 @@ func TestPostProcessorEndpointsWithTTL(t *testing.T) {
 			ttl:   "0s",
 			endpoints: []*endpoint.Endpoint{
 				nil,
-				endpoint.NewEndpointWithTTL("foo-2", "A", 60, "1.2.3.5"),
+				endpoint.MustNewEndpointWithTTL("foo-2", "A", 60, "1.2.3.5"),
 			},
 			expected: []*endpoint.Endpoint{
 				nil,
-				endpoint.NewEndpointWithTTL("foo-2", "A", 60, "1.2.3.5"),
+				endpoint.MustNewEndpointWithTTL("foo-2", "A", 60, "1.2.3.5"),
 			},
 		},
 		{
@@ -460,56 +460,56 @@ func TestPostProcessorEndpointsWithPreferAlias(t *testing.T) {
 			title:       "CNAME records get alias annotation when preferAlias is enabled",
 			preferAlias: true,
 			endpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeCNAME, "target.example.com"),
-				endpoint.NewEndpoint("bar.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeCNAME, "target.example.com"),
+				endpoint.MustNewEndpoint("bar.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeCNAME, "target.example.com").WithAliasProperty(endpoint.AliasTrue),
-				endpoint.NewEndpoint("bar.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeCNAME, "target.example.com").WithAliasProperty(endpoint.AliasTrue),
+				endpoint.MustNewEndpoint("bar.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 			},
 		},
 		{
 			title:       "CNAME records remain unchanged when preferAlias is disabled",
 			preferAlias: false,
 			endpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeCNAME, "target.example.com"),
+				endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeCNAME, "target.example.com"),
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeCNAME, "target.example.com"),
+				endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeCNAME, "target.example.com"),
 			},
 		},
 		{
 			title:       "only CNAME records are affected, A records are unchanged",
 			preferAlias: true,
 			endpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("a.example.com", endpoint.RecordTypeA, "1.2.3.4"),
-				endpoint.NewEndpoint("aaaa.example.com", endpoint.RecordTypeAAAA, "::1"),
-				endpoint.NewEndpoint("cname.example.com", endpoint.RecordTypeCNAME, "target.example.com"),
+				endpoint.MustNewEndpoint("a.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("aaaa.example.com", endpoint.RecordTypeAAAA, "::1"),
+				endpoint.MustNewEndpoint("cname.example.com", endpoint.RecordTypeCNAME, "target.example.com"),
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("a.example.com", endpoint.RecordTypeA, "1.2.3.4"),
-				endpoint.NewEndpoint("aaaa.example.com", endpoint.RecordTypeAAAA, "::1"),
-				endpoint.NewEndpoint("cname.example.com", endpoint.RecordTypeCNAME, "target.example.com").WithAliasProperty(endpoint.AliasTrue),
+				endpoint.MustNewEndpoint("a.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("aaaa.example.com", endpoint.RecordTypeAAAA, "::1"),
+				endpoint.MustNewEndpoint("cname.example.com", endpoint.RecordTypeCNAME, "target.example.com").WithAliasProperty(endpoint.AliasTrue),
 			},
 		},
 		{
 			title:       "existing alias=false is not overridden by preferAlias",
 			preferAlias: true,
 			endpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeCNAME, "target.example.com").WithAliasProperty(endpoint.AliasFalse),
+				endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeCNAME, "target.example.com").WithAliasProperty(endpoint.AliasFalse),
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeCNAME, "target.example.com").WithAliasProperty(endpoint.AliasFalse),
+				endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeCNAME, "target.example.com").WithAliasProperty(endpoint.AliasFalse),
 			},
 		},
 		{
 			title:       "existing alias=true is preserved when preferAlias is enabled",
 			preferAlias: true,
 			endpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeCNAME, "target.example.com").WithAliasProperty(endpoint.AliasTrue),
+				endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeCNAME, "target.example.com").WithAliasProperty(endpoint.AliasTrue),
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeCNAME, "target.example.com").WithAliasProperty(endpoint.AliasTrue),
+				endpoint.MustNewEndpoint("foo.example.com", endpoint.RecordTypeCNAME, "target.example.com").WithAliasProperty(endpoint.AliasTrue),
 			},
 		},
 	}

--- a/source/wrappers/ptr_test.go
+++ b/source/wrappers/ptr_test.go
@@ -94,37 +94,37 @@ func TestPTRSource(t *testing.T) {
 			name:           "TTL preserved",
 			defaultEnabled: true,
 			endpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpointWithTTL("web.example.com", endpoint.RecordTypeA, 300, "10.0.0.1"),
+				endpoint.MustNewEndpointWithTTL("web.example.com", endpoint.RecordTypeA, 300, "10.0.0.1"),
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpointWithTTL("web.example.com", endpoint.RecordTypeA, 300, "10.0.0.1"),
-				endpoint.NewEndpointWithTTL("1.0.0.10.in-addr.arpa", endpoint.RecordTypePTR, 300, "web.example.com"),
+				endpoint.MustNewEndpointWithTTL("web.example.com", endpoint.RecordTypeA, 300, "10.0.0.1"),
+				endpoint.MustNewEndpointWithTTL("1.0.0.10.in-addr.arpa", endpoint.RecordTypePTR, 300, "web.example.com"),
 			},
 		},
 		{
 			name:           "conflicting TTLs use minimum",
 			defaultEnabled: true,
 			endpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpointWithTTL("a.example.com", endpoint.RecordTypeA, 300, "10.0.0.1"),
-				endpoint.NewEndpointWithTTL("b.example.com", endpoint.RecordTypeA, 60, "10.0.0.1"),
+				endpoint.MustNewEndpointWithTTL("a.example.com", endpoint.RecordTypeA, 300, "10.0.0.1"),
+				endpoint.MustNewEndpointWithTTL("b.example.com", endpoint.RecordTypeA, 60, "10.0.0.1"),
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpointWithTTL("a.example.com", endpoint.RecordTypeA, 300, "10.0.0.1"),
-				endpoint.NewEndpointWithTTL("b.example.com", endpoint.RecordTypeA, 60, "10.0.0.1"),
-				endpoint.NewEndpointWithTTL("1.0.0.10.in-addr.arpa", endpoint.RecordTypePTR, 60, "a.example.com", "b.example.com"),
+				endpoint.MustNewEndpointWithTTL("a.example.com", endpoint.RecordTypeA, 300, "10.0.0.1"),
+				endpoint.MustNewEndpointWithTTL("b.example.com", endpoint.RecordTypeA, 60, "10.0.0.1"),
+				endpoint.MustNewEndpointWithTTL("1.0.0.10.in-addr.arpa", endpoint.RecordTypePTR, 60, "a.example.com", "b.example.com"),
 			},
 		},
 		{
 			name:           "conflicting TTLs use minimum reversed order",
 			defaultEnabled: true,
 			endpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpointWithTTL("a.example.com", endpoint.RecordTypeA, 60, "10.0.0.1"),
-				endpoint.NewEndpointWithTTL("b.example.com", endpoint.RecordTypeA, 300, "10.0.0.1"),
+				endpoint.MustNewEndpointWithTTL("a.example.com", endpoint.RecordTypeA, 60, "10.0.0.1"),
+				endpoint.MustNewEndpointWithTTL("b.example.com", endpoint.RecordTypeA, 300, "10.0.0.1"),
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpointWithTTL("a.example.com", endpoint.RecordTypeA, 60, "10.0.0.1"),
-				endpoint.NewEndpointWithTTL("b.example.com", endpoint.RecordTypeA, 300, "10.0.0.1"),
-				endpoint.NewEndpointWithTTL("1.0.0.10.in-addr.arpa", endpoint.RecordTypePTR, 60, "a.example.com", "b.example.com"),
+				endpoint.MustNewEndpointWithTTL("a.example.com", endpoint.RecordTypeA, 60, "10.0.0.1"),
+				endpoint.MustNewEndpointWithTTL("b.example.com", endpoint.RecordTypeA, 300, "10.0.0.1"),
+				endpoint.MustNewEndpointWithTTL("1.0.0.10.in-addr.arpa", endpoint.RecordTypePTR, 60, "a.example.com", "b.example.com"),
 			},
 		},
 	}
@@ -151,7 +151,7 @@ func TestPTRSource(t *testing.T) {
 func TestPTRSource_AnnotationOverride(t *testing.T) {
 	t.Run("annotation opts in when flag is off", func(t *testing.T) {
 		eps := []*endpoint.Endpoint{
-			endpoint.NewEndpoint("web.example.com", endpoint.RecordTypeA, "192.168.49.2").
+			endpoint.MustNewEndpoint("web.example.com", endpoint.RecordTypeA, "192.168.49.2").
 				WithProviderSpecific(endpoint.ProviderSpecificRecordType, "ptr"),
 		}
 		mockSource := testutils.NewMockSource(eps...)
@@ -167,7 +167,7 @@ func TestPTRSource_AnnotationOverride(t *testing.T) {
 
 	t.Run("annotation opts out when flag is on", func(t *testing.T) {
 		eps := []*endpoint.Endpoint{
-			endpoint.NewEndpoint("web.example.com", endpoint.RecordTypeA, "192.168.49.2").
+			endpoint.MustNewEndpoint("web.example.com", endpoint.RecordTypeA, "192.168.49.2").
 				WithProviderSpecific(endpoint.ProviderSpecificRecordType, ""),
 		}
 		mockSource := testutils.NewMockSource(eps...)
@@ -182,7 +182,7 @@ func TestPTRSource_AnnotationOverride(t *testing.T) {
 
 	t.Run("no annotation uses flag default true", func(t *testing.T) {
 		eps := []*endpoint.Endpoint{
-			endpoint.NewEndpoint("web.example.com", endpoint.RecordTypeA, "192.168.49.2"),
+			endpoint.MustNewEndpoint("web.example.com", endpoint.RecordTypeA, "192.168.49.2"),
 		}
 		mockSource := testutils.NewMockSource(eps...)
 		src := NewPTRSource(mockSource, true)
@@ -193,7 +193,7 @@ func TestPTRSource_AnnotationOverride(t *testing.T) {
 
 	t.Run("no annotation uses flag default false", func(t *testing.T) {
 		eps := []*endpoint.Endpoint{
-			endpoint.NewEndpoint("web.example.com", endpoint.RecordTypeA, "192.168.49.2"),
+			endpoint.MustNewEndpoint("web.example.com", endpoint.RecordTypeA, "192.168.49.2"),
 		}
 		mockSource := testutils.NewMockSource(eps...)
 		src := NewPTRSource(mockSource, false)

--- a/source/wrappers/targetfiltersource_test.go
+++ b/source/wrappers/targetfiltersource_test.go
@@ -92,28 +92,28 @@ func TestTargetFilterSourceEndpoints(t *testing.T) {
 			title:   "filter exclusion all",
 			filters: NewMockTargetNetFilter([]string{}),
 			endpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.4"),
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.5"),
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.6"),
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "1.3.4.5"),
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "1.4.4.5")},
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.5"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.6"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "1.3.4.5"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "1.4.4.5")},
 			expected: []*endpoint.Endpoint{},
 		},
 		{
 			title:   "filter exclude internal net",
 			filters: NewMockTargetNetFilter([]string{"8.8.8.8"}),
 			endpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.0.1"),
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "8.8.8.8")},
-			expected: []*endpoint.Endpoint{endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "8.8.8.8")},
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "10.0.0.1"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "8.8.8.8")},
+			expected: []*endpoint.Endpoint{endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "8.8.8.8")},
 		},
 		{
 			title:   "filter only internal",
 			filters: NewMockTargetNetFilter([]string{"10.0.0.1"}),
 			endpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.0.1"),
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "8.8.8.8")},
-			expected: []*endpoint.Endpoint{endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.0.1")},
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "10.0.0.1"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "8.8.8.8")},
+			expected: []*endpoint.Endpoint{endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "10.0.0.1")},
 		},
 	}
 	for _, tt := range tests {
@@ -152,63 +152,63 @@ func TestTargetFilterConcreteTargetFilter(t *testing.T) {
 			title:   "should skip filtering if no filters are set",
 			filters: endpoint.NewTargetNetFilterWithExclusions([]string{}, []string{}),
 			endpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.4"),
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.5"),
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.6"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.5"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.6"),
 			},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.4"),
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.5"),
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.6"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.5"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "1.2.3.6"),
 			},
 		},
 		{
 			title:   "should include all targets when filters are not correctly set",
 			filters: endpoint.NewTargetNetFilterWithExclusions([]string{"8.8.8.8"}, []string{}),
 			endpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.0.1"),
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "8.8.8.8")},
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "10.0.0.1"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "8.8.8.8")},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.0.1"),
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "8.8.8.8"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "10.0.0.1"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "8.8.8.8"),
 			},
 		},
 		{
 			title:   "should include internal when include filter is set",
 			filters: endpoint.NewTargetNetFilterWithExclusions([]string{"10.0.0.0/8"}, []string{}),
 			endpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.0.1"),
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "49.13.41.161")},
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "10.0.0.1"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "49.13.41.161")},
 			expected: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.0.1"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "10.0.0.1"),
 			},
 		},
 		{
 			title:   "exclude internal keep public ips",
 			filters: endpoint.NewTargetNetFilterWithExclusions([]string{}, []string{"10.0.0.0/8"}),
 			endpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.178.43"),
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.1.101"),
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "49.13.41.161")},
-			expected: []*endpoint.Endpoint{endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "49.13.41.161")},
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "10.0.178.43"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "10.0.1.101"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "49.13.41.161")},
+			expected: []*endpoint.Endpoint{endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "49.13.41.161")},
 		},
 		{
 			title:   "should not exclude ipv6 when excluding ipv4",
 			filters: endpoint.NewTargetNetFilterWithExclusions([]string{}, []string{"10.0.0.0/8"}),
 			endpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.178.43"),
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeAAAA, "2a01:asdf:asdf:asdf::1"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "10.0.178.43"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeAAAA, "2a01:asdf:asdf:asdf::1"),
 			},
-			expected: []*endpoint.Endpoint{endpoint.NewEndpoint("foo", endpoint.RecordTypeAAAA, "2a01:asdf:asdf:asdf::1")},
+			expected: []*endpoint.Endpoint{endpoint.MustNewEndpoint("foo", endpoint.RecordTypeAAAA, "2a01:asdf:asdf:asdf::1")},
 		},
 		{
 			title:   "should not include ipv6 when including ipv4",
 			filters: endpoint.NewTargetNetFilterWithExclusions([]string{"10.0.0.0/8"}, []string{}),
 			endpoints: []*endpoint.Endpoint{
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.178.43"),
-				endpoint.NewEndpoint("foo", endpoint.RecordTypeAAAA, "2a01:asdf:asdf:asdf::1"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "10.0.178.43"),
+				endpoint.MustNewEndpoint("foo", endpoint.RecordTypeAAAA, "2a01:asdf:asdf:asdf::1"),
 			},
-			expected: []*endpoint.Endpoint{endpoint.NewEndpoint("foo", endpoint.RecordTypeA, "10.0.178.43")},
+			expected: []*endpoint.Endpoint{endpoint.MustNewEndpoint("foo", endpoint.RecordTypeA, "10.0.178.43")},
 		},
 	}
 	for _, tt := range tests {

--- a/source/wrappers/types_test.go
+++ b/source/wrappers/types_test.go
@@ -96,7 +96,7 @@ func TestWrapSources_NAT64Error(t *testing.T) {
 
 func TestWrapSources_PTRNotAddedWhenDisabled(t *testing.T) {
 	eps := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("a.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+		endpoint.MustNewEndpoint("a.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 	}
 	cfg := NewConfig() // createPTR defaults to false
 	src, err := wrapSources([]source.Source{testutils.NewMockSource(eps...)}, cfg)
@@ -111,7 +111,7 @@ func TestWrapSources_PTRNotAddedWhenDisabled(t *testing.T) {
 
 func TestWrapSources_PTRAddedWhenEnabled(t *testing.T) {
 	eps := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("a.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+		endpoint.MustNewEndpoint("a.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 	}
 	cfg := NewConfig(WithPTRSupported(true), WithCreatePTR(true))
 	src, err := wrapSources([]source.Source{testutils.NewMockSource(eps...)}, cfg)
@@ -128,7 +128,7 @@ func TestWrapSources_PTRAddedWhenEnabled(t *testing.T) {
 
 func TestWrapSources_PTRSupportedButDefaultOff(t *testing.T) {
 	eps := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("a.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+		endpoint.MustNewEndpoint("a.example.com", endpoint.RecordTypeA, "1.2.3.4"),
 	}
 	cfg := NewConfig(WithPTRSupported(true)) // createPTR defaults to false
 	src, err := wrapSources([]source.Source{testutils.NewMockSource(eps...)}, cfg)


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->

Add an error return to `NewEndpoint()` and `NewEndpointWithTTL()`.
Also add `MustNewEndpoint()` and `MustNewEndpointWithTTL()` that panic on error (used in test in place of `NewEndpoint()` and `NewEndpointWithTTL()`)

## Motivation

<!-- What inspired you to submit this pull request? -->
`NewEndpoint()` and `NewEndpointWithTTL()` check for length and only log a warning then return nil.

Returning nil may have been unexpected for developers and may have led to issues (https://github.com/kubernetes-sigs/external-dns/pull/6653, https://github.com/kubernetes-sigs/external-dns/pull/4293).

I think returning an error in this case is more idiomatic, makes the code clearer, and reduces the risk of bugs.

Log messages are also emitted where the error actually occurs, allowing callers to decide whether it should be handled as a warning or an error.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
