### PR TITLE
fix(pdns): add request timeout and context cancellation for PowerDNS API calls

### DIFF
--- a/provider/pdns/pdns.go
+++ b/provider/pdns/pdns.go
@@ -55,6 +55,8 @@ const (
 	retryLimit = 3
 	// time in milliseconds
 	retryAfterTime = 250 * time.Millisecond
+	// defaultRequestTimeout is the default HTTP request timeout for PowerDNS API calls
+	defaultRequestTimeout = 30 * time.Second
 )
 
 // record types which require to have trailing dot
@@ -115,6 +117,7 @@ func (tlsConfig *TLSConfig) newHTTPClient() (*http.Client, error) {
 	}
 
 	return &http.Client{
+		Timeout:   defaultRequestTimeout,
 		Transport: transporter,
 	}, nil
 }
@@ -137,29 +140,32 @@ func (rt *pathPrefixRoundTripper) RoundTrip(req *http.Request) (*http.Response, 
 // PDNSAPIProvider : Interface used and extended by the PDNSAPIClient struct as
 // well as mock APIClients used in testing
 type PDNSAPIProvider interface {
-	ListZones() ([]pgo.Zone, error)
-	ListZone(zoneID string) (*pgo.Zone, error)
-	PatchZone(zoneID string, zoneStruct *pgo.Zone) error
+	ListZones(ctx context.Context) ([]pgo.Zone, error)
+	ListZone(ctx context.Context, zoneID string) (*pgo.Zone, error)
+	PatchZone(ctx context.Context, zoneID string, zoneStruct *pgo.Zone) error
 }
 
 // PDNSAPIClient : Struct that encapsulates all the PowerDNS specific implementation details
 type PDNSAPIClient struct {
-	dryRun  bool
-	authCtx context.Context
-	client  *pgo.Client
+	dryRun bool
+	client *pgo.Client
 }
 
 // ListZones : Method returns all enabled zones from PowerDNS
 // ref: https://doc.powerdns.com/authoritative/http-api/zone.html#get--servers-server_id-zones
-func (c *PDNSAPIClient) ListZones() ([]pgo.Zone, error) {
+func (c *PDNSAPIClient) ListZones(ctx context.Context) ([]pgo.Zone, error) {
 	var zones []pgo.Zone
 	var err error
 	for i := range retryLimit {
-		zones, err = c.client.Zones.List(c.authCtx)
+		zones, err = c.client.Zones.List(ctx)
 		if err != nil {
 			log.Debugf("Unable to fetch zones %v", err)
 			log.Debugf("Retrying ListZones() ... %d", i)
-			time.Sleep(retryAfterTime * (1 << uint(i)))
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(retryAfterTime * (1 << uint(i))):
+			}
 			continue
 		}
 		return zones, err
@@ -188,13 +194,17 @@ func partitionZones(zones []pgo.Zone, domainFilter *endpoint.DomainFilter) ([]pg
 
 // ListZone : Method returns the details of a specific zone from PowerDNS
 // ref: https://doc.powerdns.com/authoritative/http-api/zone.html#get--servers-server_id-zones-zone_id
-func (c *PDNSAPIClient) ListZone(zoneID string) (*pgo.Zone, error) {
+func (c *PDNSAPIClient) ListZone(ctx context.Context, zoneID string) (*pgo.Zone, error) {
 	for i := range retryLimit {
-		zone, err := c.client.Zones.Get(c.authCtx, zoneID)
+		zone, err := c.client.Zones.Get(ctx, zoneID)
 		if err != nil {
 			log.Debugf("Unable to fetch zone %v", err)
 			log.Debugf("Retrying ListZone() ... %d", i)
-			time.Sleep(retryAfterTime * (1 << uint(i)))
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(retryAfterTime * (1 << uint(i))):
+			}
 			continue
 		}
 		return zone, err
@@ -205,15 +215,19 @@ func (c *PDNSAPIClient) ListZone(zoneID string) (*pgo.Zone, error) {
 
 // PatchZone : Method used to update the contents of a particular zone from PowerDNS
 // ref: https://doc.powerdns.com/authoritative/http-api/zone.html#patch--servers-server_id-zones-zone_id
-func (c *PDNSAPIClient) PatchZone(zoneID string, zoneStruct *pgo.Zone) error {
+func (c *PDNSAPIClient) PatchZone(ctx context.Context, zoneID string, zoneStruct *pgo.Zone) error {
 	rrSets := &pgo.RRsets{Sets: zoneStruct.RRsets}
 	var err error
 	for i := range retryLimit {
-		err = c.client.Records.Patch(c.authCtx, zoneID, rrSets)
+		err = c.client.Records.Patch(ctx, zoneID, rrSets)
 		if err != nil {
 			log.Debugf("Unable to patch zone %v", err)
 			log.Debugf("Retrying PatchZone() ... %d", i)
-			time.Sleep(retryAfterTime * (1 << uint(i)))
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(retryAfterTime * (1 << uint(i))):
+			}
 			continue
 		}
 		return err
@@ -250,7 +264,7 @@ func New(ctx context.Context, cfg *externaldns.Config, domainFilter *endpoint.Do
 }
 
 // newProvider initializes a new PowerDNS based Provider.
-func newProvider(ctx context.Context, config PDNSConfig) (*PDNSProvider, error) {
+func newProvider(_ context.Context, config PDNSConfig) (*PDNSProvider, error) {
 	// Do some input validation
 
 	if config.APIKey == "" {
@@ -282,9 +296,8 @@ func newProvider(ctx context.Context, config PDNSConfig) (*PDNSProvider, error) 
 
 	provider := &PDNSProvider{
 		client: &PDNSAPIClient{
-			dryRun:  config.DryRun,
-			authCtx: ctx,
-			client:  pgo.New(config.Server, config.ServerID, pgo.WithAPIKey(config.APIKey), pgo.WithHTTPClient(httpClient)),
+			dryRun: config.DryRun,
+			client: pgo.New(config.Server, config.ServerID, pgo.WithAPIKey(config.APIKey), pgo.WithHTTPClient(httpClient)),
 		},
 		domainFilter: config.DomainFilter,
 	}
@@ -294,8 +307,8 @@ func newProvider(ctx context.Context, config PDNSConfig) (*PDNSProvider, error) 
 // filteredZones fetches all zones from the PowerDNS API and partitions them
 // using the provider's domain filter. It returns the matching zones, the
 // non-matching (residual) zones, and any error from the API call.
-func (p *PDNSProvider) filteredZones() ([]pgo.Zone, []pgo.Zone, error) {
-	zones, err := p.client.ListZones()
+func (p *PDNSProvider) filteredZones(ctx context.Context) ([]pgo.Zone, []pgo.Zone, error) {
+	zones, err := p.client.ListZones(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -309,7 +322,7 @@ func (p *PDNSProvider) GetDomainFilter() endpoint.DomainFilterInterface {
 	// double-filtering would produce an empty filter when no zones match,
 	// silently failing open instead of letting the controller see the
 	// mismatch and produce a safe empty plan.
-	zones, err := p.client.ListZones()
+	zones, err := p.client.ListZones(context.Background())
 	if err != nil {
 		log.Errorf("Unable to fetch zones from PowerDNS API: %v", err)
 		return &endpoint.DomainFilter{}
@@ -350,7 +363,7 @@ func (p *PDNSProvider) convertRRSetToEndpoints(rr pgo.RRset) []*endpoint.Endpoin
 }
 
 // ConvertEndpointsToZones marshals endpoints into pdns compatible Zone structs
-func (p *PDNSProvider) ConvertEndpointsToZones(eps []*endpoint.Endpoint, changetype pdnsChangeType) ([]pgo.Zone, error) {
+func (p *PDNSProvider) ConvertEndpointsToZones(ctx context.Context, eps []*endpoint.Endpoint, changetype pdnsChangeType) ([]pgo.Zone, error) {
 	var zoneList = make([]pgo.Zone, 0)
 	endpoints := make([]*endpoint.Endpoint, len(eps))
 	copy(endpoints, eps)
@@ -365,7 +378,7 @@ func (p *PDNSProvider) ConvertEndpointsToZones(eps []*endpoint.Endpoint, changet
 			return endpoints[i].DNSName < endpoints[j].DNSName
 		})
 
-	filteredZones, residualZones, err := p.filteredZones()
+	filteredZones, residualZones, err := p.filteredZones(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -471,8 +484,8 @@ func (p *PDNSProvider) ConvertEndpointsToZones(eps []*endpoint.Endpoint, changet
 }
 
 // mutateRecords takes a list of endpoints and creates, replaces or deletes them based on the changetype
-func (p *PDNSProvider) mutateRecords(endpoints []*endpoint.Endpoint, changetype pdnsChangeType) error {
-	zonelist, err := p.ConvertEndpointsToZones(endpoints, changetype)
+func (p *PDNSProvider) mutateRecords(ctx context.Context, endpoints []*endpoint.Endpoint, changetype pdnsChangeType) error {
+	zonelist, err := p.ConvertEndpointsToZones(ctx, endpoints, changetype)
 	if err != nil {
 		return err
 	}
@@ -483,7 +496,7 @@ func (p *PDNSProvider) mutateRecords(endpoints []*endpoint.Endpoint, changetype 
 		} else {
 			log.Debugf("Struct for PatchZone:\n%s", string(jso))
 		}
-		if err := p.client.PatchZone(pgo.StringValue(zone.ID), &zone); err != nil {
+		if err := p.client.PatchZone(ctx, pgo.StringValue(zone.ID), &zone); err != nil {
 			return err
 		}
 	}
@@ -491,8 +504,8 @@ func (p *PDNSProvider) mutateRecords(endpoints []*endpoint.Endpoint, changetype 
 }
 
 // Records returns all DNS records controlled by the configured PDNS server (for all zones)
-func (p *PDNSProvider) Records(_ context.Context) ([]*endpoint.Endpoint, error) {
-	filteredZones, _, err := p.filteredZones()
+func (p *PDNSProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	filteredZones, _, err := p.filteredZones(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -500,7 +513,7 @@ func (p *PDNSProvider) Records(_ context.Context) ([]*endpoint.Endpoint, error) 
 	var endpoints []*endpoint.Endpoint
 
 	for _, zone := range filteredZones {
-		z, err := p.client.ListZone(pgo.StringValue(zone.ID))
+		z, err := p.client.ListZone(ctx, pgo.StringValue(zone.ID))
 		if err != nil {
 			return nil, provider.NewSoftErrorf("unable to fetch records: %v", err)
 		}
@@ -529,7 +542,7 @@ func (p *PDNSProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpo
 
 // ApplyChanges takes a list of changes (endpoints) and updates the PDNS server
 // by sending the correct HTTP PATCH requests to a matching zone
-func (p *PDNSProvider) ApplyChanges(_ context.Context, changes *plan.Changes) error {
+func (p *PDNSProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
 	startTime := time.Now()
 
 	// Create
@@ -542,7 +555,7 @@ func (p *PDNSProvider) ApplyChanges(_ context.Context, changes *plan.Changes) er
 	// prevent unnecessary logging
 	if len(changes.Create) > 0 {
 		// "Replacing" non-existent records creates them
-		err := p.mutateRecords(changes.Create, PdnsReplace)
+		err := p.mutateRecords(ctx, changes.Create, PdnsReplace)
 		if err != nil {
 			return err
 		}
@@ -561,7 +574,7 @@ func (p *PDNSProvider) ApplyChanges(_ context.Context, changes *plan.Changes) er
 		log.Infof("UPDATE-NEW: %+v", change)
 	}
 	if len(changes.UpdateNew) > 0 {
-		err := p.mutateRecords(changes.UpdateNew, PdnsReplace)
+		err := p.mutateRecords(ctx, changes.UpdateNew, PdnsReplace)
 		if err != nil {
 			return err
 		}
@@ -572,7 +585,7 @@ func (p *PDNSProvider) ApplyChanges(_ context.Context, changes *plan.Changes) er
 		log.Infof("DELETE: %+v", change)
 	}
 	if len(changes.Delete) > 0 {
-		err := p.mutateRecords(changes.Delete, PdnsDelete)
+		err := p.mutateRecords(ctx, changes.Delete, PdnsDelete)
 		if err != nil {
 			return err
 		}

--- a/provider/pdns/pdns_test.go
+++ b/provider/pdns/pdns_test.go
@@ -18,9 +18,12 @@ package pdns
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	pgo "github.com/joeig/go-powerdns/v3"
 	"github.com/stretchr/testify/assert"
@@ -589,15 +592,15 @@ var (
 // API that returns a zone with multiple record types
 type PDNSAPIClientStub struct{}
 
-func (c *PDNSAPIClientStub) ListZones() ([]pgo.Zone, error) {
+func (c *PDNSAPIClientStub) ListZones(_ context.Context) ([]pgo.Zone, error) {
 	return []pgo.Zone{ZoneMixed}, nil
 }
 
-func (c *PDNSAPIClientStub) ListZone(_ string) (*pgo.Zone, error) {
+func (c *PDNSAPIClientStub) ListZone(_ context.Context, _ string) (*pgo.Zone, error) {
 	return &ZoneMixed, nil
 }
 
-func (c *PDNSAPIClientStub) PatchZone(_ string, _ *pgo.Zone) error {
+func (c *PDNSAPIClientStub) PatchZone(_ context.Context, _ string, _ *pgo.Zone) error {
 	return nil
 }
 
@@ -608,11 +611,11 @@ type PDNSAPIClientStubEmptyZones struct {
 	patchedZones []pgo.Zone
 }
 
-func (c *PDNSAPIClientStubEmptyZones) ListZones() ([]pgo.Zone, error) {
+func (c *PDNSAPIClientStubEmptyZones) ListZones(_ context.Context) ([]pgo.Zone, error) {
 	return []pgo.Zone{ZoneEmpty, ZoneEmptyLong, ZoneEmpty2}, nil
 }
 
-func (c *PDNSAPIClientStubEmptyZones) ListZone(zoneID string) (*pgo.Zone, error) {
+func (c *PDNSAPIClientStubEmptyZones) ListZone(_ context.Context, zoneID string) (*pgo.Zone, error) {
 	switch {
 	case strings.Contains(zoneID, "example.com"):
 		return &ZoneEmpty, nil
@@ -624,7 +627,7 @@ func (c *PDNSAPIClientStubEmptyZones) ListZone(zoneID string) (*pgo.Zone, error)
 	return &pgo.Zone{}, nil
 }
 
-func (c *PDNSAPIClientStubEmptyZones) PatchZone(_ string, zoneStruct *pgo.Zone) error {
+func (c *PDNSAPIClientStubEmptyZones) PatchZone(_ context.Context, _ string, zoneStruct *pgo.Zone) error {
 	c.patchedZones = append(c.patchedZones, *zoneStruct)
 	return nil
 }
@@ -637,7 +640,7 @@ type PDNSAPIClientStubPatchZoneFailure struct {
 }
 
 // Just overwrite the PatchZone method to introduce a failure
-func (c *PDNSAPIClientStubPatchZoneFailure) PatchZone(_ string, _ *pgo.Zone) error {
+func (c *PDNSAPIClientStubPatchZoneFailure) PatchZone(_ context.Context, _ string, _ *pgo.Zone) error {
 	return provider.NewSoftErrorf("Generic PDNS Error")
 }
 
@@ -649,7 +652,7 @@ type PDNSAPIClientStubListZoneFailure struct {
 }
 
 // Just overwrite the ListZone method to introduce a failure
-func (c *PDNSAPIClientStubListZoneFailure) ListZone(_ string) (*pgo.Zone, error) {
+func (c *PDNSAPIClientStubListZoneFailure) ListZone(_ context.Context, _ string) (*pgo.Zone, error) {
 	return &pgo.Zone{}, provider.NewSoftErrorf("Generic PDNS Error")
 }
 
@@ -661,7 +664,7 @@ type PDNSAPIClientStubListZonesFailure struct {
 }
 
 // Just overwrite the ListZones method to introduce a failure
-func (c *PDNSAPIClientStubListZonesFailure) ListZones() ([]pgo.Zone, error) {
+func (c *PDNSAPIClientStubListZonesFailure) ListZones(_ context.Context) ([]pgo.Zone, error) {
 	return []pgo.Zone{}, provider.NewSoftErrorf("Generic PDNS Error")
 }
 
@@ -672,11 +675,11 @@ type PDNSAPIClientStubPartitionZones struct {
 	PDNSAPIClientStubEmptyZones
 }
 
-func (c *PDNSAPIClientStubPartitionZones) ListZones() ([]pgo.Zone, error) {
+func (c *PDNSAPIClientStubPartitionZones) ListZones(_ context.Context) ([]pgo.Zone, error) {
 	return []pgo.Zone{ZoneEmpty, ZoneEmpty2, ZoneEmptySimilar}, nil
 }
 
-func (c *PDNSAPIClientStubPartitionZones) ListZone(zoneID string) (*pgo.Zone, error) {
+func (c *PDNSAPIClientStubPartitionZones) ListZone(_ context.Context, zoneID string) (*pgo.Zone, error) {
 	switch {
 	case strings.Contains(zoneID, "example.com"):
 		return &ZoneEmpty, nil
@@ -697,18 +700,18 @@ type PDNSAPIClientStubConfigurable struct {
 	listErr error
 }
 
-func (c *PDNSAPIClientStubConfigurable) ListZones() ([]pgo.Zone, error) {
+func (c *PDNSAPIClientStubConfigurable) ListZones(_ context.Context) ([]pgo.Zone, error) {
 	if c.listErr != nil {
 		return nil, c.listErr
 	}
 	return c.zones, nil
 }
 
-func (c *PDNSAPIClientStubConfigurable) ListZone(_ string) (*pgo.Zone, error) {
+func (c *PDNSAPIClientStubConfigurable) ListZone(_ context.Context, _ string) (*pgo.Zone, error) {
 	return &pgo.Zone{}, nil
 }
 
-func (c *PDNSAPIClientStubConfigurable) PatchZone(_ string, _ *pgo.Zone) error {
+func (c *PDNSAPIClientStubConfigurable) PatchZone(_ context.Context, _ string, _ *pgo.Zone) error {
 	return nil
 }
 
@@ -890,42 +893,42 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSConvertEndpointsToZones() {
 	}
 
 	// Check inserting endpoints from a single zone
-	zlist, err := p.ConvertEndpointsToZones(endpointsSimpleRecord, PdnsReplace)
+	zlist, err := p.ConvertEndpointsToZones(context.Background(), endpointsSimpleRecord, PdnsReplace)
 	suite.NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimplePatch}, zlist)
 
 	// Check deleting endpoints from a single zone
-	zlist, err = p.ConvertEndpointsToZones(endpointsSimpleRecord, PdnsDelete)
+	zlist, err = p.ConvertEndpointsToZones(context.Background(), endpointsSimpleRecord, PdnsDelete)
 	suite.NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimpleDelete}, zlist)
 
 	// Check endpoints from multiple zones #1
-	zlist, err = p.ConvertEndpointsToZones(endpointsMultipleZones, PdnsReplace)
+	zlist, err = p.ConvertEndpointsToZones(context.Background(), endpointsMultipleZones, PdnsReplace)
 	suite.NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimplePatch, ZoneEmptyToSimplePatch2}, zlist)
 
 	// Check endpoints from multiple zones #2
-	zlist, err = p.ConvertEndpointsToZones(endpointsMultipleZones2, PdnsReplace)
+	zlist, err = p.ConvertEndpointsToZones(context.Background(), endpointsMultipleZones2, PdnsReplace)
 	suite.NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimplePatch, ZoneEmptyToSimplePatch3}, zlist)
 
 	// Check endpoints from multiple zones where some endpoints which don't exist
-	zlist, err = p.ConvertEndpointsToZones(endpointsMultipleZonesWithNoExist, PdnsReplace)
+	zlist, err = p.ConvertEndpointsToZones(context.Background(), endpointsMultipleZonesWithNoExist, PdnsReplace)
 	suite.NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimplePatch}, zlist)
 
 	// Check endpoints from a zone that does not exist
-	zlist, err = p.ConvertEndpointsToZones(endpointsNonexistantZone, PdnsReplace)
+	zlist, err = p.ConvertEndpointsToZones(context.Background(), endpointsNonexistantZone, PdnsReplace)
 	suite.NoError(err)
 	suite.Equal([]pgo.Zone{}, zlist)
 
 	// Check endpoints that match multiple zones (one longer than other), is assigned to the right zone
-	zlist, err = p.ConvertEndpointsToZones(endpointsLongRecord, PdnsReplace)
+	zlist, err = p.ConvertEndpointsToZones(context.Background(), endpointsLongRecord, PdnsReplace)
 	suite.NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToLongPatch}, zlist)
 
 	// Check endpoints of type CNAME, ALIAS, MX, SRV, and NS always have their values end with a trailing dot.
-	zlist, err = p.ConvertEndpointsToZones(endpointsMixedRecords, PdnsReplace)
+	zlist, err = p.ConvertEndpointsToZones(context.Background(), endpointsMixedRecords, PdnsReplace)
 	suite.NoError(err)
 
 	trailingTypes := sets.New(
@@ -949,18 +952,18 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSConvertEndpointsToZones() {
 	}
 
 	// Check endpoints of type CNAME are converted to ALIAS on the domain apex
-	zlist, err = p.ConvertEndpointsToZones(endpointsApexRecords, PdnsReplace)
+	zlist, err = p.ConvertEndpointsToZones(context.Background(), endpointsApexRecords, PdnsReplace)
 	suite.NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToApexPatch}, zlist)
 
 	// Check endpoints of type CNAME remain CNAME when no alias annotation is set
-	zlist, err = p.ConvertEndpointsToZones(endpointsPreferAlias, PdnsReplace)
+	zlist, err = p.ConvertEndpointsToZones(context.Background(), endpointsPreferAlias, PdnsReplace)
 	suite.NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToCNAMEPatch}, zlist)
 
 	// Check endpoints with alias annotation are converted to ALIAS
 	// Note: The --prefer-alias flag now works via PostProcessor wrapper which sets the alias annotation
-	zlist, err = p.ConvertEndpointsToZones([]*endpoint.Endpoint{endpointWithAliasAnnotation}, PdnsReplace)
+	zlist, err = p.ConvertEndpointsToZones(context.Background(), []*endpoint.Endpoint{endpointWithAliasAnnotation}, PdnsReplace)
 	suite.NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToPreferAliasPatch}, zlist)
 }
@@ -973,40 +976,40 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSConvertEndpointsToZonesPartitionZ
 	}
 
 	// Check inserting endpoints from a single zone which is specified in DomainFilter
-	zlist, err := p.ConvertEndpointsToZones(endpointsSimpleRecord, PdnsReplace)
+	zlist, err := p.ConvertEndpointsToZones(context.Background(), endpointsSimpleRecord, PdnsReplace)
 	suite.Require().NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimplePatch}, zlist)
 
 	// Check deleting endpoints from a single zone which is specified in DomainFilter
-	zlist, err = p.ConvertEndpointsToZones(endpointsSimpleRecord, PdnsDelete)
+	zlist, err = p.ConvertEndpointsToZones(context.Background(), endpointsSimpleRecord, PdnsDelete)
 	suite.Require().NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimpleDelete}, zlist)
 
 	// Check endpoints from multiple zones # which one is specified in DomainFilter and one is not
-	zlist, err = p.ConvertEndpointsToZones(endpointsMultipleZones, PdnsReplace)
+	zlist, err = p.ConvertEndpointsToZones(context.Background(), endpointsMultipleZones, PdnsReplace)
 	suite.NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimplePatch}, zlist)
 
 	// Check endpoints from multiple zones where some endpoints which don't exist and one that does
 	// and is part of DomainFilter
-	zlist, err = p.ConvertEndpointsToZones(endpointsMultipleZonesWithNoExist, PdnsReplace)
+	zlist, err = p.ConvertEndpointsToZones(context.Background(), endpointsMultipleZonesWithNoExist, PdnsReplace)
 	suite.NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimplePatch}, zlist)
 
 	// Check endpoints from a zone that does not exist
-	zlist, err = p.ConvertEndpointsToZones(endpointsNonexistantZone, PdnsReplace)
+	zlist, err = p.ConvertEndpointsToZones(context.Background(), endpointsNonexistantZone, PdnsReplace)
 	suite.NoError(err)
 	suite.Equal([]pgo.Zone{}, zlist)
 
 	// Check endpoints that match multiple zones (one longer than other), is assigned to the right zone when the longer
 	// zone is not part of the DomainFilter
-	zlist, err = p.ConvertEndpointsToZones(endpointsMultipleZonesWithLongRecordNotInDomainFilter, PdnsReplace)
+	zlist, err = p.ConvertEndpointsToZones(context.Background(), endpointsMultipleZonesWithLongRecordNotInDomainFilter, PdnsReplace)
 	suite.NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimplePatchLongRecordIgnoredInDomainFilter}, zlist)
 
 	// Check endpoints that match multiple zones (one longer than other and one is very similar)
 	// is assigned to the right zone when the similar zone is not part of the DomainFilter
-	zlist, err = p.ConvertEndpointsToZones(endpointsMultipleZonesWithSimilarRecordNotInDomainFilter, PdnsReplace)
+	zlist, err = p.ConvertEndpointsToZones(context.Background(), endpointsMultipleZonesWithSimilarRecordNotInDomainFilter, PdnsReplace)
 	suite.NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimplePatch}, zlist)
 }
@@ -1021,7 +1024,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSmutateRecords() {
 	}
 
 	// Check inserting endpoints from a single zone
-	err := p.mutateRecords(endpointsSimpleRecord, pdnsChangeType("REPLACE"))
+	err := p.mutateRecords(context.Background(), endpointsSimpleRecord, pdnsChangeType("REPLACE"))
 	suite.NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimplePatch}, c.patchedZones)
 
@@ -1029,7 +1032,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSmutateRecords() {
 	c.patchedZones = []pgo.Zone{}
 
 	// Check deleting endpoints from a single zone
-	err = p.mutateRecords(endpointsSimpleRecord, pdnsChangeType("DELETE"))
+	err = p.mutateRecords(context.Background(), endpointsSimpleRecord, pdnsChangeType("DELETE"))
 	suite.NoError(err)
 	suite.Equal([]pgo.Zone{ZoneEmptyToSimpleDelete}, c.patchedZones)
 
@@ -1038,7 +1041,7 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSmutateRecords() {
 		client: &PDNSAPIClientStubPatchZoneFailure{},
 	}
 	// Check inserting endpoints from a single zone
-	err = p.mutateRecords(endpointsSimpleRecord, pdnsChangeType("REPLACE"))
+	err = p.mutateRecords(context.Background(), endpointsSimpleRecord, pdnsChangeType("REPLACE"))
 	suite.Error(err)
 	suite.ErrorIs(err, provider.SoftError)
 }
@@ -1364,5 +1367,85 @@ func TestPDNSPartitionZonesRegexBehavior(t *testing.T) {
 			filtered, residual := partitionZones(tt.zones, df)
 			tt.assertions(t, filtered, residual)
 		})
+	}
+}
+
+func TestPDNSHTTPClientTimeout(t *testing.T) {
+	tlsConfig := TLSConfig{}
+	httpClient, err := tlsConfig.newHTTPClient()
+	assert.NoError(t, err)
+	assert.Equal(t, defaultRequestTimeout, httpClient.Timeout)
+}
+
+func TestPDNSHTTPClientTimeoutTriggered(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	httpClient := &http.Client{
+		Timeout: 20 * time.Millisecond,
+	}
+	client := &PDNSAPIClient{
+		client: pgo.New(ts.URL, "localhost", pgo.WithAPIKey("test"), pgo.WithHTTPClient(httpClient)),
+	}
+
+	_, err := client.ListZones(t.Context())
+	assert.Error(t, err)
+}
+
+func TestPDNSContextCancellation(t *testing.T) {
+	client := &PDNSAPIClient{
+		client: pgo.New("http://localhost:8081", "localhost", pgo.WithAPIKey("test")),
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := client.ListZones(ctx)
+	assert.Error(t, err)
+
+	_, err = client.ListZone(ctx, "example.com.")
+	assert.Error(t, err)
+
+	err = client.PatchZone(ctx, "example.com.", &pgo.Zone{})
+	assert.Error(t, err)
+}
+
+func TestPDNSContextCancellationInFlight(t *testing.T) {
+	reqStarted := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case reqStarted <- struct{}{}:
+		default:
+		}
+		<-r.Context().Done()
+	}))
+	defer ts.Close()
+
+	client := &PDNSAPIClient{
+		client: pgo.New(ts.URL, "localhost", pgo.WithAPIKey("test")),
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := client.ListZones(ctx)
+		errCh <- err
+	}()
+
+	select {
+	case <-reqStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("request was not started")
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		assert.Error(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("ListZones did not abort on context cancellation")
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The HTTP client constructed for the PowerDNS (`pdns`) provider in `provider/pdns/pdns.go` lacked an explicit request timeout, and API client methods (`ListZones`, `ListZone`, `PatchZone`) as well as provider functions (`Records`, `ApplyChanges`, `mutateRecords`) did not propagate the incoming `context.Context`. If the remote PowerDNS API endpoint becomes unresponsive or hangs on TCP connection/request handling, the controller's reconcile loop could hang indefinitely.

This PR:
1. Sets `defaultRequestTimeout = 30 * time.Second` on `http.Client`.
2. Updates `PDNSAPIProvider` methods to accept `ctx context.Context` and passes `ctx` to all underlying `pgo` PowerDNS API calls.
3. Propagates `ctx` through `Records`, `ApplyChanges`, `ConvertEndpointsToZones`, and `mutateRecords`.
4. Replaces retry `time.Sleep` with `select` on `ctx.Done()`.

**Which issue(s) this PR fixes**:
Fixes #6670

**Special notes for your reviewer**:
- Added unit tests in `provider/pdns/pdns_test.go`: `TestPDNSHTTPClientTimeout`, `TestPDNSHTTPClientTimeoutTriggered`, `TestPDNSContextCancellation`, and `TestPDNSContextCancellationInFlight`.

**Does this PR introduce a user-facing change?**:
```release-note
fix(pdns): add default 30s request timeout and context propagation to PowerDNS API calls
```