### PR TITLE
docs(contributing): add comment style and error-handling guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,11 +108,6 @@ Self-check the change against this guide before handing it back:
 - Comments explain *why*, not *what* — no prose mirroring an `if` condition.
 - Provider/source errors: hard only for unrecoverable startup conditions,
   otherwise `provider.NewSoftErrorf` or return `nil`.
-- Anything non-obvious you learned about a source or provider is written back
-  into `docs/contributing/sources-and-providers.md`.
-- Flags or metrics added → ran `make generate-flags-documentation` /
-  `make generate-metrics-documentation`.
-- CRD types changed → ran `make crd`.
 - Ran `make go-lint` locally, and `go test -race ./<pkg>/...` for every package
   you touched (`make test` for cross-cutting changes). Both green.
 - PR title follows Conventional Commits.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,3 +100,19 @@ Common types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `build`. See
 ## Linting Notes
 
 Uses `golangci-lint` with strict `.golangci.yml` (32+ linters). Key rules: `testifylint` (use `assert`/`require` helpers correctly), `errorlint` (wrap errors properly), `gocritic`, `gochecknoinits` (no `init()` functions). All new Go files need Apache 2.0 license header.
+
+## Before You Finish
+
+Self-check the change against this guide before handing it back:
+
+- Comments explain *why*, not *what* — no prose mirroring an `if` condition.
+- Provider/source errors: hard only for unrecoverable startup conditions,
+  otherwise `provider.NewSoftErrorf` or return `nil`.
+- Anything non-obvious you learned about a source or provider is written back
+  into `docs/contributing/sources-and-providers.md`.
+- Flags or metrics added → ran `make generate-flags-documentation` /
+  `make generate-metrics-documentation`.
+- CRD types changed → ran `make crd`.
+- Ran `make go-lint` locally, and `go test -race ./<pkg>/...` for every package
+  you touched (`make test` for cross-cutting changes). Both green.
+- PR title follows Conventional Commits.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ guide.
 PR titles must follow Conventional Commits: `type(scope): imperative summary`
 (e.g. `fix(aws): respect --dry-run on record updates`). The title becomes the
 squashed commit and feeds the release changelog, so the type and scope matter.
-Common types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `build`. See
+Common types: `feat`, `fix`, `docs`, `chore`, `ci`, `refactor`, `test`. See
 `CONTRIBUTING.md`.
 
 ## Linting Notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,14 @@ Full details in `docs/contributing/sources-and-providers.md` ("Error Handling").
 When you learn something non-obvious about a source or provider, update that
 guide.
 
