### PR TITLE
fix(alibabacloud): respect dry-run for record updates and deletes

### DIFF
--- a/provider/alibabacloud/alibaba_cloud.go
+++ b/provider/alibabacloud/alibaba_cloud.go
@@ -536,7 +536,7 @@ func (p *AlibabaCloudProvider) createRecord(endpoint *endpoint.Endpoint, target 
 	request.Value = target
 
 	if p.dryRun {
-		log.Infof("Dry run: Create %s record named '%s' to '%s' with ttl %d for Alibaba Cloud DNS", endpoint.RecordType, endpoint.DNSName, target, ttl)
+		log.Infof("Dry run: Create %s public record named '%s' (target '%s', ttl %d) in Alibaba Cloud DNS", endpoint.RecordType, endpoint.DNSName, target, ttl)
 		return nil
 	}
 
@@ -557,14 +557,14 @@ func (p *AlibabaCloudProvider) createRecords(endpoints []*endpoint.Endpoint, hos
 	}
 }
 
-func (p *AlibabaCloudProvider) deleteRecord(recordID string) error {
+func (p *AlibabaCloudProvider) deleteRecord(record alidns.Record, endpoint *endpoint.Endpoint) error {
 	if p.dryRun {
-		log.Infof("Dry run: Delete record id '%s' in Alibaba Cloud DNS", recordID)
+		log.Infof("Dry run: Delete %s public record named '%s' (id '%s', target '%s') in Alibaba Cloud DNS", record.Type, endpoint.DNSName, record.RecordId, record.Value)
 		return nil
 	}
 
 	request := alidns.CreateDeleteDomainRecordRequest()
-	request.RecordId = recordID
+	request.RecordId = record.RecordId
 	request.Scheme = defaultAlibabaCloudRequestScheme
 	response, err := p.getDNSClient().DeleteDomainRecord(request)
 	if err == nil {
@@ -577,7 +577,7 @@ func (p *AlibabaCloudProvider) deleteRecord(recordID string) error {
 
 func (p *AlibabaCloudProvider) updateRecord(record alidns.Record, endpoint *endpoint.Endpoint) error {
 	if p.dryRun {
-		log.Infof("Dry run: Update %s public record named '%s' (id '%s') to '%s' with ttl %d in Alibaba Cloud DNS", record.Type, endpoint.DNSName, record.RecordId, record.Value, endpoint.RecordTTL)
+		log.Infof("Dry run: Update %s public record named '%s' (id '%s', target '%s', ttl %d) in Alibaba Cloud DNS", record.Type, endpoint.DNSName, record.RecordId, record.Value, endpoint.RecordTTL)
 		return nil
 	}
 
@@ -607,7 +607,7 @@ func (p *AlibabaCloudProvider) deleteRecords(recordMap map[string][]alidns.Recor
 		found := false
 		for _, record := range records {
 			if slices.Contains(endpoint.Targets, record.Value) {
-				p.deleteRecord(record.RecordId)
+				p.deleteRecord(record, endpoint)
 				found = true
 			}
 		}
@@ -643,7 +643,7 @@ func (p *AlibabaCloudProvider) updateRecords(recordMap map[string][]alidns.Recor
 					p.updateRecord(record, endpoint)
 				}
 			} else {
-				p.deleteRecord(record.RecordId)
+				p.deleteRecord(record, endpoint)
 			}
 		}
 		for _, target := range endpoint.Targets {
@@ -872,7 +872,7 @@ func (p *AlibabaCloudProvider) createPrivateZoneRecord(zones map[string]*alibaba
 	request.Value = target
 
 	if p.dryRun {
-		log.Infof("Dry run: Create %s record named '%s' to '%s' with ttl %d for Alibaba Cloud Private Zone", endpoint.RecordType, endpoint.DNSName, target, ttl)
+		log.Infof("Dry run: Create %s private record named '%s' (target '%s', ttl %d) in Alibaba Cloud Private Zone", endpoint.RecordType, endpoint.DNSName, target, ttl)
 		return nil
 	}
 
@@ -893,14 +893,14 @@ func (p *AlibabaCloudProvider) createPrivateZoneRecords(zones map[string]*alibab
 	}
 }
 
-func (p *AlibabaCloudProvider) deletePrivateZoneRecord(recordID int64) error {
+func (p *AlibabaCloudProvider) deletePrivateZoneRecord(record pvtz.Record, endpoint *endpoint.Endpoint) error {
 	if p.dryRun {
-		log.Infof("Dry run: Delete record id '%d' in Alibaba Cloud Private Zone", recordID)
+		log.Infof("Dry run: Delete %s private record named '%s' (id '%d', target '%s') in Alibaba Cloud Private Zone", record.Type, endpoint.DNSName, record.RecordId, record.Value)
 		return nil
 	}
 
 	request := pvtz.CreateDeleteZoneRecordRequest()
-	request.RecordId = requests.NewInteger64(recordID)
+	request.RecordId = requests.NewInteger64(record.RecordId)
 	request.Domain = pVTZDoamin
 	request.Scheme = defaultAlibabaCloudRequestScheme
 
@@ -927,7 +927,7 @@ func (p *AlibabaCloudProvider) deletePrivateZoneRecords(zones map[string]*alibab
 		for _, record := range zone.records {
 			if rr == record.Rr && endpoint.RecordType == record.Type {
 				if slices.Contains(endpoint.Targets, record.Value) {
-					p.deletePrivateZoneRecord(record.RecordId)
+					p.deletePrivateZoneRecord(record, endpoint)
 					found = true
 				}
 			}
@@ -961,7 +961,7 @@ func (p *AlibabaCloudProvider) applyChangesForPrivateZone(changes *plan.Changes)
 
 func (p *AlibabaCloudProvider) updatePrivateZoneRecord(record pvtz.Record, endpoint *endpoint.Endpoint) error {
 	if p.dryRun {
-		log.Infof("Dry run: Update %s private record named '%s' (id '%s') to '%s' with ttl %d in Alibaba Cloud DNS", record.Type, endpoint.DNSName, record.RecordId, record.Value, endpoint.RecordTTL)
+		log.Infof("Dry run: Update %s private record named '%s' (id '%d', target '%s', ttl %d) in Alibaba Cloud Private Zone", record.Type, endpoint.DNSName, record.RecordId, record.Value, endpoint.RecordTTL)
 		return nil
 	}
 
@@ -1020,7 +1020,7 @@ func (p *AlibabaCloudProvider) updatePrivateZoneRecords(zones map[string]*alibab
 					p.updatePrivateZoneRecord(record, endpoint)
 				}
 			} else {
-				p.deletePrivateZoneRecord(record.RecordId)
+				p.deletePrivateZoneRecord(record, endpoint)
 			}
 		}
 		for _, target := range endpoint.Targets {

--- a/provider/alibabacloud/alibaba_cloud.go
+++ b/provider/alibabacloud/alibaba_cloud.go
@@ -576,6 +576,11 @@ func (p *AlibabaCloudProvider) deleteRecord(recordID string) error {
 }
 
 func (p *AlibabaCloudProvider) updateRecord(record alidns.Record, endpoint *endpoint.Endpoint) error {
+	if p.dryRun {
+		log.Infof("Dry run: Update record id '%s' in Alibaba Cloud DNS", record.RecordId)
+		return nil
+	}
+
 	request := alidns.CreateUpdateDomainRecordRequest()
 	request.RecordId = record.RecordId
 	request.RR = record.RR
@@ -891,6 +896,7 @@ func (p *AlibabaCloudProvider) createPrivateZoneRecords(zones map[string]*alibab
 func (p *AlibabaCloudProvider) deletePrivateZoneRecord(recordID int64) error {
 	if p.dryRun {
 		log.Infof("Dry run: Delete record id '%d' in Alibaba Cloud Private Zone", recordID)
+		return nil
 	}
 
 	request := pvtz.CreateDeleteZoneRecordRequest()
@@ -954,6 +960,11 @@ func (p *AlibabaCloudProvider) applyChangesForPrivateZone(changes *plan.Changes)
 }
 
 func (p *AlibabaCloudProvider) updatePrivateZoneRecord(record pvtz.Record, endpoint *endpoint.Endpoint) error {
+	if p.dryRun {
+		log.Infof("Dry run: Update record id '%d' in Alibaba Cloud Private Zone", record.RecordId)
+		return nil
+	}
+
 	request := pvtz.CreateUpdateZoneRecordRequest()
 	request.RecordId = requests.NewInteger64(record.RecordId)
 	request.Rr = record.Rr

--- a/provider/alibabacloud/alibaba_cloud.go
+++ b/provider/alibabacloud/alibaba_cloud.go
@@ -577,7 +577,7 @@ func (p *AlibabaCloudProvider) deleteRecord(recordID string) error {
 
 func (p *AlibabaCloudProvider) updateRecord(record alidns.Record, endpoint *endpoint.Endpoint) error {
 	if p.dryRun {
-		log.Infof("Dry run: Update record id '%s' in Alibaba Cloud DNS", record.RecordId)
+		log.Infof("Dry run: Update %s public record named '%s' (id '%s') to '%s' with ttl %d in Alibaba Cloud DNS", record.Type, endpoint.DNSName, record.RecordId, record.Value, endpoint.RecordTTL)
 		return nil
 	}
 
@@ -961,7 +961,7 @@ func (p *AlibabaCloudProvider) applyChangesForPrivateZone(changes *plan.Changes)
 
 func (p *AlibabaCloudProvider) updatePrivateZoneRecord(record pvtz.Record, endpoint *endpoint.Endpoint) error {
 	if p.dryRun {
-		log.Infof("Dry run: Update record id '%d' in Alibaba Cloud Private Zone", record.RecordId)
+		log.Infof("Dry run: Update %s private record named '%s' (id '%s') to '%s' with ttl %d in Alibaba Cloud DNS", record.Type, endpoint.DNSName, record.RecordId, record.Value, endpoint.RecordTTL)
 		return nil
 	}
 

--- a/provider/alibabacloud/alibaba_cloud_test.go
+++ b/provider/alibabacloud/alibaba_cloud_test.go
@@ -36,12 +36,16 @@ import (
 )
 
 type MockAlibabaCloudDNSAPI struct {
-	counter int64
-	domains []*alidns.Domain
-	records map[string][]*alidns.Record
+	counter                 int64
+	addDomainRecordCalls    int
+	deleteDomainRecordCalls int
+	updateDomainRecordCalls int
+	domains                 []*alidns.Domain
+	records                 map[string][]*alidns.Record
 }
 
 func (m *MockAlibabaCloudDNSAPI) AddDomainRecord(request *alidns.AddDomainRecordRequest) (*alidns.AddDomainRecordResponse, error) {
+	m.addDomainRecordCalls++
 	if _, exist := m.records[request.DomainName]; !exist {
 		return alidns.CreateAddDomainRecordResponse(), fmt.Errorf("Domain not found")
 	}
@@ -72,6 +76,7 @@ func (m *MockAlibabaCloudDNSAPI) AddDomainRecord(request *alidns.AddDomainRecord
 }
 
 func (m *MockAlibabaCloudDNSAPI) DeleteDomainRecord(request *alidns.DeleteDomainRecordRequest) (*alidns.DeleteDomainRecordResponse, error) {
+	m.deleteDomainRecordCalls++
 	if request == nil || request.RecordId == "" {
 		return alidns.CreateDeleteDomainRecordResponse(), fmt.Errorf("Invalid request")
 	}
@@ -87,6 +92,7 @@ func (m *MockAlibabaCloudDNSAPI) DeleteDomainRecord(request *alidns.DeleteDomain
 }
 
 func (m *MockAlibabaCloudDNSAPI) UpdateDomainRecord(request *alidns.UpdateDomainRecordRequest) (*alidns.UpdateDomainRecordResponse, error) {
+	m.updateDomainRecordCalls++
 	if request == nil || request.RecordId == "" {
 		return alidns.CreateUpdateDomainRecordResponse(), fmt.Errorf("Invalid request")
 	}
@@ -171,12 +177,16 @@ func (m *MockAlibabaCloudDNSAPI) newRecord(ep *endpoint.Endpoint, target, domain
 }
 
 type MockAlibabaCloudPrivateZoneAPI struct {
-	counter int64
-	zones   []*pvtz.Zone
-	records map[string][]*pvtz.Record
+	counter               int64
+	addZoneRecordCalls    int
+	deleteZoneRecordCalls int
+	updateZoneRecordCalls int
+	zones                 []*pvtz.Zone
+	records               map[string][]*pvtz.Record
 }
 
 func (m *MockAlibabaCloudPrivateZoneAPI) AddZoneRecord(request *pvtz.AddZoneRecordRequest) (*pvtz.AddZoneRecordResponse, error) {
+	m.addZoneRecordCalls++
 	if _, exist := m.records[request.ZoneId]; !exist {
 		return pvtz.CreateAddZoneRecordResponse(), fmt.Errorf("Zone not found")
 	}
@@ -207,6 +217,7 @@ func (m *MockAlibabaCloudPrivateZoneAPI) AddZoneRecord(request *pvtz.AddZoneReco
 }
 
 func (m *MockAlibabaCloudPrivateZoneAPI) DeleteZoneRecord(request *pvtz.DeleteZoneRecordRequest) (*pvtz.DeleteZoneRecordResponse, error) {
+	m.deleteZoneRecordCalls++
 	if request == nil || request.RecordId == "" {
 		return pvtz.CreateDeleteZoneRecordResponse(), fmt.Errorf("Invalid request")
 	}
@@ -223,6 +234,7 @@ func (m *MockAlibabaCloudPrivateZoneAPI) DeleteZoneRecord(request *pvtz.DeleteZo
 }
 
 func (m *MockAlibabaCloudPrivateZoneAPI) UpdateZoneRecord(request *pvtz.UpdateZoneRecordRequest) (*pvtz.UpdateZoneRecordResponse, error) {
+	m.updateZoneRecordCalls++
 	if request == nil || request.RecordId == "" {
 		return pvtz.CreateUpdateZoneRecordResponse(), fmt.Errorf("Invalid request")
 	}
@@ -442,6 +454,7 @@ func TestAlibabaCloudProvider_Records(t *testing.T) {
 
 func TestAlibabaCloudProvider_ApplyChanges(t *testing.T) {
 	provider := newTestAlibabaCloudProvider(false)
+	client := provider.dnsClient.(*MockAlibabaCloudDNSAPI)
 	changes := plan.Changes{
 		Create: []*endpoint.Endpoint{
 			endpoint.NewEndpointWithTTL("xyz.container-service.top", "A", 300, "4.3.2.1"),
@@ -459,6 +472,9 @@ func TestAlibabaCloudProvider_ApplyChanges(t *testing.T) {
 	ctx := t.Context()
 	err := provider.ApplyChanges(ctx, &changes)
 	require.NoError(t, err, "Failed to apply changes: %v", err)
+	assert.NotZero(t, client.addDomainRecordCalls)
+	assert.NotZero(t, client.updateDomainRecordCalls)
+	assert.NotZero(t, client.deleteDomainRecordCalls)
 
 	endpoints, err := provider.Records(ctx)
 	require.NoError(t, err, "Failed to get records: %v", err)
@@ -474,6 +490,7 @@ func TestAlibabaCloudProvider_ApplyChanges(t *testing.T) {
 
 func TestAlibabaCloudProvider_ApplyChanges_UndefinedZoneDomain(t *testing.T) {
 	provider := newTestAlibabaCloudProvider(false)
+	client := provider.dnsClient.(*MockAlibabaCloudDNSAPI)
 	changes := plan.Changes{
 		Create: []*endpoint.Endpoint{
 			// no found this zone by API: DescribeDomains
@@ -492,6 +509,9 @@ func TestAlibabaCloudProvider_ApplyChanges_UndefinedZoneDomain(t *testing.T) {
 	ctx := t.Context()
 	err := provider.ApplyChanges(ctx, &changes)
 	require.NoError(t, err, "Failed to apply changes: %v", err)
+	assert.NotZero(t, client.addDomainRecordCalls)
+	assert.NotZero(t, client.updateDomainRecordCalls)
+	assert.NotZero(t, client.deleteDomainRecordCalls)
 
 	endpoints, err := provider.Records(ctx)
 	require.NoError(t, err, "Failed to get records: %v", err)
@@ -522,6 +542,7 @@ func TestAlibabaCloudProvider_PrivateZone_Records(t *testing.T) {
 
 func TestAlibabaCloudProvider_PrivateZone_ApplyChanges(t *testing.T) {
 	provider := newTestAlibabaCloudProvider(true)
+	client := provider.pvtzClient.(*MockAlibabaCloudPrivateZoneAPI)
 	changes := plan.Changes{
 		Create: []*endpoint.Endpoint{
 			endpoint.NewEndpointWithTTL("xyz.container-service.top", "A", 300, "4.3.2.1"),
@@ -538,6 +559,9 @@ func TestAlibabaCloudProvider_PrivateZone_ApplyChanges(t *testing.T) {
 	ctx := t.Context()
 	err := provider.ApplyChanges(ctx, &changes)
 	require.NoError(t, err, "Failed to apply changes: %v", err)
+	assert.NotZero(t, client.addZoneRecordCalls)
+	assert.NotZero(t, client.updateZoneRecordCalls)
+	assert.NotZero(t, client.deleteZoneRecordCalls)
 
 	endpoints, err := provider.Records(ctx)
 	require.NoError(t, err, "Failed to get records: %v", err)
@@ -549,6 +573,38 @@ func TestAlibabaCloudProvider_PrivateZone_ApplyChanges(t *testing.T) {
 
 	require.Len(t, endpoints, len(changedEndpoints), "Incorrect number of records: %d", len(endpoints))
 	assert.True(t, testutils.SameEndpoints(changedEndpoints, endpoints), "expected and actual endpoints don't match. %s:%s", changedEndpoints, endpoints)
+}
+
+func TestAlibabaCloudProvider_DNSDryRun(t *testing.T) {
+	provider := newTestAlibabaCloudProvider(false)
+	provider.dryRun = true
+	client := provider.dnsClient.(*MockAlibabaCloudDNSAPI)
+	changes := plan.Changes{
+		Create:    []*endpoint.Endpoint{endpoint.NewEndpointWithTTL("new.container-service.top", "A", 300, "4.3.2.1")},
+		UpdateNew: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL("abc.container-service.top", "A", 500, "1.2.3.4")},
+		Delete:    []*endpoint.Endpoint{endpoint.NewEndpointWithTTL("abc.container-service.top", "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\"")},
+	}
+
+	require.NoError(t, provider.ApplyChanges(t.Context(), &changes))
+	assert.Zero(t, client.addDomainRecordCalls)
+	assert.Zero(t, client.updateDomainRecordCalls)
+	assert.Zero(t, client.deleteDomainRecordCalls)
+}
+
+func TestAlibabaCloudProvider_PrivateZone_DryRun(t *testing.T) {
+	provider := newTestAlibabaCloudProvider(true)
+	provider.dryRun = true
+	client := provider.pvtzClient.(*MockAlibabaCloudPrivateZoneAPI)
+	changes := plan.Changes{
+		Create:    []*endpoint.Endpoint{endpoint.NewEndpointWithTTL("new.container-service.top", "A", 300, "4.3.2.1")},
+		UpdateNew: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL("abc.container-service.top", "A", 500, "1.2.3.4")},
+		Delete:    []*endpoint.Endpoint{endpoint.NewEndpointWithTTL("abc.container-service.top", "TXT", 300, "\"heritage=external-dns,external-dns/owner=default\"")},
+	}
+
+	require.NoError(t, provider.ApplyChanges(t.Context(), &changes))
+	assert.Zero(t, client.addZoneRecordCalls)
+	assert.Zero(t, client.updateZoneRecordCalls)
+	assert.Zero(t, client.deleteZoneRecordCalls)
 }
 
 func TestAlibabaCloudProvider_splitDNSName(t *testing.T) {


### PR DESCRIPTION
## What does it do ?

<!-- A brief description of the change being made with this pull request. -->
Respect dry-run for record updates and deletes in AlibabaCloud provider.

## Motivation

<!-- What inspired you to submit this pull request? -->
Functions `updateRecord()`, `updatePrivateZoneRecord()`, `deletePrivateZoneRecord()` in `provider/alibabacloud/alibaba_cloud.go` ignore dry-run mode.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
