### PR TITLE
fix(provider): handle transient Alibaba PrivateZone read errors

### DIFF
--- a/provider/alibabacloud/alibaba_cloud.go
+++ b/provider/alibabacloud/alibaba_cloud.go
@@ -18,14 +18,20 @@ package alibabacloud
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
 	"os"
 	"slices"
 	"sort"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
+	sdkerrors "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/alidns"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/pvtz"
@@ -68,6 +74,44 @@ type AlibabaCloudPrivateZoneAPI interface {
 	DescribeZoneRecords(request *pvtz.DescribeZoneRecordsRequest) (*pvtz.DescribeZoneRecordsResponse, error)
 	DescribeZones(request *pvtz.DescribeZonesRequest) (*pvtz.DescribeZonesResponse, error)
 	DescribeZoneInfo(request *pvtz.DescribeZoneInfoRequest) (*pvtz.DescribeZoneInfoResponse, error)
+}
+
+func convertAlibabaCloudError(err error) error {
+	if err == nil || !isTransientAlibabaCloudError(err) {
+		return err
+	}
+	return provider.NewSoftError(err)
+}
+
+func isTransientAlibabaCloudError(err error) bool {
+	var sdkErr sdkerrors.Error
+	if errors.As(err, &sdkErr) {
+		status := sdkErr.HttpStatus()
+		if status == http.StatusRequestTimeout || status == http.StatusTooManyRequests || (status >= http.StatusInternalServerError && status < 600) {
+			return true
+		}
+		if sdkErr.ErrorCode() == sdkerrors.TimeoutErrorCode {
+			return true
+		}
+		if originErr := sdkErr.OriginError(); originErr != nil && isTransientNetworkError(originErr) {
+			return true
+		}
+	}
+	return isTransientNetworkError(err)
+}
+
+func isTransientNetworkError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.EPIPE) {
+		return true
+	}
+
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
 // AlibabaCloudProvider implements the DNS provider for Alibaba Cloud.
@@ -679,15 +723,19 @@ func (p *AlibabaCloudProvider) splitDNSName(dnsName string, hostedZoneDomains []
 	return rr, domain
 }
 
