### PR TITLE
ci(source): drop embedded field type in pod test literal

### DIFF
--- a/source/pod_test.go
+++ b/source/pod_test.go
@@ -115,12 +115,10 @@ func TestPodSource(t *testing.T) {
 			nodesFixturesIPv4(),
 			[]*corev1.Pod{
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "my-pod1",
-						Namespace: "kube-system",
-						Annotations: map[string]string{
-							annotations.InternalHostnameKey: strings.Repeat("a", 64) + ".example.org",
-						},
+					Name:      "my-pod1",
+					Namespace: "kube-system",
+					Annotations: map[string]string{
+						annotations.InternalHostnameKey: strings.Repeat("a", 64) + ".example.org",
 					},
 					Spec: corev1.PodSpec{
 						HostNetwork: true,


### PR DESCRIPTION
## What does it do ?

Fix a linter issue

## Motivation

#6675 bumped go.mod to Go 1.27, enabling the `modernize` `embedlit` analyzer. 

It was somehow missed during the review / merge process.

Verified: `golangci-lint run ./...` clean, `go test ./source/` passes.
