### PR TITLE
refactor(routegroup):  integration to use informer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,8 @@ See the [sources documentation](docs/sources/about.md) for the full list and con
 | [Kubernetes Pod](https://kubernetes.io/docs/concepts/workloads/pods/)                                 | [guide](docs/sources/pod.md)                                                                                                   |
 | [Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service/)                | [guide](docs/sources/service.md), [ExternalName](docs/tutorials/externalname.md), [Headless](docs/tutorials/hostport.md)       |
 | [OpenShift Route](https://docs.openshift.com/container-platform/latest/networking/routes/route-configuration.html) | [guide](docs/sources/openshift.md)                                                                                 |
-| [Skipper RouteGroup](https://opensource.zalando.com/skipper/kubernetes/routegroups/)                  | —                                                                                                                               |
-| [Traefik IngressRoute](https://doc.traefik.io/traefik/routing/providers/kubernetes-crd/)              | [guide](docs/sources/traefik-proxy.md)                                                                                         |
+| [Skipper RouteGroup](https://opensource.zalando.com/skipper/kubernetes/routegroups/)                  | [guide](docs/sources/skipper-routegroup.md)                                                                                 |
+| [Traefik IngressRoute](https://doc.traefik.io/traefik/routing/providers/kubernetes-crd/)              | [guide](docs/sources/traefik-proxy.md)                                                                                         |/
 | [Unstructured (custom CRD)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) | [guide](docs/sources/unstructured.md)                                                                              |
 
 ## Kubernetes version compatibility

--- a/docs/sources/index.md
+++ b/docs/sources/index.md
@@ -46,7 +46,7 @@ Sources are responsible for:
 | **openshift-route**      | annotation,label | all,single | true          | false  | true              | openshift           | Route.route.openshift.io                                                              |
 | **pod**                  | annotation,label | all,single | true          | true   | false             | kubernetes core     | Pod                                                                                   |
 | **service**              | annotation,label | all,single | true          | true   | true              | kubernetes core     | Service                                                                               |
-| **skipper-routegroup**   | annotation,label | all,single | true          | false  | true              | ingress controllers | RouteGroup.zalando.org                                                                |
+| **skipper-routegroup**   | annotation,label | all,single | true          | true   | true              | ingress controllers | RouteGroup.zalando.org                                                                |
 | **traefik-proxy**        | annotation,label | all,single | true          | false  | true              | ingress controllers | IngressRoute.traefik.io<br/>IngressRouteTCP.traefik.io<br/>IngressRouteUDP.traefik.io |
 | **unstructured**         | annotation,label | all,single | true          | false  | false             | custom resources    | Unstructured                                                                          |
 

--- a/docs/sources/skipper-routegroup.md
+++ b/docs/sources/skipper-routegroup.md
@@ -1,0 +1,100 @@
+# Skipper RouteGroup Source
+
+This tutorial describes how to configure ExternalDNS to use the Skipper [RouteGroup](https://opensource.zalando.com/skipper/kubernetes/routegroup-crd) source.
+It is meant to supplement the other provider-specific setup tutorials.
+
+## Manifest (for clusters without RBAC enabled)
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      containers:
+      - name: external-dns
+        # update this to the desired external-dns version
+        image: registry.k8s.io/external-dns/external-dns:v0.22.0
+        args:
+        - --source=skipper-routegroup
+        - --policy=upsert-only # prevents ExternalDNS from deleting any records, set --policy=sync to enable full synchronization (including deletions)
+        - --provider=aws
+        - --registry=txt
+        - --txt-owner-id=my-identifier
+```
+
+## Manifest (for clusters with RBAC enabled)
+
+Could be change if you have multiple sources
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups: [""]
+  resources: ["services","pods","nodes"]
+  verbs: ["get","list","watch"]
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["get","list","watch"]
+- apiGroups: ["zalando.org"]
+  resources: ["routegroups"]
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+  namespace: default
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      serviceAccountName: external-dns
+      containers:
+      - name: external-dns
+        # update this to the desired external-dns version
+        image: registry.k8s.io/external-dns/external-dns:v0.22.0
+        args:
+        - --source=skipper-routegroup
+        - --policy=upsert-only # prevents ExternalDNS from deleting any records, set --policy=sync to enable full synchronization (including deletions)
+        - --provider=aws
+        - --registry=txt
+        - --txt-owner-id=my-identifier
+```

--- a/go.mod
+++ b/go.mod
@@ -166,6 +166,7 @@ require (
 	github.com/spf13/viper v1.21.0 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/szuecs/routegroup-client v0.36.4 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -375,6 +375,8 @@ github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWD
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/szuecs/routegroup-client v0.36.4 h1:IDkrUeGH9XBLJye+AvRlqBPDkYqqoBEDD3EtSx44HAc=
+github.com/szuecs/routegroup-client v0.36.4/go.mod h1:oelTa5TjT79Uj898mJe96uYiDuyeFUToI4QKELXWrnA=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.19.0 h1:xwxm7n691Uf3u5OFjzngavjGTh55KX5q/9w9xHW88JU=
 github.com/tidwall/gjson v1.19.0/go.mod h1:V37/opeE/JbLUOfH0QTXiNez2l0RUjYUhpT4szFQAfc=

--- a/source/skipper_routegroup.go
+++ b/source/skipper_routegroup.go
@@ -61,9 +61,6 @@ type routeGroupSource struct {
 
 // NewRouteGroupSource creates a new routeGroupSource with the given config.
 func NewRouteGroupSource(ctx context.Context, client rgversioned.Interface, cfg *Config) (Source, error) {
-	if cfg.SkipperRouteGroupVersion != "" && cfg.SkipperRouteGroupVersion != DefaultRoutegroupVersion {
-		log.Warnf("skipper-routegroup-version %q is not supported; only %q is used", cfg.SkipperRouteGroupVersion, DefaultRoutegroupVersion)
-	}
 
 	informerFactory := rginformers.NewSharedInformerFactoryWithOptions(
 		client, 0,

--- a/source/skipper_routegroup.go
+++ b/source/skipper_routegroup.go
@@ -18,37 +18,28 @@ package source
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"encoding/json"
 	"fmt"
-	"net"
-	"net/http"
-	"net/url"
-	"os"
-	"strings"
-	"sync"
-	"time"
 
 	log "github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rgv1 "github.com/szuecs/routegroup-client/apis/zalando.org/v1"
+	rgversioned "github.com/szuecs/routegroup-client/client/clientset/versioned"
+	rginformers "github.com/szuecs/routegroup-client/client/informers/externalversions"
+	rginformersv1 "github.com/szuecs/routegroup-client/client/informers/externalversions/zalando.org/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
-
-	"sigs.k8s.io/external-dns/source/types"
 
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/pkg/events"
 	"sigs.k8s.io/external-dns/source/annotations"
+	"sigs.k8s.io/external-dns/source/informers"
 	"sigs.k8s.io/external-dns/source/template"
+	"sigs.k8s.io/external-dns/source/types"
 )
 
 const (
-	defaultIdleConnTimeout = 30 * time.Second
 	// DefaultRoutegroupVersion is the default version for route groups.
-	DefaultRoutegroupVersion     = "zalando.org/v1"
-	routeGroupListResource       = "/apis/%s/routegroups"
-	routeGroupNamespacedResource = "/apis/%s/namespaces/%s/routegroups"
+	//
+	// Deprecated: the informer-based implementation is hardwired to zalando.org/v1.
+	DefaultRoutegroupVersion = "zalando.org/v1"
 )
 
 // +externaldns:source:name=skipper-routegroup
@@ -59,216 +50,74 @@ const (
 // +externaldns:source:namespace=all,single
 // +externaldns:source:fqdn-template=true
 // +externaldns:source:provider-specific=true
+// +externaldns:source:events=true
 type routeGroupSource struct {
-	cli                      routeGroupListClient
-	apiServer                string
-	namespace                string
-	apiEndpoint              string
 	annotationFilter         labels.Selector
 	labelSelector            labels.Selector
 	templateEngine           template.Engine
 	ignoreHostnameAnnotation bool
-}
-
-// for testing
-type routeGroupListClient interface {
-	getRouteGroupList(string) (*routeGroupList, error)
-}
-
-type routeGroupClient struct {
-	mu        sync.Mutex
-	quit      chan struct{}
-	client    *http.Client
-	token     string
-	tokenFile string
-}
-
-func newRouteGroupClient(token, tokenPath string, timeout time.Duration) *routeGroupClient {
-	const (
-		rootCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-	)
-
-	tr := &http.Transport{
-		DialContext: (&net.Dialer{
-			Timeout:   timeout,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		TLSHandshakeTimeout:   3 * time.Second,
-		ResponseHeaderTimeout: timeout,
-		IdleConnTimeout:       defaultIdleConnTimeout,
-		MaxIdleConns:          5,
-		MaxIdleConnsPerHost:   5,
-	}
-	cli := &routeGroupClient{
-		client: &http.Client{
-			Transport: tr,
-		},
-		quit:      make(chan struct{}),
-		tokenFile: tokenPath,
-		token:     strings.TrimSpace(token),
-	}
-
-	go func() {
-		for {
-			select {
-			case <-time.After(tr.IdleConnTimeout):
-				tr.CloseIdleConnections()
-				cli.updateToken()
-			case <-cli.quit:
-				return
-			}
-		}
-	}()
-
-	// in cluster config, errors are treated as not running in cluster
-	cli.updateToken()
-
-	// cluster internal use custom CA to reach TLS endpoint
-	rootCA, err := os.ReadFile(rootCAFile)
-	if err != nil {
-		return cli
-	}
-	certPool := x509.NewCertPool()
-	if !certPool.AppendCertsFromPEM(rootCA) {
-		return cli
-	}
-
-	tr.TLSClientConfig = &tls.Config{
-		MinVersion: tls.VersionTLS12,
-		RootCAs:    certPool,
-	}
-
-	return cli
-}
-
-func (cli *routeGroupClient) updateToken() {
-	if cli.tokenFile == "" {
-		return
-	}
-
-	token, err := os.ReadFile(cli.tokenFile)
-	if err != nil {
-		log.Errorf("Failed to read token from file (%s): %v", cli.tokenFile, err)
-		return
-	}
-
-	cli.mu.Lock()
-	cli.token = strings.TrimSpace(string(token))
-	cli.mu.Unlock()
-}
-
-func (cli *routeGroupClient) getToken() string {
-	cli.mu.Lock()
-	defer cli.mu.Unlock()
-	return cli.token
-}
-
-func (cli *routeGroupClient) getRouteGroupList(url string) (*routeGroupList, error) {
-	resp, err := cli.get(url)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to get routegroup list from %s, got: %s", url, resp.Status)
-	}
-
-	var rgs routeGroupList
-	err = json.NewDecoder(resp.Body).Decode(&rgs)
-	if err != nil {
-		return nil, err
-	}
-
-	return &rgs, nil
-}
-
-func (cli *routeGroupClient) get(url string) (*http.Response, error) {
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
-	}
-	return cli.do(req)
-}
-
-func (cli *routeGroupClient) do(req *http.Request) (*http.Response, error) {
-	if tok := cli.getToken(); tok != "" && req.Header.Get("Authorization") == "" {
-		req.Header.Set("Authorization", "Bearer "+tok)
-	}
-	return cli.client.Do(req)
+	rgInformer               rginformersv1.RouteGroupInformer
 }
 
 // NewRouteGroupSource creates a new routeGroupSource with the given config.
-func NewRouteGroupSource(cfg *Config, token, tokenPath, apiServerURL string) (Source, error) {
-	routeGroupVersion := cfg.SkipperRouteGroupVersion
-	if routeGroupVersion == "" {
-		routeGroupVersion = DefaultRoutegroupVersion
+func NewRouteGroupSource(ctx context.Context, client rgversioned.Interface, cfg *Config) (Source, error) {
+	if cfg.SkipperRouteGroupVersion != "" && cfg.SkipperRouteGroupVersion != DefaultRoutegroupVersion {
+		log.Warnf("skipper-routegroup-version %q is not supported; only %q is used", cfg.SkipperRouteGroupVersion, DefaultRoutegroupVersion)
 	}
-	u, err := url.Parse(apiServerURL)
-	if err != nil {
+
+	informerFactory := rginformers.NewSharedInformerFactoryWithOptions(
+		client, 0,
+		rginformers.WithNamespace(cfg.Namespace),
+	)
+	rgInformer := informerFactory.Zalando().V1().RouteGroups()
+
+	informers.MustAddIndexers(rgInformer.Informer(), informers.IndexerWithOptions[*rgv1.RouteGroup](
+		informers.IndexSelectorWithAnnotationFilter(cfg.AnnotationFilter),
+		informers.IndexSelectorWithLabelSelector(cfg.LabelFilter),
+		informers.IndexSelectorWithConditions(annotations.IsControllerMatch[*rgv1.RouteGroup]),
+	))
+
+	informers.MustSetTransform(rgInformer.Informer(), informers.TransformerWithOptions[*rgv1.RouteGroup](
+		informers.TransformRemoveManagedFields(),
+		informers.TransformRemoveLastAppliedConfig(),
+	))
+
+	// Add default resource event handlers to properly initialize informer.
+	informers.MustAddEventHandler(rgInformer.Informer(), informers.DefaultEventHandler())
+
+	informerFactory.Start(ctx.Done())
+
+	// wait for the local cache to be populated.
+	if err := informers.WaitForCacheSync(ctx, informerFactory); err != nil {
 		return nil, err
 	}
 
-	// created after the URL is validated, because it starts a token refresh
-	// goroutine that would otherwise outlive a discarded source.
-	cli := newRouteGroupClient(token, tokenPath, cfg.KubeAPIRequestTimeout)
-
-	apiServer := u.String()
-	// strip port if well known port, because of TLS certificate match
-	if u.Scheme == "https" && u.Port() == "443" {
-		// correctly handle IPv6 addresses by keeping surrounding `[]`.
-		apiServer = "https://" + strings.TrimSuffix(u.Host, ":443")
-	}
-
-	apiEndpoint := apiServer + fmt.Sprintf(routeGroupListResource, routeGroupVersion)
-	if cfg.Namespace != "" {
-		apiEndpoint = apiServer + fmt.Sprintf(routeGroupNamespacedResource, routeGroupVersion, cfg.Namespace)
-	}
-
 	return &routeGroupSource{
-		cli:                      cli,
-		apiServer:                apiServer,
-		namespace:                cfg.Namespace,
-		apiEndpoint:              apiEndpoint,
 		annotationFilter:         cfg.AnnotationFilter,
 		labelSelector:            cfg.LabelFilter,
 		templateEngine:           cfg.TemplateEngine,
 		ignoreHostnameAnnotation: cfg.IgnoreHostnameAnnotation,
+		rgInformer:               rgInformer,
 	}, nil
 }
 
-// AddEventHandler for routegroup is currently a no op, because we do not implement caching, yet.
-func (sc *routeGroupSource) AddEventHandler(_ context.Context, _ func()) {}
+// AddEventHandler adds an event handler that can be triggered on RouteGroup changes.
+func (sc *routeGroupSource) AddEventHandler(_ context.Context, handler func()) {
+	log.Debug("Adding event handler for routegroup")
+	informers.MustAddEventHandler(sc.rgInformer.Informer(), eventHandlerFunc(handler))
+}
 
 // Endpoints returns endpoint objects for each host-target combination that should be processed.
 // Retrieves all routeGroup resources on all namespaces.
 // Logic is ported from ingress without fqdnTemplate
 func (sc *routeGroupSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, error) {
-	rgList, err := sc.cli.getRouteGroupList(sc.apiEndpoint)
-	if err != nil {
-		log.Errorf("Failed to get RouteGroup list: %v", err)
-		return nil, err
-	}
+	routeGroups := informers.ListIndexed[*rgv1.RouteGroup](sc.rgInformer.Informer().GetIndexer())
 
-	// RouteGroups are fetched over the Kubernetes API without server-side label
-	// filtering, so apply the label selector client-side to match other sources.
-	var labelFiltered []*routeGroup
-	for _, rg := range rgList.Items {
-		if sc.labelSelector == nil || sc.labelSelector.Matches(labels.Set(rg.Labels)) {
-			labelFiltered = append(labelFiltered, rg)
-		}
-	}
-
-	filtered := annotations.Filter(labelFiltered, sc.annotationFilter)
-
-	endpoints := []*endpoint.Endpoint{}
-	for _, rg := range filtered {
-		if annotations.IsControllerMismatch(rg, types.SkipperRouteGroup) {
-			continue
-		}
-
+	var endpoints []*endpoint.Endpoint
+	for _, rg := range routeGroups {
 		eps := sc.endpointsFromRouteGroup(rg)
 
+		var err error
 		eps, err = sc.templateEngine.CombineWithEndpoints(
 			eps,
 			func() ([]*endpoint.Endpoint, error) { return sc.endpointsFromTemplate(rg) },
@@ -283,14 +132,14 @@ func (sc *routeGroupSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, 
 
 		endpoint.AttachRefObject(eps, events.NewObjectReference(rg, types.SkipperRouteGroup))
 
-		log.Debugf("Endpoints generated from ingress: %s/%s: %v", rg.Namespace, rg.Name, eps)
+		log.Debugf("Endpoints generated from routegroup: %s/%s: %v", rg.Namespace, rg.Name, eps)
 		endpoints = append(endpoints, eps...)
 	}
 
 	return endpoint.MergeEndpoints(endpoints), nil
 }
 
-func (sc *routeGroupSource) endpointsFromTemplate(rg *routeGroup) ([]*endpoint.Endpoint, error) {
+func (sc *routeGroupSource) endpointsFromTemplate(rg *rgv1.RouteGroup) ([]*endpoint.Endpoint, error) {
 	hostnames, err := sc.templateEngine.ExecFQDN(rg)
 	if err != nil {
 		return nil, err
@@ -315,7 +164,8 @@ func (sc *routeGroupSource) endpointsFromTemplate(rg *routeGroup) ([]*endpoint.E
 	}
 	return endpoints, nil
 }
-func (sc *routeGroupSource) endpointsFromRouteGroup(rg *routeGroup) []*endpoint.Endpoint {
+
+func (sc *routeGroupSource) endpointsFromRouteGroup(rg *rgv1.RouteGroup) []*endpoint.Endpoint {
 	endpoints := []*endpoint.Endpoint{}
 
 	resource := fmt.Sprintf("routegroup/%s/%s", rg.Namespace, rg.Name)
@@ -353,7 +203,7 @@ func (sc *routeGroupSource) endpointsFromRouteGroup(rg *routeGroup) []*endpoint.
 	return endpoints
 }
 
-func targetsFromRouteGroupStatus(status routeGroupStatus) endpoint.Targets {
+func targetsFromRouteGroupStatus(status rgv1.RouteGroupStatus) endpoint.Targets {
 	var targets endpoint.Targets
 
 	for _, lb := range status.LoadBalancer.RouteGroup {
@@ -366,52 +216,4 @@ func targetsFromRouteGroupStatus(status routeGroupStatus) endpoint.Targets {
 	}
 
 	return targets
-}
-
-type routeGroupList struct {
-	Kind       string                 `json:"kind"`
-	APIVersion string                 `json:"apiVersion"`
-	Metadata   routeGroupListMetadata `json:"metadata"`
-	Items      []*routeGroup          `json:"items"`
-}
-
-type routeGroupListMetadata struct {
-	SelfLink        string `json:"selfLink"`
-	ResourceVersion string `json:"resourceVersion"`
-}
-
-type routeGroup struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata"`
-	Spec              routeGroupSpec   `json:"spec"`
-	Status            routeGroupStatus `json:"status"`
-}
-
-// Metadata returns the ObjectMeta for backward-compatible template access.
-//
-// Deprecated: use top-level fields directly (e.g. {{.Name}} instead of {{.Metadata.Name}}).
-func (rg *routeGroup) Metadata() *metav1.ObjectMeta {
-	return &rg.ObjectMeta
-}
-
-func (rg *routeGroup) DeepCopyObject() runtime.Object {
-	out := *rg
-	return &out
-}
-
-type routeGroupSpec struct {
-	Hosts []string `json:"hosts"`
-}
-
-type routeGroupStatus struct {
-	LoadBalancer routeGroupLoadBalancerStatus `json:"loadBalancer"`
-}
-
-type routeGroupLoadBalancerStatus struct {
-	RouteGroup []routeGroupLoadBalancer `json:"routeGroup"`
-}
-
-type routeGroupLoadBalancer struct {
-	IP       string `json:"ip,omitempty"`
-	Hostname string `json:"hostname,omitempty"`
 }

--- a/source/skipper_routegroup.go
+++ b/source/skipper_routegroup.go
@@ -25,6 +25,7 @@ import (
 	rgversioned "github.com/szuecs/routegroup-client/client/clientset/versioned"
 	rginformers "github.com/szuecs/routegroup-client/client/informers/externalversions"
 	rginformersv1 "github.com/szuecs/routegroup-client/client/informers/externalversions/zalando.org/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"sigs.k8s.io/external-dns/endpoint"
@@ -59,9 +60,24 @@ type routeGroupSource struct {
 	rgInformer               rginformersv1.RouteGroupInformer
 }
 
+// routeGroupWrapper adds a Metadata() accessor to *rgv1.RouteGroup so that
+// fqdn templates using {{.Metadata.Name}} continue to work alongside the
+// canonical {{.Name}} form.
+//
+// Deprecated: use top-level fields directly (e.g. {{.Name}} instead of {{.Metadata.Name}}).
+type routeGroupWrapper struct {
+	*rgv1.RouteGroup
+}
+
+// Metadata returns the ObjectMeta for backward-compatible template access.
+//
+// Deprecated: use top-level fields directly (e.g. {{.Name}} instead of {{.Metadata.Name}}).
+func (w *routeGroupWrapper) Metadata() *metav1.ObjectMeta {
+	return &w.ObjectMeta
+}
+
 // NewRouteGroupSource creates a new routeGroupSource with the given config.
 func NewRouteGroupSource(ctx context.Context, client rgversioned.Interface, cfg *Config) (Source, error) {
-
 	informerFactory := rginformers.NewSharedInformerFactoryWithOptions(
 		client, 0,
 		rginformers.WithNamespace(cfg.Namespace),
@@ -137,7 +153,7 @@ func (sc *routeGroupSource) Endpoints(_ context.Context) ([]*endpoint.Endpoint, 
 }
 
 func (sc *routeGroupSource) endpointsFromTemplate(rg *rgv1.RouteGroup) ([]*endpoint.Endpoint, error) {
-	hostnames, err := sc.templateEngine.ExecFQDN(rg)
+	hostnames, err := sc.templateEngine.ExecFQDN(&routeGroupWrapper{rg})
 	if err != nil {
 		return nil, err
 	}

--- a/source/skipper_routegroup_fqdn_test.go
+++ b/source/skipper_routegroup_fqdn_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"testing"
+
+	rgv1 "github.com/szuecs/routegroup-client/apis/zalando.org/v1"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
+	templatetest "sigs.k8s.io/external-dns/source/template/testutil"
+)
+
+func TestRouteGroupFQDNTemplate(t *testing.T) {
+	t.Parallel()
+
+	lb := []rgv1.RouteGroupLoadBalancer{{Hostname: "lb.example.com"}}
+
+	tests := []struct {
+		title        string
+		routeGroup   *rgv1.RouteGroup
+		fqdnTemplate string
+		combine      bool
+		expected     []*endpoint.Endpoint
+	}{
+		{
+			title:        "fqdn-template generates endpoint when no spec hosts",
+			routeGroup:   createTestRouteGroup("ns", "my-rg", nil, nil, lb),
+			fqdnTemplate: "{{.Name}}.example.com",
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "my-rg.example.com",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.example.com"},
+					Labels:     endpoint.Labels{endpoint.ResourceLabelKey: "routegroup/ns/my-rg"},
+				},
+			},
+		},
+		{
+			title:        "fqdn-template with combine=true adds template endpoint alongside spec-hosts endpoint",
+			routeGroup:   createTestRouteGroup("ns", "my-rg", nil, []string{"spec.example.com"}, lb),
+			fqdnTemplate: "{{.Name}}.example.com",
+			combine:      true,
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "spec.example.com",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.example.com"},
+					Labels:     endpoint.Labels{endpoint.ResourceLabelKey: "routegroup/ns/my-rg"},
+				},
+				{
+					DNSName:    "my-rg.example.com",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.example.com"},
+					Labels:     endpoint.Labels{endpoint.ResourceLabelKey: "routegroup/ns/my-rg"},
+				},
+			},
+		},
+		{
+			title:        "fqdn-template without combine is ignored when spec-hosts exist",
+			routeGroup:   createTestRouteGroup("ns", "my-rg", nil, []string{"spec.example.com"}, lb),
+			fqdnTemplate: "{{.Name}}.example.com",
+			combine:      false,
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "spec.example.com",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.example.com"},
+					Labels:     endpoint.Labels{endpoint.ResourceLabelKey: "routegroup/ns/my-rg"},
+				},
+			},
+		},
+		{
+			title: "fqdn-template can reference .Kind",
+			routeGroup: &rgv1.RouteGroup{
+				APIVersion: "zalando.org/v1", Kind: "RouteGroup",
+				Name: "my-rg", Namespace: "ns",
+				Status: rgv1.RouteGroupStatus{
+					LoadBalancer: rgv1.RouteGroupLoadBalancerStatus{RouteGroup: lb},
+				},
+			},
+			fqdnTemplate: "{{.Kind | toLower}}.{{.Name}}.example.com",
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "routegroup.my-rg.example.com",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.example.com"},
+					Labels:     endpoint.Labels{endpoint.ResourceLabelKey: "routegroup/ns/my-rg"},
+				},
+			},
+		},
+		{
+			title: "fqdn-template can reference .APIVersion",
+			routeGroup: &rgv1.RouteGroup{
+				APIVersion: "zalando.org/v1", Kind: "RouteGroup",
+				Name: "my-rg", Namespace: "ns",
+				Status: rgv1.RouteGroupStatus{
+					LoadBalancer: rgv1.RouteGroupLoadBalancerStatus{RouteGroup: lb},
+				},
+			},
+			fqdnTemplate: `{{.Name}}.{{replace "/" "." .APIVersion}}.example.com`,
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "my-rg.zalando.org.v1.example.com",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.example.com"},
+					Labels:     endpoint.Labels{endpoint.ResourceLabelKey: "routegroup/ns/my-rg"},
+				},
+			},
+		},
+		{
+			title:        "fqdn-template can reference .Namespace",
+			routeGroup:   createTestRouteGroup("production", "my-rg", nil, nil, lb),
+			fqdnTemplate: "{{.Name}}.{{.Namespace}}.example.com",
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "my-rg.production.example.com",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.example.com"},
+					Labels:     endpoint.Labels{endpoint.ResourceLabelKey: "routegroup/production/my-rg"},
+				},
+			},
+		},
+		{
+			title:        "backward-compat .Metadata.Name prefix in fqdn-template",
+			routeGroup:   createTestRouteGroup("ns", "my-rg", nil, nil, lb),
+			fqdnTemplate: "{{.Metadata.Name}}.example.com",
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "my-rg.example.com",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets{"lb.example.com"},
+					Labels:     endpoint.Labels{endpoint.ResourceLabelKey: "routegroup/ns/my-rg"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			t.Parallel()
+
+			src := newTestRouteGroupSource(t, &Config{
+				TemplateEngine: templatetest.MustEngine(t, tt.fqdnTemplate, "", "", tt.combine),
+			}, tt.routeGroup)
+
+			got, err := src.Endpoints(t.Context())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			testutils.ValidateEndpoints(t, got, tt.expected)
+		})
+	}
+}

--- a/source/skipper_routegroup_test.go
+++ b/source/skipper_routegroup_test.go
@@ -17,319 +17,77 @@ limitations under the License.
 package source
 
 import (
-	"errors"
-	"net/http"
-	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"testing"
-	"time"
-
-	"sigs.k8s.io/external-dns/internal/testutils"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	rgv1 "github.com/szuecs/routegroup-client/apis/zalando.org/v1"
+	rgfake "github.com/szuecs/routegroup-client/client/clientset/versioned/fake"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
 	"sigs.k8s.io/external-dns/source/annotations"
 	templatetest "sigs.k8s.io/external-dns/source/template/testutil"
 	"sigs.k8s.io/external-dns/source/types"
 )
 
-func TestRouteGroupClientUpdateToken(t *testing.T) {
-	t.Parallel()
-
-	t.Run("no token file path leaves token unchanged", func(t *testing.T) {
-		t.Parallel()
-
-		client := &routeGroupClient{token: "initial-token"}
-		client.updateToken()
-
-		assert.Equal(t, "initial-token", client.getToken())
-	})
-
-	t.Run("token is read from file", func(t *testing.T) {
-		t.Parallel()
-
-		tokenFile := filepath.Join(t.TempDir(), "token")
-		require.NoError(t, os.WriteFile(tokenFile, []byte("updated-token"), 0o600))
-		client := &routeGroupClient{token: "initial-token", tokenFile: tokenFile}
-
-		client.updateToken()
-
-		assert.Equal(t, "updated-token", client.getToken())
-	})
-
-	t.Run("unreadable token file leaves token unchanged", func(t *testing.T) {
-		t.Parallel()
-
-		client := &routeGroupClient{
-			token:     "initial-token",
-			tokenFile: filepath.Join(t.TempDir(), "missing-token"),
-		}
-
-		client.updateToken()
-
-		assert.Equal(t, "initial-token", client.getToken())
-	})
+func createTestRouteGroup(ns, name string, anns map[string]string, hosts []string, destinations []rgv1.RouteGroupLoadBalancer) *rgv1.RouteGroup {
+	return &rgv1.RouteGroup{
+		Namespace:   ns,
+		Name:        name,
+		Annotations: anns,
+		Spec: rgv1.RouteGroupSpec{
+			Hosts: hosts,
+		},
+		Status: rgv1.RouteGroupStatus{
+			LoadBalancer: rgv1.RouteGroupLoadBalancerStatus{
+				RouteGroup: destinations,
+			},
+		},
+	}
 }
 
-func TestRouteGroupClientGetRouteGroupList(t *testing.T) {
-	t.Parallel()
-
-	t.Run("successful response", func(t *testing.T) {
-		t.Parallel()
-
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, http.MethodGet, r.Method)
-			assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
-			w.Header().Set("Content-Type", "application/json")
-			_, err := w.Write([]byte(`{"kind":"RouteGroupList","apiVersion":"zalando.org/v1","items":[{"metadata":{"name":"rg1"}}]}`))
-			assert.NoError(t, err)
-		}))
-		defer server.Close()
-
-		client := &routeGroupClient{client: server.Client(), token: "test-token"}
-		got, err := client.getRouteGroupList(server.URL)
-
-		require.NoError(t, err)
-		require.Len(t, got.Items, 1)
-		assert.Equal(t, "RouteGroupList", got.Kind)
-		assert.Equal(t, "zalando.org/v1", got.APIVersion)
-		assert.Equal(t, "rg1", got.Items[0].Name)
-	})
-
-	t.Run("non-success response", func(t *testing.T) {
-		t.Parallel()
-
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			http.Error(w, "unavailable", http.StatusServiceUnavailable)
-		}))
-		defer server.Close()
-
-		client := &routeGroupClient{client: server.Client()}
-		got, err := client.getRouteGroupList(server.URL)
-
-		assert.Nil(t, got)
-		assert.ErrorContains(t, err, "503 Service Unavailable")
-	})
-
-	t.Run("invalid JSON response", func(t *testing.T) {
-		t.Parallel()
-
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			_, err := w.Write([]byte(`{"items":`))
-			assert.NoError(t, err)
-		}))
-		defer server.Close()
-
-		client := &routeGroupClient{client: server.Client()}
-		got, err := client.getRouteGroupList(server.URL)
-
-		assert.Nil(t, got)
-		assert.Error(t, err)
-	})
-
-	t.Run("request failure", func(t *testing.T) {
-		t.Parallel()
-
-		server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-		client := &routeGroupClient{client: server.Client()}
-		server.Close()
-
-		got, err := client.getRouteGroupList(server.URL)
-
-		assert.Nil(t, got)
-		assert.Error(t, err)
-	})
-}
-
-func TestRouteGroupClientGetAndDo(t *testing.T) {
-	t.Parallel()
-
-	t.Run("invalid URL", func(t *testing.T) {
-		t.Parallel()
-
-		client := &routeGroupClient{}
-		resp, err := client.get("://invalid")
-
-		assert.Nil(t, resp)
-		assert.Error(t, err)
-	})
-
-	t.Run("existing authorization header is preserved", func(t *testing.T) {
-		t.Parallel()
-
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "Bearer request-token", r.Header.Get("Authorization"))
-			w.WriteHeader(http.StatusNoContent)
-		}))
-		defer server.Close()
-
-		client := &routeGroupClient{client: server.Client(), token: "client-token"}
-		req, err := http.NewRequest(http.MethodGet, server.URL, nil)
-		require.NoError(t, err)
-		req.Header.Set("Authorization", "Bearer request-token")
-
-		resp, err := client.do(req)
-
-		require.NoError(t, err)
-		defer resp.Body.Close()
-		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-	})
+func newTestRouteGroupSource(t *testing.T, cfg *Config, rgs ...*rgv1.RouteGroup) Source {
+	t.Helper()
+	objects := make([]runtime.Object, len(rgs))
+	for i, rg := range rgs {
+		objects[i] = rg
+	}
+	fakeClient := rgfake.NewSimpleClientset(objects...)
+	src, err := NewRouteGroupSource(t.Context(), fakeClient, cfg)
+	require.NoError(t, err)
+	return src
 }
 
 func TestNewRouteGroupSource(t *testing.T) {
 	t.Parallel()
 
-	for _, tt := range []struct {
-		name              string
-		apiServer         string
-		namespace         string
-		routeGroupVersion string
-		wantServer        string
-		wantAPI           string
-		wantErr           bool
-	}{
-		{
-			name:       "default version across all namespaces",
-			apiServer:  "http://kubernetes.default.svc",
-			wantServer: "http://kubernetes.default.svc",
-			wantAPI:    "http://kubernetes.default.svc/apis/zalando.org/v1/routegroups",
-		},
-		{
-			name:              "custom version in one namespace",
-			apiServer:         "https://kubernetes.default.svc:8443",
-			namespace:         "test-namespace",
-			routeGroupVersion: "zalando.org/v1alpha1",
-			wantServer:        "https://kubernetes.default.svc:8443",
-			wantAPI:           "https://kubernetes.default.svc:8443/apis/zalando.org/v1alpha1/namespaces/test-namespace/routegroups",
-		},
-		{
-			name:       "standard HTTPS port is removed",
-			apiServer:  "https://kubernetes.default.svc:443",
-			wantServer: "https://kubernetes.default.svc",
-			wantAPI:    "https://kubernetes.default.svc/apis/zalando.org/v1/routegroups",
-		},
-		{
-			name:       "standard HTTPS port is removed from IPv6 address",
-			apiServer:  "https://[2001:db8::1]:443",
-			wantServer: "https://[2001:db8::1]",
-			wantAPI:    "https://[2001:db8::1]/apis/zalando.org/v1/routegroups",
-		},
-		{
-			name:      "unparsable API server URL returns an error",
-			apiServer: "://invalid",
-			wantErr:   true,
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			config := Config{
-				Namespace:                tt.namespace,
-				SkipperRouteGroupVersion: tt.routeGroupVersion,
-				KubeAPIRequestTimeout:    time.Second,
-			}
-			got, err := NewRouteGroupSource(&config, "test-token", "", tt.apiServer)
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Nil(t, got)
-				return
-			}
-			require.NoError(t, err)
-
-			source, ok := got.(*routeGroupSource)
-			require.True(t, ok)
-			client, ok := source.cli.(*routeGroupClient)
-			require.True(t, ok)
-			t.Cleanup(func() { close(client.quit) })
-
-			assert.Equal(t, tt.wantServer, source.apiServer)
-			assert.Equal(t, tt.namespace, source.namespace)
-			assert.Equal(t, tt.wantAPI, source.apiEndpoint)
-			assert.Equal(t, "test-token", client.getToken())
-		})
-	}
-}
-
-func TestRouteGroupDeepCopyObject(t *testing.T) {
-	t.Parallel()
-
-	original := createTestRouteGroup(
-		"namespace1",
-		"rg1",
-		map[string]string{"key": "value"},
-		[]string{"rg1.example.org"},
-		nil,
-	)
-	cloned, ok := original.DeepCopyObject().(*routeGroup)
-	require.True(t, ok)
-
-	assert.Equal(t, original, cloned)
-	assert.NotSame(t, original, cloned)
-
-	// Top-level fields are independent.
-	cloned.Name = "rg2"
-	assert.Equal(t, "rg1", original.Name)
-
-	// Nested slices and maps are not.
-	cloned.Spec.Hosts[0] = "rg2.example.org"
-	cloned.Annotations["key"] = "changed"
-	assert.Equal(t, "rg2.example.org", original.Spec.Hosts[0])
-	assert.Equal(t, "changed", original.Annotations["key"])
-}
-
-func TestRouteGroupClientToken(t *testing.T) {
-	t.Parallel()
-
-	t.Run("trims direct token", func(t *testing.T) {
-		client := newRouteGroupClient(" direct-token\r\n", "", time.Second)
-		t.Cleanup(func() { close(client.quit) })
-
-		assert.Equal(t, "direct-token", client.getToken())
+	t.Run("creates source successfully", func(t *testing.T) {
+		t.Parallel()
+		fakeClient := rgfake.NewSimpleClientset()
+		src, err := NewRouteGroupSource(t.Context(), fakeClient, &Config{})
+		require.NoError(t, err)
+		_, ok := src.(*routeGroupSource)
+		require.True(t, ok)
 	})
 
-	t.Run("loads custom token file", func(t *testing.T) {
-		tokenFile := filepath.Join(t.TempDir(), "token")
-		require.NoError(t, os.WriteFile(tokenFile, []byte("custom-token\n"), 0o600))
-
-		client := newRouteGroupClient("initial-token", tokenFile, time.Second)
-		t.Cleanup(func() { close(client.quit) })
-
-		assert.Equal(t, tokenFile, client.tokenFile)
-		assert.Equal(t, "custom-token", client.getToken())
+	t.Run("respects namespace", func(t *testing.T) {
+		t.Parallel()
+		fakeClient := rgfake.NewSimpleClientset()
+		src, err := NewRouteGroupSource(t.Context(), fakeClient, &Config{Namespace: "test-ns"})
+		require.NoError(t, err)
+		require.NotNil(t, src)
 	})
 
-	t.Run("reloads custom token file", func(t *testing.T) {
-		tokenFile := filepath.Join(t.TempDir(), "token")
-		require.NoError(t, os.WriteFile(tokenFile, []byte("initial-file-token"), 0o600))
-
-		client := newRouteGroupClient("initial-token", tokenFile, time.Second)
-		t.Cleanup(func() { close(client.quit) })
-
-		require.NoError(t, os.WriteFile(tokenFile, []byte("rotated-file-token\r\n"), 0o600))
-		client.updateToken()
-
-		assert.Equal(t, "rotated-file-token", client.getToken())
+	t.Run("logs warning for non-default version", func(t *testing.T) {
+		t.Parallel()
+		fakeClient := rgfake.NewSimpleClientset()
+		src, err := NewRouteGroupSource(t.Context(), fakeClient, &Config{SkipperRouteGroupVersion: "zalando.org/v1alpha1"})
+		require.NoError(t, err)
+		require.NotNil(t, src)
 	})
-}
-
-func createTestRouteGroup(ns, name string, annotations map[string]string, hosts []string, destinations []routeGroupLoadBalancer) *routeGroup {
-	return &routeGroup{
-		Namespace:   ns,
-		Name:        name,
-		Annotations: annotations,
-		Spec: routeGroupSpec{
-			Hosts: hosts,
-		},
-		Status: routeGroupStatus{
-			LoadBalancer: routeGroupLoadBalancerStatus{
-				RouteGroup: destinations,
-			},
-		},
-	}
 }
 
 func TestEndpointsFromRouteGroups(t *testing.T) {
@@ -338,13 +96,13 @@ func TestEndpointsFromRouteGroups(t *testing.T) {
 	for _, tt := range []struct {
 		name   string
 		source *routeGroupSource
-		rg     *routeGroup
+		rg     *rgv1.RouteGroup
 		want   []*endpoint.Endpoint
 	}{
 		{
 			name:   "Empty routegroup should return empty endpoints",
 			source: &routeGroupSource{},
-			rg:     &routeGroup{},
+			rg:     &rgv1.RouteGroup{},
 			want:   []*endpoint.Endpoint{},
 		},
 		{
@@ -356,7 +114,7 @@ func TestEndpointsFromRouteGroups(t *testing.T) {
 		{
 			name:   "Routegroup without hosts create no endpoints",
 			source: &routeGroupSource{},
-			rg: createTestRouteGroup("namespace1", "rg1", nil, nil, []routeGroupLoadBalancer{
+			rg: createTestRouteGroup("namespace1", "rg1", nil, nil, []rgv1.RouteGroupLoadBalancer{
 				{
 					Hostname: "lb.example.org",
 				},
@@ -372,7 +130,7 @@ func TestEndpointsFromRouteGroups(t *testing.T) {
 		{
 			name:   "Routegroup with hosts and destinations creates an endpoint",
 			source: &routeGroupSource{},
-			rg: createTestRouteGroup("namespace1", "rg1", nil, []string{"rg1.k8s.example"}, []routeGroupLoadBalancer{
+			rg: createTestRouteGroup("namespace1", "rg1", nil, []string{"rg1.k8s.example"}, []rgv1.RouteGroupLoadBalancer{
 				{
 					Hostname: "lb.example.org",
 				},
@@ -395,7 +153,7 @@ func TestEndpointsFromRouteGroups(t *testing.T) {
 					annotations.HostnameKey: "my.example",
 				},
 				[]string{"rg1.k8s.example"},
-				[]routeGroupLoadBalancer{
+				[]rgv1.RouteGroupLoadBalancer{
 					{
 						Hostname: "lb.example.org",
 					},
@@ -424,7 +182,7 @@ func TestEndpointsFromRouteGroups(t *testing.T) {
 					annotations.HostnameKey: "my.example",
 				},
 				[]string{"rg1.k8s.example"},
-				[]routeGroupLoadBalancer{
+				[]rgv1.RouteGroupLoadBalancer{
 					{
 						Hostname: "lb.example.org",
 					},
@@ -448,7 +206,7 @@ func TestEndpointsFromRouteGroups(t *testing.T) {
 					annotations.TtlKey: "2189",
 				},
 				[]string{"rg1.k8s.example"},
-				[]routeGroupLoadBalancer{
+				[]rgv1.RouteGroupLoadBalancer{
 					{
 						Hostname: "lb.example.org",
 					},
@@ -471,7 +229,7 @@ func TestEndpointsFromRouteGroups(t *testing.T) {
 				"rg1",
 				nil,
 				[]string{"rg1.k8s.example"},
-				[]routeGroupLoadBalancer{
+				[]rgv1.RouteGroupLoadBalancer{
 					{
 						IP: "1.5.1.4",
 					},
@@ -493,7 +251,7 @@ func TestEndpointsFromRouteGroups(t *testing.T) {
 				"rg1",
 				nil,
 				[]string{"rg1.k8s.example"},
-				[]routeGroupLoadBalancer{
+				[]rgv1.RouteGroupLoadBalancer{
 					{
 						IP: "2001:DB8::1",
 					},
@@ -515,7 +273,7 @@ func TestEndpointsFromRouteGroups(t *testing.T) {
 				"rg1",
 				nil,
 				[]string{"rg1.k8s.example"},
-				[]routeGroupLoadBalancer{
+				[]rgv1.RouteGroupLoadBalancer{
 					{
 						Hostname: "lb.example.org",
 						IP:       "1.5.1.4",
@@ -543,7 +301,7 @@ func TestEndpointsFromRouteGroups(t *testing.T) {
 				"rg1",
 				nil,
 				[]string{"rg1.k8s.example"},
-				[]routeGroupLoadBalancer{
+				[]rgv1.RouteGroupLoadBalancer{
 					{
 						Hostname: "lb.example.org",
 						IP:       "2001:DB8::1",
@@ -573,7 +331,7 @@ func TestEndpointsFromRouteGroups(t *testing.T) {
 					annotations.AWSPrefix + "weight": "10",
 				},
 				[]string{"rg1.k8s.example"},
-				[]routeGroupLoadBalancer{
+				[]rgv1.RouteGroupLoadBalancer{
 					{
 						Hostname: "lb.example.org",
 					},
@@ -599,65 +357,36 @@ func TestEndpointsFromRouteGroups(t *testing.T) {
 	}
 }
 
-type fakeRouteGroupClient struct {
-	returnErr bool
-	rg        *routeGroupList
-}
-
-func (f *fakeRouteGroupClient) getRouteGroupList(string) (*routeGroupList, error) {
-	if f.returnErr {
-		return nil, errors.New("Fake route group list error")
-	}
-	return f.rg, nil
-}
-
 func TestRouteGroupsEndpoints(t *testing.T) {
 	for _, tt := range []struct {
 		name        string
-		source      *routeGroupSource
+		rgs         []*rgv1.RouteGroup
+		cfg         *Config
 		templates   string
 		combineFQDN bool
 		want        []*endpoint.Endpoint
 		wantErr     bool
 	}{
 		{
-			name: "routegroup client error should be returned",
-			source: &routeGroupSource{
-				cli: &fakeRouteGroupClient{returnErr: true},
-			},
-			wantErr: true,
-		},
-		{
 			name: "Empty routegroup should return empty endpoints",
-			source: &routeGroupSource{
-				cli: &fakeRouteGroupClient{
-					rg: &routeGroupList{},
-				},
-			},
-			want:    []*endpoint.Endpoint{},
-			wantErr: false,
+			rgs:  nil,
+			want: []*endpoint.Endpoint{},
 		},
 		{
 			name: "Single routegroup should return endpoints",
-			source: &routeGroupSource{
-				cli: &fakeRouteGroupClient{
-					rg: &routeGroupList{
-						Items: []*routeGroup{
-							{
-								Namespace: "namespace1",
-								Name:      "rg1",
-								UID:       "skipper-rg-uid-1234",
-								Spec: routeGroupSpec{
-									Hosts: []string{"rg1.k8s.example"},
-								},
-								Status: routeGroupStatus{
-									LoadBalancer: routeGroupLoadBalancerStatus{
-										RouteGroup: []routeGroupLoadBalancer{
-											{
-												Hostname: "lb.example.org",
-											},
-										},
-									},
+			rgs: []*rgv1.RouteGroup{
+				{
+					Namespace: "namespace1",
+					Name:      "rg1",
+					UID:       "skipper-rg-uid-1234",
+					Spec: rgv1.RouteGroupSpec{
+						Hosts: []string{"rg1.k8s.example"},
+					},
+					Status: rgv1.RouteGroupStatus{
+						LoadBalancer: rgv1.RouteGroupLoadBalancerStatus{
+							RouteGroup: []rgv1.RouteGroupLoadBalancer{
+								{
+									Hostname: "lb.example.org",
 								},
 							},
 						},
@@ -674,26 +403,20 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 		},
 		{
 			name:        "Single routegroup with combineFQDNAnnotation with fqdn template should return endpoints from fqdnTemplate and routegroup",
-			templates:   "{{.Metadata.Name}}.{{.Metadata.Namespace}}.example",
+			templates:   "{{.Name}}.{{.Namespace}}.example",
 			combineFQDN: true,
-			source: &routeGroupSource{
-				cli: &fakeRouteGroupClient{
-					rg: &routeGroupList{
-						Items: []*routeGroup{
-							createTestRouteGroup(
-								"namespace1",
-								"rg1",
-								nil,
-								[]string{"rg1.k8s.example"},
-								[]routeGroupLoadBalancer{
-									{
-										Hostname: "lb.example.org",
-									},
-								},
-							),
+			rgs: []*rgv1.RouteGroup{
+				createTestRouteGroup(
+					"namespace1",
+					"rg1",
+					nil,
+					[]string{"rg1.k8s.example"},
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb.example.org",
 						},
 					},
-				},
+				),
 			},
 			want: []*endpoint.Endpoint{
 				{
@@ -709,26 +432,20 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 			},
 		},
 		{
-			name:      "Single routegroup without, with fqdn template should return endpoints from fqdnTemplate",
-			templates: "{{.Metadata.Name}}.{{.Metadata.Namespace}}.example",
-			source: &routeGroupSource{
-				cli: &fakeRouteGroupClient{
-					rg: &routeGroupList{
-						Items: []*routeGroup{
-							createTestRouteGroup(
-								"namespace1",
-								"rg1",
-								nil,
-								nil,
-								[]routeGroupLoadBalancer{
-									{
-										Hostname: "lb.example.org",
-									},
-								},
-							),
+			name:      "Single routegroup without hosts, with fqdn template should return endpoints from fqdnTemplate",
+			templates: "{{.Name}}.{{.Namespace}}.example",
+			rgs: []*rgv1.RouteGroup{
+				createTestRouteGroup(
+					"namespace1",
+					"rg1",
+					nil,
+					nil,
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb.example.org",
 						},
 					},
-				},
+				),
 			},
 			want: []*endpoint.Endpoint{
 				{
@@ -741,44 +458,32 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 		{
 			name:      "fqdn template execution error should be returned",
 			templates: "{{index . 0}}",
-			source: &routeGroupSource{
-				cli: &fakeRouteGroupClient{
-					rg: &routeGroupList{
-						Items: []*routeGroup{
-							createTestRouteGroup(
-								"namespace1",
-								"rg1",
-								nil,
-								nil,
-								[]routeGroupLoadBalancer{{Hostname: "lb.example.org"}},
-							),
-						},
-					},
-				},
+			rgs: []*rgv1.RouteGroup{
+				createTestRouteGroup(
+					"namespace1",
+					"rg1",
+					nil,
+					nil,
+					[]rgv1.RouteGroupLoadBalancer{{Hostname: "lb.example.org"}},
+				),
 			},
 			wantErr: true,
 		},
 		{
 			name:      "Single routegroup without combineFQDNAnnotation with fqdn template should return endpoints not from fqdnTemplate",
-			templates: "{{.Metadata.Name}}.{{.Metadata.Namespace}}.example",
-			source: &routeGroupSource{
-				cli: &fakeRouteGroupClient{
-					rg: &routeGroupList{
-						Items: []*routeGroup{
-							createTestRouteGroup(
-								"namespace1",
-								"rg1",
-								nil,
-								[]string{"rg1.k8s.example"},
-								[]routeGroupLoadBalancer{
-									{
-										Hostname: "lb.example.org",
-									},
-								},
-							),
+			templates: "{{.Name}}.{{.Namespace}}.example",
+			rgs: []*rgv1.RouteGroup{
+				createTestRouteGroup(
+					"namespace1",
+					"rg1",
+					nil,
+					[]string{"rg1.k8s.example"},
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb.example.org",
 						},
 					},
-				},
+				),
 			},
 			want: []*endpoint.Endpoint{
 				{
@@ -790,26 +495,20 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 		},
 		{
 			name: "Single routegroup with TTL should return endpoint with TTL",
-			source: &routeGroupSource{
-				cli: &fakeRouteGroupClient{
-					rg: &routeGroupList{
-						Items: []*routeGroup{
-							createTestRouteGroup(
-								"namespace1",
-								"rg1",
-								map[string]string{
-									annotations.TtlKey: "2189",
-								},
-								[]string{"rg1.k8s.example"},
-								[]routeGroupLoadBalancer{
-									{
-										Hostname: "lb.example.org",
-									},
-								},
-							),
+			rgs: []*rgv1.RouteGroup{
+				createTestRouteGroup(
+					"namespace1",
+					"rg1",
+					map[string]string{
+						annotations.TtlKey: "2189",
+					},
+					[]string{"rg1.k8s.example"},
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb.example.org",
 						},
 					},
-				},
+				),
 			},
 			want: []*endpoint.Endpoint{
 				{
@@ -822,25 +521,19 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 		},
 		{
 			name: "Routegroup with hosts and mixed destinations creates endpoints",
-			source: &routeGroupSource{
-				cli: &fakeRouteGroupClient{
-					rg: &routeGroupList{
-						Items: []*routeGroup{
-							createTestRouteGroup(
-								"namespace1",
-								"rg1",
-								nil,
-								[]string{"rg1.k8s.example"},
-								[]routeGroupLoadBalancer{
-									{
-										Hostname: "lb.example.org",
-										IP:       "1.5.1.4",
-									},
-								},
-							),
+			rgs: []*rgv1.RouteGroup{
+				createTestRouteGroup(
+					"namespace1",
+					"rg1",
+					nil,
+					[]string{"rg1.k8s.example"},
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb.example.org",
+							IP:       "1.5.1.4",
 						},
 					},
-				},
+				),
 			},
 			want: []*endpoint.Endpoint{
 				{
@@ -857,57 +550,51 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 		},
 		{
 			name: "multiple routegroups should return endpoints",
-			source: &routeGroupSource{
-				cli: &fakeRouteGroupClient{
-					rg: &routeGroupList{
-						Items: []*routeGroup{
-							createTestRouteGroup(
-								"namespace1",
-								"rg1",
-								nil,
-								[]string{"rg1.k8s.example"},
-								[]routeGroupLoadBalancer{
-									{
-										Hostname: "lb.example.org",
-									},
-								},
-							),
-							createTestRouteGroup(
-								"namespace1",
-								"rg2",
-								nil,
-								[]string{"rg2.k8s.example"},
-								[]routeGroupLoadBalancer{
-									{
-										Hostname: "lb.example.org",
-									},
-								},
-							),
-							createTestRouteGroup(
-								"namespace2",
-								"rg3",
-								nil,
-								[]string{"rg3.k8s.example"},
-								[]routeGroupLoadBalancer{
-									{
-										Hostname: "lb.example.org",
-									},
-								},
-							),
-							createTestRouteGroup(
-								"namespace3",
-								"rg",
-								nil,
-								[]string{"rg.k8s.example"},
-								[]routeGroupLoadBalancer{
-									{
-										Hostname: "lb2.example.org",
-									},
-								},
-							),
+			rgs: []*rgv1.RouteGroup{
+				createTestRouteGroup(
+					"namespace1",
+					"rg1",
+					nil,
+					[]string{"rg1.k8s.example"},
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb.example.org",
 						},
 					},
-				},
+				),
+				createTestRouteGroup(
+					"namespace1",
+					"rg2",
+					nil,
+					[]string{"rg2.k8s.example"},
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb.example.org",
+						},
+					},
+				),
+				createTestRouteGroup(
+					"namespace2",
+					"rg3",
+					nil,
+					[]string{"rg3.k8s.example"},
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb.example.org",
+						},
+					},
+				),
+				createTestRouteGroup(
+					"namespace3",
+					"rg",
+					nil,
+					[]string{"rg.k8s.example"},
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb2.example.org",
+						},
+					},
+				),
 			},
 			want: []*endpoint.Endpoint{
 				{
@@ -934,64 +621,58 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 		},
 		{
 			name: "multiple routegroups with filter annotations should return only filtered endpoints",
-			source: &routeGroupSource{
-				annotationFilter: parseAnnotationFilterOrNil("kubernetes.io/ingress.class=skipper"),
-				cli: &fakeRouteGroupClient{
-					rg: &routeGroupList{
-						Items: []*routeGroup{
-							createTestRouteGroup(
-								"namespace1",
-								"rg1",
-								map[string]string{
-									"kubernetes.io/ingress.class": "skipper",
-								},
-								[]string{"rg1.k8s.example"},
-								[]routeGroupLoadBalancer{
-									{
-										Hostname: "lb.example.org",
-									},
-								},
-							),
-							createTestRouteGroup(
-								"namespace1",
-								"rg2",
-								map[string]string{
-									"kubernetes.io/ingress.class": "nginx",
-								},
-								[]string{"rg2.k8s.example"},
-								[]routeGroupLoadBalancer{
-									{
-										Hostname: "lb.example.org",
-									},
-								},
-							),
-							createTestRouteGroup(
-								"namespace2",
-								"rg3",
-								map[string]string{
-									"kubernetes.io/ingress.class": "",
-								},
-								[]string{"rg3.k8s.example"},
-								[]routeGroupLoadBalancer{
-									{
-										Hostname: "lb.example.org",
-									},
-								},
-							),
-							createTestRouteGroup(
-								"namespace3",
-								"rg",
-								nil,
-								[]string{"rg.k8s.example"},
-								[]routeGroupLoadBalancer{
-									{
-										Hostname: "lb2.example.org",
-									},
-								},
-							),
+			cfg:  &Config{AnnotationFilter: parseAnnotationFilterOrNil("kubernetes.io/ingress.class=skipper")},
+			rgs: []*rgv1.RouteGroup{
+				createTestRouteGroup(
+					"namespace1",
+					"rg1",
+					map[string]string{
+						"kubernetes.io/ingress.class": "skipper",
+					},
+					[]string{"rg1.k8s.example"},
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb.example.org",
 						},
 					},
-				},
+				),
+				createTestRouteGroup(
+					"namespace1",
+					"rg2",
+					map[string]string{
+						"kubernetes.io/ingress.class": "nginx",
+					},
+					[]string{"rg2.k8s.example"},
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb.example.org",
+						},
+					},
+				),
+				createTestRouteGroup(
+					"namespace2",
+					"rg3",
+					map[string]string{
+						"kubernetes.io/ingress.class": "",
+					},
+					[]string{"rg3.k8s.example"},
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb.example.org",
+						},
+					},
+				),
+				createTestRouteGroup(
+					"namespace3",
+					"rg",
+					nil,
+					[]string{"rg.k8s.example"},
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb2.example.org",
+						},
+					},
+				),
 			},
 			want: []*endpoint.Endpoint{
 				{
@@ -1003,64 +684,58 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 		},
 		{
 			name: "multiple routegroups with set operation annotation filter should return only filtered endpoints",
-			source: &routeGroupSource{
-				annotationFilter: parseAnnotationFilterOrNil("kubernetes.io/ingress.class in (nginx, skipper)"),
-				cli: &fakeRouteGroupClient{
-					rg: &routeGroupList{
-						Items: []*routeGroup{
-							createTestRouteGroup(
-								"namespace1",
-								"rg1",
-								map[string]string{
-									"kubernetes.io/ingress.class": "skipper",
-								},
-								[]string{"rg1.k8s.example"},
-								[]routeGroupLoadBalancer{
-									{
-										Hostname: "lb.example.org",
-									},
-								},
-							),
-							createTestRouteGroup(
-								"namespace1",
-								"rg2",
-								map[string]string{
-									"kubernetes.io/ingress.class": "nginx",
-								},
-								[]string{"rg2.k8s.example"},
-								[]routeGroupLoadBalancer{
-									{
-										Hostname: "lb.example.org",
-									},
-								},
-							),
-							createTestRouteGroup(
-								"namespace2",
-								"rg3",
-								map[string]string{
-									"kubernetes.io/ingress.class": "",
-								},
-								[]string{"rg3.k8s.example"},
-								[]routeGroupLoadBalancer{
-									{
-										Hostname: "lb.example.org",
-									},
-								},
-							),
-							createTestRouteGroup(
-								"namespace3",
-								"rg",
-								nil,
-								[]string{"rg.k8s.example"},
-								[]routeGroupLoadBalancer{
-									{
-										Hostname: "lb2.example.org",
-									},
-								},
-							),
+			cfg:  &Config{AnnotationFilter: parseAnnotationFilterOrNil("kubernetes.io/ingress.class in (nginx, skipper)")},
+			rgs: []*rgv1.RouteGroup{
+				createTestRouteGroup(
+					"namespace1",
+					"rg1",
+					map[string]string{
+						"kubernetes.io/ingress.class": "skipper",
+					},
+					[]string{"rg1.k8s.example"},
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb.example.org",
 						},
 					},
-				},
+				),
+				createTestRouteGroup(
+					"namespace1",
+					"rg2",
+					map[string]string{
+						"kubernetes.io/ingress.class": "nginx",
+					},
+					[]string{"rg2.k8s.example"},
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb.example.org",
+						},
+					},
+				),
+				createTestRouteGroup(
+					"namespace2",
+					"rg3",
+					map[string]string{
+						"kubernetes.io/ingress.class": "",
+					},
+					[]string{"rg3.k8s.example"},
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb.example.org",
+						},
+					},
+				),
+				createTestRouteGroup(
+					"namespace3",
+					"rg",
+					nil,
+					[]string{"rg.k8s.example"},
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb2.example.org",
+						},
+					},
+				),
 			},
 			want: []*endpoint.Endpoint{
 				{
@@ -1077,33 +752,27 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 		},
 		{
 			name: "multiple routegroups with matching label filter returns only labeled endpoints",
-			source: &routeGroupSource{
-				labelSelector: labels.SelectorFromSet(labels.Set{"app": "test"}),
-				cli: &fakeRouteGroupClient{
-					rg: &routeGroupList{
-						Items: []*routeGroup{
-							{
-								Namespace: "namespace1",
-								Name:      "rg-match",
-								Labels:    map[string]string{"app": "test"},
-								Spec:      routeGroupSpec{Hosts: []string{"match.example.org"}},
-								Status: routeGroupStatus{
-									LoadBalancer: routeGroupLoadBalancerStatus{
-										RouteGroup: []routeGroupLoadBalancer{{Hostname: "lb.example.org"}},
-									},
-								},
-							},
-							{
-								Namespace: "namespace1",
-								Name:      "rg-no-match",
-								Labels:    map[string]string{"app": "other"},
-								Spec:      routeGroupSpec{Hosts: []string{"no-match.example.org"}},
-								Status: routeGroupStatus{
-									LoadBalancer: routeGroupLoadBalancerStatus{
-										RouteGroup: []routeGroupLoadBalancer{{Hostname: "lb.example.org"}},
-									},
-								},
-							},
+			cfg:  &Config{LabelFilter: labels.SelectorFromSet(labels.Set{"app": "test"})},
+			rgs: []*rgv1.RouteGroup{
+				{
+					Namespace: "namespace1",
+					Name:      "rg-match",
+					Labels:    map[string]string{"app": "test"},
+					Spec:      rgv1.RouteGroupSpec{Hosts: []string{"match.example.org"}},
+					Status: rgv1.RouteGroupStatus{
+						LoadBalancer: rgv1.RouteGroupLoadBalancerStatus{
+							RouteGroup: []rgv1.RouteGroupLoadBalancer{{Hostname: "lb.example.org"}},
+						},
+					},
+				},
+				{
+					Namespace: "namespace1",
+					Name:      "rg-no-match",
+					Labels:    map[string]string{"app": "other"},
+					Spec:      rgv1.RouteGroupSpec{Hosts: []string{"no-match.example.org"}},
+					Status: rgv1.RouteGroupStatus{
+						LoadBalancer: rgv1.RouteGroupLoadBalancerStatus{
+							RouteGroup: []rgv1.RouteGroupLoadBalancer{{Hostname: "lb.example.org"}},
 						},
 					},
 				},
@@ -1118,22 +787,16 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 		},
 		{
 			name: "multiple routegroups with non-matching label filter returns no endpoints",
-			source: &routeGroupSource{
-				labelSelector: labels.SelectorFromSet(labels.Set{"app": "test"}),
-				cli: &fakeRouteGroupClient{
-					rg: &routeGroupList{
-						Items: []*routeGroup{
-							{
-								Namespace: "namespace1",
-								Name:      "rg-no-match",
-								Labels:    map[string]string{"app": "other"},
-								Spec:      routeGroupSpec{Hosts: []string{"no-match.example.org"}},
-								Status: routeGroupStatus{
-									LoadBalancer: routeGroupLoadBalancerStatus{
-										RouteGroup: []routeGroupLoadBalancer{{Hostname: "lb.example.org"}},
-									},
-								},
-							},
+			cfg:  &Config{LabelFilter: labels.SelectorFromSet(labels.Set{"app": "test"})},
+			rgs: []*rgv1.RouteGroup{
+				{
+					Namespace: "namespace1",
+					Name:      "rg-no-match",
+					Labels:    map[string]string{"app": "other"},
+					Spec:      rgv1.RouteGroupSpec{Hosts: []string{"no-match.example.org"}},
+					Status: rgv1.RouteGroupStatus{
+						LoadBalancer: rgv1.RouteGroupLoadBalancerStatus{
+							RouteGroup: []rgv1.RouteGroupLoadBalancer{{Hostname: "lb.example.org"}},
 						},
 					},
 				},
@@ -1142,50 +805,44 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 		},
 		{
 			name: "multiple routegroups with controller annotation filter should not return filtered endpoints",
-			source: &routeGroupSource{
-				cli: &fakeRouteGroupClient{
-					rg: &routeGroupList{
-						Items: []*routeGroup{
-							createTestRouteGroup(
-								"namespace1",
-								"rg1",
-								map[string]string{
-									annotations.ControllerKey: annotations.ControllerValue,
-								},
-								[]string{"rg1.k8s.example"},
-								[]routeGroupLoadBalancer{
-									{
-										Hostname: "lb.example.org",
-									},
-								},
-							),
-							createTestRouteGroup(
-								"namespace1",
-								"rg2",
-								map[string]string{
-									annotations.ControllerKey: "dns",
-								},
-								[]string{"rg2.k8s.example"},
-								[]routeGroupLoadBalancer{
-									{
-										Hostname: "lb.example.org",
-									},
-								},
-							),
-							createTestRouteGroup(
-								"namespace2",
-								"rg3",
-								nil,
-								[]string{"rg3.k8s.example"},
-								[]routeGroupLoadBalancer{
-									{
-										Hostname: "lb.example.org",
-									},
-								},
-							),
+			rgs: []*rgv1.RouteGroup{
+				createTestRouteGroup(
+					"namespace1",
+					"rg1",
+					map[string]string{
+						annotations.ControllerKey: annotations.ControllerValue,
+					},
+					[]string{"rg1.k8s.example"},
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb.example.org",
 						},
 					},
-				},
+				),
+				createTestRouteGroup(
+					"namespace1",
+					"rg2",
+					map[string]string{
+						annotations.ControllerKey: "dns",
+					},
+					[]string{"rg2.k8s.example"},
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb.example.org",
+						},
+					},
+				),
+				createTestRouteGroup(
+					"namespace2",
+					"rg3",
+					nil,
+					[]string{"rg3.k8s.example"},
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb.example.org",
+						},
+					},
+				),
 			},
 			want: []*endpoint.Endpoint{
 				{
@@ -1202,15 +859,17 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.cfg
+			if cfg == nil {
+				cfg = &Config{}
+			}
 			if tt.templates != "" {
-				if tt.combineFQDN {
-					tt.source.templateEngine = templatetest.MustEngine(t, tt.templates, "", "", true)
-				} else {
-					tt.source.templateEngine = templatetest.MustEngine(t, tt.templates, "", "", false)
-				}
+				cfg.TemplateEngine = templatetest.MustEngine(t, tt.templates, "", "", tt.combineFQDN)
 			}
 
-			got, err := tt.source.Endpoints(t.Context())
+			src := newTestRouteGroupSource(t, cfg, tt.rgs...)
+
+			got, err := src.Endpoints(t.Context())
 			if err != nil && !tt.wantErr {
 				t.Errorf("Got error, but does not want to get an error: %v", err)
 			}
@@ -1224,30 +883,33 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 }
 
 func TestResourceLabelIsSet(t *testing.T) {
-	source := &routeGroupSource{
-		cli: &fakeRouteGroupClient{
-			rg: &routeGroupList{
-				Items: []*routeGroup{
-					createTestRouteGroup(
-						"namespace1",
-						"rg1",
-						nil,
-						[]string{"rg1.k8s.example"},
-						[]routeGroupLoadBalancer{
-							{
-								Hostname: "lb.example.org",
-							},
-						},
-					),
+	src := newTestRouteGroupSource(t, &Config{},
+		createTestRouteGroup(
+			"namespace1",
+			"rg1",
+			nil,
+			[]string{"rg1.k8s.example"},
+			[]rgv1.RouteGroupLoadBalancer{
+				{
+					Hostname: "lb.example.org",
 				},
 			},
-		},
-	}
+		),
+	)
 
-	got, _ := source.Endpoints(t.Context())
+	got, _ := src.Endpoints(t.Context())
 	for _, ep := range got {
 		if _, ok := ep.Labels[endpoint.ResourceLabelKey]; !ok {
 			t.Errorf("Failed to set resource label on ep %v", ep)
 		}
 	}
+}
+
+func TestRouteGroupAddEventHandler(t *testing.T) {
+	t.Parallel()
+
+	src := newTestRouteGroupSource(t, &Config{})
+	called := false
+	src.(*routeGroupSource).AddEventHandler(t.Context(), func() { called = true })
+	assert.False(t, called, "handler should not be called immediately")
 }

--- a/source/skipper_routegroup_test.go
+++ b/source/skipper_routegroup_test.go
@@ -432,8 +432,62 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 			},
 		},
 		{
+			name:        "Single routegroup with combineFQDNAnnotation with fqdn template prefixed with .Metadata should return endpoints from fqdnTemplate and routegroup",
+			templates:   "{{.Metadata.Name}}.{{.Metadata.Namespace}}.example",
+			combineFQDN: true,
+			rgs: []*rgv1.RouteGroup{
+				createTestRouteGroup(
+					"namespace1",
+					"rg1",
+					nil,
+					[]string{"rg1.k8s.example"},
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb.example.org",
+						},
+					},
+				),
+			},
+			want: []*endpoint.Endpoint{
+				{
+					DNSName:    "rg1.k8s.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
+				},
+				{
+					DNSName:    "rg1.namespace1.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
+				},
+			},
+		},
+		{
 			name:      "Single routegroup without hosts, with fqdn template should return endpoints from fqdnTemplate",
 			templates: "{{.Name}}.{{.Namespace}}.example",
+			rgs: []*rgv1.RouteGroup{
+				createTestRouteGroup(
+					"namespace1",
+					"rg1",
+					nil,
+					nil,
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb.example.org",
+						},
+					},
+				),
+			},
+			want: []*endpoint.Endpoint{
+				{
+					DNSName:    "rg1.namespace1.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
+				},
+			},
+		},
+		{
+			name:      "Single routegroup without hosts, with fqdn template using .Metadata should return endpoints from fqdnTemplate",
+			templates: "{{.Metadata.Name}}.{{.Metadata.Namespace}}.example",
 			rgs: []*rgv1.RouteGroup{
 				createTestRouteGroup(
 					"namespace1",
@@ -472,6 +526,30 @@ func TestRouteGroupsEndpoints(t *testing.T) {
 		{
 			name:      "Single routegroup without combineFQDNAnnotation with fqdn template should return endpoints not from fqdnTemplate",
 			templates: "{{.Name}}.{{.Namespace}}.example",
+			rgs: []*rgv1.RouteGroup{
+				createTestRouteGroup(
+					"namespace1",
+					"rg1",
+					nil,
+					[]string{"rg1.k8s.example"},
+					[]rgv1.RouteGroupLoadBalancer{
+						{
+							Hostname: "lb.example.org",
+						},
+					},
+				),
+			},
+			want: []*endpoint.Endpoint{
+				{
+					DNSName:    "rg1.k8s.example",
+					RecordType: endpoint.RecordTypeCNAME,
+					Targets:    endpoint.Targets([]string{"lb.example.org"}),
+				},
+			},
+		},
+		{
+			name:      "Single routegroup without combineFQDNAnnotation with fqdn template using .Metadata should return endpoints not from fqdnTemplate",
+			templates: "{{.Metadata.Name}}.{{.Metadata.Namespace}}.example",
 			rgs: []*rgv1.RouteGroup{
 				createTestRouteGroup(
 					"namespace1",

--- a/source/store.go
+++ b/source/store.go
@@ -25,6 +25,7 @@ import (
 
 	openshift "github.com/openshift/client-go/route/clientset/versioned"
 	log "github.com/sirupsen/logrus"
+	rgversioned "github.com/szuecs/routegroup-client/client/clientset/versioned"
 	istioclient "istio.io/client-go/pkg/clientset/versioned"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/dynamic"
@@ -641,19 +642,16 @@ func buildCRDSource(ctx context.Context, p ClientGenerator, cfg *Config) (Source
 }
 
 // buildSkipperRouteGroupSource creates a Skipper RouteGroup source for exposing route groups as DNS records.
-// Special case: Does not use ClientGenerator pattern, instead manages its own authentication.
-// Retrieves bearer token from REST config for API server authentication.
-func buildSkipperRouteGroupSource(_ context.Context, p ClientGenerator, cfg *Config) (Source, error) {
-	apiServerURL := cfg.APIServerURL
-	tokenPath := ""
-	token := ""
+func buildSkipperRouteGroupSource(ctx context.Context, p ClientGenerator, cfg *Config) (Source, error) {
 	restConfig, err := p.RESTConfig()
-	if err == nil {
-		apiServerURL = restConfig.Host
-		tokenPath = restConfig.BearerTokenFile
-		token = restConfig.BearerToken
+	if err != nil {
+		return nil, err
 	}
-	return NewRouteGroupSource(cfg, token, tokenPath, apiServerURL)
+	rgClient, err := rgversioned.NewForConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+	return NewRouteGroupSource(ctx, rgClient, cfg)
 }
 
 func buildKongTCPIngressSource(ctx context.Context, p ClientGenerator, cfg *Config) (Source, error) {


### PR DESCRIPTION
## What does it do ?

refactor: routegroup integration to use informer instead of hand rolled client

The RouteGroup CRD is now mandatory to have installed if you run with `--source=skipper-routegroup`.

Deprecation: If you use `--fqdn-template` with  `--source=skipper-routegroup`, the use of  `.Metadata` in templates is deprecated so for example `{{.Metadata.Name}}` should be changed to `{{.Name}}`. For a period of time external-dns supports both. 

## Motivation

https://github.com/kubernetes-sigs/external-dns/pull/6703#discussion_r3940585615

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

