### PR TITLE
fix(rfc2136): apply min-ttl to desired endpoints to stop record churn

### DIFF
--- a/provider/rfc2136/rfc2136.go
+++ b/provider/rfc2136/rfc2136.go
@@ -284,6 +284,20 @@ OuterLoop:
 	return eps, nil
 }
 
+// AdjustEndpoints applies the rfc2136-min-ttl floor to the desired endpoints so
+// that the planned state matches what AddRecord will actually write. Without
+// this, a record whose configured TTL is below rfc2136-min-ttl is rewritten on
+// every reconciliation cycle. See https://github.com/kubernetes-sigs/external-dns/issues/6723.
+func (r *rfc2136Provider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
+	minTTL := int64(r.minTTL.Seconds())
+	for _, ep := range endpoints {
+		if ep.RecordTTL.IsConfigured() && int64(ep.RecordTTL) < minTTL {
+			ep.RecordTTL = endpoint.TTL(minTTL)
+		}
+	}
+	return endpoints, nil
+}
+
 func (r *rfc2136Provider) IncomeTransfer(m *dns.Msg, nameserver string) (chan *dns.Envelope, error) {
 	t := new(dns.Transfer)
 	if !r.insecure && !r.gssTsig {

--- a/provider/rfc2136/rfc2136_test.go
+++ b/provider/rfc2136/rfc2136_test.go
@@ -836,6 +836,27 @@ func TestRfc2136ApplyChangesWithDifferentTTLs(t *testing.T) {
 	assert.Contains(t, createRecords[2], "300")
 }
 
+func TestRfc2136AdjustEndpointsAppliesMinTTL(t *testing.T) {
+	tlsConfig := TLSConfig{}
+	stub := newStub()
+	p, err := newProvider([]string{""}, 0, nil, false, "key", "secret", "hmac-sha512", true, &endpoint.DomainFilter{}, false, 3600*time.Second, false, "", "", "", 50, tlsConfig, "", stub)
+	require.NoError(t, err)
+
+	endpoints := []*endpoint.Endpoint{
+		endpoint.NewEndpointWithTTL("below.example.com", endpoint.RecordTypeA, endpoint.TTL(60), "1.2.3.4"),
+		endpoint.NewEndpointWithTTL("above.example.com", endpoint.RecordTypeA, endpoint.TTL(7200), "1.2.3.5"),
+		endpoint.NewEndpoint("unconfigured.example.com", endpoint.RecordTypeA, "1.2.3.6"),
+	}
+
+	adjusted, err := p.AdjustEndpoints(endpoints)
+	require.NoError(t, err)
+	require.Len(t, adjusted, 3)
+
+	assert.Equal(t, endpoint.TTL(3600), adjusted[0].RecordTTL, "TTL below minTTL should be raised")
+	assert.Equal(t, endpoint.TTL(7200), adjusted[1].RecordTTL, "TTL above minTTL should be preserved")
+	assert.False(t, adjusted[2].RecordTTL.IsConfigured(), "unconfigured TTL should remain unconfigured")
+}
+
 func TestRfc2136ApplyChangesWithUpdate(t *testing.T) {
 	stub := newStub()
 


### PR DESCRIPTION
Fixes #6723

`--rfc2136-min-ttl` raises a record's TTL in `AddRecord` when it is written,
but the desired endpoints are never normalized before `plan.Calculate`. As a
result, a record whose configured TTL is below the min TTL is detected as out
of sync on every reconciliation and gets removed and re-added each cycle (the
ownership TXT record follows the same churn because its parent record is always
"updated").

This adds an `AdjustEndpoints` implementation to the RFC2136 provider that
applies the same min TTL floor to the desired endpoints, so the planned state
matches what `AddRecord` actually writes.
