### PR TITLE
fix(alibabacloud): deduplicate hosted zones before fetching records

### DIFF
--- a/provider/alibabacloud/alibaba_cloud.go
+++ b/provider/alibabacloud/alibaba_cloud.go
@@ -391,8 +391,14 @@ func (p *AlibabaCloudProvider) records() ([]alidns.Record, error) {
 			results = append(results, domainRecords...)
 		}
 	} else {
+		zonesToFetch := make(map[string]struct{})
 		for _, domainName := range p.domainFilter.Filters {
-			_, domainName = p.splitDNSName(domainName, hostedZoneDomains)
+			_, zone := p.splitDNSName(domainName, hostedZoneDomains)
+			if zone != "" {
+				zonesToFetch[zone] = struct{}{}
+			}
+		}
+		for domainName := range zonesToFetch {
 			tmpResults, err := p.getDomainRecords(domainName)
 			if err != nil {
 				log.Errorf("getDomainRecords %s error %v", domainName, err)

--- a/provider/alibabacloud/alibaba_cloud.go
+++ b/provider/alibabacloud/alibaba_cloud.go
@@ -382,30 +382,28 @@ func (p *AlibabaCloudProvider) records() ([]alidns.Record, error) {
 	if err != nil {
 		return results, fmt.Errorf("getting domain list: %w", err)
 	}
-	if !p.domainFilter.IsConfigured() {
-		for _, zoneDomain := range hostedZoneDomains {
-			domainRecords, err := p.getDomainRecords(zoneDomain)
-			if err != nil {
-				return nil, fmt.Errorf("getDomainRecords %q: %w", zoneDomain, err)
-			}
-			results = append(results, domainRecords...)
-		}
-	} else {
-		zonesToFetch := make(map[string]struct{})
+	zonesToFetch := hostedZoneDomains
+	if p.domainFilter.IsConfigured() {
+		seen := make(map[string]struct{})
+		zonesToFetch = nil
 		for _, domainName := range p.domainFilter.Filters {
 			_, zone := p.splitDNSName(domainName, hostedZoneDomains)
-			if zone != "" {
-				zonesToFetch[zone] = struct{}{}
-			}
-		}
-		for domainName := range zonesToFetch {
-			tmpResults, err := p.getDomainRecords(domainName)
-			if err != nil {
-				log.Errorf("getDomainRecords %s error %v", domainName, err)
+			if zone == "" {
 				continue
 			}
-			results = append(results, tmpResults...)
+			if _, ok := seen[zone]; ok {
+				continue
+			}
+			seen[zone] = struct{}{}
+			zonesToFetch = append(zonesToFetch, zone)
 		}
+	}
+	for _, zoneDomain := range zonesToFetch {
+		domainRecords, err := p.getDomainRecords(zoneDomain)
+		if err != nil {
+			return nil, fmt.Errorf("getDomainRecords %q: %w", zoneDomain, err)
+		}
+		results = append(results, domainRecords...)
 	}
 	log.Infof("Found %d Alibaba Cloud DNS record(s).", len(results))
 	return results, nil

--- a/provider/alibabacloud/alibaba_cloud_test.go
+++ b/provider/alibabacloud/alibaba_cloud_test.go
@@ -440,16 +440,41 @@ func createDefaultEndpoints(domain string) []*endpoint.Endpoint {
 func TestAlibabaCloudProvider_Records(t *testing.T) {
 	domain := "container-service.top"
 	defaultEndpoints := createDefaultEndpoints(domain)
-	provider := newTestAlibabaCloudProviderWithConfig(
-		endpoint.NewDomainFilter([]string{domain}), false, map[string][]*endpoint.Endpoint{
-			domain: defaultEndpoints,
-		},
-	)
-	endpoints, err := provider.Records(t.Context())
 
-	require.NoError(t, err, "Failed to get records: %v", err)
-	require.Len(t, endpoints, len(defaultEndpoints), "Incorrect number of records: %d", len(endpoints))
-	assert.True(t, testutils.SameEndpoints(defaultEndpoints, endpoints), "expected and actual endpoints don't match. %s:%s", defaultEndpoints, endpoints)
+	tests := []struct {
+		name    string
+		filters []string
+	}{
+		{
+			name:    "single domain filter",
+			filters: []string{domain},
+		},
+		{
+			// Regression test: multiple --domain-filter flags resolving to the
+			// same hosted zone used to make records() query that zone once per
+			// filter, duplicating targets in the resulting endpoints.
+			name:    "multiple domain filters targeting the same zone",
+			filters: []string{"abc." + domain, "a-abc." + domain},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := newTestAlibabaCloudProviderWithConfig(
+				endpoint.NewDomainFilter(tt.filters), false, map[string][]*endpoint.Endpoint{
+					domain: defaultEndpoints,
+				},
+			)
+			endpoints, err := provider.Records(t.Context())
+
+			require.NoError(t, err, "Failed to get records: %v", err)
+			require.Len(t, endpoints, len(defaultEndpoints), "Incorrect number of records: %d", len(endpoints))
+			assert.True(t, testutils.SameEndpoints(defaultEndpoints, endpoints), "expected and actual endpoints don't match. %s:%s", defaultEndpoints, endpoints)
+			for _, ep := range endpoints {
+				assert.Len(t, ep.Targets, 1, "targets must not be duplicated: %v", ep.Targets)
+			}
+		})
+	}
 }
 
 func TestAlibabaCloudProvider_ApplyChanges(t *testing.T) {


### PR DESCRIPTION
## What does it do ?

Deduplicates hosted zones before calling `getDomainRecords()` in the `alibabacloud` provider's `records()` method. Previously, when multiple `--domain-filter` flags resolved to the same hosted zone (e.g. `app1.example.com` and `app2.example.com` both under `example.com`), that zone's records were fetched and appended once per matching filter, duplicating targets in the resulting endpoints.

## Motivation

Reported in the linked issue: with N `--domain-filter` flags pointing at subdomains of the same zone, `Targets` end up duplicated N times (e.g. `10.0.0.1;10.0.0.1`). Since the desired endpoint only ever has one target, `UpdateOld != UpdateNew` on every reconciliation loop, causing continuous, unnecessary update calls and, in some cases, `DomainRecordDuplicate` errors from the Alibaba Cloud API.

## Validation

- `go test -race ./provider/alibabacloud/...` — added a subtest, "multiple domain filters targeting the same zone", to `TestAlibabaCloudProvider_Records`. Confirmed it fails against the pre-fix code with duplicated targets (e.g. `Targets: ["1.2.3.4;1.2.3.4"]`) and passes with this fix.
- `go build ./...`
- `golangci-lint run ./provider/alibabacloud/...` (v2.13.2, the version pinned by `scripts/install-tools.sh`): 0 issues.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

Fixes #6710

```release-note
fix(alibabacloud): deduplicate hosted zones before fetching records
```