### PR TITLE
refactor(exoscale): reduce ApplyChanges cyclomatic complexity

### DIFF
--- a/provider/exoscale/exoscale.go
+++ b/provider/exoscale/exoscale.go
@@ -200,13 +200,28 @@ func (ep *ExoscaleProvider) ApplyChanges(ctx context.Context, changes *plan.Chan
 		return err
 	}
 
-	for _, epoint := range changes.Create {
-		if !ep.domain.Match(epoint.DNSName) {
-			continue
-		}
+	if err := ep.createRecords(ctx, zones, changes.Create); err != nil {
+		return err
+	}
 
-		zoneID, name := ep.filter.EndpointZoneID(epoint, zones)
-		if zoneID == "" {
+	if err := ep.updateRecords(ctx, zones, changes.UpdateNew); err != nil {
+		return err
+	}
+
+	for _, epoint := range changes.UpdateOld {
+		// Since Exoscale "Patches", we've ignored UpdateOld
+		// We leave this logging here for information
+		log.Debugf("UPDATE-OLD (ignored) for epoint: %+v", epoint)
+	}
+
+	return ep.deleteRecords(ctx, zones, changes.Delete)
+}
+
+// createRecords adds a DNS record for every endpoint that resolves to a known zone.
+func (ep *ExoscaleProvider) createRecords(ctx context.Context, zones map[string]string, endpoints []*endpoint.Endpoint) error {
+	for _, epoint := range endpoints {
+		zoneID, name, ok := ep.resolveZone(epoint, zones)
+		if !ok {
 			continue
 		}
 
@@ -224,82 +239,96 @@ func (ep *ExoscaleProvider) ApplyChanges(ctx context.Context, changes *plan.Chan
 		}
 	}
 
-	for _, epoint := range changes.UpdateNew {
-		if !ep.domain.Match(epoint.DNSName) {
+	return nil
+}
+
+// updateRecords patches the existing record matching each endpoint. Endpoints
+// without a matching record in their zone are skipped.
+func (ep *ExoscaleProvider) updateRecords(ctx context.Context, zones map[string]string, endpoints []*endpoint.Endpoint) error {
+	for _, epoint := range endpoints {
+		zoneID, name, ok := ep.resolveZone(epoint, zones)
+		if !ok {
 			continue
 		}
 
-		zoneID, name := ep.filter.EndpointZoneID(epoint, zones)
-		if zoneID == "" {
-			continue
-		}
-
-		records, err := ep.client.ListDNSDomainRecords(ctx, v3.UUID(zoneID))
+		recordID, found, err := ep.findRecordID(ctx, zoneID, name, epoint.RecordType)
 		if err != nil {
 			return err
 		}
-
-		for _, record := range records {
-			if record.Name != name {
-				continue
-			}
-			if string(record.Type) != epoint.RecordType {
-				continue
-			}
-
-			req := v3.UpdateDNSDomainRecordRequest{
-				Content: epoint.Targets[0],
-			}
-			if epoint.RecordTTL != 0 {
-				req.Ttl = int64(epoint.RecordTTL)
-			}
-
-			if err := ep.client.UpdateDNSDomainRecord(ctx, v3.UUID(zoneID), record.ID, req); err != nil {
-				return err
-			}
-
-			break
-		}
-	}
-
-	for _, epoint := range changes.UpdateOld {
-		// Since Exoscale "Patches", we've ignored UpdateOld
-		// We leave this logging here for information
-		log.Debugf("UPDATE-OLD (ignored) for epoint: %+v", epoint)
-	}
-
-	for _, epoint := range changes.Delete {
-		if !ep.domain.Match(epoint.DNSName) {
+		if !found {
 			continue
 		}
 
-		zoneID, name := ep.filter.EndpointZoneID(epoint, zones)
-		if zoneID == "" {
-			continue
+		req := v3.UpdateDNSDomainRecordRequest{
+			Content: epoint.Targets[0],
+		}
+		if epoint.RecordTTL != 0 {
+			req.Ttl = int64(epoint.RecordTTL)
 		}
 
-		records, err := ep.client.ListDNSDomainRecords(ctx, v3.UUID(zoneID))
-		if err != nil {
+		if err := ep.client.UpdateDNSDomainRecord(ctx, v3.UUID(zoneID), recordID, req); err != nil {
 			return err
-		}
-
-		for _, record := range records {
-			if record.Name != name {
-				continue
-			}
-			if string(record.Type) != epoint.RecordType {
-				continue
-			}
-
-			if err := ep.client.DeleteDNSDomainRecord(ctx, v3.UUID(zoneID), record.ID); err != nil {
-				return err
-			}
-
-			break
 		}
 	}
 
 	return nil
+}
+
+// deleteRecords removes the existing record matching each endpoint. Endpoints
+// without a matching record in their zone are skipped.
+func (ep *ExoscaleProvider) deleteRecords(ctx context.Context, zones map[string]string, endpoints []*endpoint.Endpoint) error {
+	for _, epoint := range endpoints {
+		zoneID, name, ok := ep.resolveZone(epoint, zones)
+		if !ok {
+			continue
+		}
+
+		recordID, found, err := ep.findRecordID(ctx, zoneID, name, epoint.RecordType)
+		if err != nil {
+			return err
+		}
+		if !found {
+			continue
+		}
+
+		if err := ep.client.DeleteDNSDomainRecord(ctx, v3.UUID(zoneID), recordID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// resolveZone maps an endpoint onto the zone that should hold its record. It
+// reports false when the endpoint is filtered out or belongs to no known zone.
+func (ep *ExoscaleProvider) resolveZone(epoint *endpoint.Endpoint, zones map[string]string) (string, string, bool) {
+	if !ep.domain.Match(epoint.DNSName) {
+		return "", "", false
+	}
+
+	zoneID, name := ep.filter.EndpointZoneID(epoint, zones)
+	if zoneID == "" {
+		return "", "", false
+	}
+
+	return zoneID, name, true
+}
+
+// findRecordID returns the ID of the first record in the zone matching both the
+// record name and the record type.
+func (ep *ExoscaleProvider) findRecordID(ctx context.Context, zoneID, name, recordType string) (v3.UUID, bool, error) {
+	records, err := ep.client.ListDNSDomainRecords(ctx, v3.UUID(zoneID))
+	if err != nil {
+		return "", false, err
+	}
+
+	for _, record := range records {
+		if record.Name == name && string(record.Type) == recordType {
+			return record.ID, true, nil
+		}
+	}
+
+	return "", false, nil
 }
 
 // Records returns the list of endpoints

--- a/provider/exoscale/exoscale_test.go
+++ b/provider/exoscale/exoscale_test.go
@@ -545,3 +545,54 @@ func (s *errListRecordsStub) DeleteDNSDomainRecord(_ context.Context, _ v3.UUID,
 func (s *errListRecordsStub) UpdateDNSDomainRecord(_ context.Context, _ v3.UUID, _ v3.UUID, _ v3.UpdateDNSDomainRecordRequest) error {
 	return nil
 }
+
+func TestExoscaleApplyChangesListRecordsError(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		changes *plan.Changes
+	}{
+		{
+			name: "update",
+			changes: &plan.Changes{
+				UpdateNew: []*endpoint.Endpoint{
+					{DNSName: "v1.foo.com", RecordType: "TXT", Targets: []string{"new"}},
+				},
+			},
+		},
+		{
+			name: "delete",
+			changes: &plan.Changes{
+				Delete: []*endpoint.Endpoint{
+					{DNSName: "v1.foo.com", RecordType: "TXT", Targets: []string{"old"}},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := NewExoscaleProviderWithClient(&errListRecordsStub{}, false, 0)
+			assert.Error(t, provider.ApplyChanges(t.Context(), tt.changes))
+		})
+	}
+}
+
+func TestExoscaleApplyChangesNoMatchingRecord(t *testing.T) {
+	provider := NewExoscaleProviderWithClient(NewExoscaleClientStub(), false, 0)
+
+	deleteExoscale = make([]deleteRecordExoscale, 0)
+	updateExoscale = make([]updateRecordExoscale, 0)
+
+	// "v1" exists in the foo.com zone as a TXT record only, so neither the
+	// update nor the delete below matches an existing record.
+	changes := &plan.Changes{
+		UpdateNew: []*endpoint.Endpoint{
+			{DNSName: "v1.foo.com", RecordType: "A", Targets: []string{"1.2.3.4"}},
+		},
+		Delete: []*endpoint.Endpoint{
+			{DNSName: "v1.foo.com", RecordType: "A", Targets: []string{"1.2.3.4"}},
+		},
+	}
+
+	assert.NoError(t, provider.ApplyChanges(t.Context(), changes))
+	assert.Empty(t, updateExoscale)
+	assert.Empty(t, deleteExoscale)
+}


### PR DESCRIPTION
## What does it do ?

Splits `ExoscaleProvider.ApplyChanges` into per-operation helpers (`createRecords`,
`updateRecords`, `deleteRecords`) plus two shared helpers: `resolveZone` for the
domain-filter and zone lookup that all three repeated, and `findRecordID` for the
name and type record match that update and delete duplicated verbatim.

This lowers the function's cyclomatic complexity from 26 to 7, with no new helper
above 7, leaving `merge` (9) as the package maximum. Output, ordering, error
propagation and the number of API calls are unchanged.

Part of #5419.

## Motivation

`ApplyChanges` was the most complex function in the provider, and the update and
delete paths had drifted into near-identical copies of the same record lookup.
Separating them makes each operation reviewable on its own as the project lowers
its `cyclop` threshold.

## Testing

- `go test -race -count=1 ./provider/exoscale/` (20 tests)
- `make test` (full suite, all packages)
- `golangci-lint run --timeout=10m ./provider/exoscale/...` (0 issues)
- `make licensecheck`
- `cyclop` with `max-complexity: 1` to read the exact numbers before and after
- The two tests added here cover the `ListDNSDomainRecords` error path and the
  no-matching-record path, neither of which was covered before. Both pass
  unmodified against the pre-refactor code, so they check that the behavior is
  the same rather than only that the new structure works.

## AI assistance

Claude Code helped with the refactor and the two added tests. I reviewed the
result and checked the behavior myself with the test suite and linters.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