+## Commit and PR Titles
+
+PR titles must follow Conventional Commits: `type(scope): imperative summary`
+(e.g. `fix(aws): respect --dry-run on record updates`). The title becomes the
+squashed commit and feeds the release changelog, so the type and scope matter.
+Common types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `build`. See
+`CONTRIBUTING.md`.
+
 ## Linting Notes
 
 Uses `golangci-lint` with strict `.golangci.yml` (32+ linters). Key rules: `testifylint` (use `assert`/`require` helpers correctly), `errorlint` (wrap errors properly), `gocritic`, `gochecknoinits` (no `init()` functions). All new Go files need Apache 2.0 license header.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,28 @@ Existing in-tree providers are being actively migrated out-of-tree (see issue #4
 1. Create `source/<name>.go` implementing `Source` interface (`Endpoints`, `AddEventHandler`).
 2. Register in `source/store.go`.
 
+## Comments
+
+Comments capture intent: why the code is shaped this way, what constraint forced
+it, what breaks if you change it. The code already shows what it does.
+
+Do not narrate control flow or restate an `if` condition in prose; if the
+comment goes stale when the line below it changes, delete it. Keep comments
+short. Exported-identifier doc comments are the exception: a concise behavioral
+summary is their job.
+
+## Error Handling
+
+Hard errors (a plain `error`) are fine at startup: provider/source construction,
+credential loading, and config validation should fail fast. Inside the reconcile
+loop a plain `error` from a `Source` or `Provider` is fatal (the process exits
+and Kubernetes CrashLoopBackOffs the pod); wrap transient or expected conditions
+with `provider.NewSoftErrorf`, and return `nil` for "nothing to do".
+
+Full details in `docs/contributing/sources-and-providers.md` ("Error Handling").
+When you learn something non-obvious about a source or provider, update that
+guide.
+
 ## Linting Notes
 
 Uses `golangci-lint` with strict `.golangci.yml` (32+ linters). Key rules: `testifylint` (use `assert`/`require` helpers correctly), `errorlint` (wrap errors properly), `gocritic`, `gochecknoinits` (no `init()` functions). All new Go files need Apache 2.0 license header.

--- a/docs/contributing/sources-and-providers.md
+++ b/docs/contributing/sources-and-providers.md
@@ -395,8 +395,9 @@ Inside the reconcile loop it is different: Kubernetes restarts the pod, a
 persistent hard error becomes `CrashLoopBackOff`, and every restart forces the
 informers to resync with full LIST calls against the Kubernetes API. See
 [Operational best practices](../advanced/operational-best-practices.md) for how
-this amplifies under load. Once the controller is running, prefer a soft error;
-a hard error is justified only when continuing would corrupt state.
+this amplifies under load. Once running, treat a hard error as a last resort: it
+helps only if a fresh process would behave differently. Transient and
+recoverable conditions belong in a soft error.
 
 ### Soft errors are logged and retried
 

--- a/docs/contributing/sources-and-providers.md
+++ b/docs/contributing/sources-and-providers.md
@@ -395,8 +395,8 @@ Inside the reconcile loop it is different: Kubernetes restarts the pod, a
 persistent hard error becomes `CrashLoopBackOff`, and every restart forces the
 informers to resync with full LIST calls against the Kubernetes API. See
 [Operational best practices](../advanced/operational-best-practices.md) for how
-this amplifies under load. Once the controller is running, return a hard error
-only for a condition a restart cannot fix.
+this amplifies under load. Once the controller is running, prefer a soft error;
+a hard error is justified only when continuing would corrupt state.
 
 ### Soft errors are logged and retried
 

--- a/docs/contributing/sources-and-providers.md
+++ b/docs/contributing/sources-and-providers.md
@@ -376,6 +376,53 @@ reference. At minimum, test that:
 * Zone names are correctly mapped to filter entries (including the leading-dot variant)
 * An error from `ListZones` returns an empty `DomainFilter` gracefully
 
+## Error Handling
+
+The controller reconcile loop treats errors in two tiers. The tier you return
+from a `Source` or `Provider` decides whether ExternalDNS keeps running.
+
+### Hard errors exit the process
+
+A plain `error` from `Source.Endpoints`, `Provider.Records`, or
+`Provider.ApplyChanges` propagates out of `Controller.RunOnce`, then out of
+`Controller.Run` to `main`, and the process exits non-zero.
+
+Throwing a hard error is expected **during startup** — provider or source
+construction, credential loading, config validation. A misconfigured ExternalDNS
+should fail fast rather than run in a broken state.
+
+Inside the reconcile loop it is different: Kubernetes restarts the pod, a
+persistent hard error becomes `CrashLoopBackOff`, and every restart forces the
+informers to resync with full LIST calls against the Kubernetes API. See
+[Operational best practices](../advanced/operational-best-practices.md) for how
+this amplifies under load. Once the controller is running, return a hard error
+only for a condition a restart cannot fix.
+
+### Soft errors are logged and retried
+
+For transient or expected conditions (rate limiting, an upstream timeout, a zone
+that is not visible yet), wrap the error with `provider.NewSoftErrorf`
+(`provider/provider.go`):
+
+```go
+if err != nil {
+    return provider.NewSoftErrorf("failed to list zones: %w", err)
+}
+```
+
+The controller logs the error, keeps running, and retries on the next reconcile.
+Consecutive soft errors are exported as the
+`external_dns_controller_consecutive_soft_errors` gauge, which resets after a
+successful reconcile. The webhook provider maps HTTP `5xx` to this same
+behaviour (see [Webhook provider](../tutorials/webhook-provider.md)).
+
+### "Nothing to do" is not an error
+
+If a method has no work (no matching records, an empty change set, a resource
+this provider does not manage), log at `debug` or `info` and return `nil`.
+Returning an error for an expected no-op inflates the soft-error metric or, as a
+hard error, crashes the controller.
+
 ## Provider Blueprints
 
 The `provider/blueprint` package contains reusable building blocks for provider


### PR DESCRIPTION
## What does it do ?

I'm not sure where agents do read that guide, but still worth to add few sections

- New ## Comments section in AGENTS.md: comments carry the "why
- New ## Error Handling pointer section in AGENTS.md
- New ## Error Handling section in docs/contributing/sources-and-providers.md with the contract

We may need some hand rooled script to validate conventional commits and/or PR titles

## Motivation

- AI-written comments in recent PRs over-explain mechanics and restate the code instead of capturing intent; AGENTS.md had no rule to point at.
-  Contributors returning a plain error from a Source/Provider inside the reconcile loop can crash-loop the controller (e.g. PR #6665's fmt.Errorf("service %q has no DNS records to update")); the hard-vs-soft-error contract was only implicit in the code and in operator-facing docs.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests
- [x] Yes, I updated end user documentation accordingly

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->
