### PR TITLE
fix(pdns): restore alias property on ALIAS read-back

### DIFF
--- a/provider/pdns/pdns.go
+++ b/provider/pdns/pdns.go
@@ -342,10 +342,15 @@ func (p *PDNSProvider) convertRRSetToEndpoints(rr pgo.RRset) []*endpoint.Endpoin
 			targets = append(targets, pgo.StringValue(record.Content))
 		}
 	}
-	if rrType == string(pgo.RRTypeALIAS) {
+	isAlias := rrType == string(pgo.RRTypeALIAS)
+	if isAlias {
 		rrType = endpoint.RecordTypeCNAME
 	}
-	endpoints = append(endpoints, endpoint.NewEndpointWithTTL(pgo.StringValue(rr.Name), rrType, endpoint.TTL(pgo.Uint32Value(rr.TTL)), targets...))
+	ep := endpoint.NewEndpointWithTTL(pgo.StringValue(rr.Name), rrType, endpoint.TTL(pgo.Uint32Value(rr.TTL)), targets...)
+	if isAlias {
+		ep = ep.WithAliasProperty(endpoint.AliasTrue)
+	}
+	endpoints = append(endpoints, ep)
 	return endpoints
 }
 

--- a/provider/pdns/pdns_test.go
+++ b/provider/pdns/pdns_test.go
@@ -203,7 +203,7 @@ var (
 		endpoint.NewEndpointWithTTL("cname.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(300), "example.com"),
 		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(300), "'would smell as sweet'"),
 		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(300), "8.8.8.8", "8.8.4.4", "4.4.4.4"),
-		endpoint.NewEndpointWithTTL("alias.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(300), "example.by.any.other.name.com"),
+		endpoint.NewEndpointWithTTL("alias.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(300), "example.by.any.other.name.com").WithAliasProperty(endpoint.AliasTrue),
 		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeMX, endpoint.TTL(300), "10 mailhost1.example.com", "10 mailhost2.example.com"),
 		endpoint.NewEndpointWithTTL("_service._tls.example.com", endpoint.RecordTypeSRV, endpoint.TTL(300), "100 1 443 service.example.com"),
 		endpoint.NewEndpointWithTTL("sub.example.com", endpoint.RecordTypeNS, endpoint.TTL(300), "ns1.example.com", "ns2.example.com"),
@@ -846,6 +846,11 @@ func (suite *NewPDNSProviderTestSuite) TestPDNSRRSetToEndpoints() {
 	*/
 	eps = p.convertRRSetToEndpoints(RRSetDisabledRecord)
 	suite.Equal(endpointsDisabledRecord, eps)
+
+	eps = p.convertRRSetToEndpoints(RRSetALIASRecord)
+	suite.Equal([]*endpoint.Endpoint{
+		endpoint.NewEndpointWithTTL("alias.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(300), "example.by.any.other.name.com").WithAliasProperty(endpoint.AliasTrue),
+	}, eps)
 }
 
 func (suite *NewPDNSProviderTestSuite) TestPDNSRecords() {


### PR DESCRIPTION
## What does it do?

`convertRRSetToEndpoints` in the PowerDNS provider maps `ALIAS` rrsets to `CNAME` endpoints but does not set the `alias=true` provider-specific property on them.

Desired endpoints produced with `--prefer-alias` (or the `external-dns.kubernetes.io/alias: "true"` annotation, #6129) do carry `alias=true`. The planner compares provider-specific properties (`plan.providerSpecificChanged`), sees a property present on desired and absent on current, and schedules an UPDATE for every ALIAS record on every reconcile, forever.

This PR sets `alias=true` on read-back for `ALIAS` rrsets, the same way the AWS provider does for its ALIAS records, so current == desired and the churn stops.

## Motivation

With `--prefer-alias`, every sync cycle logs an `UPDATE` for each ALIAS record and issues a PATCH to the PowerDNS API even though nothing changed:

```
level=info msg="Changing record." action=UPDATE record=svc.example.internal type=CNAME ...
```

On a zone with a few dozen ALIAS records this is a constant stream of no-op writes. Same class of bug as #5826 (Cloudflare record comment): a default provider-specific property that is added to desired endpoints but never reflected in the current state.

## Changes

- `provider/pdns/pdns.go`: `convertRRSetToEndpoints` sets `WithAliasProperty(endpoint.AliasTrue)` when the rrset type is `ALIAS`
- `provider/pdns/pdns_test.go`: `endpointsMultipleRecords` expectation updated for the ALIAS fixture; new `convertRRSetToEndpoints` case for `RRSetALIASRecord`

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Yes, I added unit tests
- [ ] Yes, I updated end user documentation accordingly (no user-facing behaviour change besides removing the spurious updates)