-func (p *AlibabaCloudProvider) matchVPC(zoneID string) bool {
+func (p *AlibabaCloudProvider) matchVPC(zoneID string) (bool, error) {
 	request := pvtz.CreateDescribeZoneInfoRequest()
 	request.ZoneId = zoneID
 	request.Domain = pVTZDoamin
 	request.Scheme = defaultAlibabaCloudRequestScheme
 	response, err := p.getPvtzClient().DescribeZoneInfo(request)
 	if err != nil {
+		wrappedErr := fmt.Errorf("describing private zone info %q: %w", zoneID, err)
+		if isTransientAlibabaCloudError(wrappedErr) {
+			return false, provider.NewSoftError(wrappedErr)
+		}
 		log.Errorf("Failed to describe zone info %s in Alibaba Cloud DNS: %v", zoneID, err)
-		return false
+		return false, nil
 	}
 	foundVPC := false
 	for _, vpc := range response.BindVpcs.Vpc {
@@ -696,7 +744,7 @@ func (p *AlibabaCloudProvider) matchVPC(zoneID string) bool {
 			break
 		}
 	}
-	return foundVPC
+	return foundVPC, nil
 }
 
 func (p *AlibabaCloudProvider) privateZones() ([]pvtz.Zone, error) {
@@ -711,7 +759,7 @@ func (p *AlibabaCloudProvider) privateZones() ([]pvtz.Zone, error) {
 		response, err := p.getPvtzClient().DescribeZones(request)
 		if err != nil {
 			log.Errorf("Failed to describe zones in Alibaba Cloud DNS: %v", err)
-			return nil, err
+			return nil, convertAlibabaCloudError(fmt.Errorf("describing private zones: %w", err))
 		}
 		for _, zone := range response.Zones.Zone {
 			log.Infof("PrivateZones zone: %++v", zone)
@@ -722,7 +770,11 @@ func (p *AlibabaCloudProvider) privateZones() ([]pvtz.Zone, error) {
 			if !p.domainFilter.Match(zone.ZoneName) {
 				continue
 			}
-			if !p.matchVPC(zone.ZoneId) {
+			matchesVPC, err := p.matchVPC(zone.ZoneId)
+			if err != nil {
+				return nil, err
+			}
+			if !matchesVPC {
 				continue
 			}
 			zones = append(zones, zone)
@@ -766,7 +818,7 @@ func (p *AlibabaCloudProvider) getPrivateZones() (map[string]*alibabaPrivateZone
 			response, err := p.getPvtzClient().DescribeZoneRecords(request)
 			if err != nil {
 				log.Errorf("Failed to describe zone record '%s' in Alibaba Cloud DNS: %v", zone.ZoneId, err)
-				return nil, err
+				return nil, convertAlibabaCloudError(fmt.Errorf("describing records for private zone %q: %w", zone.ZoneId, err))
 			}
 
 			for _, record := range response.Records.Record {

--- a/provider/alibabacloud/alibaba_cloud_test.go
+++ b/provider/alibabacloud/alibaba_cloud_test.go
@@ -17,13 +17,20 @@ limitations under the License.
 package alibabacloud
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
 	"slices"
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"testing"
 
+	sdkerrors "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/alidns"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/pvtz"
 	"github.com/google/uuid"
@@ -33,6 +40,7 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/internal/testutils"
 	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
 )
 
 type MockAlibabaCloudDNSAPI struct {
@@ -171,9 +179,12 @@ func (m *MockAlibabaCloudDNSAPI) newRecord(ep *endpoint.Endpoint, target, domain
 }
 
 type MockAlibabaCloudPrivateZoneAPI struct {
-	counter int64
-	zones   []*pvtz.Zone
-	records map[string][]*pvtz.Record
+	counter                int64
+	zones                  []*pvtz.Zone
+	records                map[string][]*pvtz.Record
+	describeZoneRecordsErr error
+	describeZonesErr       error
+	describeZoneInfoErr    error
 }
 
 func (m *MockAlibabaCloudPrivateZoneAPI) AddZoneRecord(request *pvtz.AddZoneRecordRequest) (*pvtz.AddZoneRecordResponse, error) {
@@ -260,6 +271,9 @@ func (m *MockAlibabaCloudPrivateZoneAPI) UpdateZoneRecord(request *pvtz.UpdateZo
 }
 
 func (m *MockAlibabaCloudPrivateZoneAPI) DescribeZoneRecords(request *pvtz.DescribeZoneRecordsRequest) (*pvtz.DescribeZoneRecordsResponse, error) {
+	if m.describeZoneRecordsErr != nil {
+		return pvtz.CreateDescribeZoneRecordsResponse(), m.describeZoneRecordsErr
+	}
 	if request == nil || request.ZoneId == "" {
 		return pvtz.CreateDescribeZoneRecordsResponse(), fmt.Errorf("Invalid request")
 	}
@@ -276,6 +290,9 @@ func (m *MockAlibabaCloudPrivateZoneAPI) DescribeZoneRecords(request *pvtz.Descr
 }
 
 func (m *MockAlibabaCloudPrivateZoneAPI) DescribeZones(_ *pvtz.DescribeZonesRequest) (*pvtz.DescribeZonesResponse, error) {
+	if m.describeZonesErr != nil {
+		return pvtz.CreateDescribeZonesResponse(), m.describeZonesErr
+	}
 	var result pvtz.ZonesInDescribeZones
 	for _, zone := range m.zones {
 		result.Zone = append(result.Zone, pvtz.Zone{
@@ -289,6 +306,9 @@ func (m *MockAlibabaCloudPrivateZoneAPI) DescribeZones(_ *pvtz.DescribeZonesRequ
 }
 
 func (m *MockAlibabaCloudPrivateZoneAPI) DescribeZoneInfo(request *pvtz.DescribeZoneInfoRequest) (*pvtz.DescribeZoneInfoResponse, error) {
+	if m.describeZoneInfoErr != nil {
+		return pvtz.CreateDescribeZoneInfoResponse(), m.describeZoneInfoErr
+	}
 	if request == nil || request.ZoneId == "" {
 		return pvtz.CreateDescribeZoneInfoResponse(), fmt.Errorf("Invalid request")
 	}
@@ -518,6 +538,118 @@ func TestAlibabaCloudProvider_PrivateZone_Records(t *testing.T) {
 	require.NoError(t, err, "Failed to get records: %v", err)
 	require.Len(t, endpoints, len(defaultEndpoints), "Incorrect number of records: %d", len(endpoints))
 	assert.True(t, testutils.SameEndpoints(defaultEndpoints, endpoints), "expected and actual endpoints don't match. %s:%s", defaultEndpoints, endpoints)
+}
+
+func TestAlibabaCloudProvider_PrivateZoneReadErrors(t *testing.T) {
+	permanentErr := errors.New("invalid request")
+	tests := []struct {
+		name      string
+		err       error
+		soft      bool
+		configure func(*MockAlibabaCloudPrivateZoneAPI, error)
+	}{
+		{
+			name: "transient describe zones",
+			err:  sdkerrors.NewServerError(http.StatusTooManyRequests, `{}`, ""),
+			soft: true,
+			configure: func(client *MockAlibabaCloudPrivateZoneAPI, err error) {
+				client.describeZonesErr = err
+			},
+		},
+		{
+			name: "transient describe zone info",
+			err:  io.EOF,
+			soft: true,
+			configure: func(client *MockAlibabaCloudPrivateZoneAPI, err error) {
+				client.describeZoneInfoErr = err
+			},
+		},
+		{
+			name: "transient describe zone records",
+			err:  context.DeadlineExceeded,
+			soft: true,
+			configure: func(client *MockAlibabaCloudPrivateZoneAPI, err error) {
+				client.describeZoneRecordsErr = err
+			},
+		},
+		{
+			name: "permanent describe zones",
+			err:  permanentErr,
+			configure: func(client *MockAlibabaCloudPrivateZoneAPI, err error) {
+				client.describeZonesErr = err
+			},
+		},
+		{
+			name: "permanent describe zone records",
+			err:  permanentErr,
+			configure: func(client *MockAlibabaCloudPrivateZoneAPI, err error) {
+				client.describeZoneRecordsErr = err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newTestAlibabaCloudProvider(true)
+			tt.configure(p.pvtzClient.(*MockAlibabaCloudPrivateZoneAPI), tt.err)
+
+			endpoints, err := p.Records(t.Context())
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tt.err)
+			if tt.soft {
+				assert.ErrorIs(t, err, provider.SoftError)
+			} else {
+				assert.NotErrorIs(t, err, provider.SoftError)
+			}
+			assert.Nil(t, endpoints)
+		})
+	}
+}
+
+func TestAlibabaCloudProvider_PrivateZoneSkipsPermanentDescribeZoneInfoError(t *testing.T) {
+	p := newTestAlibabaCloudProvider(true)
+	p.pvtzClient.(*MockAlibabaCloudPrivateZoneAPI).describeZoneInfoErr = errors.New("invalid request")
+
+	endpoints, err := p.Records(t.Context())
+
+	require.NoError(t, err)
+	assert.Empty(t, endpoints)
+}
+
+func TestConvertAlibabaCloudError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		soft bool
+	}{
+		{name: "HTTP 408", err: sdkerrors.NewServerError(http.StatusRequestTimeout, `{}`, ""), soft: true},
+		{name: "HTTP 429", err: sdkerrors.NewServerError(http.StatusTooManyRequests, `{}`, ""), soft: true},
+		{name: "HTTP 5xx", err: sdkerrors.NewServerError(http.StatusServiceUnavailable, `{}`, ""), soft: true},
+		{name: "SDK timeout", err: sdkerrors.NewClientError(sdkerrors.TimeoutErrorCode, "timed out", nil), soft: true},
+		{name: "EOF", err: io.EOF, soft: true},
+		{name: "unexpected EOF", err: io.ErrUnexpectedEOF, soft: true},
+		{name: "context deadline", err: context.DeadlineExceeded, soft: true},
+		{name: "network timeout", err: &net.DNSError{IsTimeout: true}, soft: true},
+		{name: "connection reset", err: syscall.ECONNRESET, soft: true},
+		{name: "connection refused", err: syscall.ECONNREFUSED, soft: true},
+		{name: "broken pipe", err: syscall.EPIPE, soft: true},
+		{name: "HTTP 403", err: sdkerrors.NewServerError(http.StatusForbidden, `{}`, "")},
+		{name: "context canceled", err: context.Canceled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := convertAlibabaCloudError(tt.err)
+
+			assert.ErrorIs(t, err, tt.err)
+			if tt.soft {
+				assert.ErrorIs(t, err, provider.SoftError)
+			} else {
+				assert.NotErrorIs(t, err, provider.SoftError)
+			}
+		})
+	}
 }
 
 func TestAlibabaCloudProvider_PrivateZone_ApplyChanges(t *testing.T) {


### PR DESCRIPTION
## What does it do ?

- Classifies confirmed transient failures from Alibaba PrivateZone `DescribeZones`, `DescribeZoneInfo`, and `DescribeZoneRecords` calls as `provider.SoftError`.
- Preserves existing behavior for permanent errors.
- Adds focused regression tests for transient and permanent read failures.

## Motivation

Transient Alibaba Cloud API failures such as `connection reset by peer` are currently returned as regular errors. ExternalDNS treats them as fatal and exits instead of retrying on the next reconciliation.

## Scope

This change is limited to PrivateZone read operations. It does not modify public Alidns, write paths, registry behavior, dry-run handling, or zone matching.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

No user-facing configuration or documentation changes are required.

Verification:

- `go test -race -shuffle=on -count=1 ./provider/alibabacloud ./registry/txt`
- `go vet ./provider/alibabacloud ./registry/txt`
- `golangci-lint run --timeout=10m ./provider/alibabacloud/... ./registry/txt/...`
- `go build ./...`