### PR TITLE
docs: fix typo in AWS IRSA tutorial

### DIFF
--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -453,7 +453,7 @@ kubectl patch serviceaccount "external-dns" --namespace ${EXTERNALDNS_NS:-"defau
  "{\"metadata\": { \"annotations\": { \"eks.amazonaws.com/role-arn\": \"$ROLE_ARN\" }}}"
 ```
 
-If any part of this step is misconfigured, such as the role with incorrect namespace configured in the trust relationship, annotation pointing the the wrong role, etc., you will see errors like `WebIdentityErr: failed to retrieve credentials`. Check the configuration and make corrections.
+If any part of this step is misconfigured, such as the role with incorrect namespace configured in the trust relationship, annotation pointing to the wrong role, etc., you will see errors like `WebIdentityErr: failed to retrieve credentials`. Check the configuration and make corrections.
 
 When the service account annotations are updated, then the current running pods will have to be terminated, so that new pod(s) with proper configuration (environment variables) will be created automatically.
 


### PR DESCRIPTION
## What does it do ?

Fixes a duplicate \"the\" (and missing \"to\") in the AWS IRSA troubleshooting paragraph so it reads \"annotation pointing to the wrong role\".

## Motivation

Fixes #6725

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Yes, I added unit tests (N/A — docs only)
- [x] Yes, I updated end user documentation accordingly