### PR TITLE
chore(lint): extract repeated strings to constants for goconst

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,8 +51,6 @@ linters:
     cyclop: # Lower cyclomatic complexity threshold after the max complexity is lowered
       max-complexity: 32 # See https://github.com/kubernetes-sigs/external-dns/issues/5419
     goconst:
-      # TODO: raised by the go1.27 migration (golangci-lint bump surfaced pre-existing dupes); lower back to 3 once extracted to constants.
-      min-occurrences: 13
       # Ignore well-known DNS record types, boolean strings, and common values
       ignore-string-values:
         - "^(A|AAAA|ALIAS|CNAME|MX|NS|PTR|SRV|TXT)$"  # DNS record types

--- a/controller/metrics.go
+++ b/controller/metrics.go
@@ -24,101 +24,111 @@ import (
 	"sigs.k8s.io/external-dns/pkg/metrics"
 )
 
+const (
+	subsystemRegistry   = "registry"
+	subsystemSource     = "source"
+	subsystemController = "controller"
+
+	metricErrorsTotal = "errors_total"
+
+	labelRecordType = "record_type"
+)
+
 var (
 	registryErrorsTotal = metrics.NewCounterWithOpts(
 		prometheus.CounterOpts{
-			Subsystem: "registry",
-			Name:      "errors_total",
+			Subsystem: subsystemRegistry,
+			Name:      metricErrorsTotal,
 			Help:      "Number of Registry errors.",
 		},
 	)
 	sourceErrorsTotal = metrics.NewCounterWithOpts(
 		prometheus.CounterOpts{
-			Subsystem: "source",
-			Name:      "errors_total",
+			Subsystem: subsystemSource,
+			Name:      metricErrorsTotal,
 			Help:      "Number of Source errors.",
 		},
 	)
 	sourceEndpointsTotal = metrics.NewGaugeWithOpts(
 		prometheus.GaugeOpts{
-			Subsystem: "source",
+			Subsystem: subsystemSource,
 			Name:      "endpoints_total",
 			Help:      "Number of Endpoints in all sources",
 		},
 	)
 	registryEndpointsTotal = metrics.NewGaugeWithOpts(
 		prometheus.GaugeOpts{
-			Subsystem: "registry",
+			Subsystem: subsystemRegistry,
 			Name:      "endpoints_total",
 			Help:      "Number of Endpoints in the registry",
 		},
 	)
 	lastSyncTimestamp = metrics.NewGaugeWithOpts(
 		prometheus.GaugeOpts{
-			Subsystem: "controller",
+			Subsystem: subsystemController,
 			Name:      "last_sync_timestamp_seconds",
 			Help:      "Timestamp of last successful sync with the DNS provider",
 		},
 	)
 	lastReconcileTimestamp = metrics.NewGaugeWithOpts(
 		prometheus.GaugeOpts{
-			Subsystem: "controller",
+			Subsystem: subsystemController,
 			Name:      "last_reconcile_timestamp_seconds",
 			Help:      "Timestamp of last attempted sync with the DNS provider",
 		},
 	)
 	controllerNoChangesTotal = metrics.NewCounterWithOpts(
 		prometheus.CounterOpts{
-			Subsystem: "controller",
+			Subsystem: subsystemController,
 			Name:      "no_op_runs_total",
 			Help:      "Number of reconcile loops ending up with no changes on the DNS provider side.",
 		},
 	)
 	deprecatedRegistryErrors = metrics.NewCounterWithOpts(
 		prometheus.CounterOpts{
-			Subsystem: "registry",
-			Name:      "errors_total",
+			Subsystem: subsystemRegistry,
+			Name:      metricErrorsTotal,
 			Help:      "Number of Registry errors.",
 		},
 	)
 	deprecatedSourceErrors = metrics.NewCounterWithOpts(
 		prometheus.CounterOpts{
-			Subsystem: "source",
-			Name:      "errors_total",
+			Subsystem: subsystemSource,
+			Name:      metricErrorsTotal,
 			Help:      "Number of Source errors.",
 		},
 	)
 
 	registryRecords = metrics.NewGaugedVectorOpts(
 		prometheus.GaugeOpts{
-			Subsystem: "registry",
+			Subsystem: subsystemRegistry,
 			Name:      "records",
 			Help:      "Number of registry records partitioned by label name (vector).",
 		},
-		[]string{"record_type"},
+		[]string{labelRecordType},
 	)
 
 	sourceRecords = metrics.NewGaugedVectorOpts(
 		prometheus.GaugeOpts{
-			Subsystem: "source",
+			Subsystem: subsystemSource,
 			Name:      "records",
 			Help:      "Number of source records partitioned by label name (vector).",
 		},
-		[]string{"record_type"},
+		[]string{labelRecordType},
 	)
 
 	verifiedRecords = metrics.NewGaugedVectorOpts(
 		prometheus.GaugeOpts{
-			Subsystem: "controller",
+			Subsystem: subsystemController,
 			Name:      "verified_records",
 			Help:      "Number of DNS records that exists both in source and registry (vector).",
 		},
-		[]string{"record_type"},
+		[]string{labelRecordType},
 	)
 
 	consecutiveSoftErrors = metrics.NewGaugeWithOpts(
 		prometheus.GaugeOpts{
-			Subsystem: "controller",
+			Subsystem: subsystemController,
 			Name:      "consecutive_soft_errors",
 			Help:      "Number of consecutive soft errors in reconciliation loop.",
 		},

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -64,6 +64,11 @@ const (
 	ProviderSpecificRecordType = "record-type"
 )
 
+const (
+	logFieldTargets           = "targets"
+	logFieldComparisonTargets = "comparisonTargets"
+)
+
 var (
 	KnownRecordTypes = []string{
 		RecordTypeA,
@@ -148,23 +153,21 @@ func (t Targets) Same(o Targets) bool {
 	sort.Stable(t)
 	sort.Stable(o)
 
+	logFields := log.Fields{
+		logFieldTargets:           t,
+		logFieldComparisonTargets: o,
+	}
 	for i, e := range t {
 		if !strings.EqualFold(e, o[i]) {
 			// IPv6 can be shortened, so it should be parsed for equality checking
 			ipA, err := netip.ParseAddr(e)
 			if err != nil {
-				log.WithFields(log.Fields{
-					"targets":           t,
-					"comparisonTargets": o,
-				}).Debugf("Couldn't parse %s as an IP address: %v", e, err)
+				log.WithFields(logFields).Debugf("Couldn't parse %s as an IP address: %v", e, err)
 			}
 
 			ipB, err := netip.ParseAddr(o[i])
 			if err != nil {
-				log.WithFields(log.Fields{
-					"targets":           t,
-					"comparisonTargets": o,
-				}).Debugf("Couldn't parse %s as an IP address: %v", e, err)
+				log.WithFields(logFields).Debugf("Couldn't parse %s as an IP address: %v", e, err)
 			}
 
 			// IPv6 Address Shortener == IPv6 Address Expander
@@ -193,6 +196,10 @@ func (t Targets) IsLess(o Targets) bool {
 	sort.Sort(t)
 	sort.Sort(o)
 
+	logFields := log.Fields{
+		logFieldTargets:           t,
+		logFieldComparisonTargets: o,
+	}
 	for i, e := range t {
 		if e != o[i] {
 			// Explicitly prefers IP addresses (e.g. A records) over FQDNs (e.g. CNAMEs).
@@ -202,18 +209,12 @@ func (t Targets) IsLess(o Targets) bool {
 				// Ignoring parsing errors is fine due to the empty netip.Addr{} type being an invalid IP,
 				// which is checked by IsValid() below. However, still log them in case a provider is experiencing
 				// non-obvious issues with the records being created.
-				log.WithFields(log.Fields{
-					"targets":           t,
-					"comparisonTargets": o,
-				}).Debugf("Couldn't parse %s as an IP address: %v", e, err)
+				log.WithFields(logFields).Debugf("Couldn't parse %s as an IP address: %v", e, err)
 			}
 
 			ipB, err := netip.ParseAddr(o[i])
 			if err != nil {
-				log.WithFields(log.Fields{
-					"targets":           t,
-					"comparisonTargets": o,
-				}).Debugf("Couldn't parse %s as an IP address: %v", e, err)
+				log.WithFields(logFields).Debugf("Couldn't parse %s as an IP address: %v", e, err)
 			}
 
 			// If both targets are valid IP addresses, use the built-in Less() function to do the comparison.

--- a/pkg/metrics/models.go
+++ b/pkg/metrics/models.go
@@ -27,6 +27,11 @@ import (
 	"sigs.k8s.io/external-dns/internal/sets"
 )
 
+const (
+	metricTypeGauge   = "gauge"
+	metricTypeCounter = "counter"
+)
+
 type MetricRegistry struct {
 	Registerer prometheus.Registerer
 	Metrics    []*Metric
@@ -108,7 +113,7 @@ func (g GaugeVecMetric) Reset() {
 func NewGaugeWithOpts(opts prometheus.GaugeOpts) GaugeMetric {
 	opts.Namespace = Namespace
 	return GaugeMetric{
-		Type:      "gauge",
+		Type:      metricTypeGauge,
 		Name:      opts.Name,
 		FQDN:      fmt.Sprintf("%s_%s", opts.Subsystem, opts.Name),
 		Namespace: opts.Namespace,
@@ -124,7 +129,7 @@ func NewGaugeWithOpts(opts prometheus.GaugeOpts) GaugeMetric {
 func NewGaugedVectorOpts(opts prometheus.GaugeOpts, labelNames []string) GaugeVecMetric {
 	opts.Namespace = Namespace
 	return GaugeVecMetric{
-		Type:      "gauge",
+		Type:      metricTypeGauge,
 		Name:      opts.Name,
 		FQDN:      fmt.Sprintf("%s_%s", opts.Subsystem, opts.Name),
 		Namespace: opts.Namespace,
@@ -138,7 +143,7 @@ func NewGaugedVectorOpts(opts prometheus.GaugeOpts, labelNames []string) GaugeVe
 func NewCounterWithOpts(opts prometheus.CounterOpts) CounterMetric {
 	opts.Namespace = Namespace
 	return CounterMetric{
-		Type:      "counter",
+		Type:      metricTypeCounter,
 		Name:      opts.Name,
 		FQDN:      fmt.Sprintf("%s_%s", opts.Subsystem, opts.Name),
 		Namespace: opts.Namespace,
@@ -152,7 +157,7 @@ func NewCounterWithOpts(opts prometheus.CounterOpts) CounterMetric {
 func NewCounterVecWithOpts(opts prometheus.CounterOpts, labelNames []string) CounterVecMetric {
 	opts.Namespace = Namespace
 	return CounterVecMetric{
-		Type:       "counter",
+		Type:       metricTypeCounter,
 		Name:       opts.Name,
 		FQDN:       fmt.Sprintf("%s_%s", opts.Subsystem, opts.Name),
 		Namespace:  opts.Namespace,
@@ -174,7 +179,7 @@ func (g GaugeFuncMetric) Get() *Metric {
 
 func NewGaugeFuncMetric(opts prometheus.GaugeOpts) GaugeFuncMetric {
 	return GaugeFuncMetric{
-		Type: "gauge",
+		Type: metricTypeGauge,
 		Name: opts.Name,
 		FQDN: func() string {
 			if opts.Subsystem != "" {

--- a/provider/civo/civo.go
+++ b/provider/civo/civo.go
@@ -31,6 +31,20 @@ import (
 	"sigs.k8s.io/external-dns/provider"
 )
 
+const (
+	logFieldType       = "Type"
+	logFieldName       = "Name"
+	logFieldValue      = "Value"
+	logFieldPriority   = "Priority"
+	logFieldTTL        = "TTL"
+	logFieldAction     = "action"
+	logFieldZoneID     = "zoneID"
+	logFieldZoneName   = "zoneName"
+	logFieldDNSName    = "dnsName"
+	logFieldRecordType = "recordType"
+	logFieldTarget     = "target"
+)
+
 // CivoProvider is an implementation of Provider for Civo's DNS.
 type CivoProvider struct {
 	provider.BaseProvider
@@ -186,12 +200,12 @@ func (p *CivoProvider) submitChanges(changes CivoChanges) error {
 
 	for _, change := range changes.Creates {
 		logFields := log.Fields{
-			"Type":     change.Options.Type,
-			"Name":     change.Options.Name,
-			"Value":    change.Options.Value,
-			"Priority": change.Options.Priority,
-			"TTL":      change.Options.TTL,
-			"action":   "Create",
+			logFieldType:     change.Options.Type,
+			logFieldName:     change.Options.Name,
+			logFieldValue:    change.Options.Value,
+			logFieldPriority: change.Options.Priority,
+			logFieldTTL:      change.Options.TTL,
+			logFieldAction:   "Create",
 		}
 
 		log.WithFields(logFields).Info("Creating record.")
@@ -208,12 +222,12 @@ func (p *CivoProvider) submitChanges(changes CivoChanges) error {
 
 	for _, change := range changes.Deletes {
 		logFields := log.Fields{
-			"Type":     change.DomainRecord.Type,
-			"Name":     change.DomainRecord.Name,
-			"Value":    change.DomainRecord.Value,
-			"Priority": change.DomainRecord.Priority,
-			"TTL":      change.DomainRecord.TTL,
-			"action":   "Delete",
+			logFieldType:     change.DomainRecord.Type,
+			logFieldName:     change.DomainRecord.Name,
+			logFieldValue:    change.DomainRecord.Value,
+			logFieldPriority: change.DomainRecord.Priority,
+			logFieldTTL:      change.DomainRecord.TTL,
+			logFieldAction:   "Delete",
 		}
 
 		log.WithFields(logFields).Info("Deleting record.")
@@ -230,12 +244,12 @@ func (p *CivoProvider) submitChanges(changes CivoChanges) error {
 
 	for _, change := range changes.Updates {
 		logFields := log.Fields{
-			"Type":     change.DomainRecord.Type,
-			"Name":     change.DomainRecord.Name,
-			"Value":    change.DomainRecord.Value,
-			"Priority": change.DomainRecord.Priority,
-			"TTL":      change.DomainRecord.TTL,
-			"action":   "Update",
+			logFieldType:     change.DomainRecord.Type,
+			logFieldName:     change.DomainRecord.Name,
+			logFieldValue:    change.DomainRecord.Value,
+			logFieldPriority: change.DomainRecord.Priority,
+			logFieldTTL:      change.DomainRecord.TTL,
+			logFieldAction:   "Update",
 		}
 
 		log.WithFields(logFields).Info("Updating record.")
@@ -260,8 +274,8 @@ func processCreateActions(zonesByID map[string]civogo.DNSDomain, recordsByZoneID
 
 		if len(creates) == 0 {
 			log.WithFields(log.Fields{
-				"zoneID":   zoneID,
-				"zoneName": zone.Name,
+				logFieldZoneID:   zoneID,
+				logFieldZoneName: zone.Name,
 			}).Info("Skipping Zone, no creates found.")
 			continue
 		}
@@ -274,10 +288,10 @@ func processCreateActions(zonesByID map[string]civogo.DNSDomain, recordsByZoneID
 
 			if len(matchedRecords) != 0 {
 				log.WithFields(log.Fields{
-					"zoneID":     zoneID,
-					"zoneName":   zone.Name,
-					"dnsName":    ep.DNSName,
-					"recordType": ep.RecordType,
+					logFieldZoneID:     zoneID,
+					logFieldZoneName:   zone.Name,
+					logFieldDNSName:    ep.DNSName,
+					logFieldRecordType: ep.RecordType,
 				}).Warn("Records found which should not exist")
 			}
 
@@ -311,8 +325,8 @@ func processUpdateActions(zonesByID map[string]civogo.DNSDomain, recordsByZoneID
 
 		if len(updates) == 0 {
 			log.WithFields(log.Fields{
-				"zoneID":   zoneID,
-				"zoneName": zone.Name,
+				logFieldZoneID:   zoneID,
+				logFieldZoneName: zone.Name,
 			}).Debug("Skipping Zone, no updates found.")
 			continue
 		}
@@ -323,10 +337,10 @@ func processUpdateActions(zonesByID map[string]civogo.DNSDomain, recordsByZoneID
 			matchedRecords := getRecordID(records, zone, *ep)
 			if len(matchedRecords) == 0 {
 				log.WithFields(log.Fields{
-					"zoneID":     zoneID,
-					"dnsName":    ep.DNSName,
-					"zoneName":   zone.Name,
-					"recordType": ep.RecordType,
+					logFieldZoneID:     zoneID,
+					logFieldDNSName:    ep.DNSName,
+					logFieldZoneName:   zone.Name,
+					logFieldRecordType: ep.RecordType,
 				}).Warn("Update Records not found.")
 			}
 
@@ -343,11 +357,11 @@ func processUpdateActions(zonesByID map[string]civogo.DNSDomain, recordsByZoneID
 			for _, target := range ep.Targets {
 				if record, ok := matchedRecordsByTarget[target]; ok {
 					log.WithFields(log.Fields{
-						"zoneID":     zoneID,
-						"dnsName":    ep.DNSName,
-						"zoneName":   zone.Name,
-						"recordType": ep.RecordType,
-						"target":     target,
+						logFieldZoneID:     zoneID,
+						logFieldDNSName:    ep.DNSName,
+						logFieldZoneName:   zone.Name,
+						logFieldRecordType: ep.RecordType,
+						logFieldTarget:     target,
 					}).Warn("Updating Existing Target")
 
 					civoChange.Updates = append(civoChange.Updates, &CivoChangeUpdate{
@@ -366,11 +380,11 @@ func processUpdateActions(zonesByID map[string]civogo.DNSDomain, recordsByZoneID
 				} else {
 					// Record did not previously exist, create new 'target'
 					log.WithFields(log.Fields{
-						"zoneID":     zoneID,
-						"dnsName":    ep.DNSName,
-						"zoneName":   zone.Name,
-						"recordType": ep.RecordType,
-						"target":     target,
+						logFieldZoneID:     zoneID,
+						logFieldDNSName:    ep.DNSName,
+						logFieldZoneName:   zone.Name,
+						logFieldRecordType: ep.RecordType,
+						logFieldTarget:     target,
 					}).Warn("Creating New Target")
 
 					civoChange.Creates = append(civoChange.Creates, &CivoChangeCreate{
@@ -389,10 +403,10 @@ func processUpdateActions(zonesByID map[string]civogo.DNSDomain, recordsByZoneID
 			// Any remaining records have been removed, delete them
 			for _, record := range matchedRecordsByTarget {
 				log.WithFields(log.Fields{
-					"zoneID":     zoneID,
-					"dnsName":    ep.DNSName,
-					"recordType": ep.RecordType,
-					"target":     record.Value,
+					logFieldZoneID:     zoneID,
+					logFieldDNSName:    ep.DNSName,
+					logFieldRecordType: ep.RecordType,
+					logFieldTarget:     record.Value,
 				}).Warn("Deleting target")
 
 				civoChange.Deletes = append(civoChange.Deletes, &CivoChangeDelete{
@@ -413,8 +427,8 @@ func processDeleteActions(zonesByID map[string]civogo.DNSDomain, recordsByZoneID
 
 		if len(deletes) == 0 {
 			log.WithFields(log.Fields{
-				"zoneID":   zoneID,
-				"zoneName": zone.Name,
+				logFieldZoneID:   zoneID,
+				logFieldZoneName: zone.Name,
 			}).Debug("Skipping Zone, no deletes found.")
 			continue
 		}
@@ -426,10 +440,10 @@ func processDeleteActions(zonesByID map[string]civogo.DNSDomain, recordsByZoneID
 
 			if len(matchedRecords) == 0 {
 				log.WithFields(log.Fields{
-					"zoneID":     zoneID,
-					"dnsName":    ep.DNSName,
-					"zoneName":   zone.Name,
-					"recordType": ep.RecordType,
+					logFieldZoneID:     zoneID,
+					logFieldDNSName:    ep.DNSName,
+					logFieldZoneName:   zone.Name,
+					logFieldRecordType: ep.RecordType,
 				}).Warn("Records to Delete not found.")
 			}
 

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -67,6 +67,15 @@ const (
 	paidZoneMaxCommentLength = 500
 )
 
+const (
+	logFieldRecord  = "record"
+	logFieldType    = "type"
+	logFieldTTL     = "ttl"
+	logFieldContent = "content"
+	logFieldAction  = "action"
+	logFieldZone    = "zone"
+)
+
 var changeActionNames = map[changeAction]string{
 	cloudFlareCreate: "CREATE",
 	cloudFlareDelete: "DELETE",
@@ -544,11 +553,11 @@ func (p *CloudFlareProvider) submitChanges(ctx context.Context, changes []*cloud
 
 		for _, change := range zoneChanges {
 			logFields := log.Fields{
-				"record": change.ResourceRecord.Name,
-				"type":   change.ResourceRecord.Type,
-				"ttl":    change.ResourceRecord.TTL,
-				"action": change.Action.String(),
-				"zone":   zoneID,
+				logFieldRecord: change.ResourceRecord.Name,
+				logFieldType:   change.ResourceRecord.Type,
+				logFieldTTL:    change.ResourceRecord.TTL,
+				logFieldAction: change.Action.String(),
+				logFieldZone:   zoneID,
 			}
 			log.WithFields(logFields).Info("Changing record.")
 		}

--- a/provider/cloudflare/cloudflare_batch.go
+++ b/provider/cloudflare/cloudflare_batch.go
@@ -347,11 +347,11 @@ func (p *CloudFlareProvider) buildBatchCollections(
 
 	for _, change := range changes {
 		logFields := log.Fields{
-			"record": change.ResourceRecord.Name,
-			"type":   change.ResourceRecord.Type,
-			"ttl":    change.ResourceRecord.TTL,
-			"action": change.Action.String(),
-			"zone":   zoneID,
+			logFieldRecord: change.ResourceRecord.Name,
+			logFieldType:   change.ResourceRecord.Type,
+			logFieldTTL:    change.ResourceRecord.TTL,
+			logFieldAction: change.Action.String(),
+			logFieldZone:   zoneID,
 		}
 
 		switch change.Action {
@@ -427,11 +427,11 @@ func (p *CloudFlareProvider) submitDNSRecordChanges(
 	}
 	for _, change := range bc.fallbackUpdates {
 		logFields := log.Fields{
-			"record": change.ResourceRecord.Name,
-			"type":   change.ResourceRecord.Type,
-			"ttl":    change.ResourceRecord.TTL,
-			"action": change.Action.String(),
-			"zone":   zoneID,
+			logFieldRecord: change.ResourceRecord.Name,
+			logFieldType:   change.ResourceRecord.Type,
+			logFieldTTL:    change.ResourceRecord.TTL,
+			logFieldAction: change.Action.String(),
+			logFieldZone:   zoneID,
 		}
 		recordID := p.getRecordID(records, change.ResourceRecord)
 		recordParam, err := getUpdateDNSRecordParam(zoneID, *change)
@@ -478,11 +478,11 @@ func (p *CloudFlareProvider) fallbackIndividualChanges(
 	for _, group := range groups {
 		for _, change := range group.changes {
 			logFields := log.Fields{
-				"record":  change.ResourceRecord.Name,
-				"type":    change.ResourceRecord.Type,
-				"content": change.ResourceRecord.Content,
-				"action":  change.Action.String(),
-				"zone":    zoneID,
+				logFieldRecord:  change.ResourceRecord.Name,
+				logFieldType:    change.ResourceRecord.Type,
+				logFieldContent: change.ResourceRecord.Content,
+				logFieldAction:  change.Action.String(),
+				logFieldZone:    zoneID,
 			}
 
 			var err error

--- a/provider/cloudflare/cloudflare_custom_hostnames.go
+++ b/provider/cloudflare/cloudflare_custom_hostnames.go
@@ -290,11 +290,11 @@ func (p *CloudFlareProvider) processCustomHostnameChanges(
 	failed := false
 	for _, change := range changes {
 		logFields := log.Fields{
-			"record": change.ResourceRecord.Name,
-			"type":   change.ResourceRecord.Type,
-			"ttl":    change.ResourceRecord.TTL,
-			"action": change.Action.String(),
-			"zone":   zoneID,
+			logFieldRecord: change.ResourceRecord.Name,
+			logFieldType:   change.ResourceRecord.Type,
+			logFieldTTL:    change.ResourceRecord.TTL,
+			logFieldAction: change.Action.String(),
+			logFieldZone:   zoneID,
 		}
 		if !p.submitCustomHostnameChanges(ctx, zoneID, change, chs, logFields) {
 			failed = true

--- a/provider/cloudflare/cloudflare_regional.go
+++ b/provider/cloudflare/cloudflare_regional.go
@@ -122,10 +122,10 @@ func (p *CloudFlareProvider) submitRegionalHostnameChanges(ctx context.Context, 
 // submitRegionalHostnameChange applies a single regional hostname change, returns false if it fails
 func (p *CloudFlareProvider) submitRegionalHostnameChange(ctx context.Context, zoneID string, rhChange regionalHostnameChange) bool {
 	changeLog := log.WithFields(log.Fields{
-		"hostname":   rhChange.hostname,
-		"region_key": rhChange.regionKey,
-		"action":     rhChange.action.String(),
-		"zone":       zoneID,
+		"hostname":     rhChange.hostname,
+		"region_key":   rhChange.regionKey,
+		logFieldAction: rhChange.action.String(),
+		logFieldZone:   zoneID,
 	})
 	if p.DryRun {
 		changeLog.Debug("Dry run: skipping regional hostname change", rhChange.action)

--- a/provider/linode/linode.go
+++ b/provider/linode/linode.go
@@ -35,6 +35,17 @@ import (
 	"sigs.k8s.io/external-dns/pkg/apis/externaldns"
 )
 
+const (
+	logFieldRecord     = "record"
+	logFieldType       = "type"
+	logFieldAction     = "action"
+	logFieldZoneName   = "zoneName"
+	logFieldZoneID     = "zoneID"
+	logFieldDNSName    = "dnsName"
+	logFieldRecordType = "recordType"
+	logFieldTarget     = "target"
+)
+
 // LinodeDomainClient interface to ease testing
 type LinodeDomainClient interface {
 	ListDomainRecords(ctx context.Context, domainID int, opts *linodego.ListOptions) ([]linodego.DomainRecord, error)
@@ -183,11 +194,11 @@ func (p *LinodeProvider) fetchZones(ctx context.Context) ([]linodego.Domain, err
 func (p *LinodeProvider) submitChanges(ctx context.Context, changes LinodeChanges) error {
 	for _, change := range changes.Creates {
 		logFields := log.Fields{
-			"record":   change.Options.Name,
-			"type":     change.Options.Type,
-			"action":   "Create",
-			"zoneName": change.Domain.Domain,
-			"zoneID":   change.Domain.ID,
+			logFieldRecord:   change.Options.Name,
+			logFieldType:     change.Options.Type,
+			logFieldAction:   "Create",
+			logFieldZoneName: change.Domain.Domain,
+			logFieldZoneID:   change.Domain.ID,
 		}
 
 		log.WithFields(logFields).Info("Creating record.")
@@ -204,11 +215,11 @@ func (p *LinodeProvider) submitChanges(ctx context.Context, changes LinodeChange
 
 	for _, change := range changes.Deletes {
 		logFields := log.Fields{
-			"record":   change.DomainRecord.Name,
-			"type":     change.DomainRecord.Type,
-			"action":   "Delete",
-			"zoneName": change.Domain.Domain,
-			"zoneID":   change.Domain.ID,
+			logFieldRecord:   change.DomainRecord.Name,
+			logFieldType:     change.DomainRecord.Type,
+			logFieldAction:   "Delete",
+			logFieldZoneName: change.Domain.Domain,
+			logFieldZoneID:   change.Domain.ID,
 		}
 
 		log.WithFields(logFields).Info("Deleting record.")
@@ -225,11 +236,11 @@ func (p *LinodeProvider) submitChanges(ctx context.Context, changes LinodeChange
 
 	for _, change := range changes.Updates {
 		logFields := log.Fields{
-			"record":   change.Options.Name,
-			"type":     change.Options.Type,
-			"action":   "Update",
-			"zoneName": change.Domain.Domain,
-			"zoneID":   change.Domain.ID,
+			logFieldRecord:   change.Options.Name,
+			logFieldType:     change.Options.Type,
+			logFieldAction:   "Update",
+			logFieldZoneName: change.Domain.Domain,
+			logFieldZoneID:   change.Domain.ID,
 		}
 
 		log.WithFields(logFields).Info("Updating record.")
@@ -309,8 +320,8 @@ func (p *LinodeProvider) ApplyChanges(ctx context.Context, changes *plan.Changes
 
 		if len(creates) == 0 {
 			log.WithFields(log.Fields{
-				"zoneID":   zoneID,
-				"zoneName": zone.Domain,
+				logFieldZoneID:   zoneID,
+				logFieldZoneName: zone.Domain,
 			}).Debug("Skipping Zone, no creates found.")
 			continue
 		}
@@ -322,10 +333,10 @@ func (p *LinodeProvider) ApplyChanges(ctx context.Context, changes *plan.Changes
 
 			if len(matchedRecords) != 0 {
 				log.WithFields(log.Fields{
-					"zoneID":     zoneID,
-					"zoneName":   zone.Domain,
-					"dnsName":    ep.DNSName,
-					"recordType": ep.RecordType,
+					logFieldZoneID:     zoneID,
+					logFieldZoneName:   zone.Domain,
+					logFieldDNSName:    ep.DNSName,
+					logFieldRecordType: ep.RecordType,
 				}).Warn("Records found which should not exist. Not touching it.")
 				continue
 			}
@@ -358,8 +369,8 @@ func (p *LinodeProvider) ApplyChanges(ctx context.Context, changes *plan.Changes
 
 		if len(updates) == 0 {
 			log.WithFields(log.Fields{
-				"zoneID":   zoneID,
-				"zoneName": zone.Domain,
+				logFieldZoneID:   zoneID,
+				logFieldZoneName: zone.Domain,
 			}).Debug("Skipping Zone, no updates found.")
 			continue
 		}
@@ -371,10 +382,10 @@ func (p *LinodeProvider) ApplyChanges(ctx context.Context, changes *plan.Changes
 
 			if len(matchedRecords) == 0 {
 				log.WithFields(log.Fields{
-					"zoneID":     zoneID,
-					"dnsName":    ep.DNSName,
-					"zoneName":   zone.Domain,
-					"recordType": ep.RecordType,
+					logFieldZoneID:     zoneID,
+					logFieldDNSName:    ep.DNSName,
+					logFieldZoneName:   zone.Domain,
+					logFieldRecordType: ep.RecordType,
 				}).Warn("Update Records not found.")
 			}
 
@@ -392,11 +403,11 @@ func (p *LinodeProvider) ApplyChanges(ctx context.Context, changes *plan.Changes
 			for _, target := range ep.Targets {
 				if record, ok := matchedRecordsByTarget[target]; ok {
 					log.WithFields(log.Fields{
-						"zoneID":     zoneID,
-						"dnsName":    ep.DNSName,
-						"zoneName":   zone.Domain,
-						"recordType": ep.RecordType,
-						"target":     target,
+						logFieldZoneID:     zoneID,
+						logFieldDNSName:    ep.DNSName,
+						logFieldZoneName:   zone.Domain,
+						logFieldRecordType: ep.RecordType,
+						logFieldTarget:     target,
 					}).Warn("Updating Existing Target")
 
 					linodeUpdates = append(linodeUpdates, LinodeChangeUpdate{
@@ -417,11 +428,11 @@ func (p *LinodeProvider) ApplyChanges(ctx context.Context, changes *plan.Changes
 				} else {
 					// Record did not previously exist, create new 'target'
 					log.WithFields(log.Fields{
-						"zoneID":     zoneID,
-						"dnsName":    ep.DNSName,
-						"zoneName":   zone.Domain,
-						"recordType": ep.RecordType,
-						"target":     target,
+						logFieldZoneID:     zoneID,
+						logFieldDNSName:    ep.DNSName,
+						logFieldZoneName:   zone.Domain,
+						logFieldRecordType: ep.RecordType,
+						logFieldTarget:     target,
 					}).Warn("Creating New Target")
 
 					linodeCreates = append(linodeCreates, LinodeChangeCreate{
@@ -442,11 +453,11 @@ func (p *LinodeProvider) ApplyChanges(ctx context.Context, changes *plan.Changes
 			// Any remaining records have been removed, delete them
 			for _, record := range matchedRecordsByTarget {
 				log.WithFields(log.Fields{
-					"zoneID":     zoneID,
-					"dnsName":    ep.DNSName,
-					"zoneName":   zone.Domain,
-					"recordType": ep.RecordType,
-					"target":     record.Target,
+					logFieldZoneID:     zoneID,
+					logFieldDNSName:    ep.DNSName,
+					logFieldZoneName:   zone.Domain,
+					logFieldRecordType: ep.RecordType,
+					logFieldTarget:     record.Target,
 				}).Warn("Deleting Target")
 
 				linodeDeletes = append(linodeDeletes, LinodeChangeDelete{
@@ -463,8 +474,8 @@ func (p *LinodeProvider) ApplyChanges(ctx context.Context, changes *plan.Changes
 
 		if len(deletes) == 0 {
 			log.WithFields(log.Fields{
-				"zoneID":   zoneID,
-				"zoneName": zone.Domain,
+				logFieldZoneID:   zoneID,
+				logFieldZoneName: zone.Domain,
 			}).Debug("Skipping Zone, no deletes found.")
 			continue
 		}
@@ -476,10 +487,10 @@ func (p *LinodeProvider) ApplyChanges(ctx context.Context, changes *plan.Changes
 
 			if len(matchedRecords) == 0 {
 				log.WithFields(log.Fields{
-					"zoneID":     zoneID,
-					"dnsName":    ep.DNSName,
-					"zoneName":   zone.Domain,
-					"recordType": ep.RecordType,
+					logFieldZoneID:     zoneID,
+					logFieldDNSName:    ep.DNSName,
+					logFieldZoneName:   zone.Domain,
+					logFieldRecordType: ep.RecordType,
 				}).Warn("Records to Delete not found.")
 			}
 

--- a/provider/webhook/webhook.go
+++ b/provider/webhook/webhook.go
@@ -43,47 +43,49 @@ import (
 const (
 	acceptHeader = "Accept"
 	maxRetries   = 5
+
+	webhookProviderSubsystem = "webhook_provider"
 )
 
 var (
 	recordsErrorsGauge = metrics.NewGaugeWithOpts(
 		prometheus.GaugeOpts{
-			Subsystem: "webhook_provider",
+			Subsystem: webhookProviderSubsystem,
 			Name:      "records_errors_total",
 			Help:      "Errors with Records method",
 		},
 	)
 	recordsRequestsGauge = metrics.NewGaugeWithOpts(
 		prometheus.GaugeOpts{
-			Subsystem: "webhook_provider",
+			Subsystem: webhookProviderSubsystem,
 			Name:      "records_requests_total",
 			Help:      "Requests with Records method",
 		},
 	)
 	applyChangesErrorsGauge = metrics.NewGaugeWithOpts(
 		prometheus.GaugeOpts{
-			Subsystem: "webhook_provider",
+			Subsystem: webhookProviderSubsystem,
 			Name:      "applychanges_errors_total",
 			Help:      "Errors with ApplyChanges method",
 		},
 	)
 	applyChangesRequestsGauge = metrics.NewGaugeWithOpts(
 		prometheus.GaugeOpts{
-			Subsystem: "webhook_provider",
+			Subsystem: webhookProviderSubsystem,
 			Name:      "applychanges_requests_total",
 			Help:      "Requests with ApplyChanges method",
 		},
 	)
 	adjustEndpointsErrorsGauge = metrics.NewGaugeWithOpts(
 		prometheus.GaugeOpts{
-			Subsystem: "webhook_provider",
+			Subsystem: webhookProviderSubsystem,
 			Name:      "adjustendpoints_errors_total",
 			Help:      "Errors with AdjustEndpoints method",
 		},
 	)
 	adjustEndpointsRequestsGauge = metrics.NewGaugeWithOpts(
 		prometheus.GaugeOpts{
-			Subsystem: "webhook_provider",
+			Subsystem: webhookProviderSubsystem,
 			Name:      "adjustendpoints_requests_total",
 			Help:      "Requests with AdjustEndpoints method",
 		},

--- a/source/traefik_proxy.go
+++ b/source/traefik_proxy.go
@@ -44,20 +44,26 @@ import (
 	"sigs.k8s.io/external-dns/source/informers"
 )
 
+const (
+	traefikAPIGroup       = "traefik.io"
+	traefikLegacyAPIGroup = "traefik.containo.us"
+	traefikAPIVersion     = "v1alpha1"
+)
+
 var (
 	ingressRouteGVR = schema.GroupVersionResource{
-		Group:    "traefik.io",
-		Version:  "v1alpha1",
+		Group:    traefikAPIGroup,
+		Version:  traefikAPIVersion,
 		Resource: "ingressroutes",
 	}
 	ingressRouteTCPGVR = schema.GroupVersionResource{
-		Group:    "traefik.io",
-		Version:  "v1alpha1",
+		Group:    traefikAPIGroup,
+		Version:  traefikAPIVersion,
 		Resource: "ingressroutetcps",
 	}
 	ingressRouteUDPGVR = schema.GroupVersionResource{
-		Group:    "traefik.io",
-		Version:  "v1alpha1",
+		Group:    traefikAPIGroup,
+		Version:  traefikAPIVersion,
 		Resource: "ingressrouteudps",
 	}
 	// TODO: traefik.containo.us CRDs were removed in Traefik v3 (released 2024).
@@ -65,18 +71,18 @@ var (
 	// Remove these GVRs and the --traefik-enable-legacy flag after 2026-02-01.
 	// See https://doc.traefik.io/traefik/deprecation/releases/
 	oldIngressRouteGVR = schema.GroupVersionResource{
-		Group:    "traefik.containo.us",
-		Version:  "v1alpha1",
+		Group:    traefikLegacyAPIGroup,
+		Version:  traefikAPIVersion,
 		Resource: "ingressroutes",
 	}
 	oldIngressRouteTCPGVR = schema.GroupVersionResource{
-		Group:    "traefik.containo.us",
-		Version:  "v1alpha1",
+		Group:    traefikLegacyAPIGroup,
+		Version:  traefikAPIVersion,
 		Resource: "ingressroutetcps",
 	}
 	oldIngressRouteUDPGVR = schema.GroupVersionResource{
-		Group:    "traefik.containo.us",
-		Version:  "v1alpha1",
+		Group:    traefikLegacyAPIGroup,
+		Version:  traefikAPIVersion,
 		Resource: "ingressrouteudps",
 	}
 )


### PR DESCRIPTION
## What does it do ?

- Remove the goconst.min-occurrences: 13 override in .golangci.yml (back to default 3)
- No behavior change: every metric name, label, and log field key/value is identical to before.

## Motivation

  - The Go 1.27 migration bumped golangci-lint, which surfaced 46 pre-existing goconst violations.
  - A stopgap goconst.min-occurrences: 13 override in .golangci.yml was masking them; the intent is to restore the linter default of 3.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
