### PR TITLE
fix(ns1): respect --dry-run flag

### DIFF
--- a/provider/ns1/ns1.go
+++ b/provider/ns1/ns1.go
@@ -156,6 +156,7 @@ func newNS1ProviderWithHTTPClient(config NS1Config, client *http.Client) (*NS1Pr
 		client:        NS1DomainService{apiClient},
 		domainFilter:  config.DomainFilter,
 		zoneIDFilter:  config.ZoneIDFilter,
+		dryRun:        config.DryRun,
 		minTTLSeconds: config.MinTTLSeconds,
 	}, nil
 }

--- a/provider/ns1/ns1_test.go
+++ b/provider/ns1/ns1_test.go
@@ -317,3 +317,58 @@ func TestNewNS1ChangesByZone(t *testing.T) {
 	assert.Len(t, changes["bar.com"], 1)
 	assert.Len(t, changes["foo.com"], 3)
 }
+
+type MockNS1DryRunClient struct {
+	MockNS1DomainClient
+	createCalls int
+	deleteCalls int
+	updateCalls int
+}
+
+func (m *MockNS1DryRunClient) CreateRecord(_ *dns.Record) (*http.Response, error) {
+	m.createCalls++
+	return &http.Response{}, nil
+}
+
+func (m *MockNS1DryRunClient) DeleteRecord(_ string, _ string, _ string) (*http.Response, error) {
+	m.deleteCalls++
+	return &http.Response{}, nil
+}
+
+func (m *MockNS1DryRunClient) UpdateRecord(_ *dns.Record) (*http.Response, error) {
+	m.updateCalls++
+	return &http.Response{}, nil
+}
+
+func TestNS1ApplyChangesDryRun(t *testing.T) {
+	t.Setenv("NS1_APIKEY", "xxxxxxxxxxxxxxxxx")
+	provider, err := newProvider(NS1Config{
+		DomainFilter: endpoint.NewDomainFilter([]string{"foo.com."}),
+		ZoneIDFilter: provider.NewZoneIDFilter([]string{""}),
+		DryRun:       true,
+	})
+	require.NoError(t, err)
+	assert.True(t, provider.dryRun, "DryRun config must be propagated to the provider")
+
+	client := &MockNS1DryRunClient{}
+	provider.client = client
+
+	changes := &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			{DNSName: "new.foo.com", Targets: endpoint.Targets{"target"}, RecordType: "A"},
+			{DNSName: "new.subdomain.bar.com", Targets: endpoint.Targets{"target"}, RecordType: "A"},
+		},
+		UpdateNew: []*endpoint.Endpoint{
+			{DNSName: "test.foo.com", Targets: endpoint.Targets{"target-new"}, RecordType: "A"},
+		},
+		Delete: []*endpoint.Endpoint{
+			{DNSName: "test.foo.com", Targets: endpoint.Targets{"target"}, RecordType: "A"},
+		},
+	}
+
+	require.NoError(t, provider.ApplyChanges(t.Context(), changes))
+
+	assert.Zero(t, client.createCalls, "dry-run must not create records")
+	assert.Zero(t, client.updateCalls, "dry-run must not update records")
+	assert.Zero(t, client.deleteCalls, "dry-run must not delete records")
+}


### PR DESCRIPTION
## What does it do ?

`New()` populated `NS1Config.DryRun` from the CLI flag, but the `NS1Provider`
struct literal (`ns1.go:155`) never copied it into the `dryRun` field. So
`p.dryRun` was always `false` and the guard in `ns1SubmitChanges` was dead code:
records were created, updated and deleted even with `--dry-run` set.

Adds `TestNS1ApplyChangesDryRun`, in the style of the existing dry-run tests in
the aws, azure, google and exoscale providers. 

## Motivation

Same bug as #2233 (hetzner). Present since at least v0.10.2.

**Behaviour change:** anyone running NS1 with `--dry-run` today is unknowingly
relying on records being written, and their DNS management will stop silently
once this lands. Might be worth a release-note callout.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
